### PR TITLE
Grammatical corrections for compound modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,7 +447,7 @@ And the module structure to support such applications looks like this:
 
 * [SE-0430][]:
 
-  Region Based Isolation is now extended to enable the application of an
+  Region-Based Isolation is now extended to enable the application of an
   explicit `sending` annotation to function parameters and results. A function
   parameter or result that is annotated with `sending` is required to be
   disconnected at the function boundary and thus possesses the capability of
@@ -485,7 +485,7 @@ And the module structure to support such applications looks like this:
   
   func useValue() {
     let x = NonSendableType()
-    let a = await MyActor(x) // Error without Region Based Isolation!
+    let a = await MyActor(x) // Error without Region-Based Isolation!
   }
   ```
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -962,10 +962,10 @@ NOTE(sil_referencebinding_inout_binding_here, none,
       ())
 
 //===----------------------------------------------------------------------===//
-//                  MARK: Region Based Isolation Diagnostics
+//                  MARK: Region-Based Isolation Diagnostics
 //===----------------------------------------------------------------------===//
 
-// READ THIS: Please when adding diagnostics for region based isolation, keep
+// READ THIS: Please when adding diagnostics for region-based isolation, keep
 // them ordered in sections depending on which emitter uses it. It makes it
 // easier for people unfamiliar with the code to quickly see which diagnostics
 // are used by which of the SendNonSendable emitters use.
@@ -974,7 +974,7 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 // Misc
 
 ERROR(regionbasedisolation_unknown_pattern, none,
-      "pattern that the region based isolation checker does not understand how to check. Please file a bug",
+      "pattern that the region-based isolation checker does not understand how to check. Please file a bug",
       ())
 NOTE(regionbasedisolation_maybe_race, none,
      "access can happen concurrently", ())
@@ -1096,13 +1096,13 @@ NOTE(regionbasedisolation_typed_sendneversendable_via_arg_callee, none,
 // Error that is only used when the send non sendable emitter cannot discover any
 // information to give a better diagnostic.
 ERROR(regionbasedisolation_task_or_actor_isolated_sent, none,
-      "task or actor isolated value cannot be sent", ())
+      "task or actor-isolated value cannot be sent", ())
 
 //===
 // InOut Sending Emitter
 
 NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
-     "'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value",
+     "'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value",
      ())
 ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
       "'inout sending' parameter %0 cannot be %1at end of function",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5749,7 +5749,7 @@ NOTE(note_actor_isolated_witness,none,
      "%0 %kind1 cannot satisfy %2 requirement",
      (ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
-      "actor %0 cannot conform to global actor isolated protocol %1",
+      "actor %0 cannot conform to global-actor-isolated protocol %1",
       (Type, Type))
 NOTE(protocol_isolated_to_global_actor_here,none,
      "%0 is isolated to global actor %1 here", (Type, Type))

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1491,7 +1491,7 @@ def platform_c_calling_convention_EQ :
 
 def disable_sending_args_and_results_with_region_isolation : Flag<["-"],
   "disable-sending-args-and-results-with-region-based-isolation">,
-  HelpText<"Disable sending args and results when region based isolation is enabled. Only enabled with asserts">,
+  HelpText<"Disable sending args and results when region-based isolation is enabled. Only enabled with asserts">,
   Flags<[HelpHidden]>;
 
 def scanner_module_validation: Flag<["-"], "scanner-module-validation">,

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -391,7 +391,7 @@ public:
   }
 
   /// Returns the value for this instruction if it isn't a fake "represenative
-  /// value" to inject actor isolatedness. Asserts in such a case.
+  /// value" to inject actor isolation. Asserts in such a case.
   SILValue getRepresentative(Element trackableValueID) const;
 
   /// Returns the value for this instruction. If it is a fake "representative
@@ -399,7 +399,7 @@ public:
   SILValue maybeGetRepresentative(Element trackableValueID) const;
 
   /// Returns the value for this instruction if it isn't a fake "represenative
-  /// value" to inject actor isolatedness. Asserts in such a case.
+  /// value" to inject actor isolation. Asserts in such a case.
   RepresentativeValue getRepresentativeValue(Element trackableValueID) const;
 
   /// Returns the fake "representative value" for this element if it

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -93,7 +93,7 @@ class RegionAnalysisValueMap;
 /// The representative value of the equivalence class that makes up a tracked
 /// value.
 ///
-/// We use a wrapper struct here so that we can inject "fake" actor isolated
+/// We use a wrapper struct here so that we can inject "fake" actor-isolated
 /// values into the regions of values that become merged into an actor by
 /// calling a function without a non-sendable result.
 class RepresentativeValue {
@@ -103,8 +103,8 @@ class RepresentativeValue {
 
   /// If this is set to a SILValue then it is the actual represented value. If
   /// it is set to a SILInstruction, then this is a "fake" representative value
-  /// used to inject actor isolatedness. The instruction stored is the
-  /// instruction that introduced the actor isolated-ness.
+  /// used to inject actor isolation. The instruction stored is the
+  /// instruction that introduced the actor isolation.
   InnerType value;
 
 public:

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -486,7 +486,7 @@ public:
   /// for the isolated values if any to not match.
   ///
   /// This is useful if one has two non-Sendable values projected from the same
-  /// actor or global actor isolated value. E.x.: two different ref_element_addr
+  /// actor or global-actor-isolated value. E.x.: two different ref_element_addr
   /// from the same actor.
   bool hasSameIsolation(const SILIsolationInfo &other) const;
 

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -831,7 +831,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   }
 
   // If we have strict concurrency set as a feature and were told to turn off
-  // region based isolation... do so now.
+  // region-based isolation... do so now.
   if (Invocation.getLangOptions().hasFeature(Feature::StrictConcurrency)) {
     Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -62,7 +62,7 @@ FunctionTypeInfo SILGenFunction::getClosureTypeInfo(AbstractClosureExpr *expr) {
   auto fnType = cast<AnyFunctionType>(expr->getType()->getCanonicalType());
 
   // If we have a closure expr that has inherits actor context, work around AST
-  // issues that causes us to be able to get non-Sendable actor isolated
+  // issues that causes us to be able to get non-Sendable actor-isolated
   // closures.
   if (auto *ce = dyn_cast<ClosureExpr>(expr)) {
     if (ce->inheritsActorContext() && fnType->isAsync() &&

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -155,7 +155,7 @@ void SILGenFunction::emitExpectedExecutorProlog() {
   }();
 
   // FIXME: Avoid loading and checking the expected executor if concurrency is
-  // unavailable. This is specifically relevant for MainActor isolated contexts,
+  // unavailable. This is specifically relevant for MainActor-isolated contexts,
   // which are allowed to be available on OSes where concurrency is not
   // available. rdar://106827064
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -877,7 +877,7 @@ public:
   FunctionTypeInfo getFunctionTypeInfo(CanAnyFunctionType fnType);
 
   /// A helper method that calls getFunctionTypeInfo that also marks global
-  /// actor isolated async closures that are not sendable as sendable.
+  /// actor-isolated async closures that are not sendable as sendable.
   FunctionTypeInfo getClosureTypeInfo(AbstractClosureExpr *expr);
 
   bool isEmittingTopLevelCode() { return IsEmittingTopLevelCode; }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1724,7 +1724,7 @@ struct PartitionOpBuilder {
         lookupValueID(rep), lookupValueID(srcOperand->get()), srcOperand));
   }
 
-  /// Mark \p value artifically as being part of an actor isolated region by
+  /// Mark \p value artifically as being part of an actor-isolated region by
   /// introducing a new fake actor introducing representative and merging them.
   void addActorIntroducingInst(SILValue sourceValue, Operand *sourceOperand,
                                SILIsolationInfo actorIsolation) {
@@ -1794,7 +1794,7 @@ public:
 namespace {
 
 enum class TranslationSemantics {
-  /// An instruction that does not affect region based state or if it does we
+  /// An instruction that does not affect region-based state or if it does we
   /// would like to error on some other use. An example would be something
   /// like end_borrow, inject_enum_addr, or alloc_global. We do not produce
   /// any partition op.
@@ -2474,7 +2474,7 @@ public:
   void translateSILPartialApply(PartialApplyInst *pai) {
     // First check if our partial apply is Sendable and not global actor
     // isolated. In such a case, we will have emitted an earlier warning in Sema
-    // and can return early. If we have a global actor isolated partial_apply,
+    // and can return early. If we have a global-actor-isolated partial_apply,
     // we can be looser and can use region isolation since we know that the
     // Sendable closure will be executed serially due to the closure having to
     // run on the global actor queue meaning that we do not have to worry about

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1073,7 +1073,7 @@ struct UseAfterSendDiagnosticInferrer::AutoClosureWalker : ASTWalker {
           continue;
         }
 
-        // Otherwise, we are calling an actor isolated function in the async
+        // Otherwise, we are calling an actor-isolated function in the async
         // let. Emit a better error.
 
         // See if we can find a valueDecl/name for our callee so we can

--- a/lib/SILOptimizer/Utils/RegionIsolation.cpp
+++ b/lib/SILOptimizer/Utils/RegionIsolation.cpp
@@ -26,7 +26,7 @@ LoggingFlag swift::regionisolation::ENABLE_LOGGING;
 static llvm::cl::opt<LoggingFlag, true> // The parser
     RegionBasedIsolationLog(
         "sil-regionbasedisolation-log",
-        llvm::cl::desc("Enable logging for SIL region based isolation "
+        llvm::cl::desc("Enable logging for SIL region-based isolation "
                        "diagnostics"),
         llvm::cl::Hidden,
         llvm::cl::values(

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -708,7 +708,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     }
   }
 
-  // See if we have a struct_extract from a global actor isolated type.
+  // See if we have a struct_extract from a global-actor-isolated type.
   if (auto *sei = dyn_cast<StructExtractInst>(inst)) {
     auto varIsolation = swift::getActorIsolation(sei->getField());
     if (auto isolation =
@@ -729,12 +729,12 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
         varIsolation.isNonisolatedUnsafe());
   }
 
-  // See if we have an unchecked_enum_data from a global actor isolated type.
+  // See if we have an unchecked_enum_data from a global-actor-isolated type.
   if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
     return SILIsolationInfo::getGlobalActorIsolated(uedi, uedi->getEnumDecl());
   }
 
-  // See if we have an unchecked_enum_data from a global actor isolated type.
+  // See if we have an unchecked_enum_data from a global-actor-isolated type.
   if (auto *utedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
     return SILIsolationInfo::getGlobalActorIsolated(utedi,
                                                     utedi->getEnumDecl());
@@ -754,7 +754,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     }
   }
 
-  // See if we have a convert function from a Sendable actor isolated function,
+  // See if we have a convert function from a Sendable actor-isolated function,
   // we want to treat the result of the convert function as being actor isolated
   // so that we cannot escape the value.
   //
@@ -865,7 +865,7 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   if (!SILIsolationInfo::isNonSendableType(arg->getType(), arg->getFunction()))
     return {};
 
-  // Handle a switch_enum from a global actor isolated type.
+  // Handle a switch_enum from a global-actor-isolated type.
   if (auto *phiArg = dyn_cast<SILPhiArgument>(arg)) {
     if (auto *singleTerm = phiArg->getSingleTerminator()) {
       if (auto *swi = dyn_cast<SwitchEnumInst>(singleTerm)) {
@@ -913,7 +913,7 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
     // disconnected so we can construct the actor value. Users cannot write
     // allocator functions so we just need to worry about compiler generated
     // code. In the case of a non-actor, we can only have an allocator that is
-    // global actor isolated, so we will never hit this code path.
+    // global-actor isolated, so we will never hit this code path.
     if (declRef.kind == SILDeclRef::Kind::Allocator) {
       if (auto isolation = fArg->getFunction()->getActorIsolation()) {
         if (isolation->isActorInstanceIsolated()) {
@@ -1068,7 +1068,7 @@ bool SILIsolationInfo::hasSameIsolation(const SILIsolationInfo &other) const {
     // If either have an actor instance, and the actor instance doesn't match,
     // return false.
     //
-    // This ensures that cases like comparing two global actor isolated things
+    // This ensures that cases like comparing two global-actor-isolated things
     // do not hit this path.
     //
     // It also catches cases where we have a missing actor instance.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5173,7 +5173,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       case ActorIsolation::Erased:
         llvm_unreachable("storage cannot have opaque isolation");
 
-      // A reference to an actor isolated state makes key path non-Sendable.
+      // A reference to an actor-isolated state makes key path non-Sendable.
       case ActorIsolation::ActorInstance:
       case ActorIsolation::GlobalActor:
         isSendable = false;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1782,7 +1782,7 @@ static bool wasLegacyEscapingUseRestriction(AbstractFunctionDecl *fn) {
   return !(fn->hasAsync()); // basic case: not async = had restriction.
 }
 
-/// Note that while a direct access to the actor isolated property is not legal
+/// Note that while a direct access to the actor-isolated property is not legal
 /// you may want to consider introducing an accessing method for a mutation.
 static void
 maybeNoteMutatingMethodSuggestion(ASTContext &C,
@@ -2997,7 +2997,7 @@ namespace {
           auto *patternBindingDecl = getTopPatternBindingDecl();
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
             // Defer diagnosing checking of non-Sendable types that are passed
-            // into async let to SIL level region based isolation.
+            // into async let to SIL level region-based isolation.
             return;
           }
 
@@ -4801,7 +4801,7 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
     // If the local function is not Sendable, its isolation differs
     // from that of the context, and both contexts are actor isolated,
     // then capturing non-Sendable values allows the closure to stash
-    // those values into actor isolated state. The original context
+    // those values into actor-isolated state. The original context
     // may also stash those values into isolated state, enabling concurrent
     // access later on.
     isolatedStateMayEscape =
@@ -7826,8 +7826,8 @@ ActorReferenceResult ActorReferenceResult::forReference(
     return forSameConcurrencyDomain(declIsolation, options);
   }
 
-  // Initializing an actor isolated stored property with a value effectively
-  // passes that value from the init context into the actor isolated context.
+  // Initializing an actor-isolated stored property with a value effectively
+  // passes that value from the init context into the actor-isolated context.
   // It's only okay for the value to cross isolation boundaries if the property
   // type is Sendable. Note that if the init is a nonisolated actor init,
   // Sendable checking is already performed on arguments at the call-site.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -322,7 +322,7 @@ TypeCheckPrimaryFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     SF->typeCheckDelayedFunctions();
   }
 
-  // If region based isolation is enabled, we diagnose unnecessary
+  // If region-based isolation is enabled, we diagnose unnecessary
   // preconcurrency imports in the SIL pipeline in the
   // DiagnoseUnnecessaryPreconcurrencyImports pass.
   if (!Ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation))

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -17,7 +17,7 @@
 import StdlibUnittest
 
 func checkAssumeMainActor(echo: MainActorEcho) /* synchronous! */ {
-  // Echo.get("any") // error: main actor isolated, cannot perform async call here
+  // Echo.get("any") // error: MainActor isolated, cannot perform async call here
   MainActor.assumeIsolated {
     let input = "example"
     let got = echo.get(input)

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -12,7 +12,7 @@
 //  - can't pass it into a curried/partially applied function
 //  - can't pass it inout to a function that doesn't directly touch it
 //  - can't pass it into a function that was passed into the calling method
-//  - can't call async mutating function on actor isolated state
+//  - can't call async mutating function on actor-isolated state
 
 struct Point {
   var x: Int

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1264,11 +1264,11 @@ func testGlobalActorInheritance() {
 protocol GloballyIsolatedProto {
 }
 
-// rdar://75849035 - trying to conform an actor to a global-actor isolated protocol should result in an error
+// rdar://75849035 - trying to conform an actor to a global-actor-isolated protocol should result in an error
 func test_conforming_actor_to_global_actor_protocol() {
   @available(SwiftStdlib 5.1, *)
   actor MyValue : GloballyIsolatedProto {}
-  // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+  // expected-error@-1 {{actor 'MyValue' cannot conform to global-actor-isolated protocol 'GloballyIsolatedProto'}}
 }
 
 func test_nonisolated_variable() {

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -138,8 +138,8 @@ class C7: C2 {
 protocol GloballyIsolatedProto {
 }
 
-// rdar://75849035 - trying to conform an actor to a global-actor isolated protocol should result in an error
+// rdar://75849035 - trying to conform an actor to a global-actor-isolated protocol should result in an error
 func test_conforming_actor_to_global_actor_protocol() {
   actor MyValue : GloballyIsolatedProto {}
-  // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+  // expected-error@-1 {{actor 'MyValue' cannot conform to global-actor-isolated protocol 'GloballyIsolatedProto'}}
 }

--- a/test/Concurrency/flow_isolation_nonstrict.swift
+++ b/test/Concurrency/flow_isolation_nonstrict.swift
@@ -7,7 +7,7 @@ class NonSendableType {
 }
 
 // rdar://94699928 - don't emit sendable diagnostics in non-'complete' mode
-// for deinits of actor or global-actor isolated types
+// for deinits of actor- or global-actor-isolated types
 
 @available(SwiftStdlib 5.1, *)
 @MainActor class AwesomeUIView {}

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -7,7 +7,7 @@
 // Emit SIL with targeted concurrency.
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix without-transferring-
 
-// Emit SIL with strict concurrency + region based isolation + transferring
+// Emit SIL with strict concurrency + region-based isolation + transferring
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
@@ -328,7 +328,7 @@ func stripActor(_ expr: @Sendable @autoclosure () -> (() -> ())) async {
 }
 
 // We used to not emit an error here with strict-concurrency enabled since we
-// were inferring the async let to main actor isolated (which was incorrect). We
+// were inferring the async let to MainActor isolated (which was incorrect). We
 // now always treat async let as non-isolated, so we get the same error in all
 // contexts.
 @MainActor func exampleWhereConstraintSolverHasWrongDeclContext_v2() async -> Int {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -224,5 +224,5 @@ class InheritConformance: ConformInExtension {
 }
 
 func testInheritedMainActorConformance() {
-  InheritConformance().f() // okay; this is not main actor isolated
+  InheritConformance().f() // okay; this is not MainActor isolated
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -296,7 +296,7 @@ final class NonSendable {
   var z: Int { 0 }
 }
 
-// This is not an error since t.update and t.x are both main actor isolated. We
+// This is not an error since t.update and t.x are both MainActor isolated. We
 // still get the returning main actor-isolated property 'x' error though.
 @available(SwiftStdlib 5.1, *)
 func testNonSendableBaseArg() async {

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -141,7 +141,7 @@ do {
   _ = Test(obj: "Hello").utf8.count // Ok
 }
 
-// Global actor isolated properties.
+// global-actor-isolated properties.
 func testGlobalActorIsolatedReferences() {
   @MainActor struct Isolated {
     var data: Int = 42

--- a/test/Concurrency/sending_continuation.swift
+++ b/test/Concurrency/sending_continuation.swift
@@ -51,7 +51,7 @@ func withCheckedContinuation_2a() async -> NonSendableKlass {
 
 @MainActor
 func withCheckedContinuation_3() async {
-  // x is main actor isolated since withCheckedContinuation is #isolated.
+  // x is MainActor isolated since withCheckedContinuation is #isolated.
   let x = await withCheckedContinuation { continuation in
     let x = NonSendableKlass()
     continuation.resume(returning: x)
@@ -80,7 +80,7 @@ func withCheckedContinuation_3a() async {
 
 @MainActor
 func withCheckedContinuation_4() async {
-  // x is main actor isolated since withCheckedContinuation is #isolated.
+  // x is MainActor isolated since withCheckedContinuation is #isolated.
   let y = NonSendableKlass()
   let x = await withCheckedContinuation { continuation in
     continuation.resume(returning: y)
@@ -95,7 +95,7 @@ func withCheckedContinuation_4() async {
 }
 
 func withCheckedContinuation_4a() async {
-  // x is main actor isolated since withCheckedContinuation is #isolated.
+  // x is MainActor isolated since withCheckedContinuation is #isolated.
   let y = NonSendableKlass()
   let x = await withCheckedContinuation { continuation in
     continuation.resume(returning: y)
@@ -182,7 +182,7 @@ func withUnsafeContinuation_2a() async -> NonSendableKlass {
 
 @MainActor
 func withUnsafeContinuation_3() async {
-  // x is main actor isolated since withUnsafeContinuation is #isolated.
+  // x is MainActor isolated since withUnsafeContinuation is #isolated.
   let x = await withUnsafeContinuation { continuation in
     let x = NonSendableKlass()
     continuation.resume(returning: x)
@@ -209,7 +209,7 @@ func withUnsafeContinuation_3a() async {
 
 @MainActor
 func withUnsafeContinuation_4() async {
-  // x is main actor isolated since withUnsafeContinuation is #isolated.
+  // x is MainActor isolated since withUnsafeContinuation is #isolated.
   let y = NonSendableKlass()
   let x = await withUnsafeContinuation { continuation in
     continuation.resume(returning: y)
@@ -224,7 +224,7 @@ func withUnsafeContinuation_4() async {
 }
 
 func withUnsafeContinuation_4a() async {
-  // x is main actor isolated since withUnsafeContinuation is #isolated.
+  // x is MainActor isolated since withUnsafeContinuation is #isolated.
   let y = NonSendableKlass()
   let x = await withUnsafeContinuation { continuation in
     continuation.resume(returning: y)

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1557,7 +1557,7 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   }
 }
 
-// Make sure we handle the merge of the actor isolated and disconnected state
+// Make sure we handle the merge of the actor-isolated and disconnected state
 // appropriately.
 //
 // TODO: Since we are accessing the var field, we miss an
@@ -1745,8 +1745,8 @@ func sendableGlobalActorIsolated() {
   print(x) // expected-tns-note {{access can happen concurrently}}
 }
 
-// We do not get an error here since we are transferring x both times to a main
-// actor isolated thing function. We used to emit an error when using region
+// We do not get an error here since we are transferring x both times to a
+// MainActor-isolated thing function. We used to emit an error when using region
 // isolation since we would trip on the store_borrow we used to materialize the
 // value.
 func testIndirectParameterSameIsolationNoError() async {
@@ -1836,7 +1836,7 @@ func testThatGlobalActorTakesPrecedenceOverActorIsolationOnMethods() async {
   let a = MyActor()
   let ns = NonSendableKlass()
 
-  // 'ns' should be main actor isolated since useKlassMainActor is @MainActor
+  // 'ns' should be MainActor isolated since useKlassMainActor is @MainActor
   // isolated. Previously we would let MyActor take precedence here...
   a.useKlassMainActor(ns)
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -218,7 +218,7 @@ struct Clock {
 @MainActor func testGlobalAndGlobalIsolatedPartialApplyMatch() {
   let ns = mainActorIsolatedGlobal
 
-  // This is not a transfer since ns is already main actor isolated.
+  // This is not a transfer since ns is already MainActor isolated.
   let _ = { @MainActor in
     print(ns)
   }
@@ -230,7 +230,7 @@ struct Clock {
   var ns = (NonSendableKlass(), NonSendableKlass())
   ns.0 = mainActorIsolatedGlobal
 
-  // This is not a transfer since ns is already main actor isolated.
+  // This is not a transfer since ns is already MainActor isolated.
   let _ = { @MainActor in
     print(ns)
   }
@@ -245,7 +245,7 @@ struct Clock {
     print(ns)
   }
 
-  // Since useValue is running in an actor isolated context, it is ok to use the
+  // Since useValue is running in an actor-isolated context, it is ok to use the
   // transferred value 'ns' here.
   useValue(ns)
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -110,7 +110,7 @@ func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
 }
 
 ////////////////////////////////
-// MARK: Actor Isolated Class //
+// MARK: Actor-Isolated Class //
 ////////////////////////////////
 
 @CustomActor

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -676,7 +676,7 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
   let letObject = NonSendableKlass()
   var varObject = NonSendableKlass()
 
-  // This is unsafe since self is not main actor isolated, so our values are
+  // This is unsafe since self is not MainActor isolated, so our values are
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -693,7 +693,7 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
-  // This is safe since self will become main actor isolated as a result of
+  // This is safe since self will become MainActor isolated as a result of
   // test2 running.
   @MainActor func test2() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -709,7 +709,7 @@ final class FinalNonIsolatedUnsafeFieldKlass {
   let letObject = NonSendableKlass()
   var varObject = NonSendableKlass()
 
-  // This is unsafe since self is not main actor isolated, so our values are
+  // This is unsafe since self is not MainActor isolated, so our values are
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -726,7 +726,7 @@ final class FinalNonIsolatedUnsafeFieldKlass {
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
-  // This is safe since self will become main actor isolated as a result of
+  // This is safe since self will become MainActor isolated as a result of
   // test2 running.
   @MainActor func test2() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -742,7 +742,7 @@ class NonIsolatedUnsafeFieldKlass {
   let letObject = NonSendableKlass()
   var varObject = NonSendableKlass()
 
-  // This is unsafe since self is not main actor isolated, so our values are
+  // This is unsafe since self is not MainActor isolated, so our values are
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -759,7 +759,7 @@ class NonIsolatedUnsafeFieldKlass {
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
-  // This is safe since self will become main actor isolated as a result of
+  // This is safe since self will become MainActor isolated as a result of
   // test2 running.
   @MainActor func test2() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
@@ -775,7 +775,7 @@ class NonIsolatedUnsafeFieldGenericKlass<T> { // expected-complete-note 4{{}}
   let letAddressOnly: T? = nil
   var varAddressOnly: T? = nil
 
-  // This is unsafe since self is not main actor isolated, so our values are
+  // This is unsafe since self is not MainActor isolated, so our values are
   // task isolated.
   func test() async {
     await transferToMainIndirect(nonIsolatedUnsafeLetAddressOnly)
@@ -796,7 +796,7 @@ class NonIsolatedUnsafeFieldGenericKlass<T> { // expected-complete-note 4{{}}
     // expected-tns-note @-2 {{sending task-isolated value of non-Sendable type 'T?' to main actor-isolated global function 'transferToMainIndirect' risks causing races in between task-isolated and main actor-isolated uses}}
   }
 
-  // This is safe since self will become main actor isolated as a result of
+  // This is safe since self will become MainActor isolated as a result of
   // test2 running.
   @MainActor func test2() async {
     await transferToMainIndirect(nonIsolatedUnsafeLetAddressOnly)

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -387,9 +387,9 @@ func taskIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {
 @MainActor func actorIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: sending @escaping () async -> ()) {}
 
-  // We do not get an error here since fakeInit is main actor isolated since it
+  // We do not get an error here since fakeInit is MainActor isolated since it
   // is defined within this function. As a result, we are sending a @MainActor
-  // isolated thing to a MainActor isolated thing.
+  // isolated thing to a MainActor-isolated thing.
   fakeInit(operation: x)
 }
 
@@ -439,7 +439,7 @@ func testNoCrashWhenSendingNoEscapeClosure() async {
 func testInOutSendingReinit(_ x: inout sending NonSendableKlass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-} // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+} // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
 
 func testInOutSendingReinit2(_ x: inout sending NonSendableKlass) async {
   await transferToMain(x)
@@ -450,7 +450,7 @@ func testInOutSendingReinit3(_ x: inout sending NonSendableKlass) async throws {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  try throwingFunction() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+  try throwingFunction() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
 
   x = NonSendableKlass()
 }
@@ -463,7 +463,7 @@ func testInOutSendingReinit4(_ x: inout sending NonSendableKlass) async throws {
     try throwingFunction()
     x = NonSendableKlass()
   } catch {
-    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
   }
 
   x = NonSendableKlass()
@@ -476,7 +476,7 @@ func testInOutSendingReinit5(_ x: inout sending NonSendableKlass) async throws {
   do {
     try throwingFunction()
   } catch {
-    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
   }
 
   x = NonSendableKlass()
@@ -489,9 +489,9 @@ func testInOutSendingReinit6(_ x: inout sending NonSendableKlass) async throws {
   do {
     try throwingFunction()
   } catch {
-    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+    throw MyError() // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
   }
-} // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value}}
+} // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
 
 actor InOutSendingWrongIsolationActor {
   var ns = NonSendableKlass()

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -236,7 +236,7 @@ func asyncLetReabstractionThunkTest() async {
 }
 
 func asyncLetReabstractionThunkTest2() async {
-  // We emit the error here since we are returning a main actor isolated value.
+  // We emit the error here since we are returning a MainActor-isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
   // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
 
@@ -259,7 +259,7 @@ func asyncLetReabstractionThunkTest2() async {
 }
 
 @MainActor func asyncLetReabstractionThunkTestGlobalActor2() async {
-  // We emit the error here since we are returning a main actor isolated value.
+  // We emit the error here since we are returning a MainActor-isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
   // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
 

--- a/test/IRGen/has_symbol_async.swift
+++ b/test/IRGen/has_symbol_async.swift
@@ -34,7 +34,7 @@ public func testActor(_ a: A) {
   // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1AC11asyncMethodyyYaFTwS"()
   if #_hasSymbol(a.asyncMethod) {}
 
-  // FIXME: Add support for actor isolated methods
+  // FIXME: Add support for actor-isolated methods
 }
 
 // --- A.init() ---

--- a/test/stdlib/CaseIterableTests.swift
+++ b/test/stdlib/CaseIterableTests.swift
@@ -17,7 +17,7 @@ CaseIterableTests.test("Simple Enums") {
   expectEqual(SimpleEnum.allCases, [.bar, .baz, .quux])
 }
 
-CaseIterableTests.test("MainActor Isolated Enums") {
+CaseIterableTests.test("MainActor-Isolated Enums") {
   @MainActor
   enum EnumMainActor: CaseIterable {
     case a, b


### PR DESCRIPTION
The correct forms in English are "actor-isolated value" (hyphenate compound modifiers preceding nouns) and "is actor isolated" (don't hyphenate predicative compound modifiers).

[https://stylemanual.com.au/contents/editing/compound-words/compound-modifiers-including-adjectives-and-adverbs](https://stylemanual.com.au/contents/editing/compound-words/compound-modifiers-including-adjectives-and-adverbs)

