### PR TITLE
Rewrite UnsafeRawBufferPointer.Iterator.next

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -93,7 +93,7 @@ public:
   }
 
 #ifndef NDEBUG
-  void dump() { print(llvm::errs()); };
+  void dump() LLVM_ATTRIBUTE_USED { print(llvm::errs()); }
 #endif
 };
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -153,22 +153,23 @@ extension UnsafeRawBufferPointer.Iterator: IteratorProtocol, Sequence {
   ///   exists; otherwise, `nil`.
   @inlinable
   public mutating func next() -> UInt8? {
-    if _position == _end { return nil }
-
+    guard let position = _position else {
+      return nil
+    }
     // We can do an unchecked unwrap here by borrowing invariants from the pointer.
-    // For a validly constructed buffer pointer, the only way _position can be nil is
-    // if _end is also nil. We checked that case above. Thus, we can safely do an
-    // unchecked unwrap here.
-    //
-    // Additionally, validly constructed buffer pointers also have an _end that is
-    // strictly greater than or equal to _position, and so we do not need to do checked
-    // arithmetic here as we cannot possibly overflow.
-    //
+    // For a validly constructed buffer pointer, the only way _end can be nil is
+    // if _position is also nil. We checked that case above.
+    // Thus, we can safely do an unchecked unwrap here.
     // We check these invariants in debug builds to defend against invalidly constructed
     // pointers.
-    _debugPrecondition(_position! < _end!)
-    let position = _position._unsafelyUnwrappedUnchecked
+    _debugPrecondition(_end != nil)
+    let end = _end._unsafelyUnwrappedUnchecked
+    if position == end { return nil }
+    _debugPrecondition(position < end)
     let result = position.load(as: UInt8.self)
+    // Validly constructed buffer pointers also have an _end that is strictly
+    // greater than or equal to _position.
+    // So we do not need to do checked arithmetic here as we cannot possibly overflow.
     _position = position + 1
     return result
   }

--- a/test/LLVMPasses/loopinfo.swift
+++ b/test/LLVMPasses/loopinfo.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-irgen -O -o %t/loopinfo.ll  %s 
+// RUN: %swift-llvm-opt -passes='print<loops>' %t/loopinfo.ll 2>&1 | %FileCheck %s
+
+// CHECK: Loop at depth 1 containing
+public func iterate1(urbp: UnsafeRawBufferPointer) -> Int {
+  var s = 0
+  for v in urbp {
+    s += Int(v)
+  }
+  return s
+}
+
+// CHECK: Loop at depth 1 containing
+public func iterate2(ubp: UnsafeBufferPointer<Int>) -> Int {
+  var s = 0
+  for v in ubp {
+    s += v
+  }
+  return s
+}
+
+
+


### PR DESCRIPTION
In the SIL generated from the current implementation,  it isn't clear to the optimizer that `_position == nil && _end != nil` can never happen. This ends up creating a non-natural loop and none of the SIL and LLVM loop passes work for such loops. We have to find a way to fix this in SIL. Until then, rewrite so we get a natural loop.

Note: `UnsafeBufferPointer.Iterator.next` does not have this issue