### PR TITLE
[Diagnostics] Add -print-diagnostic-groups flag

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 #define SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 
+#include "swift/Basic/PrintDiagnosticNamesMode.h"
 #include "swift/Basic/WarningAsErrorRule.h"
 #include "llvm/ADT/Hashing.h"
 #include <vector>
@@ -63,9 +64,10 @@ public:
   /// Rules for escalating warnings to errors
   std::vector<WarningAsErrorRule> WarningsAsErrorsRules;
 
-  /// When printing diagnostics, include the diagnostic name (diag::whatever) at
-  /// the end.
-  bool PrintDiagnosticNames = false;
+  /// When printing diagnostics, include either the diagnostic name
+  /// (diag::whatever) at the end or the associated diagnostic group.
+  PrintDiagnosticNamesMode PrintDiagnosticNames =
+      PrintDiagnosticNamesMode::None;
 
   /// If set to true, include educational notes in printed output if available.
   /// Educational notes are documentation which supplement diagnostics.

--- a/include/swift/Basic/PrintDiagnosticNamesMode.h
+++ b/include/swift/Basic/PrintDiagnosticNamesMode.h
@@ -1,0 +1,34 @@
+//===--- PrintDiagnosticNamesMode.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_PRINTDIAGNOSTICNAMESMODE_H
+#define SWIFT_BASIC_PRINTDIAGNOSTICNAMESMODE_H
+
+namespace swift {
+
+/// What diagnostic name will be printed alongside the diagnostic message.
+enum class PrintDiagnosticNamesMode {
+  /// No diagnostic name will be printed.
+  None,
+
+  /// The identifier of a diagnostic (DiagID) will be used. Corresponds to the
+  /// `-debug-diagnostic-names` option in the frontend.
+  Identifier,
+
+  /// The associated group name (DiagGroupID) will be used. Corresponds to the
+  /// `-print-diagnostic-groups` option in the frontend.
+  Group
+};
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_PRINTDIAGNOSTICNAMESMODE_H

--- a/include/swift/Localization/LocalizationFormat.h
+++ b/include/swift/Localization/LocalizationFormat.h
@@ -157,20 +157,9 @@ public:
 };
 
 class LocalizationProducer {
-  /// This allocator will retain localized diagnostic strings containing the
-  /// diagnostic's message and identifier as `message [id]` for the duration of
-  /// compiler invocation. This will be used when the frontend flag
-  /// `-debug-diagnostic-names` is used.
-  llvm::BumpPtrAllocator localizationAllocator;
-  llvm::StringSaver localizationSaver;
-  bool printDiagnosticNames;
   LocalizationProducerState state = NotInitialized;
 
 public:
-  LocalizationProducer(bool printDiagnosticNames = false)
-      : localizationSaver(localizationAllocator),
-        printDiagnosticNames(printDiagnosticNames) {}
-
   /// If the  message isn't available/localized in current context
   /// return the fallback default message.
   virtual llvm::StringRef getMessageOr(swift::DiagID id,
@@ -181,8 +170,7 @@ public:
   /// `StringsLocalizationProducer` if the `.strings` file is available. If both
   /// files aren't available returns a `nullptr`.
   static std::unique_ptr<LocalizationProducer>
-  producerFor(llvm::StringRef locale, llvm::StringRef path,
-              bool printDiagnosticNames);
+  producerFor(llvm::StringRef locale, llvm::StringRef path);
 
   virtual ~LocalizationProducer() {}
 
@@ -206,9 +194,8 @@ class StringsLocalizationProducer final : public LocalizationProducer {
   std::vector<std::string> diagnostics;
 
 public:
-  explicit StringsLocalizationProducer(llvm::StringRef filePath,
-                                       bool printDiagnosticNames = false)
-      : LocalizationProducer(printDiagnosticNames), filePath(filePath) {}
+  explicit StringsLocalizationProducer(llvm::StringRef filePath)
+      : LocalizationProducer(), filePath(filePath) {}
 
   /// Iterate over all of the available (non-empty) translations
   /// maintained by this producer, callback gets each translation
@@ -234,8 +221,7 @@ class SerializedLocalizationProducer final : public LocalizationProducer {
 
 public:
   explicit SerializedLocalizationProducer(
-      std::unique_ptr<llvm::MemoryBuffer> buffer,
-      bool printDiagnosticNames = false);
+      std::unique_ptr<llvm::MemoryBuffer> buffer);
 
 protected:
   bool initializeImpl() override;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -469,6 +469,9 @@ def no_color_diagnostics : Flag<["-"], "no-color-diagnostics">,
 def debug_diagnostic_names : Flag<["-"], "debug-diagnostic-names">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
   HelpText<"Include diagnostic names when printing">;
+def print_diagnostic_groups : Flag<["-"], "print-diagnostic-groups">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
+  HelpText<"Include diagnostic groups in printed diagnostic output, if available">;
 def print_educational_notes : Flag<["-"], "print-educational-notes">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Include educational notes in printed diagnostic output, if available">;

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -133,12 +133,6 @@ static constexpr const char * const diagnosticStrings[] = {
     "<not a diagnostic>",
 };
 
-static constexpr const char *const debugDiagnosticStrings[] = {
-#define DIAG(KIND, ID, Group, Options, Text, Signature) Text " [" #ID "]",
-#include "swift/AST/DiagnosticsAll.def"
-    "<not a diagnostic>",
-};
-
 static constexpr const char *const diagnosticIDStrings[] = {
 #define DIAG(KIND, ID, Group, Options, Text, Signature) #ID,
 #include "swift/AST/DiagnosticsAll.def"
@@ -1518,7 +1512,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
 
   return DiagnosticInfo(
       diagnostic.getID(), loc, toDiagnosticKind(behavior),
-      diagnosticStringFor(diagnostic.getID(), getPrintDiagnosticNames()),
+      diagnosticStringFor(diagnostic.getID(), getPrintDiagnosticNamesMode()),
       diagnostic.getArgs(), Category, getDefaultDiagnosticLoc(),
       /*child note info*/ {}, diagnostic.getRanges(), fixIts,
       diagnostic.isChildNote());
@@ -1683,18 +1677,38 @@ DiagnosticKind DiagnosticEngine::declaredDiagnosticKindFor(const DiagID id) {
   return storedDiagnosticInfos[(unsigned)id].kind;
 }
 
-llvm::StringRef
-DiagnosticEngine::diagnosticStringFor(const DiagID id,
-                                      bool printDiagnosticNames) {
-  auto defaultMessage = printDiagnosticNames
-                            ? debugDiagnosticStrings[(unsigned)id]
-                            : diagnosticStrings[(unsigned)id];
-
-  if (auto producer = localization.get()) {
-    auto localizedMessage = producer->getMessageOr(id, defaultMessage);
-    return localizedMessage;
+llvm::StringRef DiagnosticEngine::diagnosticStringFor(
+    const DiagID id, PrintDiagnosticNamesMode printDiagnosticNamesMode) {
+  llvm::StringRef message = diagnosticStrings[(unsigned)id];
+  if (auto localizationProducer = localization.get()) {
+    message = localizationProducer->getMessageOr(id, message);
   }
-  return defaultMessage;
+  auto formatMessageWithName = [&](StringRef message, StringRef name) {
+    const int additionalCharsLength = 3; // ' ', '[', ']'
+    std::string messageWithName;
+    messageWithName.reserve(message.size() + name.size() +
+                            additionalCharsLength);
+    messageWithName += message;
+    messageWithName += " [";
+    messageWithName += name;
+    messageWithName += "]";
+    return DiagnosticStringsSaver.save(messageWithName);
+  };
+  switch (printDiagnosticNamesMode) {
+  case PrintDiagnosticNamesMode::None:
+    break;
+  case PrintDiagnosticNamesMode::Identifier:
+    message = formatMessageWithName(message, diagnosticIDStringFor(id));
+    break;
+  case PrintDiagnosticNamesMode::Group:
+    auto groupID = storedDiagnosticInfos[(unsigned)id].groupID;
+    if (groupID != DiagGroupID::no_group) {
+      message =
+          formatMessageWithName(message, getDiagGroupInfoByID(groupID).name);
+    }
+    break;
+  }
+  return message;
 }
 
 llvm::StringRef

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -717,8 +717,10 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   Invocation.getLangOptions().BypassResilienceChecks =
       options.BypassResilienceChecks;
-  Invocation.getDiagnosticOptions().PrintDiagnosticNames =
-      options.DebugDiagnosticNames;
+  if (options.DebugDiagnosticNames) {
+    Invocation.getDiagnosticOptions().PrintDiagnosticNames =
+        PrintDiagnosticNamesMode::Identifier;
+  }
 
   for (auto &featureName : options.UpcomingFeatures) {
     auto feature = getUpcomingFeature(featureName);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2349,7 +2349,11 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       }
     }());
   }
-  Opts.PrintDiagnosticNames |= Args.hasArg(OPT_debug_diagnostic_names);
+  if (Args.hasArg(OPT_debug_diagnostic_names)) {
+    Opts.PrintDiagnosticNames = PrintDiagnosticNamesMode::Identifier;
+  } else if (Args.hasArg(OPT_print_diagnostic_groups)) {
+    Opts.PrintDiagnosticNames = PrintDiagnosticNamesMode::Group;
+  }
   Opts.PrintEducationalNotes |= Args.hasArg(OPT_print_educational_notes);
   if (Arg *A = Args.getLastArg(OPT_diagnostic_documentation_path)) {
     Opts.DiagnosticDocumentationPath = A->getValue();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -729,9 +729,8 @@ void CompilerInstance::setUpDiagnosticOptions() {
   }
   Diagnostics.setWarningsAsErrorsRules(
       Invocation.getDiagnosticOptions().WarningsAsErrorsRules);
-  if (Invocation.getDiagnosticOptions().PrintDiagnosticNames) {
-    Diagnostics.setPrintDiagnosticNames(true);
-  }
+  Diagnostics.setPrintDiagnosticNamesMode(
+      Invocation.getDiagnosticOptions().PrintDiagnosticNames);
   Diagnostics.setDiagnosticDocumentationPath(
       Invocation.getDiagnosticOptions().DiagnosticDocumentationPath);
   Diagnostics.setLanguageVersion(

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -67,7 +67,7 @@ bool CodeCompletionDiagnostics::getDiagnostics(
     typename swift::detail::PassArgument<ArgTypes>::type... VArgs) {
   DiagID id = ID.ID;
   std::vector<DiagnosticArgument> DiagArgs{std::move(VArgs)...};
-  auto format = Engine.diagnosticStringFor(id, /*printDiagnosticNames=*/false);
+  auto format = Engine.diagnosticStringFor(id, PrintDiagnosticNamesMode::None);
   DiagnosticEngine::formatDiagnosticText(Out, format, DiagArgs);
   severity = getSeverity(Engine.declaredDiagnosticKindFor(id));
 

--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -39,12 +39,6 @@ enum LocalDiagID : uint32_t {
   NumDiags
 };
 
-static constexpr const char *const diagnosticNameStrings[] = {
-#define DIAG(KIND, ID, Group, Options, Text, Signature) " [" #ID "]",
-#include "swift/AST/DiagnosticsAll.def"
-    "<not a diagnostic>",
-};
-
 } // namespace
 
 namespace swift {
@@ -96,12 +90,6 @@ LocalizationProducer::getMessageOr(swift::DiagID id,
   auto localizedMessage = getMessage(id);
   if (localizedMessage.empty())
     return defaultMessage;
-  if (printDiagnosticNames) {
-    llvm::StringRef diagnosticName(diagnosticNameStrings[(unsigned)id]);
-    auto localizedDebugDiagnosticMessage =
-        localizationSaver.save(localizedMessage.str() + diagnosticName.str());
-    return localizedDebugDiagnosticMessage;
-  }
   return localizedMessage;
 }
 
@@ -110,9 +98,8 @@ LocalizationProducerState LocalizationProducer::getState() const {
 }
 
 SerializedLocalizationProducer::SerializedLocalizationProducer(
-    std::unique_ptr<llvm::MemoryBuffer> buffer, bool printDiagnosticNames)
-    : LocalizationProducer(printDiagnosticNames), Buffer(std::move(buffer)) {
-}
+    std::unique_ptr<llvm::MemoryBuffer> buffer)
+    : LocalizationProducer(), Buffer(std::move(buffer)) {}
 
 bool SerializedLocalizationProducer::initializeImpl() {
   auto base =
@@ -132,8 +119,8 @@ SerializedLocalizationProducer::getMessage(swift::DiagID id) const {
 }
 
 std::unique_ptr<LocalizationProducer>
-LocalizationProducer::producerFor(llvm::StringRef locale, llvm::StringRef path,
-                                  bool printDiagnosticNames) {
+LocalizationProducer::producerFor(llvm::StringRef locale,
+                                  llvm::StringRef path) {
   llvm::SmallString<128> filePath(path);
   llvm::sys::path::append(filePath, locale);
   llvm::sys::path::replace_extension(filePath, ".db");
@@ -143,13 +130,13 @@ LocalizationProducer::producerFor(llvm::StringRef locale, llvm::StringRef path,
   if (llvm::sys::fs::exists(filePath)) {
     if (auto file = llvm::MemoryBuffer::getFile(filePath)) {
       return std::make_unique<diag::SerializedLocalizationProducer>(
-          std::move(file.get()), printDiagnosticNames);
+          std::move(file.get()));
     }
   } else {
     llvm::sys::path::replace_extension(filePath, ".strings");
     if (llvm::sys::fs::exists(filePath)) {
       return std::make_unique<diag::StringsLocalizationProducer>(
-          filePath.str(), printDiagnosticNames);
+          filePath.str());
     }
   }
 

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -961,7 +961,7 @@ public:
         // Emit a specific unavailable message when we know why a decl can't be
         // exposed, or a generic message otherwise.
         auto diagString = M.getASTContext().Diags.diagnosticStringFor(
-            diag.getID(), /*PrintDiagnosticNames=*/false);
+            diag.getID(), PrintDiagnosticNamesMode::None);
         DiagnosticEngine::formatDiagnosticText(os, diagString, diag.getArgs(),
                                                DiagnosticFormatOptions());
         os << "\");\n";

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -21,10 +21,10 @@ public let M_PI_2 = Double.pi / 2
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
 public let M_PI_4 = Double.pi / 4
 
-@available(swift, deprecated: 3.0, message: "Please use 2.squareRoot()'.")
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
 public let M_SQRT2 = 2.squareRoot()
 
-@available(swift, deprecated: 3.0, message: "Please use 0.5.squareRoot()'.")
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
 public let M_SQRT1_2 = 0.5.squareRoot()
 
 @available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -print-diagnostic-groups -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null
+// RUN: %target-swift-frontend -print-diagnostic-groups -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=targeted
+// RUN: %target-swift-frontend -print-diagnostic-groups -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete
+// RUN: %target-swift-frontend -print-diagnostic-groups -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -90,7 +90,7 @@ func testCaseTrivialValue4() {
                     // expected-note @-8 {{capturing use}}
 }
 
-class Klass: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+class Klass: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead [availability_deprecated]}}
   var next: Klass? = nil
 }
 func inoutUserKlass(_ k: inout Klass) {}

--- a/test/Sema/availability_literals.swift
+++ b/test/Sema/availability_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -print-diagnostic-groups
 
 // REQUIRES: OS=macosx
 
@@ -10,8 +10,8 @@ extension SLD: ExpressibleByStringLiteral {
     init(stringLiteral value: StringLiteralType) {}
 }
 
-let _ = SLD(stringLiteral: "") // expected-warning{{'init(stringLiteral:)' is deprecated}}
-let _: SLD = "" // expected-warning{{'init(stringLiteral:)' is deprecated}}
+let _ = SLD(stringLiteral: "") // expected-warning{{'init(stringLiteral:)' is deprecated [availability_deprecated]}}
+let _: SLD = "" // expected-warning{{'init(stringLiteral:)' is deprecated [availability_deprecated]}}
 
 
 struct SLU {}
@@ -30,8 +30,8 @@ extension ILD: ExpressibleByIntegerLiteral {
   init(integerLiteral value: IntegerLiteralType) {}
 }
 
-let _ = ILD(integerLiteral: 1) // expected-warning{{'init(integerLiteral:)' is deprecated}}
-let _: ILD = 1 // expected-warning{{'init(integerLiteral:)' is deprecated}}
+let _ = ILD(integerLiteral: 1) // expected-warning{{'init(integerLiteral:)' is deprecated [availability_deprecated]}}
+let _: ILD = 1 // expected-warning{{'init(integerLiteral:)' is deprecated [availability_deprecated]}}
 
 struct ILU {}
 
@@ -51,8 +51,8 @@ extension NLD: ExpressibleByNilLiteral {
   init(nilLiteral: ()) {}
 }
 
-let _: NLD = .init(nilLiteral: ()) // expected-warning{{'init(nilLiteral:)' is deprecated}}
-let _: NLD = nil // expected-warning{{'init(nilLiteral:)' is deprecated}}
+let _: NLD = .init(nilLiteral: ()) // expected-warning{{'init(nilLiteral:)' is deprecated [availability_deprecated]}}
+let _: NLD = nil // expected-warning{{'init(nilLiteral:)' is deprecated [availability_deprecated]}}
 
 struct NLU {}
 
@@ -70,8 +70,8 @@ struct BLD {}
 extension BLD: ExpressibleByBooleanLiteral {
   init(booleanLiteral value: BooleanLiteralType) {}
 }
-let _: BLD = .init(booleanLiteral: false) // expected-warning{{'init(booleanLiteral:)' is deprecated}}
-let _: BLD = false // expected-warning{{'init(booleanLiteral:)' is deprecated}}
+let _: BLD = .init(booleanLiteral: false) // expected-warning{{'init(booleanLiteral:)' is deprecated [availability_deprecated]}}
+let _: BLD = false // expected-warning{{'init(booleanLiteral:)' is deprecated [availability_deprecated]}}
 
 struct BLU {}
 @available(macOS 100, *)
@@ -87,8 +87,8 @@ struct FLD {}
 extension FLD: ExpressibleByFloatLiteral {
   init(floatLiteral value: FloatLiteralType) {}
 }
-let _: FLD = .init(floatLiteral: 0.1) // expected-warning{{'init(floatLiteral:)' is deprecated}}
-let _: FLD = 0.1 // expected-warning{{'init(floatLiteral:)' is deprecated}}
+let _: FLD = .init(floatLiteral: 0.1) // expected-warning{{'init(floatLiteral:)' is deprecated [availability_deprecated]}}
+let _: FLD = 0.1 // expected-warning{{'init(floatLiteral:)' is deprecated [availability_deprecated]}}
 
 struct FLU {}
 @available(macOS 100, *)
@@ -104,8 +104,8 @@ struct ALD {}
 extension ALD: ExpressibleByArrayLiteral {
   init(arrayLiteral elements: Int...) {}
 }
-let _: ALD = .init(arrayLiteral: 1) // expected-warning{{'init(arrayLiteral:)' is deprecated}}
-let _: ALD = [1] // expected-warning{{'init(arrayLiteral:)' is deprecated}}
+let _: ALD = .init(arrayLiteral: 1) // expected-warning{{'init(arrayLiteral:)' is deprecated [availability_deprecated]}}
+let _: ALD = [1] // expected-warning{{'init(arrayLiteral:)' is deprecated [availability_deprecated]}}
 
 struct ALU {}
 @available(macOS 100, *)
@@ -121,8 +121,8 @@ struct DLD {}
 extension DLD: ExpressibleByDictionaryLiteral {
   init(dictionaryLiteral elements: (Int, Int)...) {}
 }
-let _: DLD = .init(dictionaryLiteral: (1,1)) // expected-warning{{'init(dictionaryLiteral:)' is deprecated}}
-let _: DLD = [1: 1] // expected-warning{{'init(dictionaryLiteral:)' is deprecated}}
+let _: DLD = .init(dictionaryLiteral: (1,1)) // expected-warning{{'init(dictionaryLiteral:)' is deprecated [availability_deprecated]}}
+let _: DLD = [1: 1] // expected-warning{{'init(dictionaryLiteral:)' is deprecated [availability_deprecated]}}
 
 struct DLU {}
 @available(macOS 100, *)
@@ -139,8 +139,8 @@ extension USLD: ExpressibleByUnicodeScalarLiteral {
   typealias UnicodeScalarLiteralType = Character
   init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {}
 }
-let _: USLD = .init(unicodeScalarLiteral: "a") // expected-warning{{'init(unicodeScalarLiteral:)' is deprecated}}
-let _: USLD = "a" // expected-warning{{'init(unicodeScalarLiteral:)' is deprecated}}
+let _: USLD = .init(unicodeScalarLiteral: "a") // expected-warning{{'init(unicodeScalarLiteral:)' is deprecated [availability_deprecated]}}
+let _: USLD = "a" // expected-warning{{'init(unicodeScalarLiteral:)' is deprecated [availability_deprecated]}}
 
 struct USLU {}
 @available(macOS 100, *)
@@ -157,8 +157,8 @@ struct GCLD {}
 extension GCLD: ExpressibleByExtendedGraphemeClusterLiteral {
   init(extendedGraphemeClusterLiteral value: Character) {}
 }
-let _: GCLD = .init(extendedGraphemeClusterLiteral: "🇧🇷") // expected-warning{{'init(extendedGraphemeClusterLiteral:)' is deprecated}}
-let _: GCLD = "🇧🇷" // expected-warning{{'init(extendedGraphemeClusterLiteral:)' is deprecated}}
+let _: GCLD = .init(extendedGraphemeClusterLiteral: "🇧🇷") // expected-warning{{'init(extendedGraphemeClusterLiteral:)' is deprecated [availability_deprecated]}}
+let _: GCLD = "🇧🇷" // expected-warning{{'init(extendedGraphemeClusterLiteral:)' is deprecated [availability_deprecated]}}
 
 struct GCLU {}
 @available(macOS 100, *)

--- a/test/Sema/bitwse_copyable_underscore.swift
+++ b/test/Sema/bitwse_copyable_underscore.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift                       \
 // RUN:     -disable-availability-checking                   \
-// RUN:     -debug-diagnostic-names
+// RUN:     -print-diagnostic-groups
 
-struct S : _BitwiseCopyable {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}
+struct S : _BitwiseCopyable {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable [availability_deprecated]}}
 
-func f<T : _BitwiseCopyable>(_ t: T) {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}
+func f<T : _BitwiseCopyable>(_ t: T) {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable [availability_deprecated]}}

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s -verify
-// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
+// RUN: %swift -typecheck -parse-as-library -print-diagnostic-groups -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s -verify
+// RUN: %swift -typecheck -parse-as-library -print-diagnostic-groups -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
 //
 // This test requires a target of OS X 51 or later to test deprecation
 // diagnostics because (1) we only emit deprecation warnings if a symbol is
