### PR TITLE
Sema: Fix `getPublicModuleName` to look only at loaded modules

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1923,15 +1923,11 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
 }
 
 Identifier ModuleDecl::getPublicModuleName(bool onlyIfImported) const {
-  if (!PublicModuleName.empty()) {
-    if (!onlyIfImported)
-      return PublicModuleName;
+  if (!PublicModuleName.empty() &&
+      (!onlyIfImported ||
+       getASTContext().getLoadedModule(PublicModuleName)))
+    return PublicModuleName;
 
-    bool publicModuleIsImported =
-      getASTContext().getModuleByIdentifier(PublicModuleName);
-    if (publicModuleIsImported)
-      return PublicModuleName;
-  }
   return getName();
 }
 

--- a/test/Sema/public-module-name.swift
+++ b/test/Sema/public-module-name.swift
@@ -47,6 +47,7 @@
 // RUN:   -verify
 // RUN: not %target-swift-frontend -typecheck %t/ClientMiddle.swift -o %t -I %t \
 // RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -diagnostic-style llvm \
 // RUN:   2>&1 | %FileCheck %t/ClientMiddle.swift
 
 /// Test more diagnostics referencing modules.
@@ -69,6 +70,7 @@
 // RUN:   -verify
 // RUN: not %target-swift-frontend -typecheck %t/ClientMiddle.swift -o %t -I %t \
 // RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -diagnostic-style llvm \
 // RUN:   2>&1 | %FileCheck %t/ClientMiddle.swift
 
 // RUN: %target-swift-frontend -typecheck %t/ClientAccessLevelOnImports.swift -o %t -I %t \


### PR DESCRIPTION
When `onlyIfImported` is true, we should return the public module name only when the public facing module is already imported. Replace the call to `getModuleByIdentifier` with `getLoadedModule` to prevent loading that module if it wasn't already loaded.

Fix the broken test where the CHECK line was matching itself from the context shown by the Swift style diagnostics.

Fixup for #76269