### PR TITLE
[Tests] Re-enable async_sequence.swift for non-macosx platforms.

### DIFF
--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -3,7 +3,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
-// rdar://76038845
 // REQUIRES: concurrency_runtime
 
 import StdlibUnittest

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -6,9 +6,6 @@
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 
-// TODO: This crashes on linux for some strange reason
-// REQUIRES: OS=macosx
-
 import StdlibUnittest
 
 // Utility functions for closure based operators to force them into throwing


### PR DESCRIPTION
This was marked as crashing on Linux but no longer appears to happen. 
Retested on aarch64-unknown-linux-gnu and x86_64-unknown-linux-gnu.