@@ -26,11 +26,11 @@ func useClassThatTriggersImportOfDeprecatedEnum() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API [availability_deprecated]}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 51: Use a different API [availability_deprecated]}}
 }
 
-func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
+func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API [availability_deprecated]}}
 }
 
 
@@ -83,20 +83,20 @@ class ClassWithComputedPropertyDeprecatedIn51 {
     }
   }
 
-  var unannotatedPropertyDeprecatedIn51 : ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+  var unannotatedPropertyDeprecatedIn51 : ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
     get {
-      return ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+      return ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
     }
     set(newValue) {
-      _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+      _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
     }
   }
 
-  var unannotatedStoredPropertyOfTypeDeprecatedIn51 : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+  var unannotatedStoredPropertyOfTypeDeprecatedIn51 : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 }
 
 func usesFunctionDeprecatedIn51() {
-  _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+  _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 51)
@@ -104,34 +104,34 @@ func annotatedUsesFunctionDeprecatedIn51() {
   _ = ClassDeprecatedIn51()
 }
 
-func hasParameterDeprecatedIn51(p: ClassDeprecatedIn51) { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+func hasParameterDeprecatedIn51(p: ClassDeprecatedIn51) { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 51)
 func annotatedHasParameterDeprecatedIn51(p: ClassDeprecatedIn51) {
 }
 
-func hasReturnDeprecatedIn51() -> ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+func hasReturnDeprecatedIn51() -> ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 }
 
 @available(OSX, introduced: 10.8, deprecated: 51)
 func annotatedHasReturnDeprecatedIn51() -> ClassDeprecatedIn51 {
 }
 
