### PR TITLE
AST: Rename AvailabilityContext to AvailabilityRange

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -69,7 +69,7 @@ namespace swift {
   class AbstractFunctionDecl;
   class ASTContext;
   enum class Associativity : unsigned char;
-  class AvailabilityContext;
+  class AvailabilityRange;
   class BoundGenericType;
   class BuiltinTupleDecl;
   class ClangModuleLoader;
@@ -870,25 +870,25 @@ public:
 
   /// Get the availability of features introduced in the specified version
   /// of the Swift compiler for the target platform.
-  AvailabilityContext getSwiftAvailability(unsigned major, unsigned minor) const;
+  AvailabilityRange getSwiftAvailability(unsigned major, unsigned minor) const;
 
   // For each feature defined in FeatureAvailability, define two functions;
   // the latter, with the suffix RuntimeAvailabilty, is for use with
-  // AvailabilityContext::forRuntimeTarget(), and only looks at the Swift
+  // AvailabilityRange::forRuntimeTarget(), and only looks at the Swift
   // runtime version.
-#define FEATURE(N, V)                                                       \
-  inline AvailabilityContext get##N##Availability() const {                 \
-    return getSwiftAvailability V;                                          \
-  }                                                                         \
-  inline AvailabilityContext get##N##RuntimeAvailability() const {          \
-    return AvailabilityContext(VersionRange::allGTE(llvm::VersionTuple V)); \
+#define FEATURE(N, V)                                                          \
+  inline AvailabilityRange get##N##Availability() const {                      \
+    return getSwiftAvailability V;                                             \
+  }                                                                            \
+  inline AvailabilityRange get##N##RuntimeAvailability() const {               \
+    return AvailabilityRange(VersionRange::allGTE(llvm::VersionTuple V));      \
   }
 
-  #include "swift/AST/FeatureAvailability.def"
+#include "swift/AST/FeatureAvailability.def"
 
   /// Get the runtime availability of features that have been introduced in the
   /// Swift compiler for future versions of the target platform.
-  AvailabilityContext getSwiftFutureAvailability() const;
+  AvailabilityRange getSwiftFutureAvailability() const;
 
   /// Returns `true` if versioned availability annotations are supported for the
   /// target triple.
