### PR TITLE
[CSSimplify] Forego any contextual score increases while checking era…

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1281,6 +1281,21 @@ public:
     return false;
   }
 
+  bool isForExistentialMemberAccessConversion() const {
+    for (auto prev = this; prev;
+         prev = prev->previous.dyn_cast<ConstraintLocatorBuilder *>()) {
+      if (auto elt = prev->element) {
+        if (elt->is<LocatorPathElt::ExistentialMemberAccessConversion>())
+          return true;
+      }
+
+      if (auto locator = prev->previous.dyn_cast<ConstraintLocator *>())
+        return bool(locator->findLast<
+                    LocatorPathElt::ExistentialMemberAccessConversion>());
+    }
+    return false;
+  }
+
   std::optional<std::pair</*witness=*/ValueDecl *, GenericTypeParamType *>>
   isForWitnessGenericParameterRequirement() const {
     SmallVector<LocatorPathElt, 2> path;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14083,6 +14083,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     // This induces conversions to occur within closures instead of
     // outside of them wherever possible.
     if (locator.isFunctionConversion()) {
+      // This conversion exists only to check adjustments in the member
+      // type, so the fact that adjustments also cause a function conversion
+      // is unrelated.
+      if (locator.isForExistentialMemberAccessConversion())
+        return;
+
       increaseScore(SK_FunctionConversion, locator);
     }
   };

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1063,3 +1063,10 @@ func packExpansionResult(p: any PackExpansionResult) {
   p.foo(t: 1, "hi")
   // expected-error@-1 {{member 'foo' cannot be used on value of type 'any PackExpansionResult'; consider using a generic constraint instead}}
 }
+
+// rdar://135974645 - invalid error: heterogeneous collection literal could only be inferred to '[Any]'
+extension StringProtocol {
+  func test(target: any StringProtocol, idx: Int) {
+    let _ = [target.prefix(idx), target.suffix(idx)] // Ok
+  }
+}


### PR DESCRIPTION
…sed member type

`resolveOverload` introduces a conversion if there were any adjustments to a member type on existential base. This conversion exists only to check adjustments in the member type, so the fact that adjustments also cause a function conversion is unrelated.

Resolves: rdar://135974645

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
