### PR TITLE
SILGen: Remove triplesAreValidForZippering() assert

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1771,7 +1771,6 @@ SILValue SILGenFunction::emitZipperedOSVersionRangeCheck(
   // macCatalyst process it will use the iOS version.
   llvm::Triple VariantTriple = *getASTContext().LangOpts.TargetVariant;
   llvm::Triple TargetTriple = getASTContext().LangOpts.Target;
-  assert(triplesAreValidForZippering(TargetTriple, VariantTriple));
 
   // From perspective of the driver and most of the frontend,
   // -target and -target-variant are symmetric. That is, the user

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1323,6 +1323,7 @@ bool swift::extractCompilerFlagsFromInterface(
   // we have loaded a Swift interface from a different-but-compatible
   // architecture slice. Use the compatible subarchitecture.
   for (unsigned I = 1; I < SubArgs.size(); ++I) {
+    // FIXME: Also fix up -target-variant (rdar://135322077).
     if (strcmp(SubArgs[I - 1], "-target") != 0) {
       continue;
     }

--- a/validation-test/ParseableInterface/rdar133020098.swift
+++ b/validation-test/ParseableInterface/rdar133020098.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// REQUIRES: OS=macosx
+
+import System


### PR DESCRIPTION
This assert was correctly catching the fact that `-target-variant` is not being normalized at the same time as `-target` when building arm64e modules from swiftinterface. That should be fixed, but at the moment it isn't causing any concrete harm and the assertion fails when building against the SDKs included with the latest Xcode 16 betas.

Resolves rdar://133020098.
