### PR TITLE
Add borrowing `_withUnprotectedUnsafePointer`

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -239,6 +239,32 @@ public func _withUnprotectedUnsafePointer<
 #endif
 }
 
+/// Invokes the given closure with a pointer to the given argument.
+///
+/// This function is similar to `withUnsafePointer`, except that it
+/// doesn't trigger stack protection for the pointer.
+///
+/// - Parameters:
+///   - value: An instance to temporarily use via pointer.
+///   - body: A closure that takes a pointer to `value` as its sole argument. If
+///     the closure has a return value, that value is also used as the return
+///     value of the `withUnsafePointer(to:_:)` function. The pointer argument
+///     is valid only for the duration of the function's execution.
+///     It is undefined behavior to try to mutate through the pointer argument
+///     by converting it to `UnsafeMutablePointer` or any other mutable pointer
+///     type. If you need to mutate the argument through the pointer, use
+///     `withUnsafeMutablePointer(to:_:)` instead.
+/// - Returns: The return value, if any, of the `body` closure.
+@_alwaysEmitIntoClient
+public func _withUnprotectedUnsafePointer<
+  T: ~Copyable, E: Error, Result: ~Copyable
+>(
+  to value: borrowing T,
+  _ body: (UnsafePointer<T>) throws(E) -> Result
+) throws(E) -> Result {
+  return try body(UnsafePointer<T>(Builtin.unprotectedAddressOfBorrow(value)))
+}
+
 extension String {
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of UTF-8 code units.

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -243,18 +243,6 @@ public func _withUnprotectedUnsafePointer<
 ///
 /// This function is similar to `withUnsafePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
-///
-/// - Parameters:
-///   - value: An instance to temporarily use via pointer.
-///   - body: A closure that takes a pointer to `value` as its sole argument. If
-///     the closure has a return value, that value is also used as the return
-///     value of the `withUnsafePointer(to:_:)` function. The pointer argument
-///     is valid only for the duration of the function's execution.
-///     It is undefined behavior to try to mutate through the pointer argument
-///     by converting it to `UnsafeMutablePointer` or any other mutable pointer
-///     type. If you need to mutate the argument through the pointer, use
-///     `withUnsafeMutablePointer(to:_:)` instead.
-/// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 public func _withUnprotectedUnsafePointer<
   T: ~Copyable, E: Error, Result: ~Copyable


### PR DESCRIPTION
For withUnsafePointer we have both an inout and a borrowing form, allowing it to be used with immutable values. Add a parallel form for the unprotected variant.

Resolves: rdar://135889076