### PR TITLE
Overhaul mapTypeIntoContext()

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -157,14 +157,14 @@ private:
   friend ArchetypeType;
   friend QueryInterfaceTypeSubstitutions;
 
-  /// Add a mapping of a generic parameter to a specific type (which may be
-  /// an archetype)
-  void addMapping(GenericParamKey key, Type contextType);
+  /// Add a mapping of a type parameter to a contextual type, usually
+  /// an archetype.
+  void addMapping(CanType depType, Type contextType);
 
-  /// Retrieve the mapping for the given generic parameter, if present.
+  /// Retrieve the mapping for the given type parameter, if present.
   ///
   /// This is only useful when lazily populating a generic environment.
-  std::optional<Type> getMappingIfPresent(GenericParamKey key) const;
+  Type getMappingIfPresent(CanType depType) const;
 
 public:
   GenericSignature getGenericSignature() const {

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -157,8 +157,6 @@ private:
   friend ArchetypeType;
   friend QueryInterfaceTypeSubstitutions;
 
-  Type getOrCreateArchetypeFromInterfaceType(Type depType);
-
   /// Add a mapping of a generic parameter to a specific type (which may be
   /// an archetype)
   void addMapping(GenericParamKey key, Type contextType);
@@ -283,12 +281,11 @@ public:
   /// Map an interface type to a contextual type.
   Type mapTypeIntoContext(Type type) const;
 
-  /// Map an interface type to a contextual type.
-  Type mapTypeIntoContext(Type type,
-                          LookupConformanceFn lookupConformance) const;
-
   /// Map a generic parameter type to a contextual type.
   Type mapTypeIntoContext(GenericTypeParamType *type) const;
+
+  /// Map a type parameter type to a contextual type.
+  Type getOrCreateArchetypeFromInterfaceType(Type depType);
 
   /// Map an interface type containing parameter packs to a contextual
   /// type in the opened element generic context.

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -404,6 +404,11 @@ public:
 
   bool isReducedType(Type type) const;
 
+  /// Return the reduced version of the given type parameter under this generic
+  /// signature. To reduce a type that more generally contains type parameters,
+  /// use GenericSignature::getReducedType().
+  CanType getReducedTypeParameter(CanType type) const;
+
   /// Determine whether the given type parameter is defined under this generic
   /// signature.
   bool isValidTypeParameter(Type type) const;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -170,9 +170,6 @@ public:
   /// Stores a set of requirements on a type parameter. Used by
   /// GenericEnvironment for building archetypes.
   struct LocalRequirements {
-    Type anchor;
-
-    Type concreteType;
     Type superclass;
 
     RequiredProtocols protos;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6580,11 +6580,7 @@ public:
   bool requiresClass() const;
 
   /// Retrieve the superclass of this type, if such a requirement exists.
-  Type getSuperclass() const {
-    if (!Bits.ArchetypeType.HasSuperclass) return Type();
-
-    return *getSubclassTrailingObjects<Type>();
-  }
+  Type getSuperclass() const;
 
   /// Retrieve the layout constraint of this type, if such a requirement exists.
   LayoutConstraint getLayoutConstraint() const {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -378,7 +378,7 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   auto genericSig = getGenericSignature();
 
   // Reduce it.
-  auto reducedType = genericSig.getReducedType(canType);
+  auto reducedType = genericSig->getReducedTypeParameter(canType);
 
   // If this type parameter is equivalent to a concrete type,
   // map the concrete type into context and cache the result.

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -507,21 +507,14 @@ Type QueryInterfaceTypeSubstitutions::operator()(SubstitutableType *type) const{
   return Type();
 }
 
-Type GenericEnvironment::mapTypeIntoContext(
-                                Type type,
-                                LookupConformanceFn lookupConformance) const {
+Type GenericEnvironment::mapTypeIntoContext(Type type) const {
   assert(!type->hasPrimaryArchetype() && "already have a contextual type");
 
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
-                           lookupConformance,
+                           LookUpConformanceInModule(),
                            SubstFlags::PreservePackExpansionLevel);
   ASSERT(getKind() != Kind::Primary || !result->hasTypeParameter());
   return result;
-
-}
-
-Type GenericEnvironment::mapTypeIntoContext(Type type) const {
-  return mapTypeIntoContext(type, LookUpConformanceInModule());
 }
 
 Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -404,14 +404,6 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   // requirements.
   auto requirements = genericSig->getLocalRequirements(reducedType);
 
-  // Substitute into the superclass.
-  Type superclass = requirements.superclass;
-  if (superclass && superclass->hasTypeParameter()) {
-    superclass = mapTypeIntoContext(superclass);
-    if (superclass->is<ErrorType>())
-      superclass = Type();
-  }
-
   Type result;
 
   auto sugaredType = genericSig->getSugaredType(reducedType);
@@ -422,11 +414,13 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     if (rootGP->isParameterPack()) {
       result = PackArchetypeType::get(ctx, this, sugaredType,
                                       requirements.packShape,
-                                      requirements.protos, superclass,
+                                      requirements.protos,
+                                      requirements.superclass,
                                       requirements.layout);
     } else {
       result = PrimaryArchetypeType::getNew(ctx, this, sugaredType,
-                                            requirements.protos, superclass,
+                                            requirements.protos,
+                                            requirements.superclass,
                                             requirements.layout);
     }
 
@@ -442,7 +436,8 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     }
 
     result = OpaqueTypeArchetypeType::getNew(this, sugaredType,
-                                             requirements.protos, superclass,
+                                             requirements.protos,
+                                             requirements.superclass,
                                              requirements.layout);
     break;
   }
@@ -468,10 +463,12 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
         protos.push_back(proto);
 
       result = OpenedArchetypeType::getNew(this, sugaredType, protos,
-                                           superclass, requirements.layout);
+                                           requirements.superclass,
+                                           requirements.layout);
     } else {
       result = OpenedArchetypeType::getNew(this, sugaredType,
-                                           requirements.protos, superclass,
+                                           requirements.protos,
+                                           requirements.superclass,
                                            requirements.layout);
     }
 
