### PR TITLE
Non-package module should load swiftinterface instead of binary module with PackageCMO.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -888,6 +888,9 @@ ERROR(serialization_target_incompatible,Fatal,
 ERROR(serialization_sdk_mismatch,Fatal,
       "cannot load module %0 built with SDK '%1' when using SDK '%2': %3",
       (Identifier, StringRef, StringRef, StringRef))
+REMARK(serialization_module_package_mismatch,none,
+      "cannot load module %0 built with package '%1' when using package '%2': %3",
+      (Identifier, StringRef, StringRef, StringRef))
 ERROR(serialization_target_incompatible_repl,none,
       "module %0 was created for incompatible target %1: %2",
       (Identifier, StringRef, StringRef))

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -87,6 +87,10 @@ enum class Status {
   /// The module file was built with a different SDK than the one in use
   /// to build the client.
   SDKMismatch,
+
+  /// The module file was built with a different package name than
+  /// the one in use to build the client.
+  PackageMismatch,
 };
 
 /// Returns the string for the Status enum.
@@ -107,6 +111,7 @@ struct ValidationInfo {
   StringRef sdkVersion = {};
   StringRef problematicRevision = {};
   StringRef problematicChannel = {};
+  StringRef packageName = {};
   size_t bytes = 0;
   Status status = Status::Malformed;
   std::vector<StringRef> allowableClients;
@@ -275,14 +280,26 @@ struct SearchPath {
 /// compiled with -enable-ossa-modules.
 /// \param requiredSDK If not empty, only accept modules built with
 /// a compatible SDK. The StringRef represents the canonical SDK name.
+/// \param packageName Used to compare the package name between
+/// the module being serialized and the module loading it to determine whether
+/// the module being serialized should be accepted.
 /// \param[out] extendedInfo If present, will be populated with additional
 /// compilation options serialized into the AST at build time that may be
 /// necessary to load it properly.
 /// \param[out] dependencies If present, will be populated with list of
 /// input files the module depends on, if present in INPUT_BLOCK.
 ValidationInfo validateSerializedAST(
-    StringRef data, bool requiresOSSAModules,
-    StringRef requiredSDK,
+    StringRef data, bool requiresOSSAModules, StringRef requiredSDK,
+    StringRef PackageName, ExtendedValidationInfo *extendedInfo = nullptr,
+    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
+        nullptr,
+    SmallVectorImpl<SearchPath> *searchPaths = nullptr);
+
+/// Calls validateSerializedAST above with an empty package name.
+/// FIXME: should be removed once the call site of this in
+/// lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp is updated.
+ValidationInfo validateSerializedAST(
+    StringRef data, bool requiresOSSAModules, StringRef requiredSDK,
     ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
         nullptr,

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -59,7 +59,7 @@ swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
   while (!buf.empty()) {
     auto info = serialization::validateSerializedAST(
         buf, Loader.isRequiredOSSAModules(),
-        /*requiredSDK*/StringRef());
+        /*requiredSDK*/ StringRef(), /*packageName*/ StringRef());
 
     assert(info.name.size() < (2 << 10) && "name failed sanity check");
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3739,12 +3739,9 @@ bool CompilerInvocation::parseArgs(
 serialization::Status
 CompilerInvocation::loadFromSerializedAST(StringRef data) {
   serialization::ExtendedValidationInfo extendedInfo;
-  serialization::ValidationInfo info =
-      serialization::validateSerializedAST(
-        data,
-        getSILOptions().EnableOSSAModules,
-        LangOpts.SDKName,
-        &extendedInfo);
+  serialization::ValidationInfo info = serialization::validateSerializedAST(
+      data, getSILOptions().EnableOSSAModules, LangOpts.SDKName,
+      LangOpts.PackageName, &extendedInfo);
 
   if (info.status != serialization::Status::Valid)
     return info.status;
@@ -3779,10 +3776,8 @@ CompilerInvocation::setUpInputForSILTool(
       InputFile(inputFilename, bePrimary, fileBufOrErr.get().get(), file_types::TY_SIL));
 
   auto result = serialization::validateSerializedAST(
-      fileBufOrErr.get()->getBuffer(),
-      getSILOptions().EnableOSSAModules,
-      LangOpts.SDKName,
-      &extendedInfo);
+      fileBufOrErr.get()->getBuffer(), getSILOptions().EnableOSSAModules,
+      LangOpts.SDKName, LangOpts.PackageName, &extendedInfo);
   bool hasSerializedAST = result.status == serialization::Status::Valid;
 
   if (hasSerializedAST) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -407,8 +407,8 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(newBuf), nullptr, nullptr,
       /*isFramework=*/isFramework, Ctx.SILOpts.EnableOSSAModules,
-      Ctx.LangOpts.SDKName, Ctx.SearchPathOpts.DeserializedPathRecoverer,
-      loadedModuleFile);
+      Ctx.LangOpts.SDKName, Ctx.LangOpts.PackageName,
+      Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());
 }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -424,10 +424,9 @@ private:
       std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
       std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
       std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-      bool isFramework,
-      bool requiresOSSAModules,
-      StringRef requiredSDK,
-      serialization::ValidationInfo &info, PathObfuscator &pathRecoverer);
+      bool isFramework, bool requiresOSSAModules, StringRef requiredSDK,
+      StringRef packageName, serialization::ValidationInfo &info,
+      PathObfuscator &pathRecoverer);
 
   /// Change the status of the current module.
   Status error(Status issue) {
@@ -562,15 +561,14 @@ public:
        std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-       bool isFramework, bool requiresOSSAModules,
-       StringRef requiredSDK, PathObfuscator &pathRecoverer,
+       bool isFramework, bool requiresOSSAModules, StringRef requiredSDK,
+       StringRef packageName, PathObfuscator &pathRecoverer,
        std::shared_ptr<const ModuleFileSharedCore> &theModule) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
         std::move(moduleSourceInfoInputBuffer), isFramework,
