### PR TITLE
[6.0.1][region-isolation] Improve the error we emit for closure literals captured as a sending parameter.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1041,6 +1041,23 @@ NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
       "%0%1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
       (StringRef, Identifier, ActorIsolation, ActorIsolation))
 
+ERROR(regionbasedisolation_typed_tns_passed_sending_closure, none,
+     "passing closure as a 'sending' parameter risks causing data races between %0 and concurrent execution of the closure",
+     (StringRef))
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value, none,
+     "closure captures %0 %1",
+     (StringRef, DeclName))
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_task_isolated, none,
+     "closure captures %0 which is accessible to code in the current task",
+     (DeclName))
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region, none,
+     "closure captures %1 which is accessible to %0 code",
+     (StringRef, DeclName))
+
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_multiple_value, none,
+     "closure captures non-Sendable %0",
+     (DeclName))
+
 NOTE(regionbasedisolation_named_transfer_nt_asynclet_capture, none,
       "sending %1 %0 into async let risks causing data races between nonisolated and %1 uses",
       (Identifier, StringRef))

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -141,6 +141,12 @@ public:
     return value.get<SILInstruction *>();
   }
 
+  bool operator==(SILValue other) const {
+    if (hasRegionIntroducingInst())
+      return false;
+    return getValue() == other;
+  }
+
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 
 private:

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -413,20 +413,20 @@ extension NotConcurrent {
   func f() { }
 
   func test() {
-    Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
-      f()
+    Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      f() // expected-tns-note {{closure captures 'self' which is accessible to code in the current task}}
     }
 
-    Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
-      self.f()
+    Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      self.f() // expected-tns-note {{closure captures 'self' which is accessible to code in the current task}}
     }
 
-    Task { [self] in // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
-      f()
+    Task { [self] in // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      f() // expected-tns-note {{closure captures 'self' which is accessible to code in the current task}}
     }
 
-    Task { [self] in // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
-      self.f()
+    Task { [self] in // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      self.f() // expected-tns-note {{closure captures 'self' which is accessible to code in the current task}}
     }
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -501,9 +501,9 @@ func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
 
   // FIXME: The `a` in the capture list and `isolated a` are the same,
   // but the actor isolation checker doesn't know that.
-  Task { [a] in // expected-tns-warning {{'a'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+  Task { [a] in // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between 'a'-isolated code and concurrent execution of the closure}}
     _ = a
-    _ = ns
+    _ = ns // expected-tns-note {{closure captures 'a'-isolated 'ns'}}
   }
 }
 

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -31,10 +31,13 @@ struct MyType3 {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3, sc: StrictClass, nsc: NonStrictClass) async {
-  // This is task isolated since we are capturing function arguments.
-  Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+  // This is task isolated since we are capturing function arguments... but
+  // since we are merging NonStrictClass from a preconcurrency module, the whole
+  // error is squelched since we allow for preconcurrency to apply to the entire
+  // capture list.
+  Task {
     print(ns)
-    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt)
     print(mt2)
     print(mt3)
     print(sc)

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -26,11 +26,11 @@ struct MyType2 {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
-    print(ns)
-    print(mt) // no warning by default: MyType is Sendable because we suppressed NonStrictClass's warning
-    print(mt2)
-    print(sc)
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(ns) // expected-tns-note {{closure captures non-Sendable 'ns'}}
+    print(mt) // expected-tns-note {{closure captures non-Sendable 'mt'}}
+    print(mt2) // expected-tns-note {{closure captures non-Sendable 'mt2'}}
+    print(sc) // expected-tns-note {{closure captures non-Sendable 'sc'}}
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -29,12 +29,12 @@ struct MyType2: Sendable {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
     print(ns)
     print(mt) // no warning with targeted: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2)
     print(sc)
-    print(nsc)
+    print(nsc) // expected-tns-note {{closure captures 'nsc' which is accessible to code in the current task}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -42,9 +42,9 @@ actor Custom {
 
 @globalActor
 struct CustomActor {
-    static var shared: Custom {
-        return Custom()
-    }
+  static var shared: Custom {
+    return Custom()
+  }
 }
 
 @MainActor func transferToMain<T>(_ t: T) {}
@@ -66,6 +66,9 @@ func twoTransferArg(_ x: sending NonSendableKlass, _ y: sending NonSendableKlass
 @MainActor var globalKlass = NonSendableKlass()
 
 struct MyError : Error {}
+
+func takeClosure(_ x: sending () -> ()) {}
+func takeClosureAndParam(_ x: NonSendableKlass, _ y: sending () -> ()) {}
 
 /////////////////
 // MARK: Tests //
@@ -503,3 +506,55 @@ func testWrongIsolationGlobalIsolation(_ x: inout sending NonSendableKlass) {
   x = globalKlass
 } // expected-warning {{'inout sending' parameter 'x' cannot be main actor-isolated at end of function}}
 // expected-note @-1 {{main actor-isolated 'x' risks causing races in between main actor-isolated uses and caller uses since caller assumes value is not actor isolated}}
+
+func taskIsolatedCaptureInSendingClosureLiteral(_ x: NonSendableKlass) {
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  }
+
+  takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  }
+
+  takeClosureAndParam(NonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  }
+
+  let y = (x, x)
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current task}}
+  }
+
+  let z = (x, y)
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    print(y, z) // expected-note @:11 {{closure captures non-Sendable 'y'}}
+    // expected-note @-1:14 {{closure captures non-Sendable 'z'}}
+  }
+}
+
+extension MyActor {
+  func actorIsolatedCaptureInSendingClosureLiteral(_ x: NonSendableKlass) {
+    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
+      print(x) // expected-note {{closure captures 'self'-isolated 'x'}}
+    }
+
+    takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
+      print(x) // expected-note {{closure captures 'self'-isolated 'x'}}
+    }
+
+    takeClosureAndParam(NonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
+      print(x) // expected-note {{closure captures 'self'-isolated 'x'}}
+    }
+
+    let y = (x, x)
+    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
+      print(y) // expected-note {{closure captures 'y' which is accessible to 'self'-isolated code}}
+    }
+
+    let z = (x, y)
+    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
+      print(y, z) // expected-note @:13 {{closure captures non-Sendable 'y'}}
+      // expected-note @-1:16 {{closure captures non-Sendable 'z'}}
+    }
+  }
+}


