### PR TITLE
SIL: Fix lowering of local functions with explicit isolated parameter

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -762,7 +762,10 @@ CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
     if (actorIsolation.getKind() == ActorIsolation::ActorInstance) {
       if (auto *var = actorIsolation.getActorInstance()) {
         assert(isa<ParamDecl>(var));
-        finder.addCapture(CapturedValue(var, 0, AFD->getLoc()));
+        // Don't capture anything if the isolation parameter is a parameter
+        // of the local function.
+        if (var->getDeclContext() != AFD)
+          finder.addCapture(CapturedValue(var, 0, AFD->getLoc()));
       }
     }
   }

--- a/test/SILGen/local_function_isolation.swift
+++ b/test/SILGen/local_function_isolation.swift
@@ -88,3 +88,14 @@ actor NestedAsyncInSyncActor {
     _ = middle
   }
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s24local_function_isolation13outerFunctionyyScA_pYaF : $@convention(thin) @async (@guaranteed any Actor) -> () {
+func outerFunction(_ a: any Actor) async {
+  // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation13outerFunctionyyScA_pYaF06middleE0L_yyScA_pYaF : $@convention(thin) @async (@guaranteed any Actor) -> () {
+  func middleFunction(_ isolated: any Actor) async {
+    // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation13outerFunctionyyScA_pYaF06middleE0L_yyScA_pYaF05innerE0L_yyYaF : $@convention(thin) @async () -> () {
+    func innerFunction() async {}
+  }
+
+  await middleFunction(a)
+}


### PR DESCRIPTION
When the isolated parameter is the function's own parameter, it is not a capture.

Fixes rdar://135607071.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
