### PR TITLE
Make sure we install the compiler's SwiftIfConfig library

### DIFF
--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -31,6 +31,7 @@ set_property(DIRECTORY "${binary_dir}" PROPERTY EXCLUDE_FROM_ALL TRUE)
 # Install swift-syntax libraries.
 set(SWIFT_SYNTAX_MODULES
   SwiftBasicFormat
+  SwiftIfConfig
   SwiftParser
   SwiftParserDiagnostics
   SwiftDiagnostics


### PR DESCRIPTION
This will allow macros in the toolchain to use the library