### PR DESCRIPTION
Explanation: [6.0.1][region-isolation] Improve the error we emit for closure literals captured as a sending parameter.

Before region isolation and sending closures, Task.init took an @Sendable closure. If non-Sendable state was captured in the closure, we emitted a specific error on the captured value. This provided a discoverable bread crumb that the user could use to trace back what the exact problem was (noting that takeSendableClosure is where Task.init) would be:

```
tmp.swift:8:11: error: capture of 'x' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure
 1 | 
 2 | class NonSendableKlass {}
   |       `- note: class 'NonSendableKlass' does not conform to the 'Sendable' protocol
 3 | 
 4 | func takeSendableClosure(_ x: @Sendable () -> ()) {}
   :
 6 | func foo(_ x: NonSendableKlass) {
 7 |   takeSendableClosure {
 8 |     print(x)
   |           `- error: capture of 'x' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure
 9 |   }
10 | }
```

When we introduced region isolation and changed Task.init to take a sending closure, we regressed this behavior unintentionally. With region isolation and a sending closure the above error is emitted instead:

```
tmp.swift:5:3: error: task-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race
3 | 
4 | func foo(_ x: NonSendableKlass) async {
5 |   Task {
  |   `- error: task-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race
6 |     print(x)
7 |   }
```

this doesn't provide a breadcrumb for the user to work back from anymore. With this change, we ameliorate this situation by introducing a special diagnostic that ensures that the user always has a breadcrumb. With this change, we now get the following error message:

```
tmp.swift:5:8: error: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure
3 | 
4 | func foo(_ x: NonSendableKlass) {
5 |   Task {
  |        `- error: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure
6 |     print(x)
  |           `- note: closure captures 'x' which is accessible to code in the current task
7 |   }
8 | }
```

Radars:

- rdar://133798044

Original PRs:

- https://github.com/swiftlang/swift/pull/75873
- https://github.com/swiftlang/swift/pull/75887

Risk: Low. This does not impact where we emit errors... it just changes the actual error that we are emitting. Also, I pattern matched specifically against closure literals passed as a sending parameter, so if I did introduce a problem, it will occur narrowly just in this case (a case that we were already going to reject anyways). So the potential fallout is not large. Also this only applies to swift 6 and swift 5 + strict-concurrency.