### PR TITLE
[cxx-interop] Teach importer to interpret lifetimebound annotations

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -235,11 +235,6 @@ public:
   static std::optional<ArrayRef<LifetimeDependenceInfo>>
   get(AbstractFunctionDecl *decl);
 
-  /// Builds LifetimeDependenceInfo from the bitvectors passes as parameters.
-  static LifetimeDependenceInfo
-  get(ASTContext &ctx, const SmallBitVector &inheritLifetimeIndices,
-      const SmallBitVector &scopeLifetimeIndices);
-
   /// Builds LifetimeDependenceInfo from SIL
   static std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
   get(FunctionTypeRepr *funcRepr, ArrayRef<SILParameterInfo> params,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -15,8 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "CFTypeInfo.h"
-#include "ImporterImpl.h"
 #include "ClangDerivedConformances.h"
+#include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
@@ -53,6 +53,7 @@
 #include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjCCommon.h"
 #include "clang/Basic/Specifiers.h"
@@ -3474,6 +3475,21 @@ namespace {
       return true;
     }
 
+    static bool
+    implicitObjectParamIsLifetimeBound(const clang::FunctionDecl *FD) {
+      const clang::TypeSourceInfo *TSI = FD->getTypeSourceInfo();
+      if (!TSI)
+        return false;
+      clang::AttributedTypeLoc ATL;
+      for (clang::TypeLoc TL = TSI->getTypeLoc();
+           (ATL = TL.getAsAdjusted<clang::AttributedTypeLoc>());
+           TL = ATL.getModifiedLoc()) {
+        if (ATL.getAttrAs<clang::LifetimeBoundAttr>())
+          return true;
+      }
+      return false;
+    }
+
     Decl *importFunctionDecl(
         const clang::FunctionDecl *decl, ImportedName importedName,
         std::optional<ImportedName> correctSwiftName,
@@ -3780,8 +3796,12 @@ namespace {
         if (!dc->isModuleScopeContext()) {
           if (selfIsInOut)
             func->setSelfAccessKind(SelfAccessKind::Mutating);
-          else
-            func->setSelfAccessKind(SelfAccessKind::NonMutating);
+          else {
+            if (implicitObjectParamIsLifetimeBound(decl))
+              func->setSelfAccessKind(SelfAccessKind::Borrowing);
+            else
+              func->setSelfAccessKind(SelfAccessKind::NonMutating);
+          }
           if (selfIdx) {
             func->setSelfIndex(selfIdx.value());
           } else {
@@ -3820,12 +3840,69 @@ namespace {
       return result;
     }
 
+    void addLifetimeDependencies(const clang::FunctionDecl *decl,
+                                 AbstractFunctionDecl *result) {
+      if (decl->getTemplatedKind() == clang::FunctionDecl::TK_FunctionTemplate)
+        return;
+
+      auto swiftParams = result->getParameters();
+      bool hasSelf = result->hasImplicitSelfDecl();
+      SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
+      SmallBitVector inheritLifetimeParamIndicesForReturn(swiftParams->size() +
+                                                          hasSelf);
+      SmallBitVector scopedLifetimeParamIndicesForReturn(swiftParams->size() +
+                                                         hasSelf);
+      for (auto [idx, param] : llvm::enumerate(decl->parameters())) {
+        if (param->hasAttr<clang::LifetimeBoundAttr>()) {
+          if (swiftParams->get(idx)->getInterfaceType()->isEscapable())
+            scopedLifetimeParamIndicesForReturn[idx] = true;
+          else
+            inheritLifetimeParamIndicesForReturn[idx] = true;
+        }
+      }
+      if (implicitObjectParamIsLifetimeBound(decl)) {
+        auto idx = result->getSelfIndex();
+        if (result->getImplicitSelfDecl()->getInterfaceType()->isEscapable())
+          scopedLifetimeParamIndicesForReturn[idx] = true;
+        else
+          inheritLifetimeParamIndicesForReturn[idx] = true;
+      }
+
+      if (inheritLifetimeParamIndicesForReturn.any() ||
+          scopedLifetimeParamIndicesForReturn.any())
+        lifetimeDependencies.push_back(LifetimeDependenceInfo(
+            inheritLifetimeParamIndicesForReturn.any()
+                ? IndexSubset::get(Impl.SwiftContext,
+                                   inheritLifetimeParamIndicesForReturn)
+                : nullptr,
+            scopedLifetimeParamIndicesForReturn.any()
+                ? IndexSubset::get(Impl.SwiftContext,
+                                   scopedLifetimeParamIndicesForReturn)
+                : nullptr,
+            swiftParams->size(),
+            /*isImmortal*/ false));
+      else if (auto *ctordecl = dyn_cast<clang::CXXConstructorDecl>(decl)) {
+        // Assume default constructed view types have no dependencies.
+        if (ctordecl->isDefaultConstructor() &&
+            importer::hasNonEscapableAttr(ctordecl->getParent()))
+          lifetimeDependencies.push_back(
+              LifetimeDependenceInfo(nullptr, nullptr, 0, /*isImmortal*/ true));
+      }
+      if (!lifetimeDependencies.empty()) {
+        Impl.SwiftContext.evaluator.cacheOutput(
+            LifetimeDependenceInfoRequest{result},
+            Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
+      }
+    }
+
     void finishFuncDecl(const clang::FunctionDecl *decl,
                         AbstractFunctionDecl *result) {
       // Set availability.
       if (decl->isVariadic()) {
         Impl.markUnavailable(result, "Variadic function is unavailable");
       }
+
+      addLifetimeDependencies(decl, result);
 
       if (decl->hasAttr<clang::ReturnsTwiceAttr>()) {
         // The Clang 'returns_twice' attribute is used for functions like

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "CFTypeInfo.h"
-#include "ClangDiagnosticConsumer.h"
 #include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
 #include "swift/ABI/MetadataValues.h"
@@ -51,7 +50,6 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 
 using namespace swift;
@@ -2649,7 +2647,9 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   // Foreign references are already references so they don't need to be passed
   // as inout.
   paramInfo->setSpecifier(isInOut ? ParamSpecifier::InOut
-                                  : ParamSpecifier::Default);
+                                  : (param->getAttr<clang::LifetimeBoundAttr>()
+                                         ? ParamSpecifier::Borrowing
+                                         : ParamSpecifier::Default));
   paramInfo->setInterfaceType(swiftParamTy);
   impl->recordImplicitUnwrapForDecl(paramInfo, isParamTypeImplicitlyUnwrapped);
 

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -11,8 +11,12 @@ module Test {
 //--- Inputs/nonescapable.h
 #include "swift/bridging"
 
-struct SWIFT_NONESCAPABLE A {
-    int a;
+struct SWIFT_NONESCAPABLE View {
+    View() : member(nullptr) {}
+    View(const int *p [[clang::lifetimebound]]) : member(p) {}
+    View(const View&) = default;
+private:
+    const int *member;
 };
 
 //--- test.swift
@@ -20,6 +24,6 @@ struct SWIFT_NONESCAPABLE A {
 import Test
 
 // CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
-public func test() -> A {
-    A()
+public func noAnnotations() -> View {
+    View()
 }

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -1,0 +1,88 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs  %t/test.swift -enable-experimental-feature NonescapableTypes -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature NonescapableTypes -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "nonescapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/nonescapable.h
+#include "swift/bridging"
+
+struct SWIFT_NONESCAPABLE View {
+    View() : member(nullptr) {}
+    View(const int *p [[clang::lifetimebound]]) : member(p) {}
+    View(const View&) = default;
+private:
+    const int *member;
+};
+
+struct Owner {
+    int data;
+
+    View handOutView() const [[clang::lifetimebound]] {
+        return View(&data);
+    }
+};
+
+Owner makeOwner() {
+    return Owner{42};
+}
+
+View getView(const Owner& owner [[clang::lifetimebound]]) {
+    return View(&owner.data);
+}
+
+View getViewFromFirst(const Owner& owner [[clang::lifetimebound]], const Owner& owner2) {
+    return View(&owner.data);
+}
+
+bool coinFlip;
+
+View getViewFromEither(const Owner& owner [[clang::lifetimebound]], const Owner& owner2 [[clang::lifetimebound]]) {
+    if (coinFlip)
+        return View(&owner.data);
+    else
+        return View(&owner2.data);
+}
+
+View getViewFromEither(View view1 [[clang::lifetimebound]], View view2 [[clang::lifetimebound]]) {
+    if (coinFlip)
+        return view1;
+    else
+        return view2;
+}
+
+struct SWIFT_NONESCAPABLE TestAnnotationTranslation {
+    TestAnnotationTranslation() : member(nullptr) {}
+    TestAnnotationTranslation(const int *p [[clang::lifetimebound]]) : member(p) {}
+    TestAnnotationTranslation(const TestAnnotationTranslation& [[clang::lifetimebound]]) = default;
+private:
+    const int *member;
+};
+
+// CHECK: sil [clang makeOwner] {{.*}}: $@convention(c) () -> Owner
+// CHECK: sil [clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> _scope(0) @autoreleased View
+// CHECK: sil [clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> _scope(0) @autoreleased View
+// CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> _scope(0, 1) @autoreleased View
+// CHECK: sil [clang Owner.handOutView] {{.*}} : $@convention(cxx_method) (@in_guaranteed Owner) -> _scope(0) @autoreleased View
+// CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@guaranteed View, @guaranteed View) -> _inherit(0, 1) @autoreleased View
+// CHECK: sil [clang View.init] {{.*}} : $@convention(c) () -> @out View
+
+//--- test.swift
+
+import Test
+
+public func test() {
+    let o = makeOwner()
+    let o2 = makeOwner()
+    let v1 = getView(o)
+    let v2 = getViewFromFirst(o, o2)
+    let _ = getViewFromEither(o, o2)
+    let _ = o.handOutView()
+    let _ = getViewFromEither(v1, v2)
+    let defaultView = View()
+}


### PR DESCRIPTION
The lifetimebound annotations are now imported as lifetime dependencies. This works for basic cases but there are still some parts missing:
* Support lifeitmebound annotations on constructors
* A way to represent immortal/static lifetimes on the C++ side

rdar://135875896
