### PR TITLE
[sending] Look through the sending type repr when printing the type of a function result using the type repr fallback path.

### DIFF
--- a/test/Concurrency/Inputs/sending_interfacefile_printing_repr_filecheck
+++ b/test/Concurrency/Inputs/sending_interfacefile_printing_repr_filecheck
@@ -1,0 +1,18 @@
+
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: public func test() -> sending NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func test() -> NonSendableKlass
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: public func test2(_ x: sending NonSendableKlass)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func test2(_ x: __owned NonSendableKlass)
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: @_Concurrency.MainActor public var closure: () -> sending NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: @_Concurrency.MainActor public var closure: () -> NonSendableKlass
+// CHECK-NEXT: #endif

--- a/test/Concurrency/sending_interfacefile_printing.swift
+++ b/test/Concurrency/sending_interfacefile_printing.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -parse-as-library -emit-module-interface-path - -module-name MyFile -swift-version 6 | %FileCheck %s
+// RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -parse-as-library -emit-module-interface-path - -module-name MyFile -swift-version 6 -module-interface-preserve-types-as-written | %FileCheck %S/Inputs/sending_interfacefile_printing_repr_filecheck
+
+// The force printing type reprs option is only available in asserts builds.
+// REQUIRES: asserts
+
+// This test validates that when we produce interface files we produce the
+// correct interface file for sending when printing normally or with type reprs
+// enabled.
+
+public class NonSendableKlass {}
+
+// The two possible outputs are MyFile.NonSendableKlass and NonSendableKlass.
+//
+// So we just check for an optional M
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: public func test() -> sending MyFile.NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func test() -> MyFile.NonSendableKlass
+// CHECK-NEXT: #endif
+public func test() -> sending NonSendableKlass { NonSendableKlass() }
+
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: public func test2(_ x: sending MyFile.NonSendableKlass)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func test2(_ x: __owned MyFile.NonSendableKlass)
+// CHECK-NEXT: #endif
+public func test2(_ x: sending NonSendableKlass) {}
+
+// CHECK: #if compiler(>=5.3) && $SendingArgsAndResults
+// CHECK-NEXT: @_Concurrency.MainActor public var closure: () -> sending MyFile.NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: @_Concurrency.MainActor public var closure: () -> MyFile.NonSendableKlass
+// CHECK-NEXT: #endif
+@MainActor public var closure: () -> sending NonSendableKlass = { NonSendableKlass() }


### PR DESCRIPTION
[sending] Look through the sending typerepr when printing the type of a function result using the type repr fallback path.

When we print types in the AST printer if for some reason we cannot find the
appropriate type to print, we fall back and use a type repr instead. This
behavior is a fallback case that is hit rarely (or we would have seen this
behavior earlier).

This behavior causes a problem due to the implementation of sending results
using a sending type repr to communicate that the relevant Function has a
sending result, but we actually do not use the sending type repr from that point
on. So as a result, in this fallback case, we put in one too many sending on the
result.

Previously, it was pretty hard to test this codepath, so I added a small option
that is available only in asserts builds that turns on the type repr behavior
all the time.

rdar://135594964