### PR TITLE
[release/6.0] ASTMangler: skip mangling Copyable dependents

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4196,18 +4196,26 @@ void ASTMangler::appendAnyProtocolConformance(
       conformance.getRequirement()->isMarkerProtocol())
     return;
 
-  // While all invertible protocols are marker protocols, do not mangle them for
-  // compatability reasons. See equivalent hack in `conformanceRequirementIndex`
-  // where only invertible protocols are unconditionally skipped.
-  if (conformance.getRequirement()->getInvertibleProtocolKind())
-    return;
+  // While all invertible protocols are marker protocols, do not mangle them
+  // as a dependent conformance. See `conformanceRequirementIndex` which skips
+  // these, too. In theory, invertible conformances should never be mangled,
+  // but we *might* have let that slip by for the other cases below, so the
+  // early-exits are highly conservative.
+  const bool forInvertible =
+      conformance.getRequirement()->getInvertibleProtocolKind().has_value();
 
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
+    if (forInvertible)
+      return;
+
     auto path = genericSig->getConformancePath(conformingType,
                                                conformance.getAbstract());
     appendDependentProtocolConformance(path, genericSig);
   } else if (auto opaqueType = conformingType->getAs<OpaqueTypeArchetypeType>()) {
+    if (forInvertible)
+      return;
+
     GenericSignature opaqueSignature =
         opaqueType->getDecl()->getOpaqueInterfaceGenericSignature();
     ConformancePath conformancePath =

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4196,6 +4196,12 @@ void ASTMangler::appendAnyProtocolConformance(
       conformance.getRequirement()->isMarkerProtocol())
     return;
 
+  // While all invertible protocols are marker protocols, do not mangle them for
+  // compatability reasons. See equivalent hack in `conformanceRequirementIndex`
+  // where only invertible protocols are unconditionally skipped.
+  if (conformance.getRequirement()->getInvertibleProtocolKind())
+    return;
+
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
     auto path = genericSig->getConformancePath(conformingType,

--- a/test/Interpreter/moveonly_generics_opaque.swift
+++ b/test/Interpreter/moveonly_generics_opaque.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -O) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+protocol Marked {
+  func announce()
+}
+extension Marked {
+  func announce() { print("\(Self.self) is Marked") }
+}
+
+struct ConcreteWrapper<Wrapped> {}
+extension ConcreteWrapper: Marked where Wrapped: Marked {}
+
+struct Hello<T: ~Copyable> {}
+extension Hello: Marked {}
+
+func makeWrapper<P>(wrapping _: P.Type) -> some Marked {
+    ConcreteWrapper<Hello<P>>()
+}
+
+do {
+  let markedVal = makeWrapper(wrapping: String.self)
+  markedVal.announce() // CHECK: ConcreteWrapper<Hello<String>> is Marked
+}


### PR DESCRIPTION
- Explanation: The Swift 6.0 compiler can crash when trying to check if a returned-value conforms to the constraint of an opaque return type. It triggers when a conformance requirement is conditional on Copyable. This results in a regression from Swift 5.10, for example, in the following program:
```
protocol Marked {
  func announce()
}
extension Marked {
  func announce() {}
}

struct MyType<Wrapped> {}
extension MyType: Marked where Wrapped: Marked {}

extension Optional: Marked {}

func makeWrapper<P>(wrapping _: P.Type) -> some Marked {
    MyType<Optional<P>>()
}
```
- Scope: This is a regression where the compiler previously accepted the program, but cause of some adoption of ~Copyable in the stdlib, it will trip over the same code without this fix.
- Issue: rdar://135310019
- Original PR: https://github.com/swiftlang/swift/pull/76293 https://github.com/swiftlang/swift/pull/76432
- Risk: Low. It's a simple, straightforward fix to skip the new Copyable requirement that has now appeared.
- Testing: Swift CI
- Reviewer: @slavapestov 