### PR TITLE
[test] Set _LIBCPP_VERSION check in check-libcxx-version.cpp to include 170004

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/check-libcxx-version.cpp
+++ b/test/Interop/Cxx/stdlib/Inputs/check-libcxx-version.cpp
@@ -6,7 +6,7 @@ int main() {
   return 1;
 #endif
 
-#if _LIBCPP_VERSION >= 170006
+#if _LIBCPP_VERSION >= 170004
   return 0;
 #else
   return 1;


### PR DESCRIPTION
This fixes test failures of libcxx-module-interface.swift and libcxx-symbolic-module-interface.swift when building against a libc++ where the std module was split. e.g libc++ included in the MacOS 14.4 SDK.
