### PR TITLE
Fix ABI mismatch involving Sendable-refining protocols and deployment targets

### DIFF
--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/non_resilient_protocol.swiftmodule -module-name=non_resilient_protocol %S/../Inputs/non_resilient_protocol.swift
 
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
@@ -8,15 +9,40 @@
 // REQUIRES: OS=macosx
 
 import resilient_protocol
+import non_resilient_protocol
 
+@available(SwiftStdlib 5.10, *)
 func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
 
 // CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable25passResilientSendableBaseyyF"()
+@available(SwiftStdlib 5.10, *)
 func passResilientSendableBase() {
   // CHECK-USAGE-NOT: ret
   // CHECK-USAGE: [[METATYPE:%.*]] = extractvalue
-  // CHECK-USAGE-BEFORE: [[WITNESS_TABLE:%.*]] = call ptr @"$s18resilient_protocol27ConformsToResilientSendableVAcA0eF4BaseAAWl"()
-  // CHECK-USAGE-BEFORE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr [[WITNESS_TABLE]])
-  // CHECK-USAGE-AFTER-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr @"$s18resilient_protocol27ConformsToResilientSendableVAA0eF4BaseAAWP")
+  // CHECK-USAGE: [[WITNESS_TABLE:%.*]] = call ptr @"$s18resilient_protocol27ConformsToResilientSendableVAcA0eF4BaseAAWl"()
+  // CHECK-USAGE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr [[WITNESS_TABLE]])
   acceptResilientSendableBase(ConformsToResilientSendable.self)
+}
+
+@available(SwiftStdlib 6.0, *)
+func acceptNewResilientSendableBase<T: NewResilientSendableBase>(_: T.Type) { }
+
+// CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable28passNewResilientSendableBaseyyF"()
+@available(SwiftStdlib 6.0, *)
+func passNewResilientSendableBase() {
+  // CHECK-USAGE-NOT: ret
+  // CHECK-USAGE: [[METATYPE:%.*]] = extractvalue
+  // CHECK-USAGE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable30acceptNewResilientSendableBaseyyxm010resilient_A00efgH0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr @"$s18resilient_protocol30ConformsToNewResilientSendableVAA0efG4BaseAAWP")
+  acceptNewResilientSendableBase(ConformsToNewResilientSendable.self)
+}
+
+@available(SwiftStdlib 5.10, *)
+func acceptNonResilientSendableBase<T: NonResilientSendableBase>(_: T.Type) { }
+
+// CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable28passNonResilientSendableBaseyyF"()
+@available(SwiftStdlib 5.10, *)
+func passNonResilientSendableBase() {
+  // CHECK-USAGE-NOT: ret
+  // CHECK-USAGE: call swiftcc void @"$s28protocol_resilience_sendable30acceptNonResilientSendableBaseyyxm014non_resilient_A00efgH0RzlF"(ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVN", ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVN", ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVAA0fgH4BaseAAWP")
+  acceptNonResilientSendableBase(ConformsToNonResilientSendable.self)
 }

--- a/test/Inputs/non_resilient_protocol.swift
+++ b/test/Inputs/non_resilient_protocol.swift
@@ -1,0 +1,12 @@
+public protocol NonResilientSendableBase: Sendable {
+  func f()
+}
+
+public protocol NonResilientSendable: NonResilientSendableBase {
+  func g()
+}
+
+public struct ConformsToNonResilientSendable: NonResilientSendable {
+  public func f() { }
+  public func g() { }
+}

--- a/test/Inputs/resilient_protocol.swift
+++ b/test/Inputs/resilient_protocol.swift
@@ -45,16 +45,34 @@ public protocol ResilientSelfDefault : ResilientBaseProtocol {
   func protocolMethod()
 }
 
+@available(SwiftStdlib 5.10, *)
 public protocol ResilientSendableBase: Sendable {
   func f()
 }
 
+@available(SwiftStdlib 5.10, *)
 public protocol ResilientSendable: ResilientSendableBase {
   func g()
 }
 
-
+@available(SwiftStdlib 5.10, *)
 public struct ConformsToResilientSendable: ResilientSendable {
+  public func f() { }
+  public func g() { }
+}
+
+@available(SwiftStdlib 6.0, *)
+public protocol NewResilientSendableBase: Sendable {
+  func f()
+}
+
+@available(SwiftStdlib 6.0, *)
+public protocol NewResilientSendable: NewResilientSendableBase {
+  func g()
+}
+
+@available(SwiftStdlib 6.0, *)
+public struct ConformsToNewResilientSendable: NewResilientSendable {
   public func f() { }
   public func g() { }
 }


### PR DESCRIPTION
A change to the way we determined whether a protocol conformance is "dependent" for marker protocols caused an ABI break for Sendable-refining protocols built with pre-6.0 Swift compilers. The fix for this issue (https://github.com/swiftlang/swift/pull/75769) gated the change on deployment target.

The deployment target change fixed the original problem, then caused a related issue when a project mixes deployment targets (pre-6.0 and 6.0+) with non-resilient protocols. Rework the logic here to (1) look at the availability of the protocol rather than the deployment target, and (2) always use the more efficient (non-dependent) answer for non-resilient protocols.

Fixes rdar://134953989.
