### PR TITLE
Introduce @lifetime attribute to specify lifetime dependence on function declarations

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2630,19 +2630,19 @@ public:
 
 class LifetimeAttr final
     : public DeclAttribute,
-      private llvm::TrailingObjects<LifetimeAttr, LifetimeDependenceSpecifier> {
+      private llvm::TrailingObjects<LifetimeAttr, LifetimeEntry> {
 
   friend TrailingObjects;
 
   unsigned NumEntries = 0;
 
   explicit LifetimeAttr(SourceLoc atLoc, SourceRange baseRange, bool implicit,
-                        ArrayRef<LifetimeDependenceSpecifier> entries);
+                        ArrayRef<LifetimeEntry> entries);
 
 public:
   static LifetimeAttr *create(ASTContext &context, SourceLoc atLoc,
                               SourceRange baseRange, bool implicit,
-                              ArrayRef<LifetimeDependenceSpecifier> entries);
+                              ArrayRef<LifetimeEntry> entries);
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Lifetime;

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -24,6 +24,7 @@
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/KnownProtocols.h"
+#include "swift/AST/LifetimeDependence.h"
 #include "swift/AST/MacroDeclaration.h"
 #include "swift/AST/Ownership.h"
 #include "swift/AST/PlatformKind.h"
@@ -2624,6 +2625,27 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::RawLayout;
+  }
+};
+
+class LifetimeAttr final
+    : public DeclAttribute,
+      private llvm::TrailingObjects<LifetimeAttr, LifetimeDependenceSpecifier> {
+
+  friend TrailingObjects;
+
+  unsigned NumEntries = 0;
+
+  explicit LifetimeAttr(SourceLoc atLoc, SourceRange baseRange, bool implicit,
+                        ArrayRef<LifetimeDependenceSpecifier> entries);
+
+public:
+  static LifetimeAttr *create(ASTContext &context, SourceLoc atLoc,
+                              SourceRange baseRange, bool implicit,
+                              ArrayRef<LifetimeDependenceSpecifier> entries);
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::Lifetime;
   }
 };
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2644,6 +2644,10 @@ public:
                               SourceRange baseRange, bool implicit,
                               ArrayRef<LifetimeEntry> entries);
 
+  ArrayRef<LifetimeEntry> getLifetimeEntries() const {
+    return {getTrailingObjects<LifetimeEntry>(), NumEntries};
+  }
+
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Lifetime;
   }

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -506,6 +506,10 @@ SIMPLE_DECL_ATTR(unsafe, Unsafe,
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   160)
 
+DECL_ATTR(lifetime, Lifetime,
+  OnAccessor | OnConstructor | OnFunc | OnSubscript | LongAttribute | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  161)
+
 LAST_DECL_ATTR(Unsafe)
 
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7952,6 +7952,9 @@ ERROR(lifetime_dependence_function_type, none,
       "lifetime dependencies on function types are not supported",
       ())
 
+ERROR(lifetime_dependence_immortal_alone, none,
+      "cannot specify any other dependence source along with immortal", ())
+
 //===----------------------------------------------------------------------===//
 //                             MARK: Sending
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -74,7 +74,9 @@ private:
 
 public:
   static LifetimeDependenceSpecifier getNamedLifetimeDependenceSpecifier(
-      SourceLoc loc, ParsedLifetimeDependenceKind kind, Identifier name) {
+      SourceLoc loc, Identifier name,
+      ParsedLifetimeDependenceKind kind =
+          ParsedLifetimeDependenceKind::Default) {
     return {loc, SpecifierKind::Named, kind, name};
   }
 
@@ -84,13 +86,15 @@ public:
   }
 
   static LifetimeDependenceSpecifier getOrderedLifetimeDependenceSpecifier(
-      SourceLoc loc, ParsedLifetimeDependenceKind kind, unsigned index) {
+      SourceLoc loc, unsigned index,
+      ParsedLifetimeDependenceKind kind =
+          ParsedLifetimeDependenceKind::Default) {
     return {loc, SpecifierKind::Ordered, kind, index};
   }
 
