### PR TITLE
[Parse] Fix type parsing when preceded by '-'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8002,12 +8002,6 @@ NOTE(unsafe_decl_here,none,
 // MARK: Value Generics
 //===----------------------------------------------------------------------===//
 
-ERROR(invalid_value_value_generic,none,
-      "%0 requires that %1 must be a valid value for %2",
-      (Type, Type, Type))
-NOTE(invalid_value_value_generic_requirement,none,
-     "requirement specified as %0 == %1%2",
-     (Type, Type, StringRef))
 ERROR(cannot_pass_type_for_value_generic,none,
       "cannot pass type %0 as a value for generic value %1", (Type, Type))
 ERROR(value_type_used_in_type_parameter,none,
@@ -8029,6 +8023,8 @@ ERROR(value_generics_missing_feature,none,
 ERROR(availability_value_generic_type_only_version_newer, none,
       "values in generic types are only available in %0 %1 or newer",
       (StringRef, llvm::VersionTuple))
+ERROR(invalid_value_for_type_same_type,none,
+      "cannot constrain type parameter %0 to be integer %1", (Type, Type))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -261,6 +261,18 @@ bool swift::rewriting::diagnoseRequirementErrors(
       diagnosedError = true;
       break;
     }
+
+    case RequirementError::Kind::InvalidValueForTypeSameType: {
+      auto req = error.getRequirement();
+
+      if (req.hasError())
+        break;
+
+      ctx.Diags.diagnose(loc, diag::invalid_value_for_type_same_type,
+                         req.getFirstType(), req.getSecondType());
+      diagnosedError = true;
+      break;
+    }
     }
   }
 

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -62,6 +62,9 @@ struct RequirementError {
     /// A value generic type was used to same-type to an unrelated type,
     /// e.g. 'where N == Int' where N == 'let N: Int'.
     InvalidValueGenericSameType,
+    /// A value type, either an integer '123' or a value generic parameter 'N',
+    /// was used to same type a regular type parameter, e.g. 'T == 123'.
+    InvalidValueForTypeSameType,
   } kind;
 
 private:
@@ -176,6 +179,13 @@ public:
                                                          SourceLoc loc) {
     Requirement requirement(RequirementKind::Conformance, subjectType, constraint);
     return {Kind::InvalidValueGenericSameType, requirement, loc};
+  }
+
+  static RequirementError forInvalidValueForTypeSameType(Type subjectType,
+                                                         Type constraint,
+                                                         SourceLoc loc) {
+    Requirement requirement(RequirementKind::Conformance, subjectType, constraint);
+    return {Kind::InvalidValueForTypeSameType, requirement, loc};
   }
 };
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -250,6 +250,18 @@ static void desugarSameTypeRequirement(
         }
       }
 
+      if (!firstType->isValueParameter() && secondType->is<IntegerType>()) {
+        errors.push_back(RequirementError::forInvalidValueForTypeSameType(
+            sugaredFirstType, secondType, loc));
+        return true;
+      }
+
+      if (!secondType->isValueParameter() && firstType->is<IntegerType>()) {
+        errors.push_back(RequirementError::forInvalidValueForTypeSameType(
+            secondType, sugaredFirstType, loc));
+        return true;
+      }
+
       if (firstType->isTypeParameter() && secondType->isTypeParameter()) {
         result.emplace_back(kind, sugaredFirstType, secondType);
         return true;

--- a/test/Parse/integer_types.swift
+++ b/test/Parse/integer_types.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+
+let a: 123 // expected-error {{integer unexpectedly used in a type position}}
+
+let b: -123 // expected-error {{integer unexpectedly used in a type position}}
+
+let c: -Int // expected-error {{expected type}}
+            // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+            // expected-error@-2 {{unary operator '-' cannot be applied to an operand of type 'Int.Type'}}
+
+struct Generic<T> {} // expected-note {{'T' declared as parameter to type 'Generic'}}
+                     // expected-note@-1 {{'T' declared as parameter to type 'Generic'}}
+
+extension Generic where T == 123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+
+extension Generic where T == -123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '-123'}}
+
+extension Generic where T == -Int {} // expected-error {{expected type}}
+                                     // expected-error@-1 {{expected '{' in extension}}
+
+let d = Generic<123>.self // expected-error {{integer unexpectedly used in a type position}}
+
+// FIXME: This should at least be parsable...?
+let e = Generic<-123>.self // expected-error {{generic parameter 'T' could not be inferred}}
+                           // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
+                           // expected-error@-2 {{'>' is not a postfix unary operator}}
+                           // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}
+
+let f = Generic<-Int>.self // expected-error {{generic parameter 'T' could not be inferred}}
+                           // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
+                           // expected-error@-2 {{'>' is not a postfix unary operator}}
+                           // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -48,6 +48,9 @@ func e(with a: A<Int>) {} // expected-error {{cannot pass type 'Int' as a value 
 struct Generic<T: ~Copyable & ~Escapable> {}
 struct GenericWithIntParam<T: ~Copyable & ~Escapable, let N: Int> {}
 
+extension Generic where T == 123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+extension Generic where T == 123.Type {} // expected-error {{integer unexpectedly used in a type position}}
+
 func f(_: Generic<123>) {} // expected-error {{integer unexpectedly used in a type position}}
 func g<let N: Int>(_: Generic<N>) {} // expected-error {{cannot use value type 'N' for generic argument 'T'}}
 func h(_: (Int, 123)) {} // expected-error {{integer unexpectedly used in a type position}}


### PR DESCRIPTION
It was mentioned post merge in this PR https://github.com/swiftlang/swift/pull/75518 that we accept parsing types as `-Int` now and these go undiagnosed. This patch fixes that to only parse `-` if it is preceded by an integer literal for integer type parsing. This also fixes an issue when same type constraining a type parameter to an integer type which previously would give diagnostics, for example,  about the type `1` not conforming to `Copyable` or `Escapable` which is a pretty poor diagnostic.