### PR TITLE
[docs] Fix links to dockerfiles

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -162,11 +162,11 @@ toolchain as a one-off, there are a couple of differences:
 ### Linux
 
 1. The latest Linux dependencies are listed in the respective Dockerfiles:
-   * [Ubuntu 18.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/ubuntu/18.04/Dockerfile)
-   * [Ubuntu 20.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile)
-   * [Ubuntu 22.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile)
-   * [CentOS 7](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/centos/7/Dockerfile)
-   * [Amazon Linux 2](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/amazon-linux/2/Dockerfile)
+   * [Ubuntu 18.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/ubuntu/18.04/Dockerfile)
+   * [Ubuntu 20.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/ubuntu/20.04/Dockerfile)
+   * [Ubuntu 22.04](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/ubuntu/22.04/Dockerfile)
+   * [CentOS 7](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/centos/7/Dockerfile)
+   * [Amazon Linux 2](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/amazon-linux/2/Dockerfile)
 
    Note that [a prebuilt Swift release toolchain](https://www.swift.org/download/)
    is installed and added to the `PATH` in all these Docker containers: it is


### PR DESCRIPTION
The `master/` directory in these paths have been renamed to `main/` in https://github.com/swiftlang/swift-docker/commit/f9be7230b6bb84f00abb680d494b1bffa39c5a72.