### PR TITLE
[Sema] Fixes for mutability handling in property wrappers

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65640.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65640.swift
@@ -4,6 +4,7 @@
 
 @propertyWrapper
 struct Wrapper {
+  // expected-error@-1{{property wrapper type 'Wrapper' does not contain a non-static property named 'wrappedValue'}}
   init(wrappedValue: Int) {}
 }
 func test(@Wrapper x: Int) {}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65640.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65640.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -package-name myPkg
+
+// https://github.com/swiftlang/swift/issues/65640
+
+@propertyWrapper
+struct Wrapper {
+  init(wrappedValue: Int) {}
+}
+func test(@Wrapper x: Int) {}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
--> 

Prevents a crash when a parameter references an invalid property wrapper. The original code assumed that mutability information would always be available, but this assumption fails when the property wrapper is invalid

Resolves https://github.com/swiftlang/swift/issues/65640

A test file is added to `validation-tests` as well
