### PR TITLE
[Concurrency] Add a debug variable that holds the current version of the concurrency library.

### DIFF
--- a/include/swift/ABI/Actor.h
+++ b/include/swift/ABI/Actor.h
@@ -20,6 +20,12 @@
 #include "swift/ABI/HeapObject.h"
 #include "swift/ABI/MetadataValues.h"
 
+// lldb knows about some of these internals. If you change things that lldb
+// knows about (or might know about in the future, as a future lldb might be
+// inspecting a process running an older Swift runtime), increment
+// _swift_concurrency_debug_internal_layout_version and add a comment describing
+// the new version.
+
 namespace swift {
 
 /// The default actor implementation.  This is the layout of both

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -43,6 +43,12 @@ class TaskOptionRecord;
 class TaskGroup;
 class ContinuationAsyncContext;
 
+// lldb knows about some of these internals. If you change things that lldb
+// knows about (or might know about in the future, as a future lldb might be
+// inspecting a process running an older Swift runtime), increment
+// _swift_concurrency_debug_internal_layout_version and add a comment describing
+// the new version.
+
 extern FullMetadata<DispatchClassMetadata> jobHeapMetadata;
 
 /// A schedulable job.

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -49,6 +49,12 @@ const void *const _swift_concurrency_debug_task_future_wait_resume_adapter;
 SWIFT_EXPORT_FROM(swift_Concurrency)
 bool _swift_concurrency_debug_supportsPriorityEscalation;
 
+/// The current version of internal data structures that lldb may decode.
+/// The version numbers used so far are:
+/// 1 - The initial version number when this variable was added, in swift 6.1.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+uint32_t _swift_concurrency_debug_internal_layout_version;
+
 } // namespace swift
 
 #endif

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -87,6 +87,8 @@ const void *const swift::_swift_concurrency_debug_asyncTaskSlabMetadata =
 bool swift::_swift_concurrency_debug_supportsPriorityEscalation =
     SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION;
 
+uint32_t swift::_swift_concurrency_debug_internal_layout_version = 1;
+
 void FutureFragment::destroy() {
   auto queueHead = waitQueue.load(std::memory_order_acquire);
   switch (queueHead.getStatus()) {

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -335,3 +335,5 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
+
+Added: __swift_concurrency_debug_internal_layout_version

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -335,3 +335,5 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
+
+Added: __swift_concurrency_debug_internal_layout_version


### PR DESCRIPTION
This allows lldb to know which version of the internals layout it needs to use.

rdar://135886268