### PR TITLE
[Windows] Teach Build-Testing how to find Foundation

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1914,6 +1914,8 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
 }
 
 function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
+  $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
+  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
   $SwiftTestingBinaryCache = Get-TargetProjectBinaryCache $Arch Testing
 
   Isolate-EnvVars {
@@ -1934,6 +1936,8 @@ function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
       -Defines (@{
         BUILD_SHARED_LIBS = "YES";
         CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
+        dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
+        Foundation_DIR = "$FoundationBinaryCache\cmake\modules";
         SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
         SwiftTesting_MACRO = "$(Get-BuildProjectBinaryCache TestingMacros)\TestingMacros.dll";
       })


### PR DESCRIPTION
Pass `Foundation_DIR` to the CMake configuration.