-  static LifetimeDependenceSpecifier
-  getSelfLifetimeDependenceSpecifier(SourceLoc loc,
-                                     ParsedLifetimeDependenceKind kind) {
+  static LifetimeDependenceSpecifier getSelfLifetimeDependenceSpecifier(
+      SourceLoc loc, ParsedLifetimeDependenceKind kind =
+                         ParsedLifetimeDependenceKind::Default) {
     return {loc, SpecifierKind::Self, kind, {}};
   }
 

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -153,6 +153,10 @@ class LifetimeDependenceInfo {
                                             unsigned sourceIndex,
                                             LifetimeDependenceKind kind);
 
+  /// Builds LifetimeDependenceInfo from @lifetime attribute
+  static std::optional<ArrayRef<LifetimeDependenceInfo>>
+  fromLifetimeAttribute(AbstractFunctionDecl *afd);
+
   /// Builds LifetimeDependenceInfo from dependsOn type modifier
   static std::optional<LifetimeDependenceInfo>
   fromDependsOn(AbstractFunctionDecl *afd, TypeRepr *targetRepr,

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1533,8 +1533,7 @@ private:
 
 class LifetimeDependentTypeRepr final
     : public SpecifierTypeRepr,
-      private llvm::TrailingObjects<LifetimeDependentTypeRepr,
-                                    LifetimeDependenceSpecifier> {
+      private llvm::TrailingObjects<LifetimeDependentTypeRepr, LifetimeEntry> {
   friend TrailingObjects;
 
   size_t numTrailingObjects(OverloadToken<LifetimeDependentTypeRepr>) const {
@@ -1542,22 +1541,20 @@ class LifetimeDependentTypeRepr final
   }
 
 public:
-  LifetimeDependentTypeRepr(TypeRepr *base,
-                            ArrayRef<LifetimeDependenceSpecifier> specifiers)
+  LifetimeDependentTypeRepr(TypeRepr *base, ArrayRef<LifetimeEntry> specifiers)
       : SpecifierTypeRepr(TypeReprKind::LifetimeDependent, base,
                           specifiers.front().getLoc()) {
     assert(base);
     Bits.LifetimeDependentTypeRepr.NumDependencies = specifiers.size();
     std::uninitialized_copy(specifiers.begin(), specifiers.end(),
-                            getTrailingObjects<LifetimeDependenceSpecifier>());
+                            getTrailingObjects<LifetimeEntry>());
   }
 
-  static LifetimeDependentTypeRepr *
-  create(ASTContext &C, TypeRepr *base,
-         ArrayRef<LifetimeDependenceSpecifier> specifiers);
+  static LifetimeDependentTypeRepr *create(ASTContext &C, TypeRepr *base,
+                                           ArrayRef<LifetimeEntry> specifiers);
 
-  ArrayRef<LifetimeDependenceSpecifier> getLifetimeDependencies() const {
-    return {getTrailingObjects<LifetimeDependenceSpecifier>(),
+  ArrayRef<LifetimeEntry> getLifetimeDependencies() const {
+    return {getTrailingObjects<LifetimeEntry>(),
             Bits.LifetimeDependentTypeRepr.NumDependencies};
   }
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1270,8 +1270,8 @@ public:
                                         ConventionTypeAttr *&result,
                                         bool justChecking);
 
-  ParserStatus parseLifetimeDependenceSpecifiers(
-      SmallVectorImpl<LifetimeDependenceSpecifier> &specifierList);
+  ParserStatus
+  parseLifetimeEntries(SmallVectorImpl<LifetimeEntry> &specifierList);
 
   ParserResult<ImportDecl> parseDeclImport(ParseDeclOptions Flags,
                                            DeclAttributes &Attributes);
@@ -1474,7 +1474,7 @@ public:
     SourceLoc ConstLoc;
     SourceLoc SendingLoc;
     SmallVector<TypeOrCustomAttr> Attributes;
-    SmallVector<LifetimeDependenceSpecifier> lifetimeDependenceSpecifiers;
+    SmallVector<LifetimeEntry> lifetimeEntries;
 
     ParsedTypeAttributeList(ParseTypeReason reason) : ParseReason(reason) {}
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1178,6 +1178,10 @@ public:
       MacroSyntax syntax, SourceLoc AtLoc, SourceLoc Loc
   );
 
+  /// Parse the @lifetime attribute.
+  ParserResult<LifetimeAttr> parseLifetimeAttribute(SourceLoc AtLoc,
+                                                    SourceLoc Loc);
+
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                   SourceLoc AtEndLoc,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3579,7 +3579,7 @@ public:
     for (auto &dep : T->getLifetimeDependencies()) {
       printFieldRaw(
           [&](raw_ostream &out) {
-            out << " " << dep.getLifetimeDependenceSpecifierString() << " ";
+            out << " " << dep.getDependsOnString() << " ";
           },
           "");
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4110,7 +4110,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         if (auto *typeRepr = dyn_cast_or_null<LifetimeDependentTypeRepr>(
                 decl->getResultTypeRepr())) {
           for (auto &dep : typeRepr->getLifetimeDependencies()) {
-            Printer << " " << dep.getLifetimeDependenceSpecifierString() << " ";
+            Printer << " " << dep.getDependsOnString() << " ";
           }
         }
       }
@@ -4335,7 +4335,7 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
         auto *typeRepr =
             cast<LifetimeDependentTypeRepr>(decl->getResultTypeRepr());
         for (auto &dep : typeRepr->getLifetimeDependencies()) {
-          Printer << dep.getLifetimeDependenceSpecifierString() << " ";
+          Printer << dep.getDependsOnString() << " ";
         }
         // TODO: Handle failable initializers with lifetime dependent returns
         Printer << "Self";

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1813,6 +1813,20 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::Lifetime: {
+    auto *attr = cast<LifetimeAttr>(this);
+    bool firstElem = true;
+    Printer << "@lifetime(";
+    for (auto entry : attr->getLifetimeEntries()) {
+      if (!firstElem) {
+        Printer << ", ";
+      }
+      Printer << entry.getParamString();
+    }
+    Printer << ")";
+    break;
+  }
+
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
 #include "swift/AST/DeclAttr.def"
     llvm_unreachable("handled above");

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2011,6 +2011,8 @@ StringRef DeclAttribute::getAttrName() const {
     } else {
       return "_allowFeatureSuppression";
     }
+  case DeclAttrKind::Lifetime:
+    return "lifetime";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -3038,6 +3040,24 @@ AllowFeatureSuppressionAttr *AllowFeatureSuppressionAttr::create(
   auto *mem = ctx.Allocate(size, alignof(AllowFeatureSuppressionAttr));
   return new (mem)
       AllowFeatureSuppressionAttr(atLoc, range, implicit, inverted, features);
+}
+
+LifetimeAttr::LifetimeAttr(SourceLoc atLoc, SourceRange baseRange,
+                           bool implicit,
+                           ArrayRef<LifetimeDependenceSpecifier> entries)
+    : DeclAttribute(DeclAttrKind::Lifetime, atLoc, baseRange, implicit),
+      NumEntries(entries.size()) {
+  std::copy(entries.begin(), entries.end(),
+            getTrailingObjects<LifetimeDependenceSpecifier>());
+}
+
+LifetimeAttr *
+LifetimeAttr::create(ASTContext &context, SourceLoc atLoc,
+                     SourceRange baseRange, bool implicit,
+                     ArrayRef<LifetimeDependenceSpecifier> entries) {
+  unsigned size = totalSizeToAlloc<LifetimeDependenceSpecifier>(entries.size());
+  void *mem = context.Allocate(size, alignof(LifetimeDependenceSpecifier));
+  return new (mem) LifetimeAttr(atLoc, baseRange, implicit, entries);
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -3043,20 +3043,18 @@ AllowFeatureSuppressionAttr *AllowFeatureSuppressionAttr::create(
 }
 
 LifetimeAttr::LifetimeAttr(SourceLoc atLoc, SourceRange baseRange,
-                           bool implicit,
-                           ArrayRef<LifetimeDependenceSpecifier> entries)
+                           bool implicit, ArrayRef<LifetimeEntry> entries)
     : DeclAttribute(DeclAttrKind::Lifetime, atLoc, baseRange, implicit),
       NumEntries(entries.size()) {
   std::copy(entries.begin(), entries.end(),
-            getTrailingObjects<LifetimeDependenceSpecifier>());
+            getTrailingObjects<LifetimeEntry>());
 }
 
-LifetimeAttr *
-LifetimeAttr::create(ASTContext &context, SourceLoc atLoc,
-                     SourceRange baseRange, bool implicit,
-                     ArrayRef<LifetimeDependenceSpecifier> entries) {
-  unsigned size = totalSizeToAlloc<LifetimeDependenceSpecifier>(entries.size());
-  void *mem = context.Allocate(size, alignof(LifetimeDependenceSpecifier));
+LifetimeAttr *LifetimeAttr::create(ASTContext &context, SourceLoc atLoc,
+                                   SourceRange baseRange, bool implicit,
+                                   ArrayRef<LifetimeEntry> entries) {
+  unsigned size = totalSizeToAlloc<LifetimeEntry>(entries.size());
+  void *mem = context.Allocate(size, alignof(LifetimeEntry));
   return new (mem) LifetimeAttr(atLoc, baseRange, implicit, entries);
 }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -675,11 +675,11 @@ SourceLoc SILBoxTypeRepr::getLocImpl() const {
   return LBraceLoc;
 }
 
-LifetimeDependentTypeRepr *LifetimeDependentTypeRepr::create(
-    ASTContext &C, TypeRepr *base,
-    ArrayRef<LifetimeDependenceSpecifier> specifiers) {
-  auto size = totalSizeToAlloc<LifetimeDependenceSpecifier>(specifiers.size());
-  auto mem = C.Allocate(size, alignof(LifetimeDependenceSpecifier));
+LifetimeDependentTypeRepr *
+LifetimeDependentTypeRepr::create(ASTContext &C, TypeRepr *base,
+                                  ArrayRef<LifetimeEntry> specifiers) {
+  auto size = totalSizeToAlloc<LifetimeEntry>(specifiers.size());
+  auto mem = C.Allocate(size, alignof(LifetimeEntry));
   return new (mem) LifetimeDependentTypeRepr(base, specifiers);
 }
 
@@ -699,7 +699,7 @@ void LifetimeDependentTypeRepr::printImpl(ASTPrinter &Printer,
                                           const PrintOptions &Opts) const {
   Printer << " ";
   for (auto &dep : getLifetimeDependencies()) {
-    Printer << dep.getLifetimeDependenceSpecifierString() << " ";
+    Printer << dep.getDependsOnString() << " ";
   }
 
   printTypeRepr(getBase(), Printer, Opts);

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -189,6 +189,8 @@ extension ASTGenVisitor {
         fatalError("unimplemented")
       case .allowFeatureSuppression:
         return self.generateAllowFeatureSuppressionAttr(attribute: node)?.asDeclAttribute
+      case .lifetime:
+        fatalError("unimplemented")
 
       // Simple attributes.
       case .alwaysEmitConformanceMetadata,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2801,6 +2801,96 @@ static std::optional<Identifier> parseSingleAttrOptionImpl(
   return P.Context.getIdentifier(parsedName);
 }
 
+ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
+                                                          SourceLoc loc) {
+  ParserStatus status;
+  SmallVector<LifetimeDependenceSpecifier> lifetimeEntries;
+
+  if (!Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
+    diagnose(loc, diag::requires_experimental_feature, "lifetime attribute",
+             false, getFeatureName(Feature::NonescapableTypes));
+    status.setIsParseError();
+    return status;
+  }
+
+  if (!Tok.isFollowingLParen()) {
+    diagnose(loc, diag::expected_lparen_after_lifetime_dependence);
+    status.setIsParseError();
+    return status;
+  }
+  // consume the l_paren
+  auto lParenLoc = consumeToken();
+
+  SourceLoc rParenLoc;
+  bool foundParamId = false;
+  status = parseList(
+      tok::r_paren, lParenLoc, rParenLoc, /*AllowSepAfterLast*/ false,
+      diag::expected_rparen_after_lifetime_dependence, [&]() -> ParserStatus {
+        ParserStatus listStatus;
+        foundParamId = true;
+        switch (Tok.getKind()) {
+        case tok::identifier: {
+          Identifier paramName;
+          auto paramLoc =
+              consumeIdentifier(paramName, /*diagnoseDollarPrefix=*/false);
+          if (paramName.is("immortal")) {
+            lifetimeEntries.push_back(
+                LifetimeDependenceSpecifier::
+                    getImmortalLifetimeDependenceSpecifier(paramLoc));
+          } else {
+            lifetimeEntries.push_back(
+                LifetimeDependenceSpecifier::
+                    getNamedLifetimeDependenceSpecifier(paramLoc, paramName));
+          }
+          break;
+        }
+        case tok::integer_literal: {
+          SourceLoc paramLoc;
+          unsigned paramNum;
+          if (parseUnsignedInteger(
+                  paramNum, paramLoc,
+                  diag::expected_param_index_lifetime_dependence)) {
+            listStatus.setIsParseError();
+            return listStatus;
+          }
+          lifetimeEntries.push_back(
+              LifetimeDependenceSpecifier::
+                  getOrderedLifetimeDependenceSpecifier(paramLoc, paramNum));
+          break;
+        }
+        case tok::kw_self: {
+          auto paramLoc = consumeToken(tok::kw_self);
+          lifetimeEntries.push_back(
+              LifetimeDependenceSpecifier::getSelfLifetimeDependenceSpecifier(
+                  paramLoc));
+          break;
+        }
+        default:
+          diagnose(
+              Tok,
+              diag::
+                  expected_identifier_or_index_or_self_after_lifetime_dependence);
+          listStatus.setIsParseError();
+          return listStatus;
+        }
+        return listStatus;
+      });
+
+  if (!foundParamId) {
+    diagnose(
+        Tok,
+        diag::expected_identifier_or_index_or_self_after_lifetime_dependence);
+    status.setIsParseError();
+    return status;
+  }
+
+  assert(!lifetimeEntries.empty());
+  SourceRange range(loc, rParenLoc);
+  return ParserResult<LifetimeAttr>(
+      LifetimeAttr::create(Context, atLoc, SourceRange(loc, rParenLoc),
+                           /* implicit */ false, lifetimeEntries));
+}
+
 /// Parses a (possibly optional) argument for an attribute containing a single, arbitrary identifier.
 ///
 /// \param P The parser object.
@@ -4062,6 +4152,13 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     Attributes.add(attr);
     break;
   }
+  case DeclAttrKind::Lifetime: {
+    auto Attr = parseLifetimeAttribute(AtLoc, Loc);
+    Status |= Attr;
+    if (Attr.isNonNull())
+      Attributes.add(Attr.get());
+    break;
+  }
   }
 
   if (DuplicateAttribute) {
@@ -5147,7 +5244,7 @@ ParserStatus Parser::parseLifetimeDependenceSpecifiers(
               specifierList.push_back(
                   LifetimeDependenceSpecifier::
                       getNamedLifetimeDependenceSpecifier(
-                          paramLoc, lifetimeDependenceKind, paramName));
+                          paramLoc, paramName, lifetimeDependenceKind));
             }
             break;
           }
@@ -5163,7 +5260,7 @@ ParserStatus Parser::parseLifetimeDependenceSpecifiers(
             specifierList.push_back(
                 LifetimeDependenceSpecifier::
                     getOrderedLifetimeDependenceSpecifier(
-                        paramLoc, lifetimeDependenceKind, paramNum));
+                        paramLoc, paramNum, lifetimeDependenceKind));
             break;
           }
           case tok::kw_self: {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -58,9 +58,8 @@ Parser::ParsedTypeAttributeList::applyAttributesToType(Parser &p,
     ty = new (p.Context) SendingTypeRepr(ty, SendingLoc);
   }
 
-  if (!lifetimeDependenceSpecifiers.empty()) {
-    ty = LifetimeDependentTypeRepr::create(p.Context, ty,
-                                           lifetimeDependenceSpecifiers);
+  if (!lifetimeEntries.empty()) {
+    ty = LifetimeDependentTypeRepr::create(p.Context, ty, lifetimeEntries);
   }
   return ty;
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -366,6 +366,7 @@ public:
   void visitWeakLinkedAttr(WeakLinkedAttr *attr);
   void visitSILGenNameAttr(SILGenNameAttr *attr);
   void visitUnsafeAttr(UnsafeAttr *attr);
+  void visitLifetimeAttr(LifetimeAttr *attr);
 };
 
 } // end anonymous namespace
