### PR TITLE
ASTMangler: sink fix to be more safe

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4192,18 +4192,26 @@ void ASTMangler::appendAnyProtocolConformance(
       conformance.getRequirement()->isMarkerProtocol())
     return;
 
-  // While all invertible protocols are marker protocols, do not mangle them for
-  // compatability reasons. See equivalent hack in `conformanceRequirementIndex`
-  // where only invertible protocols are unconditionally skipped.
-  if (conformance.getRequirement()->getInvertibleProtocolKind())
-    return;
+  // While all invertible protocols are marker protocols, do not mangle them
+  // as a dependent conformance. See `conformanceRequirementIndex` which skips
+  // these, too. In theory, invertible conformances should never be mangled,
+  // but we *might* have let that slip by for the other cases below, so the
+  // early-exits are highly conservative.
+  const bool forInvertible =
+      conformance.getRequirement()->getInvertibleProtocolKind().has_value();
 
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
+    if (forInvertible)
+      return;
+
     auto path = genericSig->getConformancePath(conformingType,
                                                conformance.getAbstract());
     appendDependentProtocolConformance(path, genericSig);
   } else if (auto opaqueType = conformingType->getAs<OpaqueTypeArchetypeType>()) {
+    if (forInvertible)
+      return;
+
     GenericSignature opaqueSignature =
         opaqueType->getDecl()->getOpaqueInterfaceGenericSignature();
     ConformancePath conformancePath =


### PR DESCRIPTION
My previous fix in `6f6a46f` was the correct fix in theory, but in practice it could accidentally change the mangling of something I haven't considered, which would break ABI with Swift 6.0

I've narrowed that fix here to only affect dependent conformances specifically for Copyable/Escapable. The existing code in `appendDependentProtocolConformance` would always reach a trap because we're mangling a conformance path that ends with Copyable/Escapable.

We can assume no such symbol has been successfully been mangled before, thanks to the pre-existing skip in `conformanceRequirementIndex`, so there's no risk of ABI change.

rdar://135310019

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
