### PR TITLE
[SE-0447] Span and RawSpan implementation

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -754,9 +754,10 @@ func _COWBufferForReading<T: AnyObject>(_ object: T) -> T {
 /// Returns `true` if type is a POD type. A POD type is a type that does not
 /// require any special handling on copying or destruction.
 @_transparent
+@_preInverseGenerics
 public // @testable
-func _isPOD<T>(_ type: T.Type) -> Bool {
-  return Bool(Builtin.ispod(type))
+func _isPOD<T: ~Copyable & ~Escapable>(_ type: T.Type) -> Bool {
+  Bool(Builtin.ispod(type))
 }
 
 /// Returns `true` if `type` is known to refer to a concrete type once all

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -154,6 +154,7 @@ split_embedded_sources(
   EMBEDDED Slice.swift
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
+  EMBEDDED Span/RawSpan.swift
   EMBEDDED StaticString.swift
   EMBEDDED StaticPrint.swift
   EMBEDDED Stride.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -155,6 +155,7 @@ split_embedded_sources(
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
   EMBEDDED Span/RawSpan.swift
+  EMBEDDED Span/Span.swift
   EMBEDDED StaticString.swift
   EMBEDDED StaticPrint.swift
   EMBEDDED Stride.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -198,7 +198,8 @@
     "UnsafeRawBufferPointer.swift"
   ],
   "Span": [
-    "RawSpan.swift"
+    "RawSpan.swift",
+    "Span.swift"
   ],
   "Protocols": [
     "CompilerProtocols.swift",

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -197,6 +197,9 @@
     "UnsafeBufferPointerSlice.swift",
     "UnsafeRawBufferPointer.swift"
   ],
+  "Span": [
+    "RawSpan.swift"
+  ],
   "Protocols": [
     "CompilerProtocols.swift",
     "ShadowProtocols.swift"

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -1,0 +1,665 @@
+//===--- RawSpan.swift ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// A RawSpan represents a span of initialized memory
+// of unspecified type.
+@frozen
+public struct RawSpan: Copyable, ~Escapable {
+  @usableFromInline let _pointer: UnsafeRawPointer?
+
+  @usableFromInline @inline(__always)
+  var _start: UnsafeRawPointer { _pointer.unsafelyUnwrapped }
+
+  @usableFromInline let _count: Int
+
+  @_alwaysEmitIntoClient
+  internal init(
+    _unchecked start: UnsafeRawPointer?,
+    byteCount: Int
+  ) -> dependsOn(immortal) Self {
+    _pointer = start
+    _count = byteCount
+  }
+}
+
+@available(*, unavailable)
+extension RawSpan: Sendable {}
+
+extension RawSpan {
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeBytes buffer: UnsafeRawBufferPointer
+  ) -> dependsOn(immortal) Self {
+    self.init(
+      _unchecked: buffer.baseAddress, byteCount: buffer.count
+    )
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory over `count` bytes starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized byte.
+  ///   - byteCount: the number of initialized bytes in the span.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeStart pointer: UnsafeRawPointer,
+    byteCount: Int
+  ) -> dependsOn(immortal) Self {
+    precondition(byteCount >= 0, "Count must not be negative")
+    self.init(_unchecked: pointer, byteCount: byteCount)
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: UnsafeBufferPointer<T>
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: UnsafeMutableBufferPointer<T>
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeElements: UnsafeBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory over `count` bytes starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized byte.
+  ///   - byteCount: the number of initialized bytes in the span.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `RawSpan`.
+  @_alwaysEmitIntoClient
+  public init<T: BitwiseCopyable>(
+    _unsafeStart pointer: UnsafePointer<T>,
+    count: Int
+  ) -> dependsOn(immortal) Self {
+    precondition(count >= 0, "Count must not be negative")
+    self.init(
+      _unchecked: pointer, byteCount: count*MemoryLayout<T>.stride
+    )
+  }
+
+  /// Create a `RawSpan` over the memory represented by a `Span<T>`
+  ///
+  /// - Parameters:
+  ///   - span: An existing `Span<T>`, which will define both this
+  ///           `RawSpan`'s lifetime and the memory it represents.
+  @_alwaysEmitIntoClient
+  public init<T: BitwiseCopyable>(
+    _unsafeSpan span: borrowing Span<T>
+  ) -> dependsOn(immortal) Self {
+    self.init(
+      _unchecked: UnsafeRawPointer(span._start),
+      byteCount: span.count * MemoryLayout<T>.stride
+    )
+  }
+}
+
+extension RawSpan {
+  /// Returns a Boolean value indicating whether two `RawSpan` instances
+  /// refer to the same region in memory.
+  @_alwaysEmitIntoClient
+  public static func ===(_ a: Self, _ b: Self) -> Bool {
+    (a._pointer == b._pointer) && (a._count == b._count)
+  }
+}
+
+extension RawSpan {
+
+  private var _address: String {
+    String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
+  }
+
+  public var _description: String {
+    "(0x\(_address), \(_count))"
+  }
+}
+
+extension RawSpan {
+
+  /// The number of bytes in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var byteCount: Int { _count }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var isEmpty: Bool { byteCount == 0 }
+
+  /// The indices that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var _byteOffsets: Range<Int> {
+    .init(uncheckedBounds: (0, byteCount))
+  }
+}
+
+//MARK: Bounds Checking
+extension RawSpan {
+
+  /// Return true if `offset` is a valid byte offset into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - position: a byte offset to validate
+  /// - Returns: true if `offset` is a valid byte offset
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offset: Int) -> Bool {
+    0 <= offset && offset < byteCount
+  }
+
+  /// Return true if `offsets` is a valid range of offsets into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of byte offsets to validate
+  /// - Returns: true if `offsets` is a valid range of byte offsets
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offsets: Range<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound <= byteCount
+  }
+
+  /// Return true if `offsets` is a valid range of offsets into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of byte offsets to validate
+  /// - Returns: true if `offsets` is a valid range of byte offsets
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offsets: ClosedRange<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound < byteCount
+  }
+}
+
+//MARK: extracting sub-spans
+extension RawSpan {
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A span over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(_ bounds: Range<Int>) -> Self {
+    precondition(boundsContain(bounds))
+    return _extracting(unchecked: bounds)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(to bounds: Range<Int>) {
+    self = _extracting(bounds)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A span over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(unchecked bounds: Range<Int>) -> Self {
+    RawSpan(
+      _unchecked: _pointer?.advanced(by: bounds.lowerBound),
+      byteCount: bounds.count
+    )
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(unchecked bounds: Range<Int>) {
+    self = _extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A span over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    _extracting(bounds.relative(to: _byteOffsets))
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(_ bounds: some RangeExpression<Int>) {
+    self = _extracting(bounds)
+  }
+
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A span over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(
+    unchecked bounds: some RangeExpression<Int>
+  ) -> Self {
+    _extracting(unchecked: bounds.relative(to: _byteOffsets))
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(unchecked bounds: some RangeExpression<Int>) {
+    self = _extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over all the bytes of this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A span over all the bytes of this span.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+extension RawSpan {
+
+  //FIXME: mark closure parameter as non-escaping
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
+  public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try body(.init(start: (byteCount==0) ? nil : _start, count: byteCount))
+  }
+}
+
+extension RawSpan {
+
+  /// View the bytes of this span as type `T`
+  ///
+  /// This is the equivalent of `unsafeBitCast(_:to:)`. The
+  /// underlying bytes must be initialized as type `T`, be
+  /// initialized to a type that is layout-compatible with `T`,
+  /// or the function mapping bit patterns of length `8*MemoryLayout<T>.size`
+  /// to instances of `T` must be surjective.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce invalid values of `T`.
+  ///
+  /// - Parameters:
+  ///   - type: The type as which to view the bytes of this span.
+  /// - Returns: A typed span viewing these bytes as instances of `T`.
+  @_alwaysEmitIntoClient
+  public func unsafeView<T: BitwiseCopyable>(
+    as type: T.Type
+  ) -> Span<T> {
+    Span(_unsafeStart: _start, byteCount: byteCount)
+  }
+}
+
+//MARK: load
+extension RawSpan {
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance is memory-managed and unassociated
+  ///     with the value in the memory referenced by this pointer.
+  @_alwaysEmitIntoClient
+  public func unsafeLoad<T>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    precondition(boundsContain(
+      Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
+    ))
+    return unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access, and failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance is memory-managed and unassociated
+  ///     with the value in the memory referenced by this pointer.
+  @_alwaysEmitIntoClient
+  public func unsafeLoad<T>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start.load(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be initialized to `T`
+  /// or another type that is layout compatible with `T`.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance isn't associated
+  ///     with the value in the range of memory referenced by this pointer.
+  @_alwaysEmitIntoClient
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    precondition(boundsContain(
+      Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
+    ))
+    return unsafeLoadUnaligned(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be initialized to `T`
+  /// or another type that is layout compatible with `T`.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access, and failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance isn't associated
+  ///     with the value in the range of memory referenced by this pointer.
+  @_alwaysEmitIntoClient
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start.loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+}
+
+extension RawSpan {
+
+  /// Returns true if the memory represented by `span` is a subrange of
+  /// the memory represented by `self`
+  ///
+  /// Parameters:
+  /// - span: a span of the same type as `self`
+  /// Returns: whether `span` is a subrange of `self`
+  @_alwaysEmitIntoClient
+  public func contains(_ span: borrowing Self) -> Bool {
+    if span._count > _count { return false }
+    if _count == 0 || span._count == 0 { return true }
+    if _start > span._start { return false }
+    return span._start.advanced(by: span._count) <= _start.advanced(by: _count)
+  }
+
+  /// Returns the offsets where the memory of `span` is located within
+  /// the memory represented by `self`
+  ///
+  /// Note: `span` must be a subrange of `self`
+  ///
+  /// Parameters:
+  /// - span: a subrange of `self`
+  /// Returns: A range of offsets within `self`
+  @_alwaysEmitIntoClient
+  public func offsets(of span: borrowing Self) -> Range<Int> {
+    precondition(contains(span))
+    var (s, e) = (0, 0)
+    if _pointer != nil && span._pointer != nil {
+      s = _start.distance(to: span._start)
+      e = s + span._count
+    }
+    return Range(uncheckedBounds: (s, e))
+  }
+}
+
+//MARK: one-sided slicing operations
+extension RawSpan {
+
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum byte count.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the bytes.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(first maxLength: Int) -> Self {
+    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+    let newCount = min(maxLength, byteCount)
+    return Self(_unchecked: _pointer, byteCount: newCount)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toFirst maxLength: Int) {
+    self = _extracting(first: maxLength)
+  }
+
+  /// Returns a span over all but the given number of trailing bytes.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of bytes to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(droppingLast k: Int) -> Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let dc = min(k, byteCount)
+    return Self(_unchecked: _pointer, byteCount: byteCount&-dc)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(droppingLast k: Int) {
+    self = _extracting(droppingLast: k)
+  }
+
+  /// Returns a span containing the trailing bytes of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the bytes.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(last maxLength: Int) -> Self {
+    precondition(maxLength >= 0, "Can't have a suffix of negative length.")
+    let newCount = min(maxLength, byteCount)
+    let newStart = _pointer?.advanced(by: byteCount&-newCount)
+    return Self(_unchecked: newStart, byteCount: newCount)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toLast maxLength: Int) {
+    self = _extracting(last: maxLength)
+  }
+
+  /// Returns a span over all but the given number of initial bytes.
+  ///
+  /// If the number of elements to drop exceeds the number of bytes in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of bytes to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of bytes.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @usableFromInline func _extracting(droppingFirst k: Int) -> Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let dc = min(k, byteCount)
+    let newStart = _pointer?.advanced(by: dc)
+    return Self(_unchecked: newStart, byteCount: byteCount&-dc)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(droppingFirst k: Int) {
+    self = _extracting(droppingFirst: k)
+  }
+}

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -251,7 +251,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func _extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
-      UInt(bitPattern: bounds.lowerBound) <  UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "byte offset range out of bounds"
     )
@@ -454,8 +454,8 @@ extension RawSpan {
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
     _precondition(
-      UInt(bitPattern: offset) <  UInt(bitPattern: _count) &&
-      UInt(bitPattern: offset&+MemoryLayout<T>.size) <= UInt(bitPattern: _count),
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
       "byte offset range out of bounds"
     )
     return unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
@@ -511,8 +511,8 @@ extension RawSpan {
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
     _precondition(
-      UInt(bitPattern: offset) <  UInt(bitPattern: _count) &&
-      UInt(bitPattern: offset&+MemoryLayout<T>.size) <= UInt(bitPattern: _count),
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
       "byte offset range out of bounds"
     )
     return unsafeLoadUnaligned(fromUncheckedByteOffset: offset, as: T.self)

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -258,12 +258,6 @@ extension RawSpan {
     return _extracting(unchecked: bounds)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(to bounds: Range<Int>) {
-    self = _extracting(bounds)
-  }
-
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
@@ -289,13 +283,6 @@ extension RawSpan {
     )
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @unsafe
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toUnchecked bounds: Range<Int>) {
-    self = _extracting(unchecked: bounds)
-  }
-
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
@@ -313,12 +300,6 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
     _extracting(bounds.relative(to: byteOffsets))
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(_ bounds: some RangeExpression<Int>) {
-    self = _extracting(bounds)
   }
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -343,13 +324,6 @@ extension RawSpan {
     unchecked bounds: some RangeExpression<Int>
   ) -> Self {
     _extracting(unchecked: bounds.relative(to: byteOffsets))
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @unsafe
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toUnchecked bounds: some RangeExpression<Int>) {
-    self = _extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over all the bytes of this span.
@@ -606,12 +580,6 @@ extension RawSpan {
     return Self(_unchecked: _pointer, byteCount: newCount)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toFirst maxLength: Int) {
-    self = _extracting(first: maxLength)
-  }
-
   /// Returns a span over all but the given number of trailing bytes.
   ///
   /// If the number of elements to drop exceeds the number of elements in
@@ -632,12 +600,6 @@ extension RawSpan {
     _precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = min(k, byteCount)
     return Self(_unchecked: _pointer, byteCount: byteCount&-dc)
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(droppingLast k: Int) {
-    self = _extracting(droppingLast: k)
   }
 
   /// Returns a span containing the trailing bytes of the span,
@@ -664,12 +626,6 @@ extension RawSpan {
     return Self(_unchecked: newStart, byteCount: newCount)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toLast maxLength: Int) {
-    self = _extracting(last: maxLength)
-  }
-
   /// Returns a span over all but the given number of initial bytes.
   ///
   /// If the number of elements to drop exceeds the number of bytes in
@@ -691,11 +647,5 @@ extension RawSpan {
     let dc = min(k, byteCount)
     let newStart = _pointer?.advanced(by: dc)
     return Self(_unchecked: newStart, byteCount: byteCount&-dc)
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(droppingFirst k: Int) {
-    self = _extracting(droppingFirst: k)
   }
 }

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -13,6 +13,7 @@
 // A RawSpan represents a span of initialized memory
 // of unspecified type.
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 @frozen
 public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline let _pointer: UnsafeRawPointer?
@@ -35,9 +36,11 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan: @unchecked Sendable {}
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
@@ -198,6 +201,7 @@ extension RawSpan {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// The number of bytes in the span.
@@ -227,6 +231,7 @@ extension RawSpan {
 
 //MARK: extracting sub-spans
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -364,6 +369,7 @@ extension RawSpan {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   //FIXME: mark closure parameter as non-escaping
@@ -391,6 +397,7 @@ extension RawSpan {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// View the bytes of this span as type `T`
@@ -420,6 +427,7 @@ extension RawSpan {
 
 //MARK: load
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// Returns a new instance of the given type, constructed from the raw memory
@@ -538,6 +546,7 @@ extension RawSpan {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
   /// Returns a Boolean value indicating whether two `RawSpan` instances
   /// refer to the same region in memory.
@@ -572,6 +581,7 @@ extension RawSpan {
 
 //MARK: one-sided slicing operations
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension RawSpan {
 
   /// Returns a span containing the initial bytes of this span,

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -29,10 +29,10 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   internal init(
-    _unchecked pointer: UnsafeRawPointer?,
+    _unchecked pointer: borrowing UnsafeRawPointer?,
     byteCount: Int
   ) {
-    _pointer = pointer
+    _pointer = copy pointer
     _count = byteCount
   }
 }
@@ -58,7 +58,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: UnsafeRawBufferPointer
+    _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
   ) {
     self.init(
       _unchecked: buffer.baseAddress, byteCount: buffer.count
@@ -69,7 +69,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -87,7 +87,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+    _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -96,7 +96,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -116,11 +116,11 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeStart pointer: UnsafeRawPointer,
+    _unsafeStart pointer: borrowing UnsafeRawPointer,
     byteCount: Int
   ) {
     _precondition(byteCount >= 0, "Count must not be negative")
-    self.init(_unchecked: pointer, byteCount: byteCount)
+    self.init(_unchecked: copy pointer, byteCount: byteCount)
   }
 
   /// Unsafely create a `RawSpan` over initialized memory.
@@ -136,7 +136,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
-    _unsafeElements buffer: UnsafeBufferPointer<T>
+    _unsafeElements buffer: borrowing UnsafeBufferPointer<T>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -172,7 +172,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
-    _unsafeElements buffer: UnsafeMutableBufferPointer<T>
+    _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<T>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
@@ -210,12 +210,12 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
-    _unsafeStart pointer: UnsafePointer<T>,
+    _unsafeStart pointer: borrowing UnsafePointer<T>,
     count: Int
   ) {
     _precondition(count >= 0, "Count must not be negative")
     self.init(
-      _unchecked: pointer, byteCount: count * MemoryLayout<T>.stride
+      _unchecked: copy pointer, byteCount: count * MemoryLayout<T>.stride
     )
   }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -143,6 +143,24 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
+  /// The memory in `buffer` must be valid and initialized
+  /// for at least as long as the returned `RawSpan` exists.
+  ///
+  /// - Parameters:
+  ///   - buffer: a raw buffer to initialized memory.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
+  ) {
+    self.init(
+      _unsafeBytes: .init(UnsafeBufferPointer(rebasing: buffer))
+    )
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
   /// The memory in `buffer` must be owned by the instance `owner`,
   /// meaning that as long as `owner` is alive the memory will remain valid.
   ///
@@ -157,6 +175,24 @@ extension RawSpan {
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be valid and initialized
+  /// for at least as long as the returned `RawSpan` exists.
+  ///
+  /// - Parameters:
+  ///   - buffer: a raw buffer to initialized memory.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
+  ) {
+    self.init(
+      _unsafeBytes: .init(UnsafeBufferPointer(rebasing: buffer))
+    )
   }
 
   /// Unsafely create a `RawSpan` over initialized memory.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -392,7 +392,7 @@ extension RawSpan {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    try body(.init(start: (byteCount==0) ? nil : _start, count: byteCount))
+    try body(.init(start: _pointer, count: byteCount))
   }
 }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -179,7 +179,7 @@ extension RawSpan {
   ) {
     _precondition(count >= 0, "Count must not be negative")
     self.init(
-      _unchecked: pointer, byteCount: count*MemoryLayout<T>.stride
+      _unchecked: pointer, byteCount: count * MemoryLayout<T>.stride
     )
   }
 
@@ -601,8 +601,8 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func _extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements.")
-    let dc = min(k, byteCount)
-    return Self(_unchecked: _pointer, byteCount: byteCount&-dc)
+    let droppedCount = min(k, byteCount)
+    return Self(_unchecked: _pointer, byteCount: byteCount &- droppedCount)
   }
 
   /// Returns a span containing the trailing bytes of the span,
@@ -625,7 +625,7 @@ extension RawSpan {
   public func _extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let newCount = min(maxLength, byteCount)
-    let newStart = _pointer?.advanced(by: byteCount&-newCount)
+    let newStart = _pointer?.advanced(by: byteCount &- newCount)
     return Self(_unchecked: newStart, byteCount: newCount)
   }
 
@@ -647,8 +647,8 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func _extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements.")
-    let dc = min(k, byteCount)
-    let newStart = _pointer?.advanced(by: dc)
-    return Self(_unchecked: newStart, byteCount: byteCount&-dc)
+    let droppedCount = min(k, byteCount)
+    let newStart = _pointer?.advanced(by: droppedCount)
+    return Self(_unchecked: newStart, byteCount: byteCount &- droppedCount)
   }
 }

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -568,14 +568,13 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func byteOffsets(of span: borrowing Self) -> Range<Int>? {
     if span._count > _count { return nil }
-    guard let subspanStart = span._pointer, _count > 0 else {
-      return _pointer == span._pointer ? Range(uncheckedBounds: (0, 0)) : nil
+    guard let spanStart = span._pointer, _count > 0 else {
+      return _pointer == span._pointer ? Range(_uncheckedBounds: (0, 0)) : nil
     }
-    if subspanStart < _start { return nil }
-    let lower = _start.distance(to: subspanStart)
-    let upper = lower + span._count
-    guard upper <= _count else { return nil }
-    return Range(uncheckedBounds: (lower, upper))
+    let spanEnd = spanStart + span._count
+    if spanStart < _start || (_start + _count) < spanEnd { return nil }
+    let lower = _start.distance(to: spanStart)
+    return Range(_uncheckedBounds: (lower, lower &+ span._count))
   }
 }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -27,6 +27,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow pointer) rdar://138672380
   @lifetime(immortal)
   internal init(
     _unchecked pointer: borrowing UnsafeRawPointer?,
@@ -56,6 +57,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
@@ -67,6 +69,7 @@ extension RawSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
@@ -85,6 +88,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
@@ -94,6 +98,7 @@ extension RawSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
@@ -114,6 +119,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeStart pointer: borrowing UnsafeRawPointer,
@@ -134,6 +140,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing UnsafeBufferPointer<T>
@@ -150,6 +157,7 @@ extension RawSpan {
   ///   - buffer: a raw buffer to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
@@ -170,6 +178,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<T>
@@ -186,6 +195,7 @@ extension RawSpan {
   ///   - buffer: a raw buffer to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
@@ -208,6 +218,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: borrowing UnsafePointer<T>,

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -227,9 +227,9 @@ extension RawSpan {
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe // remove when fixing the lifetime annotation
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(span)
   public init<Element: BitwiseCopyable>(
-    _unsafeSpan span: borrowing Span<Element>
+    _unsafeSpan span: consuming Span<Element>
   ) {
     self.init(
       _unchecked: span._pointer,
@@ -429,8 +429,8 @@ extension RawSpan {
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
-  public func _unsafeView<T: BitwiseCopyable>(
+  @lifetime(self)
+  consuming public func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> Span<T> {
     Span(_unsafeBytes: .init(start: _pointer, count: _count))

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -82,13 +82,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -101,6 +100,14 @@ extension RawSpan {
     )
   }
 
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -113,13 +120,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
-  ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -142,15 +148,14 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory over `count` bytes starting at
-  /// `pointer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The region of memory representing `byteCount` bytes starting at `pointer`
+  /// must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized byte.
   ///   - byteCount: the number of initialized bytes in the span.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -165,13 +170,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -184,11 +188,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be valid and initialized
-  /// for at least as long as the returned `RawSpan` exists.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
-  ///   - buffer: a raw buffer to initialized memory.
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -203,13 +208,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
-  ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -222,11 +226,12 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory in `buffer` must be valid and initialized
-  /// for at least as long as the returned `RawSpan` exists.
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
-  ///   - buffer: a raw buffer to initialized memory.
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
@@ -241,15 +246,14 @@ extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
-  /// The memory over `count` bytes starting at
-  /// `pointer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The region of memory representing `byteCount` bytes starting at `pointer`
+  /// must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `RawSpan`.
+  /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized byte.
   ///   - byteCount: the number of initialized bytes in the span.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   //FIXME: should be @lifetime(borrow <argname>) rdar://138672380

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -274,12 +274,9 @@ extension RawSpan {
   ///   - span: An existing `Span<T>`, which will define both this
   ///           `RawSpan`'s lifetime and the memory it represents.
   @_disallowFeatureSuppression(NonescapableTypes)
-  @unsafe // remove when fixing the lifetime annotation
   @_alwaysEmitIntoClient
   @lifetime(span)
-  public init<Element: BitwiseCopyable>(
-    _unsafeSpan span: consuming Span<Element>
-  ) {
+  public init<Element: BitwiseCopyable>(_elements span: consuming Span<Element>) {
     self.init(
       _unchecked: span._pointer,
       byteCount: span.count &* MemoryLayout<Element>.stride

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1,0 +1,780 @@
+//===--- Span.swift -------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// A Span<Element> represents a span of memory which
+// contains initialized instances of `Element`.
+@frozen
+public struct Span<Element: ~Copyable & ~Escapable>: Copyable, ~Escapable {
+  @usableFromInline let _pointer: UnsafeRawPointer?
+
+  @usableFromInline @inline(__always)
+  var _start: UnsafeRawPointer { _pointer.unsafelyUnwrapped }
+
+  @usableFromInline let _count: Int
+
+  @_alwaysEmitIntoClient
+  internal init(
+    _unchecked start: UnsafeRawPointer?,
+    count: Int
+  ) -> dependsOn(immortal) Self {
+    _pointer = .init(start)
+    _count = count
+  }
+}
+
+@available(*, unavailable)
+extension Span: Sendable {}
+
+extension UnsafePointer where Pointee: ~Copyable /*& ~Escapable*/ {
+
+  @_alwaysEmitIntoClient
+  var isAligned: Bool {
+    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment&-1)) == 0
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+  @_alwaysEmitIntoClient
+  internal init(
+    _unchecked elements: UnsafeBufferPointer<Element>
+  ) -> dependsOn(immortal) Self {
+    _pointer = .init(elements.baseAddress)
+    _count = elements.count
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeElements buffer: UnsafeBufferPointer<Element>
+  ) -> dependsOn(immortal) Self {
+    precondition(
+      buffer.count == 0 || buffer.baseAddress.unsafelyUnwrapped.isAligned,
+      "baseAddress must be properly aligned for accessing \(Element.self)"
+    )
+    self.init(_unchecked: buffer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeElements: UnsafeBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeStart start: UnsafePointer<Element>,
+    count: Int
+  ) -> dependsOn(immortal) Self {
+    precondition(count >= 0, "Count must not be negative")
+    precondition(
+      start.isAligned,
+      "baseAddress must be properly aligned for accessing \(Element.self)"
+    )
+    self.init(_unchecked: start, count: count)
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeElements buffer: UnsafeBufferPointer<Element>
+  ) -> dependsOn(immortal) Self {
+    self.init(_unchecked: buffer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeElements: UnsafeBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeStart start: UnsafePointer<Element>,
+    count: Int
+  ) -> dependsOn(immortal) Self {
+    precondition(count >= 0, "Count must not be negative")
+    self.init(_unchecked: start, count: count)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `unsafeBytes` must be owned by the instance `owner`
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// `unsafeBytes` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - unsafeBytes: a buffer to initialized elements.
+  ///   - type: the type to use when interpreting the bytes in memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeBytes buffer: UnsafeRawBufferPointer
+  ) -> dependsOn(immortal) Self {
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    precondition(byteCount >= 0, "Count must not be negative")
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    precondition(remainder == 0)
+    self.init(
+      _unchecked: buffer.baseAddress?.assumingMemoryBound(to: Element.self),
+      count: count
+    )
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `unsafeBytes` must be owned by the instance `owner`
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// `unsafeBytes` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - unsafeBytes: a buffer to initialized elements.
+  ///   - type: the type to use when interpreting the bytes in memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+  ) -> dependsOn(immortal) Self {
+    self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_alwaysEmitIntoClient
+  public init(
+    _unsafeStart pointer: UnsafeRawPointer,
+    byteCount: Int
+  ) -> dependsOn(immortal) Self {
+    precondition(byteCount >= 0, "Count must not be negative")
+    let stride = MemoryLayout<Element>.stride
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    precondition(remainder == 0)
+    self.init(
+      _unchecked: pointer.assumingMemoryBound(to: Element.self),
+      count: count
+    )
+  }
+}
+
+extension Span where Element: Equatable {
+
+  /// Returns a Boolean value indicating whether this and another span
+  /// contain equal elements in the same order.
+  ///
+  /// - Parameters:
+  ///   - other: A span to compare to this one.
+  /// - Returns: `true` if this sequence and `other` contain equivalent items,
+  ///   using `areEquivalent` as the equivalence test; otherwise, `false.`
+  ///
+  /// - Complexity: O(*m*), where *m* is the lesser of the length of the
+  ///   sequence and the length of `other`.
+  @_alwaysEmitIntoClient
+  public func _elementsEqual(_ other: Self) -> Bool {
+    guard count == other.count else { return false }
+    if count == 0 { return true }
+
+    //FIXME: This could be short-cut
+    //       with a layout constraint where stride equals size,
+    //       as long as there is at most 1 unused bit pattern.
+    // if Element is BitwiseEquatable {
+    // return _swift_stdlib_memcmp(lhs.baseAddress, rhs.baseAddress, count) == 0
+    // }
+    for o in 0..<count {
+      if self[unchecked: o] != other[unchecked: o] { return false }
+    }
+    return true
+  }
+
+  /// Returns a Boolean value indicating whether this span and a Collection
+  /// contain equal elements in the same order.
+  ///
+  /// - Parameters:
+  ///   - other: A Collection to compare to this span.
+  /// - Returns: `true` if this sequence and `other` contain equivalent items,
+  ///   using `areEquivalent` as the equivalence test; otherwise, `false.`
+  ///
+  /// - Complexity: O(*m*), where *m* is the lesser of the length of the
+  ///   sequence and the length of `other`.
+  @_alwaysEmitIntoClient
+  public func _elementsEqual(_ other: some Collection<Element>) -> Bool {
+    guard count == other.count else { return false }
+    if count == 0 { return true }
+
+    return _elementsEqual(AnySequence(other))
+  }
+
+  /// Returns a Boolean value indicating whether this span and a Sequence
+  /// contain equal elements in the same order.
+  ///
+  /// - Parameters:
+  ///   - other: A Sequence to compare to this span.
+  /// - Returns: `true` if this sequence and `other` contain equivalent items,
+  ///   using `areEquivalent` as the equivalence test; otherwise, `false.`
+  ///
+  /// - Complexity: O(*m*), where *m* is the lesser of the length of the
+  ///   sequence and the length of `other`.
+  @_alwaysEmitIntoClient
+  public func _elementsEqual(_ other: some Sequence<Element>) -> Bool {
+    var offset = 0
+    for otherElement in other {
+      if offset >= count { return false }
+      if self[unchecked: offset] != otherElement { return false }
+      offset += 1
+    }
+    return offset == count
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+  /// Returns a Boolean value indicating whether two `RawSpan` instances
+  /// refer to the same region in memory.
+  @_alwaysEmitIntoClient
+  public static func ===(_ a: Self, _ b: Self) -> Bool {
+    (a._pointer == b._pointer) && (a._count == b._count)
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  private var _address: String {
+    String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
+  }
+
+  public var description: String {
+    "(0x\(_address), \(_count))"
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// The number of elements in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var count: Int { _count }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var isEmpty: Bool { _count == 0 }
+
+  /// The indices that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var _indices: Range<Int> {
+    .init(uncheckedBounds: (0, _count))
+  }
+}
+
+//MARK: Bounds Checking
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Return true if `offset` is a valid offset into this `Span`
+  ///
+  /// - Parameters:
+  ///   - position: an index to validate
+  /// - Returns: true if `offset` is a valid index
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offset: Int) -> Bool {
+    0 <= offset && offset < count
+  }
+
+  /// Return true if `offsets` is a valid range of offsets into this `Span`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of indices to validate
+  /// - Returns: true if `offsets` is a valid range of indices
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offsets: Range<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound <= count
+  }
+
+  /// Return true if `offsets` is a valid range of offsets into this `Span`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of indices to validate
+  /// - Returns: true if `offsets` is a valid range of indices
+  @_alwaysEmitIntoClient
+  public func boundsContain(_ offsets: ClosedRange<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound < count
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+#warning("Restore this computed property once lifetime annotations exist")
+//  /// Construct a RawSpan over the memory represented by this span
+//  ///
+//  /// - Returns: a RawSpan over the memory represented by this span
+//  @_alwaysEmitIntoClient
+//  public var rawSpan: RawSpan { RawSpan(self) }
+}
+
+//MARK: integer offset subscripts
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Int) -> Element {
+    _read {
+      precondition(boundsContain(position))
+      yield self[unchecked: position]
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Int) -> Element {
+    _read {
+      let element = UnsafeRawPointer(_start).advanced(by: position&*MemoryLayout<Element>.stride)
+      let binding = Builtin.bindMemory(element._rawValue, count._builtinWordValue, Element.self)
+      defer { Builtin.rebindMemory(element._rawValue, binding) }
+      yield UnsafePointer<Element>(element._rawValue).pointee
+    }
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Int) -> Element {
+    get {
+      precondition(boundsContain(position))
+      return self[unchecked: position]
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Int) -> Element {
+    get {
+      let address = UnsafeRawPointer(_start).advanced(by: position&*MemoryLayout<Element>.stride)
+      return address.loadUnaligned(as: Element.self)
+    }
+  }
+}
+
+//MARK: extracting sub-spans
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    precondition(boundsContain(bounds))
+    return extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
+    Span(
+      _unchecked: _pointer?.advanced(by: bounds.lowerBound*MemoryLayout<Element>.stride),
+      count: bounds.count
+    )
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: _indices))
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(
+    uncheckedBounds bounds: some RangeExpression<Int>
+  ) -> Self {
+    extracting(unchecked: bounds.relative(to: _indices))
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `Span` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+//MARK: withUnsafePointer, etc.
+extension Span where Element: ~Copyable  /*& ~Escapable*/ {
+
+  //FIXME: mark closure parameter as non-escaping
+  /// Calls a closure with a pointer to the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage. If `body` has
+  ///   a return value, that value is also used as the return value
+  ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
+  ///   parameter is valid only for the duration of its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
+  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable & ~Escapable>(
+    _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    guard let pointer = _pointer, count > 0 else {
+      return try body(.init(start: nil, count: 0))
+    }
+    let binding = Builtin.bindMemory(pointer._rawValue, count._builtinWordValue, Element.self)
+    defer { Builtin.rebindMemory(pointer._rawValue, binding) }
+    return try body(.init(start: .init(pointer._rawValue), count: count))
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  //FIXME: mark closure parameter as non-escaping
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
+  public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try RawSpan(_unsafeSpan: self).withUnsafeBytes(body)
+  }
+}
+
+// `first` and `last` can't exist where Element: ~Copyable
+// because we can't construct an Optional of a borrow
+extension Span where Element: Copyable {
+
+  /// The first element in the span.
+  ///
+  /// If the span is empty, the value of this property is `nil`.
+  ///
+  /// - Returns: The first element in the span, or `nil` if empty
+  @_alwaysEmitIntoClient
+  public var first: Element? {
+    isEmpty ? nil : self[unchecked: 0]
+  }
+
+  /// The last element in the span.
+  ///
+  /// If the span is empty, the value of this property is `nil`.
+  ///
+  /// - Returns: The last element in the span, or `nil` if empty
+  @_alwaysEmitIntoClient
+  public var last: Element? {
+    isEmpty ? nil : self[unchecked: count &- 1]
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Returns true if the memory represented by `span` is a subrange of
+  /// the memory represented by `self`
+  ///
+  /// Parameters:
+  /// - span: a span of the same type as `self`
+  /// Returns: whether `span` is a subrange of `self`
+  @_alwaysEmitIntoClient
+  public func contains(_ span: borrowing Self) -> Bool {
+    if span._count > _count { return false }
+    if _count == 0 || span._count == 0 { return true }
+    if _start > span._start { return false }
+    let stride = MemoryLayout<Element>.stride
+    return span._start.advanced(by: span._count*stride) <= _start.advanced(by: _count*stride)
+  }
+
+  /// Returns the offsets where the memory of `span` is located within
+  /// the memory represented by `self`
+  ///
+  /// Note: `span` must be a subrange of `self`
+  ///
+  /// Parameters:
+  /// - span: a subrange of `self`
+  /// Returns: A range of offsets within `self`
+  @_alwaysEmitIntoClient
+  public func offsets(of span: borrowing Self) -> Range<Int> {
+    precondition(contains(span))
+    var (s, e) = (0, 0)
+    if _pointer != nil && span._pointer != nil {
+      s = _start.distance(to: span._start)/MemoryLayout<Element>.stride
+      e = s + span._count
+    }
+    return Range(uncheckedBounds: (s, e))
+  }
+}
+
+//MARK: one-sided slicing operations
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(first maxLength: Int) -> Self {
+    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+    let newCount = min(maxLength, count)
+    return Self(_unchecked: _pointer, count: newCount)
+  }
+
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(droppingLast k: Int) -> Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let droppedCount = min(k, count)
+    return Self(_unchecked: _pointer, count: count&-droppedCount)
+  }
+
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(last maxLength: Int) -> Self {
+    precondition(maxLength >= 0, "Can't have a suffix of negative length.")
+    let newCount = min(maxLength, count)
+    let newStart = _pointer?.advanced(by: (count&-newCount)*MemoryLayout<Element>.stride)
+    return Self(_unchecked: newStart, count: newCount)
+  }
+
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(droppingFirst k: Int) -> Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let droppedCount = min(k, count)
+    let newStart = _pointer?.advanced(by: droppedCount*MemoryLayout<Element>.stride)
+    return Self(_unchecked: newStart, count: count&-droppedCount)
+  }
+}

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -504,12 +504,6 @@ extension Span where Element: ~Copyable {
     return _extracting(unchecked: bounds)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(to bounds: Range<Index>) {
-    self = _extracting(bounds)
-  }
-
   /// Constructs a new span over the items within the supplied range of
   /// positions within this span.
   ///
@@ -533,13 +527,6 @@ extension Span where Element: ~Copyable {
     return Span(_unchecked: _pointer?.advanced(by: delta), count: bounds.count)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @unsafe
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toUnchecked bounds: Range<Index>) {
-    self = _extracting(unchecked: bounds)
-  }
-
   /// Constructs a new span over the items within the supplied range of
   /// positions within this span.
   ///
@@ -557,12 +544,6 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
     _extracting(bounds.relative(to: indices))
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(to bounds: some RangeExpression<Int>) {
-    self = _extracting(bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -587,13 +568,6 @@ extension Span where Element: ~Copyable {
     uncheckedBounds bounds: some RangeExpression<Int>
   ) -> Self {
     _extracting(unchecked: bounds.relative(to: indices))
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @unsafe
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toUnchecked bounds: some RangeExpression<Int>) {
-    self = _extracting(uncheckedBounds: bounds)
   }
 
   /// Constructs a new span over all the items of this span.
@@ -736,12 +710,6 @@ extension Span where Element: ~Copyable {
     return Self(_unchecked: _pointer, count: newCount)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toFirst maxLength: Int) {
-    self = _extracting(first: maxLength)
-  }
-
   /// Returns a span over all but the given number of trailing elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
@@ -762,12 +730,6 @@ extension Span where Element: ~Copyable {
     _precondition(k >= 0, "Can't drop a negative number of elements.")
     let droppedCount = min(k, count)
     return Self(_unchecked: _pointer, count: count&-droppedCount)
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(droppingLast k: Int) {
-    self = _extracting(droppingLast: k)
   }
 
   /// Returns a span containing the final elements of the span,
@@ -794,12 +756,6 @@ extension Span where Element: ~Copyable {
     return Self(_unchecked: newStart, count: newCount)
   }
 
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(toLast maxLength: Int) {
-    self = _extracting(last: maxLength)
-  }
-
   /// Returns a span over all but the given number of initial elements.
   ///
   /// If the number of elements to drop exceeds the number of elements in
@@ -821,11 +777,5 @@ extension Span where Element: ~Copyable {
     let droppedCount = min(k, count)
     let newStart = _pointer?.advanced(by: droppedCount*MemoryLayout<Element>.stride)
     return Self(_unchecked: newStart, count: count&-droppedCount)
-  }
-
-  @_disallowFeatureSuppression(NonescapableTypes)
-  @_alwaysEmitIntoClient
-  public mutating func _shrink(droppingFirst k: Int) {
-    self = _extracting(droppingFirst: k)
   }
 }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -635,7 +635,7 @@ extension Span where Element: ~Copyable  {
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = _pointer, count > 0 else {
+    guard let pointer = _pointer else {
       return try body(.init(start: nil, count: 0))
     }
     let binding = Builtin.bindMemory(

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -492,7 +492,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public func _extracting(_ bounds: Range<Index>) -> Self {
     _precondition(
-      UInt(bitPattern: bounds.lowerBound) <  UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "index range out of bounds"
     )

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -28,6 +28,7 @@ public struct Span<Element: ~Copyable & ~Escapable>
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow pointer) rdar://138672380
   @lifetime(immortal)
   internal init(
     _unchecked pointer: borrowing UnsafeRawPointer?,
@@ -57,6 +58,7 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeElements buffer: borrowing UnsafeBufferPointer<Element>
@@ -81,6 +83,7 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<Element>
@@ -101,6 +104,7 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeStart pointer: borrowing UnsafePointer<Element>,
@@ -126,6 +130,7 @@ extension Span {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<Element>>
@@ -144,6 +149,7 @@ extension Span {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>
@@ -172,6 +178,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
@@ -206,6 +213,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
@@ -230,6 +238,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeStart pointer: borrowing UnsafeRawPointer,
@@ -255,6 +264,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
@@ -278,6 +288,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
   @lifetime(immortal)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -695,17 +695,16 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public func indices(of span: borrowing Self) -> Range<Index>? {
     if span._count > _count { return nil }
-    guard let subspanStart = span._pointer, _count > 0 else {
+    guard let spanStart = span._pointer, _count > 0 else {
       return _pointer == span._pointer ? Range(_uncheckedBounds: (0, 0)) : nil
     }
-    if subspanStart < _start { return nil }
-    let byteOffset = _start.distance(to: subspanStart)
     let stride = MemoryLayout<Element>.stride
+    let spanEnd = spanStart + stride&*span._count
+    if spanStart < _start || spanEnd > (_start + stride&*_count) { return nil }
+    let byteOffset = _start.distance(to: spanStart)
     let (lower, r) = byteOffset.quotientAndRemainder(dividingBy: stride)
     guard r == 0 else { return nil }
-    let upper = lower + span._count
-    guard upper <= _count else { return nil }
-    return Range(_uncheckedBounds: (lower, upper))
+    return Range(_uncheckedBounds: (lower, lower &+ span._count))
   }
 }
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -325,6 +325,11 @@ extension Span where Element: Equatable {
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func _elementsEqual(_ other: some Collection<Element>) -> Bool {
+    let equal = other.withContiguousStorageIfAvailable {
+      _elementsEqual(Span(_unsafeElements: $0))
+    }
+    if let equal { return equal }
+
     guard count == other.count else { return false }
     if count == 0 { return true }
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -30,10 +30,10 @@ public struct Span<Element: ~Copyable & ~Escapable>
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   internal init(
-    _unchecked pointer: UnsafeRawPointer?,
+    _unchecked pointer: borrowing UnsafeRawPointer?,
     count: Int
   ) {
-    _pointer = pointer
+    _pointer = copy pointer
     _count = count
   }
 }
@@ -59,14 +59,15 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeElements buffer: UnsafeBufferPointer<Element>
+    _unsafeElements buffer: borrowing UnsafeBufferPointer<Element>
   ) {
+    let baseAddress = buffer.baseAddress //FIXME: rdar://138665760
     _precondition(
-      ((Int(bitPattern: buffer.baseAddress) &
+      ((Int(bitPattern: baseAddress) &
         (MemoryLayout<Element>.alignment &- 1)) == 0),
       "baseAddress must be properly aligned to access Element"
     )
-    self.init(_unchecked: buffer.baseAddress, count: buffer.count)
+    self.init(_unchecked: baseAddress, count: buffer.count)
   }
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -82,7 +83,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
+    _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<Element>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
@@ -102,11 +103,11 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeStart pointer: UnsafePointer<Element>,
+    _unsafeStart pointer: borrowing UnsafePointer<Element>,
     count: Int
   ) {
     _precondition(count >= 0, "Count must not be negative")
-    self.init(_unsafeElements: .init(start: pointer, count: count))
+    self.init(_unsafeElements: .init(start: copy pointer, count: count))
   }
 }
 
@@ -127,7 +128,7 @@ extension Span {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeElements buffer: Slice<UnsafeBufferPointer<Element>>
+    _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<Element>>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
   }
@@ -145,7 +146,7 @@ extension Span {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeElements buffer: Slice<UnsafeMutableBufferPointer<Element>>
+    _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
   }
@@ -173,10 +174,11 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: UnsafeRawBufferPointer
+    _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
   ) {
+    let baseAddress = buffer.baseAddress //FIXME: rdar://138665760
     _precondition(
-      ((Int(bitPattern: buffer.baseAddress) &
+      ((Int(bitPattern: baseAddress) &
         (MemoryLayout<Element>.alignment &- 1)) == 0),
       "baseAddress must be properly aligned to access Element"
     )
@@ -185,7 +187,7 @@ extension Span where Element: BitwiseCopyable {
     _precondition(
       remainder == 0, "Span must contain a whole number of elements"
     )
-    self.init(_unchecked: buffer.baseAddress, count: count)
+    self.init(_unchecked: baseAddress, count: count)
   }
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -206,7 +208,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+    _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -230,11 +232,11 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeStart pointer: UnsafeRawPointer,
+    _unsafeStart pointer: borrowing UnsafeRawPointer,
     byteCount: Int
   ) {
     _precondition(byteCount >= 0, "Count must not be negative")
-    self.init(_unsafeBytes: .init(start: pointer, count: byteCount))
+    self.init(_unsafeBytes: .init(start: copy pointer, count: byteCount))
   }
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -255,7 +257,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -278,7 +280,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -14,6 +14,7 @@
 // contains initialized instances of `Element`.
 @_disallowFeatureSuppression(NonescapableTypes)
 @frozen
+@available(SwiftStdlib 6.1, *)
 public struct Span<Element: ~Copyable & ~Escapable>
 : ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline let _pointer: UnsafeRawPointer?
@@ -36,9 +37,11 @@ public struct Span<Element: ~Copyable & ~Escapable>
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span: @unchecked Sendable where Element: Sendable {}
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -106,6 +109,7 @@ extension Span where Element: ~Copyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span {
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -146,6 +150,7 @@ extension Span {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: BitwiseCopyable {
 
   /// Unsafely creates a `Span` over initialized memory.
@@ -276,6 +281,7 @@ extension Span where Element: BitwiseCopyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: Equatable {
 
   /// Returns a Boolean value indicating whether this and another span
@@ -349,6 +355,7 @@ extension Span where Element: Equatable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
 
   /// The number of elements in the span.
@@ -381,6 +388,7 @@ extension Span where Element: ~Copyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
 
   /// Accesses the element at the specified position in the `Span`.
@@ -422,6 +430,7 @@ extension Span where Element: ~Copyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: BitwiseCopyable {
 
   /// Accesses the element at the specified position in the `Span`.
@@ -463,6 +472,7 @@ extension Span where Element: BitwiseCopyable {
 
 //MARK: sub-spans
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
 
   /// Constructs a new span over the items within the supplied range of
@@ -599,6 +609,7 @@ extension Span where Element: ~Copyable {
 
 //MARK: UnsafeBufferPointer access hatch
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable  {
 
   //FIXME: mark closure parameter as non-escaping
@@ -631,6 +642,7 @@ extension Span where Element: ~Copyable  {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: BitwiseCopyable {
 
   //FIXME: mark closure parameter as non-escaping
@@ -658,6 +670,7 @@ extension Span where Element: BitwiseCopyable {
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
   /// Returns a Boolean value indicating whether two `Span` instances
   /// refer to the same region in memory.
@@ -693,6 +706,7 @@ extension Span where Element: ~Copyable {
 
 //MARK: prefixes and suffixes
 @_disallowFeatureSuppression(NonescapableTypes)
+@available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
 
   /// Returns a span containing the initial elements of this span,

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -12,8 +12,10 @@
 
 // A Span<Element> represents a span of memory which
 // contains initialized instances of `Element`.
+@_disallowFeatureSuppression(NonescapableTypes)
 @frozen
-public struct Span<Element: ~Copyable & ~Escapable>: Copyable, ~Escapable {
+public struct Span<Element: ~Copyable & ~Escapable>
+: ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline let _pointer: UnsafeRawPointer?
 
   @usableFromInline @inline(__always)
@@ -21,227 +23,259 @@ public struct Span<Element: ~Copyable & ~Escapable>: Copyable, ~Escapable {
 
   @usableFromInline let _count: Int
 
-  @_alwaysEmitIntoClient
-  internal init(
-    _unchecked start: UnsafeRawPointer?,
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @usableFromInline @inline(__always)
+  @lifetime(immortal)
+  init(
+    _unchecked pointer: UnsafeRawPointer?,
     count: Int
-  ) -> dependsOn(immortal) Self {
-    _pointer = .init(start)
+  ) {
+    _pointer = pointer
     _count = count
   }
 }
 
-@available(*, unavailable)
-extension Span: Sendable {}
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span: @unchecked Sendable where Element: Sendable {}
 
-extension UnsafePointer where Pointee: ~Copyable /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
 
-  @_alwaysEmitIntoClient
-  var isAligned: Bool {
-    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment&-1)) == 0
-  }
-}
-
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
-  @_alwaysEmitIntoClient
-  internal init(
-    _unchecked elements: UnsafeBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
-    _pointer = .init(elements.baseAddress)
-    _count = elements.count
-  }
-
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeElements buffer: UnsafeBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
-    precondition(
-      buffer.count == 0 || buffer.baseAddress.unsafelyUnwrapped.isAligned,
-      "baseAddress must be properly aligned for accessing \(Element.self)"
+  ) {
+    _precondition(
+      ((Int(bitPattern: buffer.baseAddress) &
+        (MemoryLayout<Element>.alignment&-1)) == 0),
+      "baseAddress must be properly aligned to access Element"
     )
-    self.init(_unchecked: buffer)
+    self.init(_unchecked: buffer.baseAddress, count: buffer.count)
   }
 
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
   ///
   /// - Parameters:
   ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
 
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
   /// The memory representing `count` instances starting at
-  /// `pointer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// `pointer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
   ///   - count: the number of initialized elements in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeStart start: UnsafePointer<Element>,
     count: Int
-  ) -> dependsOn(immortal) Self {
-    precondition(count >= 0, "Count must not be negative")
-    precondition(
-      start.isAligned,
-      "baseAddress must be properly aligned for accessing \(Element.self)"
-    )
-    self.init(_unchecked: start, count: count)
+  ) {
+    _precondition(count >= 0, "Count must not be negative")
+    self.init(_unsafeElements: .init(start: start, count: count))
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span {
+
+  /// Unsafely creates a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init(
+    _unsafeElements buffer: Slice<UnsafeBufferPointer<Element>>
+  ) {
+    self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
+  }
+
+  /// Unsafely creates a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init(
+    _unsafeElements buffer: Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
+  }
+}
+
+@_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: BitwiseCopyable {
 
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
   ///
-  /// - Parameters:
-  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `Span`.
-  @_alwaysEmitIntoClient
-  public init(
-    _unsafeElements buffer: UnsafeBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
-    self.init(_unchecked: buffer)
-  }
-
-  /// Unsafely create a `Span` over initialized memory.
-  ///
-  /// The memory in `buffer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
-  ///
-  /// - Parameters:
-  ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `Span`.
-  @_alwaysEmitIntoClient
-  public init(
-    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
-    self.init(_unsafeElements: UnsafeBufferPointer(buffer))
-  }
-
-  /// Unsafely create a `Span` over initialized memory.
-  ///
-  /// The memory representing `count` instances starting at
-  /// `pointer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
-  ///
-  /// - Parameters:
-  ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the span.
-  ///   - owner: a binding whose lifetime must exceed that of
-  ///            the newly created `Span`.
-  @_alwaysEmitIntoClient
-  public init(
-    _unsafeStart start: UnsafePointer<Element>,
-    count: Int
-  ) -> dependsOn(immortal) Self {
-    precondition(count >= 0, "Count must not be negative")
-    self.init(_unchecked: start, count: count)
-  }
-
-  /// Unsafely create a `Span` over initialized memory.
-  ///
-  /// The memory in `unsafeBytes` must be owned by the instance `owner`
-  /// meaning that as long as `owner` is alive the memory will remain valid.
-  ///
-  /// `unsafeBytes` must be correctly aligned for accessing
+  /// `buffer` must be correctly aligned for accessing
   /// an element of type `Element`, and must contain a number of bytes
   /// that is an exact multiple of `Element`'s stride.
   ///
   /// - Parameters:
-  ///   - unsafeBytes: a buffer to initialized elements.
+  ///   - buffer: a buffer to initialized elements.
   ///   - type: the type to use when interpreting the bytes in memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
-  ) -> dependsOn(immortal) Self {
-    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
-    precondition(byteCount >= 0, "Count must not be negative")
-    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
-    precondition(remainder == 0)
-    self.init(
-      _unchecked: buffer.baseAddress?.assumingMemoryBound(to: Element.self),
-      count: count
+  ) {
+    _precondition(
+      ((Int(bitPattern: buffer.baseAddress) &
+        (MemoryLayout<Element>.alignment&-1)) == 0),
+      "baseAddress must be properly aligned to access Element"
     )
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    _precondition(remainder == 0, "Span must contain a whole number of elements")
+    self.init(_unchecked: buffer.baseAddress, count: count)
   }
 
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
-  /// The memory in `unsafeBytes` must be owned by the instance `owner`
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
   ///
-  /// `unsafeBytes` must be correctly aligned for accessing
+  /// `buffer` must be correctly aligned for accessing
   /// an element of type `Element`, and must contain a number of bytes
   /// that is an exact multiple of `Element`'s stride.
   ///
   /// - Parameters:
-  ///   - unsafeBytes: a buffer to initialized elements.
+  ///   - buffer: a buffer to initialized elements.
   ///   - type: the type to use when interpreting the bytes in memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
 
-  /// Unsafely create a `Span` over initialized memory.
+  /// Unsafely creates a `Span` over initialized memory.
   ///
   /// The memory representing `count` instances starting at
-  /// `pointer` must be owned by the instance `owner`,
-  /// meaning that as long as `owner` is alive the memory will remain valid.
+  /// `pointer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
+  ///
+  /// `pointer` must be correctly aligned for accessing
+  /// an element of type `Element`, and `byteCount`
+  /// must be an exact multiple of `Element`'s stride.
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the span.
+  ///   - byteCount: the number of initialized elements in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
-  ) -> dependsOn(immortal) Self {
-    precondition(byteCount >= 0, "Count must not be negative")
-    let stride = MemoryLayout<Element>.stride
-    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
-    precondition(remainder == 0)
-    self.init(
-      _unchecked: pointer.assumingMemoryBound(to: Element.self),
-      count: count
-    )
+  ) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    self.init(_unsafeBytes: .init(start: pointer, count: byteCount))
+  }
+
+  /// Unsafely creates a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  ///   - type: the type to use when interpreting the bytes in memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init(
+    _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
+  ) {
+    self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
+  }
+
+  /// Unsafely creates a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid throughout the lifetime of
+  /// the newly-created `Span`.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  ///   - type: the type to use when interpreting the bytes in memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the newly created `Span`.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(immortal)
+  public init(
+    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: Equatable {
 
   /// Returns a Boolean value indicating whether this and another span
@@ -254,6 +288,7 @@ extension Span where Element: Equatable {
   ///
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func _elementsEqual(_ other: Self) -> Bool {
     guard count == other.count else { return false }
@@ -281,6 +316,7 @@ extension Span where Element: Equatable {
   ///
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func _elementsEqual(_ other: some Collection<Element>) -> Bool {
     guard count == other.count else { return false }
@@ -299,6 +335,7 @@ extension Span where Element: Equatable {
   ///
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func _elementsEqual(_ other: some Sequence<Element>) -> Bool {
     var offset = 0
@@ -311,27 +348,8 @@ extension Span where Element: Equatable {
   }
 }
 
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
-  /// Returns a Boolean value indicating whether two `RawSpan` instances
-  /// refer to the same region in memory.
-  @_alwaysEmitIntoClient
-  public static func ===(_ a: Self, _ b: Self) -> Bool {
-    (a._pointer == b._pointer) && (a._count == b._count)
-  }
-}
-
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
-
-  private var _address: String {
-    String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
-  }
-
-  public var description: String {
-    "(0x\(_address), \(_count))"
-  }
-}
-
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
 
   /// The number of elements in the span.
   ///
@@ -348,62 +366,23 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   @_alwaysEmitIntoClient
   public var isEmpty: Bool { _count == 0 }
 
+  /// The representation for a position in `Span`.
+  public typealias Index = Int
+
   /// The indices that are valid for subscripting the span, in ascending
   /// order.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public var _indices: Range<Int> {
-    .init(uncheckedBounds: (0, _count))
+  public var indices: Range<Index> {
+    Range(_uncheckedBounds: (0, _count))
   }
-}
-
-//MARK: Bounds Checking
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
-
-  /// Return true if `offset` is a valid offset into this `Span`
-  ///
-  /// - Parameters:
-  ///   - position: an index to validate
-  /// - Returns: true if `offset` is a valid index
-  @_alwaysEmitIntoClient
-  public func boundsContain(_ offset: Int) -> Bool {
-    0 <= offset && offset < count
-  }
-
-  /// Return true if `offsets` is a valid range of offsets into this `Span`
-  ///
-  /// - Parameters:
-  ///   - offsets: a range of indices to validate
-  /// - Returns: true if `offsets` is a valid range of indices
-  @_alwaysEmitIntoClient
-  public func boundsContain(_ offsets: Range<Int>) -> Bool {
-    0 <= offsets.lowerBound && offsets.upperBound <= count
-  }
-
-  /// Return true if `offsets` is a valid range of offsets into this `Span`
-  ///
-  /// - Parameters:
-  ///   - offsets: a range of indices to validate
-  /// - Returns: true if `offsets` is a valid range of indices
-  @_alwaysEmitIntoClient
-  public func boundsContain(_ offsets: ClosedRange<Int>) -> Bool {
-    0 <= offsets.lowerBound && offsets.upperBound < count
-  }
-}
-
-extension Span where Element: BitwiseCopyable {
-
-#warning("Restore this computed property once lifetime annotations exist")
-//  /// Construct a RawSpan over the memory represented by this span
-//  ///
-//  /// - Returns: a RawSpan over the memory represented by this span
-//  @_alwaysEmitIntoClient
-//  public var rawSpan: RawSpan { RawSpan(self) }
 }
 
 //MARK: integer offset subscripts
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
 
   /// Accesses the element at the specified position in the `Span`.
   ///
@@ -411,10 +390,11 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public subscript(_ position: Int) -> Element {
+  public subscript(_ position: Index) -> Element {
     _read {
-      precondition(boundsContain(position))
+      _precondition(indices.contains(position), "index out of bounds")
       yield self[unchecked: position]
     }
   }
@@ -427,10 +407,13 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
-  public subscript(unchecked position: Int) -> Element {
+  public subscript(unchecked position: Index) -> Element {
+    //FIXME: change to unsafeRawAddress or unsafeAddress when ready
     _read {
-      let element = UnsafeRawPointer(_start).advanced(by: position&*MemoryLayout<Element>.stride)
+      let element = _start.advanced(by: position&*MemoryLayout<Element>.stride)
       let binding = Builtin.bindMemory(element._rawValue, count._builtinWordValue, Element.self)
       defer { Builtin.rebindMemory(element._rawValue, binding) }
       yield UnsafePointer<Element>(element._rawValue).pointee
@@ -438,6 +421,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: BitwiseCopyable {
 
   /// Accesses the element at the specified position in the `Span`.
@@ -446,10 +430,14 @@ extension Span where Element: BitwiseCopyable {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public subscript(_ position: Int) -> Element {
+  public subscript(_ position: Index) -> Element {
     get {
-      precondition(boundsContain(position))
+      _precondition(
+        UInt(bitPattern: position) <  UInt(bitPattern: _count),
+        "index out of bounds"
+      )
       return self[unchecked: position]
     }
   }
@@ -462,17 +450,20 @@ extension Span where Element: BitwiseCopyable {
   ///     must be greater or equal to zero, and less than `count`.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
-  public subscript(unchecked position: Int) -> Element {
+  public subscript(unchecked position: Index) -> Element {
     get {
-      let address = UnsafeRawPointer(_start).advanced(by: position&*MemoryLayout<Element>.stride)
+      let address = _start.advanced(by: position&*MemoryLayout<Element>.stride)
       return address.loadUnaligned(as: Element.self)
     }
   }
 }
 
 //MARK: extracting sub-spans
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
 
   /// Constructs a new span over the items within the supplied range of
   /// positions within this span.
@@ -487,51 +478,21 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(_ bounds: Range<Int>) -> Self {
-    precondition(boundsContain(bounds))
-    return extracting(unchecked: bounds)
-  }
-
-  /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
-  /// This function does not validate `bounds`; this is an unsafe operation.
-  ///
-  /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `Span`.
-  ///
-  /// - Returns: A `Span` over the items within `bounds`
-  ///
-  /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
-  public func extracting(unchecked bounds: Range<Int>) -> Self {
-    Span(
-      _unchecked: _pointer?.advanced(by: bounds.lowerBound*MemoryLayout<Element>.stride),
-      count: bounds.count
+  public func _extracting(_ bounds: Range<Index>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <  UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "index range out of bounds"
     )
+    return _extracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
-  ///
-  /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not share their indices with the
-  /// span from which they are extracted.
-  ///
-  /// - Parameter bounds: A valid range of positions. Every position in
-  ///     this range must be within the bounds of this `Span`.
-  ///
-  /// - Returns: A `Span` over the items within `bounds`
-  ///
-  /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
-    extracting(bounds.relative(to: _indices))
+  public mutating func _shrink(to bounds: Range<Index>) {
+    self = _extracting(bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -549,11 +510,75 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
-  public func extracting(
+  public func _extracting(unchecked bounds: Range<Index>) -> Self {
+    let delta = bounds.lowerBound&*MemoryLayout<Element>.stride
+    return Span(_unchecked: _pointer?.advanced(by: delta), count: bounds.count)
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toUnchecked bounds: Range<Index>) {
+    self = _extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    _extracting(bounds.relative(to: indices))
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(to bounds: some RangeExpression<Int>) {
+    self = _extracting(bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func _extracting(
     uncheckedBounds bounds: some RangeExpression<Int>
   ) -> Self {
-    extracting(unchecked: bounds.relative(to: _indices))
+    _extracting(unchecked: bounds.relative(to: indices))
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toUnchecked bounds: some RangeExpression<Int>) {
+    self = _extracting(uncheckedBounds: bounds)
   }
 
   /// Constructs a new span over all the items of this span.
@@ -565,14 +590,16 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A `Span` over all the items of this span.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(_: UnboundedRange) -> Self {
+  public func _extracting(_: UnboundedRange) -> Self {
     self
   }
 }
 
 //MARK: withUnsafePointer, etc.
-extension Span where Element: ~Copyable  /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable  {
 
   //FIXME: mark closure parameter as non-escaping
   /// Calls a closure with a pointer to the viewed contiguous storage.
@@ -587,19 +614,23 @@ extension Span where Element: ~Copyable  /*& ~Escapable*/ {
   ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable & ~Escapable>(
+  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
     guard let pointer = _pointer, count > 0 else {
       return try body(.init(start: nil, count: 0))
     }
-    let binding = Builtin.bindMemory(pointer._rawValue, count._builtinWordValue, Element.self)
+    let binding = Builtin.bindMemory(
+      pointer._rawValue, count._builtinWordValue, Element.self
+    )
     defer { Builtin.rebindMemory(pointer._rawValue, binding) }
     return try body(.init(start: .init(pointer._rawValue), count: count))
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: BitwiseCopyable {
 
   //FIXME: mark closure parameter as non-escaping
@@ -617,78 +648,52 @@ extension Span where Element: BitwiseCopyable {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
     try RawSpan(_unsafeSpan: self).withUnsafeBytes(body)
   }
 }
 
-// `first` and `last` can't exist where Element: ~Copyable
-// because we can't construct an Optional of a borrow
-extension Span where Element: Copyable {
-
-  /// The first element in the span.
-  ///
-  /// If the span is empty, the value of this property is `nil`.
-  ///
-  /// - Returns: The first element in the span, or `nil` if empty
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
+  /// Returns a Boolean value indicating whether two `Span` instances
+  /// refer to the same region in memory.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public var first: Element? {
-    isEmpty ? nil : self[unchecked: 0]
+  public func isIdentical(to other: Self) -> Bool {
+    (self._pointer == other._pointer) && (self._count == other._count)
   }
 
-  /// The last element in the span.
-  ///
-  /// If the span is empty, the value of this property is `nil`.
-  ///
-  /// - Returns: The last element in the span, or `nil` if empty
-  @_alwaysEmitIntoClient
-  public var last: Element? {
-    isEmpty ? nil : self[unchecked: count &- 1]
-  }
-}
-
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
-
-  /// Returns true if the memory represented by `span` is a subrange of
-  /// the memory represented by `self`
+  /// Returns the indices within `self` where the memory represented by `span`
+  /// is located, or `nil` if `span` is not located within `self`.
   ///
   /// Parameters:
-  /// - span: a span of the same type as `self`
-  /// Returns: whether `span` is a subrange of `self`
+  /// - span: a span that may be a subrange of `self`
+  /// Returns: A range of indices within `self`, or `nil`
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func contains(_ span: borrowing Self) -> Bool {
-    if span._count > _count { return false }
-    if _count == 0 || span._count == 0 { return true }
-    if _start > span._start { return false }
-    let stride = MemoryLayout<Element>.stride
-    return span._start.advanced(by: span._count*stride) <= _start.advanced(by: _count*stride)
-  }
-
-  /// Returns the offsets where the memory of `span` is located within
-  /// the memory represented by `self`
-  ///
-  /// Note: `span` must be a subrange of `self`
-  ///
-  /// Parameters:
-  /// - span: a subrange of `self`
-  /// Returns: A range of offsets within `self`
-  @_alwaysEmitIntoClient
-  public func offsets(of span: borrowing Self) -> Range<Int> {
-    precondition(contains(span))
-    var (s, e) = (0, 0)
-    if _pointer != nil && span._pointer != nil {
-      s = _start.distance(to: span._start)/MemoryLayout<Element>.stride
-      e = s + span._count
+  public func indices(of span: borrowing Self) -> Range<Index>? {
+    if span._count > _count { return nil }
+    guard let subspanStart = span._pointer, _count > 0 else {
+      return _pointer == span._pointer ? Range(_uncheckedBounds: (0, 0)) : nil
     }
-    return Range(uncheckedBounds: (s, e))
+    if subspanStart < _start { return nil }
+    let byteOffset = _start.distance(to: subspanStart)
+    let stride = MemoryLayout<Element>.stride
+    let (lower, r) = byteOffset.quotientAndRemainder(dividingBy: stride)
+    guard r == 0 else { return nil }
+    let upper = lower + span._count
+    guard upper <= _count else { return nil }
+    return Range(_uncheckedBounds: (lower, upper))
   }
 }
 
 //MARK: one-sided slicing operations
-extension Span where Element: ~Copyable /*& ~Escapable*/ {
+@_disallowFeatureSuppression(NonescapableTypes)
+extension Span where Element: ~Copyable {
 
   /// Returns a span containing the initial elements of this span,
   /// up to the specified maximum length.
@@ -705,11 +710,18 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(first maxLength: Int) -> Self {
-    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+  public func _extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let newCount = min(maxLength, count)
     return Self(_unchecked: _pointer, count: newCount)
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toFirst maxLength: Int) {
+    self = _extracting(first: maxLength)
   }
 
   /// Returns a span over all but the given number of trailing elements.
@@ -726,11 +738,18 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span leaving off the specified number of elements at the end.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(droppingLast k: Int) -> Self {
-    precondition(k >= 0, "Can't drop a negative number of elements.")
+  public func _extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements.")
     let droppedCount = min(k, count)
     return Self(_unchecked: _pointer, count: count&-droppedCount)
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(droppingLast k: Int) {
+    self = _extracting(droppingLast: k)
   }
 
   /// Returns a span containing the final elements of the span,
@@ -748,12 +767,19 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(last maxLength: Int) -> Self {
-    precondition(maxLength >= 0, "Can't have a suffix of negative length.")
+  public func _extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let newCount = min(maxLength, count)
     let newStart = _pointer?.advanced(by: (count&-newCount)*MemoryLayout<Element>.stride)
     return Self(_unchecked: newStart, count: newCount)
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(toLast maxLength: Int) {
+    self = _extracting(last: maxLength)
   }
 
   /// Returns a span over all but the given number of initial elements.
@@ -770,11 +796,18 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span starting after the specified number of elements.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func extracting(droppingFirst k: Int) -> Self {
-    precondition(k >= 0, "Can't drop a negative number of elements.")
+  public func _extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements.")
     let droppedCount = min(k, count)
     let newStart = _pointer?.advanced(by: droppedCount*MemoryLayout<Element>.stride)
     return Self(_unchecked: newStart, count: count&-droppedCount)
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  public mutating func _shrink(droppingFirst k: Int) {
+    self = _extracting(droppingFirst: k)
   }
 }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -380,7 +380,6 @@ extension Span where Element: ~Copyable {
   }
 }
 
-//MARK: integer offset subscripts
 @_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: ~Copyable {
 
@@ -393,6 +392,7 @@ extension Span where Element: ~Copyable {
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
+    //FIXME: change to unsafeRawAddress or unsafeAddress when ready
     _read {
       _precondition(indices.contains(position), "index out of bounds")
       yield self[unchecked: position]
@@ -461,7 +461,7 @@ extension Span where Element: BitwiseCopyable {
   }
 }
 
-//MARK: extracting sub-spans
+//MARK: sub-spans
 @_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: ~Copyable {
 
@@ -597,7 +597,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-//MARK: withUnsafePointer, etc.
+//MARK: UnsafeBufferPointer access hatch
 @_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: ~Copyable  {
 
@@ -691,7 +691,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-//MARK: one-sided slicing operations
+//MARK: prefixes and suffixes
 @_disallowFeatureSuppression(NonescapableTypes)
 extension Span where Element: ~Copyable {
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -462,7 +462,7 @@ extension Span where Element: ~Copyable {
     //FIXME: change to unsafeRawAddress when ready
     unsafeAddress {
       _precondition(indices.contains(position), "Index out of bounds")
-      return unsafeAddressOfElement(unchecked: position)
+      return _unsafeAddressOfElement(unchecked: position)
     }
   }
 
@@ -481,14 +481,14 @@ extension Span where Element: ~Copyable {
   public subscript(unchecked position: Index) -> Element {
     //FIXME: change to unsafeRawAddress when ready
     unsafeAddress {
-      unsafeAddressOfElement(unchecked: position)
+      _unsafeAddressOfElement(unchecked: position)
     }
   }
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe
   @_alwaysEmitIntoClient
-  internal func unsafeAddressOfElement(
+  internal func _unsafeAddressOfElement(
     unchecked position: Index
   ) -> UnsafePointer<Element> {
     let elementOffset = position &* MemoryLayout<Element>.stride

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -634,7 +634,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self)
   public func _extracting(
-    uncheckedBounds bounds: some RangeExpression<Int>
+    unchecked bounds: some RangeExpression<Int>
   ) -> Self {
     _extracting(unchecked: bounds.relative(to: indices))
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -320,14 +320,14 @@ extension Span where Element: BitwiseCopyable {
   /// Create a `Span` over the bytes represented by a `RawSpan`
   ///
   /// - Parameters:
-  ///   - rawSpan: An existing `RawSpan`, which will define both this
-  ///             `Span`'s lifetime and the memory it represents.
+  ///   - bytes: An existing `RawSpan`, which will define both this
+  ///            `Span`'s lifetime and the memory it represents.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(rawSpan)
-  public init(_bytes rawSpan: consuming RawSpan) {
+  @lifetime(bytes)
+  public init(_bytes bytes: consuming RawSpan) {
     self.init(
-      _unsafeBytes: .init(start: rawSpan._pointer, count: rawSpan.byteCount)
+      _unsafeBytes: .init(start: bytes._pointer, count: bytes.byteCount)
     )
   }
 }
@@ -712,7 +712,7 @@ extension Span where Element: BitwiseCopyable {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    try RawSpan(_unsafeSpan: self).withUnsafeBytes(body)
+    try RawSpan(_elements: self).withUnsafeBytes(body)
   }
 }
 

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -776,11 +776,8 @@ Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
 // SE-0447 Span and RawSpan
 Added: _$ss4SpanVMa
 Added: _$ss4SpanVMn
-Added: _$ss4SpanVsRi_zRi0_zrlE10_unchecked5countAByxGSVSg_SitcfC
 Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
 Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivpMV
-Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvg
-Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvpMV
 Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg
 Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvpMV
 Added: _$ss4SpanVsRi_zrlE5countSivpMV
@@ -788,12 +785,9 @@ Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
 Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
-Added: _$ss7RawSpanV10_unchecked9byteCountABSVSg_SitcfC
 Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
 Added: _$ss7RawSpanV6_countSivg
 Added: _$ss7RawSpanV6_countSivpMV
-Added: _$ss7RawSpanV6_startSVvg
-Added: _$ss7RawSpanV6_startSVvpMV
 Added: _$ss7RawSpanV7isEmptySbvpMV
 Added: _$ss7RawSpanV8_pointerSVSgvg
 Added: _$ss7RawSpanV8_pointerSVSgvpMV

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -772,3 +772,32 @@ Added: _$sSo19_SwiftStdlibVersionasE6v6_1_0ABvpZMV
 Added: _$sSS5IndexV16debugDescriptionSSvpMV
 Added: _$sSS5IndexVs28CustomDebugStringConvertiblesMc
 Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
+
+// SE-0447 Span and RawSpan
+Added: _$ss4SpanVMa
+Added: _$ss4SpanVMn
+Added: _$ss4SpanVsRi_zRi0_zrlE10_unchecked5countAByxGSVSg_SitcfC
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvg
+Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvpMV
+Added: _$ss4SpanVsRi_zrlE5countSivpMV
+Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
+Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
+Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
+Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
+Added: _$ss7RawSpanV10_unchecked9byteCountABSVSg_SitcfC
+Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
+Added: _$ss7RawSpanV6_countSivg
+Added: _$ss7RawSpanV6_countSivpMV
+Added: _$ss7RawSpanV6_startSVvg
+Added: _$ss7RawSpanV6_startSVvpMV
+Added: _$ss7RawSpanV7isEmptySbvpMV
+Added: _$ss7RawSpanV8_pointerSVSgvg
+Added: _$ss7RawSpanV8_pointerSVSgvpMV
+Added: _$ss7RawSpanV9byteCountSivpMV
+Added: _$ss7RawSpanVMa
+Added: _$ss7RawSpanVMn
+Added: _$ss7RawSpanVN

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -773,3 +773,32 @@ Added: _$ss7UnicodeO5UTF32O27encodedReplacementCharacters15CollectionOfOneVys6UI
 Added: _$sSS5IndexV16debugDescriptionSSvpMV
 Added: _$sSS5IndexVs28CustomDebugStringConvertiblesMc
 Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
+
+// SE-0447 Span and RawSpan
+Added: _$ss4SpanVMa
+Added: _$ss4SpanVMn
+Added: _$ss4SpanVsRi_zRi0_zrlE10_unchecked5countAByxGSVSg_SitcfC
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvg
+Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvpMV
+Added: _$ss4SpanVsRi_zrlE5countSivpMV
+Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
+Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
+Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
+Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
+Added: _$ss7RawSpanV10_unchecked9byteCountABSVSg_SitcfC
+Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
+Added: _$ss7RawSpanV6_countSivg
+Added: _$ss7RawSpanV6_countSivpMV
+Added: _$ss7RawSpanV6_startSVvg
+Added: _$ss7RawSpanV6_startSVvpMV
+Added: _$ss7RawSpanV7isEmptySbvpMV
+Added: _$ss7RawSpanV8_pointerSVSgvg
+Added: _$ss7RawSpanV8_pointerSVSgvpMV
+Added: _$ss7RawSpanV9byteCountSivpMV
+Added: _$ss7RawSpanVMa
+Added: _$ss7RawSpanVMn
+Added: _$ss7RawSpanVN

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -777,11 +777,8 @@ Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
 // SE-0447 Span and RawSpan
 Added: _$ss4SpanVMa
 Added: _$ss4SpanVMn
-Added: _$ss4SpanVsRi_zRi0_zrlE10_unchecked5countAByxGSVSg_SitcfC
 Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
 Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivpMV
-Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvg
-Added: _$ss4SpanVsRi_zRi0_zrlE6_startSVvpMV
 Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg
 Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvpMV
 Added: _$ss4SpanVsRi_zrlE5countSivpMV
@@ -789,12 +786,9 @@ Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
 Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
-Added: _$ss7RawSpanV10_unchecked9byteCountABSVSg_SitcfC
 Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
 Added: _$ss7RawSpanV6_countSivg
 Added: _$ss7RawSpanV6_countSivpMV
-Added: _$ss7RawSpanV6_startSVvg
-Added: _$ss7RawSpanV6_startSVvpMV
 Added: _$ss7RawSpanV7isEmptySbvpMV
 Added: _$ss7RawSpanV8_pointerSVSgvg
 Added: _$ss7RawSpanV8_pointerSVSgvpMV

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -793,6 +793,9 @@ Var UnsafeBufferPointer.debugDescription has mangled name changing from 'Swift.U
 Var UnsafeBufferPointer.debugDescription is now with @_preInverseGenerics
 Var UnsafeMutableBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.debugDescription : Swift.String'
 Var UnsafeMutableBufferPointer.debugDescription is now with @_preInverseGenerics
+Func _isPOD(_:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
+Func _isPOD(_:) has mangled name changing from 'Swift._isPOD<A>(A.Type) -> Swift.Bool' to 'Swift._isPOD<A where A: ~Swift.Copyable, A: ~Swift.Escapable>(A.Type) -> Swift.Bool'
+Func _isPOD(_:) is now with @_preInverseGenerics
 
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
 


### PR DESCRIPTION
Implementation of SE-0447, the `Span` [proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md) ([review thread](https://forums.swift.org/t/74676)).

The tests will be added in a separate pull request; they are being ported from https://github.com/apple/swift-collections/tree/future/Tests/FutureTests.