### PR TITLE
[test] Fix test/IRGen/metadata.swift to match the correct symbol

### DIFF
--- a/test/IRGen/metadata.swift
+++ b/test/IRGen/metadata.swift
@@ -10,10 +10,10 @@ enum Singleton {
 
 // CHECK: @"$s1A1GC14zeroSizedFieldAA9SingletonOvpWvd" = hidden constant i{{(64|32)}} 0
 // Check that the instance start is after the header (at 8 or 16).
-// CHECK-macosx: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
-// CHECK-ios: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
-// CHECK-watchos: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
-// CHECK-tvos: _DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|129)}}, i32 {{(16|8|40)}}
+// CHECK-macosx: @_DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|192)}}, i32 {{(16|8)}}
+// CHECK-ios: @_DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|192)}}, i32 {{(16|8)}}
+// CHECK-watchos: @_DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|192)}}, i32 {{(16|8)}}
+// CHECK-tvos: @_DATA__TtC1A1G = internal constant {{.*}} { i32 {{(128|192)}}, i32 {{(16|8)}}
 
 class G {
   var zeroSizedField = Singleton.only


### PR DESCRIPTION
When this test was updated for new platforms it was accidentally changed to match the _METACLASS_DATA symbol instead of the _DATA symbol. Fix that and update the flags to match. This lets us remove the instance start value 40 from the checks, so the test now matches the comment saying it should be 8 or 16.

rdar://135453916
