### PR TITLE
[Concurrency] Handle implicitly async operator expressions in the actor isolation checker.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2887,22 +2887,27 @@ namespace {
       assert(applyStack.size() > 0 && "not contained within an Apply?");
 
       const auto End = applyStack.rend();
-      for (auto I = applyStack.rbegin(); I != End; ++I)
-        if (auto call = dyn_cast<CallExpr>(I->dyn_cast<ApplyExpr *>())) {
-          if (setAsync) {
-            call->setImplicitlyAsync(*setAsync);
-          }
-          if (setThrows) {
-            call->setImplicitlyThrows(true);
-          }else {
-            call->setImplicitlyThrows(false);
-          }
-          if (setDistributedThunk) {
-            call->setShouldApplyDistributedThunk(true);
-          }
-          return;
+      for (auto I = applyStack.rbegin(); I != End; ++I) {
+        auto *apply = I->dyn_cast<ApplyExpr *>();
+        if (!apply || isa<SelfApplyExpr>(apply)) {
+          continue;
         }
-      llvm_unreachable("expected a CallExpr in applyStack!");
+
+        if (setAsync) {
+          apply->setImplicitlyAsync(*setAsync);
+        }
+        if (setThrows) {
+          apply->setImplicitlyThrows(true);
+        } else {
+          apply->setImplicitlyThrows(false);
+        }
+        if (setDistributedThunk) {
+          apply->setShouldApplyDistributedThunk(true);
+        }
+        return;
+      }
+
+      llvm_unreachable("expected an ApplyExpr in applyStack!");
     }
 
     MacroWalking getMacroWalkingBehavior() const override {

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -576,3 +576,23 @@ func tryTheActorSubscripts(a : SubscriptA, t : SubscriptT, at : SubscriptAT) asy
 
   _ = try await at[0]
 }
+
+@MainActor
+final class IsolatedOperator: @preconcurrency Equatable {
+  static func == (lhs: IsolatedOperator, rhs: IsolatedOperator) -> Bool {
+    lhs.num == rhs.num
+  }
+
+  var num = 0
+
+  init(num: Int = 0) {
+    self.num = num
+  }
+
+  nonisolated func callEqual() async -> Bool {
+    let foo = await IsolatedOperator()
+    // expected-error@+2{{expression is 'async' but is not marked with 'await'}}
+    // expected-note@+1{{calls to operator function '==' from outside of its actor context are implicitly asynchronous}}
+    return foo == self
+  }
+}


### PR DESCRIPTION
Previously, the actor isolation checker would crash when attempting to mark an operator call as implicitly async, because it was specifically expecting to see a `CallExpr`. Instead, accept all `ApplyExpr`s except for `SelfApplyExpr`.

Resolves https://github.com/swiftlang/swift/issues/75696
