### PR TITLE
[CSSimplify] Don't increase impact if member doesn't exist on Any/Any…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11031,9 +11031,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         impact += 10;
       }
 
-      if (instanceTy->isAny() || instanceTy->isAnyObject())
-        impact += 5;
-
       auto *anchorExpr = getAsExpr(locator->getAnchor());
       if (anchorExpr) {
         if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchorExpr)) {

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -826,3 +826,14 @@ do {
     // expected-error@-1 {{value of type 'any BinaryInteger' has no member 'op'}}
   }
 }
+
+do {
+  func test<T>(_: T) -> T? { nil }
+  func test<U>(_: U) -> Int { 0 }
+
+  func compute(x: Any) {
+    test(x)!.unknown()
+    // expected-error@-1 {{value of type 'Any' has no member 'unknown'}}
+    // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+  }
+}


### PR DESCRIPTION
…Object

`Any` used to be the type used to indicate placeholders before and that's reflected in the score of the `DefineMemberBasedOnUse`, this is no longer the same and the impact increase should be dropped.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
