### PR TITLE
ASTMangler: skip mangling Copyable dependents

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4201,6 +4201,12 @@ void ASTMangler::appendAnyProtocolConformance(
       conformance.getRequirement()->isMarkerProtocol())
     return;
 
+  // While all invertible protocols are marker protocols, do not mangle them for
+  // compatability reasons. See equivalent hack in `conformanceRequirementIndex`
+  // where only invertible protocols are unconditionally skipped.
+  if (conformance.getRequirement()->getInvertibleProtocolKind())
+    return;
+
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
     auto path = genericSig->getConformancePath(conformingType,

--- a/test/Interpreter/moveonly_generics_opaque.swift
+++ b/test/Interpreter/moveonly_generics_opaque.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -O) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+protocol Marked {
+  func announce()
+}
+extension Marked {
+  func announce() { print("\(Self.self) is Marked") }
+}
+
+struct ConcreteWrapper<Wrapped> {}
+extension ConcreteWrapper: Marked where Wrapped: Marked {}
+
+struct Hello<T: ~Copyable> {}
+extension Hello: Marked {}
+
+func makeWrapper<P>(wrapping _: P.Type) -> some Marked {
+    ConcreteWrapper<Hello<P>>()
+}
+
+do {
+  let markedVal = makeWrapper(wrapping: String.self)
+  markedVal.announce() // CHECK: ConcreteWrapper<Hello<String>> is Marked
+}


### PR DESCRIPTION
Typically, a conformance that is dependent on a conformance to a marker protocol never reaches this point in the compiler, where we're mangling the metadata for an opaque return type.

But with the invertible protocols like Copyable, we do permit them, so we should avoid mangling Copyable as that's generally ABI incompatible with existing code.

resolves rdar://135310019