-var globalWithDeprecatedType : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+var globalWithDeprecatedType : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 
 @available(OSX, introduced: 10.8, deprecated: 51)
 var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn51?
 
 
 enum EnumWithDeprecatedCasePayload {
-  case WithDeprecatedPayload(p: ClassDeprecatedIn51) // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
+  case WithDeprecatedPayload(p: ClassDeprecatedIn51) // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 
   @available(OSX, introduced: 10.8, deprecated: 51)
   case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn51)
 }
 
-extension ClassDeprecatedIn51 { // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51}}
+extension ClassDeprecatedIn51 { // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 
 }
 
@@ -142,9 +142,9 @@ extension ClassDeprecatedIn51 {
 }
 
 func callMethodInDeprecatedExtension() {
-  let o = ClassDeprecatedIn51() // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51}}
+  let o = ClassDeprecatedIn51() // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51 [availability_deprecated]}}
 
-  o.methodInExtensionOfClassDeprecatedIn51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn51()' was deprecated in macOS 51}}
+  o.methodInExtensionOfClassDeprecatedIn51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn51()' was deprecated in macOS 51 [availability_deprecated]}}
 }
 
 func functionWithDeprecatedMethodInDeadElseBranch() {
@@ -179,7 +179,7 @@ class I59843_A {
   func method(with: Int) {}
 
   func f() {
-    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:)'}}
+    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:)' [availability_deprecated]}}
     // expected-note@-1{{use 'method(with:)' instead}} {{none}} 
   }
 }
@@ -207,18 +207,18 @@ class I59843_B {
   static func contextDiff(with: Int, and: Int) {}
   
   func f() {
-    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:and:)'}}
+    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:and:)' [availability_deprecated]}}
     // expected-note@-1{{use 'method(with:and:)' instead}} {{17-18=with}} {{25-26=and}}
   }
 }
 
 func I59843_f() {
-  I59843_A.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:)'}}
+  I59843_A.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:)' [availability_deprecated]}}
   // expected-note@-1{{use 'configure(with:)' instead}} {{none}}
-  I59843_B.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:and:)'}}
+  I59843_B.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:and:)' [availability_deprecated]}}
   // expected-note@-1{{use 'configure(with:and:)' instead}} {{22-23=with}} {{30-31=and}}
-  I59843_B.context(a: "a", b: "b") // expected-warning{{'context(a:b:)' was deprecated in macOS 51: replaced by 'I59843_B.context(with:and:)'}}
+  I59843_B.context(a: "a", b: "b") // expected-warning{{'context(a:b:)' was deprecated in macOS 51: replaced by 'I59843_B.context(with:and:)' [availability_deprecated]}}
   // expected-note@-1{{use 'I59843_B.context(with:and:)' instead}} {{20-21=with}} {{28-29=and}}
-  I59843_B.contextDiff(a: "a", b: "b") // expected-warning{{'contextDiff(a:b:)' was deprecated in macOS 51: replaced by 'I59843_A.contextDiff(with:and:)'}}
+  I59843_B.contextDiff(a: "a", b: "b") // expected-warning{{'contextDiff(a:b:)' was deprecated in macOS 51: replaced by 'I59843_A.contextDiff(with:and:)' [availability_deprecated]}}
   // expected-note@-1{{use 'I59843_A.contextDiff(with:and:)' instead}} {{3-23=I59843_A.contextDiff}} {{24-25=with}} {{32-33=and}}
 }

