### PR TITLE
Expand the tuple "hack" for initializable values to local tuples

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7587,8 +7587,14 @@ VarDecl::mutability(const DeclContext *UseDC,
   // declaration.  To handle top-level code properly, we look through
   // the TopLevelCode decl on the use (if present) since the vardecl may be
   // one level up.
-  if (getDeclContext() == UseDC)
+  if (getDeclContext() == UseDC) {
+    // Treat values of tuple type as mutable in these contexts, because
+    // SILGen wants to see them as lvalues.
+    if (getInterfaceType()->is<TupleType>())
+      return StorageMutability::Mutable;
+
     return StorageMutability::Initializable;
+  }
 
   if (isa<TopLevelCodeDecl>(UseDC) &&
       getDeclContext() == UseDC->getParent())

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1626,6 +1626,14 @@ struct S {
   }
 }
 
+// rdar://135028163 - trying local 'lets' of tuple type as immutable rvalues, i.e.,
+// the same issue as the above rdar://129031705.
+func tupleAsLocal() {
+  let rotation: (Int, Int)
+  rotation.0 = 0
+  rotation.1 = rotation.0
+}
+
 // rdar://128890586: Init accessors
 final class HasInitAccessors {
   private var _ints: [Int] = []


### PR DESCRIPTION
Back off treating local lets of tuple type as "initializable", expanding on the narrow carve-out from #74133. Without this, we would reject local lets of tuple type that are initialized piecemeal.

Fixes rdar://135028163.
