### PR TITLE
[Sema] Remove workaround from `TypeExpr::createForSpecializedDecl`

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2295,36 +2295,6 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
     specializedTR->setValue(boundDecl, ParentTR->getDeclContext());
   } else {
     auto *const qualIdentTR = cast<QualifiedIdentTypeRepr>(ParentTR);
-    if (isa<TypeAliasDecl>(boundDecl)) {
-      // If any of our parent types are unbound, bail out and let
-      // the constraint solver can infer generic parameters for them.
-      //
-      // This is because a type like GenericClass.GenericAlias<Int>
-      // cannot be represented directly.
-      //
-      // This also means that [GenericClass.GenericAlias<Int>]()
-      // won't parse correctly, whereas if we fully specialize
-      // GenericClass, it does.
-      //
-      // FIXME: Once we can model generic typealiases properly, rip
-      // this out.
-      QualifiedIdentTypeRepr *currTR = qualIdentTR;
-      while (auto *declRefBaseTR =
-                 dyn_cast<DeclRefTypeRepr>(currTR->getBase())) {
-        if (!declRefBaseTR->hasGenericArgList()) {
-          auto *decl =
-              dyn_cast_or_null<GenericTypeDecl>(declRefBaseTR->getBoundDecl());
-          if (decl && decl->isGeneric())
-            return nullptr;
-        }
-
-        currTR = dyn_cast<QualifiedIdentTypeRepr>(declRefBaseTR);
-        if (!currTR) {
-          break;
-        }
-      }
-    }
-
     specializedTR = QualifiedIdentTypeRepr::create(
         C, qualIdentTR->getBase(), ParentTR->getNameLoc(),
         ParentTR->getNameRef(), Args, AngleLocs);

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -126,3 +126,11 @@ do {
   // expected-note@-2 {{remove the space between the elements to silence this warning}}{{14-15=}}
   ]
 }
+
+struct TupleWith<T> {
+  typealias And<U> = (T, U)
+}
+_ = [TupleWith<String>.And<Int>](repeating: ("", 0), count: 0)
+_ = [TupleWith.And<Int>](repeating: ("", 0), count: 0)
+_ = [TupleWith<String>.And](repeating: ("", 0), count: 0)
+_ = [TupleWith.And](repeating: ("", 0), count: 0)


### PR DESCRIPTION
This no longer seems to be necessary now that we eagerly open UnboundGenericTypes in `resolveTypeReferenceInExpression`.