### PR TITLE
[ScanDependency] Fix a container overflow bug when removing arguments

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -170,10 +170,11 @@ static void removeMacroSearchPaths(std::vector<std::string> &cmd) {
   };
 
   // Remove macro search path option and its argument.
-  for (auto it = cmd.begin(), ie=cmd.end(); it != ie; ++it) {
-    if (macroSearchOptions.contains(*it) && it + 1 != ie) {
+  for (auto it = cmd.begin(); it != cmd.end();) {
+    if (macroSearchOptions.contains(*it) && it + 1 != cmd.end())
       it = cmd.erase(it, it + 2);
-    }
+    else
+      ++it;
   }
 }
 


### PR DESCRIPTION
Fix a bug that when the last argument is removed as macro search options, the iterator increment afterwards is going to bring it pass the end of the container.

rdar://135366279

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