--- a/test/Sema/diag_deprecated_string_interpolation.swift
+++ b/test/Sema/diag_deprecated_string_interpolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -print-diagnostic-groups
 
 extension DefaultStringInterpolation {
     @available(*, deprecated) func appendInterpolation(deprecated: Int) {}
@@ -6,16 +6,16 @@ extension DefaultStringInterpolation {
 
 // Make sure diagnostics emitted via string interpolations have a reasonable source location
 
-_ = "\(deprecated: 42)" // expected-warning@:7 {{'appendInterpolation(deprecated:)' is deprecated}}
+_ = "\(deprecated: 42)" // expected-warning@:7 {{'appendInterpolation(deprecated:)' is deprecated [availability_deprecated]}}
 
-_ = "hello, world\(deprecated: 42)!!!" // expected-warning@:19 {{'appendInterpolation(deprecated:)' is deprecated}}
+_ = "hello, world\(deprecated: 42)!!!" // expected-warning@:19 {{'appendInterpolation(deprecated:)' is deprecated [availability_deprecated]}}
 
 _ = "\(42)\(deprecated: 42)test\(deprecated: 42)"
-// expected-warning@-1:12 {{'appendInterpolation(deprecated:)' is deprecated}}
-// expected-warning@-2:33 {{'appendInterpolation(deprecated:)' is deprecated}}
+// expected-warning@-1:12 {{'appendInterpolation(deprecated:)' is deprecated [availability_deprecated]}}
+// expected-warning@-2:33 {{'appendInterpolation(deprecated:)' is deprecated [availability_deprecated]}}
 _ = """
 This is a multiline literal with a deprecated interpolation:
 
 \(deprecated: 42)
 """
-// expected-warning@-2:2 {{'appendInterpolation(deprecated:)' is deprecated}}
+// expected-warning@-2:2 {{'appendInterpolation(deprecated:)' is deprecated [availability_deprecated]}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -module-name Test
+// RUN: %target-typecheck-verify-swift -module-name Test -print-diagnostic-groups
 
 @available(*, unavailable)
 func unavailable_func() {}
@@ -191,8 +191,8 @@ func deprecated_func_with_message() {}
 struct DeprecatedTypeWithMessage { }
 
 func use_deprecated_with_message() {
-  deprecated_func_with_message() // expected-warning{{'deprecated_func_with_message()' is deprecated: Say \"Hi\"}}
-  var _: DeprecatedTypeWithMessage // expected-warning{{'DeprecatedTypeWithMessage' is deprecated: Pandas \u{1F43C} are cute}}
+  deprecated_func_with_message() // expected-warning{{'deprecated_func_with_message()' is deprecated: Say \"Hi\" [availability_deprecated]}}
+  var _: DeprecatedTypeWithMessage // expected-warning{{'DeprecatedTypeWithMessage' is deprecated: Pandas \u{1F43C} are cute [availability_deprecated]}}
 }
 
 @available(*, deprecated, message: "message")
@@ -210,16 +210,16 @@ func deprecated_func_with_message_renamed() {}
 struct DeprecatedTypeWithRename { }
 
 func use_deprecated_with_renamed() {
-  deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg'}}
+  deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg' [availability_deprecated]}}
   // expected-note@-1{{use 'blarg'}}{{3-31=blarg}}
 
-  Test.deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg'}}
+  Test.deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg' [availability_deprecated]}}
   // expected-note@-1{{use 'blarg' instead}}
 
-  deprecated_func_with_message_renamed() //expected-warning{{'deprecated_func_with_message_renamed()' is deprecated: blarg is your friend}}
+  deprecated_func_with_message_renamed() //expected-warning{{'deprecated_func_with_message_renamed()' is deprecated: blarg is your friend [availability_deprecated]}}
   // expected-note@-1{{use 'blarg'}}{{3-39=blarg}}
 
-  var _: DeprecatedTypeWithRename // expected-warning{{'DeprecatedTypeWithRename' is deprecated: renamed to 'wobble'}}
+  var _: DeprecatedTypeWithRename // expected-warning{{'DeprecatedTypeWithRename' is deprecated: renamed to 'wobble' [availability_deprecated]}}
   // expected-note@-1{{use 'wobble'}}{{10-34=wobble}}
 }
 
@@ -304,7 +304,7 @@ func -(x: DummyType, y: DummyType) {}
 
 func testOperators(x: DummyType, y: DummyType) {
   x + y // expected-error {{'+' has been renamed to '&+'}} {{5-6=&+}}
-  x - y // expected-warning {{'-' is deprecated: renamed to '&-'}} expected-note {{use '&-' instead}} {{5-6=&-}}
+  x - y // expected-warning {{'-' is deprecated: renamed to '&-' [availability_deprecated]}} expected-note {{use '&-' instead}} {{5-6=&-}}
 }
 
 @available(*, unavailable, renamed: "DummyType.foo")
@@ -321,11 +321,11 @@ typealias DeprecatedType = Int
 
 func testGlobalToMembers() {
   unavailableMember() // expected-error {{'unavailableMember()' has been renamed to 'DummyType.foo'}} {{3-20=DummyType.foo}}
-  deprecatedMember() // expected-warning {{'deprecatedMember()' is deprecated: renamed to 'DummyType.bar'}} expected-note {{use 'DummyType.bar' instead}} {{3-19=DummyType.bar}}
+  deprecatedMember() // expected-warning {{'deprecatedMember()' is deprecated: renamed to 'DummyType.bar' [availability_deprecated]}} expected-note {{use 'DummyType.bar' instead}} {{3-19=DummyType.bar}}
   unavailableNestedMember() // expected-error {{'unavailableNestedMember()' has been renamed to 'DummyType.Inner.foo'}} {{3-26=DummyType.Inner.foo}}
   let x: UnavailableType? = nil // expected-error {{'UnavailableType' has been renamed to 'DummyType.Foo'}} {{10-25=DummyType.Foo}}
   _ = x
-  let y: DeprecatedType? = nil // expected-warning {{'DeprecatedType' is deprecated: renamed to 'DummyType.Bar'}} expected-note {{use 'DummyType.Bar' instead}} {{10-24=DummyType.Bar}}
+  let y: DeprecatedType? = nil // expected-warning {{'DeprecatedType' is deprecated: renamed to 'DummyType.Bar' [availability_deprecated]}} expected-note {{use 'DummyType.Bar' instead}} {{10-24=DummyType.Bar}}
   _ = y
 }
 
@@ -374,13 +374,13 @@ func unavailableNestedInit(a: Int) {} // expected-note 2 {{here}}
 
 func testArgNames() {
   unavailableArgNames(a: 0) // expected-error {{'unavailableArgNames(a:)' has been renamed to 'shinyLabeledArguments(example:)'}} {{3-22=shinyLabeledArguments}} {{23-24=example}}
-  deprecatedArgNames(b: 1) // expected-warning {{'deprecatedArgNames(b:)' is deprecated: renamed to 'moreShinyLabeledArguments(example:)'}} expected-note {{use 'moreShinyLabeledArguments(example:)' instead}} {{3-21=moreShinyLabeledArguments}} {{22-23=example}}
+  deprecatedArgNames(b: 1) // expected-warning {{'deprecatedArgNames(b:)' is deprecated: renamed to 'moreShinyLabeledArguments(example:)' [availability_deprecated]}} expected-note {{use 'moreShinyLabeledArguments(example:)' instead}} {{3-21=moreShinyLabeledArguments}} {{22-23=example}}
 
   unavailableMemberArgNames(a: 0) // expected-error {{'unavailableMemberArgNames(a:)' has been replaced by 'DummyType.shinyLabeledArguments(example:)'}} {{3-28=DummyType.shinyLabeledArguments}} {{29-30=example}}
-  deprecatedMemberArgNames(b: 1) // expected-warning {{'deprecatedMemberArgNames(b:)' is deprecated: replaced by 'DummyType.moreShinyLabeledArguments(example:)'}} expected-note {{use 'DummyType.moreShinyLabeledArguments(example:)' instead}} {{3-27=DummyType.moreShinyLabeledArguments}} {{28-29=example}}
+  deprecatedMemberArgNames(b: 1) // expected-warning {{'deprecatedMemberArgNames(b:)' is deprecated: replaced by 'DummyType.moreShinyLabeledArguments(example:)' [availability_deprecated]}} expected-note {{use 'DummyType.moreShinyLabeledArguments(example:)' instead}} {{3-27=DummyType.moreShinyLabeledArguments}} {{28-29=example}}
 
   unavailableMemberArgNamesMsg(a: 0) // expected-error {{'unavailableMemberArgNamesMsg(a:)' has been replaced by 'DummyType.shinyLabeledArguments(example:)': ha}} {{3-31=DummyType.shinyLabeledArguments}} {{32-33=example}}
-  deprecatedMemberArgNamesMsg(b: 1) // expected-warning {{'deprecatedMemberArgNamesMsg(b:)' is deprecated: ha}} expected-note {{use 'DummyType.moreShinyLabeledArguments(example:)' instead}} {{3-30=DummyType.moreShinyLabeledArguments}} {{31-32=example}}
+  deprecatedMemberArgNamesMsg(b: 1) // expected-warning {{'deprecatedMemberArgNamesMsg(b:)' is deprecated: ha [availability_deprecated]}} expected-note {{use 'DummyType.moreShinyLabeledArguments(example:)' instead}} {{3-30=DummyType.moreShinyLabeledArguments}} {{31-32=example}}
 
   unavailableNoArgs() // expected-error {{'unavailableNoArgs()' has been renamed to 'shinyLabeledArguments()'}} {{3-20=shinyLabeledArguments}}
   unavailableSame(a: 0) // expected-error {{'unavailableSame(a:)' has been renamed to 'shinyLabeledArguments(a:)'}} {{3-18=shinyLabeledArguments}}
@@ -452,8 +452,8 @@ func testRenameInstance() {
   unavailableInstance(a: 0 + 0) // expected-error{{'unavailableInstance(a:)' has been replaced by instance method 'Int.foo()'}} {{3-22=(0 + 0).foo}} {{23-31=}}
 
   unavailableInstanceMessage(a: 0) // expected-error{{'unavailableInstanceMessage(a:)' has been replaced by instance method 'Int.foo()': blah}} {{3-29=0.foo}} {{30-34=}}
-  deprecatedInstance(a: 0) // expected-warning{{'deprecatedInstance(a:)' is deprecated: replaced by instance method 'Int.foo()'}} expected-note{{use 'Int.foo()' instead}} {{3-21=0.foo}} {{22-26=}}
-  deprecatedInstanceMessage(a: 0) // expected-warning{{'deprecatedInstanceMessage(a:)' is deprecated: blah}} expected-note{{use 'Int.foo()' instead}} {{3-28=0.foo}} {{29-33=}}
+  deprecatedInstance(a: 0) // expected-warning{{'deprecatedInstance(a:)' is deprecated: replaced by instance method 'Int.foo()' [availability_deprecated]}} expected-note{{use 'Int.foo()' instead}} {{3-21=0.foo}} {{22-26=}}
+  deprecatedInstanceMessage(a: 0) // expected-warning{{'deprecatedInstanceMessage(a:)' is deprecated: blah [availability_deprecated]}} expected-note{{use 'Int.foo()' instead}} {{3-28=0.foo}} {{29-33=}}
 
   unavailableNestedInstance(a: 0) // expected-error{{'unavailableNestedInstance(a:)' has been replaced by instance method 'Foo.Bar.foo()'}} {{3-28=0.foo}} {{29-33=}}
 }
@@ -519,13 +519,13 @@ func testRenameGetters() {
   unavailableClassPropertyMessage() // expected-error{{'unavailableClassPropertyMessage()' has been replaced by property 'Int.prop': blah}} {{3-34=Int.prop}} {{34-36=}}
   unavailableGlobalPropertyMessage() // expected-error{{'unavailableGlobalPropertyMessage()' has been replaced by 'global': blah}} {{3-35=global}} {{35-37=}}
 
-  deprecatedInstanceProperty(a: 1) // expected-warning {{'deprecatedInstanceProperty(a:)' is deprecated: replaced by property 'Int.prop'}} expected-note{{use 'Int.prop' instead}} {{3-29=1.prop}} {{29-35=}}
-  deprecatedClassProperty() // expected-warning {{'deprecatedClassProperty()' is deprecated: replaced by property 'Int.prop'}} expected-note{{use 'Int.prop' instead}} {{3-26=Int.prop}} {{26-28=}}
-  deprecatedGlobalProperty() // expected-warning {{'deprecatedGlobalProperty()' is deprecated: replaced by 'global'}} expected-note{{use 'global' instead}} {{3-27=global}} {{27-29=}}
+  deprecatedInstanceProperty(a: 1) // expected-warning {{'deprecatedInstanceProperty(a:)' is deprecated: replaced by property 'Int.prop' [availability_deprecated]}} expected-note{{use 'Int.prop' instead}} {{3-29=1.prop}} {{29-35=}}
+  deprecatedClassProperty() // expected-warning {{'deprecatedClassProperty()' is deprecated: replaced by property 'Int.prop' [availability_deprecated]}} expected-note{{use 'Int.prop' instead}} {{3-26=Int.prop}} {{26-28=}}
+  deprecatedGlobalProperty() // expected-warning {{'deprecatedGlobalProperty()' is deprecated: replaced by 'global' [availability_deprecated]}} expected-note{{use 'global' instead}} {{3-27=global}} {{27-29=}}
 
-  deprecatedInstancePropertyMessage(a: 1) // expected-warning {{'deprecatedInstancePropertyMessage(a:)' is deprecated: blah}} expected-note{{use 'Int.prop' instead}} {{3-36=1.prop}} {{36-42=}}
-  deprecatedClassPropertyMessage() // expected-warning {{'deprecatedClassPropertyMessage()' is deprecated: blah}} expected-note{{use 'Int.prop' instead}} {{3-33=Int.prop}} {{33-35=}}
-  deprecatedGlobalPropertyMessage() // expected-warning {{'deprecatedGlobalPropertyMessage()' is deprecated: blah}} expected-note{{use 'global' instead}} {{3-34=global}} {{34-36=}}
+  deprecatedInstancePropertyMessage(a: 1) // expected-warning {{'deprecatedInstancePropertyMessage(a:)' is deprecated: blah [availability_deprecated]}} expected-note{{use 'Int.prop' instead}} {{3-36=1.prop}} {{36-42=}}
+  deprecatedClassPropertyMessage() // expected-warning {{'deprecatedClassPropertyMessage()' is deprecated: blah [availability_deprecated]}} expected-note{{use 'Int.prop' instead}} {{3-33=Int.prop}} {{33-35=}}
+  deprecatedGlobalPropertyMessage() // expected-warning {{'deprecatedGlobalPropertyMessage()' is deprecated: blah [availability_deprecated]}} expected-note{{use 'global' instead}} {{3-34=global}} {{34-36=}}
 }
 
 @available(*, unavailable, renamed: "setter:Int.prop(self:_:)")
@@ -636,7 +636,7 @@ class DeprecatedInitBase {
   convenience init(testSelf: Int) {
     // https://github.com/apple/swift/issues/57354
     // The fix-it should not remove `.init`
-    self.init(old: testSelf) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{15-18=new}}
+    self.init(old: testSelf) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{15-18=new}}
   }
 
   init(testSuper: Int) {}
@@ -655,32 +655,32 @@ class DeprecatedInitSub1: DeprecatedInitBase {
   override init(testSuper: Int) {
     // https://github.com/apple/swift/issues/57354
     // The fix-it should not remove `.init`
-    super.init(old: testSuper) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{16-19=new}}
+    super.init(old: testSuper) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{16-19=new}}
   }
 }
 
 class DeprecatedInitSub2: DeprecatedInitBase { }
 
