### PR TITLE
Swift CI: test: Concurrency/Backdeploy/linking_maccatalyst.swift is failing on macCatalyst

### DIFF
--- a/test/Concurrency/Backdeploy/linking_maccatalyst.swift
+++ b/test/Concurrency/Backdeploy/linking_maccatalyst.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx12 %s -o %t/linking_direct
 // RUN: %target-build-swift -target %target-cpu-apple-macosx11 %s -o %t/linking_rpath
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.13 %s -o %t/linking_rpath_old
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/linking_rpath_old
 
 // RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s


### PR DESCRIPTION
When I did https://github.com/swiftlang/swift/pull/74920 I forgot to update test/Concurrency/Backdeploy/linking_maccatalyst.swift the same way linking.swift got updated.

rdar://132710925