### PR TITLE
[concurrency] Represent a SILFunction without isolation as std::optional<ActorIsolation> instead of ActorIsolation::Unspecified.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -353,7 +353,7 @@ private:
   unsigned BlockListChangeIdx = 0;
 
   /// The isolation of this function.
-  ActorIsolation actorIsolation = ActorIsolation::forUnspecified();
+  std::optional<ActorIsolation> actorIsolation;
 
   /// The function's bare attribute. Bare means that the function is SIL-only
   /// and does not require debug info.
@@ -1453,7 +1453,9 @@ public:
     actorIsolation = newActorIsolation;
   }
 
-  ActorIsolation getActorIsolation() const { return actorIsolation; }
+  std::optional<ActorIsolation> getActorIsolation() const {
+    return actorIsolation;
+  }
 
   /// Return the source file that this SILFunction belongs to if it exists.
   SourceFile *getSourceFile() const;

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1425,9 +1425,9 @@ private:
       // our transferring operand. If so, we can squelch this.
       if (auto functionIsolation =
               transferringOp->getUser()->getFunction()->getActorIsolation()) {
-        if (functionIsolation.isActorIsolated() &&
+        if (functionIsolation->isActorIsolated() &&
             SILIsolationInfo::get(transferringOp->getUser())
-                .hasSameIsolation(functionIsolation))
+                .hasSameIsolation(*functionIsolation))
           return;
       }
     }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3376,9 +3376,10 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   if (auto functionIsolation = getActorIsolation()) {
     OS << "// Isolation: ";
-    functionIsolation.print(OS);
+    functionIsolation->print(OS);
     OS << '\n';
   }
+
   printClangQualifiedNameCommentIfPresent(OS, getClangDecl());
 
   OS << "sil ";

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -754,10 +754,7 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
 
   // If we have global actor isolation for our constant, put the isolation onto
   // the function.
-  if (auto isolation =
-          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
-    F->setActorIsolation(isolation);
-  }
+  F->setActorIsolation(getActorIsolationOfContext(constant.getInnermostDeclContext()));
 
   assert(F && "SILFunction should have been defined");
 
@@ -1248,12 +1245,7 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
     F->setGenericEnvironment(genericEnv, capturedEnvs, forwardingSubs);
   }
 
