### PR TITLE
[test] Add REQUIRES: assert to test using --debug-only

### DIFF
--- a/test/SILOptimizer/cold_block_info.swift
+++ b/test/SILOptimizer/cold_block_info.swift
@@ -7,6 +7,8 @@
 // RUN: %FileCheck %s --input-file=%t/debug.txt \
 // RUN:               --implicit-check-not 'converged after {{[3-9]}} iters'
 
+// REQUIRES: asserts
+
 public enum MyError: Error { case err; case number(Int) }
 
 @inline(never)


### PR DESCRIPTION
The test is using LLVM's `--debug-only=` but it is not marked as `REQUIRES: asserts`, so it will try to run in non-asserts compilers and fail.`