@@ -903,78 +903,78 @@ public:
 
   /// Get the runtime availability of features introduced in the Swift 5.0
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift50Availability() const {
+  inline AvailabilityRange getSwift50Availability() const {
     return getSwiftAvailability(5, 0);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.1
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift51Availability() const {
+  inline AvailabilityRange getSwift51Availability() const {
     return getSwiftAvailability(5, 1);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift52Availability() const {
+  inline AvailabilityRange getSwift52Availability() const {
     return getSwiftAvailability(5, 2);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.3
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift53Availability() const {
+  inline AvailabilityRange getSwift53Availability() const {
     return getSwiftAvailability(5, 3);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.4
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift54Availability() const {
+  inline AvailabilityRange getSwift54Availability() const {
     return getSwiftAvailability(5, 4);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.5
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift55Availability() const {
+  inline AvailabilityRange getSwift55Availability() const {
     return getSwiftAvailability(5, 5);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.6
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift56Availability() const {
+  inline AvailabilityRange getSwift56Availability() const {
     return getSwiftAvailability(5, 6);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.7
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift57Availability() const {
+  inline AvailabilityRange getSwift57Availability() const {
     return getSwiftAvailability(5, 7);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.8
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift58Availability() const {
+  inline AvailabilityRange getSwift58Availability() const {
     return getSwiftAvailability(5, 8);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.9
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift59Availability() const {
+  inline AvailabilityRange getSwift59Availability() const {
     return getSwiftAvailability(5, 9);
   }
 
   /// Get the runtime availability of features introduced in the Swift 5.10
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift510Availability() const {
+  inline AvailabilityRange getSwift510Availability() const {
     return getSwiftAvailability(5, 10);
   }
 
   /// Get the runtime availability of features introduced in the Swift 6.0
   /// compiler for the target platform.
-  inline AvailabilityContext getSwift60Availability() const {
+  inline AvailabilityRange getSwift60Availability() const {
     return getSwiftAvailability(6, 0);
   }
 
   /// Get the runtime availability for a particular version of Swift (5.0+).
-  inline AvailabilityContext
+  inline AvailabilityRange
   getSwift5PlusAvailability(llvm::VersionTuple swiftVersion) const {
     return getSwiftAvailability(swiftVersion.getMajor(),
                                 *swiftVersion.getMinor());
@@ -982,7 +982,7 @@ public:
 
   /// Get the runtime availability of getters and setters of multi payload enum
   /// tag single payloads.
-  inline AvailabilityContext getMultiPayloadEnumTagSinglePayload() const {
+  inline AvailabilityRange getMultiPayloadEnumTagSinglePayload() const {
     // This didn't fit the pattern, so needed renaming
     return getMultiPayloadEnumTagSinglePayloadAvailability();
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -64,7 +64,7 @@ namespace swift {
   enum class AccessSemantics : unsigned char;
   class AccessorDecl;
   class ApplyExpr;
-  class AvailabilityContext;
+  class AvailabilityRange;
   class GenericEnvironment;
   class ArchetypeType;
   class ASTContext;
@@ -1326,7 +1326,7 @@ public:
     return getAttrs().hasAttribute<NoImplicitCopyAttr>();
   }
 
-  AvailabilityContext getAvailabilityForLinkage() const;
+  AvailabilityRange getAvailabilityForLinkage() const;
 
   /// Whether this declaration or one of its outer contexts has the
   /// @_weakLinked attribute.

--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -255,19 +255,19 @@ struct RequirementCheck {
 
   /// The required availability, if the check failed due to the
   /// witness being less available than the requirement.
-  AvailabilityContext RequiredAvailability;
+  AvailabilityRange RequiredAvailability;
 
   RequirementCheck(CheckKind kind)
-    : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
-      RequiredAvailability(AvailabilityContext::alwaysAvailable()) { }
+      : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
+        RequiredAvailability(AvailabilityRange::alwaysAvailable()) {}
 
   RequirementCheck(CheckKind kind, AccessScope requiredAccessScope)
-    : Kind(kind), RequiredAccessScope(requiredAccessScope),
-      RequiredAvailability(AvailabilityContext::alwaysAvailable()) { }
+      : Kind(kind), RequiredAccessScope(requiredAccessScope),
+        RequiredAvailability(AvailabilityRange::alwaysAvailable()) {}
 
-  RequirementCheck(CheckKind kind, AvailabilityContext requiredAvailability)
-    : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
-      RequiredAvailability(requiredAvailability) { }
+  RequirementCheck(CheckKind kind, AvailabilityRange requiredAvailability)
+      : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
+        RequiredAvailability(requiredAvailability) {}
 };
 
 

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -171,12 +171,12 @@ private:
 
   /// A canonical availability info for this context, computed top-down from the
   /// root context.
-  AvailabilityContext AvailabilityInfo;
+  AvailabilityRange AvailabilityInfo;
 
   /// If this context was annotated with an availability attribute, this property captures that.
   /// It differs from the above `AvailabilityInfo` by being independent of the deployment target,
   /// and is used for providing availability attribute redundancy warning diagnostics.
-  AvailabilityContext ExplicitAvailabilityInfo;
+  AvailabilityRange ExplicitAvailabilityInfo;
 
   std::vector<TypeRefinementContext *> Children;
 
@@ -187,36 +187,35 @@ private:
 
   TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
                         TypeRefinementContext *Parent, SourceRange SrcRange,
-                        const AvailabilityContext &Info,
-                        const AvailabilityContext &ExplicitInfo);
+                        const AvailabilityRange &Info,
+                        const AvailabilityRange &ExplicitInfo);
 
 public:
   
   /// Create the root refinement context for the given SourceFile.
   static TypeRefinementContext *
-  createForSourceFile(SourceFile *SF, const AvailabilityContext &Info);
+  createForSourceFile(SourceFile *SF, const AvailabilityRange &Info);
 
   /// Create a refinement context for the given declaration.
-  static TypeRefinementContext *createForDecl(ASTContext &Ctx, Decl *D,
-                                              TypeRefinementContext *Parent,
-                                              const AvailabilityContext &Info,
-                                              const AvailabilityContext &ExplicitInfo,
-                                              SourceRange SrcRange);
+  static TypeRefinementContext *
+  createForDecl(ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
+                const AvailabilityRange &Info,
+                const AvailabilityRange &ExplicitInfo, SourceRange SrcRange);
 
   /// Create a refinement context for the given declaration.
   static TypeRefinementContext *
   createForDeclImplicit(ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
-                        const AvailabilityContext &Info, SourceRange SrcRange);
+                        const AvailabilityRange &Info, SourceRange SrcRange);
 
   /// Create a refinement context for the Then branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtThen(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,
-                      const AvailabilityContext &Info);
+                      const AvailabilityRange &Info);
 
   /// Create a refinement context for the Else branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtElse(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,
-                      const AvailabilityContext &Info);
+                      const AvailabilityRange &Info);
 
   /// Create a refinement context for the true-branch control flow to
   /// further StmtConditionElements following a #available() query in
@@ -225,26 +224,24 @@ public:
   createForConditionFollowingQuery(ASTContext &Ctx, PoundAvailableInfo *PAI,
                                    const StmtConditionElement &LastElement,
                                    TypeRefinementContext *Parent,
-                                   const AvailabilityContext &Info);
+                                   const AvailabilityRange &Info);
 
   /// Create a refinement context for the fallthrough of a GuardStmt.
-  static TypeRefinementContext *
-  createForGuardStmtFallthrough(ASTContext &Ctx, GuardStmt *RS,
-                                  BraceStmt *ContainingBraceStmt,
-                                  TypeRefinementContext *Parent,
-                                  const AvailabilityContext &Info);
+  static TypeRefinementContext *createForGuardStmtFallthrough(
+      ASTContext &Ctx, GuardStmt *RS, BraceStmt *ContainingBraceStmt,
+      TypeRefinementContext *Parent, const AvailabilityRange &Info);
 
   /// Create a refinement context for the else branch of a GuardStmt.
   static TypeRefinementContext *
   createForGuardStmtElse(ASTContext &Ctx, GuardStmt *RS,
                          TypeRefinementContext *Parent,
-                         const AvailabilityContext &Info);
+                         const AvailabilityRange &Info);
 
   /// Create a refinement context for the body of a WhileStmt.
   static TypeRefinementContext *
   createForWhileStmtBody(ASTContext &Ctx, WhileStmt *WS,
                          TypeRefinementContext *Parent,
-                         const AvailabilityContext &Info);
+                         const AvailabilityRange &Info);
 
   Decl *getDeclOrNull() const {
     auto IntroReason = getReason();
@@ -282,13 +279,13 @@ public:
 
   /// Returns the information on what can be assumed present at run time when
   /// running code contained in this context.
-  const AvailabilityContext &getAvailabilityInfo() const {
+  const AvailabilityRange &getAvailabilityInfo() const {
     return AvailabilityInfo;
   }
 
   /// Returns the information on what availability was specified by the programmer
   /// on this context (if any).
-  const AvailabilityContext &getExplicitAvailabilityInfo() const {
+  const AvailabilityRange &getExplicitAvailabilityInfo() const {
     return ExplicitAvailabilityInfo;
   }
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -33,7 +33,7 @@ class Triple;
 }
 
 namespace swift {
-class AvailabilityContext;
+class AvailabilityRange;
 
 namespace irgen {
 class IRGenModule;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1094,7 +1094,7 @@ public:
   /// \p Attr is where to store the parsed attribute
   bool parseSpecializeAttribute(
       swift::tok ClosingBrace, SourceLoc AtLoc, SourceLoc Loc,
-      SpecializeAttr *&Attr, AvailabilityContext *SILAvailability,
+      SpecializeAttr *&Attr, AvailabilityRange *SILAvailability,
       llvm::function_ref<bool(Parser &)> parseSILTargetName =
           [](Parser &) { return false; },
       llvm::function_ref<bool(Parser &)> parseSILSIPModule =
@@ -1106,7 +1106,7 @@ public:
       std::optional<bool> &Exported,
       std::optional<SpecializeAttr::SpecializationKind> &Kind,
       TrailingWhereClause *&TrailingWhereClause, DeclNameRef &targetFunction,
-      AvailabilityContext *SILAvailability,
+      AvailabilityRange *SILAvailability,
       SmallVectorImpl<Identifier> &spiGroups,
       SmallVectorImpl<AvailableAttr *> &availableAttrs,
       size_t &typeErasedParamsCount,

--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -22,7 +22,7 @@
 
 namespace swift {
 
-class AvailabilityContext;
+class AvailabilityRange;
 class ASTContext;
 
 namespace irgen {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -690,7 +690,8 @@ bool BridgedFunction::isSwift51RuntimeAvailable() const {
     return false;
 
   swift::ASTContext &ctxt = getFunction()->getModule().getASTContext();
-  return swift::AvailabilityContext::forDeploymentTarget(ctxt).isContainedIn(ctxt.getSwift51Availability());
+  return swift::AvailabilityRange::forDeploymentTarget(ctxt).isContainedIn(
+      ctxt.getSwift51Availability());
 }
 
 bool BridgedFunction::isPossiblyUsedExternally() const {

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -554,7 +554,7 @@ struct SILDeclRef {
                                                     AbstractFunctionDecl *func);
 
   /// Returns the availability of the decl for computing linkage.
-  std::optional<AvailabilityContext> getAvailabilityForLinkage() const;
+  std::optional<AvailabilityRange> getAvailabilityForLinkage() const;
 
   /// True if the referenced entity is some kind of thunk.
   bool isThunk() const;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -106,13 +106,11 @@ public:
   static GenericSignature buildTypeErasedSignature(
       GenericSignature sig, ArrayRef<Type> typeErasedParams);
 
-  static SILSpecializeAttr *create(SILModule &M,
-                                   GenericSignature specializedSignature,
-                                   ArrayRef<Type> typeErasedParams,
-                                   bool exported, SpecializationKind kind,
-                                   SILFunction *target, Identifier spiGroup,
-                                   const ModuleDecl *spiModule,
-                                   AvailabilityContext availability);
+  static SILSpecializeAttr *
+  create(SILModule &M, GenericSignature specializedSignature,
+         ArrayRef<Type> typeErasedParams, bool exported,
+         SpecializationKind kind, SILFunction *target, Identifier spiGroup,
+         const ModuleDecl *spiModule, AvailabilityRange availability);
 
   bool isExported() const {
     return exported;
@@ -158,7 +156,7 @@ public:
     return spiModule;
   }
 
-  AvailabilityContext getAvailability() const {
+  AvailabilityRange getAvailability() const {
     return availability;
   }
 
@@ -171,7 +169,7 @@ private:
   GenericSignature unerasedSpecializedSignature;
   llvm::SmallVector<Type, 2> typeErasedParams;
   Identifier spiGroup;
-  AvailabilityContext availability;
+  AvailabilityRange availability;
   const ModuleDecl *spiModule = nullptr;
   SILFunction *F = nullptr;
   SILFunction *targetFunction = nullptr;
@@ -182,7 +180,7 @@ private:
                     ArrayRef<Type> typeErasedParams,
                     SILFunction *target, Identifier spiGroup,
                     const ModuleDecl *spiModule,
-                    AvailabilityContext availability);
+                    AvailabilityRange availability);
 };
 
 /// SILFunction - A function body that has been lowered to SIL. This consists of
@@ -334,7 +332,7 @@ private:
 
   /// The availability used to determine if declarations of this function
   /// should use weak linking.
-  AvailabilityContext Availability;
+  AvailabilityRange Availability;
 
   Purpose specialPurpose = Purpose::None;
 
@@ -928,11 +926,11 @@ public:
 
   /// Returns the availability context used to determine if the function's
   /// symbol should be weakly referenced across module boundaries.
-  AvailabilityContext getAvailabilityForLinkage() const {
+  AvailabilityRange getAvailabilityForLinkage() const {
     return Availability;
   }
 
-  void setAvailabilityForLinkage(AvailabilityContext availability) {
+  void setAvailabilityForLinkage(AvailabilityRange availability) {
     Availability = availability;
   }
 

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -43,7 +43,7 @@ class SILGenFunctionBuilder;
 ///    code-reuse in between these different SILFunction creation sites.
 class SILFunctionBuilder {
   SILModule &mod;
-  AvailabilityContext availCtx;
+  AvailabilityRange availCtx;
 
   friend class SILParserFunctionBuilder;
   friend class SILSerializationFunctionBuilder;
@@ -51,11 +51,10 @@ class SILFunctionBuilder {
   friend class Lowering::SILGenFunctionBuilder;
 
   SILFunctionBuilder(SILModule &mod)
-      : SILFunctionBuilder(mod,
-                           AvailabilityContext::forDeploymentTarget(
-                             mod.getASTContext())) {}
+      : SILFunctionBuilder(
+            mod, AvailabilityRange::forDeploymentTarget(mod.getASTContext())) {}
 
-  SILFunctionBuilder(SILModule &mod, AvailabilityContext availCtx)
+  SILFunctionBuilder(SILModule &mod, AvailabilityRange availCtx)
       : mod(mod), availCtx(availCtx) {}
 
   /// Return the declaration of a utility function that can, but needn't, be

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1190,13 +1190,13 @@ LifetimeAnnotation Decl::getLifetimeAnnotation() const {
   return getLifetimeAnnotationFromAttributes();
 }
 
-AvailabilityContext Decl::getAvailabilityForLinkage() const {
+AvailabilityRange Decl::getAvailabilityForLinkage() const {
   ASTContext &ctx = getASTContext();
 
   // When computing availability for linkage, use the "before" version from
   // the @backDeployed attribute, if present.
   if (auto backDeployVersion = getBackDeployedBeforeOSVersion(ctx))
-    return AvailabilityContext{VersionRange::allGTE(*backDeployVersion)};
+    return AvailabilityRange{VersionRange::allGTE(*backDeployVersion)};
 
   auto containingContext =
       AvailabilityInference::annotatedAvailableRange(this, getASTContext());
@@ -1230,7 +1230,7 @@ AvailabilityContext Decl::getAvailabilityForLinkage() const {
   else if (auto *nominal = dyn_cast<NominalTypeDecl>(dc))
     return nominal->getAvailabilityForLinkage();
 
-  return AvailabilityContext::alwaysAvailable();
+  return AvailabilityRange::alwaysAvailable();
 }
 
 bool Decl::isAlwaysWeakImported() const {
@@ -1287,7 +1287,7 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
     return false;
 
   auto &ctx = fromModule->getASTContext();
-  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+  auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
 
   if (ctx.LangOpts.WeakLinkAtTarget)
     return !availability.isSupersetOf(deploymentTarget);

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1549,11 +1549,10 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
 
   auto &ctx = getASTContext();
 
-  AvailabilityContext conformanceAvailability{
+  AvailabilityRange conformanceAvailability{
       AvailabilityInference::availableRange(ext, ctx)};
 
-  auto deploymentTarget =
-      AvailabilityContext::forDeploymentTarget(ctx);
+  auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
 
   return deploymentTarget.isContainedIn(conformanceAvailability);
 }

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -27,13 +27,12 @@
 
 using namespace swift;
 
-TypeRefinementContext::TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
-                                             TypeRefinementContext *Parent,
-                                             SourceRange SrcRange,
-                                             const AvailabilityContext &Info,
-                                             const AvailabilityContext &ExplicitInfo)
-    : Node(Node), SrcRange(SrcRange),
-      AvailabilityInfo(Info), ExplicitAvailabilityInfo(ExplicitInfo) {
+TypeRefinementContext::TypeRefinementContext(
+    ASTContext &Ctx, IntroNode Node, TypeRefinementContext *Parent,
+    SourceRange SrcRange, const AvailabilityRange &Info,
+    const AvailabilityRange &ExplicitInfo)
+    : Node(Node), SrcRange(SrcRange), AvailabilityInfo(Info),
+      ExplicitAvailabilityInfo(ExplicitInfo) {
   if (Parent) {
     assert(SrcRange.isValid());
     Parent->addChild(this);
@@ -44,14 +43,14 @@ TypeRefinementContext::TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
 
 TypeRefinementContext *
 TypeRefinementContext::createForSourceFile(SourceFile *SF,
-                                           const AvailabilityContext &Info) {
+                                           const AvailabilityRange &Info) {
   assert(SF);
 
   ASTContext &Ctx = SF->getASTContext();
 
   SourceRange range;
   TypeRefinementContext *parentContext = nullptr;
-  AvailabilityContext availabilityContext = Info;
+  AvailabilityRange availabilityRange = Info;
   switch (SF->Kind) {
   case SourceFileKind::MacroExpansion:
   case SourceFileKind::DefaultArgument: {
@@ -65,7 +64,7 @@ TypeRefinementContext::createForSourceFile(SourceFile *SF,
       parentContext =
           parentTRC->findMostRefinedSubContext(originalNode.getStartLoc(), Ctx);
       if (parentContext)
-        availabilityContext = parentContext->getAvailabilityInfo();
+        availabilityRange = parentContext->getAvailabilityInfo();
     }
     break;
   }
@@ -78,17 +77,14 @@ TypeRefinementContext::createForSourceFile(SourceFile *SF,
   }
 
   return new (Ctx)
-      TypeRefinementContext(Ctx, SF, parentContext, range,
-                            availabilityContext,
-                            AvailabilityContext::alwaysAvailable());
+      TypeRefinementContext(Ctx, SF, parentContext, range, availabilityRange,
+                            AvailabilityRange::alwaysAvailable());
 }
 
-TypeRefinementContext *
-TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
-                                     TypeRefinementContext *Parent,
-                                     const AvailabilityContext &Info,
-                                     const AvailabilityContext &ExplicitInfo,
-                                     SourceRange SrcRange) {
+TypeRefinementContext *TypeRefinementContext::createForDecl(
+    ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
+    const AvailabilityRange &Info, const AvailabilityRange &ExplicitInfo,
+    SourceRange SrcRange) {
   assert(D);
   assert(Parent);
   return new (Ctx)
@@ -97,18 +93,18 @@ TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
 
 TypeRefinementContext *TypeRefinementContext::createForDeclImplicit(
     ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
-    const AvailabilityContext &Info, SourceRange SrcRange) {
+    const AvailabilityRange &Info, SourceRange SrcRange) {
   assert(D);
   assert(Parent);
   return new (Ctx) TypeRefinementContext(
       Ctx, IntroNode(D, Reason::DeclImplicit), Parent, SrcRange, Info,
-      AvailabilityContext::alwaysAvailable());
+      AvailabilityRange::alwaysAvailable());
 }
 
 TypeRefinementContext *
 TypeRefinementContext::createForIfStmtThen(ASTContext &Ctx, IfStmt *S,
                                            TypeRefinementContext *Parent,
-                                           const AvailabilityContext &Info) {
+                                           const AvailabilityRange &Info) {
   assert(S);
   assert(Parent);
   return new (Ctx)
@@ -120,7 +116,7 @@ TypeRefinementContext::createForIfStmtThen(ASTContext &Ctx, IfStmt *S,
 TypeRefinementContext *
 TypeRefinementContext::createForIfStmtElse(ASTContext &Ctx, IfStmt *S,
                                            TypeRefinementContext *Parent,
-                                           const AvailabilityContext &Info) {
+                                           const AvailabilityRange &Info) {
   assert(S);
   assert(Parent);
   return new (Ctx)
@@ -129,12 +125,10 @@ TypeRefinementContext::createForIfStmtElse(ASTContext &Ctx, IfStmt *S,
                             Info, /* ExplicitInfo */Info);
 }
 
-TypeRefinementContext *
-TypeRefinementContext::createForConditionFollowingQuery(ASTContext &Ctx,
-                                 PoundAvailableInfo *PAI,
-                                 const StmtConditionElement &LastElement,
-                                 TypeRefinementContext *Parent,
-                                 const AvailabilityContext &Info) {
+TypeRefinementContext *TypeRefinementContext::createForConditionFollowingQuery(
+    ASTContext &Ctx, PoundAvailableInfo *PAI,
+    const StmtConditionElement &LastElement, TypeRefinementContext *Parent,
+    const AvailabilityRange &Info) {
   assert(PAI);
   assert(Parent);
   SourceRange Range(PAI->getEndLoc(), LastElement.getEndLoc());
@@ -142,12 +136,9 @@ TypeRefinementContext::createForConditionFollowingQuery(ASTContext &Ctx,
                                          Info, /* ExplicitInfo */Info);
 }
 
-TypeRefinementContext *
-TypeRefinementContext::createForGuardStmtFallthrough(ASTContext &Ctx,
-                                  GuardStmt *RS,
-                                  BraceStmt *ContainingBraceStmt,
-                                  TypeRefinementContext *Parent,
-                                  const AvailabilityContext &Info) {
+TypeRefinementContext *TypeRefinementContext::createForGuardStmtFallthrough(
+    ASTContext &Ctx, GuardStmt *RS, BraceStmt *ContainingBraceStmt,
+    TypeRefinementContext *Parent, const AvailabilityRange &Info) {
   assert(RS);
   assert(ContainingBraceStmt);
   assert(Parent);
@@ -160,7 +151,7 @@ TypeRefinementContext::createForGuardStmtFallthrough(ASTContext &Ctx,
 TypeRefinementContext *
 TypeRefinementContext::createForGuardStmtElse(ASTContext &Ctx, GuardStmt *RS,
                                               TypeRefinementContext *Parent,
-                                              const AvailabilityContext &Info) {
+                                              const AvailabilityRange &Info) {
   assert(RS);
   assert(Parent);
   return new (Ctx)
@@ -171,7 +162,7 @@ TypeRefinementContext::createForGuardStmtElse(ASTContext &Ctx, GuardStmt *RS,
 TypeRefinementContext *
 TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
                                               TypeRefinementContext *Parent,
-                                              const AvailabilityContext &Info) {
+                                              const AvailabilityRange &Info) {
   assert(S);
   assert(Parent);
   return new (Ctx) TypeRefinementContext(
@@ -361,7 +352,7 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
 }
 
 static std::string
-stringForAvailability(const AvailabilityContext &availability) {
+stringForAvailability(const AvailabilityRange &availability) {
   if (availability.isAlwaysAvailable())
     return "all";
   if (availability.isKnownUnreachable())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -527,7 +527,7 @@ static ImportedType rectifySubscriptTypes(Type getterType, bool getterIsIUO,
 
 /// Add an AvailableAttr to the declaration for the given
 /// version range.
-static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
+static void applyAvailableAttribute(Decl *decl, AvailabilityRange &info,
                                     ASTContext &C) {
   // If the range is "all", this is the same as not having an available
   // attribute.
@@ -566,13 +566,13 @@ static void inferProtocolMemberAvailability(ClangImporter::Implementation &impl,
   if (!valueDecl)
     return;
 
-  AvailabilityContext requiredRange =
+  AvailabilityRange requiredRange =
       AvailabilityInference::inferForType(valueDecl->getInterfaceType());
 
   ASTContext &C = impl.SwiftContext;
 
   const Decl *innermostDecl = dc->getInnermostDeclarationDeclContext();
-  AvailabilityContext containingDeclRange =
+  AvailabilityRange containingDeclRange =
       AvailabilityInference::availableRange(innermostDecl, C);
 
   requiredRange.intersectWith(containingDeclRange);
@@ -6714,7 +6714,7 @@ bool SwiftDeclConverter::existingConstructorIsWorse(
   // FIXME: But if one of them is now deprecated, should we prefer the
   // other?
   llvm::VersionTuple introduced = findLatestIntroduction(objcMethod);
-  AvailabilityContext existingAvailability =
+  AvailabilityRange existingAvailability =
       AvailabilityInference::availableRange(existingCtor, Impl.SwiftContext);
   assert(!existingAvailability.isKnownUnreachable());
 
@@ -9000,8 +9000,8 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
 
       if (proto->getAttrs().hasAttribute<AvailableAttr>()) {
         if (!result->getAttrs().hasAttribute<AvailableAttr>()) {
-          AvailabilityContext protoRange =
-            AvailabilityInference::availableRange(proto, SwiftContext);
+          AvailabilityRange protoRange =
+              AvailabilityInference::availableRange(proto, SwiftContext);
           applyAvailableAttribute(result, protoRange, SwiftContext);
         }
       } else {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -521,8 +521,8 @@ getAddressOfOpaqueTypeDescriptor(IRGenFunction &IGF,
 MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           DynamicMetadataRequest request) {
-  bool signedDescriptor = IGF.IGM.getAvailabilityContext().isContainedIn(
-    IGF.IGM.Context.getSignedDescriptorAvailability());
+  bool signedDescriptor = IGF.IGM.getAvailabilityRange().isContainedIn(
+      IGF.IGM.Context.getSignedDescriptorAvailability());
 
   auto accessorFn = signedDescriptor ?
     IGF.IGM.getGetOpaqueTypeMetadata2FunctionPointer() :
@@ -564,8 +564,8 @@ MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
 llvm::Value *irgen::emitOpaqueTypeWitnessTableRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           ProtocolDecl *protocol) {
-  bool signedDescriptor = IGF.IGM.getAvailabilityContext().isContainedIn(
-    IGF.IGM.Context.getSignedDescriptorAvailability());
+  bool signedDescriptor = IGF.IGM.getAvailabilityRange().isContainedIn(
+      IGF.IGM.Context.getSignedDescriptorAvailability());
 
   auto accessorFn = signedDescriptor ?
     IGF.IGM.getGetOpaqueTypeConformance2FunctionPointer() :

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2778,7 +2778,7 @@ llvm::Constant *irgen::emitObjCProtocolData(IRGenModule &IGM,
   // situation when both an objective c object and a swift object define the
   // protocol under the same symbol name.
   auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(IGM.Context);
+      AvailabilityRange::forDeploymentTarget(IGM.Context);
   bool canUseClangEmission = deploymentAvailability.isContainedIn(
     IGM.Context.getSwift58Availability());
 
@@ -2966,7 +2966,7 @@ IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
     // If the Objective-C runtime is new enough, we can just use the update
     // pattern unconditionally.
     auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(Context);
+        AvailabilityRange::forDeploymentTarget(Context);
     if (deploymentAvailability.isContainedIn(
           Context.getObjCMetadataUpdateCallbackAvailability()))
       return ClassMetadataStrategy::Update;

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -258,8 +258,8 @@ llvm::Value *irgen::emitBuiltinStartAsyncLet(IRGenFunction &IGF,
   // space, so that we don't run into that bug. We leave a note on the
   // declaration so that coroutine splitting can pad out the final context
   // size after splitting.
-  auto deploymentAvailability
-    = AvailabilityContext::forDeploymentTarget(IGF.IGM.Context);
+  auto deploymentAvailability =
+      AvailabilityRange::forDeploymentTarget(IGF.IGM.Context);
   if (!deploymentAvailability.isContainedIn(
                                    IGF.IGM.Context.getSwift57Availability()))
   {

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1302,8 +1302,8 @@ FunctionPointer IRGenModule::getFixedClassInitializationFn() {
   if (ObjCInterop) {
     // In new enough ObjC runtimes, objc_opt_self provides a direct fast path
     // to realize a class.
-    if (getAvailabilityContext()
-         .isContainedIn(Context.getSwift51Availability())) {
+    if (getAvailabilityRange().isContainedIn(
+            Context.getSwift51Availability())) {
       fn = getObjCOptSelfFunctionPointer();
     }
     // Otherwise, the Swift runtime always provides a `get
@@ -1384,7 +1384,7 @@ llvm::Value *IRGenFunction::emitLoadRefcountedPtr(Address addr,
 llvm::Value *IRGenFunction::
 emitIsUniqueCall(llvm::Value *value, ReferenceCounting style, SourceLoc loc, bool isNonNull) {
   FunctionPointer fn;
-  bool nonObjC = !IGM.getAvailabilityContext().isContainedIn(
+  bool nonObjC = !IGM.getAvailabilityRange().isContainedIn(
       IGM.Context.getObjCIsUniquelyReferencedAvailability());
   switch (style) {
   case ReferenceCounting::Native: {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3304,7 +3304,7 @@ static void emitInitializeRawLayoutOld(IRGenFunction &IGF, SILType likeType,
   // emit a call to the swift_initStructMetadata tricking it into thinking
   // we have a single field.
   auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(IGF.IGM.Context);
+      AvailabilityRange::forDeploymentTarget(IGF.IGM.Context);
   auto initRawAvail = IGF.IGM.Context.getInitRawStructMetadataAvailability();
 
   if (!IGF.IGM.Context.LangOpts.DisableAvailabilityChecking &&
@@ -3337,7 +3337,7 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
   // If our deployment target doesn't contain the swift_initRawStructMetadata2,
   // emit a call to the older swift_initRawStructMetadata.
   auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(IGF.IGM.Context);
+      AvailabilityRange::forDeploymentTarget(IGF.IGM.Context);
   auto initRaw2Avail = IGF.IGM.Context.getInitRawStructMetadata2Availability();
 
   if (!IGF.IGM.Context.LangOpts.DisableAvailabilityChecking &&
@@ -5166,7 +5166,7 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
     // runtimes.
     auto requiredAvailability=ctx.getUpdatePureObjCClassMetadataAvailability();
     // FIXME: Take the class's availability into account
-    auto currentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
+    auto currentAvailability = AvailabilityRange::forDeploymentTarget(ctx);
     if (currentAvailability.isContainedIn(requiredAvailability))
       break;
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1547,7 +1547,7 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   // metadata update callback when realizing a Swift class referenced from
   // Objective-C.
   auto deploymentAvailability =
-    AvailabilityContext::forDeploymentTarget(IGM.Context);
+      AvailabilityRange::forDeploymentTarget(IGM.Context);
   bool supportsObjCMetadataUpdateCallback =
     deploymentAvailability.isContainedIn(
         IGM.Context.getObjCMetadataUpdateCallbackAvailability());

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -888,7 +888,8 @@ void IRGenFunction::emitResumeAsyncContinuationThrowing(
 void IRGenFunction::emitClearSensitive(Address address, llvm::Value *size) {
   // If our deployment target doesn't contain the new swift_clearSensitive,
   // fall back to memset_s
-  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(IGM.Context);
+  auto deploymentAvailability =
+      AvailabilityRange::forDeploymentTarget(IGM.Context);
   auto clearSensitiveAvail = IGM.Context.getClearSensitiveAvailability();
   if (!deploymentAvailability.isContainedIn(clearSensitiveAvail)) {
     Builder.CreateCall(IGM.getMemsetSFunctionPointer(),

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -664,7 +664,7 @@ public:
   const llvm::Triple VariantTriple;
   std::unique_ptr<llvm::TargetMachine> TargetMachine;
   ModuleDecl *getSwiftModule() const;
-  AvailabilityContext getAvailabilityContext() const;
+  AvailabilityRange getAvailabilityRange() const;
   Lowering::TypeConverter &getSILTypes() const;
   SILModule &getSILModule() const { return IRGen.SIL; }
   const IRGenOptions &getOptions() const { return IRGen.Opts; }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1446,7 +1446,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::KnownAsyncFunctionPointer:
     auto &context = module->getASTContext();
     auto deploymentAvailability =
-        AvailabilityContext::forDeploymentTarget(context);
+        AvailabilityRange::forDeploymentTarget(context);
     return !deploymentAvailability.isContainedIn(
         context.getConcurrencyAvailability());
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3095,8 +3095,7 @@ static bool canIssueIncompleteMetadataRequests(IRGenModule &IGM) {
   // We can only answer blocking complete metadata requests with the <=5.1
   // runtime ABI entry points.
   auto &context = IGM.getSwiftModule()->getASTContext();
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(context);
+  auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(context);
   return deploymentAvailability.isContainedIn(
       context.getTypesInAbstractMetadataStateAvailability());
 }
@@ -3249,8 +3248,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     stringAddr = subIGF.Builder.CreateIntToPtr(stringAddr, IGM.Int8PtrTy);
 
     llvm::CallInst *call;
-    bool signedDescriptor = IGM.getAvailabilityContext().isContainedIn(
-      IGM.Context.getSignedDescriptorAvailability());
+    bool signedDescriptor = IGM.getAvailabilityRange().isContainedIn(
+        IGM.Context.getSignedDescriptorAvailability());
     if (request.isStaticallyAbstract()) {
       call = signedDescriptor ?
         subIGF.Builder.CreateCall(

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -776,7 +776,7 @@ bool Parser::parseSpecializeAttributeArguments(
     std::optional<bool> &Exported,
     std::optional<SpecializeAttr::SpecializationKind> &Kind,
     swift::TrailingWhereClause *&TrailingWhereClause,
-    DeclNameRef &targetFunction, AvailabilityContext *SILAvailability,
+    DeclNameRef &targetFunction, AvailabilityRange *SILAvailability,
     SmallVectorImpl<Identifier> &spiGroups,
     SmallVectorImpl<AvailableAttr *> &availableAttrs,
     size_t &typeErasedParamsCount,
@@ -825,7 +825,7 @@ bool Parser::parseSpecializeAttributeArguments(
                                  diag::sil_availability_expected_version))
           return false;
 
-        *SILAvailability = AvailabilityContext(VersionRange::allGTE(version));
+        *SILAvailability = AvailabilityRange(VersionRange::allGTE(version));
       }
       if (ParamLabel == "availability") {
         SourceRange attrRange;
@@ -1090,7 +1090,7 @@ bool Parser::parseAvailability(
 
 bool Parser::parseSpecializeAttribute(
     swift::tok ClosingBrace, SourceLoc AtLoc, SourceLoc Loc,
-    SpecializeAttr *&Attr, AvailabilityContext *SILAvailability,
+    SpecializeAttr *&Attr, AvailabilityRange *SILAvailability,
     llvm::function_ref<bool(Parser &)> parseSILTargetName,
     llvm::function_ref<bool(Parser &)> parseSILSIPModule) {
   assert(ClosingBrace == tok::r_paren || ClosingBrace == tok::r_square);

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -230,8 +230,7 @@ ASTContext &SILDeclRef::getASTContext() const {
   return DC->getASTContext();
 }
 
-std::optional<AvailabilityContext>
-SILDeclRef::getAvailabilityForLinkage() const {
+std::optional<AvailabilityRange> SILDeclRef::getAvailabilityForLinkage() const {
   // Back deployment thunks and fallbacks don't have availability since they
   // are non-ABI.
   // FIXME: Generalize this check to all kinds of non-ABI functions.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -102,7 +102,7 @@ SILSpecializeAttr::SILSpecializeAttr(bool exported, SpecializationKind kind,
                                      ArrayRef<Type> typeErasedParams,
                                      SILFunction *target, Identifier spiGroup,
                                      const ModuleDecl *spiModule,
-                                     AvailabilityContext availability)
+                                     AvailabilityRange availability)
     : kind(kind), exported(exported), specializedSignature(specializedSig),
       unerasedSpecializedSignature(unerasedSpecializedSig),
       typeErasedParams(typeErasedParams.begin(), typeErasedParams.end()),
@@ -118,7 +118,7 @@ SILSpecializeAttr::create(SILModule &M, GenericSignature specializedSig,
                           bool exported, SpecializationKind kind,
                           SILFunction *target, Identifier spiGroup,
                           const ModuleDecl *spiModule,
-                          AvailabilityContext availability) {
+                          AvailabilityRange availability) {
   auto erasedSpecializedSig =
       SILSpecializeAttr::buildTypeErasedSignature(specializedSig,
                                                   typeErasedParams);
@@ -218,7 +218,7 @@ SILFunction::SILFunction(
     IsRuntimeAccessible_t isRuntimeAccessible)
     : SwiftObjectHeader(functionMetatype), Module(Module),
       index(Module.getNewFunctionIndex()),
-      Availability(AvailabilityContext::alwaysAvailable()) {
+      Availability(AvailabilityRange::alwaysAvailable()) {
   init(Linkage, Name, LoweredType, genericEnv, isBareSILFunction, isTrans,
        serializedKind, entryCount, isThunk, classSubclassScope, inlineStrategy, E,
        DebugScope, isDynamic, isExactSelfClass, isDistributed,
@@ -248,7 +248,7 @@ void SILFunction::init(
   this->LoweredType = LoweredType;
   this->SpecializationInfo = nullptr;
   this->EntryCount = entryCount;
-  this->Availability = AvailabilityContext::alwaysAvailable();
+  this->Availability = AvailabilityRange::alwaysAvailable();
   this->Bare = isBareSILFunction;
   this->Transparent = isTrans;
   this->SerializedKind = serializedKind;
@@ -624,7 +624,7 @@ bool SILFunction::isWeakImported(ModuleDecl *module) const {
     return false;
 
   auto deploymentTarget =
-      AvailabilityContext::forDeploymentTarget(getASTContext());
+      AvailabilityRange::forDeploymentTarget(getASTContext());
 
   if (getASTContext().LangOpts.WeakLinkAtTarget)
     return !Availability.isSupersetOf(deploymentTarget);

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -680,7 +680,7 @@ static bool parseDeclSILOptional(
     OptimizationMode *optimizationMode, PerformanceConstraints *perfConstraints,
     bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *section,
     bool *isLet, bool *isWeakImported, bool *needStackProtection,
-    AvailabilityContext *availability, bool *isWithoutActuallyEscapingThunk,
+    AvailabilityRange *availability, bool *isWithoutActuallyEscapingThunk,
     SmallVectorImpl<std::string> *Semantics,
     SmallVectorImpl<ParsedSpecAttr> *SpecAttrs, ValueDecl **ClangDecl,
     EffectsKind *MRK, SILParser &SP, SILModule &M) {
@@ -756,7 +756,7 @@ static bool parseDeclSILOptional(
                                  diag::sil_availability_expected_version))
         return true;
 
-      *availability = AvailabilityContext(VersionRange::allGTE(version));
+      *availability = AvailabilityRange(VersionRange::allGTE(version));
 
       SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
       continue;
@@ -890,7 +890,7 @@ static bool parseDeclSILOptional(
       SpecializeAttr *Attr;
       StringRef targetFunctionName;
       ModuleDecl *module = nullptr;
-      AvailabilityContext availability = AvailabilityContext::alwaysAvailable();
+      AvailabilityRange availability = AvailabilityRange::alwaysAvailable();
       if (!SP.P.parseSpecializeAttribute(
               tok::r_square, AtLoc, Loc, Attr, &availability,
               [&targetFunctionName](Parser &P) -> bool {
@@ -7156,7 +7156,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   SILFunction::Purpose specialPurpose = SILFunction::Purpose::None;
   bool isWeakImported = false;
   bool needStackProtection = false;
-  AvailabilityContext availability = AvailabilityContext::alwaysAvailable();
+  AvailabilityRange availability = AvailabilityRange::alwaysAvailable();
   bool isWithoutActuallyEscapingThunk = false;
   Inline_t inlineStrategy = InlineDefault;
   OptimizationMode optimizationMode = OptimizationMode::NotSet;

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -33,7 +33,7 @@ struct ParsedSpecAttr {
   SILFunction *target = nullptr;
   Identifier spiGroupID;
   ModuleDecl *spiModule;
-  AvailabilityContext availability = AvailabilityContext::alwaysAvailable();
+  AvailabilityRange availability = AvailabilityRange::alwaysAvailable();
 };
 
 /// The parser for an individual SIL function.

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -224,9 +224,9 @@ bool SILGenModule::requiresBackDeploymentThunk(ValueDecl *decl,
   // Use of a back deployment thunk is unnecessary if the deployment target is
   // high enough that the ABI implementation of the back deployed declaration is
   // guaranteed to be available.
-  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
+  auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(ctx);
   auto declAvailability =
-      AvailabilityContext(VersionRange::allGTE(*backDeployBeforeVersion));
+      AvailabilityRange(VersionRange::allGTE(*backDeployBeforeVersion));
   if (deploymentAvailability.isContainedIn(declAvailability))
     return false;
 

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -600,7 +600,7 @@ static bool isCheckExpectedExecutorIntrinsicAvailable(SILGenModule &SGM) {
   // in main-actor context.
   auto &C = checkExecutor->getASTContext();
   if (!C.LangOpts.DisableAvailabilityChecking) {
-    auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(C);
+    auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(C);
     auto declAvailability =
         AvailabilityInference::availableRange(checkExecutor, C);
     return deploymentAvailability.isContainedIn(declAvailability);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1804,7 +1804,7 @@ shouldReplaceCallByContiguousArrayStorageAnyObject(SILFunction &F,
 
   // On SwiftStdlib 5.7 we can replace the call.
   auto &ctxt = storageMetaTy->getASTContext();
-  auto deployment = AvailabilityContext::forDeploymentTarget(ctxt);
+  auto deployment = AvailabilityRange::forDeploymentTarget(ctxt);
   if (!deployment.isContainedIn(ctxt.getSwift57Availability()))
     return std::nullopt;
 

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1800,8 +1800,7 @@ static bool isApplyOfKnownAvailability(SILInstruction &I) {
   if (!callee->hasSemanticsAttr("availability.osversion"))
     return false;
   auto &context = I.getFunction()->getASTContext();
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(context);
+  auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(context);
   if (apply.getNumArguments() != 3)
     return false;
   auto arg0 = dyn_cast<IntegerLiteralInst>(apply.getArgument(0));
@@ -1818,7 +1817,7 @@ static bool isApplyOfKnownAvailability(SILInstruction &I) {
       arg0->getValue().getLimitedValue(), arg1->getValue().getLimitedValue(),
       arg2->getValue().getLimitedValue()));
 
-  auto callAvailability = AvailabilityContext(version);
+  auto callAvailability = AvailabilityRange(version);
   return deploymentAvailability.isContainedIn(callAvailability);
 }
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2889,7 +2889,7 @@ static bool usePrespecialized(
   if (refF->getSpecializeAttrs().empty())
     return false;
 
-  SmallVector<std::tuple<unsigned, ReabstractionInfo, AvailabilityContext>, 4>
+  SmallVector<std::tuple<unsigned, ReabstractionInfo, AvailabilityRange>, 4>
       layoutMatches;
 
   ReabstractionInfo specializedReInfo(funcBuilder.getModule().getSwiftModule(),
@@ -2917,7 +2917,7 @@ static bool usePrespecialized(
     // target depending which one is more recent.
     auto specializationAvail = SA->getAvailability();
     auto &ctxt = funcBuilder.getModule().getSwiftModule()->getASTContext();
-    auto deploymentAvail = AvailabilityContext::forDeploymentTarget(ctxt);
+    auto deploymentAvail = AvailabilityRange::forDeploymentTarget(ctxt);
     auto currentFn = apply.getFunction();
     auto isInlinableCtxt = (currentFn->getResilienceExpansion()
                              == ResilienceExpansion::Minimal);
@@ -3068,7 +3068,7 @@ static bool usePrespecialized(
 
   if (!layoutMatches.empty()) {
 
-    std::tuple<unsigned, ReabstractionInfo, AvailabilityContext> res =
+    std::tuple<unsigned, ReabstractionInfo, AvailabilityRange> res =
         layoutMatches[0];
     for (auto &tuple : layoutMatches) {
       if (std::get<0>(tuple) > std::get<0>(res))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1680,7 +1680,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     // While it's possible that @objc @implementation would function with
     // pre-stable runtimes, this isn't a configuration that's been tested or
     // supported.
-    auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(Ctx);
+    auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(Ctx);
     if (!deploymentAvailability.isContainedIn(Ctx.getSwift50Availability())) {
       auto diag = diagnose(
           attr->getLocation(),
@@ -2178,8 +2178,8 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   // range annotation and ensure that this attribute's available version range
   // is fully contained within that declaration's range. If there is no such
   // enclosing declaration, then there is nothing to check.
-  std::optional<AvailabilityContext> EnclosingAnnotatedRange;
-  AvailabilityContext AttrRange =
+  std::optional<AvailabilityRange> EnclosingAnnotatedRange;
+  AvailabilityRange AttrRange =
       AvailabilityInference::availableRange(attr, Ctx);
 
   if (auto *parent = getEnclosingDeclForDecl(D)) {
@@ -2223,8 +2223,8 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   std::optional<Diagnostic> MaybeNotAllowed =
       TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D);
   if (MaybeNotAllowed.has_value()) {
-    AvailabilityContext DeploymentRange
-        = AvailabilityContext::forDeploymentTarget(Ctx);
+    AvailabilityRange DeploymentRange =
+        AvailabilityRange::forDeploymentTarget(Ctx);
     if (EnclosingAnnotatedRange.has_value())
       DeploymentRange.intersectWith(*EnclosingAnnotatedRange);
 
@@ -3031,7 +3031,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
 
   if (!mainFunction) {
     const bool hasAsyncSupport =
-        AvailabilityContext::forDeploymentTarget(context).isContainedIn(
+        AvailabilityRange::forDeploymentTarget(context).isContainedIn(
             context.getBackDeployedConcurrencyAvailability());
     context.Diags.diagnose(attr->getLocation(),
                            diag::attr_MainType_without_main,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -45,7 +45,7 @@
 using namespace swift;
 
 ExportContext::ExportContext(
-    DeclContext *DC, AvailabilityContext runningOSVersion,
+    DeclContext *DC, AvailabilityRange runningOSVersion,
     FragileFunctionKind kind, bool spi, bool exported, bool implicit,
     bool deprecated, std::optional<PlatformKind> unavailablePlatformKind)
     : DC(DC), RunningOSVersion(runningOSVersion), FragileKind(kind) {
@@ -231,8 +231,9 @@ ExportContext ExportContext::forDeclSignature(Decl *D) {
   auto fragileKind = DC->getFragileFunctionKind();
   auto runningOSVersion =
       (Ctx.LangOpts.DisableAvailabilityChecking
-       ? AvailabilityContext::alwaysAvailable()
-       : TypeChecker::overApproximateAvailabilityAtLocation(D->getLoc(), DC));
+           ? AvailabilityRange::alwaysAvailable()
+           : TypeChecker::overApproximateAvailabilityAtLocation(D->getLoc(),
+                                                                DC));
   bool spi = Ctx.LangOpts.LibraryLevel == LibraryLevel::SPI;
   bool implicit = false;
   bool deprecated = false;
@@ -259,8 +260,8 @@ ExportContext ExportContext::forFunctionBody(DeclContext *DC, SourceLoc loc) {
   auto fragileKind = DC->getFragileFunctionKind();
   auto runningOSVersion =
       (Ctx.LangOpts.DisableAvailabilityChecking
-       ? AvailabilityContext::alwaysAvailable()
-       : TypeChecker::overApproximateAvailabilityAtLocation(loc, DC));
+           ? AvailabilityRange::alwaysAvailable()
+           : TypeChecker::overApproximateAvailabilityAtLocation(loc, DC));
 
   bool spi = Ctx.LangOpts.LibraryLevel == LibraryLevel::SPI;
   bool implicit = false;
@@ -304,7 +305,7 @@ ExportContext ExportContext::withExported(bool exported) const {
 }
 
 ExportContext ExportContext::withRefinedAvailability(
-    const AvailabilityContext &availability) const {
+    const AvailabilityRange &availability) const {
   auto copy = *this;
   copy.RunningOSVersion.intersectWith(availability);
   return copy;
@@ -352,7 +353,7 @@ static bool hasActiveAvailableAttribute(Decl *D,
 static bool computeContainedByDeploymentTarget(TypeRefinementContext *TRC,
                                                ASTContext &ctx) {
   return TRC->getAvailabilityInfo()
-                  .isContainedIn(AvailabilityContext::forDeploymentTarget(ctx));
+                  .isContainedIn(AvailabilityRange::forDeploymentTarget(ctx));
 }
 
 /// Returns true if the reference or any of its parents is an
@@ -659,7 +660,7 @@ private:
 
     // Declarations with an explicit availability attribute always get a TRC.
     if (hasActiveAvailableAttribute(D, Context)) {
-      AvailabilityContext DeclaredAvailability =
+      AvailabilityRange DeclaredAvailability =
           swift::AvailabilityInference::availableRange(D, Context);
 
       return TypeRefinementContext::createForDecl(
@@ -673,9 +674,9 @@ private:
     // internal property in a public struct can be effectively less available
     // than the containing struct decl because the internal property will only
     // be accessed by code running at the deployment target or later.
-    AvailabilityContext CurrentAvailability =
+    AvailabilityRange CurrentAvailability =
         getCurrentTRC()->getAvailabilityInfo();
-    AvailabilityContext EffectiveAvailability =
+    AvailabilityRange EffectiveAvailability =
         getEffectiveAvailabilityForDeclSignature(D, CurrentAvailability);
     if (CurrentAvailability.isSupersetOf(EffectiveAvailability))
       return TypeRefinementContext::createForDeclImplicit(
@@ -685,9 +686,9 @@ private:
     return nullptr;
   }
 
-  AvailabilityContext getEffectiveAvailabilityForDeclSignature(
-      Decl *D, const AvailabilityContext BaseAvailability) {
-    AvailabilityContext EffectiveAvailability = BaseAvailability;
+  AvailabilityRange getEffectiveAvailabilityForDeclSignature(
+      Decl *D, const AvailabilityRange BaseAvailability) {
+    AvailabilityRange EffectiveAvailability = BaseAvailability;
 
     // As a special case, extension decls are treated as effectively as
     // available as the nominal type they extend, up to the deployment target.
@@ -704,14 +705,14 @@ private:
         // the extension, so limit the effective availability to the deployment
         // target.
         EffectiveAvailability.unionWith(
-            AvailabilityContext::forDeploymentTarget(Context));
+            AvailabilityRange::forDeploymentTarget(Context));
       }
     }
 
     EffectiveAvailability.intersectWith(getCurrentTRC()->getAvailabilityInfo());
     if (shouldConstrainSignatureToDeploymentTarget(D))
       EffectiveAvailability.intersectWith(
-          AvailabilityContext::forDeploymentTarget(Context));
+          AvailabilityRange::forDeploymentTarget(Context));
 
     return EffectiveAvailability;
   }
@@ -778,8 +779,8 @@ private:
   // target for `range` in decl `D`.
   TypeRefinementContext *
   createImplicitDeclContextForDeploymentTarget(Decl *D, SourceRange range){
-    AvailabilityContext Availability =
-        AvailabilityContext::forDeploymentTarget(Context);
+    AvailabilityRange Availability =
+        AvailabilityRange::forDeploymentTarget(Context);
     Availability.intersectWith(getCurrentTRC()->getAvailabilityInfo());
 
     return TypeRefinementContext::createForDeclImplicit(
@@ -931,8 +932,8 @@ private:
   /// There is no need for the caller to explicitly traverse the children
   /// of this node.
   void buildIfStmtRefinementContext(IfStmt *IS) {
-    std::optional<AvailabilityContext> ThenRange;
-    std::optional<AvailabilityContext> ElseRange;
+    std::optional<AvailabilityRange> ThenRange;
+    std::optional<AvailabilityRange> ElseRange;
     std::tie(ThenRange, ElseRange) =
         buildStmtConditionRefinementContext(IS->getCond());
 
@@ -977,7 +978,7 @@ private:
   /// There is no need for the caller to explicitly traverse the children
   /// of this node.
   void buildWhileStmtRefinementContext(WhileStmt *WS) {
-    std::optional<AvailabilityContext> BodyRange =
+    std::optional<AvailabilityRange> BodyRange =
         buildStmtConditionRefinementContext(WS->getCond()).first;
 
     if (BodyRange.has_value()) {
@@ -1007,8 +1008,8 @@ private:
     // This is slightly tricky because, unlike our other control constructs,
     // the refined region is not lexically contained inside the construct
     // introducing the refinement context.
-    std::optional<AvailabilityContext> FallthroughRange;
-    std::optional<AvailabilityContext> ElseRange;
+    std::optional<AvailabilityRange> FallthroughRange;
+    std::optional<AvailabilityRange> ElseRange;
     std::tie(FallthroughRange, ElseRange) =
         buildStmtConditionRefinementContext(GS->getCond());
 
@@ -1041,8 +1042,8 @@ private:
   /// of optional version ranges, the first for the true branch and the second
   /// for the false branch. A value of None for a given branch indicates that
   /// the branch does not introduce a new refinement.
-  std::pair<std::optional<AvailabilityContext>,
-            std::optional<AvailabilityContext>>
+  std::pair<std::optional<AvailabilityRange>,
+            std::optional<AvailabilityRange>>
   buildStmtConditionRefinementContext(StmtCondition Cond) {
 
     // Any refinement contexts introduced in the statement condition
@@ -1055,7 +1056,7 @@ private:
     unsigned NestedCount = 0;
 
     // Tracks the potential version range when the condition is false.
-    auto FalseFlow = AvailabilityContext::neverAvailable();
+    auto FalseFlow = AvailabilityRange::neverAvailable();
 
     TypeRefinementContext *StartingTRC = getCurrentTRC();
 
@@ -1064,9 +1065,9 @@ private:
 
     for (StmtConditionElement Element : Cond) {
       TypeRefinementContext *CurrentTRC = getCurrentTRC();
-      AvailabilityContext CurrentInfo = CurrentTRC->getAvailabilityInfo();
-      AvailabilityContext CurrentExplicitInfo =
-        CurrentTRC->getExplicitAvailabilityInfo();
+      AvailabilityRange CurrentInfo = CurrentTRC->getAvailabilityInfo();
+      AvailabilityRange CurrentExplicitInfo =
+          CurrentTRC->getExplicitAvailabilityInfo();
 
       // If the element is not a condition, walk it in the current TRC.
       if (Element.getKind() != StmtConditionElement::CK_Availability) {
@@ -1118,7 +1119,7 @@ private:
         continue;
       }
 
-      AvailabilityContext NewConstraint = contextForSpec(Spec, false);
+      AvailabilityRange NewConstraint = contextForSpec(Spec, false);
       Query->setAvailableRange(contextForSpec(Spec, true).getRawVersionRange());
 
       // When compiling zippered for macCatalyst, we need to collect both
@@ -1194,7 +1195,7 @@ private:
       ++NestedCount;
     }
 
-    std::optional<AvailabilityContext> FalseRefinement = std::nullopt;
+    std::optional<AvailabilityRange> FalseRefinement = std::nullopt;
     // The version range for the false branch should never have any versions
     // that weren't possible when the condition started evaluating.
     assert(FalseFlow.isContainedIn(StartingTRC->getAvailabilityInfo()));
@@ -1209,8 +1210,8 @@ private:
     }
 
     auto makeResult =
-        [isUnavailability](std::optional<AvailabilityContext> TrueRefinement,
-                           std::optional<AvailabilityContext> FalseRefinement) {
+        [isUnavailability](std::optional<AvailabilityRange> TrueRefinement,
+                           std::optional<AvailabilityRange> FalseRefinement) {
           if (isUnavailability.has_value() && isUnavailability.value()) {
             // If this is an unavailability check, invert the result.
             return std::make_pair(FalseRefinement, TrueRefinement);
@@ -1279,10 +1280,10 @@ private:
   }
 
   /// Return the availability context for the given spec.
-  AvailabilityContext contextForSpec(AvailabilitySpec *Spec,
-                                    bool GetRuntimeContext) {
+  AvailabilityRange contextForSpec(AvailabilitySpec *Spec,
+                                   bool GetRuntimeContext) {
     if (isa<OtherPlatformAvailabilitySpec>(Spec)) {
-      return AvailabilityContext::alwaysAvailable();
+      return AvailabilityRange::alwaysAvailable();
     }
 
     auto *VersionSpec = cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
@@ -1291,7 +1292,7 @@ private:
                                     VersionSpec->getRuntimeVersion() :
                                     VersionSpec->getVersion());
 
-    return AvailabilityContext(VersionRange::allGTE(Version));
+    return AvailabilityRange(VersionRange::allGTE(Version));
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -1319,7 +1320,7 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
     // The root type refinement context reflects the fact that all parts of
     // the source file are guaranteed to be executing on at least the minimum
     // platform version for inlining.
-    auto MinPlatformReq = AvailabilityContext::forInliningTarget(Context);
+    auto MinPlatformReq = AvailabilityRange::forInliningTarget(Context);
     RootTRC = TypeRefinementContext::createForSourceFile(&SF, MinPlatformReq);
     SF.setTypeRefinementContext(RootTRC);
   }
@@ -1364,10 +1365,9 @@ ExpandChildTypeRefinementContextsRequest::evaluate(
   return parentTRC->Children;
 }
 
-AvailabilityContext
-TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
-                                                   const DeclContext *DC,
-                                                   const TypeRefinementContext **MostRefined) {
+AvailabilityRange TypeChecker::overApproximateAvailabilityAtLocation(
+    SourceLoc loc, const DeclContext *DC,
+    const TypeRefinementContext **MostRefined) {
   SourceFile *SF;
   if (loc.isValid())
     SF = DC->getParentModule()->getSourceFileContainingLocation(loc);
@@ -1390,7 +1390,7 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
   // this will be a real problem.
 
   // We can assume we are running on at least the minimum inlining target.
-  auto OverApproximateContext = AvailabilityContext::forInliningTarget(Context);
+  auto OverApproximateContext = AvailabilityRange::forInliningTarget(Context);
   auto isInvalidLoc = [SF](SourceLoc loc) {
     return SF ? loc.isInvalid() : true;
   };
@@ -1401,7 +1401,7 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
 
     loc = D->getLoc();
 
-    std::optional<AvailabilityContext> Info =
+    std::optional<AvailabilityRange> Info =
         AvailabilityInference::annotatedAvailableRange(D, Context);
 
     if (Info.has_value()) {
@@ -1430,7 +1430,7 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
 
 bool TypeChecker::isDeclarationUnavailable(
     const Decl *D, const DeclContext *referenceDC,
-    llvm::function_ref<AvailabilityContext()> getAvailabilityContext) {
+    llvm::function_ref<AvailabilityRange()> getAvailabilityRange) {
   ASTContext &Context = referenceDC->getASTContext();
   if (Context.LangOpts.DisableAvailabilityChecking) {
     return false;
@@ -1442,13 +1442,13 @@ bool TypeChecker::isDeclarationUnavailable(
     return false;
   }
 
-  AvailabilityContext safeRangeUnderApprox{
+  AvailabilityRange safeRangeUnderApprox{
       AvailabilityInference::availableRange(D, Context)};
 
   if (safeRangeUnderApprox.isAlwaysAvailable())
     return false;
 
-  AvailabilityContext runningOSOverApprox = getAvailabilityContext();
+  AvailabilityRange runningOSOverApprox = getAvailabilityRange();
 
   // The reference is safe if an over-approximation of the running OS
   // versions is fully contained within an under-approximation
@@ -1458,7 +1458,7 @@ bool TypeChecker::isDeclarationUnavailable(
   return !runningOSOverApprox.isContainedIn(safeRangeUnderApprox);
 }
 
-std::optional<AvailabilityContext>
+std::optional<AvailabilityRange>
 TypeChecker::checkDeclarationAvailability(const Decl *D,
                                           const ExportContext &Where) {
   // Skip computing potential unavailability if the declaration is explicitly
@@ -1468,7 +1468,7 @@ TypeChecker::checkDeclarationAvailability(const Decl *D,
       return std::nullopt;
 
   if (isDeclarationUnavailable(D, Where.getDeclContext(), [&Where] {
-        return Where.getAvailabilityContext();
+        return Where.getAvailabilityRange();
       })) {
     auto &Context = Where.getDeclContext()->getASTContext();
     return AvailabilityInference::availableRange(D, Context);
@@ -1477,7 +1477,7 @@ TypeChecker::checkDeclarationAvailability(const Decl *D,
   return std::nullopt;
 }
 
-std::optional<AvailabilityContext>
+std::optional<AvailabilityRange>
 TypeChecker::checkConformanceAvailability(const RootProtocolConformance *conf,
                                           const ExtensionDecl *ext,
                                           const ExportContext &where) {
@@ -1856,7 +1856,7 @@ static void findAvailabilityFixItNodes(
 /// on the given declaration for the given version range.
 static void
 fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
-                       const AvailabilityContext &RequiredAvailability,
+                       const AvailabilityRange &RequiredAvailability,
                        ASTContext &Context) {
   assert(D);
 
@@ -1905,7 +1905,7 @@ fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
 /// condition to the required range.
 static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     SourceRange ReferenceRange, const DeclContext *ReferenceDC,
-    const AvailabilityContext &RequiredAvailability, ASTContext &Context,
+    const AvailabilityRange &RequiredAvailability, ASTContext &Context,
     InFlightDiagnostic &Err) {
   const TypeRefinementContext *TRC = nullptr;
   (void)TypeChecker::overApproximateAvailabilityAtLocation(ReferenceRange.Start,
@@ -1913,7 +1913,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
   if (!TRC)
     return false;
 
-  AvailabilityContext AvailabilityAtLoc = TRC->getExplicitAvailabilityInfo();
+  AvailabilityRange AvailabilityAtLoc = TRC->getExplicitAvailabilityInfo();
   if (!AvailabilityAtLoc.isAlwaysAvailable() &&
       !RequiredAvailability.isAlwaysAvailable() &&
       TRC->getReason() != TypeRefinementContext::Reason::Root &&
@@ -1950,7 +1950,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
 /// Emit a diagnostic note and Fix-It to add an if #available(...) { } guard
 /// that checks for the given version range around the given node.
 static void fixAvailabilityByAddingVersionCheck(
-    ASTNode NodeToWrap, const AvailabilityContext &RequiredAvailability,
+    ASTNode NodeToWrap, const AvailabilityRange &RequiredAvailability,
     SourceRange ReferenceRange, ASTContext &Context) {
   // If this is an implicit variable that wraps an expression,
   // let's point to it's initializer. For example, result builder
@@ -2025,7 +2025,7 @@ static void fixAvailabilityByAddingVersionCheck(
 /// requiting the given OS version range.
 static void fixAvailability(SourceRange ReferenceRange,
                             const DeclContext *ReferenceDC,
-                            const AvailabilityContext &RequiredAvailability,
+                            const AvailabilityRange &RequiredAvailability,
                             ASTContext &Context) {
   if (ReferenceRange.isInvalid())
     return;
@@ -2059,7 +2059,7 @@ static void fixAvailability(SourceRange ReferenceRange,
 
 void TypeChecker::diagnosePotentialUnavailability(
     SourceRange ReferenceRange, Diag<StringRef, llvm::VersionTuple> Diag,
-    const DeclContext *ReferenceDC, const AvailabilityContext &Availability) {
+    const DeclContext *ReferenceDC, const AvailabilityRange &Availability) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
   {
@@ -2077,7 +2077,7 @@ void TypeChecker::diagnosePotentialUnavailability(
 }
 
 bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
-                                    AvailabilityContext RequiredAvailability,
+                                    AvailabilityRange RequiredAvailability,
                                     Diag<StringRef, llvm::VersionTuple> Diag,
                                     const DeclContext *ReferenceDC) {
   ASTContext &ctx = ReferenceDC->getASTContext();
@@ -2106,9 +2106,9 @@ void TypeChecker::checkConcurrencyAvailability(SourceRange ReferenceRange,
 }
 
 static bool
-requiresDeploymentTargetOrEarlier(const AvailabilityContext &availability,
+requiresDeploymentTargetOrEarlier(const AvailabilityRange &availability,
                                   ASTContext &ctx) {
-  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+  auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
   return deploymentTarget.isContainedIn(availability);
 }
 
@@ -2116,7 +2116,7 @@ requiresDeploymentTargetOrEarlier(const AvailabilityContext &availability,
 /// \p IsError accordingly.
 static Diagnostic getPotentialUnavailabilityDiagnostic(
     const ValueDecl *D, const DeclContext *ReferenceDC,
-    const AvailabilityContext &Availability, bool WarnBeforeDeploymentTarget,
+    const AvailabilityRange &Availability, bool WarnBeforeDeploymentTarget,
     bool &IsError) {
   ASTContext &Context = ReferenceDC->getASTContext();
   auto Platform = Context.getTargetPlatformStringForDiagnostics();
@@ -2141,7 +2141,7 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
 
 bool TypeChecker::diagnosePotentialUnavailability(
     const ValueDecl *D, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, const AvailabilityContext &Availability,
+    const DeclContext *ReferenceDC, const AvailabilityRange &Availability,
     bool WarnBeforeDeploymentTarget = false) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
@@ -2164,7 +2164,7 @@ bool TypeChecker::diagnosePotentialUnavailability(
 
 void TypeChecker::diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, const AvailabilityContext &Availability,
+    const DeclContext *ReferenceDC, const AvailabilityRange &Availability,
     bool ForInout) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
@@ -2210,7 +2210,7 @@ behaviorLimitForExplicitUnavailability(
 void TypeChecker::diagnosePotentialUnavailability(
     const RootProtocolConformance *rootConf, const ExtensionDecl *ext,
     SourceLoc loc, const DeclContext *dc,
-    const AvailabilityContext &availability) {
+    const AvailabilityRange &availability) {
   ASTContext &ctx = dc->getASTContext();
 
   {
@@ -2679,7 +2679,7 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
   auto *ReferenceDC = Where.getDeclContext();
   auto &Context = ReferenceDC->getASTContext();
   if (!Context.LangOpts.DisableAvailabilityChecking) {
-    AvailabilityContext RunningOSVersions = Where.getAvailabilityContext();
+    AvailabilityRange RunningOSVersions = Where.getAvailabilityRange();
     if (RunningOSVersions.isKnownUnreachable()) {
       // Suppress a deprecation warning if the availability checking machinery
       // thinks the reference program location will not execute on any
@@ -2763,7 +2763,7 @@ bool TypeChecker::diagnoseIfDeprecated(SourceLoc loc,
   auto *dc = where.getDeclContext();
   auto &ctx = dc->getASTContext();
   if (!ctx.LangOpts.DisableAvailabilityChecking) {
-    AvailabilityContext runningOSVersion = where.getAvailabilityContext();
+    AvailabilityRange runningOSVersion = where.getAvailabilityRange();
     if (runningOSVersion.isKnownUnreachable()) {
       // Suppress a deprecation warning if the availability checking machinery
       // thinks the reference program location will not execute on any

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -103,7 +103,7 @@ enum class ExportabilityReason : unsigned {
 /// without producing a warning or error, respectively.
 class ExportContext {
   DeclContext *DC;
-  AvailabilityContext RunningOSVersion;
+  AvailabilityRange RunningOSVersion;
   FragileFunctionKind FragileKind;
   unsigned SPI : 1;
   unsigned Exported : 1;
@@ -113,7 +113,7 @@ class ExportContext {
   unsigned Platform : 8;
   unsigned Reason : 3;
 
-  ExportContext(DeclContext *DC, AvailabilityContext runningOSVersion,
+  ExportContext(DeclContext *DC, AvailabilityRange runningOSVersion,
                 FragileFunctionKind kind, bool spi, bool exported,
                 bool implicit, bool deprecated,
                 std::optional<PlatformKind> unavailablePlatformKind);
@@ -156,11 +156,11 @@ public:
   /// Produce a new context with the same properties as this one, except the
   /// availability context is constrained by \p availability if necessary.
   ExportContext
-  withRefinedAvailability(const AvailabilityContext &availability) const;
+  withRefinedAvailability(const AvailabilityRange &availability) const;
 
   DeclContext *getDeclContext() const { return DC; }
 
-  AvailabilityContext getAvailabilityContext() const {
+  AvailabilityRange getAvailabilityRange() const {
     return RunningOSVersion;
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1504,10 +1504,11 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
     canRemoveOldDecls = true;
   } else {
     // Check if the availability of nominal is high enough to be using the ExecutorJob version
-    AvailabilityContext requirementInfo
-        = AvailabilityInference::availableRange(moveOnlyEnqueueRequirement, C);
-    AvailabilityContext declInfo =
-        TypeChecker::overApproximateAvailabilityAtLocation(nominal->getLoc(), dyn_cast<DeclContext>(nominal));
+    AvailabilityRange requirementInfo =
+        AvailabilityInference::availableRange(moveOnlyEnqueueRequirement, C);
+    AvailabilityRange declInfo =
+        TypeChecker::overApproximateAvailabilityAtLocation(
+            nominal->getLoc(), dyn_cast<DeclContext>(nominal));
     canRemoveOldDecls = declInfo.isContainedIn(requirementInfo);
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1660,7 +1660,7 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
 bool TypeChecker::isAvailabilitySafeForConformance(
     const ProtocolDecl *proto, const ValueDecl *requirement,
     const ValueDecl *witness, const DeclContext *dc,
-    AvailabilityContext &requirementInfo) {
+    AvailabilityRange &requirementInfo) {
 
   // We assume conformances in
   // non-SourceFiles have already been checked for availability.
@@ -1681,11 +1681,11 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   // (an over-approximation of) the intersection of the witnesses's available
   // range with both the conforming type's available range and the protocol
   // declaration's available range.
-  AvailabilityContext witnessInfo =
+  AvailabilityRange witnessInfo =
       AvailabilityInference::availableRange(witness, Context);
   requirementInfo = AvailabilityInference::availableRange(requirement, Context);
 
-  AvailabilityContext infoForConformingDecl =
+  AvailabilityRange infoForConformingDecl =
       overApproximateAvailabilityAtLocation(dc->getAsDecl()->getLoc(), dc);
 
   // Relax the requirements for @_spi witnesses by treating the requirement as
@@ -1697,8 +1697,8 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   // compatibility with some existing code and is reasonably safe for the
   // majority of cases.
   if (witness->isSPI()) {
-    AvailabilityContext deploymentTarget =
-        AvailabilityContext::forDeploymentTarget(Context);
+    AvailabilityRange deploymentTarget =
+        AvailabilityRange::forDeploymentTarget(Context);
     requirementInfo.constrainWith(deploymentTarget);
   }
 
@@ -1706,7 +1706,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   witnessInfo.constrainWith(infoForConformingDecl);
   requirementInfo.constrainWith(infoForConformingDecl);
 
-  AvailabilityContext infoForProtocolDecl =
+  AvailabilityRange infoForProtocolDecl =
       overApproximateAvailabilityAtLocation(proto->getLoc(), proto);
 
   witnessInfo.constrainWith(infoForProtocolDecl);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -522,16 +522,16 @@ static VersionRange getMinOSVersionForClassStubs(const llvm::Triple &target) {
   return VersionRange::all();
 }
 
-static AvailabilityContext getObjCClassStubAvailability(ASTContext &ctx) {
+static AvailabilityRange getObjCClassStubAvailability(ASTContext &ctx) {
   // FIXME: This should just be ctx.getSwift51Availability(), but that breaks
   // tests on arm64 arches.
-  return AvailabilityContext(getMinOSVersionForClassStubs(ctx.LangOpts.Target));
+  return AvailabilityRange(getMinOSVersionForClassStubs(ctx.LangOpts.Target));
 }
 
 static bool checkObjCClassStubAvailability(ASTContext &ctx, const Decl *decl) {
   auto stubAvailability = getObjCClassStubAvailability(ctx);
 
-  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+  auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
   if (deploymentTarget.isContainedIn(stubAvailability))
     return true;
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1776,10 +1776,9 @@ static bool isAvailabilitySafeForOverride(ValueDecl *override,
   // API availability ranges are contravariant: make sure the version range
   // of an overridden declaration is fully contained in the range of the
   // overriding declaration.
-  AvailabilityContext overrideInfo =
-    AvailabilityInference::availableRange(override, ctx);
-  AvailabilityContext baseInfo =
-    AvailabilityInference::availableRange(base, ctx);
+  AvailabilityRange overrideInfo =
+      AvailabilityInference::availableRange(override, ctx);
+  AvailabilityRange baseInfo = AvailabilityInference::availableRange(base, ctx);
 
   if (baseInfo.isContainedIn(overrideInfo))
     return true;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -30,7 +30,7 @@
 namespace swift {
 
 class AssociatedTypeDecl;
-class AvailabilityContext;
+class AvailabilityRange;
 class DeclContext;
 class FuncDecl;
 class NormalProtocolConformance;
@@ -90,7 +90,7 @@ protected:
 
   bool checkWitnessAvailability(ValueDecl *requirement,
                                 ValueDecl *witness,
-                                AvailabilityContext *requirementInfo);
+                                AvailabilityRange *requirementInfo);
 
   RequirementCheck checkWitness(ValueDecl *requirement,
                                 const RequirementMatch &match);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -999,13 +999,13 @@ bool diagnoseConformanceExportability(SourceLoc loc,
 bool isAvailabilitySafeForConformance(
     const ProtocolDecl *proto, const ValueDecl *requirement,
     const ValueDecl *witness, const DeclContext *dc,
-    AvailabilityContext &requiredAvailability);
+    AvailabilityRange &requiredAvailability);
 
 /// Returns an over-approximation of the range of operating system versions
 /// that could the passed-in location could be executing upon for
 /// the target platform. If MostRefined != nullptr, set to the most-refined
 /// TRC found while approximating.
-AvailabilityContext overApproximateAvailabilityAtLocation(
+AvailabilityRange overApproximateAvailabilityAtLocation(
     SourceLoc loc, const DeclContext *DC,
     const TypeRefinementContext **MostRefined = nullptr);
 
@@ -1032,18 +1032,18 @@ std::optional<Diagnostic> diagnosticIfDeclCannotBeUnavailable(const Decl *D);
 /// unavailability.
 bool isDeclarationUnavailable(
     const Decl *D, const DeclContext *referenceDC,
-    llvm::function_ref<AvailabilityContext()> getAvailabilityContext);
+    llvm::function_ref<AvailabilityRange()> getAvailabilityRange);
 
 /// Checks whether a declaration should be considered unavailable when
 /// referred to at the given location and, if so, returns the unmet required
 /// version range. Returns None is the declaration is definitely available.
-std::optional<AvailabilityContext>
+std::optional<AvailabilityRange>
 checkDeclarationAvailability(const Decl *D, const ExportContext &Where);
 
 /// Checks whether a conformance should be considered unavailable when
 /// referred to at the given location and, if so, returns the unmet required
 /// version range. Returns None is the declaration is definitely available.
-std::optional<AvailabilityContext>
+std::optional<AvailabilityRange>
 checkConformanceAvailability(const RootProtocolConformance *Conf,
                              const ExtensionDecl *Ext,
                              const ExportContext &Where);
@@ -1060,7 +1060,7 @@ void checkIgnoredExpr(Expr *E);
 bool diagnosePotentialUnavailability(const ValueDecl *D,
                                      SourceRange ReferenceRange,
                                      const DeclContext *ReferenceDC,
-                                     const AvailabilityContext &Availability,
+                                     const AvailabilityRange &Availability,
                                      bool WarnBeforeDeploymentTarget);
 
 // Emits a diagnostic for a protocol conformance that is potentially
@@ -1069,13 +1069,12 @@ void diagnosePotentialUnavailability(const RootProtocolConformance *rootConf,
                                      const ExtensionDecl *ext,
                                      SourceLoc loc,
                                      const DeclContext *dc,
-                                     const AvailabilityContext &availability);
+                                     const AvailabilityRange &availability);
 
-void
-diagnosePotentialUnavailability(SourceRange ReferenceRange,
-                                Diag<StringRef, llvm::VersionTuple> Diag,
-                                const DeclContext *ReferenceDC,
-                                const AvailabilityContext &Availability);
+void diagnosePotentialUnavailability(SourceRange ReferenceRange,
+                                     Diag<StringRef, llvm::VersionTuple> Diag,
+                                     const DeclContext *ReferenceDC,
+                                     const AvailabilityRange &Availability);
 
 /// Type check a 'distributed actor' declaration.
 void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
@@ -1086,7 +1085,7 @@ void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
 bool checkDistributedFunc(FuncDecl *func);
 
 bool checkAvailability(SourceRange ReferenceRange,
-                       AvailabilityContext RequiredAvailability,
+                       AvailabilityRange RequiredAvailability,
                        Diag<StringRef, llvm::VersionTuple> Diag,
                        const DeclContext *ReferenceDC);
 
@@ -1097,7 +1096,7 @@ void checkConcurrencyAvailability(SourceRange ReferenceRange,
 /// potentially unavailable.
 void diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, const AvailabilityContext &Availability,
+    const DeclContext *ReferenceDC, const AvailabilityRange &Availability,
     bool ForInout);
 
 /// Returns the availability attribute indicating deprecation if the

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -719,9 +719,8 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);
     fn->setAvailabilityForLinkage(
-      available.empty()
-      ? AvailabilityContext::alwaysAvailable()
-      : AvailabilityContext(VersionRange::allGTE(available)));
+        available.empty() ? AvailabilityRange::alwaysAvailable()
+                          : AvailabilityRange(VersionRange::allGTE(available)));
 
     fn->setIsDynamic(IsDynamicallyReplaceable_t(isDynamic));
     fn->setIsExactSelfClass(IsExactSelfClass_t(isExactSelfClass));
@@ -838,9 +837,9 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);
-    auto availability = available.empty()
-      ? AvailabilityContext::alwaysAvailable()
-      : AvailabilityContext(VersionRange::allGTE(available));
+    auto availability =
+        available.empty() ? AvailabilityRange::alwaysAvailable()
+                          : AvailabilityRange(VersionRange::allGTE(available));
 
     llvm::SmallVector<Type, 4> typeErasedParams;
     for (auto id : typeErasedParamsIDs) {


### PR DESCRIPTION
The generality of the `AvailabilityContext` name made it seem like it encapsulates more than it does. Really it just augments `VersionRange` with additional set algebra operations that are useful for availability computations. The `AvailabilityContext` name should be reserved for something pulls together more than just a single version.