-        requiresOSSAModules, requiredSDK, info,
-        pathRecoverer);
+        requiresOSSAModules, requiredSDK, packageName, info, pathRecoverer);
     if (!moduleInterfacePath.empty()) {
       ArrayRef<char> path;
       core->allocateBuffer(path, moduleInterfacePath);

--- a/test/ModuleInterface/load_interface_for_external_client.swift
+++ b/test/ModuleInterface/load_interface_for_external_client.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Bar.swift -I %t \
+// RUN:   -module-name Bar -package-name barpkg \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -module-cache-path %t/ModuleCache \
+// RUN:   -emit-module -emit-module-path %t/Bar.swiftmodule \
+// RUN:   -O -wmo -allow-non-resilient-access -package-cmo \
+// RUN:   -disable-print-package-name-for-non-package-interface \
+// RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
+
+// RUN: %target-swift-frontend -typecheck %t/InPkgClient.swift -I %t \
+// RUN:   -package-name barpkg \
+// RUN:   -Rmodule-loading 2> %t/load-adjacent-module.txt
+// RUN: %FileCheck -check-prefix=LOAD-ADJACENT %s < %t/load-adjacent-module.txt
+
+// RUN: %target-swift-frontend -typecheck %t/ExtClient.swift -I %t \
+// RUN:   -Rmodule-loading 2> %t/load-interface.txt
+// RUN: %FileCheck -check-prefix=LOAD-INTERFACE %s < %t/load-interface.txt
+
+// LOAD-ADJACENT: remark: loaded module 'Bar'; source: '{{.*}}Bar.private.swiftinterface', loaded: '{{.*}}Bar.swiftmodule'
+
+// LOAD-INTERFACE: remark: rebuilding module 'Bar' from interface '{{.*}}Bar.private.swiftinterface'
+// LOAD-INTERFACE: note: unable to load compiled module '{{.*}}Bar.swiftmodule': Package name does not match
+
+//--- Bar.swift
+public class PubKlass {
+  public var pubVar = "1"
+  public init() {}
+}
+
+package class PkgKlass {
+  package var pkgVar = "2"
+  package init() {}
+}
+
+//--- InPkgClient.swift
+import Bar
+
+func foo() {
+  print(PubKlass().pubVar, PkgKlass().pkgVar)
+}
+
+//--- ExtClient.swift
+import Bar
+
+func foo() {
+  print(PubKlass().pubVar)
+}

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -51,8 +51,9 @@ static bool validateModule(
     llvm::SmallVectorImpl<swift::serialization::SearchPath> &searchPaths) {
   info = swift::serialization::validateSerializedAST(
       data, requiresOSSAModules,
-      /*requiredSDK*/ StringRef(), &extendedInfo, /* dependencies*/ nullptr,
-      &searchPaths);
+      /*requiredSDK*/ StringRef(),
+      /*packageName*/ StringRef(), &extendedInfo,
+      /* dependencies*/ nullptr, &searchPaths);
   if (info.status != swift::serialization::Status::Valid) {
     llvm::outs() << "error: validateSerializedAST() failed\n";
     return false;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -152,7 +152,7 @@ protected:
     auto bufData = (*bufOrErr)->getBuffer();
     auto validationInfo = serialization::validateSerializedAST(
         bufData, silOpts.EnableOSSAModules,
-        /*requiredSDK*/StringRef());
+        /*requiredSDK*/ StringRef(), /*packageName*/ StringRef());
     ASSERT_EQ(serialization::Status::Valid, validationInfo.status);
     ASSERT_EQ(bufData, moduleBuffer->getBuffer());
   }


### PR DESCRIPTION
If the binary module optimized with Package CMO is loaded for a non-package client module, the client module does not understand the serialized content of the optimized binary module because it contains attributes and instructions specific to the optimization, i.e. [serialized_for_package] definition that contains operations on non-loadable types that are normally not allowed. This can cause an assert or a crash in SIL verifier.

This PR checks whether the optimized binary module and the client module are in the same package, and require loading swiftinterface module if not.

Resolves rdar://134584629

