### PR TITLE
Remove SWIFT_MEMORY_ORDER_CONSUME

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -25,19 +25,6 @@
 #include <intrin.h>
 #endif
 
-
-// FIXME: Workaround for rdar://problem/18889711. 'Consume' does not require
-// a barrier on ARM64, but LLVM doesn't know that. Although 'relaxed'
-// is formally UB by C++11 language rules, we should be OK because neither
-// the processor model nor the optimizer can realistically reorder our uses
-// of 'consume'.
-#if defined(__arm__) || defined(_M_ARM) || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_relaxed)
-#else
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_consume)
-#endif
-
-
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(__arm__) || defined(__aarch64__)
 #define SWIFT_HAS_MSVC_ARM_ATOMICS 1
 #else

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -176,7 +176,6 @@ public:
       
       storage = newStorage;
       Capacity = newCapacity;
-
       Elements.store(storage, std::memory_order_release);
     }
     
@@ -192,7 +191,7 @@ public:
 
   Snapshot snapshot() {
     incrementReaders();
-    auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
+    auto *storage = Elements.load(std::memory_order_consume);
     if (storage == nullptr) {
       return Snapshot(this, nullptr, 0);
     }

--- a/lib/Demangling/Errors.cpp
+++ b/lib/Demangling/Errors.cpp
@@ -64,7 +64,7 @@ static void reportOnCrash(uint32_t flags, const char *message) {
 
   oldMessage = std::atomic_load_explicit(
     (volatile std::atomic<char *> *)&gCRAnnotations.message,
-    SWIFT_MEMORY_ORDER_CONSUME);
+    std::memory_order_consume);
 
   do {
     if (newMessage) {
@@ -81,7 +81,7 @@ static void reportOnCrash(uint32_t flags, const char *message) {
              (volatile std::atomic<char *> *)&gCRAnnotations.message,
              &oldMessage, newMessage,
              std::memory_order_release,
-             SWIFT_MEMORY_ORDER_CONSUME));
+             std::memory_order_consume));
 
   if (oldMessage && malloc_size(oldMessage))
     free(oldMessage);

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1478,7 +1478,7 @@ void DefaultActorImpl::enqueueStealer(Job *job, JobPriority priority) {
 void DefaultActorImpl::processIncomingQueue() {
   // Pairs with the store release in DefaultActorImpl::enqueue
   bool distributedActorIsRemote = swift_distributed_actor_is_remote(this);
-  auto oldState = _status().load(SWIFT_MEMORY_ORDER_CONSUME);
+  auto oldState = _status().load(std::memory_order_consume);
   _swift_tsan_consume(this);
 
   // We must ensure that any jobs not seen by collectJobs() don't have any

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -116,7 +116,7 @@ static bool waitForStatusRecordUnlockIfNotSelfLocked(AsyncTask *task,
       // Pairs with the store_release in installation of lock record in
       // withStatusRecordLock so that lock record contents are visible due to
       // load-through HW address dependency
-      status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
+      status = task->_private()._status().load(std::memory_order_consume);
       _swift_tsan_consume(task);
 
       if (!status.isStatusRecordLocked())
@@ -135,7 +135,7 @@ static bool waitForStatusRecordUnlockIfNotSelfLocked(AsyncTask *task,
       return selfLocked;
 
     // Reload the status before trying to relock
-    status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
+    status = task->_private()._status().load(std::memory_order_consume);
     _swift_tsan_consume(task);
     if (!status.isStatusRecordLocked())
       return false;
@@ -161,7 +161,7 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
       // Pairs with the store_release in installation of lock record in
       // withStatusRecordLock so that lock record contents are visible due to
       // load-through HW address dependency
-      status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
+      status = task->_private()._status().load(std::memory_order_consume);
       _swift_tsan_consume(task);
       if (!status.isStatusRecordLocked())
         return nullptr;
@@ -178,7 +178,7 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
       return;
 
     // Reload the status before trying to relock.
-    status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
+    status = task->_private()._status().load(std::memory_order_consume);
     _swift_tsan_consume(task);
     if (!status.isStatusRecordLocked())
       return;
@@ -926,7 +926,7 @@ static void swift_task_cancelImpl(AsyncTask *task) {
 
     // consume here pairs with the release in addStatusRecord.
     if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
-            /*success*/ SWIFT_MEMORY_ORDER_CONSUME,
+            /*success*/ std::memory_order_consume,
             /*failure*/ std::memory_order_relaxed)) {
       _swift_tsan_consume(task);
       break;
@@ -1037,7 +1037,7 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
 
     // consume here pairs with the release in addStatusRecord.
     if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
-            /* success */ SWIFT_MEMORY_ORDER_CONSUME,
+            /* success */ std::memory_order_consume,
             /* failure */ std::memory_order_relaxed)) {
       _swift_tsan_consume(task);
       break;

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -299,7 +299,7 @@ reportOnCrash(uint32_t flags, const char *message)
 
   oldMessage = std::atomic_load_explicit(
     (volatile std::atomic<char *> *)&gCRAnnotations.message,
-    SWIFT_MEMORY_ORDER_CONSUME);
+    std::memory_order_consume);
 
   do {
     if (newMessage) {
@@ -316,12 +316,12 @@ reportOnCrash(uint32_t flags, const char *message)
              (volatile std::atomic<char *> *)&gCRAnnotations.message,
              &oldMessage, newMessage,
              std::memory_order_release,
-             SWIFT_MEMORY_ORDER_CONSUME));
+             std::memory_order_consume));
 #else
   const char *previous = nullptr;
   char *current = nullptr;
   previous =
