### PR TITLE
[AST] Make `IsNonUserModuleRequest` consider `SourceFile` inputs as well.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -4039,11 +4039,15 @@ bool IsNonUserModuleRequest::evaluate(Evaluator &evaluator, ModuleDecl *mod) con
   if (!mod->hasName() || mod->getFiles().empty())
     return false;
   
-  auto *LF = dyn_cast_or_null<LoadedFile>(mod->getFiles().front());
-  if (!LF)
-    return false;
-  
-  StringRef modulePath = LF->getSourceFilename();
+  StringRef modulePath;
+  auto fileUnit = mod->getFiles().front();
+  if (auto *LF = dyn_cast_or_null<LoadedFile>(fileUnit)) {
+    modulePath = LF->getSourceFilename();
+  } else if (auto *SF = dyn_cast_or_null<SourceFile>(fileUnit)) {
+    // Checking for SourceFiles lets custom tools get the correct is-system
+    // state for index units when compiling a textual interface directly.
+    modulePath = SF->getFilename();
+  }
   if (modulePath.empty())
     return false;
 

--- a/test/IDE/complete_cgfloat_double.swift
+++ b/test/IDE/complete_cgfloat_double.swift
@@ -10,5 +10,5 @@ func foo(_ x: Double) {}
 
 // Make sure we suggest completions for both CGFloat and Double.
 foo(.#^FOO^#)
-// FOO-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#CGFloat#]; name=init()
+// FOO-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init()[#CGFloat#]; name=init()
 // FOO-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init()[#Double#]; name=init()

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -156,7 +156,7 @@ func test014() {
   }
 // NSERROR_DOT-DAG: Decl[InstanceVar]/CurrNominal/IsSystem: domain[#String#]; name=domain
 // NSERROR_DOT-DAG: Decl[InstanceVar]/CurrNominal/IsSystem: code[#Int#]; name=code
-// NSERROR_DOT-DAG: Decl[InstanceVar]/Super:                hashValue[#Int#]; name=hashValue
+// NSERROR_DOT-DAG: Decl[InstanceVar]/Super/IsSystem:       hashValue[#Int#]; name=hashValue
 // NSERROR_DOT-DAG: Decl[InstanceMethod]/Super/IsSystem:    myClass()[#AnyClass!#]; name=myClass()
 // NSERROR_DOT-DAG: Decl[InstanceMethod]/Super/IsSystem:    isEqual({#(other): NSObject!#})[#Bool#]; name=isEqual(:)
 // NSERROR_DOT-DAG: Decl[InstanceVar]/Super/IsSystem:       hash[#Int#]; name=hash

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -72,7 +72,7 @@ func completeInKeyPath6() {
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop3[#[ObjCClass]?#]; name=prop3
-// CHECK-IN_KEYPATH: Decl[InstanceVar]/Super:            hashValue[#Int#]; name=hashValue
+// CHECK-IN_KEYPATH: Decl[InstanceVar]/Super/IsSystem:   hashValue[#Int#]; name=hashValue
 
 // Make sure we unwrap optionals (members of Optional itself are invalid in this context)
 //

--- a/test/Index/Store/unit-system-source-file.swift
+++ b/test/Index/Store/unit-system-source-file.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SDK)
+// RUN: cp %s %t/SDK/FakeSystemModule.swift
+
+// When the source file is in the SDK, consider it a system module.
+//
+// RUN: %target-swift-frontend -c -o %t/FakeSystemModule.o -index-store-path %t/idx -sdk %t/SDK %t/SDK/FakeSystemModule.swift
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+//
+// CHECK: FakeSystemModule.o-{{[A-Z0-9]*}}
+// CHECK: --------
+// CHECK: is-system: 1
+
+// RUN: %target-swift-frontend -c -o %t/FakeSystemModule.o -index-store-path %t/idx %t/SDK/FakeSystemModule.swift
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix NO-SDK
+//
+// NO-SDK: FakeSystemModule.o-{{[A-Z0-9]*}}
+// NO-SDK: --------
+// NO-SDK: is-system: 0
+
+func someFunc() {}


### PR DESCRIPTION
We're using a small custom frontend tool to generate indexstore data for `.swiftinterface` files in the SDKs. We do this by treating the `.swiftinterface` file as the input of an interface compilation, but this exits early because it treats it as a `SourceFile` instead of an external `LoadedFile`. This happens even if we call `setIsSystemModule(true)` unless we skip setting the SDK path, but that causes other problems. It seems harmless to check for `SourceFile`s as well, so that a tool processing an SDK interface as a direct input still gets the right state.
