### PR TITLE
Change memory order in Task Status

### DIFF
--- a/stdlib/toolchain/Compatibility56/Concurrency/TaskStatus.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/TaskStatus.cpp
@@ -159,7 +159,7 @@ static bool withStatusRecordLock(AsyncTask *task,
       ActiveTaskStatus newStatus = status.withCancelled();
       if (task->_private().Status.compare_exchange_weak(status, newStatus,
             /*success*/ std::memory_order_relaxed,
-            /*failure*/ loadOrdering)) {
+            /*failure*/ std::memory_order_relaxed)) {
         status = newStatus;
         return false;
       }


### PR DESCRIPTION
compare_exchange_weak is actually undefined behavior if success has a stronger ordering than failure, so make failure relaxed since success is.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
