### PR TITLE
Fix typo in Options.td

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -875,7 +875,7 @@ def strict_concurrency : Joined<["-"], "strict-concurrency=">,
   HelpText<"Specify the how strict concurrency checking will be. The value may "
            "be 'minimal' (most 'Sendable' checking is disabled), "
            "'targeted' ('Sendable' checking is enabled in code that uses the "
-           "concurrency model, or 'complete' ('Sendable' and other checking is "
+           "concurrency model), or 'complete' ('Sendable' and other checking is "
            "enabled for all code in the module)">;
 
 def enable_experimental_feature :


### PR DESCRIPTION
This PR adds a missing closing parenthesis to the help text of the `-strict-concurrency` option.