@@ -485,7 +482,8 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     }
 
     result = ElementArchetypeType::getNew(this, sugaredType,
-                                          requirements.protos, superclass,
+                                          requirements.protos,
+                                          requirements.superclass,
                                           requirements.layout);
     break;
   }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -412,12 +412,7 @@ bool GenericSignatureImpl::isRequirementSatisfied(
     auto *genericEnv = getGenericEnvironment();
 
     requirement = requirement.subst(
-        [&](SubstitutableType *type) -> Type {
-          if (auto *paramType = type->getAs<GenericTypeParamType>())
-            return genericEnv->mapTypeIntoContext(paramType);
-
-          return type;
-        },
+        QueryInterfaceTypeSubstitutions{genericEnv},
         LookUpConformanceInModule());
   }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -327,8 +327,7 @@ GenericSignature::LocalRequirements
 GenericSignatureImpl::getLocalRequirements(Type depType) const {
   assert(depType->isTypeParameter() && "Expected a type parameter here");
 
-  return getRequirementMachine()->getLocalRequirements(
-      depType, getGenericParams());
+  return getRequirementMachine()->getLocalRequirements(depType);
 }
 
 ASTContext &GenericSignatureImpl::getASTContext() const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -504,6 +504,11 @@ CanType GenericSignatureImpl::getReducedType(Type type) const {
       type, { })->getCanonicalType();
 }
 
+CanType GenericSignatureImpl::getReducedTypeParameter(CanType type) const {
+  return getRequirementMachine()->getReducedTypeParameter(
+      type, { })->getCanonicalType();
+}
+
 bool GenericSignatureImpl::isValidTypeParameter(Type type) const {
   return getRequirementMachine()->isValidTypeParameter(type);
 }

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -345,6 +345,120 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
       std::nullopt);
 }
 
