### PR TITLE
Relax Swift tool check to find swiftc

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -45,7 +45,7 @@ class EarlySwiftDriver(product.Product):
             return False
 
         if self.args.build_early_swift_driver:
-            if toolchain.host_toolchain().find_tool("swift") is None:
+            if toolchain.host_toolchain().find_tool("swiftc") is None:
                 warn_msg = 'Host toolchain could not locate a '\
                            'compiler to build swift-driver. '\
                            '(Try `--skip-early-swift-driver`)'


### PR DESCRIPTION
The Swift-Driver build here only requires a working `swiftc`, not necessarily all of SPM. Relaxing the required tool check to accept building the driver if there's a Swift compiler available.