### PR TITLE
IRGen: Workaround for type substitution limitation

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -157,8 +157,6 @@ public:
   }
 
 private:
-  void initGenerics();
-
   template <typename ...Args>
   void considerNewTypeSource(IsExact_t isExact, MetadataSource::Kind kind,
                              CanType type, Args... args);
@@ -213,9 +211,8 @@ private:
 PolymorphicConvention::PolymorphicConvention(IRGenModule &IGM,
                                              CanSILFunctionType fnType,
                                              bool considerParameterSources = true)
-  : IGM(IGM), M(*IGM.getSwiftModule()), FnType(fnType){
-  initGenerics();
-
+  : IGM(IGM), M(*IGM.getSwiftModule()), FnType(fnType),
+    Generics(fnType->getInvocationGenericSignature()) {
   auto rep = fnType->getRepresentation();
 
   if (fnType->isPseudogeneric()) {
@@ -263,11 +260,8 @@ PolymorphicConvention::PolymorphicConvention(IRGenModule &IGM,
 
 void PolymorphicConvention::addPseudogenericFulfillments() {
   enumerateRequirements([&](GenericRequirement reqt) {
-    auto archetype = Generics.getGenericEnvironment()
-                        ->mapTypeIntoContext(reqt.getTypeParameter())
-                        ->getAs<ArchetypeType>();
-    assert(archetype && "did not get an archetype by mapping param?");
-    auto erasedTypeParam = archetype->getExistentialType()->getCanonicalType();
+    auto erasedTypeParam = Generics->getExistentialType(reqt.getTypeParameter())
+                              ->getCanonicalType();
     Sources.emplace_back(MetadataSource::Kind::ErasedTypeMetadata,
                          reqt.getTypeParameter(), erasedTypeParam);
 
@@ -331,10 +325,6 @@ enumerateUnfulfilledRequirements(const RequirementCallback &callback) {
     if (!Fulfillments.getFulfillment(requirement))
       callback(requirement);
   });
-}
-
-void PolymorphicConvention::initGenerics() {
-  Generics = FnType->getInvocationGenericSignature();
 }
 
 template <typename ...Args>

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -111,10 +111,24 @@ protected:
   FulfillmentMap Fulfillments;
 
   GenericSignature::RequiredProtocols getRequiredProtocols(Type t) {
+    // FIXME: We need to rework this to use archetypes instead of interface
+    // types, or fix the bad interaction between interface type substitution
+    // and concretized conformance requirements. Then we can remove the hack
+    // from getReducedType() to handle this case, and also stop calling
+    // getReducedType() here.
+    t = Generics.getReducedType(t);
+    if (!t->isTypeParameter())
+      return {};
+
     return Generics->getRequiredProtocols(t);
   }
 
   CanType getSuperclassBound(Type t) {
+    // See above.
+    t = Generics.getReducedType(t);
+    if (!t->isTypeParameter())
+      return CanType();
+
     if (auto superclassTy = Generics->getSuperclassBound(t))
       return superclassTy->getCanonicalType();
     return CanType();

--- a/test/IRGen/conditional_conformance_concretized_conformance_requirement.swift
+++ b/test/IRGen/conditional_conformance_concretized_conformance_requirement.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+// https://github.com/swiftlang/swift/issues/76479
+
+public struct G<T> where T: P1, T.A: P1, T.A.A: P1 {}
+
+public protocol P1 {
+  associatedtype A
+}
+
+extension Int: P1 {
+  public typealias A = Int
+}
+
+public protocol P2 {
+  func f()
+}
+
+extension G: P2 where T.A == Int {
+  public func f() {}
+}


### PR DESCRIPTION
If a constrained extension has fewer conformance requirements than the nominal type declaration, because some of the type parameters of the nominal type are fixed to concrete types by the extension, we would run into trouble because interface type substitution does not correctly handle this case.

Applying an identity substitution map to an interface type does not look up concrete types in the output generic signature, so we get back a type parameter that is not valid.

getReducedType() has a hack to deal with this. I'd like to get rid of the hack and fix interface type substitution to do this correctly, but until then, this will do.

Fixes https://github.com/swiftlang/swift/issues/76479