-  // If we have global actor isolation for our constant, put the isolation onto
-  // the function.
-  if (auto isolation =
-          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
-    F->setActorIsolation(isolation);
-  }
+  F->setActorIsolation(getActorIsolationOfContext(constant.getInnermostDeclContext()));
 
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -509,59 +509,62 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
 
   // Treat function ref as either actor isolated or sendable.
   if (auto *fri = dyn_cast<FunctionRefInst>(inst)) {
-    auto isolation = fri->getReferencedFunction()->getActorIsolation();
+    if (auto optIsolation = fri->getReferencedFunction()->getActorIsolation()) {
+      auto isolation = *optIsolation;
 
-    // First check if we are actor isolated at the AST level... if we are, then
-    // create the relevant actor isolated.
-    if (isolation.isActorIsolated()) {
-      if (isolation.isGlobalActor()) {
-        return SILIsolationInfo::getGlobalActorIsolated(
-            fri, isolation.getGlobalActor());
+      // First check if we are actor isolated at the AST level... if we are,
+      // then create the relevant actor isolated.
+      if (isolation.isActorIsolated()) {
+        if (isolation.isGlobalActor()) {
+          return SILIsolationInfo::getGlobalActorIsolated(
+              fri, isolation.getGlobalActor());
+        }
+
+        // TODO: We need to be able to support flow sensitive actor instances
+        // like we do for partial apply. Until we do so, just store SILValue()
+        // for this. This could cause a problem if we can construct a function
+        // ref and invoke it with two different actor instances of the same type
+        // and pass in the same parameters to both. We should error and we would
+        // not with this impl since we could not distinguish the two.
+        if (isolation.getKind() == ActorIsolation::ActorInstance) {
+          return SILIsolationInfo::getFlowSensitiveActorIsolated(fri,
+                                                                 isolation);
+        }
+
+        assert(isolation.getKind() != ActorIsolation::Erased &&
+               "Implement this!");
       }
 
-      // TODO: We need to be able to support flow sensitive actor instances like
-      // we do for partial apply. Until we do so, just store SILValue() for
-      // this. This could cause a problem if we can construct a function ref and
-      // invoke it with two different actor instances of the same type and pass
-      // in the same parameters to both. We should error and we would not with
-      // this impl since we could not distinguish the two.
-      if (isolation.getKind() == ActorIsolation::ActorInstance) {
-        return SILIsolationInfo::getFlowSensitiveActorIsolated(fri, isolation);
-      }
-
-      assert(isolation.getKind() != ActorIsolation::Erased &&
-             "Implement this!");
-    }
-
-    // Then check if we have something that is nonisolated unsafe.
-    if (isolation.isNonisolatedUnsafe()) {
-      // First check if our function_ref is a method of a global actor isolated
-      // type. In such a case, we create a global actor isolated
-      // nonisolated(unsafe) so that if we assign the value to another variable,
-      // the variable still says that it is the appropriate global actor
-      // isolated thing.
-      //
-      // E.x.:
-      //
-      // @MainActor
-      // struct X { nonisolated(unsafe) var x: NonSendableThing { ... } }
-      //
-      // We want X.x to be safe to use... but to have that 'z' in the following
-      // is considered MainActor isolated.
-      //
-      // let z = X.x
-      //
-      auto *func = fri->getReferencedFunction();
-      auto funcType = func->getLoweredFunctionType();
-      if (funcType->hasSelfParam()) {
-        auto selfParam = funcType->getSelfInstanceType(
-            fri->getModule(), func->getTypeExpansionContext());
-        if (auto *nomDecl = selfParam->getNominalOrBoundGenericNominal()) {
-          auto isolation = swift::getActorIsolation(nomDecl);
-          if (isolation.isGlobalActor()) {
-            return SILIsolationInfo::getGlobalActorIsolated(
-                fri, isolation.getGlobalActor())
-              .withUnsafeNonIsolated(true);
+      // Then check if we have something that is nonisolated unsafe.
+      if (isolation.isNonisolatedUnsafe()) {
+        // First check if our function_ref is a method of a global actor
+        // isolated type. In such a case, we create a global actor isolated
+        // nonisolated(unsafe) so that if we assign the value to another
+        // variable, the variable still says that it is the appropriate global
+        // actor isolated thing.
+        //
+        // E.x.:
+        //
+        // @MainActor
+        // struct X { nonisolated(unsafe) var x: NonSendableThing { ... } }
+        //
+        // We want X.x to be safe to use... but to have that 'z' in the
+        // following is considered MainActor isolated.
+        //
+        // let z = X.x
+        //
+        auto *func = fri->getReferencedFunction();
+        auto funcType = func->getLoweredFunctionType();
+        if (funcType->hasSelfParam()) {
+          auto selfParam = funcType->getSelfInstanceType(
+              fri->getModule(), func->getTypeExpansionContext());
+          if (auto *nomDecl = selfParam->getNominalOrBoundGenericNominal()) {
+            auto nomDeclIsolation = swift::getActorIsolation(nomDecl);
+            if (nomDeclIsolation.isGlobalActor()) {
+              return SILIsolationInfo::getGlobalActorIsolated(
+                         fri, nomDeclIsolation.getGlobalActor())
+                  .withUnsafeNonIsolated(true);
+            }
           }
         }
       }
@@ -868,8 +871,11 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
     // code. In the case of a non-actor, we can only have an allocator that is
     // global actor isolated, so we will never hit this code path.
     if (declRef.kind == SILDeclRef::Kind::Allocator) {
-      if (fArg->getFunction()->getActorIsolation().isActorInstanceIsolated()) {
-        return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
+      if (auto isolation = fArg->getFunction()->getActorIsolation()) {
+        if (isolation->isActorInstanceIsolated()) {
+          return SILIsolationInfo::getDisconnected(
+              false /*nonisolated(unsafe)*/);
+        }
       }
     }
 
@@ -878,13 +884,13 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
     // we need to pass in a "fake" ActorInstance that users know is a sentinel
     // for the self value.
     if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      if (functionIsolation.isActorInstanceIsolated() && declRef.getDecl()) {
+      if (functionIsolation->isActorInstanceIsolated() && declRef.getDecl()) {
         if (auto *accessor =
                 dyn_cast_or_null<AccessorDecl>(declRef.getFuncDecl())) {
           if (accessor->isInitAccessor()) {
             return SILIsolationInfo::getActorInstanceIsolated(
                 fArg, ActorInstance::getForActorAccessorInit(),
-                functionIsolation.getActor());
+                functionIsolation->getActor());
           }
         }
       }
@@ -894,15 +900,15 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Otherwise, if we do not have an isolated argument and are not in an
   // allocator, then we might be isolated via global isolation.
   if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-    if (functionIsolation.isActorIsolated()) {
-      if (functionIsolation.isGlobalActor()) {
+    if (functionIsolation->isActorIsolated()) {
+      if (functionIsolation->isGlobalActor()) {
         return SILIsolationInfo::getGlobalActorIsolated(
-            fArg, functionIsolation.getGlobalActor());
+            fArg, functionIsolation->getGlobalActor());
       }
 
       return SILIsolationInfo::getActorInstanceIsolated(
           fArg, ActorInstance::getForActorAccessorInit(),
-          functionIsolation.getActor());
+          functionIsolation->getActor());
     }
   }
 

--- a/test/Concurrency/actor_isolation_filecheck.swift
+++ b/test/Concurrency/actor_isolation_filecheck.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking %s -emit-silgen -o - | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking %s -emit-sil -o /dev/null -verify
+
+// README: This file contains FileCheck tests that validate that specific Swift
+// entities have their respective SILFunctions assigned the correct actor
+// isolation by FileChecking against SILGen.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+func useValueAsync<T>(_ t: T) async {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK: // synchronousActorIsolatedFinalClassMethodError()
+// CHECK-NEXT: // Isolation: global_actor. type: MainActor
+// CHECK-NEXT: sil hidden [ossa] @$s25actor_isolation_filecheck45synchronousActorIsolatedFinalClassMethodErroryyYaF : $@convention(thin) @async () -> () {
+@MainActor func synchronousActorIsolatedFinalClassMethodError() async {
+  @MainActor final class Test {
+    // CHECK: // foo() in Test #1 in synchronousActorIsolatedFinalClassMethodError()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    // CHECK-NEXT: sil private [ossa] @$s25actor_isolation_filecheck45synchronousActorIsolatedFinalClassMethodErroryyYaF4TestL_C3fooyyF : $@convention(method) (@guaranteed Test) -> () {
+    func foo() {}
+  }
+
+  let t = Test()
+  let erased: () -> Void = t.foo
+
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+}

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -97,6 +97,7 @@ struct G {
 
 // CHECK-NOT: default_constructor.G.init()
 // CHECK-LABEL: default_constructor.G.init(bar: Swift.Optional<Swift.Int32>)
+// CHECK-NEXT: // Isolation:
 // CHECK-NEXT: sil hidden [ossa] @$s19default_constructor1GV{{[_0-9a-zA-Z]*}}fC
 // CHECK-NOT: default_constructor.G.init()
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -481,6 +481,7 @@ func testNoescape() {
 }
 
 // CHECK-LABEL: functions.testNoescape() -> ()
+// CHECK-NEXT: // Isolation:
 // CHECK-NEXT: sil hidden [ossa] @$s9functions12testNoescapeyyF : $@convention(thin) () -> ()
 // CHECK: function_ref closure #1 () -> () in functions.testNoescape() -> ()
 // CHECK-NEXT: function_ref @$s9functions12testNoescapeyyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> ()

--- a/test/SILGen/global_init_attribute.swift
+++ b/test/SILGen/global_init_attribute.swift
@@ -10,6 +10,7 @@ import def_global
 let InternalConst = 42
 // CHECK-NOT: [global_init]
 // CHECK: // global_init_attribute.InternalConst.unsafeMutableAddressor : Swift.Int
+// CHECK-NEXT: // Isolation:
 // CHECK-NEXT: sil hidden [global_init] [ossa] @$s21global_init_attribute13InternalConstSivau
 
 func foo() -> Int {
@@ -22,10 +23,12 @@ func bar(i: Int) {
 
 // CHECK-NOT: [global_init]
 // CHECK: // def_global.ExportedVar.unsafeMutableAddressor : Swift.Int
+// CHECK-NEXT: // Isolation:
 // CHECK-NEXT: sil [global_init] @$s10def_global11ExportedVarSivau
 
 var InternalFoo = foo()
 
 // CHECK-NOT: [global_init]
 // CHECK: // global_init_attribute.InternalFoo.unsafeMutableAddressor : Swift.Int
+// CHECK-NEXT: // Isolation:
 // CHECK-NEXT: sil hidden [global_init] [ossa] @$s21global_init_attribute11InternalFooSivau

--- a/test/SILGen/package_sil_linkage.swift
+++ b/test/SILGen/package_sil_linkage.swift
@@ -12,11 +12,11 @@
 
 /// Check serialization in SILGEN with resilience enabled.
 // RUN: %target-swift-emit-silgen -emit-verbose-sil -sil-verify-all -enable-library-evolution -module-name Utils %t/Utils.swift -package-name mypkg -I %t > %t/Utils-Res.sil
-// RUN: %FileCheck %s --check-prefixes=UTILS-RES,UTILS-COMMON < %t/Utils-Res.sil
+// RUN: %FileCheck %s --check-prefixes=UTILS-RES,UTILS-COMMON -input-file=%t/Utils-Res.sil
 
 /// Check for indirect access with a resiliently built module dependency.
 // RUN: %target-swift-emit-silgen -sil-verify-all %t/Client.swift -package-name mypkg -I %t > %t/Client-Res.sil
-// RUN: %FileCheck %s --check-prefixes=CLIENT-RES,CLIENT-COMMON < %t/Client-Res.sil
+// RUN: %FileCheck %s --check-prefixes=CLIENT-RES,CLIENT-COMMON -input-file=%t/Client-Res.sil
 
 // RUN: rm -rf %t/Utils.swiftmodule
 
@@ -30,11 +30,11 @@
 
 /// Check serialization in SILGEN with resilience not enabled.
 // RUN: %target-swift-emit-silgen -emit-verbose-sil -sil-verify-all -module-name Utils %t/Utils.swift -package-name mypkg -I %t > %t/Utils-NonRes.sil
-// RUN: %FileCheck %s --check-prefixes=UTILS-NONRES,UTILS-COMMON < %t/Utils-NonRes.sil
+// RUN: %FileCheck %s --check-prefixes=UTILS-NONRES,UTILS-COMMON -input-file %t/Utils-NonRes.sil
 
 /// Check for indirect access with a non-resiliently built module dependency.
 // RUN: %target-swift-emit-silgen -sil-verify-all %t/Client.swift -package-name mypkg -I %t > %t/Client-NonRes.sil
-// RUN: %FileCheck %s --check-prefixes=CLIENT-NONRES,CLIENT-COMMON < %t/Client-NonRes.sil
+// RUN: %FileCheck %s --check-prefixes=CLIENT-NONRES,CLIENT-COMMON -input-file %t/Client-NonRes.sil
 
 
 //--- Utils.swift
@@ -538,11 +538,14 @@ package func f(_ arg: PublicStruct) -> Int {
 }
 
 // CLIENT-RES-LABEL: // f(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int
 // CLIENT-RES-LABEL: // PublicStruct.data.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int
 
 // CLIENT-NONRES-LABEL: // f(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (PublicStruct) -> Int
 
 public func ff(_ arg: PublicStruct) -> Int {
@@ -550,9 +553,11 @@ public func ff(_ arg: PublicStruct) -> Int {
 }
 
 // CLIENT-RES-LABEL: // ff(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil [ossa] @$s6Client2ffySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int
 
 // CLIENT-NONRES-LABEL: // ff(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil [ossa] @$s6Client2ffySi5Utils12PublicStructVF : $@convention(thin) (PublicStruct) -> Int
 
 
@@ -587,11 +592,14 @@ package func g(_ arg: PkgStruct) -> Int {
 }
 
 // CLIENT-RES-LABEL: // g(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (@in_guaranteed PkgStruct) -> Int
 // CLIENT-RES-LABEL: // PkgStruct.data.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package_external @$s5Utils9PkgStructV4dataSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int
 
 // CLIENT-NONRES-LABEL: // g(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (PkgStruct) -> Int
 
 package func gx(_ arg: UfiPkgClass) -> Int {
@@ -599,6 +607,7 @@ package func gx(_ arg: UfiPkgClass) -> Int {
 }
 
 // CLIENT-COMMON-LABEL: // gx(_:)
+// CLIENT-COMMON-NEXT: // Isolation: unspecified
 // CLIENT-COMMON-NEXT: sil package [ossa] @$s6Client2gxySi5Utils11UfiPkgClassCF : $@convention(thin) (@guaranteed UfiPkgClass) -> Int {
 
 package func m<T>(_ arg: PkgStructGeneric<T>) -> T {
@@ -606,12 +615,15 @@ package func m<T>(_ arg: PkgStructGeneric<T>) -> T {
 }
 
 // CLIENT-RES-LABEL: // m<A>(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
 
 // CLIENT-RES-LABEL: // PkgStructGeneric.data.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package_external @$s5Utils16PkgStructGenericV4dataxvg : $@convention(method) <τ_0_0> (@in_guaranteed PkgStructGeneric<τ_0_0>) -> @out τ_0_0
 
 // CLIENT-NONRES-LABEL: // m<A>(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
 
 
@@ -625,12 +637,16 @@ package func n(_ arg: PkgStructWithPublicMember) -> Int {
 }
 
 // CLIENT-RES-LABEL: // n(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicMember) -> Int
+
 // CLIENT-RES-LABEL: // PkgStructWithPublicMember.member.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package_external @$s5Utils25PkgStructWithPublicMemberV6memberAA0eC0Vvg : $@convention(method) (@in_guaranteed PkgStructWithPublicMember) -> @out PublicStruct
 
 
 // CLIENT-NONRES-LABEL: // n(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (PkgStructWithPublicMember) -> Int
 
 package func p(_ arg: PkgStructWithPublicExistential) -> any PublicProto {
@@ -638,13 +654,16 @@ package func p(_ arg: PkgStructWithPublicExistential) -> any PublicProto {
 }
 
 // CLIENT-RES-LABEL: // p(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
 
 // CLIENT-RES-LABEL: // PkgStructWithPublicExistential.member.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package_external @$s5Utils30PkgStructWithPublicExistentialV6memberAA0E5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto
 
 
 // CLIENT-NONRES-LABEL: // p(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
 
 package func q(_ arg: PkgStructWithPkgExistential) -> any PkgProto {
@@ -652,13 +671,16 @@ package func q(_ arg: PkgStructWithPkgExistential) -> any PkgProto {
 }
 
 // CLIENT-RES-LABEL: // q(_:)
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package [ossa] @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
 
 // CLIENT-RES-LABEL: // PkgStructWithPkgExistential.member.getter
+// CLIENT-RES-NEXT: // Isolation: unspecified
 // CLIENT-RES-NEXT: sil package_external @$s5Utils013PkgStructWithB11ExistentialV6memberAA0B5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto
 
 
 // CLIENT-NONRES-LABEL: // q(_:)
+// CLIENT-NONRES-NEXT: // Isolation: unspecified
 // CLIENT-NONRES-NEXT: sil package [ossa] @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
 
 package func r(_ arg: PublicProto) -> Int {
@@ -666,6 +688,7 @@ package func r(_ arg: PublicProto) -> Int {
 }
 
 // CLIENT-COMMON-LABEL: // r(_:)
+// CLIENT-COMMON-NEXT: // Isolation: unspecified
 // CLIENT-COMMON-NEXT: sil package [ossa] @$s6Client1rySi5Utils11PublicProto_pF : $@convention(thin) (@in_guaranteed any PublicProto) -> Int {
 
 package func s(_ arg: PkgProto) -> Int {
@@ -673,6 +696,7 @@ package func s(_ arg: PkgProto) -> Int {
 }
 
 // CLIENT-COMMON-LABEL: // s(_:)
+// CLIENT-COMMON-NEXT: // Isolation: unspecified
 // CLIENT-COMMON-NEXT: sil package [ossa] @$s6Client1sySi5Utils8PkgProto_pF : $@convention(thin) (@in_guaranteed any PkgProto) -> Int {
 
 public func t(_ arg: any PublicProto) -> Int {
@@ -700,4 +724,5 @@ package func w(_ arg: PkgKlass) -> Int {
 }
 
 // CLIENT-COMMON-LABEL: // w(_:)
+// CLIENT-COMMON-NEXT: // Isolation: unspecified
 // CLIENT-COMMON-NEXT: sil package [ossa] @$s6Client1wySi5Utils8PkgKlassCF : $@convention(thin) (@guaranteed PkgKlass) -> Int

--- a/test/SILGen/stored_property_default_arg.swift
+++ b/test/SILGen/stored_property_default_arg.swift
@@ -3,6 +3,7 @@
 // Currently, this only appears for memberwise initializers.
 
 // CHECK: default argument 0 of A.init(b:c:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1AV1b1cACSi_SbtcfcfA_ : $@convention(thin) () -> Int {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of A.b
@@ -12,6 +13,7 @@
 // CHECK-NEXT: }
 
 // CHECK: default argument 1 of A.init(b:c:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1AV1b1cACSi_SbtcfcfA0_ : $@convention(thin) () -> Bool {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of A.c
@@ -45,6 +47,7 @@ func checkConcreteType() {
 }
 
 // CHECK: default argument 1 of F.init(g:h:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1FV1g1hACyxGx_SitcfcfA0_ : $@convention(thin) <T> () -> Int {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of F.h
@@ -90,6 +93,7 @@ func checkOptionalNil() {
 }
 
 // CHECK: default argument 0 of O.init(p:q:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1OV1p1qACyxGx_x_SittcfcfA_ : $@convention(thin) <T where T : ExpressibleByIntegerLiteral> () -> @out T {
 // CHECK:      bb0([[PARAM_0:.*]] : $*T):
 // CHECK-NEXT:   function_ref variable initialization expression of O.p
@@ -100,6 +104,7 @@ func checkOptionalNil() {
 // CHECK-NEXT: }
 
 // CHECK: default argument 1 of O.init(p:q:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1OV1p1qACyxGx_x_SittcfcfA0_ : $@convention(thin) <T where T : ExpressibleByIntegerLiteral> () -> (@out T, Int) {
 // CHECK:      bb0([[PARAM_0:.*]] : $*T):
 // CHECK-NEXT:   function_ref variable initialization expression of O.q
@@ -135,6 +140,7 @@ func checkIndirect() {
 }
 
 // CHECK: default argument 0 of U.init(v:w:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1UV1v1wAcA1TCSg_AGtcfcfA_ : $@convention(thin) () -> @owned Optional<T> {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of U.v
@@ -144,6 +150,7 @@ func checkIndirect() {
 // CHECK-NEXT: }
 
 // CHECK: default argument 1 of U.init(v:w:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg1UV1v1wAcA1TCSg_AGtcfcfA0_ : $@convention(thin) () -> @owned T {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of U.w
@@ -179,6 +186,7 @@ func checkReferenceTypes() {
 }
 
 // CHECK: default argument 0 of AA.init(ab:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s27stored_property_default_arg2AAV2abAcA1ZCSg2ac_AG2adt_tcfcfA_ : $@convention(thin) () -> (@owned Optional<Z>, @owned Optional<Z>) {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   function_ref variable initialization expression of AA.ab

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -64,14 +64,17 @@ class Nonfinal<T> {
 
 extension Final: Encodable where T: Encodable {}
 // CHECK-LABEL: // Final<A>.encode(to:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s29synthesized_conformance_class5FinalCAASERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed any Encoder, @guaranteed Final<T>) -> @error any Error {
 
 extension Final: Decodable where T: Decodable {}
 // CHECK-LABEL: // Final<A>.init(from:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [exact_self_class] [ossa] @$s29synthesized_conformance_class5FinalCAASeRzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable> (@in any Decoder, @thick Final<T>.Type) -> (@owned Final<T>, @error any Error) {
 
 extension Nonfinal: Encodable where T: Encodable {}
 // CHECK-LABEL: // Nonfinal<A>.encode(to:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s29synthesized_conformance_class8NonfinalCAASERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed any Encoder, @guaranteed Nonfinal<T>) -> @error any Error {
 
 final class FinalHashableClass : Hashable {

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -36,22 +36,28 @@ enum NoValues {
 
 extension Enum: Equatable where T: Equatable {}
 // CHECK-FRAGILE-LABEL: // static Enum<A>.__derived_enum_equals(_:_:)
+// CHECK-FRAGILE-NEXT: // Isolation: unspecified
 // CHECK-FRAGILE-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASQRzlE010__derived_C7_equalsySbACyxG_AEtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Enum<T>, @in_guaranteed Enum<T>, @thin Enum<T>.Type) -> Bool {
 // CHECK-RESILIENT-LABEL: // static Enum<A>.== infix(_:_:)
+// CHECK-RESILIENT-NEXT: // Isolation: unspecified
 // CHECK-RESILIENT-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASQRzlE2eeoiySbACyxG_AEtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Enum<T>, @in_guaranteed Enum<T>, @thin Enum<T>.Type) -> Bool {
 
 extension Enum: Hashable where T: Hashable {}
 // CHECK-LABEL: // Enum<A>.hash(into:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASHRzlE4hash4intoys6HasherVz_tF : $@convention(method) <T where T : Hashable> (@inout Hasher, @in_guaranteed Enum<T>) -> () {
 
 // CHECK-LABEL: // Enum<A>.hashValue.getter
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASHRzlE9hashValueSivg : $@convention(method) <T where T : Hashable> (@in_guaranteed Enum<T>) -> Int {
 
 extension Enum: Codable where T: Codable {}
 // CHECK-LABEL: // Enum<A>.encode(to:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASeRzSERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Decodable, T : Encodable> (@in_guaranteed any Encoder, @in_guaranteed Enum<T>) -> @error any Error {
 
 // CHECK-LABEL: // Enum<A>.init(from:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum4EnumOAASeRzSERzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable, T : Encodable> (@in any Decoder, @thin Enum<T>.Type) -> (@out Enum<T>, @error any Error)
 
 extension NoValues: CaseIterable {}
@@ -61,9 +67,11 @@ extension NoValues: CaseIterable {}
 
 extension NoValues: Codable {}
 // CHECK-LABEL: // NoValues.encode(to:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum8NoValuesO6encode2toys7Encoder_p_tKF : $@convention(method) (@in_guaranteed any Encoder, NoValues) -> @error any Error {
 
 // CHECK-LABEL: // NoValues.init(from:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum8NoValuesO4fromACs7Decoder_p_tKcfC : $@convention(method) (@in any Decoder, @thin NoValues.Type) -> (NoValues, @error any Error)
 
 // Witness tables for Enum

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -35,22 +35,28 @@ struct Struct<T> {
 
 extension Struct: Equatable where T: Equatable {}
 // CHECK-FRAGILE-LABEL: // static Struct<A>.__derived_struct_equals(_:_:)
+// CHECK-FRAGILE-NEXT: // Isolation: unspecified
 // CHECK-FRAGILE-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASQRzlE010__derived_C7_equalsySbACyxG_AEtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Struct<T>, @in_guaranteed Struct<T>, @thin Struct<T>.Type) -> Bool {
 // CHECK-RESILIENT-LABEL: // static Struct<A>.== infix(_:_:)
+// CHECK-RESILIENT-NEXT: // Isolation: unspecified
 // CHECK-RESILIENT-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASQRzlE2eeoiySbACyxG_AEtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Struct<T>, @in_guaranteed Struct<T>, @thin Struct<T>.Type) -> Bool {
 
 extension Struct: Hashable where T: Hashable {}
 // CHECK-LABEL: // Struct<A>.hash(into:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASHRzlE4hash4intoys6HasherVz_tF : $@convention(method) <T where T : Hashable> (@inout Hasher, @in_guaranteed Struct<T>) -> () {
 
 // CHECK-LABEL: // Struct<A>.hashValue.getter
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASHRzlE9hashValueSivg : $@convention(method) <T where T : Hashable> (@in_guaranteed Struct<T>) -> Int {
 
 extension Struct: Codable where T: Codable {}
 // CHECK-LABEL: // Struct<A>.encode(to:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASeRzSERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Decodable, T : Encodable> (@in_guaranteed any Encoder, @in_guaranteed Struct<T>) -> @error any Error {
 
 // CHECK-LABEL: // Struct<A>.init(from:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil hidden [ossa] @$s30synthesized_conformance_struct6StructVAASeRzSERzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable, T : Encodable> (@in any Decoder, @thin Struct<T>.Type) -> (@out Struct<T>, @error any Error)
 
 

--- a/test/SILOptimizer/moveonly_raw_layout.swift
+++ b/test/SILOptimizer/moveonly_raw_layout.swift
@@ -13,6 +13,7 @@ struct Lock: ~Copyable {
     var _address: Builtin.RawPointer { return Builtin.addressOfBorrow(self) }
 
     // CHECK-LABEL: // Lock.init()
+    // CHECK-NEXT: Isolation: unspecified
     // CHECK-NEXT: sil{{.*}} @[[INIT:\$.*4LockV.*fC]] :
     init() {
         // CHECK-NOT: destroy_addr
@@ -26,6 +27,7 @@ struct Lock: ~Copyable {
     }
 
     // CHECK-LABEL: // Lock.deinit
+    // CHECK-NEXT: Isolation: unspecified
     // CHECK-NEXT: sil{{.*}} @[[DEINIT:\$.*4LockV.*fD]] :
     deinit {
         // CHECK-NOT: destroy_addr

--- a/test/SILOptimizer/specialize_self.swift
+++ b/test/SILOptimizer/specialize_self.swift
@@ -4,12 +4,14 @@
 // CHECK-NOT: generic specialization <Swift.AnyObject, Self> of specialize_self.cast <A, B>(A) -> Swift.Optional<B>
 
 // CHECK-LABEL: specialize_self.cast<A, B>(A) -> Swift.Optional<B>
+// CHECK-NEXT: Isolation: unspecified
 // CHECK-NEXT: sil hidden @$s15specialize_self4cast{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T, R> (@in_guaranteed T) -> @out Optional<R>
 func cast<T,R>(_ x: T) -> R? {
   return x as? R
 }
 
 // CHECK-LABEL: static specialize_self.Base.returnIfSelf(Swift.AnyObject) -> Swift.Optional<Self>
+// CHECK-NEXT: Isolation: unspecified
 // CHECK-NEXT: sil hidden @$s15specialize_self4BaseC12returnIfSelf{{[_0-9a-zA-Z]*}}FZ : $@convention(method) (@guaranteed AnyObject, @thick Base.Type) -> @owned Optional<Base>
 // CHECK: [[CAST:%[0-9]+]] = function_ref @$s15specialize_self4cast{{[_0-9a-zA-Z]*}}F
 // CHECK: apply [[CAST]]<AnyObject, @dynamic_self Base>

--- a/test/Serialization/nested-protocols.swift
+++ b/test/Serialization/nested-protocols.swift
@@ -4,9 +4,11 @@
 import nestedprotocolsource
 
 // CHECK: usesNested<A>(_:)
+// CHECK-NEXT: Isolation: unspecified
 // CHECK-NEXT: sil @$s4main10usesNestedyyx20nestedprotocolsource5OuterV5InnerRzlF :
 public func usesNested(_ x: some Outer.Inner) {}
 
 // CHECK: usesNestedInExtension<A>(_:)
+// CHECK-NEXT: Isolation: unspecified
 // CHECK-NEXT: sil @$s4main21usesNestedInExtensionyyx20nestedprotocolsource5OuterV05InnerdE0RzlF :
 public func usesNestedInExtension(_ x: some Outer.InnerInExtension) {}


### PR DESCRIPTION
The reason why is that we want to distinguish inbetween SILFunction's that are marked as unspecified by SILGen and those that are parsed from textual SIL that do not have any specified isolation. This will make it easier to write nice FileCheck tests against SILGen output on what is the inferred isolation for various items.

NFCI.