### PR TITLE
Only include stdint.h in __STDC_HOSTED__ (i.e. not -ffreestanding)

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -43,6 +43,8 @@ typedef __UINT64_TYPE__ __swift_uint64_t;
 #else
 typedef unsigned __INT64_TYPE__ __swift_uint64_t;
 #endif
+#define __swift_int64_max __INT64_MAX__
+#define __swift_uint64_max __UINT64_MAX__
 
 typedef __INT32_TYPE__ __swift_int32_t;
 #ifdef __UINT32_TYPE__
@@ -50,6 +52,8 @@ typedef __UINT32_TYPE__ __swift_uint32_t;
 #else
 typedef unsigned __INT32_TYPE__ __swift_uint32_t;
 #endif
+#define __swift_int32_max __INT32_MAX__
+#define __swift_uint32_max __UINT32_MAX__
 
 typedef __INT16_TYPE__ __swift_int16_t;
 #ifdef __UINT16_TYPE__
@@ -57,6 +61,8 @@ typedef __UINT16_TYPE__ __swift_uint16_t;
 #else
 typedef unsigned __INT16_TYPE__ __swift_uint16_t;
 #endif
+#define __swift_int16_max __INT16_MAX__
+#define __swift_uint16_max __UINT16_MAX__
 
 typedef __INT8_TYPE__ __swift_int8_t;
 #ifdef __UINT8_TYPE__
@@ -64,11 +70,15 @@ typedef __UINT8_TYPE__ __swift_uint8_t;
 #else
 typedef unsigned __INT8_TYPE__ __swift_uint8_t;
 #endif
+#define __swift_int8_max __INT8_MAX__
+#define __swift_uint8_max __UINT8_MAX__
 
 #define __swift_join3(a,b,c) a ## b ## c
 
 #define __swift_intn_t(n) __swift_join3(__swift_int, n, _t)
 #define __swift_uintn_t(n) __swift_join3(__swift_uint, n, _t)
+#define __swift_intn_max(n) __swift_join3(__swift_int, n, _max)
+#define __swift_uintn_max(n) __swift_join3(__swift_uint, n, _max)
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #if defined(_WIN64)
@@ -83,6 +93,8 @@ typedef __swift_uint32_t __swift_uintptr_t;
 #else
 typedef __swift_intn_t(__INTPTR_WIDTH__) __swift_intptr_t;
 typedef __swift_uintn_t(__INTPTR_WIDTH__) __swift_uintptr_t;
+#define __swift_intptr_max __swift_intn_max(__INTPTR_WIDTH__)
+#define __swift_uintptr_max __swift_uintn_max(__INTPTR_WIDTH__)
 #endif
 #endif
 

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -36,6 +36,16 @@ typedef int8_t __swift_int8_t;
 typedef uint8_t __swift_uint8_t;
 typedef intptr_t __swift_intptr_t;
 typedef uintptr_t __swift_uintptr_t;
+#define __swift_int64_max INT64_MAX
+#define __swift_uint64_max UINT64_MAX
+#define __swift_int32_max INT32_MAX
+#define __swift_uint32_max UINT32_MAX
+#define __swift_int16_max INT16_MAX
+#define __swift_uint16_max UINT16_MAX
+#define __swift_int8_max INT8_MAX
+#define __swift_uint8_max UINT8_MAX
+#define __swift_intptr_max INTPTR_MAX
+#define __swift_uintptr_max UINTPTR_MAX
 #else
 typedef __INT64_TYPE__ __swift_int64_t;
 #ifdef __UINT64_TYPE__
@@ -84,9 +94,13 @@ typedef unsigned __INT8_TYPE__ __swift_uint8_t;
 #if defined(_WIN64)
 typedef __swift_int64_t __swift_intptr_t;
 typedef __swift_uint64_t __swift_uintptr_t;
+#define __swift_intptr_max __swift_int64_max
+#define __swift_uintptr_max __swift_uint64_max
 #elif defined(_WIN32)
 typedef __swift_int32_t __swift_intptr_t;
 typedef __swift_uint32_t __swift_uintptr_t;
+#define __swift_intptr_max __swift_int32_max
+#define __swift_uintptr_max __swift_uint32_max
 #else
 #error unknown windows pointer width
 #endif

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__) && __STDC_HOSTED__
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;

--- a/stdlib/public/stubs/Unicode/UnicodeData.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeData.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/shims/UnicodeData.h"
-#include <stdint.h>
 
 // Every 4 byte chunks of data that we need to hash (in this case only ever
 // scalars and levels who are all uint32), we need to calculate K. At the end
