### PR TITLE
[cxx-interop] Import certain types as @unsafe

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -408,6 +408,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AllowUnsafeAttribute, true)
 /// Warn on use of unsafe constructs.
 EXPERIMENTAL_FEATURE(WarnUnsafe, true)
 
+/// Import unsafe C and C++ constructs as @unsafe.
+EXPERIMENTAL_FEATURE(SafeInterop, true)
+
 // Enable values in generic signatures, e.g. <let N: Int>
 EXPERIMENTAL_FEATURE(ValueGenerics, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -300,6 +300,7 @@ static bool usesFeatureAllowUnsafeAttribute(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(WarnUnsafe)
+UNINTERESTING_FEATURE(SafeInterop)
 
 static bool usesFeatureValueGenerics(Decl *decl) {
   auto genericContext = decl->getAsGenericContext();

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7391,6 +7391,10 @@ bool importer::hasNonEscapableAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, "~Escapable");
 }
 
+bool importer::hasEscapableAttr(const clang::RecordDecl *decl) {
+  return hasSwiftAttribute(decl, "Escapable");
+}
+
 /// Recursively checks that there are no pointers in any fields or base classes.
 /// Does not check C++ records with specific API annotations.
 static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -37,6 +37,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Stmt.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
@@ -8154,6 +8155,21 @@ bool swift::importer::isMutabilityAttr(const clang::SwiftAttrAttr *swiftAttr) {
          swiftAttr->getAttribute() == "nonmutating";
 }
 
+static bool importAsUnsafe(const ASTContext &context,
+                           const clang::RecordDecl *decl,
+                           const Decl *MappedDecl) {
+  if (!context.LangOpts.hasFeature(Feature::SafeInterop) ||
+      !context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute) || !decl)
+    return false;
+
+  if (isa<ClassDecl>(MappedDecl))
+    return false;
+
+  // TODO: Add logic to cover structural rules.
+  return !importer::hasNonEscapableAttr(decl) &&
+         !importer::hasEscapableAttr(decl);
+}
+
 void
 ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
   auto ClangDecl =
@@ -8178,6 +8194,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
     //
     // __attribute__((swift_attr("attribute")))
     //
+    bool seenUnsafe = false;
     for (auto swiftAttr : ClangDecl->specific_attrs<clang::SwiftAttrAttr>()) {
       // FIXME: Hard-code @MainActor and @UIActor, because we don't have a
       // point at which to do name lookup for imported entities.
@@ -8287,8 +8304,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
       if (swiftAttr->getAttribute() == "unsafe") {
         if (!SwiftContext.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
           continue;
-        auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/false);
-        MappedDecl->getAttrs().add(attr);
+        seenUnsafe = true;
         continue;
       }
 
@@ -8331,6 +8347,13 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         diagnose(attrLoc, diag::clang_swift_attr_unhandled,
                  swiftAttr->getAttribute());
       }
+    }
+
+    if (seenUnsafe ||
+        importAsUnsafe(SwiftContext, dyn_cast<clang::RecordDecl>(ClangDecl),
+                       MappedDecl)) {
+      auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/!seenUnsafe);
+      MappedDecl->getAttrs().add(attr);
     }
   };
   importAttrsFromDecl(ClangDecl);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2031,6 +2031,8 @@ bool hasUnsafeAPIAttr(const clang::Decl *decl);
 
 bool hasNonEscapableAttr(const clang::RecordDecl *decl);
 
+bool hasEscapableAttr(const clang::RecordDecl *decl);
+
 bool isViewType(const clang::CXXRecordDecl *decl);
 
 } // end namespace importer

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -164,6 +164,13 @@
 #define SWIFT_NONESCAPABLE \
   __attribute__((swift_attr("~Escapable")))
 
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a escapable Swift value. While this matches the default behavior,
+/// in safe mode interop mode it ensures that the type is not marked as
+/// unsafe.
+#define SWIFT_ESCAPABLE \
+  __attribute__((swift_attr("Escapable")))
+
 /// Specifies that the return value is passed as owned for C++ functions and
 /// methods returning types annotated as `SWIFT_SHARED_REFERENCE`
 #define SWIFT_RETURNS_RETAINED __attribute__((swift_attr("returns_retained")))
@@ -187,6 +194,7 @@
 #define SWIFT_UNCHECKED_SENDABLE
 #define SWIFT_NONCOPYABLE
 #define SWIFT_NONESCAPABLE
+#define SWIFT_ESCAPABLE
 #define SWIFT_RETURNS_RETAINED
 #define SWIFT_RETURNS_UNRETAINED
 

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -1,0 +1,43 @@
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs  %t/test.swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -enable-experimental-feature NonescapableTypes -enable-experimental-feature SafeInterop -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+
+// REQUIRES: objc_interop
+
+//--- Inputs/module.modulemap
+module Test {
+    header "nonescapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/nonescapable.h
+#include "swift/bridging"
+
+struct SWIFT_NONESCAPABLE View {
+    __attribute__((swift_attr("@lifetime(immortal)")))
+    View() : member(nullptr) {}
+    __attribute__((swift_attr("@lifetime(p)")))
+    View(const int *p [[clang::lifetimebound]]) : member(p) {}
+    View(const View&) = default;
+private:
+    const int *member;
+};
+
+struct SWIFT_ESCAPABLE Owner {};
+
+struct Unannotated {};
+
+//--- test.swift
+
+import Test
+import CoreFoundation
+
+func useUnsafeParam(x: Unannotated) { // expected-warning{{reference to unsafe struct 'Unannotated'}}
+}
+
+func useSafeParams(x: Owner, y: View) {
+}
+
+func useCfType(x: CFArray) {
+}


### PR DESCRIPTION
In this mode all C++ types are imported as unsafe by default. Users explicitly marking types are escapable or not escapable can make them imported as safe. In the future, we also want to import unannotated functions as unsafe and add more logic to infer types that are actually safe, like aggregates of escapable types.

rdar://135876415
