### PR TITLE
[SIL] Don't abort via llvm_unreachable.

### DIFF
--- a/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
+++ b/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
@@ -208,7 +208,7 @@ private:
     }
 
     llvm::errs() << "Found ownership error?!\n";
-    llvm_unreachable("triggering standard assertion failure routine");
+    llvm::report_fatal_error("triggering standard assertion failure routine");
   }
 };
 


### PR DESCRIPTION
It is a way to indicate to the compiler that the line can't be reached. On some configurations, it does happen to trap, as desired.  Use a function that always traps, since that's the intent.
