### PR TITLE
[IRGen] Fix SignatureExpansion::expandAsyncAwaitType

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2330,17 +2330,14 @@ void SignatureExpansion::expandAsyncAwaitType() {
     if (!nativeError.shouldReturnTypedErrorIndirectly()) {
       auto combined = combineResultAndTypedErrorType(IGM, native, nativeError);
 
-      if (combined.combinedTy->isVoidTy()) {
-        addErrorResult();
-        return;
-      }
-
-      if (auto *structTy = dyn_cast<llvm::StructType>(combined.combinedTy)) {
-        for (auto *elem : structTy->elements()) {
-          components.push_back(elem);
+      if (!combined.combinedTy->isVoidTy()) {
+        if (auto *structTy = dyn_cast<llvm::StructType>(combined.combinedTy)) {
+          for (auto *elem : structTy->elements()) {
+            components.push_back(elem);
+          }
+        } else {
+          components.push_back(combined.combinedTy);
         }
-      } else {
-        components.push_back(combined.combinedTy);
       }
       addErrorResult();
       ResultIRType = llvm::StructType::get(IGM.getLLVMContext(), components);

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -6,6 +6,8 @@
 
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-library-evolution
 
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -O
+
 // XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
@@ -231,4 +233,17 @@ protocol Proto {
 
   // This used to crash.
   static func f2() throws(SP) -> Int64
+}
+
+@inline(never)
+@available(SwiftStdlib 6.0, *)
+public func passthroughAsync<T, E: Error>(f: () async throws(E) -> T) async throws(E) -> T {
+  try await f()
+}
+
+@available(SwiftStdlib 6.0, *)
+public func reabstractAsyncVoidThrowsNever() async {
+  await passthroughAsync {
+    ()
+  }
 }


### PR DESCRIPTION
For typed throws async functions, when the error type is `Never` and the result type `Void`, we still have to add the error context
