### PR TITLE
test: Fix raw_layout.swift for 32-bit platforms

### DIFF
--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -322,8 +322,9 @@ struct ConcreteVectorMovesAsLike: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 16
 // stride
 // CHECK-SAME:  , {{i64|i32}} 16
-// flags: alignment 3, not copyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, not copyable, (on 32-bit platforms) not storable inline
+// CHECK-64-SAME:  , <i32 0x800003>
+// CHECK-32-SAME:  , <i32 0x820003>
 struct ConcreteVectorIntMovesAsLike: ~Copyable {
   let vector: VectorMovesAsLike<Int32, 4>
 }


### PR DESCRIPTION
The test was failing on 32-bit platforms after https://github.com/swiftlang/swift/pull/75518

Revealed by WebAssembly CI: https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1458/console

```
FAIL: Swift(wasi-wasm32) :: IRGen/raw_layout.swift (876 of 1311)
******************** TEST 'Swift(wasi-wasm32) :: IRGen/raw_layout.swift' FAILED ********************
Script:
--
: 'RUN: at line 1';   rm -rf "/home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp" && mkdir -p "/home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp"
: 'RUN: at line 2';   /usr/bin/python3.8 /home/build-user/swift/utils/chex.py < /home/build-user/swift/test/IRGen/raw_layout.swift > /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp/raw_layout.sil
: 'RUN: at line 3';   /home/build-user/swift-nightly-install/usr/bin/swift-frontend -target wasm32-unknown-wasi -sdk /home/build-user/build/buildbot_linux/wasi-sysroot/wasm32-wasi -resource-dir /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/./lib/swift_static -module-cache-path /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/swift-test-results/wasm32-unknown-wasi/clang-module-cache -swift-version 4  -define-availability 'SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999' -define-availability 'SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2' -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' -define-availability 'SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4' -define-availability 'SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0' -define-availability 'SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5' -define-availability 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0' -define-availability 'SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4' -define-availability 'SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0' -define-availability 'SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4' -define-availability 'SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0' -define-availability 'SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1' -define-availability 'SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -define-availability 'SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999' -typo-correction-limit 10  -enable-experimental-feature RawLayout -enable-experimental-feature ValueGenerics -emit-ir -disable-availability-checking -I /home/build-user/swift/test/IRGen/Inputs -cxx-interoperability-mode=upcoming-swift /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp/raw_layout.sil | /usr/bin/python3.8 /home/build-user/swift/utils/PathSanitizingFileCheck --allow-unused-prefixes --sanitize BUILD_DIR=/home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64 --sanitize SOURCE_DIR=/home/build-user/swift --use-filecheck /home/build-user/build/buildbot_linux/llvm-linux-x86_64/bin/FileCheck   /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-32
--
Exit Code: 1

Command Output (stderr):
--
/home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp/raw_layout.sil:326:16: error: CHECK-SAME: expected string not found in input
// CHECK-SAME: , i32 8388611
               ^
<stdin>:363:427: note: scanning from here
@"$s10raw_layout28ConcreteVectorIntMovesAsLikeVWV" = internal constant %swift.vwtable { ptr @__swift_cannot_copy_noncopyable_type, ptr @__swift_noop_void_return, ptr @__swift_cannot_copy_noncopyable_type, ptr @__swift_cannot_copy_noncopyable_type, ptr @__swift_memcpy16_4, ptr @__swift_memcpy16_4, ptr @"$s10raw_layout28ConcreteVectorIntMovesAsLikeVwet", ptr @"$s10raw_layout28ConcreteVectorIntMovesAsLikeVwst", i32 16, i32 16, i32 8519683, i32 0 }, align 4
                                                                                                                                                                                                                                                                                                                                                                                                                                          ^

Input file: <stdin>
Check file: /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/test-wasi-wasm32/IRGen/Output/raw_layout.swift.tmp/raw_layout.sil

-dump-input=help explains the following input dump.
```