### PR TITLE
Import tgmath_h instead of Darwin.C.tgmath

### DIFF
--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -15,7 +15,11 @@
 import Swift
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
-  import Darwin.C.tgmath
+  #if canImport(tgmath_h)
+    import tgmath_h
+  #else
+    import Darwin.C.tgmath
+  #endif
 #elseif canImport(Musl)
   import Musl
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Cygwin) || os(Haiku)

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -1,7 +1,9 @@
 // RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
 // REQUIRES: executable_test
 
-#if canImport(Darwin)
+#if canImport(tgmath_h)
+  import tgmath_h
+#elseif canImport(Darwin)
   import Darwin.C.tgmath
 #elseif canImport(Glibc)
   import Glibc

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -19,8 +19,10 @@
 
 // REQUIRES: rdar94452524
 
-#if canImport(Darwin)
-  import Darwin.C.tgmath
+#if canImport(tgmath_h)
+  import tgmath_h
+#elseif canImport(Darwin)
+  import tgmath_h
 #elseif canImport(Glibc)
   import Glibc
 #elseif os(WASI)


### PR DESCRIPTION
Recent Apple SDKs moved tgmath.h from Darwin.C.tgmath to tgmath_h.

rdar://135982993