### PR TITLE
[DebugInfo] Dont generate line information at the split point of async funclets

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -50,6 +50,7 @@
 #include "GenPoly.h"
 #include "GenProto.h"
 #include "GenType.h"
+#include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
@@ -219,6 +220,9 @@ llvm::CallInst *IRGenFunction::emitSuspendAsyncCall(
   auto *id = Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_suspend_async,
                                          {resultTy}, args);
   if (restoreCurrentContext) {
+    // This is setup code after the split point. Don't associate any line
+    // numbers to it.
+    irgen::PrologueLocation LocRAII(IGM.DebugInfo.get(), Builder);
     llvm::Value *calleeContext =
         Builder.CreateExtractValue(id, asyncContextIndex);
     calleeContext =

--- a/test/DebugInfo/async-await-no-debug-info-after-split-point.swift
+++ b/test/DebugInfo/async-await-no-debug-info-after-split-point.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend %s -emit-irgen -g -o - \
+// RUN:    -module-name M  -disable-availability-checking \
+// RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
+
+// REQUIRES: concurrency
+
+
+func ASYNC___1___() async -> Int {
+  return 42
+}
+
+// Check that the first debug location after a split point is for the line
+// _after_ the await.
+
+// CHECK: define {{.*}} @"$s1M12ASYNC___2___SiyYaF"
+func ASYNC___2___() async -> Int {
+  var x = 10
+  await ASYNC___1___()
+  // CHECK: call {{.*}} @llvm.coro.suspend.async{{.*}} ptr @__swift_async_resume_get_context{{.*}} !dbg
+  // CHECK: !dbg ![[FirstDbg:[0-9]+]]
+  // CHECK: ![[FirstDbg]] = !DILocation(line: [[@LINE+1]]
+  x = 12
+  return x
+}

--- a/test/DebugInfo/async-let.swift
+++ b/test/DebugInfo/async-let.swift
@@ -8,7 +8,7 @@ public actor Alice {
   let bob = Bob()
 
   // CHECK: define {{.*}}$s1M5AliceC4callyyYaFTY0_{{.*}} !dbg ![[SCOPE0:[0-9]+]]
-  // CHECK:   load ptr, ptr {{.*}} !dbg ![[HOP0:[0-9]+]]
+  // CHECK:   asyncLet_begin{{.*}} !dbg ![[HOP0:[0-9]+]]
 
   // CHECK: define {{.*}}$s1M5AliceC4callyyYaFTY1_{{.*}} !dbg ![[SCOPE1:[0-9]+]]
   // CHECK:   load ptr, ptr {{.*}} !dbg ![[HOP1:[0-9]+]]
@@ -20,7 +20,7 @@ public actor Alice {
   // CHECK:   load ptr, ptr {{.*}} !dbg ![[LET_HOP1:[0-9]+]]
   public func call() async {
     // CHECK: ![[SCOPE0]] = distinct !DISubprogram({{.*}}line: [[@LINE-1]]
-    // CHECK: ![[HOP0]] = !DILocation(line: [[@LINE-2]], column: 15
+    // CHECK: ![[HOP0]] = !DILocation(line: [[@LINE+1]], column: 11
     async let a = bob.call(x: 1)
     // CHECK: ![[SCOPE1]] = distinct !DISubprogram({{.*}}line: [[@LINE-4]]
     // CHECK: ![[HOP1]] = !DILocation(line: [[@LINE+5]], column: 17


### PR DESCRIPTION

    Unless there is some meaningful code on the same line as an await call (e.g.
    other parts of an expression), there should be no additional line entries
    associated with that line on the continuation funclet.

    This patch changes codegen to avoid emitting debug location for the "prologue" code
    at the start of a funclet, instead of simply copying the debug location of the
    split point.

