### PR TITLE
[preset] Build armv7k and i386 watch modules in package presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1423,6 +1423,9 @@ darwin-toolchain-version=%(darwin_toolchain_version)s
 darwin-toolchain-alias=%(darwin_toolchain_alias)s
 darwin-toolchain-require-use-os-runtime=0
 
+# Build the swiftmodule/tbd for armv7k watchos and i386 watchsimulator.
+swift-darwin-module-archs=armv7k;i386
+
 [preset: mixin_osx_package_test]
 build-subdir=buildbot_osx
 
@@ -2977,6 +2980,9 @@ llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libcla
 swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;libexec;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s
+
+# Build the swiftmodule/tbd for armv7k watchos and i386 watchsimulator.
+swift-darwin-module-archs=armv7k;i386
 
 [preset: source_compat_suite_linux_base]
 mixin-preset=source_compat_suite_base


### PR DESCRIPTION
After bumping the deployment target to watch 9+, these architectures are no longer supported when building dylibs, but we can still build the swiftmodule to support compiling for older platforms.

rdar://135560598