### PR TITLE
[android] build libxml2 and curl with -fPIC on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1502,6 +1502,7 @@ function Build-XML2([Platform]$Platform, $Arch) {
       BUILD_SHARED_LIBS = "NO";
       CMAKE_INSTALL_BINDIR = "bin/$Platform/$ArchName";
       CMAKE_INSTALL_LIBDIR = "lib/$Platform/$ArchName";
+      CMAKE_POSITION_INDEPENDENT_CODE = "YES";
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LIBXML2_WITH_ICONV = "NO";
       LIBXML2_WITH_ICU = "NO";
@@ -1568,6 +1569,7 @@ function Build-CURL([Platform]$Platform, $Arch) {
       BUILD_SHARED_LIBS = "NO";
       BUILD_TESTING = "NO";
       CMAKE_INSTALL_LIBDIR = "lib/$Platform/$ArchName";
+      CMAKE_POSITION_INDEPENDENT_CODE = "YES";
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       BUILD_CURL_EXE = "NO";
       BUILD_LIBCURL_DOCS = "NO";


### PR DESCRIPTION
## Purpose
Defines `CMAKE_POSITION_INDEPENDENT_CODE=YES` when building libxml2 and curl on Windows with `build.ps1`. Defining this property makes `build.ps` consistent with the Python build scripts `swift_build_support\products\libxml2.py` and `swift_build_support\products\curl.py`.

## Problem Details
Android i686/x86 binaries fail to link against libraries compiled without `-fPIC`.

## Validation
Successfully built swift toolchain locally with the following command on Windows:
```
S:\SourceCache\swift\utils\build.cmd -AndroidSDKs x86_64,aarch64,i686
```
This command previously failed linking with i686 libcurl due to not being compiled with `-fPIC`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