@@ -7673,6 +7674,8 @@ void AttributeChecker::visitUnsafeAttr(UnsafeAttr *attr) {
 
   diagnoseAndRemoveAttr(attr, diag::unsafe_attr_disabled);
 }
+
+void AttributeChecker::visitLifetimeAttr(LifetimeAttr *attr) {}
 
 namespace {
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1701,6 +1701,7 @@ namespace  {
     UNINTERESTING_ATTR(UnsafeNonEscapableResult)
     UNINTERESTING_ATTR(StaticExclusiveOnly)
     UNINTERESTING_ATTR(PreInverseGenerics)
+    UNINTERESTING_ATTR(Lifetime)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -1084,9 +1084,8 @@ public:
   maybeReadLifetimeDependence(unsigned numParams);
 
   // Reads lifetime dependence specifier from decl if present
-  bool maybeReadLifetimeDependenceSpecifier(
-      SmallVectorImpl<LifetimeDependenceSpecifier> &specifierList,
-      unsigned numDeclParams, bool hasSelf);
+  bool maybeReadLifetimeEntry(SmallVectorImpl<LifetimeEntry> &specifierList,
+                              unsigned numDeclParams, bool hasSelf);
 
   /// Reads inlinable body text from \c DeclTypeCursor, if present.
   std::optional<StringRef> maybeReadInlinableBodyText();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 889; // public-module-name
+const uint16_t SWIFTMODULE_VERSION_MINOR = 890; // @lifetime attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2489,6 +2489,15 @@ namespace decls_block {
                                //   - argument labels
                                // trialed by introduced conformances
   >;
+
+  using LifetimeDeclAttrLayout =
+      BCRecordLayout<Lifetime_DECL_ATTR,
+                     BCVBR<4>,           // targetIndex
+                     BCFixed<1>,         // isImmortal
+                     BCFixed<1>,         // hasInheritLifetimeParamIndices
+                     BCFixed<1>,         // hasScopeLifetimeParamIndices
+                     BCArray<BCFixed<1>> // concatenated param indices
+                     >;
 
 #undef SYNTAX_SUGAR_TYPE_LAYOUT
 #undef TYPE_LAYOUT

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3382,6 +3382,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       RawLayoutDeclAttrLayout::emitRecord(
         S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
         typeID, countID, rawSize, rawAlign, attr->shouldMoveAsLikeType());
+      return;
+    }
+    case DeclAttrKind::Lifetime: {
+      return;
     }
     }
   }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -111,7 +111,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NEXT:             Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
