### PR TITLE
[6.0] Add missed case to AssignAddressToDef. (#72617)

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3798,6 +3798,15 @@ protected:
     assignment.mapValueToAddress(origValue, newAddr);
     assignment.markForDeletion(bc);
   }
+
+  void visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *bc) {
+    auto builder = assignment.getBuilder(bc->getIterator());
+    auto opdAddr = assignment.getAddressForValue(bc->getOperand());
+    auto newAddr = builder.createUncheckedAddrCast(
+        bc->getLoc(), opdAddr, bc->getType().getAddressType());
+    assignment.mapValueToAddress(origValue, newAddr);
+    assignment.markForDeletion(bc);
+  }
 };
 } // namespace
 

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -24,6 +24,25 @@ struct X {
   var x16: Int
 }
 
+struct X2 {
+  var x1 : Int
+  var x2 : Int
+  var x3 : Int
+  var x4: Int
+  var x5: Int
+  var x6: Int
+  var x7: Int
+  var x8: Int
+  var x9: Int
+  var x10: Int
+  var x11: Int
+  var x12: Int
+  var x13: Int
+  var x14: Int
+  var x15: Int
+  var x16: Int
+}
+
 struct Y {
   var y1 : X
   var y2: X
@@ -268,4 +287,22 @@ bb0(%0 : $*C1, %1 : $*Small):
   retain_value %3 : $C1
   %t = tuple ()
   return %t : $()
+}
+
+// CHECK: sil @test13
+// CHECK:  [[ADDR:%.*]] = unchecked_addr_cast %1 : $*X to $*Y
+// CHECK:  copy_addr [take] [[ADDR]] to [init] %2 : $*Y
+// CHECK: } // end sil function 'test13'
+sil @test13 : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  %1 = alloc_stack $Y
+  %2 = alloc_stack $X
+  copy_addr [take] %0 to [init] %2 : $*X
+  %4 = load %2 : $*X
+  %7 = unchecked_bitwise_cast %4 : $X to $Y
+  store %7 to %1: $*Y
+  %13 = tuple ()
+  dealloc_stack %2 : $*X
+  dealloc_stack %1 : $*Y
+  return %13 : $()
 }


### PR DESCRIPTION
Fixes a crash in asserts compiler toolchains.

Fixes #71744
Cherry-picked from a63078f279e76a64ae92f338c1875c3d372c540b

Description: Fixes a missing case to large types reg2mem. Without adding this case asserts compiler will complain and cause the compiler to crash.

Risk: Low. This should merely be a slightly more optimized code that we would have generated without an asserts compiler where we are fallback to a solution that loads and stores back to memory.

Scope: Fixes a compiler crasher in asserts toolchains.

Testing: Regression test added.

rdar://135227988
Issue #71744