@@ -162,7 +161,7 @@ __swift_intptr_t _swift_stdlib_getScalarBitArrayIdx(__swift_uint32_t scalar,
   // If our chunk index is larger than the quick look indices, then it means
   // our scalar appears in chunks who are all 0 and trailing.
   if ((__swift_uint64_t) idx > quickLookSize - 1) {
-    return INTPTR_MAX;
+    return __swift_intptr_max;
   }
 
   // Our scalar actually exists in a quick look bit array that was implemented.
@@ -172,7 +171,7 @@ __swift_intptr_t _swift_stdlib_getScalarBitArrayIdx(__swift_uint32_t scalar,
   // (chunkSize) of the scalars being represented have no property and ours is
   // one of them.
   if ((quickLook & ((__swift_uint64_t) 1 << chunkBit)) == 0) {
-    return INTPTR_MAX;
+    return __swift_intptr_max;
   }
 
   // Ok, our scalar failed the quick look check. Go lookup our scalar in the
@@ -223,7 +222,7 @@ __swift_intptr_t _swift_stdlib_getScalarBitArrayIdx(__swift_uint32_t scalar,
   // If our scalar specifically is not turned on within our chunk's bit array,
   // then we know for sure that our scalar does not inhibit this property.
   if ((chunkWord & ((__swift_uint64_t) 1 << scalarSpecificBit)) == 0) {
-    return INTPTR_MAX;
+    return __swift_intptr_max;
   }
 
   // Otherwise, this scalar does have whatever property this scalar array is

--- a/stdlib/public/stubs/Unicode/UnicodeGrapheme.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeGrapheme.cpp
@@ -16,7 +16,6 @@
 #include "swift/Runtime/Debug.h"
 #endif
 #include "swift/shims/UnicodeData.h"
-#include <stdint.h>
 
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
@@ -68,7 +67,7 @@ __swift_bool _swift_stdlib_isLinkingConsonant(__swift_uint32_t scalar) {
                                           _swift_stdlib_linkingConsonant,
                                           _swift_stdlib_linkingConsonant_ranks);
 
-  if (idx == INTPTR_MAX) {
+  if (idx == __swift_intptr_max) {
     return false;
   }
 

--- a/stdlib/public/stubs/Unicode/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeNormalization.cpp
@@ -23,7 +23,6 @@
 #endif
 
 #include "swift/shims/UnicodeData.h"
-#include <stdint.h>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_uint16_t _swift_stdlib_getNormData(__swift_uint32_t scalar) {
@@ -42,7 +41,7 @@ __swift_uint16_t _swift_stdlib_getNormData(__swift_uint32_t scalar) {
 
   // If we don't have an index into the data indices, then this scalar has no
   // normalization information.
-  if (dataIdx == INTPTR_MAX) {
+  if (dataIdx == __swift_intptr_max) {
     return 0;
   }
 
@@ -91,7 +90,7 @@ __swift_uint32_t _swift_stdlib_getComposition(__swift_uint32_t x,
   auto realY = (array[0] << 11) >> 11;
 
   if (y != realY) {
-    return UINT32_MAX;
+    return __swift_uint32_max;
   }
 
   auto count = array[0] >> 21;
@@ -134,6 +133,6 @@ __swift_uint32_t _swift_stdlib_getComposition(__swift_uint32_t x,
   // If we made it out here, then our scalar was not found in the composition
   // array.
   // Return the max here to indicate that we couldn't find one.
-  return UINT32_MAX;
+  return __swift_uint32_max;
 #endif
 }

--- a/stdlib/public/stubs/Unicode/UnicodeScalarProps.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeScalarProps.cpp
@@ -26,7 +26,6 @@
 #endif
 
 #include "swift/shims/UnicodeData.h"
-#include <stdint.h>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_uint64_t _swift_stdlib_getBinaryProperties(__swift_uint32_t scalar) {
@@ -124,7 +123,7 @@ __swift_uint8_t _swift_stdlib_getNumericType(__swift_uint32_t scalar) {
   // If we made it out here, then our scalar was not found in the composition
   // array.
   // Return the max here to indicate that we couldn't find one.
-  return UINT8_MAX;
+  return __swift_uint8_max;
 #endif
 }
 
@@ -153,7 +152,7 @@ const char *_swift_stdlib_getNameAlias(__swift_uint32_t scalar) {
                                                     _swift_stdlib_nameAlias,
                                                   _swift_stdlib_nameAlias_ranks);
 
-  if (dataIdx == INTPTR_MAX) {
+  if (dataIdx == __swift_intptr_max) {
     return nullptr;
   }
 
@@ -171,7 +170,7 @@ __swift_int32_t _swift_stdlib_getMapping(__swift_uint32_t scalar,
                                                     _swift_stdlib_mappings,
                                                   _swift_stdlib_mappings_ranks);
 
-  if (dataIdx == INTPTR_MAX) {
+  if (dataIdx == __swift_intptr_max) {
     return 0;
   }
 
@@ -219,7 +218,7 @@ const __swift_uint8_t *_swift_stdlib_getSpecialMapping(__swift_uint32_t scalar,
                                                  _swift_stdlib_special_mappings,
                                           _swift_stdlib_special_mappings_ranks);
 
-  if (dataIdx == INTPTR_MAX) {
+  if (dataIdx == __swift_intptr_max) {
     return nullptr;
   }
 
@@ -261,7 +260,7 @@ __swift_intptr_t _swift_stdlib_getScalarName(__swift_uint32_t scalar,
 #else
   auto setOffset = _swift_stdlib_names_scalar_sets[scalar >> 7];
 
-  if (setOffset == UINT16_MAX) {
+  if (setOffset == __swift_uint16_max) {
     return 0;
   }
 
@@ -385,7 +384,7 @@ __swift_uint16_t _swift_stdlib_getAge(__swift_uint32_t scalar) {
   // If we made it out here, then our scalar was not found in the composition
   // array.
   // Return the max here to indicate that we couldn't find one.
-  return UINT16_MAX;
+  return __swift_uint16_max;
 #endif
 }
 
@@ -427,7 +426,7 @@ __swift_uint8_t _swift_stdlib_getGeneralCategory(__swift_uint32_t scalar) {
   // If we made it out here, then our scalar was not found in the composition
   // array.
   // Return the max here to indicate that we couldn't find one.
-  return UINT8_MAX;
+  return __swift_uint8_max;
 #endif
 }
 
@@ -485,7 +484,7 @@ __swift_uint8_t _swift_stdlib_getScript(__swift_uint32_t scalar) {
   // all in the array. This should never happen because the array represents all
   // scalars from 0x0 to 0x10FFFF, but if somehow this branch gets reached,
   // return 255 to indicate a failure.
-  return UINT8_MAX;
+  return __swift_uint8_max;
 #endif
 }
 
@@ -501,7 +500,7 @@ const __swift_uint8_t *_swift_stdlib_getScriptExtensions(__swift_uint32_t scalar
   
   // If we don't have an index into the data indices, then this scalar has no
   // script extensions
-  if (dataIdx == INTPTR_MAX) {
+  if (dataIdx == __swift_intptr_max) {
     return 0;
   }
   

--- a/stdlib/public/stubs/Unicode/UnicodeWord.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeWord.cpp
@@ -16,7 +16,6 @@
 #include "swift/Runtime/Debug.h"
 #endif
 #include "swift/shims/UnicodeData.h"
-#include <stdint.h>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_uint8_t _swift_stdlib_getWordBreakProperty(__swift_uint32_t scalar) {
@@ -46,6 +45,6 @@ __swift_uint8_t _swift_stdlib_getWordBreakProperty(__swift_uint32_t scalar) {
   // If we made it out here, then our scalar was not found in the word
   // array (this occurs when a scalar doesn't map to any word break
   // property). Return the max value here to indicate .any.
-  return UINT8_MAX;
+  return __swift_uint8_max;
 #endif
 }


### PR DESCRIPTION
Attempt to fix this CI job on rebranch: https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-RA-linux-ubuntu-22_04-long-test/2833/console

```
In file included from /home/build-user/swift/stdlib/public/stubs/Unicode/UnicodeWord.cpp:14:
In file included from /home/build-user/swift/stdlib/public/stubs/Unicode/Common/WordData.h:19:
In file included from /home/build-user/swift/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h:28:
In file included from /home/build-user/build/buildbot_incremental/llvm-linux-x86_64/bin/../include/c++/v1/stdint.h:106:
/home/build-user/build/buildbot_incremental/llvm-linux-x86_64/bin/../include/c++/v1/__config:924:8: error: "No thread API"
  924 | #      error "No thread API"
      |        ^
1 error generated.
```