+Type RequirementMachine::getReducedTypeParameter(
+    CanType t,
+    ArrayRef<GenericTypeParamType *> genericParams) const {
+  // Get a simplified term T.
+  auto term = Context.getMutableTermForType(t, /*proto=*/nullptr);
+  System.simplify(term);
+
+  // We need to handle "purely concrete" member types, eg if I have a
+  // signature <T where T == Foo>, and we're asked to reduce the
+  // type T.[P:A] where Foo : A.
+  //
+  // This comes up because we can derive the signature <T where T == Foo>
+  // from a generic signature like <T where T : P>; adding the
+  // concrete requirement 'T == Foo' renders 'T : P' redundant. We then
+  // want to take interface types written against the original signature
+  // and reduce them with respect to the derived signature.
+  //
+  // The problem is that T.[P:A] is not a valid term in the rewrite system
+  // for <T where T == Foo>, since we do not have the requirement T : P.
+  //
+  // A more principled solution would build a substitution map when
+  // building a derived generic signature that adds new requirements;
+  // interface types would first be substituted before being reduced
+  // in the new signature.
+  //
+  // For now, we handle this with a two-step process; we split a term up
+  // into a longest valid prefix, which must resolve to a concrete type,
+  // and the remaining suffix, which we use to perform a concrete
+  // substitution using subst().
+
+  // In the below, let T be a type term, with T == UV, where U is the
+  // longest valid prefix.
+  //
+  // Note that V can be empty if T is fully valid; we expect this to be
+  // true most of the time.
+  auto prefix = getLongestValidPrefix(term);
+
+  // Get a type (concrete or dependent) for U.
+  auto prefixType = [&]() -> Type {
+    if (prefix.empty())
+      return Type();
+
+    verify(prefix);
+
+    auto *props = Map.lookUpProperties(prefix);
+    if (props) {
+      if (props->isConcreteType()) {
+        auto concreteType = props->getConcreteType(genericParams,
+                                                   prefix, Map);
+        if (!concreteType->hasTypeParameter())
+          return concreteType;
+
+        // FIXME: Recursion guard is needed here
+        return getReducedType(concreteType, genericParams);
+      }
+
+      // Skip this part if the entire input term is valid, because in that
+      // case we don't want to replace the term with its superclass bound;
+      // unlike a fixed concrete type, the superclass bound only comes into
+      // play when looking up a member type.
+      if (props->hasSuperclassBound() &&
+          prefix.size() != term.size()) {
+        auto superclass = props->getSuperclassBound(genericParams,
+                                                    prefix, Map);
+        if (!superclass->hasTypeParameter())
+          return superclass;
+
+        // FIXME: Recursion guard is needed here
+        return getReducedType(superclass, genericParams);
+      }
+    }
+
+    return Map.getTypeForTerm(prefix, genericParams);
+  }();
+
+  // If T is already valid, the longest valid prefix U of T is T itself, and
+  // V is empty. Just return the type we computed above.
+  //
+  // This is the only case where U is allowed to be dependent.
+  if (prefix.size() == term.size())
+    return prefixType;
+
+  // If U is not concrete, we have an invalid member type of a dependent
+  // type, which is not valid in this generic signature. Give up.
+  if (prefix.empty() || prefixType->isTypeParameter()) {
+    llvm::errs() << "\n";
+    llvm::errs() << "getReducedTypeParameter() was called\n";
+    llvm::errs() << "       with " << Sig << ",\n";
+    llvm::errs() << "       and " << t << ".\n\n";
+    if (prefix.empty()) {
+      llvm::errs() << "This type parameter contains the generic parameter "
+                   << Type(t->getRootGenericParam()) << ".\n\n";
+      llvm::errs() << "This generic parameter is not part of the given "
+                   << "generic signature.\n\n";
+    } else {
+      llvm::errs() << "This type parameter's reduced term is " << term << ".\n\n";
+      llvm::errs() << "This is not a valid term, because " << prefix << " does not "
+                   << "have a member type named " << term[prefix.size()] << ".\n\n";
+    }
+    llvm::errs() << "This usually indicates the caller passed the wrong type or "
+                 << "generic signature to getReducedType().\n\n";
+
+    dump(llvm::errs());
+    abort();
+  }
+
+  // Compute the type of the unresolved suffix term V.
+  auto substType = substPrefixType(t, term.size() - prefix.size(),
+                                   prefixType, Sig);
+
+  // FIXME: Recursion guard is needed here
+  return getReducedType(substType, genericParams);
+}
+
 /// Unlike most other queries, the input type can be any type, not just a
 /// type parameter.
 ///
