### PR TITLE
[test] Fix stdlib/RuntimeObjC.swift with newer deployment target

### DIFF
--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
-// RUN: %target-build-swift -parse-stdlib -Xfrontend -disable-access-control -module-name a -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o %s -o %t.out -Xfrontend -disable-deserialization-safety
+// RUN: %target-build-swift -parse-stdlib -Xfrontend -disable-access-control -module-name a -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o %s -o %t.out -Xfrontend -disable-deserialization-safety -lswiftCoreGraphics
 // RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test


### PR DESCRIPTION
This test stops working with deployment targets that no longer link @rpath/libswiftCoreGraphics.dylib when running on OSes that still require the CoreGraphics overlay. Explicitly link it to workaround.

rdar://135451615

---

Note: we previously applied this fix to stdlib/Reflection_objc.swift in #75914. I'm not sure why that