### PR TITLE
[cxx-interop] Benchmarks for std::span in Swift

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -210,6 +210,7 @@ set(SWIFT_BENCH_MODULES
     single-source/XorLoop
     cxx-source/CreateObjects
     cxx-source/CxxSetToCollection
+    cxx-source/CxxSpanTests
     cxx-source/CxxStringConversion
     cxx-source/CxxVectorSum
     # TODO: rdar://92120528

--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -129,7 +129,9 @@ targets.append(
     sources: ["main.swift"],
     swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
                                   "-I",
-                                  "utils/CxxTests"])]))
+                                  "utils/CxxTests",
+                                  // FIXME(rdar://136138941): these flags should be redundant because of cxxLanguageStandard
+                                  "-Xcc", "-std=c++20"])]))
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 targets.append(
@@ -168,6 +170,8 @@ targets += cxxSingleSourceLibraries.map { name in
     swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
                                   "-I",
                                   "utils/CxxTests",
+                                  // FIXME(rdar://136138941): these flags should be redundant because of cxxLanguageStandard
+                                  "-Xcc", "-std=c++20",
                                   // FIXME: https://github.com/apple/swift/issues/61453
                                   "-Xfrontend", "-validate-tbd-against-ir=none"])])
 }

--- a/benchmark/cxx-source/CxxSpanTests.swift
+++ b/benchmark/cxx-source/CxxSpanTests.swift
@@ -1,0 +1,121 @@
+//===--- CxxSpanTests.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+import CxxStdlibPerformance
+
+let iterRepeatFactor = 7
+
+// FIXME swift-ci linux tests do not support std::span
+#if os(Linux)
+public let benchmarks = [BenchmarkInfo]()
+#else
+
+public let benchmarks = [
+  BenchmarkInfo(
+    name: "CxxSpanTests.raw.iterator",
+    runFunction: run_CxxSpanOfU32_RawIterator,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+  BenchmarkInfo(
+    name: "CxxSpanTests.index.subscript",
+    runFunction: run_CxxSpanOfU32_IndexAndSubscript,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+  BenchmarkInfo(
+    name: "CxxSpanTests.for.loop",
+    runFunction: run_CxxSpanOfU32_ForInLoop,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+  BenchmarkInfo(
+    name: "CxxSpanTests.map",
+    runFunction: run_CxxSpanOfU32_MapSpan,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+  BenchmarkInfo(
+    name: "CxxSpanTests.filter",
+    runFunction: run_CxxSpanOfU32_FilterSpan,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+  BenchmarkInfo(
+    name: "CxxSpanTests.reduce",
+    runFunction: run_CxxSpanOfU32_ReduceSpan,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSpanOnce),
+]
+
+func makeSpanOnce() {
+  initSpan()
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_RawIterator(_ n: Int) {
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor * 2) {
+    var b = span.__beginUnsafe()
+    let e = span.__endUnsafe()
+    while b != e {
+      sum = sum &+ b.pointee
+      b = b.successor()
+    }
+  }
+  blackHole(sum)
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_IndexAndSubscript(_ n: Int) {
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor * 2) {
+    for i in 0..<span.size() {
+      sum = sum &+ span[i]
+    }
+  }
+  blackHole(sum)
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_ForInLoop(_ n: Int) {
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor * 2) {
+    for x in span {
+      sum = sum &+ x
+    }
+  }
+  blackHole(sum)
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_MapSpan(_ n: Int) {
+  for _ in 0..<(n * iterRepeatFactor) {
+    let result = span.map { $0 &+ 5 }
+    blackHole(result)
+  }
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_FilterSpan(_ n: Int) {
+  for _ in 0..<(n * iterRepeatFactor) {
+    let result = span.filter { $0 % 2 == 0 }
+    blackHole(result)
+  }
+}
+
+@inline(never)
+public func run_CxxSpanOfU32_ReduceSpan(_ n: Int) {
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor * 2) {
+    sum = sum &+ span.reduce(sum, &+)
+  }
+  blackHole(sum)
+}
+
+#endif

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -4,11 +4,26 @@
 #include <vector>
 #include <set>
 
+// FIXME swift-ci linux tests do not support std::span
+#ifndef __linux__
+#include <span>
+#endif
+
+static const size_t spanSize = 50000;
+
 using VectorOfU32 = std::vector<uint32_t>;
 using SetOfU32 = std::set<uint32_t>;
+#ifndef __linux__
+using ArrayOfU32 = uint32_t[spanSize];
+using SpanOfU32 = std::span<uint32_t>;
+#endif
 
 static inline VectorOfU32 vec;
 static inline SetOfU32 set;
+#ifndef __linux__
+static inline ArrayOfU32 array;
+static inline SpanOfU32 span;
+#endif
 
 inline void initVector(size_t size) {
     if (!vec.empty()) {
@@ -28,6 +43,18 @@ inline void initSet(size_t size) {
         set.insert(uint32_t(i));
     }
 }
+
+#ifndef __linux__
+inline void initSpan() {
+    if (!span.empty()) {
+        return;
+    }
+    for (size_t i = 0; i < spanSize; ++i) {
+        array[i] = uint32_t(i);
+    }
+    span = SpanOfU32(array);
+}
+#endif
 
 inline VectorOfU32 makeVector32(size_t size) {
     initVector(size);

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -57,6 +57,7 @@ import CountAlgo
 import CreateObjects
 // rdar://128520766
 // import CxxSetToCollection
+import CxxSpanTests
 import CxxStringConversion
 // rdar://128520766
 // import CxxVectorSum
@@ -255,6 +256,7 @@ register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
 // rdar://128520766
 // register(CxxSetToCollection.benchmarks)
+register(CxxSpanTests.benchmarks)
 register(CxxStringConversion.benchmarks)
 // rdar://128520766
 // register(CxxVectorSum.benchmarks)


### PR DESCRIPTION
* std::span is not supported in swift-ci linux
* explicitly pass -std=c++20 in Package.swift: rdar://136138941

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
