### PR TITLE
Ensure that BridgedTypeArray is indirectly returned

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -780,6 +780,10 @@ struct BridgedSubstitutionMap {
 struct BridgedTypeArray {
   BridgedArrayRef typeArray;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64,
+  BridgedTypeArray() : typeArray() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedTypeArray(llvm::ArrayRef<swift::Type> types) : typeArray(types) {}
 

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -14,3 +14,8 @@ module UnsafeProjections {
   
   export *
 }
+
+module SRetWinARM64 {
+  header "sret-win-arm64.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/method/Inputs/sret-win-arm64.h
+++ b/test/Interop/Cxx/class/method/Inputs/sret-win-arm64.h
@@ -1,0 +1,84 @@
+#ifndef TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H
+#define TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H
+
+#include <stdint.h>
+
+namespace llvm {
+
+template<typename T>
+class ArrayRef {
+public:
+   const T *Data = nullptr;
+   size_t Length = 0;
+};
+
+} // namespace llvm
+
+namespace swift {
+
+class Type {
+};
+
+class SubstitutionMap {
+private:
+  void *storage = nullptr;
+
+public:
+  llvm::ArrayRef<Type> getReplacementTypes() const;
+};
+
+} // namespace swift
+
+class BridgedArrayRef {
+public:
+  const void * Data;
+  size_t Length;
+
+  BridgedArrayRef() : Data(nullptr), Length(0) {}
+
+#ifdef USED_IN_CPP_SOURCE
+  template <typename T>
+  BridgedArrayRef(llvm::ArrayRef<T> arr)
+      : Data(arr.Data), Length(arr.Length) {}
+
+  template <typename T>
+  llvm::ArrayRef<T> unbridged() const {
+    return {static_cast<const T *>(Data), Length};
+  }
+#endif
+};
+
+struct BridgedSubstitutionMap {
+  uint64_t storage[1];
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedSubstitutionMap(swift::SubstitutionMap map) {
+    *reinterpret_cast<swift::SubstitutionMap *>(&storage) = map;
+  }
+  swift::SubstitutionMap unbridged() const {
+    return *reinterpret_cast<const swift::SubstitutionMap *>(&storage);
+  }
+#endif
+
+  BridgedSubstitutionMap() {}
+};
+
+struct BridgedTypeArray {
+  BridgedArrayRef typeArray;
+
+#ifdef AFTER_FIX
+   BridgedTypeArray() : typeArray() {}
+#endif
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedTypeArray(llvm::ArrayRef<swift::Type> types) : typeArray(types) {}
+
+  llvm::ArrayRef<swift::Type> unbridged() const {
+    return typeArray.unbridged<swift::Type>();
+  }
+#endif
+
+  static BridgedTypeArray fromReplacementTypes(BridgedSubstitutionMap substMap);
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H

--- a/test/Interop/Cxx/class/method/sret-win-arm64.swift
+++ b/test/Interop/Cxx/class/method/sret-win-arm64.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s -check-prefix=CHECK-before-fix
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s -Xcc -DAFTER_FIX | %FileCheck %s -check-prefix=CHECK-after-fix
+
+// REQUIRES: OS=windows-msvc && CPU=aarch64
+
+import SRetWinARM64
+
+public struct OptionalTypeArray {
+  private let bridged: BridgedTypeArray
+  public init(bridged: BridgedTypeArray) {
+    self.bridged = bridged
+  }
+}
+
+public struct SubstitutionMap {
+  public let bridged: BridgedSubstitutionMap
+
+  public var replacementTypes: OptionalTypeArray {
+    let types = BridgedTypeArray.fromReplacementTypes(bridged)
+    return OptionalTypeArray(bridged: types)
+  }
+}
+
+public func test(sm: SubstitutionMap) -> OptionalTypeArray {
+  return sm.replacementTypes
+}
+
+// Check that BridgedTypeArray is indirectly returned via sret after the fix
+
+// CHECK-before-fix: declare {{.*}} [2 x i64] @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(i64)
+// CHECK-after-fix: declare {{.*}} void @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(ptr inreg sret(%struct.BridgedTypeArray) align 8, i64)


### PR DESCRIPTION
On Windows ARM64, how a struct value type is returned is sensitive to conditions including whether a user-defined constructor exists, etc. See

https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170#return-values

That caused a calling convention mismatch between the non-USED_IN_CPP_SOURCE (Swift) side and the USE_IN_CPP_SOURCE (C++) side and a crash.

Add this constructor so that the calling convention matches.

This is a fix for the OnoneSimplification crash in

https://github.com/swiftlang/swift/issues/74866#issuecomment-2319618579

and is a partial fix for

https://github.com/swiftlang/swift/issues/74866#issuecomment-2319618579
