### PR TITLE
[cxx-interop] Install CxxShim library for macCatalyst

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -9,6 +9,11 @@ foreach(sdk ${SWIFT_SDKS})
     add_custom_command(OUTPUT ${module_dir_static}
                        COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir_static}")
   endif()
+  if(SWIFT_ENABLE_MACCATALYST AND "${sdk}" STREQUAL "OSX")
+    set(maccatalyst_module_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}")
+    add_custom_command(OUTPUT ${maccatalyst_module_dir}
+                       COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${maccatalyst_module_dir}")
+  endif()
 
   set(outputs)
   foreach(source libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h)
@@ -25,10 +30,20 @@ foreach(sdk ${SWIFT_SDKS})
                          COMMENT "Copying ${source} to ${module_dir_static}")
       list(APPEND outputs "${module_dir_static}/${source}")
     endif()
+    if(SWIFT_ENABLE_MACCATALYST AND "${sdk}" STREQUAL "OSX")
+      add_custom_command(OUTPUT ${maccatalyst_module_dir}/${source}
+                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
+                         COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${maccatalyst_module_dir}/${source}"
+                         COMMENT "Copying ${source} to ${maccatalyst_module_dir}")
+      list(APPEND outputs "${maccatalyst_module_dir}/${source}")
+    endif()
   endforeach()
   list(APPEND outputs ${module_dir})
   if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
     list(APPEND outputs ${module_dir_static})
+  endif()
+  if(SWIFT_ENABLE_MACCATALYST AND "${sdk}" STREQUAL "OSX")
+    list(APPEND outputs ${maccatalyst_module_dir})
   endif()
 
   add_custom_target(cxxshim-${sdk} ALL
@@ -43,6 +58,11 @@ foreach(sdk ${SWIFT_SDKS})
   if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
     swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
                                DESTINATION "lib/swift_static/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+                               COMPONENT compiler)
+  endif()
+  if(SWIFT_ENABLE_MACCATALYST AND "${sdk}" STREQUAL "OSX")
+    swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
+                               DESTINATION "lib/swift/${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}"
                                COMPONENT compiler)
   endif()
 endforeach()


### PR DESCRIPTION
This is a follow-up after the change that enabled Cxx and CxxStdlib overlays on macCatalyst: https://github.com/swiftlang/swift/pull/74994.

The compiler relies on the presence of these shim libraries in the toolchain.

rdar://135275773

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
