### PR TITLE
[embedded] Disable building from textual interface files in Embedded Swift

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3701,6 +3701,7 @@ bool CompilerInvocation::parseArgs(
     IRGenOpts.DisableLegacyTypeInfo = true;
     IRGenOpts.ReflectionMetadata = ReflectionMetadataMode::None;
     IRGenOpts.EnableReflectionNames = false;
+    FrontendOpts.DisableBuildingInterface = true;
     TypeCheckerOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 actor Number {

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 func fib(_ n: Int) -> Int {

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -9,10 +9,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 public func test() async -> Int {

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -11,10 +11,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 // BEGIN BridgingHeader.h
 
 #include <unistd.h>

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -9,10 +9,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import Darwin
 
 @main

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -47,10 +47,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
-// The Darwin SDK overlay module in the macOS SDK cannot be imported in
-// embedded Swift mode.
-// XFAIL: OS=macosx
-
 import _Concurrency
 
 public func test() async -> Int {


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/76359 is removing Darwin.swiftmodule from the local build of the compiler, falling back to the Darwin module in the SDK. As part of that, Embedded Swift tests that used the Darwin module were disabled. This restores the ability to import the Darwin module (including the ability to import the Concurrency module again) by simply disabling building of modules from .swiftinterface files. Embedded Swift does not (currently) allow library evolution to be used, so it doesn't really make sense to attempt doing that in the first place, and when .swiftinterface files are disabled, the fallback path automatically imports the underlaying Clang module if it exists.

rdar://134050928
