### PR TITLE
ModuleInterface: Don't alias Foundation module in swiftinterfaces

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -97,6 +97,10 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
           importedName == BUILTIN_NAME)
         continue;
 
+      // Aliasing Foundation confuses the typechecker (rdar://128897610).
+      if (importedName == "Foundation")
+        continue;
+
       if (AliasModuleNamesTargets.insert(importedName).second) {
         out << " -module-alias " << MODULE_DISAMBIGUATING_PREFIX <<
                importedName << "=" << importedName;

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -alias-module-names-in-module-interface -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: objc_interop
+
+// CHECK: import Foundation
+import Foundation
+
+public class C: NSObject {
+  // CHECK: @objc override dynamic public func observeValue(forKeyPath keyPath: Swift.String?, of object: Any?, change: [Foundation.NSKeyValueChangeKey : Any]?, context: Swift.UnsafeMutableRawPointer?)
+  public override func observeValue(
+    forKeyPath keyPath: String?,
+    of object: Any?,
+    change: [NSKeyValueChangeKey : Any]?,
+    context: UnsafeMutableRawPointer?
+  ){}
+}


### PR DESCRIPTION
Skip aliasing Foundation when `-alias-module-names-in-module-interface` is specified since it appears to confuse the typechecker. The module name "Foundation" is hardcoded and checked in several places, so aliasing Foundation may be changing some subtle behaviors.

Resolves rdar://128897610.
