### PR TITLE
Serialization: Indicate application extension mode via XCC

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -238,6 +238,9 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions.push_back("--target=" +
                                                   LangOpts.ClangTarget->str());
   }
+  if (LangOpts.EnableAppExtensionRestrictions) {
+    serializationOpts.ExtraClangOptions.push_back("-fapplication-extension");
+  }
 
   serializationOpts.PluginSearchOptions =
       getSearchPathOptions().PluginSearchOpts;

--- a/test/Serialization/application-extension.swift
+++ b/test/Serialization/application-extension.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name AppExtSafe -emit-module-path %t/AppExtSafe.swiftmodule -parse-as-library -serialize-debugging-options -application-extension %s
+
+// Check the serialized flags paths.
+// RUN: llvm-bcanalyzer -dump %t/AppExtSafe.swiftmodule > %t/AppExtSafe.swiftmodule.txt
+// RUN: %FileCheck %s < %t/AppExtSafe.swiftmodule.txt
+
+// CHECK-LABEL: <OPTIONS_BLOCK
+// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '-fapplication-extension'
+// CHECK: </OPTIONS_BLOCK>


### PR DESCRIPTION
This fixes the debugger's ability to perform expression evaluation when debugging an executable that was built with both under the following circumstances:

1. explicit module build
2. `-application-extension`

The fix is to include `-fapplication-extension` as an XCC field in the swiftmodule. This primes the debugger's ClangImporter with the correct flag needed to load the explicitly built pcm files generated at build time.