### PR TITLE
Repair WebAssembly CI by build script and IRGen test fix

### DIFF
--- a/test/IRGen/stdlib/Mutex.swift
+++ b/test/IRGen/stdlib/Mutex.swift
@@ -33,10 +33,10 @@ final class Awaitable<Value, Failure>: Sendable where Value: Sendable, Failure: 
 // CHECK:   [[DEST_HANDLE_PTR:%.*]] = getelementptr inbounds %T15Synchronization5MutexV, ptr [[DEST]], i32 0, i32 0
 // CHECK:   [[SRC_HANDLE_PTR:%.*]] = getelementptr inbounds %T15Synchronization5MutexV, ptr [[SRC]], i32 0, i32 0
 // CHECK:   call void @llvm.memcpy.p0.p0.i{{32|64}}(ptr {{.*}} [[DEST_HANDLE_PTR]], ptr {{.*}} [[SRC_HANDLE_PTR]], i{{32|64}} {{.*}}, i1 false)
-// CHECK:   [[DEST_MUTEX_VALUE_OFFSET_PTR:%.*]] = getelementptr inbounds i32, ptr [[MUTEX]], i{{32|64}} 7
+// CHECK:   [[DEST_MUTEX_VALUE_OFFSET_PTR:%.*]] = getelementptr inbounds i32, ptr [[MUTEX]], i{{32 4|64 7}}
 // CHECK:   [[DEST_MUTEX_VALUE_OFFSET:%.*]] = load i32, ptr [[DEST_MUTEX_VALUE_OFFSET_PTR]]
 // CHECK:   [[DEST_VALUE_PTR:%.*]] = getelementptr inbounds i8, ptr [[DEST]], i32 [[DEST_MUTEX_VALUE_OFFSET]]
-// CHECK:   [[SRC_MUTEX_VALUE_OFFSET_PTR:%.*]] = getelementptr inbounds i32, ptr [[MUTEX]], i{{32|64}} 7
+// CHECK:   [[SRC_MUTEX_VALUE_OFFSET_PTR:%.*]] = getelementptr inbounds i32, ptr [[MUTEX]], i{{32 4|64 7}}
 // CHECK:   [[SRC_MUTEX_VALUE_OFFSET:%.*]] = load i32, ptr [[SRC_MUTEX_VALUE_OFFSET_PTR]]
 // CHECK:   [[SRC_VALUE_PTR:%.*]] = getelementptr inbounds i8, ptr [[SRC]], i32 [[SRC_MUTEX_VALUE_OFFSET]]
 

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -87,6 +87,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         # Build only static stdlib
         self.cmake_options.define('SWIFT_BUILD_STATIC_STDLIB:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_BUILD_DYNAMIC_STDLIB:BOOL', 'FALSE')
+        self.cmake_options.define('SWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_STDLIB_TRACING:BOOL', 'FALSE')
         self.cmake_options.define('SWIFT_STDLIB_HAS_ASLR:BOOL', 'FALSE')
         self.cmake_options.define('SWIFT_STDLIB_CONCURRENCY_TRACING:BOOL', 'FALSE')


### PR DESCRIPTION
- 37927fd7076d62ba59bc1b9e8059c336ee4ba6c2: wasm: Build static SDK overlay explicitly
  The static SDK overlay has been built implicitly for a long time, but this is not the case anymore after 5bf2c937abe09689190191fb379ac1dc04018929. We need to build it explicitly now. Otherwise we get the following error:
  ```
  ninja: error: 'test/swiftStdlibCollectionUnittest-wasi', needed by 'test/CMakeFiles/check-swift-wasi-wasm32-custom', missing and no known rule to make it
  ```
- e66ad5a69181f8403f91982bd52fab9f422b4d51: test: Fix test/IRGen/stdlib/Mutex.swift for 32-bit platforms
   The test was failing on 32-bit platforms because the offset of the layout of struct metadata depends on the pointer size.

| Field                   | Type | Offset (32-bit) | Offset (64-bit) |
|-------------------------|------|-----------------|-----------------|
| Layout String Pointer   | ptr  | 4 * (-2)        | 4 * (-4)        |
| VWT                     | ptr  | 4 * (-1)        | 4 * (-2)        |
| Metadata Flags          | ptr  | 4 * 0           | 4 * 0           |
| Nominal Type Descriptor | ptr  | 4 * 1           | 4 * 2           |
| Generic Requirement     | ptr  | 4 * 2           | 4 * 4           |
| Field Offset for `handle` | i32  | 4 * 3           | 4 * 6           |
| Field Offset for `value`  | i32  | 4 * 4           | 4 * 7           |