### PR TITLE
Suppress certain warnings in inactive `#if` regions without relying on `IfConfigDecl`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
@@ -25,10 +25,7 @@ extension ASTGenVisitor {
   /// produced due to the evaluation.
   func activeClause(in node: IfConfigDeclSyntax) -> IfConfigClauseSyntax? {
     // Determine the active clause.
-    let (activeClause, diagnostics) = node.activeClause(in: buildConfiguration)
-    diagnoseAll(diagnostics)
-
-    return activeClause
+    return configuredRegions.activeClause(for: node)
   }
 
   /// Visit a collection of elements that may contain #if clauses within it

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -13,6 +13,7 @@
 import ASTBridging
 import BasicBridging
 import ParseBridging
+import SwiftIfConfig
 // Needed to use BumpPtrAllocator
 @_spi(BumpPtrAllocator) @_spi(RawSyntax) import SwiftSyntax
 
@@ -76,7 +77,7 @@ struct ASTGenVisitor {
 
   let ctx: BridgedASTContext
 
-  let buildConfiguration: CompilerBuildConfiguration
+  let configuredRegions: ConfiguredRegions
 
   fileprivate let allocator: SwiftSyntax.BumpPtrAllocator = .init(initialSlabSize: 256)
 
@@ -89,17 +90,15 @@ struct ASTGenVisitor {
     sourceBuffer: UnsafeBufferPointer<UInt8>,
     declContext: BridgedDeclContext,
     astContext: BridgedASTContext,
+    configuredRegions: ConfiguredRegions,
     legacyParser: BridgedLegacyParser
   ) {
     self.diagnosticEngine = diagnosticEngine
     self.base = sourceBuffer
     self.declContext = declContext
     self.ctx = astContext
+    self.configuredRegions = configuredRegions
     self.legacyParse = legacyParser
-    self.buildConfiguration = CompilerBuildConfiguration(
-      ctx: ctx,
-      sourceBuffer: sourceBuffer
-    )
   }
 
   func generate(sourceFile node: SourceFileSyntax) -> [BridgedDecl] {
@@ -423,7 +422,7 @@ extension TokenSyntax {
 @_cdecl("swift_ASTGen_buildTopLevelASTNodes")
 public func buildTopLevelASTNodes(
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   dc: BridgedDeclContext,
   ctx: BridgedASTContext,
   legacyParser: BridgedLegacyParser,
@@ -431,15 +430,20 @@ public func buildTopLevelASTNodes(
   callback: @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void
 ) {
   let sourceFile = sourceFilePtr.assumingMemoryBound(to: ExportedSourceFile.self)
-  ASTGenVisitor(
+  let visitor = ASTGenVisitor(
     diagnosticEngine: diagEngine,
     sourceBuffer: sourceFile.pointee.buffer,
     declContext: dc,
     astContext: ctx,
+    configuredRegions: sourceFile.pointee.configuredRegions(astContext: ctx),
     legacyParser: legacyParser
   )
-  .generate(sourceFile: sourceFile.pointee.syntax)
-  .forEach { callback($0.raw, outputContext) }
+
+  visitor.generate(sourceFile: sourceFile.pointee.syntax)
+    .forEach { callback($0.raw, outputContext) }
+
+  // Diagnose any errors from evaluating #ifs.
+  visitor.diagnoseAll(visitor.configuredRegions.diagnostics)
 }
 
 /// Generate an AST node at the given source location. Returns the generated
@@ -447,7 +451,7 @@ public func buildTopLevelASTNodes(
 private func _build<Node: SyntaxProtocol, Result>(
   generator: (ASTGenVisitor) -> (Node) -> Result,
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLoc: BridgedSourceLoc,
   declContext: BridgedDeclContext,
   astContext: BridgedASTContext,
@@ -480,6 +484,7 @@ private func _build<Node: SyntaxProtocol, Result>(
       sourceBuffer: sourceFile.pointee.buffer,
       declContext: declContext,
       astContext: astContext,
+      configuredRegions: sourceFile.pointee.configuredRegions(astContext: astContext),
       legacyParser: legacyParser
     )
   )(node)
@@ -489,7 +494,7 @@ private func _build<Node: SyntaxProtocol, Result>(
 @usableFromInline
 func buildTypeRepr(
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLoc: BridgedSourceLoc,
   declContext: BridgedDeclContext,
   astContext: BridgedASTContext,
@@ -512,7 +517,7 @@ func buildTypeRepr(
 @usableFromInline
 func buildDecl(
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLoc: BridgedSourceLoc,
   declContext: BridgedDeclContext,
   astContext: BridgedASTContext,
@@ -535,7 +540,7 @@ func buildDecl(
 @usableFromInline
 func buildExpr(
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLoc: BridgedSourceLoc,
   declContext: BridgedDeclContext,
   astContext: BridgedASTContext,
@@ -558,7 +563,7 @@ func buildExpr(
 @usableFromInline
 func buildStmt(
   diagEngine: BridgedDiagnosticEngine,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLoc: BridgedSourceLoc,
   declContext: BridgedDeclContext,
   astContext: BridgedASTContext,

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -38,6 +38,11 @@ public struct ExportedSourceFile {
   /// Cached so we don't need to re-build the line table every time we need to convert a position.
   let sourceLocationConverter: SourceLocationConverter
 
+  /// Configured regions for this source file.
+  ///
+  /// This is a cached value; access via configuredRegions(astContext:).
+  var _configuredRegions: ConfiguredRegions? = nil
+
   public func position(of location: BridgedSourceLoc) -> AbsolutePosition? {
     let sourceFileBaseAddress = UnsafeRawPointer(buffer.baseAddress!)
     guard let opaqueValue = location.getOpaquePointerValue() else {
@@ -162,12 +167,7 @@ public func emitParserDiagnostics(
     let diags = ParseDiagnosticsGenerator.diagnostics(for: sourceFileSyntax)
 
     let diagnosticEngine = BridgedDiagnosticEngine(raw: diagEnginePtr)
-    let buildConfiguration = CompilerBuildConfiguration(
-      ctx: ctx,
-      sourceBuffer: sourceFile.pointee.buffer
-    )
-
-    let configuredRegions = sourceFileSyntax.configuredRegions(in: buildConfiguration)
+    let configuredRegions = sourceFile.pointee.configuredRegions(astContext: ctx)
     for diag in diags {
       // If the diagnostic is in an unparsed #if region, don't emit it.
       if configuredRegions.isActive(diag.node) == .unparsed {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -19,6 +19,7 @@
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckInvertible.h"
 #include "TypeChecker.h"
+#include "swift/AST/ASTBridging.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -3160,6 +3161,9 @@ class VarDeclUsageChecker : public ASTWalker {
   DeclContext *DC;
 
   DiagnosticEngine &Diags;
+
+  SourceRange FullRange;
+
   // Keep track of some information about a variable.
   enum {
     RK_Defined     = 1,      ///< Whether it was ever defined in this scope.
@@ -3195,8 +3199,9 @@ class VarDeclUsageChecker : public ASTWalker {
   void operator=(const VarDeclUsageChecker &) = delete;
 
 public:
-  VarDeclUsageChecker(DeclContext *DC,
-                      DiagnosticEngine &Diags) : DC(DC), Diags(Diags) {}
+  VarDeclUsageChecker(DeclContext *DC, DiagnosticEngine &Diags,
+                      SourceRange range)
+      : DC(DC), Diags(Diags), FullRange(range) {}
 
   // After we have scanned the entire region, diagnose variables that could be
   // declared with a narrower usage kind.
@@ -3266,11 +3271,6 @@ public:
     if (isa<TypeDecl>(D))
       return Action::SkipNode();
 
-    // The body of #if clauses are not walked into, we need custom processing
-    // for them.
-    if (auto *ICD = dyn_cast<IfConfigDecl>(D))
-      handleIfConfig(ICD);
-      
     // If this is a VarDecl, then add it to our list of things to track.
     if (auto *vd = dyn_cast<VarDecl>(D)) {
       if (shouldTrackVarDecl(vd)) {
@@ -3353,9 +3353,6 @@ public:
 
   /// The heavy lifting happens when visiting expressions.
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
-
-  /// handle #if directives.
-  void handleIfConfig(IfConfigDecl *ICD);
 
   /// Custom handling for statements.
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
@@ -3864,6 +3861,16 @@ SourceLoc swift::getFixItLocForVarToLet(VarDecl *var) {
   return SourceLoc();
 }
 
+extern "C" bool swift_ASTGen_inactiveCodeContainsReference(
+    BridgedASTContext ctx,
+    BridgedStringRef sourceFileBuffer,
+    BridgedStringRef searchRange,
+    BridgedStringRef name,
+    void **cache
+);
+
+extern "C" void swift_ASTGen_freeInactiveCodeContainsReferenceCache(void *cache);
+
 // After we have scanned the entire region, diagnose variables that could be
 // declared with a narrower usage kind.
 VarDeclUsageChecker::~VarDeclUsageChecker() {
@@ -3872,6 +3879,35 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
   // lets let the bigger issues get resolved first.
   if (sawError)
     return;
+
+  /// Check whether the given variable might have been referenced from an
+  /// inactive region of the source code.
+  void *usedInInactiveCache = nullptr;
+  auto isUsedInInactive = [&](VarDecl *var) -> bool {
+#if SWIFT_BUILD_SWIFT_SYNTAX
+    // Extract the full buffer containing the source range.
+    ASTContext &ctx = DC->getASTContext();
+    SourceManager &sourceMgr = ctx.SourceMgr;
+    auto bufferID = sourceMgr.findBufferContainingLoc(FullRange.Start);
+    StringRef sourceFileText = sourceMgr.getEntireTextForBuffer(bufferID);
+
+    // Extract the search text from that buffer.
+    auto searchTextCharRange = Lexer::getCharSourceRangeFromSourceRange(
+        sourceMgr, FullRange);
+    StringRef searchText = sourceMgr.extractText(searchTextCharRange, bufferID);
+
+    return swift_ASTGen_inactiveCodeContainsReference(
+        ctx, sourceFileText, searchText, var->getName().str(),
+        &usedInInactiveCache);
+#else
+    return false;
+#endif
+  };
+  SWIFT_DEFER {
+#if SWIFT_BUILD_SWIFT_SYNTAX
+    swift_ASTGen_freeInactiveCodeContainsReferenceCache(usedInInactiveCache);
+#endif
+  };
 
   for (auto p : VarDecls) {
     VarDecl *var;
@@ -3907,7 +3943,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         auto VD = dyn_cast<VarDecl>(FD->getStorage());
         if ((access & RK_Read) == 0) {
           auto found = AssociatedGetterRefExpr.find(VD);
-          if (found != AssociatedGetterRefExpr.end()) {
+          if (found != AssociatedGetterRefExpr.end() && !isUsedInInactive(VD)) {
             auto *DRE = found->second;
             Diags.diagnose(DRE->getLoc(), diag::unused_setter_parameter,
                            var->getName());
@@ -3941,6 +3977,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       // produce a fixit hint with a parent map, but this is a lot of effort for
       // a narrow case.
       if (access & RK_CaptureList) {
+        if (isUsedInInactive(var))
+          continue;
+
         Diags.diagnose(var->getLoc(), diag::capture_never_used,
                        var->getName());
         continue;
@@ -3954,6 +3993,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       if (auto *pbd = var->getParentPatternBinding()) {
         if (pbd->getSingleVar() == var && pbd->getInit(0) != nullptr &&
             !isa<TypedPattern>(pbd->getPattern(0))) {
+          if (isUsedInInactive(var))
+            continue;
+
           unsigned varKind = var->isLet();
           SourceRange replaceRange(
               pbd->getStartLoc(),
@@ -3984,6 +4026,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
               if (isa<NamedPattern>(LP->getSubPattern())) {
                 auto initExpr = SC->getCond()[0].getInitializer();
                 if (initExpr->getStartLoc().isValid()) {
+                  if (isUsedInInactive(var))
+                    continue;
+
                   unsigned noParens = initExpr->canAppendPostfixExpression();
 
                   // If the subexpr is an "as?" cast, we can rewrite it to
@@ -4051,6 +4096,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         });
 
         if (foundVP) {
+          if (isUsedInInactive(var))
+            continue;
+
           unsigned varKind = var->isLet();
           Diags
               .diagnose(var->getLoc(), diag::variable_never_used,
@@ -4062,6 +4110,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       
       // Otherwise, this is something more complex, perhaps
       //    let (a,b) = foo()
+      if (isUsedInInactive(var))
+        continue;
+
       if (isWrittenLet) {
         Diags.diagnose(var->getLoc(),
                        diag::immutable_value_never_used_but_assigned,
@@ -4084,6 +4135,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         // never mutated, but 'x' was.
         !isVarDeclPartOfPBDThatHadSomeMutation(var)) {
       SourceLoc FixItLoc = getFixItLocForVarToLet(var);
+
+      if (isUsedInInactive(var))
+        continue;
 
       // If this is a parameter explicitly marked 'var', remove it.
       if (FixItLoc.isInvalid()) {
@@ -4113,6 +4167,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
     
     // If this is a variable that was only written to, emit a warning.
     if ((access & RK_Read) == 0) {
+      if (isUsedInInactive(var))
+        continue;
+
       Diags.diagnose(var->getLoc(), diag::variable_never_read, var->getName());
       continue;
     }
@@ -4334,56 +4391,12 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   return Action::Continue(E);
 }
 
-/// handle #if directives.  All of the active clauses are already walked by the
-/// AST walker, but we also want to handle the inactive ones to avoid false
-/// positives.
-void VarDeclUsageChecker::handleIfConfig(IfConfigDecl *ICD) {
-  struct ConservativeDeclMarker : public ASTWalker {
-    VarDeclUsageChecker &VDUC;
-    SourceFile *SF;
-
-    ConservativeDeclMarker(VarDeclUsageChecker &VDUC)
-      : VDUC(VDUC), SF(VDUC.DC->getParentSourceFile()) {}
-
-    MacroWalking getMacroWalkingBehavior() const override {
-      return MacroWalking::Arguments;
-    }
-
-    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
-      // If we see a bound reference to a decl in an inactive #if block, then
-      // conservatively mark it read and written.  This will silence "variable
-      // unused" and "could be marked let" warnings for it.
-      if (auto *DRE = dyn_cast<DeclRefExpr>(E))
-        VDUC.addMark(DRE->getDecl(), RK_Read | RK_Written);
-      else if (auto *declRef = dyn_cast<UnresolvedDeclRefExpr>(E)) {
-        auto name = declRef->getName();
-        auto loc = declRef->getLoc();
-        if (name.isSimpleName() && loc.isValid()) {
-          auto *varDecl = dyn_cast_or_null<VarDecl>(
-            ASTScope::lookupSingleLocalDecl(SF, name.getFullName(), loc));
-          if (varDecl)
-            VDUC.addMark(varDecl, RK_Read|RK_Written);
-        }
-      }
-      return Action::Continue(E);
-    }
-  };
-
-  for (auto &clause : ICD->getClauses()) {
-    // Active clauses are handled by the normal AST walk.
-    if (clause.isActive) continue;
-
-    for (auto elt : clause.Elements)
-      elt.walk(ConservativeDeclMarker(*this));
-  }
-}
-
 /// Apply the warnings managed by VarDeclUsageChecker to the top level
 /// code declarations that haven't been checked yet.
 void swift::
 performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD) {
   auto &ctx = TLCD->getDeclContext()->getASTContext();
-  VarDeclUsageChecker checker(TLCD, ctx.Diags);
+  VarDeclUsageChecker checker(TLCD, ctx.Diags, TLCD->getSourceRange());
   TLCD->walk(checker);
 }
 
@@ -4398,7 +4411,7 @@ void swift::performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD) {
     // declared as constants. Skip local functions though, since they will
     // be checked as part of their parent function or TopLevelCodeDecl.
     auto &ctx = AFD->getDeclContext()->getASTContext();
-    VarDeclUsageChecker checker(AFD, ctx.Diags);
+    VarDeclUsageChecker checker(AFD, ctx.Diags, AFD->getBody()->getSourceRange());
     AFD->walk(checker);
   }
 

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -50,6 +50,13 @@ func one() {
   }
 
   do {
+#if compiler(>=10)
+    throw opaque_error()
+#endif
+  } catch {    // don't warn, #if code should be scanned.
+  }
+
+  do {
 #if false
     throw opaque_error()
 #endif

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -237,8 +237,13 @@ func testForceValueExpr() {
 func testBuildConfigs() {
   let abc = 42    // no warning.
   var mut = 18    // no warning.
+  let other = 15  // no warning?
+  var othermut = 15  // no warning
 #if false
   mut = abc    // These uses prevent abc/mut from being unused/unmutated.
+#endif
+#if compiler(>=10.0)
+  othermut = other    // This use prevents other/othermut from being unused/unmutated
 #endif
 }
 

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -247,6 +247,14 @@ func testBuildConfigs() {
 #endif
 }
 
+func postfixSuppression() -> Int {
+  let x = 10 // used to have warning: ... 'x' was never used...
+  return 5
+     #if FLAG
+     .modifier(x)
+     #endif
+}
+
 // same as above, but with a guard statement
 func testGuardWithPoundIf(x: Int?) {
   guard let x = x else { return }


### PR DESCRIPTION
For a few categories of warnings, we currently look through inactive code (represented by `IfConfigDecl`) to try to determine whether there are other configurations of code that might not have the warning. If we find evidence of that, we suppress the warning. This includes, e.g.,
* Warnings about variables that are set but never used
* Warnings about mutable variables that are never mutated
* Warnings about do..catch blocks with no "try" or "throw" inside them

For example, we don't warn about the lack of try/throw in this code:

```swift
do {
  #if DEBUG
  try foo()
  #endif
} catch {
  // ...
}
```

even if `DEBUG` is not set.

Reimplement this suppression mechanism in terms of the pure syntax tree with `SwiftIfConfig` deciding which regions are inactive. This eliminates a dependency on having the inactive clauses represented in an `IfConfigDecl` as well as expanding the suppression to "unparsed" code:

```swift
do {
  #if compiler(>=7.0)
  try foo()
  #endif
} catch {
  // ...
}
```
