### PR TITLE
[CS] A couple of CSApply cleanups

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2059,10 +2059,17 @@ struct DynamicCallableMethods {
   }
 };
 
-/// A function that rewrites a syntactic element target in the context
-/// of solution application.
-using RewriteTargetFn = std::function<std::optional<SyntacticElementTarget>(
-    SyntacticElementTarget)>;
+/// Abstract base class for applying a solution to a SyntacticElementTarget.
+class SyntacticElementTargetRewriter {
+public:
+  virtual Solution &getSolution() const = 0;
+  virtual DeclContext *&getCurrentDC() const = 0;
+
+  virtual std::optional<SyntacticElementTarget>
+  rewriteTarget(SyntacticElementTarget target) = 0;
+
+  virtual ~SyntacticElementTargetRewriter() = default;
+};
 
 enum class ConstraintSystemPhase {
   ConstraintGeneration,
@@ -5534,67 +5541,38 @@ public:
   /// Apply the given solution to the given function's body and, for
   /// closure expressions, the expression itself.
   ///
-  /// \param solution The solution to apply.
   /// \param fn The function to which the solution is being applied.
-  /// \param currentDC The declaration context in which transformations
-  /// will be applied.
-  /// \param rewriteTarget Function that performs a rewrite of any targets
-  /// within the context.
+  /// \param rewriter The rewriter to apply the solution with.
   ///
   SolutionApplicationToFunctionResult
-  applySolution(Solution &solution, AnyFunctionRef fn, DeclContext *&currentDC,
-                std::function<std::optional<SyntacticElementTarget>(
-                    SyntacticElementTarget)>
-                    rewriteTarget);
+  applySolution(AnyFunctionRef fn, SyntacticElementTargetRewriter &rewriter);
 
   /// Apply the given solution to the given closure body.
   ///
-  ///
-  /// \param solution The solution to apply.
   /// \param fn The function or closure to which the solution is being applied.
-  /// \param currentDC The declaration context in which transformations
-  /// will be applied.
-  /// \param rewriteTarget Function that performs a rewrite of any targets
-  /// within the context.
+  /// \param rewriter The rewriter to apply the solution with.
   ///
   /// \returns true if solution cannot be applied.
-  bool applySolutionToBody(Solution &solution, AnyFunctionRef fn,
-                           DeclContext *&currentDC,
-                           std::function<std::optional<SyntacticElementTarget>(
-                               SyntacticElementTarget)>
-                               rewriteTarget);
+  bool applySolutionToBody(AnyFunctionRef fn,
+                           SyntacticElementTargetRewriter &rewriter);
 
   /// Apply the given solution to the given SingleValueStmtExpr.
   ///
-  /// \param solution The solution to apply.
   /// \param SVE The SingleValueStmtExpr to rewrite.
-  /// \param DC The declaration context in which transformations will be
-  /// applied.
-  /// \param rewriteTarget Function that performs a rewrite of any targets
-  /// within the context.
+  /// \param rewriter The rewriter to apply the solution with.
   ///
   /// \returns true if solution cannot be applied.
-  bool applySolutionToSingleValueStmt(
-      Solution &solution, SingleValueStmtExpr *SVE, DeclContext *DC,
-      std::function<
-          std::optional<SyntacticElementTarget>(SyntacticElementTarget)>
-          rewriteTarget);
+  bool applySolutionToSingleValueStmt(SingleValueStmtExpr *SVE,
+                                      SyntacticElementTargetRewriter &rewriter);
 
   /// Apply the given solution to the given tap expression.
   ///
-  /// \param solution The solution to apply.
   /// \param tapExpr The tap expression to which the solution is being applied.
-  /// \param currentDC The declaration context in which transformations
-  /// will be applied.
-  /// \param rewriteTarget Function that performs a rewrite of any
-  /// solution application target within the context.
+  /// \param rewriter The rewriter to apply the solution with.
   ///
   /// \returns true if solution cannot be applied.
-  bool applySolutionToBody(Solution &solution, TapExpr *tapExpr,
-                           DeclContext *&currentDC,
-                           std::function<std::optional<SyntacticElementTarget>(
-                               SyntacticElementTarget)>
-                               rewriteTarget);
+  bool applySolutionToBody(TapExpr *tapExpr,
+                           SyntacticElementTargetRewriter &rewriter);
 
   /// Reorder the disjunctive clauses for a given expression to
   /// increase the likelihood that a favored constraint will be successfully

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2087,9 +2087,6 @@ enum class SolutionApplicationToFunctionResult {
   /// Application of the solution failed.
   /// TODO: This should probably go away entirely.
   Failure,
-  /// The solution could not be applied immediately, and type checking for
-  /// this function should be delayed until later.
-  Delay,
 };
 
 /// Retrieve the closure type from the constraint system.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2065,6 +2065,8 @@ public:
   virtual Solution &getSolution() const = 0;
   virtual DeclContext *&getCurrentDC() const = 0;
 
+  virtual void addLocalDeclToTypeCheck(Decl *D) = 0;
+
   virtual std::optional<SyntacticElementTarget>
   rewriteTarget(SyntacticElementTarget target) = 0;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2080,15 +2080,6 @@ enum class ConstraintSystemPhase {
   Finalization
 };
 
-/// Describes the result of applying a solution to a given function.
-enum class SolutionApplicationToFunctionResult {
-  /// Application of the solution succeeded.
-  Success,
-  /// Application of the solution failed.
-  /// TODO: This should probably go away entirely.
-  Failure,
-};
-
 /// Retrieve the closure type from the constraint system.
 struct GetClosureType {
   ConstraintSystem &cs;
@@ -5543,8 +5534,8 @@ public:
   /// \param fn The function to which the solution is being applied.
   /// \param rewriter The rewriter to apply the solution with.
   ///
-  SolutionApplicationToFunctionResult
-  applySolution(AnyFunctionRef fn, SyntacticElementTargetRewriter &rewriter);
+  bool applySolution(AnyFunctionRef fn,
+                     SyntacticElementTargetRewriter &rewriter);
 
   /// Apply the given solution to the given closure body.
   ///

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8907,13 +8907,7 @@ namespace {
     ///
     /// \returns true if an error occurred.
     bool rewriteFunction(AnyFunctionRef fn) {
-      switch (Rewriter.cs.applySolution(fn, *this)) {
-      case SolutionApplicationToFunctionResult::Success:
-        return false;
-
-      case SolutionApplicationToFunctionResult::Failure:
-        return true;
-      }
+      return Rewriter.cs.applySolution(fn, *this);
     }
 
     bool rewriteSingleValueStmtExpr(SingleValueStmtExpr *SVE) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8908,14 +8908,8 @@ namespace {
     /// \returns true if an error occurred.
     bool rewriteFunction(AnyFunctionRef fn) {
       switch (Rewriter.cs.applySolution(fn, *this)) {
-      case SolutionApplicationToFunctionResult::Success: {
-        if (auto closure =
-                dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
-          TypeChecker::checkClosureAttributes(closure);
-          TypeChecker::checkParameterList(closure->getParameters(), closure);
-        }
+      case SolutionApplicationToFunctionResult::Success:
         return false;
-      }
 
       case SolutionApplicationToFunctionResult::Failure:
         return true;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8858,11 +8858,6 @@ namespace {
         hadError |= cs.applySolutionToBody(
             solution, closure, Rewriter.dc, [&](SyntacticElementTarget target) {
               auto resultTarget = rewriteTarget(target);
-              if (resultTarget) {
-                if (auto expr = resultTarget->getAsExpr())
-                  solution.setExprTypes(expr);
-              }
-
               return resultTarget;
             });
 
@@ -8946,11 +8941,6 @@ namespace {
           Rewriter.solution, fn, Rewriter.dc,
           [&](SyntacticElementTarget target) {
             auto resultTarget = rewriteTarget(target);
-            if (resultTarget) {
-              if (auto expr = resultTarget->getAsExpr())
-                Rewriter.solution.setExprTypes(expr);
-            }
-
             return resultTarget;
           });
 
@@ -8983,12 +8973,6 @@ namespace {
       return Rewriter.cs.applySolutionToSingleValueStmt(
           solution, SVE, solution.getDC(), [&](SyntacticElementTarget target) {
             auto resultTarget = rewriteTarget(target);
-            if (!resultTarget)
-              return resultTarget;
-
-            if (auto expr = resultTarget->getAsExpr())
-              solution.setExprTypes(expr);
-
             return resultTarget;
          });
     }
@@ -9004,11 +8988,6 @@ namespace {
       (void)Rewriter.cs.applySolutionToBody(
           solution, tap, Rewriter.dc, [&](SyntacticElementTarget target) {
             auto resultTarget = rewriteTarget(target);
-            if (resultTarget) {
-              if (auto expr = resultTarget->getAsExpr())
-                solution.setExprTypes(expr);
-            }
-
             return resultTarget;
           });
     }
@@ -9779,11 +9758,6 @@ ExprWalker::rewriteTarget(SyntacticElementTarget target) {
     auto forEachResultTarget = applySolutionToForEachStmt(
         solution, target, [&](SyntacticElementTarget target) {
           auto resultTarget = rewriteTarget(target);
-          if (resultTarget) {
-            if (auto expr = resultTarget->getAsExpr())
-              solution.setExprTypes(expr);
-          }
-
           return resultTarget;
         });
     if (!forEachResultTarget)

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2573,6 +2573,9 @@ ConstraintSystem::applySolution(AnyFunctionRef fn,
     }
 
     applySolutionToClosurePropertyWrappers(closure, solution);
+
+    TypeChecker::checkClosureAttributes(closure);
+    TypeChecker::checkParameterList(closure->getParameters(), closure);
   }
 
   // Enter the context of the function before performing any additional

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2592,21 +2592,9 @@ ConstraintSystem::applySolution(AnyFunctionRef fn,
   }
   assert(closure && "Can only get here with a closure at the moment");
 
-  // If this closure is checked as part of the enclosing expression, handle
-  // that now.
-  //
-  // Multi-statement closures are handled separately because they need to
-  // wait until all of the `ExtInfo` flags are propagated from the context
-  // e.g. parameter could be no-escape if closure is applied to a call.
-  if (closure->hasSingleExpressionBody()) {
-    bool hadError = applySolutionToBody(closure, rewriter);
-    return hadError ? SolutionApplicationToFunctionResult::Failure
-                    : SolutionApplicationToFunctionResult::Success;
-  }
-
-  // Otherwise, we need to delay type checking of the closure until later.
-  solution.setExprTypes(closure);
-  return SolutionApplicationToFunctionResult::Delay;
+  bool hadError = applySolutionToBody(closure, rewriter);
+  return hadError ? SolutionApplicationToFunctionResult::Failure
+                  : SolutionApplicationToFunctionResult::Success;
 }
 
 bool ConstraintSystem::applySolutionToBody(

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2541,9 +2541,8 @@ static void applySolutionToClosurePropertyWrappers(ClosureExpr *closure,
   }
 }
 
-SolutionApplicationToFunctionResult
-ConstraintSystem::applySolution(AnyFunctionRef fn,
-                                SyntacticElementTargetRewriter &rewriter) {
+bool ConstraintSystem::applySolution(AnyFunctionRef fn,
+                                     SyntacticElementTargetRewriter &rewriter) {
   auto &solution = rewriter.getSolution();
   auto &cs = solution.getConstraintSystem();
   auto *closure = getAsExpr<ClosureExpr>(fn.getAbstractClosureExpr());
@@ -2590,14 +2589,10 @@ ConstraintSystem::applySolution(AnyFunctionRef fn,
     fn.setParsedBody(transform->transformedBody);
 
     ResultBuilderRewriter builderRewriter(fn, *transform, rewriter);
-    return builderRewriter.apply() ? SolutionApplicationToFunctionResult::Failure
-                                   : SolutionApplicationToFunctionResult::Success;
+    return builderRewriter.apply();
   }
   assert(closure && "Can only get here with a closure at the moment");
-
-  bool hadError = applySolutionToBody(closure, rewriter);
-  return hadError ? SolutionApplicationToFunctionResult::Failure
-                  : SolutionApplicationToFunctionResult::Success;
+  return applySolutionToBody(closure, rewriter);
 }
 
 bool ConstraintSystem::applySolutionToBody(

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2267,11 +2267,6 @@ public:
     assert(funcRef);
 
     funcRef->setTypecheckedBody(castToStmt<BraceStmt>(body));
-
-    if (auto *closure =
-            getAsExpr<ClosureExpr>(funcRef->getAbstractClosureExpr()))
-      solution.setExprTypes(closure);
-
     return false;
   }
 

--- a/test/SILGen/lazy_locals.swift
+++ b/test/SILGen/lazy_locals.swift
@@ -43,3 +43,11 @@ func lazyLocalWithNestedClosure() {
     return 3
   }()
 }
+
+func lazyLocalInClosure() {
+  // Make sure we can type-check.
+  _ = {
+    lazy var x = 0
+    return x
+  }
+}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -1792,3 +1792,15 @@ class rdar129475277 {
     }
   }
 }
+
+class TestLazyLocal {
+  func bar() -> Int { 0 }
+  func foo() {
+    _ = { // expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+      lazy var x = bar()
+      // expected-error@-1 {{call to method 'bar' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      // expected-note@-2 {{reference 'self.' explicitly}}
+      return x
+    }
+  }
+}


### PR DESCRIPTION
Generalize the delayed type-checking of local decls, factor out an abstract base class for target rewriting, and rip out the delaying logic for multi-statement closures.