### PR TITLE
ConstraintSystem: Use scoring to implement MemberImportVisibility

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -680,6 +680,9 @@ public:
   /// Looks up a precedence group with a given \p name.
   PrecedenceGroupLookupResult lookupPrecedenceGroup(Identifier name) const;
 
+  /// Returns true if the parent module of \p decl is imported by this context.
+  bool isDeclImported(const Decl *decl) const;
+
   /// Return the ASTContext for a specified DeclContext by
   /// walking up to the enclosing module and returning its ASTContext.
   LLVM_READONLY

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -507,11 +507,6 @@ public:
     MissingImportForMemberDiagnostics[decl].push_back(loc);
   }
 
-  /// Returns true if there is a pending missing import diagnostic for \p decl.
-  bool hasDelayedMissingImportForMemberDiagnostic(const ValueDecl *decl) const {
-    return MissingImportForMemberDiagnostics.contains(decl);
-  }
-
   DelayedMissingImportForMemberDiags
   takeDelayedMissingImportForMemberDiagnostics() {
     DelayedMissingImportForMemberDiags diags;

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1926,14 +1926,11 @@ public:
 };
 
 class AllowInaccessibleMember final : public AllowInvalidMemberRef {
-  bool IsMissingImport;
-
   AllowInaccessibleMember(ConstraintSystem &cs, Type baseType,
                           ValueDecl *member, DeclNameRef name,
-                          ConstraintLocator *locator, bool isMissingImport)
+                          ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowInaccessibleMember, baseType,
-                              member, name, locator),
-        IsMissingImport(isMissingImport) {}
+                              member, name, locator) {}
 
 public:
   std::string getName() const override {
@@ -1948,8 +1945,7 @@ public:
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
-                                         ConstraintLocator *locator,
-                                         bool isMissingImport);
+                                         ConstraintLocator *locator);
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInaccessibleMember;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1980,10 +1980,6 @@ struct MemberLookupResult {
     /// The member is inaccessible (e.g. a private member in another file).
     UR_Inaccessible,
 
-    /// The member is not visible because it comes from a module that was not
-    /// imported.
-    UR_MissingImport,
-
     /// This is a `WritableKeyPath` being used to look up read-only member,
     /// used in situations involving dynamic member lookup via keypath,
     /// because it's not known upfront what access capability would the

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -960,6 +960,8 @@ enum ScoreKind: unsigned int {
   SK_Hole,
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
+  /// A reference to a declaration from a module that has not been imported.
+  SK_MissingImport,
   /// A reference to an async function in a synchronous context.
   ///
   /// \note Any score kind after this is considered a conversion that doesn't
@@ -1123,6 +1125,9 @@ struct Score {
 
     case SK_Unavailable:
       return "use of an unavailable declaration";
+
+    case SK_MissingImport:
+      return "use of a declaration that has not been imported";
 
     case SK_AsyncInSyncMismatch:
       return "async-in-synchronous mismatch";

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2325,8 +2325,7 @@ static bool missingImportForMemberDecl(const DeclContext *dc, ValueDecl *decl) {
   if (!ctx.LangOpts.hasFeature(Feature::MemberImportVisibility))
     return false;
 
-  auto declModule = decl->getDeclContext()->getParentModule();
-  return !ctx.getImportCache().isImportedBy(declModule, dc);
+  return !dc->isDeclImported(decl);
 }
 
 /// Determine whether the given declaration is an acceptable lookup
@@ -2502,6 +2501,11 @@ bool DeclContext::lookupQualified(Type type,
 
   return lookupQualified(nominalTypesToLookInto, member,
                          loc, options, decls);
+}
+
+bool DeclContext::isDeclImported(const Decl *decl) const {
+  auto declModule = decl->getDeclContext()->getParentModule();
+  return getASTContext().getImportCache().isImportedBy(declModule, this);
 }
 
 static void installPropertyWrapperMembersIfNeeded(NominalTypeDecl *target,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6250,11 +6250,6 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
   }
 
   auto loc = nameLoc.isValid() ? nameLoc.getStartLoc() : ::getLoc(anchor);
-  if (IsMissingImport) {
-    maybeDiagnoseMissingImportForMember(Member, getDC(), loc);
-    return true;
-  }
-
   auto accessLevel = Member->getFormalAccessScope().accessLevelForDiagnostics();
   if (auto *CD = dyn_cast<ConstructorDecl>(Member)) {
     emitDiagnosticAt(loc, diag::init_candidate_inaccessible,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1640,13 +1640,11 @@ private:
 /// ```
 class InaccessibleMemberFailure final : public FailureDiagnostic {
   ValueDecl *Member;
-  bool IsMissingImport;
 
 public:
   InaccessibleMemberFailure(const Solution &solution, ValueDecl *member,
-                            ConstraintLocator *locator, bool isMissingImport)
-      : FailureDiagnostic(solution, locator), Member(member),
-        IsMissingImport(isMissingImport) {}
+                            ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), Member(member) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1153,16 +1153,16 @@ MoveOutOfOrderArgument *MoveOutOfOrderArgument::create(
 
 bool AllowInaccessibleMember::diagnose(const Solution &solution,
                                        bool asNote) const {
-  InaccessibleMemberFailure failure(solution, getMember(), getLocator(),
-                                    IsMissingImport);
+  InaccessibleMemberFailure failure(solution, getMember(), getLocator());
   return failure.diagnose(asNote);
 }
 
-AllowInaccessibleMember *AllowInaccessibleMember::create(
-    ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclNameRef name,
-    ConstraintLocator *locator, bool isMissingImport) {
-  return new (cs.getAllocator()) AllowInaccessibleMember(
-      cs, baseType, member, name, locator, isMissingImport);
+AllowInaccessibleMember *
+AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
+                                ValueDecl *member, DeclNameRef name,
+                                ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowInaccessibleMember(cs, baseType, member, name, locator);
 }
 
 bool AllowAnyObjectKeyPathRoot::diagnose(const Solution &solution,

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -963,7 +963,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
              ? SolutionCompareResult::Better
              : SolutionCompareResult::Worse;
   }
-  
+
   // Compute relative score.
   unsigned score1 = 0;
   unsigned score2 = 0;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10381,12 +10381,6 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     if (lookupUnviable(lookupOptions | NameLookupFlags::IgnoreAccessControl,
                        MemberLookupResult::UR_Inaccessible))
       return result;
-
-    // Ignore missing import statements in order to find more candidates that
-    // might have been missed before.
-    if (lookupUnviable(lookupOptions | NameLookupFlags::IgnoreMissingImports,
-                       MemberLookupResult::UR_MissingImport))
-      return result;
   }
   
   return result;
@@ -10587,11 +10581,9 @@ static ConstraintFix *fixMemberRef(
     }
 
     case MemberLookupResult::UR_Inaccessible:
-    case MemberLookupResult::UR_MissingImport:
       assert(choice.isDecl());
-      return AllowInaccessibleMember::create(
-          cs, baseTy, choice.getDecl(), memberName, locator,
-          *reason == MemberLookupResult::UR_MissingImport);
+      return AllowInaccessibleMember::create(cs, baseTy, choice.getDecl(),
+                                             memberName, locator);
 
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10346,7 +10346,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // include them in the unviable candidates list.
   if (result.ViableCandidates.empty() && result.UnviableCandidates.empty() &&
       includeInaccessibleMembers) {
-    NameLookupOptions lookupOptions = defaultMemberLookupOptions;
+    NameLookupOptions lookupOptions =
+        defaultConstraintSolverMemberLookupOptions;
 
     // Local function that looks up additional candidates using the given lookup
     // options, recording the results as unviable candidates.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -292,8 +292,8 @@ LookupResult &ConstraintSystem::lookupMember(Type base, DeclNameRef name,
   if (result) return *result;
 
   // Lookup the member.
-  result = TypeChecker::lookupMember(DC, base, name, loc,
-                                     defaultMemberLookupOptions);
+  result = TypeChecker::lookupMember(
+      DC, base, name, loc, defaultConstraintSolverMemberLookupOptions);
 
   // If we are in an @_unsafeInheritExecutor context, swap out
   // declarations for their _unsafeInheritExecutor_ counterparts if they
@@ -3965,6 +3965,12 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // If the declaration is unavailable, note that in the score.
     if (isDeclUnavailable(decl, locator))
       increaseScore(SK_Unavailable, locator);
+
+    // If the declaration is from a module that hasn't been imported, note that.
+    if (getASTContext().LangOpts.hasFeature(Feature::MemberImportVisibility)) {
+      if (!useDC->isDeclImported(decl))
+        increaseScore(SK_MissingImport, locator);
+    }
 
     // If this overload is disfavored, note that.
     if (decl->getAttrs().hasAttribute<DisfavoredOverloadAttr>())

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -279,8 +279,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
   // Some diagnostics emitted with the `MemberImportVisibility` feature enabled
   // subsume these diagnostics.
   if (originKind == DisallowedOriginKind::MissingImport &&
-      ctx.LangOpts.hasFeature(Feature::MemberImportVisibility) && SF &&
-      SF->hasDelayedMissingImportForMemberDiagnostic(D))
+      ctx.LangOpts.hasFeature(Feature::MemberImportVisibility) && SF)
     return false;
 
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -174,6 +174,14 @@ inline NameLookupOptions operator|(NameLookupFlags flag1,
 /// Default options for member name lookup.
 const NameLookupOptions defaultMemberLookupOptions;
 
+/// Default options for member name lookup in the constraint solver.
+/// Overloads which come from modules that have not been imported should be
+/// deprioritized by ranking and diagnosed by MiscDiagnostics, so we allow
+/// them to be found in constraint solver lookups to improve diagnostics
+/// overall.
+const NameLookupOptions defaultConstraintSolverMemberLookupOptions(
+    NameLookupFlags::IgnoreMissingImports);
+
 /// Default options for member type lookup.
 const NameLookupOptions defaultMemberTypeLookupOptions;
 

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -1,4 +1,6 @@
-public struct X { }
+public struct X {
+  public init() {}
+}
 
 public protocol P { }
 

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -14,6 +14,13 @@ extension X {
   package struct NestedInB_package {}
 }
 
+// Members with the same names are also declared in C.
+extension X {
+  public init(_ x: Int) { self.init() }
+  public func ambiguous() -> Int { return 1 }
+  public func ambiguousDisfavored() -> Int { return 1 }
+}
+
 extension Y {
   public func YinB() { }
 

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -12,6 +12,13 @@ extension X {
   public struct NestedInC {}
 }
 
+// Members with the same names are also declared in B.
+extension X {
+  public init(_ x: Bool) { self.init() }
+  public func ambiguous() -> Bool { return false }
+  @_disfavoredOverload public func ambiguousDisfavored() -> Bool { return false }
+}
+
 extension Y {
   public func YinC() { }
 

--- a/test/NameLookup/members_transitive_multifile_access_level.swift
+++ b/test/NameLookup/members_transitive_multifile_access_level.swift
@@ -35,19 +35,19 @@
 
 //--- function_bodies.swift
 
-// FIXME: The access level of some of these fix-its should be public/package instead of internal.
+// FIXME: The access level on the fix-it for PackageUsesOnly is wrong.
 import Swift // Just here to anchor the fix-its
 // expected-note      {{add import of module 'InternalUsesOnly'}}{{1-1=internal import InternalUsesOnly\n}}
 // expected-note@-1   {{add import of module 'InternalUsesOnlyDefaultedImport'}}{{1-1=import InternalUsesOnlyDefaultedImport\n}}
-// expected-note@-2   {{add import of module 'PackageUsesOnly'}}{{1-1=internal import PackageUsesOnly\n}}
-// expected-note@-3   {{add import of module 'PublicUsesOnly'}}{{1-1=internal import PublicUsesOnly\n}}
+// expected-note@-2   {{add import of module 'PackageUsesOnly'}}{{1-1=public import PackageUsesOnly\n}}
+// expected-note@-3   {{add import of module 'PublicUsesOnly'}}{{1-1=public import PublicUsesOnly\n}}
 // expected-note@-4   {{add import of module 'PublicUsesOnlyDefaultedImport'}}{{1-1=import PublicUsesOnlyDefaultedImport\n}}
-// expected-note@-5 3 {{add import of module 'MixedUses'}}{{1-1=internal import MixedUses\n}}
+// expected-note@-5 3 {{add import of module 'MixedUses'}}{{1-1=public import MixedUses\n}}
 // expected-note@-6   {{add import of module 'InternalUsesOnlyTransitivelyImported'}}{{1-1=internal import InternalUsesOnlyTransitivelyImported\n}}
 // expected-note@-7   {{add import of module 'InternalUsesOnlySPIOnly'}}{{1-1=internal import InternalUsesOnlySPIOnly\n}}
 // expected-public-by-default-note@-8     {{add import of module 'InternalUsesOnlyDefaultedImportSPIOnly'}}{{1-1=@_spiOnly import InternalUsesOnlyDefaultedImportSPIOnly\n}}
 // expected-internal-by-default-note@-9   {{add import of module 'InternalUsesOnlyDefaultedImportSPIOnly'}}{{1-1=import InternalUsesOnlyDefaultedImportSPIOnly\n}}
-// expected-note@-10  {{add import of module 'PublicUsesOnlySPIOnly'}}{{1-1=internal import PublicUsesOnlySPIOnly\n}}
+// expected-note@-10  {{add import of module 'PublicUsesOnlySPIOnly'}}{{1-1=@_spiOnly public import PublicUsesOnlySPIOnly\n}}
 
 
 func internalFunc(_ x: Int) {

--- a/test/NameLookup/members_transitive_objc.swift
+++ b/test/NameLookup/members_transitive_objc.swift
@@ -19,9 +19,9 @@ func test(x: X) {
   x.fromOverlayForA()
   x.fromB()
   x.fromOverlayForB()
-  x.fromC() // expected-member-visibility-error {{class method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
+  x.fromC() // expected-member-visibility-error {{instance method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
   x.fromOverlayForC() // expected-member-visibility-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
-  x.fromSubmoduleOfD() // expected-member-visibility-error {{class method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
+  x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
 }
 


### PR DESCRIPTION
 Previously, the constraint solver would first attempt member lookup that excluded members from transitively imported modules. If there were no viable candidates, it would perform a second lookup that included the previously excluded members, treating any candidates as unviable. This meant that if the member reference did resolve to one of the unviable candidates the resulting AST would be broken, which could cause unwanted knock-on diagnostics.
    
Now, members from transitively imported modules are always returned in the set of viable candidates. However, scoring will always prioritize candidates from directly imported modules over members from transitive imports. This solves the ambiguities that `MemberImportVisibility` is designed to prevent. If the only viable candidates are from transitively imported modules, though, then the reference will be resolved successfully and diagnosed later in `MiscDiagnostics.cpp`. The resulting AST will not contain any errors, which ensures that necessary access levels can be computed correctly for the imports suggested by `MemberImportVisibility` fix-its.
    
Resolves rdar://126637855.
