### PR TITLE
BinaryInteger/advanced(by:) enhancement

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1502,12 +1502,9 @@ extension BinaryInteger {
   @inline(__always)
   public func advanced(by n: Int) -> Self {
     // This compares its maximum bit width versus Int.bitWidth.
+    // All small unsigned integers are bounded by [0, Int.max].
     // It should constant-fold since we use constant arguments.
-    let typeIsSmall  = Self.isSigned
-    ? Self(exactly:  Int.max) == nil
-    : Self(exactly: UInt.max) == nil
-    
-    if typeIsSmall {
+    if Self(exactly: Int.min.magnitude) == nil {
       return Self(Int(truncatingIfNeeded: self) + n)
     } else if Self.isSigned {
       return self + Self(truncatingIfNeeded: n)


### PR DESCRIPTION
#### Summary

1. Fixes an arbitrary, signed, binary integer crash case.
2. Improves the performance of small, unsigned, integers.

#### When does the current method crash?

`BinaryInteger/bitWidth` is a lower bound when `Self` is non-fixed-width:

```swift
:: BigInt(1).advanced(by: Int.max) 
-> BigInt(Int(truncatingIfNeeded: self) + Int.max) 
-> BigInt(Int(1) + Int.max) // crash
```

You can observe it with your favorite big integer package (here's mine: [Ultimathnum](https://github.com/oscbyspro/Ultimathnum)).

#### How does this improve small, unsigned, integer performance?

Small, unsigned, integers now take the same code path as small, signed, integers.
