### PR TITLE
[cxx-interop] Tests that check if the correct std::span index function is called

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -D HARDENING_ENABLED)
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -650,6 +650,20 @@ StdSpanTestSuite.test("Span as arg to generic func") {
   accessSpanAsSomeGenericParam(ispan)
   accessSpanAsSomeGenericParam(scspan)
   accessSpanAsSomeGenericParam(sspan)
+}
+
+// TODO CxxRandomAccessCollection
+StdSpanTestSuite.test("Check if the correct index function is called") {
+  #if !HARDENING_ENABLED
+  expectEqual(icspan.size(), 3)
+  let _ = icspan[3]
+  expectEqual(ispan.size(), 3)
+  let _ = ispan[3]
+  expectEqual(scspan.size(), 3)
+  let _ = scspan[3]
+  expectEqual(sspan.size(), 3)
+  let _ = sspan[3]
+  #endif
 }
 
 runAllTests()


### PR DESCRIPTION
When using `std::span` from Swift, sometimes the `CxxRandomAccessCollection` index function is called instead of the C++ `std::span` index function. 
This tests check that doesn't happen by doing invalid accesses to `std::span`, which trap in the `CxxRandomAccessCollection` index function, but in the C++ index function.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
