### PR TITLE
[6.0] Fix ABI mismatch involving Sendable-refining non-resilient protocols and deployment targets

### DIFF
--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/non_resilient_protocol.swiftmodule -module-name=non_resilient_protocol %S/../Inputs/non_resilient_protocol.swift
 
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
@@ -8,6 +9,7 @@
 // REQUIRES: OS=macosx
 
 import resilient_protocol
+import non_resilient_protocol
 
 func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
 
@@ -19,4 +21,13 @@ func passResilientSendableBase() {
   // CHECK-USAGE-BEFORE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr [[WITNESS_TABLE]])
   // CHECK-USAGE-AFTER-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr @"$s18resilient_protocol27ConformsToResilientSendableVAA0eF4BaseAAWP")
   acceptResilientSendableBase(ConformsToResilientSendable.self)
+}
+
+func acceptNonResilientSendableBase<T: NonResilientSendableBase>(_: T.Type) { }
+
+// CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable28passNonResilientSendableBaseyyF"()
+func passNonResilientSendableBase() {
+  // CHECK-USAGE-NOT: ret
+  // CHECK-USAGE: call swiftcc void @"$s28protocol_resilience_sendable30acceptNonResilientSendableBaseyyxm014non_resilient_A00efgH0RzlF"(ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVN", ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVN", ptr @"$s22non_resilient_protocol30ConformsToNonResilientSendableVAA0fgH4BaseAAWP")
+  acceptNonResilientSendableBase(ConformsToNonResilientSendable.self)
 }

--- a/test/Inputs/non_resilient_protocol.swift
+++ b/test/Inputs/non_resilient_protocol.swift
@@ -1,0 +1,12 @@
+public protocol NonResilientSendableBase: Sendable {
+  func f()
+}
+
+public protocol NonResilientSendable: NonResilientSendableBase {
+  func g()
+}
+
+public struct ConformsToNonResilientSendable: NonResilientSendable {
+  public func f() { }
+  public func g() { }
+}


### PR DESCRIPTION
- **Explanation**: Conformances to `Sendable`-refining, non-resilient protocols that are built with an older (pre-Swift-6.0) deployment then used from code compiled with newer (Swift 6.0+) deployment target could cause a crash. This regression was caused by a [fix](https://github.com/swiftlang/swift/pull/75770) for an ABI break with such protocols. 
- **Scope**: Affects binaries that use conformances of `Sendable`-conforming protocols across targets with mismatched deployment targets. 
- **Issues**: rdar://134953989
- **Original PRs**: https://github.com/swiftlang/swift/pull/76380
- **Risk**: Low. We're eliminate the deployment-target gating for non-resilient protocols, effectively narrowing the fix from https://github.com/swiftlang/swift/pull/75770 even further.
- **Testing**: Tested against an affected project, plus new tests
- **Reviewer**: @slavapestov 
