### PR TITLE
Sema: Pick the most relevant import for diagnostics about the source of a decl

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2672,10 +2672,10 @@ NOTE(add_preconcurrency_to_conformance,none,
      "add '@preconcurrency' to the %0 conformance to defer isolation checking to run time", (DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
-        (const ModuleDecl *))
+        (Identifier))
 WARNING(remove_package_import,none,
         "package import of %0 was not used in package declarations",
-        (const ModuleDecl *))
+        (Identifier))
 WARNING(public_decl_needs_sendable,none,
         "public %kind0 does not specify whether it is 'Sendable' or not",
         (const ValueDecl *))

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2949,17 +2949,44 @@ SourceFile::getImportAccessLevel(const ModuleDecl *targetModule) const {
   assert(targetModule != getParentModule() &&
          "getImportAccessLevel doesn't support checking for a self-import");
 
+  /// Order of relevancy of `import` to reach `targetModule`.
+  /// Lower is better/more authoritative.
+  auto rateImport = [&](const ImportAccessLevel import) -> int {
+    auto importedModule = import->module.importedModule;
+
+    // Prioritize public names:
+    if (targetModule->getExportAsName() == importedModule->getBaseIdentifier())
+      return 0;
+    if (targetModule->getPublicModuleName(/*onlyIfImported*/false) ==
+          importedModule->getName())
+      return 1;
+
+    // The defining module or overlay:
+    if (targetModule == importedModule)
+      return 2;
+    if (targetModule == importedModule->getUnderlyingModuleIfOverlay())
+      return 3;
+
+    // Any import in the sources.
+    if (import->importLoc.isValid())
+      return 4;
+
+    return 10;
+  };
+
+  // Find the import with the least restrictive access-level.
+  // Among those prioritize more relevant one.
   auto &imports = getASTContext().getImportCache();
   ImportAccessLevel restrictiveImport = std::nullopt;
-
   for (auto &import : *Imports) {
     if ((!restrictiveImport.has_value() ||
-         import.accessLevel > restrictiveImport->accessLevel) &&
+         import.accessLevel > restrictiveImport->accessLevel ||
+         (import.accessLevel == restrictiveImport->accessLevel &&
+          rateImport(import) < rateImport(restrictiveImport))) &&
         imports.isImportedBy(targetModule, import.module.importedModule)) {
       restrictiveImport = import;
     }
   }
-
   return restrictiveImport;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2781,6 +2781,9 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   wrapper->setIsSystemModule(underlying->IsSystem);
   wrapper->setIsNonSwiftModule();
   wrapper->setHasResolvedImports();
