### PR TITLE
[SourceKit] Format macro decl without crashing

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -1414,6 +1414,12 @@ private:
       // interpolated string literal.
       if (E->getArgs() == Args)
         ContextLoc = getContextLocForArgs(SM, E);
+    } else if (auto *D = Parent.getAsDecl()) {
+      if (auto *MED = dyn_cast<MacroExpansionDecl>(D)) {
+        if (MED->getArgs() == Args) {
+          ContextLoc = MED->getStartLoc();
+        }
+      }
     }
 
     auto Action = HandlePre(Args, Args->isImplicit());
@@ -2700,10 +2706,17 @@ private:
     if (TrailingTarget)
       return std::nullopt;
 
-    auto *ParentE = Parent.getAsExpr();
-    assert(ParentE && "Trailing closures can only occur in expr contexts");
-    return IndentContext{
-        ContextLoc, !OutdentChecker::hasOutdent(SM, ContextToEnd, ParentE)};
+    bool hasOutdent;
+    if (auto *ParentE = Parent.getAsExpr()) {
+      hasOutdent = OutdentChecker::hasOutdent(SM, ContextToEnd, ParentE);
+    } else if (auto *ParentD = Parent.getAsDecl()) {
+      assert(isa<MacroExpansionDecl>(ParentD) && "Trailing closures in decls can only occur in macro expansions");
+      hasOutdent = OutdentChecker::hasOutdent(SM, ContextToEnd, ParentD);
+    } else {
+      assert(false && "Trailing closures can only occur in expr contexts and macro expansions");
+      return std::nullopt;
+    }
+    return IndentContext{ContextLoc, !hasOutdent};
   }
 
   std::optional<IndentContext>

--- a/test/SourceKit/CodeFormat/indent-available-macro.swift
+++ b/test/SourceKit/CodeFormat/indent-available-macro.swift
@@ -1,0 +1,6 @@
+@available(iOS 17, *)
+#Preview("") {
+  UIView()
+}
+
+// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response

--- a/test/SourceKit/CodeFormat/indent-available-macro.swift
+++ b/test/SourceKit/CodeFormat/indent-available-macro.swift
@@ -1,6 +1,9 @@
 @available(iOS 17, *)
 #Preview("") {
-  UIView()
+UIView()
 }
 
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "    UIView()"


### PR DESCRIPTION
Resolves #70002

Fix SourceKit crash occurring when formatting a macro with both an available attribute and a trailing closure.
SourceKit's formatting code was expecting trailing closures to only be present on expressions (`Expr`), but an available attribute on a macro makes it a declaration (`Decl`).

I don't have much knowledge of how SourceKit's formatting works so I wouldn't be surprised if this was incomplete.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
