### PR TITLE
[ASTGen] Don’t map `sendingArgsAndResults`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -67,7 +67,6 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.ThenStatements, to: .thenStatements)
     mapFeature(.DoExpressions, to: .doExpressions)
     mapFeature(.NonescapableTypes, to: .nonescapableTypes)
-    mapFeature(.SendingArgsAndResults, to: .sendingArgsAndResults)
     mapFeature(.TrailingComma, to: .trailingComma)
   }
 }


### PR DESCRIPTION
Companion of https://github.com/swiftlang/swift-syntax/pull/2835.

---

The corresponding evolution proposal has been accepted and the experimental feature no longer exists in swift-syntax.
