### PR TITLE
Revert "[CMake] [Darwin] Don't build the SDK overlays by default on Apple platforms"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,17 +244,10 @@ option(SWIFT_BUILD_CLANG_OVERLAYS
   "Build Swift overlays for the clang builtin modules"
   TRUE)
 
-# The SDK overlay is provided by the SDK itself on Darwin platforms.
-if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
-  set(SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default FALSE)
-else()
-  set(SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default TRUE)
-endif()
-
 option(SWIFT_BUILD_DYNAMIC_SDK_OVERLAY
     "Build dynamic variants of the Swift SDK overlay"
-    "${SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default}")
-  
+    TRUE)
+
 option(SWIFT_BUILD_STATIC_SDK_OVERLAY
     "Build static variants of the Swift SDK overlay"
     FALSE)

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -716,7 +716,7 @@ function(swift_benchmark_compile)
 
   if(NOT SWIFT_BENCHMARK_BUILT_STANDALONE)
     set(stdlib_dependencies "swift-frontend" "swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
-    if((SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS) AND SWIFT_BUILD_SDK_OVERLAY)
+    if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
       list(APPEND stdlib_dependencies "swiftDarwin-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
     endif()
     foreach(stdlib_dependency ${UNIVERSAL_LIBRARY_NAMES_${SWIFT_BENCHMARK_COMPILE_PLATFORM}})

--- a/cmake/modules/DarwinSDKs.cmake
+++ b/cmake/modules/DarwinSDKs.cmake
@@ -38,11 +38,7 @@ if(swift_build_freestanding AND (SWIFT_FREESTANDING_FLAVOR STREQUAL "apple"))
   configure_target_variant(FREESTANDING-R  "FREESTANDING Release"         FREESTANDING R  "Release")
   configure_target_variant(FREESTANDING-S  "FREESTANDING MinSizeRelease"  FREESTANDING S  "MinSizeRelease")
 
-  if(SWIFT_BUILD_SDK_OVERLAY)
-    set(SWIFT_FREESTANDING_TEST_DEPENDENCIES "Darwin")
-  else()
-    set(SWIFT_FREESTANDING_TEST_DEPENDENCIES "")
-  endif()
+  set(SWIFT_FREESTANDING_TEST_DEPENDENCIES "Darwin")
 endif()
 
 # Compatible cross-compile SDKS for Darwin OSes: IOS, IOS_SIMULATOR, TVOS,

--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -1,7 +1,6 @@
-if(SWIFT_BUILD_SDK_OVERLAY OR (SWIFT_BUILD_TEST_SUPPORT_MODULES AND NOT SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default))
+if(SWIFT_BUILD_SDK_OVERLAY)
   # SwiftPrivateThreadExtras makes use of Darwin/Glibc, which is part of the
-  # SDK overlay. If the SDK overlay doesn't build by default, then it should
-  # be available in the SDK and DifferentiationUnittest can still be built.
+  # SDK overlay. It can't be built separately from the SDK overlay.
   if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
     add_subdirectory(DifferentiationUnittest)
   endif()
@@ -21,7 +20,7 @@ if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
   add_subdirectory(StdlibUnittest)
 endif()
 
-if(SWIFT_BUILD_SDK_OVERLAY OR (SWIFT_BUILD_TEST_SUPPORT_MODULES AND NOT SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default))
+if(SWIFT_BUILD_SDK_OVERLAY)
   add_subdirectory(OSLog)
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -266,7 +266,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
 
-  if(SWIFT_BUILD_CLANG_OVERLAYS OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
+  if(SWIFT_BUILD_CLANG_OVERLAYS)
     add_subdirectory(ClangOverlays)
   endif()
 
@@ -315,12 +315,13 @@ if(SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(SwiftRemoteMirror)
 endif()
 
-if(SWIFT_BUILD_SDK_OVERLAY OR (SWIFT_BUILD_TEST_SUPPORT_MODULES AND SWIFT_BUILD_DYNAMIC_SDK_OVERLAY_default))
+if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
   add_subdirectory(Platform)
 endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY)
-  # On Apple platforms, we aren't building any overlays. Instead, we're picking them up from the SDK.
+  # On Apple platforms, we aren't building any overlays (other than Darwin in
+  # Platform above). Instead, we're picking them up from the SDK.
 
   if(WINDOWS IN_LIST SWIFT_SDKS)
     add_subdirectory(Windows)

--- a/test/Driver/loaded_module_trace_foundation.swift
+++ b/test/Driver/loaded_module_trace_foundation.swift
@@ -9,12 +9,12 @@
 // CHECK: "arch":"{{[^"]*}}"
 // CHECK: "swiftmodules":[
 
-// Swift and SwiftOnoneSupport is expected to be locally built;
+// Darwin, Swift and SwiftOnoneSupport is expected to be locally built;
 // everything else comes from the SDK, built from swiftinterface.
 
 // CHECK-DAG: "{{[^"]*}}/ObjectiveC.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
 // CHECK-DAG: "{{[^"]*}}/Dispatch.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
-// CHECK-DAG: "{{[^"]*}}/Darwin.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
+// CHECK-DAG: "{{[^"]*}}/Darwin.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"
 // CHECK-DAG: "{{[^"]*}}/Foundation.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
 // CHECK-DAG: "{{[^"]*}}/Swift.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"
 // CHECK-DAG: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"

--- a/test/Driver/loaded_module_trace_header.swift
+++ b/test/Driver/loaded_module_trace_header.swift
@@ -11,7 +11,7 @@
 // CHECK: "swiftmodules":[
 // CHECK-DAG: "{{[^"]*}}/ObjectiveC.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
 // CHECK-DAG: "{{[^"]*}}/Dispatch.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
-// CHECK-DAG: "{{[^"]*}}/Darwin.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
+// CHECK-DAG: "{{[^"]*}}/Darwin.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"
 // CHECK-DAG: "{{[^"]*}}/Foundation.swiftmodule{{(\\/[^"]+[.]swift(module|interface))?}}"
 // CHECK-DAG: "{{[^"]*}}/Swift.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"
 // CHECK-DAG: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule{{(\\/[^"]+[.]swiftmodule)?}}"

--- a/test/SIL/Serialization/deserialize_darwin.sil
+++ b/test/SIL/Serialization/deserialize_darwin.sil
@@ -1,0 +1,7 @@
+// Make sure that we can deserialize darwin.
+// RUN: %target-sil-opt %platform-sdk-overlay-dir/Darwin.swiftmodule/%target-swiftmodule-name -module-name Darwin > /dev/null
+// RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/Darwin.swiftmodule/%target-swiftmodule-name | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK-NOT: Unknown

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 actor Number {

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 func fib(_ n: Int) -> Int {

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 public func test() async -> Int {

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -11,10 +11,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 // BEGIN BridgingHeader.h
 
 #include <unistd.h>

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -9,10 +9,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import Darwin
 
 @main

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -47,10 +47,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 public func test() async -> Int {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1533,8 +1533,8 @@ if run_vendor == 'apple':
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
     config.target_swift_emit_pcm = (
-        '%s -emit-pcm -target %s -sdk %r' %
-        (config.swiftc, config.variant_triple, config.variant_sdk))
+        '%s -emit-pcm -target %s' %
+        (config.swiftc, config.variant_triple))
     subst_target_swift_frontend_mock_sdk_after = \
         target_options_for_mock_sdk_after
     config.target_sil_opt = (

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -8,7 +8,6 @@
 
 import multiprocessing
 import os
-import platform
 
 import android.adb.commands
 
@@ -1141,7 +1140,7 @@ def create_argument_parser():
            help='build static variants of the Swift standard library')
 
     option('--build-swift-dynamic-sdk-overlay', toggle_true,
-           default=platform.system() != "Darwin",
+           default=True,
            help='build dynamic variants of the Swift SDK overlay')
 
     option('--build-swift-static-sdk-overlay', toggle_true,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -8,7 +8,6 @@
 
 
 import multiprocessing
-import platform
 
 from build_swift import argparse
 from build_swift import defaults
@@ -80,7 +79,7 @@ EXPECTED_DEFAULTS = {
     'build_runtime_with_host_compiler': False,
     'build_stdlib_deployment_targets': ['all'],
     'build_subdir': None,
-    'build_swift_dynamic_sdk_overlay': platform.system() != "Darwin",
+    'build_swift_dynamic_sdk_overlay': True,
     'build_swift_dynamic_stdlib': True,
     'build_swift_inspect': False,
     'build_swift_private_stdlib': True,


### PR DESCRIPTION
Reverts swiftlang/swift#75918