### PR TITLE
[Backtracer][macOS] Fix crashing thread index when Rosetta is in use.

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
@@ -249,11 +249,12 @@ class Target {
 
       if info.thread_id == crashingThread {
         ctx = HostContext.fromHostMContext(mcontext)
-        crashingThreadNdx = Int(ndx)
+        crashingThreadNdx = threads.count
       } else {
         guard let threadCtx = HostContext.fromHostThread(ports[Int(ndx)]) else {
           // This can happen legitimately, e.g. when looking at a Rosetta 2
           // process, where there are ARM64 threads AS WELL AS the x86_64 ones.
+          mach_port_deallocate(mach_task_self_, ports[Int(ndx)])
           continue
         }
         ctx = threadCtx


### PR DESCRIPTION
If you're using Rosetta 2, there are ARM64 threads in your process as well, which the backtracer skips.  Unfortunately doing that messed up the crashing thread index, so the backtracer might have crashed or told you that a different thread was crashing than the one you thought.

This only affects running x86-64 code on an Apple Silicon Mac.

rdar://135787913
