### PR TITLE
[embedded] Fix generic function skipping in PerfDiags, diagnose KeyPathInsts in closures

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -203,7 +203,7 @@ bool PerformanceDiagnostics::visitFunctionEmbeddedSwift(
     SILFunction *function, LocWithParent *parentLoc) {
   // Don't check generic functions in embedded Swift, they're about to be
   // removed anyway.
-  if (function->getLoweredFunctionType()->getSubstGenericSignature())
+  if (function->isGeneric())
     return false;
 
   if (!function->isDefinition())

--- a/test/embedded/keypaths4.swift
+++ b/test/embedded/keypaths4.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-ir -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public func foo() {
+  let number = 42
+  _ = withUnsafeBytes(of: number) { bytes in
+      bytes.map(\.description).joined(separator: ".") // expected-error {{cannot use key path in embedded Swift}}
+  }
+}


### PR DESCRIPTION
We were skipping some functions (generic, but fully specialized) in PerformanceDiagnostics, and that resulted in e.g. a KeyPathInst in a closure not being flagged. See the attached testcase, which ends up crashing the compiler in IRGen when an attempt to lower a KeyPathInst is made. Let's fix that.

rdar://135948987
