### PR TITLE
SIL: fix `Phi.init` for arguments in unreachable blocks

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -83,11 +83,22 @@ public struct Phi {
   // is only included here for compatibility with .sil tests that have
   // not been migrated.
   public init?(_ value: Value) {
-    guard let argument = value as? Argument else { return nil }
+    guard let argument = value as? Argument else {
+      return nil
+    }
     var preds = argument.parentBlock.predecessors
-    guard let pred = preds.next() else { return nil }
-    let term = pred.terminator
-    guard term is BranchInst || term is CondBranchInst else { return nil }
+    if let pred = preds.next() {
+      let term = pred.terminator
+      guard term is BranchInst || term is CondBranchInst else {
+        return nil
+      }
+    } else {
+      // No predecessors indicates an unreachable block (except for function arguments).
+      // Treat this like a degenerate phi so we don't consider it a terminator result.
+      if argument is FunctionArgument {
+        return nil
+      }
+    }
     self.value = argument
   }
 

--- a/test/SILOptimizer/borrowed_from_updater.sil
+++ b/test/SILOptimizer/borrowed_from_updater.sil
@@ -286,3 +286,22 @@ bb2(%8 : @reborrow @guaranteed $PairC, %9 : @guaranteed $C):
   return %99 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @unreachable_block :
+// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK-NEXT:    = borrowed [[A1]] : $C from ()
+// CHECK:       bb2([[A2:%.*]] : @reborrow @guaranteed $C):
+// CHECK-NEXT:    = borrowed [[A2]] : $C from (%0 : $C)
+// CHECK:       } // end sil function 'unreachable_block'
+sil [ossa] @unreachable_block : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0 : $C
+  br bb2(%1 : $C)
+
+bb1(%3 : @guaranteed $C):
+  br bb2(%3 : $C)
+
+bb2(%5 : @guaranteed $C):
+  end_borrow %5 : $C
+  return %0 : $C
+}
+


### PR DESCRIPTION
Treat arguments in unreachable blocks like a degenerated phi so we don't consider it a terminator result.

Fixes a compiler crash.
rdar://135336430
