### PR TITLE
[CSBindings] Prevent `BindingSet::isViable` from dropping viable bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1205,6 +1205,16 @@ bool BindingSet::isViable(PotentialBinding &binding, bool isTransitive) {
     if (!existingNTD || NTD != existingNTD)
       continue;
 
+    // What is going on here needs to be thoroughly re-evaluated,
+    // but at least for now, let's not filter bindings of different
+    // kinds so if we have a situation like: `Array<$T0> conv $T1`
+    // and `$T1 conv Array<(String, Int)>` we can't lose `Array<$T0>`
+    // as a binding because `$T0` could be inferred to
+    // `(key: String, value: Int)` and binding `$T1` to `Array<(String, Int)>`
+    // eagerly would be incorrect.
+    if (existing->Kind != binding.Kind)
+      continue;
+
     // If new type has a type variable it shouldn't
     // be considered  viable.
     if (type->hasTypeVariable())

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -415,3 +415,13 @@ do {
     ]
   }
 }
+
+
+do {
+  func f<R>(fn: () -> [R]) -> [R] { [] }
+
+  // Requires collection upcast from Array<(key: String, value: String)> to `Array<(String, String)>`
+  func g(v: [String: String]) {
+    let _: [(String, String)] = f { return Array(v) } + v // Ok
+  }
+}

--- a/validation-test/Sema/SwiftUI/rdar98862079.swift
+++ b/validation-test/Sema/SwiftUI/rdar98862079.swift
@@ -22,7 +22,7 @@ struct MyView : View {
 
   var body: some View {
     test(value: true ? $newBounds.maxBinding : $newBounds.minBinding, in: bounds)
-    // expected-error@-1 2 {{result values in '? :' expression have mismatching types 'Binding<Binding<Double>?>' and 'Binding<Double>'}}
-    // expected-note@-2 2 {{arguments to generic parameter 'Value' ('Binding<Double>?' and 'Double') are expected to be equal}}
+    // expected-error@-1 {{cannot convert value of type 'Binding<Binding<Double>?>' to expected argument type 'Binding<Double>'}}
+    // expected-note@-2 {{arguments to generic parameter 'Value' ('Binding<Double>?' and 'Double') are expected to be equal}}
   }
 }


### PR DESCRIPTION
I think the original idea was to elide `Array<$T>` if there is a 
binding a resolved generic arguments i.e. `Array<Float>`, but
the check doesn't account for the fact that bindings could be
of different kinds and there are some implicit conversions that
could be missed if we remove the bindings.

For example, given the following constraints:

`Array<$T0> conv $T1`
`$T1 conv Array<(String, Int)>`

`$T0` can be a supertype of `Array<$T0>` and subtype of `Array<(String, Int)>`.

The solver should accept both types as viable bindings because the `$T0`
could be bound to `(key: String, value: Int)` and that would match `Array<(String, Int)>` conversion.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
