### PR TITLE
[Windows][Concurrency] Use the same clock as Dispatch.

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -15,7 +15,10 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS -I${CMAKE_CURRENT_SOURCE_DIR}/Internal
 
 set(swift_concurrency_private_link_libraries)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  list(APPEND swift_concurrency_private_link_libraries Synchronization)
+  list(APPEND swift_concurrency_private_link_libraries
+    Synchronization
+    mincore.lib # For QueryInterruptTime()
+  )
 endif()
 
 set(swift_concurrency_incorporate_object_libraries_so swiftThreading)

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -147,10 +147,8 @@ switch (clock_id) {
 #elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__))
       clock_getres(CLOCK_MONOTONIC, &continuous);
 #elif defined(_WIN32)
-      LARGE_INTEGER freq;
-      QueryPerformanceFrequency(&freq);
       continuous.tv_sec = 0;
-      continuous.tv_nsec = 1'000'000'000 / freq.QuadPart;
+      continuous.tv_nsec = 100;
 #else
 #error Missing platform continuous time definition
 #endif


### PR DESCRIPTION
The Concurrency runtime calculates deadlines for scheduling itself using `swift_get_time()`; unfortunately, on Windows that was using `QueryPerformanceCounter()`, while Dispatch uses
`QueryInterruptTimePrecise()`.  The problem with that is that the two do not necessarily correspond *at all*.  In general
`QueryPerformanceCounter()` may be using any of a number of hardware timers depending on the machine on which we're running.

In the VM I was testing on, the two differed by 20ms, but the worst case is that they are completely unrelated, in which case `Task.sleep()` will wait essentially a random amount of time.

Fixes #72095.

rdar://135413803