-_ = DeprecatedInitBase(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
-_ = DeprecatedInitBase.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
-let _: DeprecatedInitBase = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
-_ = DeprecatedInitSub2(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
-_ = DeprecatedInitSub2.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
-let _: DeprecatedInitSub2 = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
+_ = DeprecatedInitBase(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
+_ = DeprecatedInitBase.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
+let _: DeprecatedInitBase = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
+_ = DeprecatedInitSub2(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
+_ = DeprecatedInitSub2.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
+let _: DeprecatedInitSub2 = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
 
-_ = DeprecatedInitBase(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
-_ = DeprecatedInitBase.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
-let _: DeprecatedInitBase = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
-_ = DeprecatedInitSub2(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
-_ = DeprecatedInitSub2.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
-let _: DeprecatedInitSub2 = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
+_ = DeprecatedInitBase(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
+_ = DeprecatedInitBase.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
+let _: DeprecatedInitBase = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
+_ = DeprecatedInitSub2(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
+_ = DeprecatedInitSub2.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
+let _: DeprecatedInitSub2 = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
 
-_ = DeprecatedInitBase(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
-_ = DeprecatedInitBase.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
-let _: DeprecatedInitBase = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
-_ = DeprecatedInitSub2(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
-_ = DeprecatedInitSub2.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
-let _: DeprecatedInitSub2 = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
+_ = DeprecatedInitBase(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
+_ = DeprecatedInitBase.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
+let _: DeprecatedInitBase = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
+_ = DeprecatedInitSub2(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
+_ = DeprecatedInitSub2.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
+let _: DeprecatedInitSub2 = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)' [availability_deprecated]}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
 
 
 class Base {
@@ -950,31 +950,31 @@ var deprecatedProperty: Int {
   @available(*, deprecated, message: "bad setter") set {}
 }
 
-_ = deprecatedGetter // expected-warning {{getter for 'deprecatedGetter' is deprecated}} {{none}}
+_ = deprecatedGetter // expected-warning {{getter for 'deprecatedGetter' is deprecated [availability_deprecated]}} {{none}}
 deprecatedGetter = 0
-deprecatedGetter += 1 // expected-warning {{getter for 'deprecatedGetter' is deprecated}} {{none}}
+deprecatedGetter += 1 // expected-warning {{getter for 'deprecatedGetter' is deprecated [availability_deprecated]}} {{none}}
 
-_ = deprecatedGetterOnly // expected-warning {{getter for 'deprecatedGetterOnly' is deprecated}} {{none}}
+_ = deprecatedGetterOnly // expected-warning {{getter for 'deprecatedGetterOnly' is deprecated [availability_deprecated]}} {{none}}
 
 _ = deprecatedSetter
-deprecatedSetter = 0 // expected-warning {{setter for 'deprecatedSetter' is deprecated}} {{none}}
-deprecatedSetter += 1 // expected-warning {{setter for 'deprecatedSetter' is deprecated}} {{none}}
+deprecatedSetter = 0 // expected-warning {{setter for 'deprecatedSetter' is deprecated [availability_deprecated]}} {{none}}
+deprecatedSetter += 1 // expected-warning {{setter for 'deprecatedSetter' is deprecated [availability_deprecated]}} {{none}}
 
-_ = deprecatedBoth // expected-warning {{getter for 'deprecatedBoth' is deprecated}} {{none}}
-deprecatedBoth = 0 // expected-warning {{setter for 'deprecatedBoth' is deprecated}} {{none}}
-deprecatedBoth += 1 // expected-warning {{getter for 'deprecatedBoth' is deprecated}} {{none}} expected-warning {{setter for 'deprecatedBoth' is deprecated}} {{none}}
+_ = deprecatedBoth // expected-warning {{getter for 'deprecatedBoth' is deprecated [availability_deprecated]}} {{none}}
+deprecatedBoth = 0 // expected-warning {{setter for 'deprecatedBoth' is deprecated [availability_deprecated]}} {{none}}
+deprecatedBoth += 1 // expected-warning {{getter for 'deprecatedBoth' is deprecated [availability_deprecated]}} {{none}} expected-warning {{setter for 'deprecatedBoth' is deprecated [availability_deprecated]}} {{none}}
 
-_ = deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}}
-deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
-deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
+_ = deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}}
+deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
+deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
 
-_ = deprecatedRename // expected-warning {{getter for 'deprecatedRename' is deprecated: renamed to 'betterThing()'}} {{none}}
-deprecatedRename = 0  // expected-warning {{setter for 'deprecatedRename' is deprecated: renamed to 'setBetterThing(_:)'}} {{none}}
-deprecatedRename += 1 // expected-warning {{getter for 'deprecatedRename' is deprecated: renamed to 'betterThing()'}} {{none}} expected-warning {{setter for 'deprecatedRename' is deprecated: renamed to 'setBetterThing(_:)'}} {{none}}
+_ = deprecatedRename // expected-warning {{getter for 'deprecatedRename' is deprecated: renamed to 'betterThing()' [availability_deprecated]}} {{none}}
+deprecatedRename = 0  // expected-warning {{setter for 'deprecatedRename' is deprecated: renamed to 'setBetterThing(_:)' [availability_deprecated]}} {{none}}
+deprecatedRename += 1 // expected-warning {{getter for 'deprecatedRename' is deprecated: renamed to 'betterThing()' [availability_deprecated]}} {{none}} expected-warning {{setter for 'deprecatedRename' is deprecated: renamed to 'setBetterThing(_:)' [availability_deprecated]}} {{none}}
 
-_ = deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated: bad variable}} {{none}}
-deprecatedProperty = 0 // expected-warning {{'deprecatedProperty' is deprecated: bad variable}} {{none}}
-deprecatedProperty += 1 // expected-warning {{'deprecatedProperty' is deprecated: bad variable}} {{none}}
+_ = deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated: bad variable [availability_deprecated]}} {{none}}
+deprecatedProperty = 0 // expected-warning {{'deprecatedProperty' is deprecated: bad variable [availability_deprecated]}} {{none}}
+deprecatedProperty += 1 // expected-warning {{'deprecatedProperty' is deprecated: bad variable [availability_deprecated]}} {{none}}
 
 var unavailableGetter: Int {
   @available(*, unavailable) get { return 0 } // expected-note * {{here}}
@@ -1060,29 +1060,29 @@ struct DeprecatedAccessors {
   }
 
   mutating func testAccessors(other: inout DeprecatedAccessors) {
-    _ = deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}}
-    deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
-    deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
+    _ = deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}}
+    deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
+    deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
 
-    _ = other.deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}}
-    other.deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
-    other.deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter}} {{none}}
+    _ = other.deprecatedMessage // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}}
+    other.deprecatedMessage = 0 // expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
+    other.deprecatedMessage += 1 // expected-warning {{getter for 'deprecatedMessage' is deprecated: bad getter [availability_deprecated]}} {{none}} expected-warning {{setter for 'deprecatedMessage' is deprecated: bad setter [availability_deprecated]}} {{none}}
 
