### PR TITLE
[Dependency Scanning] Inherit target SDK name and version for textual interface build recipes

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1670,6 +1670,19 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     GenericArgs.push_back(triple);
   }
 
+  // Inherit the target SDK name and version
+  if (!LangOpts.SDKName.empty()) {
+    genericSubInvocation.getLangOptions().SDKName = LangOpts.SDKName;
+    GenericArgs.push_back("-target-sdk-name");
+    GenericArgs.push_back(ArgSaver.save(LangOpts.SDKName));
+  }
+  if (LangOpts.SDKVersion.has_value()) {
+    genericSubInvocation.getLangOptions().SDKVersion = LangOpts.SDKVersion;
+    GenericArgs.push_back("-target-sdk-version");
+    GenericArgs.push_back(ArgSaver.save(LangOpts.SDKVersion.value()
+                                                .getAsString()));
+  }
+
   // Inherit the Swift language version
   genericSubInvocation.getLangOptions().EffectiveLanguageVersion =
     LangOpts.EffectiveLanguageVersion;

--- a/test/ScanDependencies/include-target-sdk-in-interface-recipe.swift
+++ b/test/ScanDependencies/include-target-sdk-in-interface-recipe.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface %s -o %t/deps.json -target-sdk-version 15.0 -target-sdk-name macosx15.0.test_name
+
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+func foo() { print(1) }
+
+// CHECK: "-target-sdk-name",
+// CHECK-NEXT: "macosx15.0.test_name"
+// CHECK: "-target-sdk-version",
+// CHECK-NEXT: "15.0"


### PR DESCRIPTION
Otherwise they get built with an empty SDK name string and we do not get the benefit of the SDK name compatibility check in case they are loading modules from an incompatible SDK

Resolves rdar://135972810
