### PR TITLE
[cxx-interop] do not rely on bodyParams being always non-null when im…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3621,18 +3621,18 @@ namespace {
         }
       }
 
-      if (name && name.isSimpleName()) {
-        assert(importedName.hasCustomName() &&
-               "imported function with simple name?");
-        // Just fill in empty argument labels.
-        name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
-      }
-
       if (!bodyParams) {
         Impl.addImportDiagnostic(
             decl, Diagnostic(diag::invoked_func_not_imported, decl),
             decl->getSourceRange().getBegin());
         return nullptr;
+      }
+
+      if (name && name.isSimpleName()) {
+        assert(importedName.hasCustomName() &&
+               "imported function with simple name?");
+        // Just fill in empty argument labels.
+        name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
       }
 
       if (name && name.getArgumentNames().size() != bodyParams->size()) {

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -501,6 +501,23 @@ public:
    }
 };
 
+
+// This type is intentionally unimportable,
+// to ensure that the function that uses in a parameter
+// cannot import its parameter list.
+struct UnimportableCxxTypeByDefault {
+private:
+  UnimportableCxxTypeByDefault(const UnimportableCxxTypeByDefault &) = delete;
+  UnimportableCxxTypeByDefault(UnimportableCxxTypeByDefault &&) = delete;
+};
+
+struct HasStaticOperatorCallWithUnimportableCxxType {
+  // This operator won't be imported.
+  static int operator()(const UnimportableCxxTypeByDefault &) noexcept {
+      return 0;
+  }
+};
+
 struct ClassWithOperatorStarAvailable {
   int value;
 

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -307,3 +307,7 @@
 // CHECK:   func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK:   func callAsFunction(_ x: Int32) -> Int32
 // CHECK: }
+
+// CHECK: struct HasStaticOperatorCallWithUnimportableCxxType {
+// CHECK-NEXT:  init()
+// CHECK-NEXT: }


### PR DESCRIPTION
…porting function's name

This change fixes a swift-ide-test crash that occured in the Interop\Cxx\stdlib\msvcprt-module-interface.swift testcase with a newer MSVC, as one of its operator() had a parameter with a type that couldn't have been imported. The change ensures that body params are not used if they're null.