-    _ = other.deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated: bad property}} {{none}}
-    other.deprecatedProperty = 0 // expected-warning {{'deprecatedProperty' is deprecated: bad property}} {{none}}
-    other.deprecatedProperty += 1 // expected-warning {{'deprecatedProperty' is deprecated: bad property}} {{none}}
+    _ = other.deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated: bad property [availability_deprecated]}} {{none}}
+    other.deprecatedProperty = 0 // expected-warning {{'deprecatedProperty' is deprecated: bad property [availability_deprecated]}} {{none}}
+    other.deprecatedProperty += 1 // expected-warning {{'deprecatedProperty' is deprecated: bad property [availability_deprecated]}} {{none}}
 
-    _ = DeprecatedAccessors.staticDeprecated // expected-warning {{getter for 'staticDeprecated' is deprecated: bad getter}} {{none}}
-    DeprecatedAccessors.staticDeprecated = 0 // expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter}} {{none}}
-    DeprecatedAccessors.staticDeprecated += 1 // expected-warning {{getter for 'staticDeprecated' is deprecated: bad getter}} {{none}} expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter}} {{none}}
+    _ = DeprecatedAccessors.staticDeprecated // expected-warning {{getter for 'staticDeprecated' is deprecated: bad getter [availability_deprecated]}} {{none}}
+    DeprecatedAccessors.staticDeprecated = 0 // expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter [availability_deprecated]}} {{none}}
+    DeprecatedAccessors.staticDeprecated += 1 // expected-warning {{getter for 'staticDeprecated' is deprecated: bad getter [availability_deprecated]}} {{none}} expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter [availability_deprecated]}} {{none}}
 
-    _ = other[0] // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}} {{none}}
-    other[0] = 0 // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}} {{none}}
-    other[0] += 1 // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}} {{none}} expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}} {{none}}
+    _ = other[0] // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter [availability_deprecated]}} {{none}}
+    other[0] = 0 // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter [availability_deprecated]}} {{none}}
+    other[0] += 1 // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter [availability_deprecated]}} {{none}} expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter [availability_deprecated]}} {{none}}
 
-    _ = other[alsoDeprecated: 0] // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript!}} {{none}}
-    other[alsoDeprecated: 0] = 0 // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript!}} {{none}}
-    other[alsoDeprecated: 0] += 1 // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript!}} {{none}}
+    _ = other[alsoDeprecated: 0] // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript! [availability_deprecated]}} {{none}}
+    other[alsoDeprecated: 0] = 0 // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript! [availability_deprecated]}} {{none}}
+    other[alsoDeprecated: 0] += 1 // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript! [availability_deprecated]}} {{none}}
   }
 }
 
@@ -1198,7 +1198,7 @@ struct BadRename {
 }
 
 func testBadRename() {
-  _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: replaced by 'init(range:step:)'}}
+  _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: replaced by 'init(range:step:)' [availability_deprecated]}}
   // expected-note@-1{{use 'init(range:step:)' instead}}
 }
 
