### PR TITLE
Consolidate get(Opaque|Opened)TypeArchetypeProperties into archetypeProperties()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6556,6 +6556,14 @@ protected:
   }
 
 public:
+  /// Compute the recursive type properties for an archtype, merging the
+  /// given properties with those derived from the other arguments.
+  static RecursiveTypeProperties archetypeProperties(
+      RecursiveTypeProperties properties,
+      ArrayRef<ProtocolDecl *> conformsTo,
+      Type superclass,
+      SubstitutionMap subs);
+
   /// Retrieve the name of this archetype.
   Identifier getName() const;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3494,11 +3494,14 @@ std::string ArchetypeType::getFullName() const {
 }
 
 /// Determine the recursive type properties for an archetype.
-static RecursiveTypeProperties archetypeProperties(
+RecursiveTypeProperties ArchetypeType::archetypeProperties(
     RecursiveTypeProperties properties,
     ArrayRef<ProtocolDecl *> conformsTo,
-    Type superclass
+    Type superclass,
+    SubstitutionMap subs
 ) {
+  properties |= subs.getRecursiveProperties();
+
   for (auto proto : conformsTo) {
     if (proto->isUnsafe()) {
       properties |= RecursiveTypeProperties::IsUnsafe;
@@ -3538,7 +3541,7 @@ PrimaryArchetypeType::getNew(const ASTContext &Ctx,
 
   RecursiveTypeProperties Properties = archetypeProperties(
     RecursiveTypeProperties::HasPrimaryArchetype,
-    ConformsTo, Superclass);
+    ConformsTo, Superclass, SubstitutionMap());
   assert(!Properties.hasTypeVariable());
 
   auto arena = AllocationArena::Permanent;
@@ -3611,7 +3614,7 @@ PackArchetypeType::get(const ASTContext &Ctx,
   RecursiveTypeProperties properties = archetypeProperties(
     (RecursiveTypeProperties::HasPrimaryArchetype |
      RecursiveTypeProperties::HasPackArchetype),
-    ConformsTo, Superclass);
+    ConformsTo, Superclass, SubstitutionMap());
   assert(!properties.hasTypeVariable());
 
   auto arena = AllocationArena::Permanent;


### PR DESCRIPTION
When I introduced `archetypeProperties`, I missed the other two functions that do similar things. Consolidate them all under a new `ArchetypeType::archetypeProperties()`.