### PR TITLE
Revert "[CSBindings] Mark generic parameter type vars as complete if they don't have any adjacent vars"

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -174,30 +174,9 @@ bool BindingSet::involvesTypeVariables() const {
 }
 
 bool BindingSet::isPotentiallyIncomplete() const {
-  // Always marking generic parameter type variables as incomplete
-  // is too aggressive. That was the way to make sure that they
-  // are never attempted to eagerly, but really there are only a
-  // couple of situations where that can cause issues:
-  //
-  // 1. Int <: $T_param
-  //    $T1 <: $T_param
-  //
-  // 2. $T2 conv Generic<$T_param>
-  //    $T2 conv Generic<Int?>
-  //    Int <: $T_param
-  //
-  // Attempting $T_param before $T1 in 1. could result in a missed
-  // optional type binding for example.
-  //
-  // Attempting $T_param too early in this case (before $T2) could
-  // miss some transitive bindings inferred through conversion
-  // of `Generic` type.
-  //
-  // If a type variable that represents a generic parameter is no longer
-  // associated with any type variables (directly or indirectly) it's safe
-  // to assume that its binding set is complete.
+  // Generic parameters are always potentially incomplete.
   if (Info.isGenericParameter())
-    return involvesTypeVariables();
+    return true;
 
   // Key path literal type is incomplete until there is a
   // contextual type or key path is resolved enough to infer

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -393,3 +393,25 @@ struct TestMultipleOverloadedInits {
     let _ = [Float(x), Float(x), Float(x), Float(x)]
   }
 }
+
+do {
+  struct Section {
+    var rows: [Row<Any>]?
+  }
+
+  struct Row<T> {
+      init(value: T?) {}
+  }
+
+  struct Asset {
+    var orientation: Int32
+  }
+
+  func test(asset: Asset) -> [Section] {
+    return [
+      Section(rows: [
+        Row(value: String(describing: asset.orientation)) // Ok
+      ])
+    ]
+  }
+}


### PR DESCRIPTION
This reverts commit 22e0f4a3d69942f56f62e7b050b75b0f8873dc09.

Binding inference doesn't mark type variables that appear in
dependent member chains as "adjacent" which means that type
variables that represent generic arguments cannot be attempted
sooner due to incomplete information provided by the inference.

To fix this we'd need to remove `findInferrableTypeVars` and
replace its uses with `Type::getTypeVariables(...)`. This is
a risky change that would require some evaluation because it
could end breaking existing code but it would make sure that
for cases like `Row<$T0> conv $T1.ArrayLiteralElement` `$T0`
always gets associated with `$T1`.

Resolves: rdar://135203192
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
