### PR TITLE
Disable printing of #ifs from the AST

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -439,9 +439,6 @@ struct PrintOptions {
   /// Print all decls that have at least this level of access.
   AccessLevel AccessFilter = AccessLevel::Private;
 
-  /// Print IfConfigDecls.
-  bool PrintIfConfig = true;
-
   /// Whether we are printing for sil.
   bool PrintForSIL = false;
 
@@ -661,7 +658,6 @@ struct PrintOptions {
     result.ExcludeAttrList.push_back(DeclAttrKind::Rethrows);
     result.PrintOverrideKeyword = false;
     result.AccessFilter = accessFilter;
-    result.PrintIfConfig = false;
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::TypesOnly;
     result.PrintDocumentationComments = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -213,7 +213,6 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   result.IsForSwiftInterface = true;
   result.PrintLongAttrsOnSeparateLines = true;
   result.TypeDefinitions = true;
-  result.PrintIfConfig = false;
   result.CurrentModule = ModuleToPrint;
   result.FullyQualifiedTypes = true;
   result.FullyQualifiedTypesIfAmbiguous = true;
@@ -2281,7 +2280,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
   }
 
   if (isa<IfConfigDecl>(D)) {
-    return Options.PrintIfConfig;
+    return false;
   }
 
   return true;
@@ -3360,21 +3359,7 @@ void PrintAST::visitTopLevelCodeDecl(TopLevelCodeDecl *decl) {
 }
 
 void PrintAST::visitIfConfigDecl(IfConfigDecl *ICD) {
-  if (!Options.PrintIfConfig)
-    return;
-
-  for (auto &Clause : ICD->getClauses()) {
-    if (&Clause == &*ICD->getClauses().begin())
-      Printer << tok::pound_if << " /* condition */"; // FIXME: print condition
-    else if (Clause.Cond)
-      Printer << tok::pound_elseif << " /* condition */"; // FIXME: print condition
-    else
-      Printer << tok::pound_else;
-    printASTNodes(Clause.Elements);
-    Printer.printNewline();
-    indent();
-  }
-  Printer << tok::pound_endif;
+  // Never printed
 }
 
 void PrintAST::visitPoundDiagnosticDecl(PoundDiagnosticDecl *PDD) {
@@ -5603,7 +5588,7 @@ bool Decl::shouldPrintInContext(const PrintOptions &PO) const {
   }
 
   if (isa<IfConfigDecl>(this)) {
-    return PO.PrintIfConfig;
+    return false;
   }
 
   // Print everything else.

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4591,7 +4591,6 @@ PrintOptions PrintOptions::printSIL(const SILPrintContext *ctx) {
   result.PrintForSIL = true;
   result.PrintInSILBody = true;
   result.PreferTypeRepr = false;
-  result.PrintIfConfig = false;
   result.OpaqueReturnTypePrinting =
      OpaqueReturnTypePrintingMode::StableReference;
   if (ctx && ctx->printFullConvention())

--- a/test/IDE/print_ast_non_typechecked.swift
+++ b/test/IDE/print_ast_non_typechecked.swift
@@ -13,13 +13,4 @@ func baz() {}
 func qux() {}
 #endif
 
-// CHECK1: {{^}}#if /* condition */
-// CHECK1: {{^}}  func bar() {
-// CHECK1: {{^}}  }
-// CHECK1: {{^}}#elseif /* condition */
-// CHECK1: {{^}}  func baz() {
-// CHECK1: {{^}}  }
-// CHECK1: {{^}}#else
-// CHECK1: {{^}}  func qux() {
-// CHECK1: {{^}}  }
-// CHECK1: {{^}}#endif
+// CHECK1-NOT: #if

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1431,10 +1431,7 @@ protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int {
 #elseif false
 #else
 #endif
-// PASS_PRINT_AST: #if
-// PASS_PRINT_AST: #elseif
-// PASS_PRINT_AST: #else
-// PASS_PRINT_AST: #endif
+// PASS_PRINT_AST-NOT: #if
 
 public struct MyPair<A, B> { var a: A, b: B }
 public typealias MyPairI<B> = MyPair<Int, B>


### PR DESCRIPTION
The option to print #ifs defaulted to "on", but was disabled in most of the actual compiler inputs that mattered, and the results weren't ever actually used. Remove the option so we never print #ifs.

