### PR TITLE
[ASTPrinter] Fix missing operators in synthesized `==` impls printed by `-print-ast`.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4792,6 +4792,10 @@ void PrintAST::visitBinaryExpr(BinaryExpr *expr) {
     Printer << operatorRef->getDecl()->getBaseName();
   } else if (auto *operatorRef = dyn_cast<DeclRefExpr>(expr->getFn())) {
     Printer << operatorRef->getDecl()->getBaseName();
+  } else if (auto *operatorRef =
+                 dyn_cast<UnresolvedDeclRefExpr>(expr->getFn())) {
+    // Synthesized `==` uses this.
+    Printer << operatorRef->getName();
   }
   Printer << " ";
   visit(expr->getRHS());

--- a/test/decl/enum/derived_hashable_equatable.swift
+++ b/test/decl/enum/derived_hashable_equatable.swift
@@ -68,12 +68,12 @@ enum HasAssociatedValues: Hashable {
   // CHECK:        @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasAssociatedValues, _ b: HasAssociatedValues) -> Bool {
   // CHECK-NEXT:     switch (a, b) {
   // CHECK-NEXT:     case (.a(let l0), .a(let r0)):
-  // CHECK-NEXT:       guard l0  r0 else {
+  // CHECK-NEXT:       guard l0 == r0 else {
   // CHECK-NEXT:         return false
   // CHECK-NEXT:       }
   // CHECK-NEXT:       return true
   // CHECK-NEXT:     case (.b(let l0), .b(let r0)):
-  // CHECK-NEXT:       guard l0  r0 else {
+  // CHECK-NEXT:       guard l0 == r0 else {
   // CHECK-NEXT:         return false
   // CHECK-NEXT:       }
   // CHECK-NEXT:       return true
@@ -158,7 +158,7 @@ enum HasAssociatedValuesAndUnavailableElement: Hashable {
   // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasAssociatedValuesAndUnavailableElement, _ b: HasAssociatedValuesAndUnavailableElement) -> Bool {
   // CHECK-NEXT:    switch (a, b) {
   // CHECK-NEXT:    case (.a(let l0), .a(let r0)):
-  // CHECK-NEXT:      guard l0  r0 else {
+  // CHECK-NEXT:      guard l0 == r0 else {
   // CHECK-NEXT:        return false
   // CHECK-NEXT:      }
   // CHECK-NEXT:      return true


### PR DESCRIPTION
`visitBinaryExpr` wasn't handling `UnresolvedDeclRefExpr` nodes, which the synthesized `==` implementation uses to compare fields/payloads. Also fixed the test that wasn't catching it since it also left out the operators.