+  if (!underlying->ExportAsModule.empty())
+    wrapper->setExportAsName(
+        SwiftContext.getIdentifier(underlying->ExportAsModule));
 
   auto file = new (SwiftContext) ClangModuleUnit(*wrapper, *this,
                                                  underlying);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2552,7 +2552,7 @@ void swift::diagnoseUnnecessaryPublicImports(SourceFile &SF) {
                                           diag::remove_package_import;
     auto inFlight = ctx.Diags.diagnose(import.importLoc,
                                        diagId,
-                                       importedModule);
+                                       importedModule->getName());
 
     if (levelUsed == AccessLevel::Package) {
       inFlight.fixItReplace(import.accessLevelRange, "package");

--- a/test/Sema/authoritative-import-priority.swift
+++ b/test/Sema/authoritative-import-priority.swift
@@ -133,7 +133,7 @@ public func useTypesC(a: FarClangType) {}
 //--- ExportedClient_FileA.swift
 /// Prefer the defining module.
 public import NotLib // expected-warning {{public import of 'NotLib' was not used in public declarations or inlinable code}}
-public import LibCore
+public import LibCore // We should warn here.
 public import Lib
 
 public func useTypesA(a: ExportedType) {}
@@ -162,7 +162,7 @@ public func useTypesD(a: ExportedType) {}
 
 //--- SwiftLibClient_FileA.swift
 /// Prefer the import matching public-module-name.
-public import SwiftPublicNameCore
+public import SwiftPublicNameCore // We should warn here.
 public import SwiftPublicName
 
 public func useTypesA(a: SwiftStruct) {}

--- a/test/Sema/authoritative-import-priority.swift
+++ b/test/Sema/authoritative-import-priority.swift
@@ -1,0 +1,192 @@
+/// Point to the most relevant import relative to the target decl.
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+/// Build the Swift libraries.
+// RUN: %target-swift-frontend -emit-module %t/SwiftPublicNameCore.swift -o %t \
+// RUN:   -public-module-name SwiftPublicName
+// RUN: %target-swift-frontend -emit-module %t/SwiftPublicName.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/MixedDep.swift -o %t -I %t
+
+/// Client testing order between indirect imports of the same priority.
+// RUN: %target-swift-frontend -typecheck -I %t \
+// RUN:   %t/OrderClient_FileA.swift %t/OrderClient_FileB.swift \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -Rmodule-api-import -verify
+
+/// Client testing order of preference for more levels of imports.
+// RUN: %target-swift-frontend -typecheck -I %t \
+// RUN:   %t/ExportedClient_FileExported.swift %t/ExportedClient_FileA.swift \
+// RUN:   %t/ExportedClient_FileB.swift %t/ExportedClient_FileC.swift %t/ExportedClient_FileD.swift \
+// RUN:   -import-underlying-module -module-name ExportedClient \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -Rmodule-api-import -verify
+
+/// Client testing -public-module-name ordering.
+// RUN: %target-swift-frontend -typecheck -I %t \
+// RUN:   %t/SwiftLibClient_FileA.swift %t/SwiftLibClient_FileB.swift \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -Rmodule-api-import -verify
+
+/// Client testing import of the overlay vs an unrelated module.
+// RUN: %target-swift-frontend -typecheck -I %t \
+// RUN:   %t/OverlayClient_FileA.swift %t/OverlayClient_FileB.swift \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -Rmodule-api-import -verify
+
+//--- module.modulemap
+module FarClangDep {
+    header "FarClangDep.h"
+}
+
+module MixedDep {
+    export *
+    header "MixedDep.h"
+}
+
+module IndirectClangDepA {
+    export *
+    header "IndirectClangDepA.h"
+}
+
+module IndirectClangDepB {
+    export *
+    header "IndirectClangDepB.h"
+}
+
+module LibCore {
+    export *
+    export_as Lib
+    header "LibCore.h"
+}
+
+module Lib {
+    export *
+    header "Lib.h"
+}
+
+module NotLib {
+    export *
+    header "NotLib.h"
+}
+
+module ExportedClient {
+    export *
+    header "ExportedClient.h"
+}
+
+//--- FarClangDep.h
+struct FarClangType{};
+
+//--- MixedDep.h
+struct UnderlyingType{};
+
+//--- IndirectClangDepA.h
+#include <FarClangDep.h>
+#include <MixedDep.h>
+
+//--- IndirectClangDepB.h
+#include <FarClangDep.h>
+#include <MixedDep.h>
+
+//--- LibCore.h
+struct ExportedType {};
+
+//--- Lib.h
+#include <LibCore.h>
+
+//--- NotLib.h
+#include <LibCore.h>
+
+//--- ExportedClient.h
+#include <LibCore.h>
+
+//--- SwiftPublicNameCore.swift
+public struct SwiftStruct {}
+
+//--- SwiftPublicName.swift
+@_exported import SwiftPublicNameCore
+
+//--- MixedDep.swift
+@_exported import MixedDep
+
+//--- OrderClient_FileA.swift
+/// Between indirect imports, prefer the first one.
+public import IndirectClangDepA
+public import IndirectClangDepB // expected-warning {{public import of 'IndirectClangDepB' was not used in public declarations or inlinable code}}
+
+public func useTypesB(a: FarClangType) {}
+// expected-remark @-1 {{struct 'FarClangType' is imported via 'IndirectClangDepA', which reexports definition from 'FarClangDep'}}
+
+//--- OrderClient_FileB.swift
+/// Still prefer the first one after changing the order.
+public import IndirectClangDepB
+public import IndirectClangDepA // expected-warning {{public import of 'IndirectClangDepA' was not used in public declarations or inlinable code}}
+
+public func useTypesC(a: FarClangType) {}
+// expected-remark @-1 {{struct 'FarClangType' is imported via 'IndirectClangDepB', which reexports definition from 'FarClangDep'}}
+
+
+//--- ExportedClient_FileExported.swift
+@_exported public import ExportedClient
+
+//--- ExportedClient_FileA.swift
+/// Prefer the defining module.
+public import NotLib // expected-warning {{public import of 'NotLib' was not used in public declarations or inlinable code}}
+public import LibCore
+public import Lib
+
+public func useTypesA(a: ExportedType) {}
+// expected-remark @-1 {{struct 'ExportedType' is imported via 'Lib', which reexports definition from 'LibCore'}}
+
+//--- ExportedClient_FileB.swift
+/// Then prefer the export_as module.
+public import NotLib // expected-warning {{public import of 'NotLib' was not used in public declarations or inlinable code}}
+public import Lib
+
+public func useTypesB(a: ExportedType) {}
+// expected-remark @-1 {{struct 'ExportedType' is imported via 'Lib'}}
+
+//--- ExportedClient_FileC.swift
+/// Then prefer any local import.
+public import NotLib
+
+public func useTypesC(a: ExportedType) {}
+// expected-remark @-1 {{struct 'ExportedType' is imported via 'NotLib', which reexports definition from 'LibCore'}}
+
+//--- ExportedClient_FileD.swift
+/// Last used the module-wide @_exported import.
+public func useTypesD(a: ExportedType) {}
+// expected-remark @-1 {{struct 'ExportedType' is imported via 'ExportedClient', which reexports definition from 'LibCore'}}
+
+
+//--- SwiftLibClient_FileA.swift
+/// Prefer the import matching public-module-name.
+public import SwiftPublicNameCore
+public import SwiftPublicName
+
+public func useTypesA(a: SwiftStruct) {}
+// expected-remark @-1 {{struct 'SwiftStruct' is imported via 'SwiftPublicName', which reexports definition from 'SwiftPublicName'}}
+
+//--- SwiftLibClient_FileB.swift
+/// Fallback on read definition site.
+public import SwiftPublicNameCore
+
+public func useTypesB(a: SwiftStruct) {}
+// expected-remark @-1 {{struct 'SwiftStruct' is imported via 'SwiftPublicName'}}
+
+
+//--- OverlayClient_FileA.swift
+/// Prefer a Swift overlay to an unrelated 3rd module.
+public import IndirectClangDepA // expected-warning {{public import of 'IndirectClangDepA' was not used in public declarations or inlinable code}}
+public import MixedDep
+
+public func useTypesA(a: UnderlyingType) {}
+// expected-remark @-1 {{struct 'UnderlyingType' is imported via 'MixedDep', which reexports definition from 'MixedDep'}}
+
+//--- OverlayClient_FileB.swift
+/// Fallback on any reexporter.
+public import IndirectClangDepA
+
+public func useTypesB(a: UnderlyingType) {}
+// expected-remark @-1 {{struct 'UnderlyingType' is imported via 'IndirectClangDepA', which reexports definition from 'MixedDep'}}


### PR DESCRIPTION
Improve how we pick the import declaration used in diagnostics as a source of a referenced decl. In some cases more than one import gives access to a decl via reexports. This change mostly affects the warning about superfluously public imports where the compiler warns on imports not used in API. This warning encourages the developer to remove import statements from the sources, it should push them to remove only bad ones.

The order was previously limited to picking one of the most public imports. It also had a tendency to pick the implicit import of the underlying module. This lead to diagnostics that are not useful and may encourage deleting imports in the sources to instead rely on transitive import. We should instead at least accept dependencies declared locally even if they could be removed.

We now prioritize imports in this order:
1. The most public import. (Preserving the current behavior in type-checking of access-level on imports)
2. The import of the public facing sibling of the module defining the decl, determined via `export_as` or `-public-module-name`.
3. The import of the module defining the decl.
4. The first import in the sources bringing the decl via reexports.
5. Any other import, usually the underlying clang module that is `@_exported` from a different file.

Since the rule 1. doesn't change, this doesn't affect the results of access-level on imports type-checking. Future work could review that priority and allow the access-level on more precise imports to override the one from more general imports.

rdar://135357155