### PR TITLE
[cxx-interop] Add a `MutableCollection` test that relies on `std::string` being `Comparable`

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -97,6 +97,11 @@ StdVectorTestSuite.test("VectorOfString as MutableCollection") {
     expectEqual(v[0], std.string("xyz"))
     expectEqual(v[1], std.string("abc"))
     expectEqual(v[2], std.string("ijk"))
+
+    v.sort() // Swift function
+    expectEqual(v[0], std.string("abc"))
+    expectEqual(v[1], std.string("ijk"))
+    expectEqual(v[2], std.string("xyz"))
 }
 #endif
 


### PR DESCRIPTION
This is possible after https://github.com/swiftlang/swift/pull/76223.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
