### PR TITLE
[cxx-interop] Remove `-experimental-cxx-stdlib` flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -779,11 +779,6 @@ def experimental_c_foreign_reference_types :
   Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"Enable experimental C foreign references types (with reference counting).">;
 
-def experimental_cxx_stdlib :
-  Separate<["-"], "experimental-cxx-stdlib">,
-  Flags<[HelpHidden]>,
-  HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;
-
 def experimental_hermetic_seal_at_link:
   Flag<["-"], "experimental-hermetic-seal-at-link">,
   Flags<[FrontendOption, HelpHidden]>,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -999,13 +999,6 @@ toolchains::Darwin::validateArguments(DiagnosticEngine &diags,
 		  options::OPT_no_link_objc_runtime)) {
     diags.diagnose(SourceLoc(), diag::warn_darwin_link_objc_deprecated);
   }
-
-  // If a C++ standard library is specified, it has to be libc++.
-  if (auto arg = args.getLastArg(options::OPT_experimental_cxx_stdlib)) {
-    if (StringRef(arg->getValue()) != "libc++") {
-      diags.diagnose(SourceLoc(), diag::error_darwin_only_supports_libcxx); 
-    }
-  }
 }
 
 void

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -204,14 +204,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back("-disable-objc-interop");
   }
 
-  // Add flags for C++ interop.
-  if (const Arg *arg =
-          inputArgs.getLastArg(options::OPT_experimental_cxx_stdlib)) {
-    arguments.push_back("-Xcc");
-    arguments.push_back(
-        inputArgs.MakeArgString(Twine("-stdlib=") + arg->getValue()));
-  }
-
   if (inputArgs.hasArg(options::OPT_experimental_hermetic_seal_at_link)) {
     arguments.push_back("-enable-llvm-vfe");
     arguments.push_back("-enable-llvm-wme");

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -344,13 +344,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     }
   }
 
-  // Link against the desired C++ standard library.
-  if (const Arg *A =
-          context.Args.getLastArg(options::OPT_experimental_cxx_stdlib)) {
-    Arguments.push_back(
-        context.Args.MakeArgString(Twine("-stdlib=") + A->getValue()));
-  }
-
   // Explicitly pass the target to the linker
   Arguments.push_back(
       context.Args.MakeArgString("--target=" + getTriple().str()));

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -174,13 +174,6 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(context.OI.SDKPath));
   }
 
-  // Link against the desired C++ standard library.
-  if (const Arg *A =
-      context.Args.getLastArg(options::OPT_experimental_cxx_stdlib)) {
-    Arguments.push_back(context.Args.MakeArgString(
-        Twine("-stdlib=") + A->getValue()));
-  }
-
   if (job.getKind() == LinkKind::Executable) {
     if (context.OI.SelectedSanitizers & SanitizerKind::Address)
       addLinkRuntimeLib(context.Args, Arguments,

--- a/test/Driver/cxx_interop.swift
+++ b/test/Driver/cxx_interop.swift
@@ -1,10 +1,4 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -Xfrontend -enable-experimental-cxx-interop 2>^1 | %FileCheck -check-prefix ENABLE %s
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -Xfrontend -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ 2>^1 | %FileCheck -check-prefix STDLIB %s
-
 // ENABLE: swift
 // ENABLE: -enable-experimental-cxx-interop
-
-// STDLIB: swift
-// STDLIB-DAG: -enable-experimental-cxx-interop
-// STDLIB-DAG: -Xcc -stdlib=libc++

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -104,20 +104,15 @@
 // INFERRED_NAMED_DARWIN tests above: 'libLINKER.dylib'.
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -o libLINKER.dylib | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 
-// On Darwin, when C++ interop is turned on, we link against libc++ explicitly
-// regardless of whether -experimental-cxx-stdlib is specified or not. So also
-// run a test where C++ interop is turned off to make sure we don't link
+// On Darwin, when C++ interop is turned on, we link against libc++ explicitly.
+// So also run a test where C++ interop is turned off to make sure we don't link
 // against libc++ in this case.
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix IOS-no-cxx-interop %s
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-ios7.1 -enable-experimental-cxx-interop %s 2>&1 | %FileCheck -check-prefix IOS-cxx-interop-libcxx %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-ios7.1 -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ %s 2>&1 | %FileCheck -check-prefix IOS-cxx-interop-libcxx %s
-// RUN: not %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-ios7.1 -enable-experimental-cxx-interop -experimental-cxx-stdlib libstdc++ %s 2>&1 | %FileCheck -check-prefix IOS-cxx-interop-libstdcxx %s
 
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -enable-experimental-cxx-interop %s 2>&1 | %FileCheck -check-prefix LINUX-cxx-interop %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ %s 2>&1 | %FileCheck -check-prefix LINUX-cxx-interop-libcxx %s
 
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-windows-msvc -enable-experimental-cxx-interop %s 2>&1 | %FileCheck -check-prefix WINDOWS-cxx-interop %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-windows-msvc -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ %s 2>&1 | %FileCheck -check-prefix WINDOWS-cxx-interop-libcxx %s
 
 // Check reading the SDKSettings.json from an SDK
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.9 -sdk %S/Inputs/MacOSX10.15.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15 %s
@@ -460,29 +455,9 @@
 // IOS-cxx-interop-libcxx-DAG: -lc++
 // IOS-cxx-interop-libcxx: -o linker
 
-// IOS-cxx-interop-libstdcxx: error: The only C++ standard library supported on Apple platforms is libc++
-
 // LINUX-cxx-interop-NOT: -stdlib
 
-// LINUX-cxx-interop-libcxx: swift
-// LINUX-cxx-interop-libcxx-DAG: -enable-experimental-cxx-interop
-// LINUX-cxx-interop-libcxx-DAG: -o [[OBJECTFILE:.*]]
-
-// LINUX-cxx-interop-libcxx: clang++{{(\.exe)?"? }}
-// LINUX-cxx-interop-libcxx-DAG: [[OBJECTFILE]]
-// LINUX-cxx-interop-libcxx-DAG: -stdlib=libc++
-// LINUX-cxx-interop-libcxx: -o linker
-
 // WINDOWS-cxx-interop-NOT: -stdlib
-
-// WINDOWS-cxx-interop-libcxx: swift
-// WINDOWS-cxx-interop-libcxx-DAG: -enable-experimental-cxx-interop
-// WINDOWS-cxx-interop-libcxx-DAG: -o [[OBJECTFILE:.*]]
-
-// WINDOWS-cxx-interop-libcxx: clang++{{(\.exe)?"? }}
-// WINDOWS-cxx-interop-libcxx-DAG: [[OBJECTFILE]]
-// WINDOWS-cxx-interop-libcxx-DAG: -stdlib=libc++
-// WINDOWS-cxx-interop-libcxx: -o linker
 
 // Test ld detection. We use hard links to make sure
 // the Swift driver really thinks it's been moved.


### PR DESCRIPTION
This flag was added back in 2020, but it didn't function properly, since a lot of other code in the compiler assumed the platform-default C++ stdlib until recently (https://github.com/swiftlang/swift/pull/75589).

The recommended way to use a non-default C++ stdlib in Swift now is to pass `-Xcc -stdlib=xyz` argument to the compiler.

This change removes the `-experimental-cxx-stdlib` flag.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
