### PR TITLE
Remove `shouldWalkCaptureInitializerExpressions`

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -642,11 +642,6 @@ public:
   /// value of a property wrapper placeholder.
   virtual bool shouldWalkIntoPropertyWrapperPlaceholderValue() { return true; }
 
-  /// This method configures whether the walker should visit the capture
-  /// initializer expressions within a capture list directly, rather than
-  /// walking the declarations.
-  virtual bool shouldWalkCaptureInitializerExpressions() { return false; }
-
   /// This method configures whether the walker should exhibit the legacy
   /// behavior where accessors appear as peers of their storage, rather
   /// than children nested inside of it.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -977,17 +977,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
   Expr *visitCaptureListExpr(CaptureListExpr *expr) {
     for (auto c : expr->getCaptureList()) {
-      if (Walker.shouldWalkCaptureInitializerExpressions()) {
-        for (auto entryIdx : range(c.PBD->getNumPatternEntries())) {
-          if (auto newInit = doIt(c.PBD->getInit(entryIdx)))
-            c.PBD->setInit(entryIdx, newInit);
-          else
-            return nullptr;
-        }
-      } else {
-        if (doIt(c.PBD))
-          return nullptr;
-      }
+      if (doIt(c.PBD))
+        return nullptr;
     }
 
     AbstractClosureExpr *body = expr->getClosureBody();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -105,8 +105,6 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       return Action::Continue();
     }
 
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // See through implicit conversions of the expression.  We want to be able
       // to associate the parent of this expression with the ultimate callee.
@@ -1579,8 +1577,6 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
              cast<VarDecl>(DRE->getDecl())->isSelfParameter();
     }
 
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::Expansion;
     }
@@ -2225,8 +2221,6 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       return parentContext->getInnermostClosureForSelfCapture();
     }
-
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
     bool shouldRecordClosure(const AbstractClosureExpr *E) {
       // Record all closures in Swift 6 mode.
@@ -4560,8 +4554,6 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
   public:
     DiagnoseWalker(ASTContext &ctx) : Ctx(ctx) { }
 
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::Expansion;
     }
@@ -4684,8 +4676,6 @@ class ObjCSelectorWalker : public ASTWalker {
 public:
   ObjCSelectorWalker(const DeclContext *dc, Type selectorTy)
     : Ctx(dc->getASTContext()), DC(dc), SelectorTy(selectorTy) { }
-
-  bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Expansion;
@@ -5547,8 +5537,6 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       }
     }
 
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::Expansion;
     }
@@ -5621,8 +5609,6 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
         }
       }
     }
-
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::Expansion;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2905,8 +2905,6 @@ namespace {
       llvm_unreachable("expected a CallExpr in applyStack!");
     }
 
-    bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
     MacroWalking getMacroWalkingBehavior() const override {
       return MacroWalking::Expansion;
     }


### PR DESCRIPTION
There doesn't seem to be any reason we can't walk the PatternBindingDecls directly here.