### PR TITLE
ModuleInterface: Print patterns with opaque result types using `some` keyword

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1335,6 +1335,8 @@ void PrintAST::printTypedPattern(const TypedPattern *TP) {
   printPattern(TP->getSubPattern());
   Printer << ": ";
 
+  PrintWithOpaqueResultTypeKeywordRAII x(Options);
+
   // Make sure to check if the underlying var decl is an implicitly unwrapped
   // optional.
   bool isIUO = false;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2771,7 +2771,18 @@ public:
         // Properties with an opaque return type need an initializer to
         // determine their underlying type.
         if (var->getOpaqueResultTypeDecl()) {
-          var->diagnose(diag::opaque_type_var_no_init);
+          // ...but don't enforce this for SIL or module interface files.
+          switch (SF->Kind) {
+          case SourceFileKind::Interface:
+          case SourceFileKind::SIL:
+            break;
+          case SourceFileKind::DefaultArgument:
+          case SourceFileKind::Main:
+          case SourceFileKind::Library:
+          case SourceFileKind::MacroExpansion:
+            var->diagnose(diag::opaque_type_var_no_init);
+            break;
+          }
         }
 
         // Non-member observing properties need an initializer.

--- a/test/ModuleInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ModuleInterface/Inputs/opaque-result-types-client.swift
@@ -60,4 +60,19 @@ func someTypeIsTheSame() {
   f = barString.foo(MyFoo()) // expected-error{{cannot assign}}
   f = barInt.foo(YourFoo()) // expected-error{{cannot convert value of type 'YourFoo' to expected argument type 'MyFoo'}}
   f = barString.foo(MyFoo()) // expected-error{{cannot assign}}
+
+  var g = globalComputedVar
+  g = globalVar // expected-error{{cannot assign}}
+  g = globalComputedVar
+  g = 123 // expected-error{{cannot assign}}
+
+  var h = globalVar
+  h = globalComputedVar // expected-error{{cannot assign}}
+  h = globalVar
+  h = 123 // expected-error{{cannot assign}}
+
+  var i = globalVarTuple
+  i = (123, foo(123)) // expected-error{{cannot assign}}
+  i = globalVarTuple
+  i = (globalVarTuple.0, globalVarTuple.1)
 }

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -25,6 +25,20 @@ public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
 
+// CHECK-LABEL: public var globalComputedVar: some OpaqueResultTypes.Foo {
+// CHECK-NEXT:    get
+// CHECK-NEXT:  }
+@available(SwiftStdlib 5.1, *)
+public var globalComputedVar: some Foo { 123 }
+
+// CHECK-LABEL: public var globalVar: some OpaqueResultTypes.Foo{{$}}
+@available(SwiftStdlib 5.1, *)
+public var globalVar: some Foo = 123
+
+// CHECK-LABEL: public var globalVarTuple: (some OpaqueResultTypes.Foo, some OpaqueResultTypes.Foo){{$}}
+@available(SwiftStdlib 5.1, *)
+public var globalVarTuple: (some Foo, some Foo) = (123, foo(123))
+
 public protocol AssocTypeInference {
   associatedtype Assoc: Foo
   associatedtype AssocProperty: Foo


### PR DESCRIPTION
Previously, the opaque types in patterns were printed using their full stable reference which cannot be resolved when parsing a swiftinterface.
    
Resolves rdar://127771885.
