### PR TITLE
[test] Add `-disable-experimental-parser-round-trip` to value generic tests

### DIFF
--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking -Xfrontend -disable-experimental-parser-round-trip) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name ValueGeneric -enable-experimental-feature ValueGenerics -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name ValueGeneric -enable-experimental-feature ValueGenerics -disable-availability-checking -disable-experimental-parser-round-trip
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking
 // RUN: %FileCheck %s < %t.swiftinterface
 

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ValueGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ValueGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking -disable-experimental-parser-round-trip
 
 protocol P {}
 

--- a/test/Serialization/value_generics.swift
+++ b/test/Serialization/value_generics.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature ValueGenerics -enable-experimental-feature RawLayout -disable-availability-checking -parse-as-library -o %t
+// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature ValueGenerics -enable-experimental-feature RawLayout -disable-availability-checking -disable-experimental-parser-round-trip -parse-as-library -o %t
 // RUN: %target-sil-opt -enable-sil-verify-all %t/value_generics.swiftmodule -o - | %FileCheck %s
 
 // CHECK: @_rawLayout(likeArrayOf: Element, count: Count) struct Vector<Element, let Count : Int> : ~Copyable where Element : ~Copyable {


### PR DESCRIPTION
Parsing of integer literals as generic arguments isn’t implemented in SwiftParser yet, blocking swift-syntax PR testing.

CC @Azoy