-      std::atomic_load_explicit(&kFatalErrorMessage, SWIFT_MEMORY_ORDER_CONSUME);
+      std::atomic_load_explicit(&kFatalErrorMessage, std::memory_order_consume);
 
   do {
     ::free(current);
@@ -335,7 +335,7 @@ reportOnCrash(uint32_t flags, const char *message)
                                                          &previous,
                                                          static_cast<const char *>(current),
                                                          std::memory_order_release,
-                                                         SWIFT_MEMORY_ORDER_CONSUME));
+                                                         std::memory_order_consume));
 #endif // SWIFT_HAVE_CRASHREPORTERCLIENT
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -904,7 +904,7 @@ MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
 
   using CachedMetadata = std::atomic<const Metadata *>;
   auto cachedMetadataAddr = ((CachedMetadata *)cacheMetadataPtr);
-  auto *cachedMetadata = cachedMetadataAddr->load(SWIFT_MEMORY_ORDER_CONSUME);
+  auto *cachedMetadata = cachedMetadataAddr->load(std::memory_order_consume);
   if (SWIFT_LIKELY(cachedMetadata != nullptr)) {
     // Cached metadata pointers are always complete.
     return MetadataResponse{(const Metadata *)cachedMetadata,
@@ -6116,7 +6116,7 @@ getNondependentWitnessTable(const ProtocolConformanceDescriptor *conformance,
   auto tablePtr = reinterpret_cast<std::atomic<WitnessTable*> *>(
                      conformance->getGenericWitnessTable()->PrivateData.get());
   
-  auto existingTable = tablePtr->load(SWIFT_MEMORY_ORDER_CONSUME);
+  auto existingTable = tablePtr->load(std::memory_order_consume);
   if (existingTable) {
     return existingTable;
   }
@@ -6133,7 +6133,7 @@ getNondependentWitnessTable(const ProtocolConformanceDescriptor *conformance,
   // See whether we can claim to be the one true table.
   WitnessTable *orig = nullptr;
   if (!tablePtr->compare_exchange_strong(orig, table, std::memory_order_release,
-                                         SWIFT_MEMORY_ORDER_CONSUME)) {
+                                         std::memory_order_consume)) {
     // Someone beat us to the punch. Throw away our table and return the
     // existing one.
     allocator.Deallocate(buffer);

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -22,7 +22,7 @@ namespace swift {
 template <>
 HeapObjectSideTableEntry* RefCounts<InlineRefCountBits>::allocateSideTable(bool failIfDeiniting)
 {
-  auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
+  auto oldbits = refCounts.load(std::memory_order_consume);
 
   // Preflight failures before allocating a new side table.
   if (oldbits.hasSideTable()) {

--- a/stdlib/toolchain/Compatibility51/Concurrent.h
+++ b/stdlib/toolchain/Compatibility51/Concurrent.h
@@ -447,13 +447,16 @@ public:
     new(&storage->data()[count]) ElemTy(elem);
     storage->Count.store(count + 1, std::memory_order_release);
     
-    if (ReaderCount.load(std::memory_order_acquire) == 0)
+    // The standard says that std::memory_order_seq_cst only applies to
+    // read-modify-write operations, so we need an explicit fence:
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    if (ReaderCount.load(std::memory_order_relaxed) == 0)
       deallocateFreeList();
   }
   
   Snapshot snapshot() {
     incrementReaders();
-    auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
+    auto *storage = Elements.load(std::memory_order_consume);
     if (storage == nullptr) {
       return Snapshot(this, nullptr, 0);
     }

--- a/stdlib/toolchain/Compatibility56/Concurrency/TaskStatus.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/TaskStatus.cpp
@@ -159,7 +159,7 @@ static bool withStatusRecordLock(AsyncTask *task,
       ActiveTaskStatus newStatus = status.withCancelled();
       if (task->_private().Status.compare_exchange_weak(status, newStatus,
             /*success*/ std::memory_order_relaxed,
-            /*failure*/ loadOrdering)) {
+            /*failure*/ std::memory_order_relaxed)) {
         status = newStatus;
         return false;
       }


### PR DESCRIPTION
Honestly, it is not a good idea to rely on specific compiler behavior, even if we may have gotten away with it for so long

Semantically, by substituting SWIFT_MEMORY_ORDER_CONSUME with relaxed, there is no guarantee of any synchronization points, and just because we have not been able to detect them does not mean they are not there.

Of course this required visiting every single use of SWIFT_MEMORY_ORDER_CONSUME.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
