### PR TITLE
[CSSimplify] Delay `inout` type to pointer conversion until `inout` is sufficiently resolved

### DIFF
--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -478,20 +478,17 @@ func rdar75146811() {
 
   var arr: [Double]! = []
 
-  test(&arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test(&arr) // Ok
   test((&arr)) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
-  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test(&(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test(&(arr)) // Ok
 
-  test_tuple(&arr, x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_tuple(&arr, x: 0) // Ok
   test_tuple((&arr), x: 0) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
-  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test_tuple(&(arr), x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_tuple(&(arr), x: 0) // Ok
 
-  test_named(x: &arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_named(x: &arr) // Ok
   test_named(x: (&arr)) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
-  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test_named(x: &(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_named(x: &(arr)) // Ok
 }
 
 // rdar://75514153 - Unable to produce a diagnostic for ambiguities related to use of `nil`

--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -51,3 +51,21 @@ do {
 func rdar68254165(ptr: UnsafeMutablePointer<Int8>) {
   _ = String(decodingCString: ptr, as: .utf8) // expected-error {{generic parameter 'Encoding' could not be inferred}}
 }
+
+// The base of leading-dot syntax could be inferred through an implicit pointer conversion.
+do {
+  struct S {
+    static var prop = S()
+  }
+
+  func inference_through_optional(_ ptr: UnsafePointer<S>?) {}
+
+  inference_through_optional(&.prop) // Ok
+
+  func inference_through_force_unwrap(name: String) {
+    func test(_: UnsafeMutablePointer<Float>!) {}
+
+    var outputs = [String: [Float]]()
+    test(&outputs[name]!) // Ok
+  }
+}

--- a/test/Sema/diag_non_ephemeral.swift
+++ b/test/Sema/diag_non_ephemeral.swift
@@ -198,8 +198,10 @@ takesMutableRaw(&ResilientStruct.staticStoredProperty, 5) // expected-error {{ca
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
 // expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-// FIXME: This should also produce an error.
-takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5)
+
+takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesMutableRaw'}}
+// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
+// expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
 //   - Resilient struct or class bases
 
@@ -221,8 +223,10 @@ takesRaw(&topLevelP.property) // expected-error {{cannot use inout expression he
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
 // expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-// FIXME: This should also produce an error.
-takesRaw(&type(of: topLevelP).staticProperty)
+
+takesRaw(&type(of: topLevelP).staticProperty) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
+// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
+// expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
 takesRaw(&topLevelP[]) // expected-error {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}

--- a/test/Sema/diag_non_ephemeral_warning.swift
+++ b/test/Sema/diag_non_ephemeral_warning.swift
@@ -198,8 +198,9 @@ takesMutableRaw(&ResilientStruct.staticStoredProperty, 5) // expected-warning {{
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
 // expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-// FIXME: This should also produce a warning.
-takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5)
+takesMutableRaw(&type(of: topLevelResilientS).staticStoredProperty, 5) // expected-warning {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesMutableRaw'}}
+// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeMutableRawPointer' produces a pointer valid only for the duration of the call to 'takesMutableRaw'}}
+// expected-note@-2 {{use 'withUnsafeMutableBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
 //   - Resilient struct or class bases
 
@@ -221,8 +222,9 @@ takesRaw(&topLevelP.property) // expected-warning {{cannot use inout expression 
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
 // expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
-// FIXME: This should also produce a warning.
-takesRaw(&type(of: topLevelP).staticProperty)
+takesRaw(&type(of: topLevelP).staticProperty) // expected-warning {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
+// expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}
+// expected-note@-2 {{use 'withUnsafeBytes' in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
 takesRaw(&topLevelP[]) // expected-warning {{cannot use inout expression here; argument #1 must be a pointer that outlives the call to 'takesRaw'}}
 // expected-note@-1 {{implicit argument conversion from 'Int8' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'takesRaw'}}


### PR DESCRIPTION
If left-hand side of any conversion constraint is `inout` type
and right is a pointer (or optional thereof), delay simplification
until `inout` is at least partially structurally resolved (cannot
be a type variable or dependent member) because eager simplification
won't record all of the possible conversions.

Allow inferring type of `inout` from a pointer type
(or optional thereof) but delay the binding set because
it might not be complete and object type of `inout` could
also be an Array or C-style pointer type.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
