### PR TITLE
[test] Update IRGen/metadata.swift to pass on later tvOS

### DIFF
--- a/test/IRGen/metadata.swift
+++ b/test/IRGen/metadata.swift
@@ -13,7 +13,7 @@ enum Singleton {
 // CHECK-macosx: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
 // CHECK-ios: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
 // CHECK-watchos: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
-// CHECK-tvos: _DATA__TtC1A1G = internal constant {{.*}} { i32 128, i32 {{(16|8)}}
+// CHECK-tvos: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
 
 class G {
   var zeroSizedField = Singleton.only


### PR DESCRIPTION
This test has been failing on arm64-tvos-simulator forever, and after we bumped the default deployment target is also failing on x86_64. Update the test to match ios/watchos, which were already fixed in the past.

rdar://135453916