@@ -375,117 +489,7 @@ Type RequirementMachine::getReducedType(
     if (!t->isTypeParameter())
       return std::nullopt;
 
-    // Get a simplified term T.
-    auto term = Context.getMutableTermForType(t->getCanonicalType(),
-                                              /*proto=*/nullptr);
-    System.simplify(term);
-
-    // We need to handle "purely concrete" member types, eg if I have a
-    // signature <T where T == Foo>, and we're asked to reduce the
-    // type T.[P:A] where Foo : A.
-    //
-    // This comes up because we can derive the signature <T where T == Foo>
-    // from a generic signature like <T where T : P>; adding the
-    // concrete requirement 'T == Foo' renders 'T : P' redundant. We then
-    // want to take interface types written against the original signature
-    // and reduce them with respect to the derived signature.
-    //
-    // The problem is that T.[P:A] is not a valid term in the rewrite system
-    // for <T where T == Foo>, since we do not have the requirement T : P.
-    //
-    // A more principled solution would build a substitution map when
-    // building a derived generic signature that adds new requirements;
-    // interface types would first be substituted before being reduced
-    // in the new signature.
-    //
-    // For now, we handle this with a two-step process; we split a term up
-    // into a longest valid prefix, which must resolve to a concrete type,
-    // and the remaining suffix, which we use to perform a concrete
-    // substitution using subst().
-
-    // In the below, let T be a type term, with T == UV, where U is the
-    // longest valid prefix.
-    //
-    // Note that V can be empty if T is fully valid; we expect this to be
-    // true most of the time.
-    auto prefix = getLongestValidPrefix(term);
-
-    // Get a type (concrete or dependent) for U.
-    auto prefixType = [&]() -> Type {
-      if (prefix.empty())
-        return Type();
-
-      verify(prefix);
-
-      auto *props = Map.lookUpProperties(prefix);
-      if (props) {
-        if (props->isConcreteType()) {
-          auto concreteType = props->getConcreteType(genericParams,
-                                                     prefix, Map);
-          if (!concreteType->hasTypeParameter())
-            return concreteType;
-
-          // FIXME: Recursion guard is needed here
-          return getReducedType(concreteType, genericParams);
-        }
-
-        // Skip this part if the entire input term is valid, because in that
-        // case we don't want to replace the term with its superclass bound;
-        // unlike a fixed concrete type, the superclass bound only comes into
-        // play when looking up a member type.
-        if (props->hasSuperclassBound() &&
-            prefix.size() != term.size()) {
-          auto superclass = props->getSuperclassBound(genericParams,
-                                                      prefix, Map);
-          if (!superclass->hasTypeParameter())
-            return superclass;
-
-          // FIXME: Recursion guard is needed here
-          return getReducedType(superclass, genericParams);
-        }
-      }
-
-      return Map.getTypeForTerm(prefix, genericParams);
-    }();
-
-    // If T is already valid, the longest valid prefix U of T is T itself, and
-    // V is empty. Just return the type we computed above.
-    //
-    // This is the only case where U is allowed to be dependent.
-    if (prefix.size() == term.size())
-      return prefixType;
-
-    // If U is not concrete, we have an invalid member type of a dependent
-    // type, which is not valid in this generic signature. Give up.
-    if (prefix.empty() || prefixType->isTypeParameter()) {
-      llvm::errs() << "\n";
-      llvm::errs() << "getReducedType() was called\n";
-      llvm::errs() << "       with " << Sig << ",\n";
-      llvm::errs() << "       and " << type << ".\n\n";
-      llvm::errs() << "This type contains the type parameter " << t << ".\n\n";
-      if (prefix.empty()) {
-        llvm::errs() << "This type parameter contains the generic parameter "
-                     << Type(t->getRootGenericParam()) << ".\n\n";
-        llvm::errs() << "This generic parameter is not part of the given "
-                     << "generic signature.\n\n";
-      } else {
-        llvm::errs() << "This type parameter's reduced term is " << term << ".\n\n";
-        llvm::errs() << "This is not a valid term, because " << prefix << " does not "
-                     << "have a member type named " << term[prefix.size()] << ".\n\n";
-      }
-      llvm::errs() << "This usually indicates the caller passed the wrong type or "
-                   << "generic signature to getReducedType().\n\n";
-
-      dump(llvm::errs());
-      abort();
-    }
-
-    // Compute the type of the unresolved suffix term V.
-    auto substType = substPrefixType(t, term.size() - prefix.size(),
-                                     prefixType, Sig);
-
-    // FIXME: Recursion guard is needed here
-    return getReducedType(substType, genericParams);
+    return getReducedTypeParameter(t->getCanonicalType(), genericParams);
   });
 }
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -154,6 +154,8 @@ public:
                        const ProtocolDecl *proto=nullptr) const;
   bool areReducedTypeParametersEqual(Type depType1, Type depType2) const;
   bool isReducedType(Type type) const;
