### PR TITLE
[6.0.1🍒][cxx-interop] Do not import `std::chrono::time_zone_link`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2640,6 +2640,15 @@ namespace {
         return nullptr;
       }
 
+      // Bail if this is `std::chrono::tzdb`. This type causes issues in copy
+      // constructor instantiation.
+      // FIXME: https://github.com/apple/swift/issues/73037
+      if (decl->getDeclContext()->isNamespace() &&
+          decl->getDeclContext()->getParent()->isStdNamespace() &&
+          decl->getIdentifier() &&
+          (decl->getName() == "tzdb" || decl->getName() == "time_zone_link"))
+        return nullptr;
+
       auto &clangSema = Impl.getClangSema();
       // Make Clang define any implicit constructors it may need (copy,
       // default). Make sure we only do this if the class has been fully defined


### PR DESCRIPTION
This type is non-copyable, but its implementation in libstdc++13 does not explicitly declare a deleted copy constructor.

After rebranch, we should start using API Notes to annotate the type as a non-copyable type in Swift.

For now, this change disables import of this type.

See https://github.com/swiftlang/swift/pull/73086

rdar://134432426

(cherry picked from commit 386c8eba13b6299c41d9d0ce2c89922a328318fb)

6.0 PR: https://github.com/swiftlang/swift/pull/76069

Needed to fix the `Swift(linux-x86_64) :: Interop/Cxx/stdlib/foundation-and-std-module.swift` test failure on Fedora 39, Debian 12, and others.