### PR TITLE
[TypeChecker] Warn if witness mismatches only on sendability until Sw…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5619,6 +5619,7 @@ bool ConstraintSystem::repairFailures(
     // Matching a witness to an protocol requirement.
     if (isa<ProtocolDecl>(VD->getDeclContext()) &&
         VD->isProtocolRequirement() &&
+        VD->preconcurrency() &&
         path[0].is<LocatorPathElt::Witness>() &&
         // Note that the condition below is very important,
         // we need to wait until the very last moment to strip

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1261,9 +1261,12 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
       // If there are no other issues, let's check whether this are
       // missing Sendable conformances when matching ObjC requirements.
-      // This is not an error until Swift 6 because `swift_attr` wasn't
-      // allowed in type contexts initially.
-      return solution->getFixedScore()
+      // This is not an error until Swift 6 because i.e. `swift_attr` wasn't
+      // allowed in type contexts initially and introducing new concurrency
+      // attributes shouldn't break witnesses without strict concurrency
+      // enabled.
+      return req->preconcurrency() &&
+             solution->getFixedScore()
                      .Data[SK_MissingSynthesizableConformance] > 0;
     }();
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1263,8 +1263,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
       // missing Sendable conformances when matching ObjC requirements.
       // This is not an error until Swift 6 because `swift_attr` wasn't
       // allowed in type contexts initially.
-      return req->isObjC() &&
-             solution->getFixedScore()
+      return solution->getFixedScore()
                      .Data[SK_MissingSynthesizableConformance] > 0;
     }();
 

--- a/test/Concurrency/witness_matching_with_sendable.swift
+++ b/test/Concurrency/witness_matching_with_sendable.swift
@@ -3,10 +3,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
 
 protocol P {
-  var prop: [String: any Sendable] { get set }
+  @preconcurrency var prop: [String: any Sendable] { get set }
   // expected-swift5-note@-1 3 {{expected sendability to match requirement here}}
   // expected-swift6-note@-2 3 {{protocol requires property 'prop' with type '[String : any Sendable]'}}
-  func reqFn(_: [String: any Sendable], _: @Sendable ((any Sendable)?) -> Void)
+  @preconcurrency func reqFn(_: [String: any Sendable], _: @Sendable ((any Sendable)?) -> Void)
   // expected-swift5-note@-1 2 {{expected sendability to match requirement here}}
   // expected-swift6-note@-2 2 {{protocol requires function 'reqFn' with type '([String : any Sendable], @Sendable ((any Sendable)?) -> Void) -> ()'}}
 }
@@ -36,4 +36,20 @@ struct S3 : P { // expected-swift6-error {{type 'S3' does not conform to protoco
   // expected-swift6-note@-2 {{candidate has non-matching type '[String : Any]'}}
 
   func reqFn(_: [String: any Sendable], _: ((any Sendable)?) -> Void) {} // Ok
+}
+
+protocol Q {
+  var prop: [String: [String: any Sendable]] { get set }
+  // expected-note@-1 {{protocol requires property 'prop' with type '[String : [String : any Sendable]]'}}
+
+  func test(_: [() -> (any Sendable)?])
+  // expected-note@-1 {{protocol requires function 'test' with type '([() -> (any Sendable)?]) -> ()'}}
+}
+
+struct S4 : Q { // expected-error {{type 'S4' does not conform to protocol 'Q'}} expected-note {{add stubs for conformance}}
+  var prop: [String: [String: Any]] = [:]
+  // expected-note@-1 {{candidate has non-matching type '[String : [String : Any]]'}}
+
+  func test(_: [() -> Any?]) {}
+  // expected-note@-1 {{candidate has non-matching type '([() -> Any?]) -> ()'}}
 }

--- a/test/Concurrency/witness_matching_with_sendable.swift
+++ b/test/Concurrency/witness_matching_with_sendable.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
+
+protocol P {
+  var prop: [String: any Sendable] { get set }
+  // expected-swift5-note@-1 3 {{expected sendability to match requirement here}}
+  // expected-swift6-note@-2 3 {{protocol requires property 'prop' with type '[String : any Sendable]'}}
+  func reqFn(_: [String: any Sendable], _: @Sendable ((any Sendable)?) -> Void)
+  // expected-swift5-note@-1 2 {{expected sendability to match requirement here}}
+  // expected-swift6-note@-2 2 {{protocol requires function 'reqFn' with type '([String : any Sendable], @Sendable ((any Sendable)?) -> Void) -> ()'}}
+}
+
+struct S1 : P { // expected-swift6-error {{type 'S1' does not conform to protocol 'P'}} expected-swift6-note {{add stubs for conformance}}
+  var prop: [String: Any] = [:]
+  // expected-swift5-warning@-1 {{sendability of function types in property 'prop' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode}}
+  // expected-swift6-note@-2 {{candidate has non-matching type '[String : Any]'}}
+  func reqFn(_: [String: Any], _: (Any?) -> Void) {}
+  // expected-swift5-warning@-1 {{sendability of function types in instance method 'reqFn' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode}}
+  // expected-swift6-note@-2 {{candidate has non-matching type '([String : Any], (Any?) -> Void) -> ()'}}
+}
+
+struct S2 : P { // expected-swift6-error {{type 'S2' does not conform to protocol 'P'}} expected-swift6-note {{add stubs for conformance}}
+  var prop: [String: Any] = [:]
+  // expected-swift5-warning@-1 {{sendability of function types in property 'prop' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode}}
+  // expected-swift6-note@-2 {{candidate has non-matching type '[String : Any]'}}
+
+  func reqFn(_: [String: Any], _: ((any Sendable)?) -> Void) {}
+  // expected-swift5-warning@-1 {{sendability of function types in instance method 'reqFn' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode}}
+  // expected-swift6-note@-2 {{candidate has non-matching type '([String : Any], ((any Sendable)?) -> Void) -> ()'}}
+}
+
+struct S3 : P { // expected-swift6-error {{type 'S3' does not conform to protocol 'P'}} expected-swift6-note {{add stubs for conformance}}
+  var prop: [String: Any] = [:]
+  // expected-swift5-warning@-1 {{sendability of function types in property 'prop' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode}}
+  // expected-swift6-note@-2 {{candidate has non-matching type '[String : Any]'}}
+
+  func reqFn(_: [String: any Sendable], _: ((any Sendable)?) -> Void) {} // Ok
+}

--- a/test/decl/protocol/conforms/isolated_any.swift
+++ b/test/decl/protocol/conforms/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 6 %s
 
 struct A<T> {
   // expected-note @+1 {{candidate has non-matching type}}

--- a/test/decl/protocol/conforms/isolated_any.swift
+++ b/test/decl/protocol/conforms/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 6 %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 struct A<T> {
   // expected-note @+1 {{candidate has non-matching type}}


### PR DESCRIPTION
…ift 6 mode

This expands the downgrade for Objective-C requirements to all preconcurrency
requirements until strict concurrency checking is enabled (either via a flag in Swift 5
language mode or by switching to Swift 6 language mode).

Resolves: rdar://134503878

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