+  Type getReducedTypeParameter(CanType type,
+                      ArrayRef<GenericTypeParamType *> genericParams) const;
   Type getReducedType(Type type,
                       ArrayRef<GenericTypeParamType *> genericParams) const;
   bool isValidTypeParameter(Type type) const;

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -140,8 +140,7 @@ public:
   // Generic signature queries. Generally you shouldn't have to construct a
   // RequirementMachine instance; instead, call the corresponding methods on
   // GenericSignature, which lazily create a RequirementMachine for you.
-  GenericSignature::LocalRequirements getLocalRequirements(Type depType,
-                      ArrayRef<GenericTypeParamType *> genericParams) const;
+  GenericSignature::LocalRequirements getLocalRequirements(Type depType) const;
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3450,6 +3450,14 @@ bool ArchetypeType::requiresClass() const {
   return false;
 }
 
+Type ArchetypeType::getSuperclass() const {
+  if (!Bits.ArchetypeType.HasSuperclass) return Type();
+
+  auto *genericEnv = getGenericEnvironment();
+  return genericEnv->mapTypeIntoContext(
+      *getSubclassTrailingObjects<Type>());
+}
+
 Type ArchetypeType::getValueType() const {
   if (auto gp = getInterfaceType()->getAs<GenericTypeParamType>())
     return gp->getValueType();
@@ -3506,7 +3514,12 @@ static RecursiveTypeProperties archetypeProperties(
     }
   }
 