@@ -1231,27 +1231,27 @@ func threeTrailingClosuresRemoveLabels(_ x: TypeWithTrailingClosures, a: () -> V
 func variadicTrailingClosures(_ x: TypeWithTrailingClosures, a: (() -> Void)...) {}
 
 func testMultipleTrailingClosures(_ x: TypeWithTrailingClosures) {
-  twoTrailingClosures(x) {} b: {} // expected-warning {{'twoTrailingClosures(_:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)'}}
+  twoTrailingClosures(x) {} b: {} // expected-warning {{'twoTrailingClosures(_:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' instead}} {{3-22=x.twoTrailingClosures}} {{23-24=}} {{none}}
   x.twoTrailingClosures() {} b: {}
 
-  twoTrailingClosuresWithDefaults(x: x) {} b: {} // expected-warning {{'twoTrailingClosuresWithDefaults(x:y:z:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)'}}
+  twoTrailingClosuresWithDefaults(x: x) {} b: {} // expected-warning {{'twoTrailingClosuresWithDefaults(x:y:z:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' instead}} {{3-34=x.twoTrailingClosures}} {{35-39=}} {{none}}
   x.twoTrailingClosures() {} b: {}
 
-  threeTrailingClosures(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosures(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)'}}
+  threeTrailingClosures(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosures(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' instead}} {{3-24=x.threeTrailingClosures}} {{25-28=}} {{none}}
   x.threeTrailingClosures(a: {}) {} c: {}
 
-  threeTrailingClosuresDiffLabels(x, x: {}) {} z: {} // expected-warning {{'threeTrailingClosuresDiffLabels(_:x:y:z:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)'}}
+  threeTrailingClosuresDiffLabels(x, x: {}) {} z: {} // expected-warning {{'threeTrailingClosuresDiffLabels(_:x:y:z:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' instead}} {{3-34=x.threeTrailingClosures}} {{35-38=}} {{38-39=a}} {{48-49=c}} {{none}}
   x.threeTrailingClosures(a: {}) {} c: {}
 
-  threeTrailingClosuresRemoveLabels(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosuresRemoveLabels(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeUnlabeledTrailingClosures(_:_:_:)'}}
+  threeTrailingClosuresRemoveLabels(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosuresRemoveLabels(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeUnlabeledTrailingClosures(_:_:_:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.threeUnlabeledTrailingClosures(_:_:_:)' instead}} {{3-36=x.threeUnlabeledTrailingClosures}} {{37-40=}} {{40-43=}} {{50-51=_}} {{none}}
   x.threeUnlabeledTrailingClosures({}) {} _: {}
 
-  variadicTrailingClosures(x) {} _: {} _: {} // expected-warning {{'variadicTrailingClosures(_:a:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.variadicTrailingClosures(a:b:c:)'}}
+  variadicTrailingClosures(x) {} _: {} _: {} // expected-warning {{'variadicTrailingClosures(_:a:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.variadicTrailingClosures(a:b:c:)' [availability_deprecated]}}
   // expected-note@-1 {{use 'TypeWithTrailingClosures.variadicTrailingClosures(a:b:c:)' instead}} {{3-27=x.variadicTrailingClosures}} {{28-29=}} {{none}}
   x.variadicTrailingClosures() {} _: {} _: {}
 }
@@ -1294,16 +1294,16 @@ struct UnavailableSubscripts {
     _ = self[getAValue: 3] // expected-error {{'subscript(getAValue:)' has been renamed to 'getAValue(new:)'}} {{13-14=.getAValue(}} {{26-27=)}} {{14-23=new}}
     _ = x[getAValue: 3] // expected-error {{'subscript(getAValue:)' has been renamed to 'getAValue(new:)'}} {{10-11=.getAValue(}} {{23-24=)}} {{11-20=new}}
 
-    _ = self[argg1: 3, argg2: 3, argg3: 3] // expected-warning {{'subscript(argg1:argg2:argg3:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)'}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{14-19=arg1}} {{24-29=arg2}} {{34-39=arg3}}
-    _ = x[argg1: 3, argg2: 3, argg3: 3] // expected-warning {{'subscript(argg1:argg2:argg3:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)'}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{11-16=arg1}} {{21-26=arg2}} {{31-36=arg3}}
+    _ = self[argg1: 3, argg2: 3, argg3: 3] // expected-warning {{'subscript(argg1:argg2:argg3:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)' [availability_deprecated]}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{14-19=arg1}} {{24-29=arg2}} {{34-39=arg3}}
+    _ = x[argg1: 3, argg2: 3, argg3: 3] // expected-warning {{'subscript(argg1:argg2:argg3:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)' [availability_deprecated]}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{11-16=arg1}} {{21-26=arg2}} {{31-36=arg3}}
 
     // Different number of parameters emit no fixit
-    _ = self[only1: 3, only2: 3] // expected-warning {{'subscript(only1:only2:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)'}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{none}}
+    _ = self[only1: 3, only2: 3] // expected-warning {{'subscript(only1:only2:)' is deprecated: renamed to 'subscript(arg1:arg2:arg3:)' [availability_deprecated]}} // expected-note {{use 'subscript(arg1:arg2:arg3:)' instead}} {{none}}
 
     _ = self[3, 3, 3] // expected-error {{'subscript(_:_:_:)' has been renamed to 'subscript(arg1:arg2:arg3:)'}} {{14-14=arg1: }} {{17-17=arg2: }} {{20-20=arg3: }}
     _ = x[3, 3, 3] // expected-error {{'subscript(_:_:_:)' has been renamed to 'subscript(arg1:arg2:arg3:)'}} {{11-11=arg1: }} {{14-14=arg2: }} {{17-17=arg3: }}
 
-    _ = self[to: 3] // expected-warning {{'subscript(to:)' is deprecated: renamed to 'subscriptTo(_:)'}} // expected-note {{use 'subscriptTo(_:)' instead}} {{13-14=.subscriptTo(}} {{19-20=)}} {{14-18=}}
-    _ = x[to: 3] // expected-warning {{'subscript(to:)' is deprecated: renamed to 'subscriptTo(_:)'}} // expected-note {{use 'subscriptTo(_:)' instead}} {{10-11=.subscriptTo(}} {{16-17=)}} {{11-15=}}
+    _ = self[to: 3] // expected-warning {{'subscript(to:)' is deprecated: renamed to 'subscriptTo(_:)' [availability_deprecated]}} // expected-note {{use 'subscriptTo(_:)' instead}} {{13-14=.subscriptTo(}} {{19-20=)}} {{14-18=}}
+    _ = x[to: 3] // expected-warning {{'subscript(to:)' is deprecated: renamed to 'subscriptTo(_:)' [availability_deprecated]}} // expected-note {{use 'subscriptTo(_:)' instead}} {{10-11=.subscriptTo(}} {{16-17=)}} {{11-15=}}
   }
 }

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -1,8 +1,8 @@
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs/custom-modules
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -parse-as-library -I %S/Inputs/custom-modules
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -print-diagnostic-groups -I %S/Inputs/custom-modules
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -print-diagnostic-groups -parse-as-library -I %S/Inputs/custom-modules
 
 import ObjcAsync
 
@@ -275,7 +275,7 @@ func asyncContext(t: HandlerTest) async {
   // expected-warning@+1{{consider using asynchronous alternative function}}
   defaultedParamsEnd4(arg: 1) { }
   // expected-warning@+2{{consider using asynchronous alternative function}}
-  // expected-warning@+1{{'manyAttrs(completionHandler:)' is deprecated}}
+  // expected-warning@+1{{'manyAttrs(completionHandler:)' is deprecated [availability_deprecated]}}
   manyAttrs() { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
   platformOnly() { }

--- a/test/attr/attr_availability_types.swift
+++ b/test/attr/attr_availability_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups
 
 // Test that availability analysis traverses our type representations.
 
@@ -6,36 +6,36 @@
 class D {}
 
 protocol P<T1> {
-  associatedtype T1 = D // expected-warning {{'D' is deprecated}}
-  associatedtype T2: P where T2: D // expected-warning {{'D' is deprecated}}
+  associatedtype T1 = D // expected-warning {{'D' is deprecated [availability_deprecated]}}
+  associatedtype T2: P where T2: D // expected-warning {{'D' is deprecated [availability_deprecated]}}
 }
 
-class C<T1>: D { // expected-warning {{'D' is deprecated}}
+class C<T1>: D { // expected-warning {{'D' is deprecated [availability_deprecated]}}
   struct Nested<T2> {
-    let d: D // expected-warning {{'D' is deprecated}}
+    let d: D // expected-warning {{'D' is deprecated [availability_deprecated]}}
   }
 }
-extension C<D> {} // expected-warning {{'D' is deprecated}}
+extension C<D> {} // expected-warning {{'D' is deprecated [availability_deprecated]}}
 
 func f<each T>(
   _: (
-    D, // expected-warning {{'D' is deprecated}}
-    (D), // expected-warning {{'D' is deprecated}}
-    C<D> // expected-warning {{'D' is deprecated}}
-      .Nested<D>, // expected-warning {{'D' is deprecated}}
-    () -> D, // expected-warning {{'D' is deprecated}}
-    (inout D) -> Void, // expected-warning {{'D' is deprecated}}
-    (D...) -> Void, // expected-warning {{'D' is deprecated}}
-    D?, // expected-warning {{'D' is deprecated}}
-    [D], // expected-warning {{'D' is deprecated}}
-    [Int : D], // expected-warning {{'D' is deprecated}}
+    D, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    (D), // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    C<D> // expected-warning {{'D' is deprecated [availability_deprecated]}}
+      .Nested<D>, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    () -> D, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    (inout D) -> Void, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    (D...) -> Void, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    D?, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    [D], // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    [Int : D], // expected-warning {{'D' is deprecated [availability_deprecated]}}
     // FIXME: Emitted twice.
-    some P<D>, // expected-warning 2 {{'D' is deprecated}}
-    any P<D>, // expected-warning {{'D' is deprecated}}
-    any C<D> & P, // expected-warning {{'D' is deprecated}}
-    D.Type, // expected-warning {{'D' is deprecated}}
-    repeat (D, each T) // expected-warning {{'D' is deprecated}}
+    some P<D>, // expected-warning 2 {{'D' is deprecated [availability_deprecated]}}
+    any P<D>, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    any C<D> & P, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    D.Type, // expected-warning {{'D' is deprecated [availability_deprecated]}}
+    repeat (D, each T) // expected-warning {{'D' is deprecated [availability_deprecated]}}
   ),
-  _: @escaping (D) -> Void // expected-warning {{'D' is deprecated}}
+  _: @escaping (D) -> Void // expected-warning {{'D' is deprecated [availability_deprecated]}}
 )
-where repeat each T: D {} // expected-warning {{'D' is deprecated}}
+where repeat each T: D {} // expected-warning {{'D' is deprecated [availability_deprecated]}}

--- a/test/diagnostics/print-diagnostic-groups.swift
+++ b/test/diagnostics/print-diagnostic-groups.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -print-diagnostic-groups %s 2>&1 | %FileCheck %s --check-prefix=CHECK
+
+
+// This test checks that "-print-diagnostic-groups" prints the diagnostic group
+// if it exists, and prints nothing if it does not.
+
+
+@available(*, deprecated, renamed: "bar2")
+func bar() {
+}
+
+// CHECK: warning: 'bar()' is deprecated: renamed to 'bar2' [availability_deprecated]{{$}}
+bar()
+
+
+func foo() {
+  // CHECK: warning: initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it{{$}}
+  let x = 42
+}

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups
 // REQUIRES: concurrency
 
 // Make sure the import succeeds
@@ -8,7 +8,7 @@ import _Concurrency
 // short-term source compatibility)
 @available(SwiftStdlib 5.1, *)
 extension PartialAsyncTask {
-  // expected-warning@-1 {{'PartialAsyncTask' is deprecated: renamed to 'UnownedJob'}}
+  // expected-warning@-1 {{'PartialAsyncTask' is deprecated: renamed to 'UnownedJob' [availability_deprecated]}}
   // expected-note@-2 {{use 'UnownedJob' instead}}
 }
 @available(SwiftStdlib 5.1, *)

--- a/test/stdlib/FlatMapDeprecation.swift
+++ b/test/stdlib/FlatMapDeprecation.swift
@@ -1,32 +1,32 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -print-diagnostic-groups
 
 func flatMapOnSequence<
   S : Sequence
 >(xs: S, f: (S.Element) -> S.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value [availability_deprecated]}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazySequence<
   S : LazySequenceProtocol
 >(xs: S, f: (S.Element) -> S.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value [availability_deprecated]}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazyCollection<
   C : LazyCollectionProtocol
 >(xs: C, f: (C.Element) -> C.Element?) {
-  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value [availability_deprecated]}} expected-note {{compactMap}}
 }
 
 func flatMapOnLazyBidirectionalCollection<
   C : LazyCollectionProtocol & BidirectionalCollection
 >(xs: C, f: (C.Element) -> C.Element?)
 where C.Elements : BidirectionalCollection {
-  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value [availability_deprecated]}} expected-note {{compactMap}}
 }
 
 func flatMapOnCollectionOfStrings<
   C : Collection
 >(xs: C, f: (C.Element) -> String?) {
-  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value}} expected-note {{compactMap}}
+  _ = xs.flatMap(f) // expected-warning {{'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value [availability_deprecated]}} expected-note {{compactMap}}
 }

--- a/test/stdlib/FloatConstants.swift
+++ b/test/stdlib/FloatConstants.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups
 
 #if canImport(Darwin)
   import Darwin
@@ -14,20 +14,20 @@
 #error("Unsupported platform")
 #endif
 
-_ = FLT_RADIX // expected-warning {{is deprecated}}
+_ = FLT_RADIX //  expected-warning {{is deprecated: Please use 'T.radix' to get the radix of a FloatingPoint type 'T'. [availability_deprecated]}}
 
-_ = FLT_MANT_DIG // expected-warning {{is deprecated}}
-_ = FLT_MIN_EXP // expected-warning {{is deprecated}}
-_ = FLT_MAX_EXP // expected-warning {{is deprecated}}
-_ = FLT_MAX // expected-warning {{is deprecated}}
-_ = FLT_EPSILON // expected-warning {{is deprecated}}
-_ = FLT_MIN // expected-warning {{is deprecated}}
-_ = FLT_TRUE_MIN // expected-warning {{is deprecated}}
+_ = FLT_MANT_DIG // expected-warning {{is deprecated: Please use 'Float.significandBitCount + 1'. [availability_deprecated]}}
+_ = FLT_MIN_EXP // expected-warning {{is deprecated: Please use 'Float.leastNormalMagnitude.exponent + 1'. [availability_deprecated]}}
+_ = FLT_MAX_EXP // expected-warning {{is deprecated: Please use 'Float.greatestFiniteMagnitude.exponent + 1'. [availability_deprecated]}}
+_ = FLT_MAX // expected-warning {{is deprecated: Please use 'Float.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'. [availability_deprecated]}}
+_ = FLT_EPSILON // expected-warning {{is deprecated: Please use 'Float.ulpOfOne' or '.ulpOfOne'. [availability_deprecated]}}
+_ = FLT_MIN // expected-warning {{is deprecated: Please use 'Float.leastNormalMagnitude' or '.leastNormalMagnitude'. [availability_deprecated]}}
+_ = FLT_TRUE_MIN // expected-warning {{is deprecated: Please use 'Float.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'. [availability_deprecated]}}
 
-_ = DBL_MANT_DIG // expected-warning {{is deprecated}}
-_ = DBL_MIN_EXP // expected-warning {{is deprecated}}
-_ = DBL_MAX_EXP // expected-warning {{is deprecated}}
-_ = DBL_MAX // expected-warning {{is deprecated}}
-_ = DBL_EPSILON // expected-warning {{is deprecated}}
-_ = DBL_MIN // expected-warning {{is deprecated}}
-_ = DBL_TRUE_MIN // expected-warning {{is deprecated}}
+_ = DBL_MANT_DIG // expected-warning {{is deprecated: Please use 'Double.significandBitCount + 1'. [availability_deprecated]}}
+_ = DBL_MIN_EXP // expected-warning {{is deprecated: Please use 'Double.leastNormalMagnitude.exponent + 1'. [availability_deprecated]}}
+_ = DBL_MAX_EXP // expected-warning {{is deprecated: Please use 'Double.greatestFiniteMagnitude.exponent + 1'. [availability_deprecated]}}
+_ = DBL_MAX // expected-warning {{is deprecated: Please use 'Double.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'. [availability_deprecated]}}
+_ = DBL_EPSILON // expected-warning {{is deprecated: Please use 'Double.ulpOfOne' or '.ulpOfOne'. [availability_deprecated]}}
+_ = DBL_MIN // expected-warning {{is deprecated: Please use 'Double.leastNormalMagnitude' or '.leastNormalMagnitude'. [availability_deprecated]}}
+_ = DBL_TRUE_MIN // expected-warning {{is deprecated: Please use 'Double.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'. [availability_deprecated]}}

--- a/test/stdlib/IndexDistanceRemoval.swift
+++ b/test/stdlib/IndexDistanceRemoval.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -print-diagnostic-groups
 
 struct Int64Distance<Element>: Collection {
   let _storage: [Element]
@@ -16,7 +16,7 @@ struct Int64Distance<Element>: Collection {
 let c = Int64Distance(_storage: [1,2,3])
 
 let i64: Int64 = 2
-_ = c.index(c.startIndex, offsetBy: i64) // expected-warning {{'index(_:offsetBy:)' is deprecated: all index distances are now of type Int}}
+_ = c.index(c.startIndex, offsetBy: i64) // expected-warning {{'index(_:offsetBy:)' is deprecated: all index distances are now of type Int [availability_deprecated]}}
 
-let _: Int64 = c.distance(from: c.startIndex, to: c.endIndex) // expected-warning {{distance(from:to:)' is deprecated: all index distances are now of type Int}}
+let _: Int64 = c.distance(from: c.startIndex, to: c.endIndex) // expected-warning {{distance(from:to:)' is deprecated: all index distances are now of type Int [availability_deprecated]}}
 

--- a/test/stdlib/IndexOfRenaming.swift
+++ b/test/stdlib/IndexOfRenaming.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -print-diagnostic-groups
 
 let a = [10, 20, 30, 40, 50, 60]
 
-_ = a.index(of: 30) // expected-warning {{'index(of:)' is deprecated: renamed to 'firstIndex(of:)'}} expected-note {{use 'firstIndex(of:)' instead}}
+_ = a.index(of: 30) // expected-warning {{'index(of:)' is deprecated: renamed to 'firstIndex(of:)' [availability_deprecated]}} expected-note {{use 'firstIndex(of:)' instead}}
 _ = a.firstIndex(of: 30)
-_ = a.index(where: { $0 > 30 }) // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)'}} expected-note {{use 'firstIndex(where:)' instead}}
+_ = a.index(where: { $0 > 30 }) // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)' [availability_deprecated]}} expected-note {{use 'firstIndex(where:)' instead}}
 _ = a.firstIndex(where: { $0 > 30 })

--- a/test/stdlib/MathConstants.swift
+++ b/test/stdlib/MathConstants.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups
 
 #if canImport(Darwin)
   import Darwin
@@ -14,9 +14,9 @@
 #error("Unsupported platform")
 #endif
 
-_ = M_PI // expected-warning {{is deprecated}}
-_ = M_PI_2 // expected-warning {{is deprecated}}
-_ = M_PI_4 // expected-warning {{is deprecated}}
+_ = M_PI // expected-warning {{is deprecated: Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting. [availability_deprecated]}}
+_ = M_PI_2 // expected-warning {{is deprecated: Please use 'Double.pi / 2' or '.pi / 2' to get the value of correct type and avoid casting. [availability_deprecated]}}
+_ = M_PI_4 // expected-warning {{is deprecated: Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting. [availability_deprecated]}}
 
-_ = M_SQRT2 // expected-warning {{is deprecated}}
-_ = M_SQRT1_2 // expected-warning {{is deprecated}}
+_ = M_SQRT2 // expected-warning {{is deprecated: Please use '2.squareRoot()'. [availability_deprecated]}}
+_ = M_SQRT1_2 // expected-warning {{is deprecated: Please use '0.5.squareRoot()'. [availability_deprecated]}}

--- a/test/stdlib/StringAPICStringDiagnostics.swift
+++ b/test/stdlib/StringAPICStringDiagnostics.swift
@@ -1,37 +1,37 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -print-diagnostic-groups
 
 import StdlibUnittest
 
 func checkStringOverloadCompilationDiagnostics() {
 
-  _ = String(cString: "string") // expected-warning {{'init(cString:)' is deprecated: Use a copy of the String argument}}
+  _ = String(cString: "string") // expected-warning {{'init(cString:)' is deprecated: Use a copy of the String argument [availability_deprecated]}}
 
-  _ = String(validatingUTF8: "string") // expected-warning {{init(validatingUTF8:)' is deprecated: Use a copy of the String argument}}
+  _ = String(validatingUTF8: "string") // expected-warning {{init(validatingUTF8:)' is deprecated: Use a copy of the String argument [availability_deprecated]}}
 
-  _ = String(validatingCString: "string") // expected-warning {{'init(validatingCString:)' is deprecated: Use a copy of the String argument}}
+  _ = String(validatingCString: "string") // expected-warning {{'init(validatingCString:)' is deprecated: Use a copy of the String argument [availability_deprecated]}}
 
-  _ = String.decodeCString("string", as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use a copy of the String argument}}
+  _ = String.decodeCString("string", as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use a copy of the String argument [availability_deprecated]}}
 
-  _ = String(decodingCString: "string", as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use a copy of the String argument}}
+  _ = String(decodingCString: "string", as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use a copy of the String argument [availability_deprecated]}}
 }
 
 func checkInoutConversionOverloadCompilationDiagnostics() {
 
   var i = UInt8.zero
 
-  _ = String(cString: &i) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String(cString: &i) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 
   var c = CChar.zero
 
-  _ = String(cString: &c) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String(cString: &c) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 
-  _ = String(validatingUTF8: &c) // expected-warning {{init(validatingUTF8:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String(validatingUTF8: &c) // expected-warning {{init(validatingUTF8:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 
-  _ = String(validatingCString: &c) // expected-warning {{'init(validatingCString:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String(validatingCString: &c) // expected-warning {{'init(validatingCString:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 
   var u = Unicode.UTF8.CodeUnit.zero
 
-  _ = String.decodeCString(&u, as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String.decodeCString(&u, as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 
-  _ = String(decodingCString: &u, as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
+  _ = String(decodingCString: &u, as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use String(_ scalar: Unicode.Scalar) [availability_deprecated]}}
 }

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -1,18 +1,18 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 4 %s -verify
+// RUN: %target-swift-frontend -typecheck -print-diagnostic-groups -swift-version 4 %s -verify
 
 func testPopFirst() {
   let str = "abc"
-  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String directly}}
-  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String directly}}
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String directly [availability_deprecated]}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String directly [availability_deprecated]}}
   dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use Substring directly}}
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use Substring directly [availability_deprecated]}}
   _ = substr.unicodeScalars.popFirst() // ok
 
