### PR TITLE
Sema: Warn on all non-resilient uses of `@_implementationOnly import`, even for clang targets

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -792,11 +792,7 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
 
 void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
                                        SourceFile &SF) {
-  ASTContext &ctx = SF.getASTContext();
-
-  // Per getTopLevelModule(), we'll only get nullptr here for non-Swift modules,
-  // so these two really mean the same thing.
-  if (!topLevelModule || topLevelModule.get()->isNonSwiftModule())
+  if (!topLevelModule)
     return;
 
   // If the module we're validating is the builtin one, then just return because
@@ -804,6 +800,7 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
   // itself with resiliency. This can occur when one has passed
   // '-enable-builtin-module' and is explicitly importing the Builtin module in
   // their sources.
+  ASTContext &ctx = SF.getASTContext();
   if (topLevelModule.get() == ctx.TheBuiltinModule)
     return;
 
@@ -841,7 +838,8 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
   }
 
   // Report public imports of non-resilient modules from a resilient module.
-  if (import.options.contains(ImportFlags::ImplementationOnly) ||
+  if (topLevelModule.get()->isNonSwiftModule() ||
+      import.options.contains(ImportFlags::ImplementationOnly) ||
       import.accessLevel < AccessLevel::Public)
     return;
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -818,11 +818,13 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
       import.implementationOnlyRange.isValid()) {
     if (SF.getParentModule()->isResilient()) {
       // Encourage replacing `@_implementationOnly` with `internal import`.
-      auto inFlight =
-        ctx.Diags.diagnose(import.importLoc,
-                           diag::implementation_only_deprecated);
-      inFlight.fixItReplace(import.implementationOnlyRange, "internal");
-    } else if ( // Non-resilient
+      if (!topLevelModule.get()->isNonSwiftModule()) {
+        auto inFlight =
+          ctx.Diags.diagnose(import.importLoc,
+                             diag::implementation_only_deprecated);
+        inFlight.fixItReplace(import.implementationOnlyRange, "internal");
+      }
+    } else if ( // Non-resilient client
       !(((targetName.str() == "CCryptoBoringSSL" ||
           targetName.str() == "CCryptoBoringSSLShims") &&
          (importerName.str() == "Crypto" ||

--- a/test/ClangImporter/objc_init_redundant.swift
+++ b/test/ClangImporter/objc_init_redundant.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules -F %S/Inputs/frameworks) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s -verify
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules -F %S/Inputs/frameworks) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s > %t.log 2>&1
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules -F %S/Inputs/frameworks) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s -verify -swift-version 5 -enable-library-evolution
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules -F %S/Inputs/frameworks) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s -swift-version 5 -enable-library-evolution > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
 // REQUIRES: objc_interop

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
 // RUN: %FileCheck -implicit-check-not BAD %s < %t.swiftinterface
 

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -53,9 +53,7 @@ import ClangModuleB
 import SwiftModuleB
 
 @_implementationOnly import ClangModuleA
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 @_implementationOnly import ClangModuleA.Submodule
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 import ClangModuleB
 
 //--- Crypto.swift

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file %s %t --leading-lines
 
 /// Build 2 libs.
-// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/A.swiftmodule \
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/SwiftModuleA.swiftmodule \
 // RUN:   -enable-library-evolution -swift-version 5
-// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/B.swiftmodule \
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/SwiftModuleB.swiftmodule \
 // RUN:   -enable-library-evolution -swift-version 5
 
 /// Build a client with and without library-evolution.
@@ -19,18 +19,47 @@
 // RUN: %target-swift-frontend -typecheck %t/Crypto.swift -I %t -verify \
 // RUN:   -module-name Crypto
 
+//--- module.modulemap
+module ClangModuleA {
+    header "ClangModuleA.h"
+
+    module Submodule {
+        header "ClangSubmodule.h"
+    }
+}
+
+module ClangModuleB {
+    header "ClangModuleB.h"
+}
+
+//--- ClangModuleA.h
+//--- ClangSubmodule.h
+//--- ClangModuleB.h
+
 //--- empty.swift
 
 //--- client-non-resilient.swift
-@_implementationOnly import A // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
-import B
+@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+import SwiftModuleB
+
+@_implementationOnly import ClangModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+@_implementationOnly import ClangModuleA.Submodule // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+import ClangModuleB
 
 //--- client-resilient.swift
-@_implementationOnly import A
+@_implementationOnly import SwiftModuleA
 // expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
-import B
+import SwiftModuleB
+
+@_implementationOnly import ClangModuleA
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
+@_implementationOnly import ClangModuleA.Submodule
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
+import ClangModuleB
 
 //--- Crypto.swift
-@_implementationOnly import A // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Crypto' may lead to instability during execution}}
-import B
+@_implementationOnly import SwiftModuleA // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Crypto' may lead to instability during execution}}
+import SwiftModuleB
 @_implementationOnly import CCryptoBoringSSL
+import ClangModuleB

--- a/test/decl/ext/objc_implementation_class_extension.swift
+++ b/test/decl/ext/objc_implementation_class_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -import-underlying-module -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_class_extension.modulemap -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -import-underlying-module -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_class_extension.modulemap -target %target-stable-abi-triple -swift-version 5 -enable-library-evolution
 // REQUIRES: objc_interop
 
 @_implementationOnly import objc_implementation_class_extension_internal

--- a/test/decl/ext/objc_implementation_impl_only.swift
+++ b/test/decl/ext/objc_implementation_impl_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -target %target-stable-abi-triple -swift-version 5 -enable-library-evolution
 // REQUIRES: objc_interop
 
 @_implementationOnly import objc_implementation_internal

--- a/test/decl/import/inconsistent-implementation-only.swift
+++ b/test/decl/import/inconsistent-implementation-only.swift
@@ -2,11 +2,11 @@
 // RUN: split-file %s %t
 
 // Check that the diagnostics are produced regardless of what primary file we're using.
-// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %t/1.swift -primary-file %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck %t/1.swift -primary-file %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify -swift-version 5 -enable-library-evolution
 
 //--- 1.swift
 


### PR DESCRIPTION
The warning about `using '@_implementationOnly' without enabling library evolution for 'client' may lead to instability during execution` was wrongly restricted to only imports of Swift modules. Make sure they are raised for imports of clang modules as well.

rdar://135233043