### PR TITLE
[Package.swift] Bump macOS deployment target version to 13.0

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -58,9 +58,6 @@ private extension Target {
 let package = Package(
   name: "SwiftCompilerSources",
   platforms: [
-    // We need at least macOS 13 here to avoid hitting an availability error
-    // for CxxStdlib. It's only needed for the package though, the CMake build
-    // works fine with a lower deployment target.
     .macOS(.v13),
   ],
   products: [

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -36,16 +36,13 @@ let swiftSetttings: [SwiftSetting] = [
     "-Xcc", "-I\(swiftSourceDirectory)/../build/Default/swift/include",
     "-Xcc", "-I\(swiftSourceDirectory)/../build/Default/llvm/include",
     "-Xcc", "-I\(swiftSourceDirectory)/../build/Default/llvm/tools/clang/include",
-
-    // FIXME: Needed to work around an availability issue with CxxStdlib
-    "-Xfrontend", "-disable-target-os-checking",
   ]),
 ]
 
 let package = Package(
   name: "swiftSwiftCompiler",
   platforms: [
-    .macOS(.v10_15)
+    .macOS(.v13)
   ],
   products: [
     .library(name: "swiftASTGen", targets: ["swiftASTGen"]),

--- a/tools/swift-plugin-server/Package.swift
+++ b/tools/swift-plugin-server/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 
 import PackageDescription
 
 let package = Package(
   name: "swift-plugin-server",
   platforms: [
-    .macOS(.v10_15)
+    .macOS(.v13)
   ],
   products: [
     .executable(name: "swift-plugin-server", targets: ["swift-plugin-server"]),


### PR DESCRIPTION
Compiler's minimum deployment target version is now 13.0
