### PR TITLE
[swift_snapshot_tool] Some small fixes and add a run_toolchain command for running a command against a specific toolchain.

### DIFF
--- a/utils/swift_snapshot_tool/Package.swift
+++ b/utils/swift_snapshot_tool/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "swift_snapshot_tool",
-  platforms: [.macOS(.v12)],
+  platforms: [.macOS(.v14)],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.
     .executable(

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
@@ -55,7 +55,9 @@ private func downloadFile(url: URL, localPath: URL, verboseDownload: Bool = true
   }
 }
 
-private func shell(_ command: String, environment: [String: String] = [:]) -> (
+private func shell(_ command: String, environment: [String: String] = [:],
+                   mustSucceed: Bool = true,verbose: Bool = false,
+                   extraArgs: [String] = []) -> (
   stdout: String, stderr: String, exitCode: Int
 ) {
   let task = Process()
@@ -64,11 +66,15 @@ private func shell(_ command: String, environment: [String: String] = [:]) -> (
 
   task.standardOutput = stdout
   task.standardError = stderr
-  task.arguments = ["-c", command]
+  var newCommand = command
+  if extraArgs.count != 0 {
+    newCommand = newCommand.appending(" ").appending(extraArgs.joined(separator: " "))
+  }
+  task.arguments = ["-c", newCommand]
   if !environment.isEmpty {
     if let e = task.environment {
-      print("Task Env: \(e)")
-      print("Passed in Env: \(environment)")
+      log("Task Env: \(e)")
+      log("Passed in Env: \(environment)")
       task.environment = e.merging(
         environment,
         uniquingKeysWith: {
@@ -78,7 +84,9 @@ private func shell(_ command: String, environment: [String: String] = [:]) -> (
       task.environment = environment
     }
   }
-
+  if verbose {
+    log("Command: \(command)\n")
+  }
   task.launchPath = "/bin/zsh"
   task.standardInput = nil
   task.launch()
@@ -88,20 +96,22 @@ private func shell(_ command: String, environment: [String: String] = [:]) -> (
     decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
   let stdoutData = String(
     decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-  if task.terminationStatus != 0 {
-    log("Command Failed: \(command)")
+  if verbose {
     log("StdErr:\n\(stderrData)\n")
     log("StdOut:\n\(stdoutData)\n")
+  }
+  if mustSucceed && task.terminationStatus != 0 {
+    log("Command Failed!")
     fatalError()
   }
-
   return (stdout: stdoutData, stderr: stderrData, Int(task.terminationStatus))
 }
 
 func downloadToolchainAndRunTest(
   platform: Platform, tag: Tag, branch: Branch,
   workspace: String, script: String,
-  verboseDownload: Bool = true
+  extraArgs: [String],
+  verbose: Bool = false
 ) async throws -> Int {
   let fileType = platform.fileType
   let toolchainType = platform.toolchainType
@@ -117,6 +127,8 @@ func downloadToolchainAndRunTest(
     log("[INFO] Starting Download: \(downloadURL) -> \(downloadPath)")
     try await downloadFile(url: downloadURL, localPath: downloadPath)
     log("[INFO] Finished Download: \(downloadURL) -> \(downloadPath)")
+  } else {
+    log("[INFO] File exists! No need to download! Path: \(downloadPath)")
   }
 
   switch platform {
@@ -126,16 +138,21 @@ func downloadToolchainAndRunTest(
       _ = shell("pkgutil --expand \(downloadPath.path) \(toolchainDir)")
       let payloadPath = "\(toolchainDir)/\(tag.name)-osx-package.pkg/Payload"
       _ = shell("tar -xf \(payloadPath) -C \(toolchainDir)")
-      let swiftcPath = "\(toolchainDir)/usr/bin/swiftc"
-      let swiftFrontendPath = "\(toolchainDir)/usr/bin/swift-frontend"
-      log(shell("\(swiftcPath) --version").stdout)
-      let exitCode = shell(
-        "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath]
-      ).exitCode
-      log("[INFO] Exit code: \(exitCode). Tag: \(tag.name). Script: \(script)")
-      return exitCode
+    } else {
+      log("[INFO] No need to install: \(downloadPath)")
     }
-    return 0
+
+    let swiftcPath = "\(toolchainDir)/usr/bin/swiftc"
+    let swiftFrontendPath = "\(toolchainDir)/usr/bin/swift-frontend"
+    log(shell("\(swiftcPath) --version").stdout)
+    let exitCode = shell(
+      "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath],
+      mustSucceed: false,
+      verbose: verbose,
+      extraArgs: extraArgs
+    ).exitCode
+    log("[INFO] Exit code: \(exitCode). Tag: \(tag.name). Script: \(script)")
+    return exitCode
   case .ubuntu1404, .ubuntu1604, .ubuntu1804:
     fatalError("Unsupported platform: \(platform)")
   }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
@@ -14,7 +14,22 @@ struct Tag: Decodable {
   var name: Substring {
     ref.dropFirst(10)
   }
+
+  func dateString(_ branch: Branch) -> Substring {
+    // FIXME: If we ever actually use interesting a-b builds, we should capture this information
+    // would be better to do it sooner than later.
+    return name.dropFirst("swift-".count + branch.rawValue.count + "-SNAPSHOT-".count).dropLast(2)
+  }
+
+  func date(branch: Branch) -> Date {
+    // TODO: I think that d might be a class... if so, we really want to memoize
+    // this.
+    let d = DateFormatter()
+    d.dateFormat = "yyyy-MM-dd"
+    return d.date(from: String(dateString(branch)))!
+  }
 }
+
 
 extension Tag: CustomDebugStringConvertible {
   var debugDescription: String {
@@ -22,25 +37,46 @@ extension Tag: CustomDebugStringConvertible {
   }
 }
 
-func getTagsFromSwiftRepo(branch: Branch) async throws -> [Tag] {
-  let GITHUB_BASE_URL = "https://api.github.com"
-  let GITHUB_TAG_LIST_URL = URL(string: "\(GITHUB_BASE_URL)/repos/apple/swift/git/refs/tags")!
+/// A pair of a branch and a tag
+struct BranchTag {
+  var tag: Tag
+  var branch: Branch
+}
+
+extension BranchTag: CustomDebugStringConvertible {
+  var debugDescription: String {
+    tag.debugDescription
+  }
+}
+
+func getTagsFromSwiftRepo(branch: Branch, dryRun: Bool = false) async throws -> [BranchTag] {
+  let github_tag_list_url: URL
+  if !dryRun {
+    github_tag_list_url = URL(string: "https://api.github.com/repos/apple/swift/git/refs/tags")!
+  } else {
+    github_tag_list_url = URL(string: "file:///Users/gottesmm/triage/github_data")!
+  }
 
   let decoder = JSONDecoder()
   decoder.keyDecodingStrategy = .convertFromSnakeCase
 
   log("[INFO] Starting to download snapshot information from github.")
-  async let data = URLSession.shared.data(from: GITHUB_TAG_LIST_URL).0
+  async let data = URLSession.shared.data(from: github_tag_list_url).0
   let allTags = try! decoder.decode([Tag].self, from: await data)
   log("[INFO] Finished downloading snapshot information from github.")
 
   let snapshotTagPrefix = "swift-\(branch.rawValue.uppercased())"
 
-  // Then filter the tags to just include the specific snapshot prefix.
-  var filteredTags = allTags.filter {
+  // Then filter the tags to just include the specific snapshot branch
+  // prefix. Add the branch to an aggregate BranchTag.
+  var filteredTags: [BranchTag] = allTags.filter {
     $0.name.starts(with: snapshotTagPrefix)
+  }.map {
+    BranchTag(tag: $0, branch: branch)
   }
-  filteredTags.sort { $0.ref < $1.ref }
+
+  // Then sort so that the newest branch prefix 
+  filteredTags.sort { $0.tag.ref < $1.tag.ref }
   filteredTags.reverse()
 
   return filteredTags

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -1,0 +1,92 @@
+
+import ArgumentParser
+import Foundation
+
+struct RunToolchains: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "run",
+    discussion: """
+      Run a toolchain like bisect would. Passes in name of swift as the
+      environment variabless SWIFTC and SWIFT_FRONTEND
+      """)
+
+  @Flag var platform: Platform = .osx
+
+  @Flag(help: "The specific branch of toolchains we should download")
+  var branch: Branch = .development
+
+  @Option(
+    help: """
+      The directory where toolchains should be downloaded to.
+      """)
+  var workspace: String = "/tmp/swift_snapshot_tool_workspace_v1"
+
+  @Option(
+    help: """
+      The script that should be run. The environment variable
+      SWIFT_EXEC is used by the script to know where swift-frontend is
+      """)
+  var script: String
+
+  @Option(help: "Snapshot tag to run the test for")
+  var tag: String
+
+  @Flag(help: "Invert the test so that we assume the newest succeeds")
+  var invert = false
+
+  @Argument(help: "Extra constant arguments to pass to the test")
+  var extraArgs: [String] = []
+
+  @Flag(help: "Attempt to use the snapshot tag that is immediately younger than the selected")
+  var offset_by_one = false
+
+  @Flag(help: "Emit verbose logging")
+  var verbose = false
+
+  mutating func run() async throws {
+    if !FileManager.default.fileExists(atPath: workspace) {
+      do {
+        log("[INFO] Creating workspace: \(workspace)")
+        try FileManager.default.createDirectory(
+          atPath: workspace,
+          withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        log(error.localizedDescription)
+      }
+    }
+
+    // Load our tags from swift's github repo
+    let tags = try! await getTagsFromSwiftRepo(branch: branch, dryRun: true)
+
+    guard var tagIndex = tags.firstIndex(where: { $0.tag.name == self.tag }) else {
+      log("Failed to find tag: \(self.tag)")
+      fatalError()
+    }
+
+    if self.offset_by_one {
+      if tagIndex == tags.startIndex {
+        log("[INFO] Cannot run one tag earlier than the first snapshot tag?!")
+        fatalError()
+      }
+      tagIndex = tagIndex - 1
+    }
+
+    // Newest is first. So 0 maps to the newest tag. We do this so someone can
+    // just say 50 toolchains ago. To get a few weeks worth. This is easier than
+    // writing dates a lot.
+
+    let result = try! await downloadToolchainAndRunTest(
+      platform: platform, tag: tags[tagIndex].tag, branch: branch, workspace: workspace, script: script,
+      extraArgs: extraArgs, verbose: verbose)
+    var success = result == 0
+    if self.invert {
+      success = !success
+    }
+    if success {
+      log("[INFO] Snapshot succeeds!")
+      //fatalError()
+    } else {
+      log("[INFO] Snapshot fails!")
+    }
+  }
+}

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/swift_snapshot_tool.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/swift_snapshot_tool.swift
@@ -6,6 +6,7 @@ struct SwiftSnapshotTool: ParsableCommand {
     subcommands: [
       BisectToolchains.self,
       ListSnapshots.self,
+      RunToolchains.self,
     ])
 }
 


### PR DESCRIPTION
run_toolchain is mainly useful for diagnosing issues with ones script without
needing to fully bisect... but it also can just be used independently.