-  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use Substring directly}}
-  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use Substring directly}}
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use Substring directly [availability_deprecated]}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use Substring directly [availability_deprecated]}}
   dump(charSubView)
 
   var _ = String(str.utf8) ?? "" // expected-warning{{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}}

--- a/test/stdlib/freestanding_diags_stdlib.swift
+++ b/test/stdlib/freestanding_diags_stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -concurrency-model=task-to-thread
+// RUN: %target-typecheck-verify-swift -concurrency-model=task-to-thread -print-diagnostic-groups
 
 // REQUIRES: freestanding
 
@@ -36,19 +36,19 @@ func foo() async throws {
     _ = tg.addTaskUnlessCancelled { return 1 } // ok
 
     _ = await tg.add(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                   // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
     tg.spawn(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)' [availability_deprecated]}}
                           // expected-note@-1{{use 'addTask(operation:)' instead}}
     _ = tg.spawnUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                              // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
     tg.async(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)' [availability_deprecated]}}
                           // expected-note@-1{{use 'addTask(operation:)' instead}}
     _ = tg.asyncUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                              // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
   }
   func withThrowingTaskGroup(_ tg: inout ThrowingTaskGroup<Int, Error>) async throws {
@@ -58,19 +58,19 @@ func foo() async throws {
     _ = tg.addTaskUnlessCancelled { return 1 } // ok
 
     _ = await tg.add(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                   // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
     tg.spawn(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)' [availability_deprecated]}}
                           // expected-note@-1{{use 'addTask(operation:)' instead}}
     _ = tg.spawnUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                              // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
     tg.async(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)' [availability_deprecated]}}
                           // expected-note@-1{{use 'addTask(operation:)' instead}}
     _ = tg.asyncUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
-    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)' [availability_deprecated]}}
                                              // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
   }
 }


### PR DESCRIPTION
This change adds the `-print-diagnostic-groups` flag as described by SE-0443.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
