### PR TITLE
[6.0.0] Disable test/SILOptimizer/sil_verify_all_triggers_verifier_without_as…

### DIFF
--- a/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
+++ b/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
@@ -5,6 +5,8 @@
 
 // UNSUPPORTED: asserts
 
+// REQUIRES: rdar135847553
+
 class Klass {}
 
 sil [ossa] @leaky_code : $@convention(thin) () -> () {


### PR DESCRIPTION
…serts.sil

  - **Explanation**: Disable test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts because it's causing a hang on Linux bots. 
  - **Scope**: Disabling the test
  - **Issues**: Causing hangs in CI when building non assert toolchain for Linux platforms
  - **Original PRs**: https://github.com/swiftlang/swift/pull/76424
  - **Risk**: Low
  - **Testing**: Toolchain CI bot
  - **Reviewers**: @nate-chandler 