-// KEYWORD2-NOT:              Keyword
+// KEYWORD2-NEXT              Keyword/None:                       lifetime[#Func Attribute#]; name=lifetime
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#Result Builder#]; name=MyResultBuilder
@@ -250,6 +250,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-DAG: Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
+// ON_METHOD-DAG: Keyword/None:                       lifetime[#Func Attribute#]; name=lifetime
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -323,6 +324,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
 // ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
+// ON_MEMBER_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -394,6 +396,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
+// KEYWORD_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyGenericPropertyWrapper[#Property Wrapper#]; name=MyGenericPropertyWrapper

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes 
+// REQUIRES: asserts
+
+struct NE : ~Escapable {
+
+}
+
+@lifetime(ne)
+func derive(_ ne: NE) -> NE {
+  ne
+}
+
+@lifetime // expected-error{{expected '(' after lifetime dependence specifier}} 
+func testMissingLParenError(_ ne: NE) -> NE {
+  ne
+}
+
+@lifetime() // expected-error{{expected identifier, index or self in lifetime dependence specifier}}
+func testMissingDependence(_ ne: NE) -> NE {
+  ne
+}
+

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,0 +1,179 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+// TODO: Use real Range
+public struct FakeRange<Bound> {
+  public let lowerBound: Bound
+  public let upperBound: Bound
+}
+
+// TODO: Use real Optional
+public enum FakeOptional<T> {
+  case none
+  case some(T)
+}
+
+public struct SpanIndex<Element> {
+  let _rawValue: UnsafeRawPointer
+
+  internal init(rawValue: UnsafeRawPointer) {
+    _rawValue = rawValue
+  }
+
+  var isAligned: Bool {
+    (Int(bitPattern: _rawValue) & (MemoryLayout<Element>.alignment-1)) == 0
+  }
+}
+
+extension SpanIndex: Equatable {}
+
+extension SpanIndex: Hashable {}
+
+extension SpanIndex: Strideable {
+  public typealias Stride = Int
+
+  public func distance(to other: SpanIndex) -> Int {
+    let bytes = _rawValue.distance(to: other._rawValue)
+    let (q, r) = bytes.quotientAndRemainder(dividingBy: MemoryLayout<Element>.stride)
+    precondition(r == 0)
+    return q
+  }
+
+  public func advanced(by n: Int) -> SpanIndex {
+    .init(rawValue: _rawValue.advanced(by: n &* MemoryLayout<Element>.stride))
+  }
+}
+
+extension SpanIndex: Comparable {
+  public static func <(lhs: SpanIndex, rhs: SpanIndex) -> Bool {
+    lhs._rawValue < rhs._rawValue
+  }
+}
+
+public struct Span<Element> : ~Escapable {
+  let start: SpanIndex<Element>
+  public let count: Int
+  private var baseAddress: UnsafeRawPointer { start._rawValue }
+// CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV11baseAddress5count9dependsOnACyxGSV_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (UnsafeRawPointer, Int, @in_guaranteed Owner, @thin Span<Element>.Type) -> _inherit(2) @owned Span<Element> {
+  @lifetime(owner)
+  public init<Owner: ~Copyable & ~Escapable>(
+      baseAddress: UnsafeRawPointer,
+      count: Int,
+      dependsOn owner: borrowing Owner
+    ) {
+      self.init(
+        start: .init(rawValue: baseAddress), count: count, dependsOn: owner
+      )
+  }
+// CHECK-LABEL: sil hidden @$s025lifetime_dependence_span_A5_attr4SpanV5start5count9dependsOnACyxGAA0E5IndexVyxG_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (SpanIndex<Element>, Int, @in_guaranteed Owner, @thin Span<Element>.Type) -> _inherit(2) @owned Span<Element> {
+  @lifetime(owner)
+  init<Owner: ~Copyable & ~Escapable>(
+    start index: SpanIndex<Element>,
+    count: Int,
+    dependsOn owner: borrowing Owner
+  ) {
+    precondition(count >= 0, "Count must not be negative")
+    if !_isPOD(Element.self) {
+      precondition(
+        index.isAligned,
+        "baseAddress must be properly aligned for \(Element.self)"
+      )
+    }
+    self.start = index
+    self.count = count
+  }
+  @_unsafeNonescapableResult
+  init(start index: SpanIndex<Element>,
+    count: Int) {
+    precondition(count >= 0, "Count must not be negative")
+    if !_isPOD(Element.self) {
+      precondition(
+        index.isAligned,
+        "baseAddress must be properly aligned for \(Element.self)"
+      )
+    }
+    self.start = index
+    self.count = count
+  }
+}
+
+extension Span {
+  public typealias Index = SpanIndex<Element>
+  public typealias SubSequence = Self
+
+  public var startIndex: Index { start }
+  public var endIndex: Index { start.advanced(by: count) }  
+
+  @inlinable @inline(__always) 
+  public func distance(from start: Index, to end: Index) -> Int {
+    start.distance(to: end)
+  }
+ 
+  public subscript(position: Index) -> Element {
+    get {
+      if _isPOD(Element.self) {
+        return position._rawValue.loadUnaligned(as: Element.self)
+      }
+      else {
+        return position._rawValue.load(as: Element.self)
+      }
+    }
+  }
+ 
+// CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanVyACyxGAA9FakeRangeVyAA0E5IndexVyxGGcig : $@convention(method) <Element> (FakeRange<SpanIndex<Element>>, @guaranteed Span<Element>) -> _inherit(1) @owned Span<Element> {
+  public subscript(bounds: FakeRange<SpanIndex<Element>>) -> Self {
+  @lifetime(self)
+    get {
+      Span(
+        start: bounds.lowerBound,
+        count: bounds.upperBound.distance(to:bounds.lowerBound) / MemoryLayout<Element>.stride
+      )
+    }
+  }
+
+// CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefix4upToACyxGAA0E5IndexVyxG_tF : $@convention(method) <Element> (SpanIndex<Element>, @guaranteed Span<Element>) -> _inherit(1) @owned Span<Element> {
+  @lifetime(self)
+  borrowing public func prefix(upTo index: SpanIndex<Element>) -> Self {
+    index == startIndex
+    ? Self(start: start, count: 0, dependsOn: copy self)
+    : prefix(through: index.advanced(by: -1))
+  }
+
+// CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefix7throughACyxGAA0E5IndexVyxG_tF : $@convention(method) <Element> (SpanIndex<Element>, @guaranteed Span<Element>) -> _inherit(1) @owned Span<Element> {
+  @lifetime(self)
+  borrowing public func prefix(through index: Index) -> Self {
+    let nc = distance(from: startIndex, to: index) &+ 1
+    return Self(start: start, count: nc, dependsOn: copy self)
+  }
+
+// CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefixyACyxGSiF : $@convention(method) <Element> (Int, @owned Span<Element>) -> _inherit(1) @owned Span<Element> {
+  @lifetime(self)
+  consuming public func prefix(_ maxLength: Int) -> Self {
+    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+    let nc = maxLength < count ? maxLength : count
+    return Self(start: start, count: nc, dependsOn: self)
+  }
+}
+
+extension ContiguousArray {
+  public var view: Span<Element> {
+    @lifetime(self)
+    borrowing _read {
+      yield Span(
+        baseAddress: _baseAddressIfContiguous!, count: count, dependsOn: self
+      )
+    }
+  }
+}
+
+public func array_view_element(a: ContiguousArray<Int> , i: SpanIndex<Int>) -> Int {
+  a.view[i]
+}
+
+public func array_view_slice_element(a: ContiguousArray<Int> , sliceIdx: FakeRange<SpanIndex<Int>>, Idx: SpanIndex<Int>) -> Int {
+  a.view[sliceIdx][Idx]
+}
+

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes
+// REQUIRES: asserts
+
+struct NE : ~Escapable {
+  @lifetime(self) // expected-error{{invalid lifetime dependence on self in an initializer}}
+  init() {}
+}
+
+@lifetime(nonexisting) // expected-error{{invalid parameter name specified 'nonexisting'}}
+func invalidAttrOnNonExistingParam(_ ne: NE) -> NE {
+  ne
+}
+
+@lifetime(self) // expected-error{{invalid lifetime dependence specifier on non-existent self}}
+func invalidAttrOnNonExistingSelf(_ ne: NE) -> NE {
+  ne
+}
+
+@lifetime(2) // expected-error{{invalid parameter index specified 2}}
+func invalidAttrOnNonExistingParamIndex(_ ne: NE) -> NE {
+  ne
+}
+
+@lifetime(ne, ne) // expected-error{{duplicate lifetime dependence specifier}}
+func invalidDuplicateLifetimeDependence1(_ ne: borrowing NE) -> NE {
+  ne
+}
+
+class Klass {}
+
+@lifetime(x) // expected-error{{invalid use of lifetime dependence on an Escapable parameter with consuming ownership}}
+func invalidDependence(_ x: consuming Klass) -> NE {
+  NE()
+}
+


### PR DESCRIPTION
This implements an alternate way to specify lifetime dependence as described here - https://github.com/swiftlang/swift-evolution/blob/9ba7a574d1557eefb4bc3cce1d07efee51861f21/proposals/NNNN-lifetime-dependency.md#lifetime-annotation

rdar://134975439


TODO: Support lifetime dependence on parameter and self targets