-  if (superclass) properties |= superclass->getRecursiveProperties();
+  if (superclass) {
+    auto superclassProps = superclass->getRecursiveProperties();
+    superclassProps.removeHasTypeParameter();
+    superclassProps.removeHasDependentMember();
+    properties |= superclassProps;
+  }
 
   return properties;
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2715,20 +2715,18 @@ namespace {
         auto underlyingDependentType = R.getFirstType()->getCanonicalType();
 
         auto underlyingType =
-            underlyingDependentType.subst(substitutions)->getCanonicalType();
+            underlyingDependentType.subst(substitutions);
         auto underlyingConformance =
             substitutions.lookupConformance(underlyingDependentType, P);
 
         if (underlyingType->hasTypeParameter()) {
-          underlyingConformance = underlyingConformance.subst(
-              underlyingType, QueryInterfaceTypeSubstitutions(genericEnv),
-              LookUpConformanceInModule());
-
-          underlyingType = genericEnv->mapTypeIntoContext(underlyingType)
-                               ->getCanonicalType();
+          std::tie(underlyingType, underlyingConformance)
+              = GenericEnvironment::mapConformanceRefIntoContext(
+                    genericEnv, underlyingType, underlyingConformance);
         }
 
-        return emitWitnessTableRef(IGF, underlyingType, underlyingConformance);
+        return emitWitnessTableRef(IGF, underlyingType->getCanonicalType(),
+                                   underlyingConformance);
       }
     };
   };

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2051,7 +2051,7 @@ static void bindArchetypesFromContext(
   // Find the innermost non-type context.
   for (const auto *parentDC = outerDC;
        !parentDC->isModuleScopeContext();
-       parentDC = parentDC->getParent()) {
+       parentDC = parentDC->getParentForLookup()) {
     if (parentDC->isTypeContext()) {
       if (parentDC != outerDC && parentDC->getSelfProtocolDecl()) {
         auto selfTy = parentDC->getSelfInterfaceType();

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -203,7 +203,8 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
   // The context substitution map for the base type fixes the declaration's
   // outer generic parameters.
   auto substMap = BaseTy->getContextSubstitutionMap(
-      VD->getDeclContext(), genericDecl->getGenericEnvironment());
+      VD->getDeclContext(),
+      VD->getDeclContext()->getGenericEnvironmentOfContext());
 
   // The innermost generic parameters are mapped to error types.
   unsigned innerDepth = genericSig->getMaxDepth();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1000,50 +1000,64 @@ findMissingGenericRequirementForSolutionFix(
   type = solution.simplifyType(type);
   missingType = solution.simplifyType(missingType);
 
-  if (auto *env = conformance->getGenericEnvironment()) {
-    // We use subst() with LookUpConformanceInModule here, because
-    // associated type inference failures mean that we can end up
-    // here with a DependentMemberType with an ArchetypeType base.
-    missingType = missingType.subst(
-      [&](SubstitutableType *type) -> Type {
-        return env->mapTypeIntoContext(type->mapTypeOutOfContext());
-      },
-      LookUpConformanceInModule(),
-      SubstFlags::SubstitutePrimaryArchetypes);
-  }
-
   auto missingRequirementMatch = [&](Type type) -> RequirementMatch {
     Requirement requirement(requirementKind, type, missingType);
     return RequirementMatch(witness, MatchKind::MissingRequirement,
                             requirement);
   };
 
-  if (type->is<DependentMemberType>())
-    return missingRequirementMatch(type);
+  auto selfTy = conformance->getProtocol()->getSelfInterfaceType()
+      .subst(reqEnvironment.getRequirementToWitnessThunkSubs());
 
-  type = type->mapTypeOutOfContext();
-  if (type->hasTypeParameter())
-    if (auto env = conformance->getGenericEnvironment())
-      if (auto assocType = env->mapTypeIntoContext(type))
-        return missingRequirementMatch(assocType);
+  auto sig = conformance->getGenericSignature();
+  auto *env = conformance->getGenericEnvironment();
 
-  auto reqSubMap = reqEnvironment.getRequirementToWitnessThunkSubs();
-  auto proto = conformance->getProtocol();
-  Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
-  if (type->isEqual(selfTy)) {
-    type = conformance->getType();
+  auto &ctx = conformance->getDeclContext()->getASTContext();
 
+  if (type->is<ArchetypeType>() &&
+      type->mapTypeOutOfContext()->isEqual(selfTy) &&
+      missingType->isEqual(conformance->getType())) {
     // e.g. `extension P where Self == C { func foo() { ... } }`
     // and `C` doesn't actually conform to `P`.
-    if (type->isEqual(missingType)) {
-      requirementKind = RequirementKind::Conformance;
-      missingType = proto->getDeclaredInterfaceType();
-    }
-
-    if (auto agt = type->getAs<AnyGenericType>())
-      type = agt->getDecl()->getDeclaredInterfaceType();
-    return missingRequirementMatch(type);
+    requirementKind = RequirementKind::Conformance;
+    missingType = conformance->getProtocol()->getDeclaredInterfaceType();
   }
+
+  // Map the interface types of the witness thunk signature back to
+  // sugared generic parameter types of the conformance, for printing.
+  auto getTypeInConformanceContext = [&](Type type) -> Type {
+    return type.subst([&](SubstitutableType *t) -> Type {
+      auto *gp = cast<GenericTypeParamType>(t);
+      if (selfTy->is<GenericTypeParamType>()) {
+        if (gp->isEqual(selfTy))
+          return conformance->getType();
+
+        ASSERT(gp->getDepth() > 0);
+        gp = GenericTypeParamType::get(gp->getParamKind(),
+                                       gp->getDepth() - 1,
+                                       gp->getIndex(),
+                                       gp->getValueType(),
+                                       ctx);
+      }
+
+      if (!sig)
+        return ErrorType::get(ctx);
+
+      auto params = sig.getGenericParams();
+      unsigned ordinal = sig->getGenericParamOrdinal(gp);
+      if (ordinal == params.size())
+        return ErrorType::get(ctx);
+
+      return env->mapTypeIntoContext(gp);
+    },
+    LookUpConformanceInModule());
+  };
+
+  type = getTypeInConformanceContext(type);
+  missingType = getTypeInConformanceContext(missingType);
+
+  if (!type->hasError() && !missingType->hasError())
+    return missingRequirementMatch(type);
 
   return std::optional<RequirementMatch>();
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1220,7 +1220,15 @@ Type TypeResolution::applyUnboundGenericArguments(
       if (result->hasTypeParameter()) {
         if (const auto contextSig = getGenericSignature()) {
           auto *genericEnv = contextSig.getGenericEnvironment();
-          return genericEnv->mapTypeIntoContext(result);
+          // FIXME: This should just use mapTypeIntoContext(), but we can't yet
+          // because we sometimes have type parameters here that are invalid for
+          // our generic signature. This can happen if the type parameter was
+          // found via unqualified lookup, but the current context's
+          // generic signature failed to build because of circularity or
+          // completion failure.
+          return result.subst(QueryInterfaceTypeSubstitutions{genericEnv},
+                              LookUpConformanceInModule(),
+                              SubstFlags::PreservePackExpansionLevel);
         }
       }
       return result;

--- a/test/Generics/recursive_superclass.swift
+++ b/test/Generics/recursive_superclass.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift
+
+// While we disallow explicitly-stated requirements like
+// `T: C<T>`, there are ways to sneak them past the
+// diagnostic.
+//
+// We could relax the diagnostic eventually by rejecting
+// the truly invalid cases, where the superclass contains
+// a member type of a conformance made redundant by the
+// superclass requirement itself.
+
+class C<T> {
+  var t: T
+
+  init(t: T) {
+    self.t = t
+  }
+}
+
+protocol P1 {
+  associatedtype A: C<B.A>
+  associatedtype B: P1
+}
+
+func f<T: P1>(_: T, t: T.A) -> C<T.B.B.B.B.A> {
+  return t.t.t.t
+}
+
+protocol P2 {
+  associatedtype A: C<B>
+  associatedtype B
+}
+
+extension P2 where Self == A {
+  func f() -> C<B> {
+    return self
+  }
+}
+
+extension P2 where Self == A, A == B {
+  func g() -> C<Self> {
+    return self
+  }
+}

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -10,7 +10,7 @@ protocol P {
 
 extension P {
   func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B { }
-  // expected-note@-1 {{candidate would match if 'X' was the same type as 'X.B' (aka 'Int')}}
+  // expected-note@-1 {{candidate would match if 'X.A' (aka 'X') was the same type as 'X.B' (aka 'Int')}}
 }
 
 struct X : P { 
@@ -77,9 +77,23 @@ struct S2 : P6 {
   typealias U = String
 
   func foo() {}
-  // expected-note@-1 {{candidate has non-matching type '() -> ()'}}
+  // expected-note@-1 {{candidate would match if 'S2.T' (aka 'Int') was the same type as 'S2.U' (aka 'String')}}
 
   // FIXME: This error is bogus and should be omitted on account of the protocol requirement itself
   // being invalid.
 }
 
+// This used to emit a diagnostic with a canonical type in it.
+protocol P7 {
+  associatedtype A
+  func f() // expected-note {{protocol requires function 'f()' with type '() -> ()'}}
+}
+
+extension P7 where A: Equatable {
+  func f() {} // expected-note {{candidate would match if 'C7<T>.A' (aka 'T') conformed to 'Equatable'}}
+}
+
+class C7<T>: P7 { // expected-error {{type 'C7<T>' does not conform to protocol 'P7'}}
+// expected-note@-1 {{add stubs for conformance}}
+  typealias A = T
+}


### PR DESCRIPTION
`mapTypeIntoContext()` is now implemented as a `TypeTransform`, instead of via `subst()`.

`subst()` is based on replacement of generic parameters; if substituting a dependent member type, we substitute the base type first and then look up the member in the result. This meant that mapping a dependent member type into context would instantiate all of its parent archetypes and then recursively call `getNestedType()` on each one. In the new implementation, all of this goes away. We structurally walk the type we're mapping into context, and replace each type parameter with the archetype without materializing unnecessary archetypes.

Now, `mapTypeIntoContext()` will deterministically abort if given an invalid type parameter, instead of silently returning an `ErrorType` as before. This uncovered a few call sites where we were passing in truly invalid type parameters because we were mixing up generic environments. There was one spot where the type parameter might not be valid for a legitimate reason, and I changed it to do the mapping in a more verbose way using `subst()`, for the same behavior as before.

Also, previously, `getNestedType()` would end up calling `getLocalRequirements()` on the generic signature before looking up the type parameter in the generic environment's cache, so mapping a dependent member type into context would always issue generic signature queries. Now, generic environment's cache now contains both reduced and non-reduced type parameters. We make sure to populate both the original key and the reduced key, if they differ, and we always look up the non-reduced key before performing any generic signature queries.

Finally, the superclass type of an archetype is itself written in terms of the generic environment's own archetypes; for example, if you have a requirement like `T: C<U>`. When instantiating an archetype, we would eagerly map the superclass type into context. This could result in circular or unbounded recursion. In the circular case we'd end up with an ErrorType in the AST, and no other diagnostic. In the unbounded case, we would crash. Make this lazy, so that an archetype stores the interface type of its superclass, and only maps it into context if you call `ArchetypeType::getSuperclass()`.

At this point, there is not much of a reason to keep the diagnostic that bans a requirement like `T: C<T>` or `T: C<T.A>`. The diagnostic check was not fully sound and people found ways around it, and the only case it's needed is when the superclass type contains a member type that depends on a conformance which becomes redundant, eg:

```
protocol P {
  associatedtype A
}

class C<A>: P {}

extension P where Self: C<Self.A> {}
```

In the case where `C` does not conform to any protocols in common with `Self`, the diagnostic is spurious. I'm leaving it in place for now, though.

Fixes rdar://problem/135348472.