### PR TITLE
Partially revert “Support @objc(CustomName) on extensions”

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -424,10 +424,7 @@ private:
       os << "\n";
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
-    if (ED->getObjCCategoryName().empty())
-      os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
-    else
-      os << " (" << ED->getObjCCategoryName() << ")";
+    os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
     printMembers(ED->getMembers());

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -137,13 +137,6 @@ extension NSObject {
   @objc var some: Int { return 1 }
 }
 
-// CHECK-LABEL: @interface NSString (CustomName)
-// CHECK-NEXT: - (void)test3;
-// CHECK-NEXT: @end
-@objc(CustomName) extension NSString {
-  func test3() {}
-}
-
 // NEGATIVE-NOT: @class NSString;
 // CHECK: @class NSColor;
 // CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(extensions))


### PR DESCRIPTION
Revert portions of 07b9fe9ce6692da25f386fb933deffb71c21b8a2 to temporarily avoid applying `@objc(CustomName) extension`s to generated header category names.

Fixes rdar://135924149.