### PR TITLE
Delete build script flag which enabled NonEscapableTypes in the standard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,10 +703,6 @@ option(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED
   "Enable experimental distributed actors and functions"
   FALSE)
 
-option(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES
-  "Enable experimental NonescapableTypes"
-  FALSE)
-
 option(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING
   "Enable experimental string processing"
   FALSE)
@@ -1385,7 +1381,6 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
   message(STATUS "Differentiable Programming Support: ${SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING}")
   message(STATUS "Concurrency Support:                ${SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY}")
   message(STATUS "Distributed Support:                ${SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED}")
-  message(STATUS "NonEscapableTypes Support:          ${SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES}")
   message(STATUS "String Processing Support:          ${SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING}")
   message(STATUS "Backtracing Support:                ${SWIFT_ENABLE_BACKTRACING}")
   message(STATUS "Unicode Support:                    ${SWIFT_STDLIB_ENABLE_UNICODE_DATA}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,7 +200,6 @@ normalize_boolean_spelling(SWIFT_ENABLE_SOURCEKIT_TESTS)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
-normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
 normalize_boolean_spelling(SWIFT_ENABLE_MACCATALYST)
@@ -405,10 +404,6 @@ foreach(SDK ${SWIFT_SDKS})
 
         if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
           list(APPEND LIT_ARGS "--param" "distributed")
-        endif()
-
-        if(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
-          list(APPEND LIT_ARGS "--param" "nonescapable_types")
         endif()
 
         if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)

--- a/test/ModuleInterface/nonescapable_types.swift
+++ b/test/ModuleInterface/nonescapable_types.swift
@@ -1,88 +1,88 @@
 // RUN: %empty-directory(%t)
- // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature NonescapableTypes
- // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
- // RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature NonescapableTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
+// RUN: %FileCheck %s < %t.swiftinterface
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: public protocol P : ~Escapable {
- // CHECK:   associatedtype A
- // CHECK: }
- // CHECK: #else
- // CHECK: public protocol P {
- // CHECK:   associatedtype A
- // CHECK: }
- // CHECK: #endif
- public protocol P: ~Escapable {
-   associatedtype A
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: public protocol P : ~Escapable {
+// CHECK:   associatedtype A
+// CHECK: }
+// CHECK: #else
+// CHECK: public protocol P {
+// CHECK:   associatedtype A
+// CHECK: }
+// CHECK: #endif
+public protocol P: ~Escapable {
+  associatedtype A
+}
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: public struct X<T> : ~Swift.Escapable where T : ~Escapable {
- // CHECK: }
- // CHECK: #else
- // CHECK: public struct X<T> {
- // CHECK: }
- // CHECK: #endif
- public struct X<T: ~Escapable>: ~Escapable { }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: public struct X<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK: }
+// CHECK: #else
+// CHECK: public struct X<T> {
+// CHECK: }
+// CHECK: #endif
+public struct X<T: ~Escapable>: ~Escapable { }
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK:      extension Test.X {
- // CHECK-NEXT:   func f()
- // CHECK:      }
- // CHECK: #else
- // CHECK:      extension Test.X {
- // CHECK-NEXT:   func f()
- // CHECK:      }
- extension X where T: Escapable {
-   public func f() { }
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK:      extension Test.X {
+// CHECK-NEXT:   func f()
+// CHECK:      }
+// CHECK: #else
+// CHECK:      extension Test.X {
+// CHECK-NEXT:   func f()
+// CHECK:      }
+extension X where T: Escapable {
+  public func f() { }
+}
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: extension Test.X where T : ~Escapable {
- // CHECK:   public func g(other: borrowing T)
- // CHECK: }
- // CHECK: #else
- // CHECK: extension Test.X {
- // CHECK:   public func g(other: borrowing T)
- // CHECK: }
- // CHECK: #endif
- extension X where T: ~Escapable {
-   public func g(other: borrowing T) { }
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: extension Test.X where T : ~Escapable {
+// CHECK:   public func g(other: borrowing T)
+// CHECK: }
+// CHECK: #else
+// CHECK: extension Test.X {
+// CHECK:   public func g(other: borrowing T)
+// CHECK: }
+// CHECK: #endif
+extension X where T: ~Escapable {
+  public func g(other: borrowing T) { }
+}
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: public enum Y<T> : ~Swift.Escapable where T : ~Escapable {
- // CHECK:   case none
- // CHECK:   case some(T)
- // CHECK: }
- // CHECK: #else
- // CHECK: public enum Y<T> {
- // CHECK:   case none
- // CHECK:   case some(T)
- // CHECK: }
- public enum Y<T: ~Escapable>: ~Escapable {
-   case none
-   case some(T)
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: public enum Y<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK:   case none
+// CHECK:   case some(T)
+// CHECK: }
+// CHECK: #else
+// CHECK: public enum Y<T> {
+// CHECK:   case none
+// CHECK:   case some(T)
+// CHECK: }
+public enum Y<T: ~Escapable>: ~Escapable {
+  case none
+  case some(T)
+}
 
- extension Y: Escapable where T: Escapable { }
+extension Y: Escapable where T: Escapable { }
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: @lifetime(y)
- // CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T> where T : ~Escapable
- // CHECK: #else
- // CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T>
- // CHECK: #endif
- @lifetime(y)
- public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
-   y
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: @lifetime(y)
+// CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T> where T : ~Escapable
+// CHECK: #else
+// CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T>
+// CHECK: #endif
+@lifetime(y)
+public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
+  y
+}
 
- // CHECK: #if compiler(>=5.3) && $NonescapableTypes
- // CHECK: public func derive<T>(_ x: Test.X<T>) -> dependsOn(x) Test.X<T> where T : ~Escapable
- // CHECK: #else
- // CHECK: public func derive<T>(_ x: Test.X<T>) -> Test.X<T>
- // CHECK: #endif
- public func derive<T : ~Escapable>(_ x: X<T>) -> dependsOn(x) X<T> {
-   x
- }
+// CHECK: #if compiler(>=5.3) && $NonescapableTypes
+// CHECK: public func derive<T>(_ x: Test.X<T>) -> dependsOn(x) Test.X<T> where T : ~Escapable
+// CHECK: #else
+// CHECK: public func derive<T>(_ x: Test.X<T>) -> Test.X<T>
+// CHECK: #endif
+public func derive<T : ~Escapable>(_ x: X<T>) -> dependsOn(x) X<T> {
+  x
+}

--- a/test/SIL/lifetime_dependence_buffer_view_test.swift
+++ b/test/SIL/lifetime_dependence_buffer_view_test.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
@@ -57,8 +57,7 @@ public struct BufferView<Element> : ~Escapable {
   let start: BufferViewIndex<Element>
   public let count: Int
   private var baseAddress: UnsafeRawPointer { start._rawValue }
-// TODO: Enable diagnostics once this initializer's store to temporary is handled  
-// CHECK: sil @$s31lifetime_dependence_scope_fixup10BufferViewV11baseAddress5count9dependsOnACyxGSVYls_Siqd__htclufC : $@convention(method) <Element><Owner> (UnsafeRawPointer, Int, @in_guaranteed Owner, @thin BufferView<Element>.Type) -> _scope(1) @owned BufferView<Element> {
+// CHECK: sil @$s36lifetime_dependence_buffer_view_test10BufferViewV11baseAddress5count9dependsOnACyxGSV_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (UnsafeRawPointer, Int, @in_guaranteed Owner, @thin BufferView<Element>.Type) -> _inherit(2) @owned BufferView<Element> {
   public init<Owner: ~Copyable & ~Escapable>(
       baseAddress: UnsafeRawPointer,
       count: Int,
@@ -68,7 +67,7 @@ public struct BufferView<Element> : ~Escapable {
         start: .init(rawValue: baseAddress), count: count, dependsOn: owner
       )
   }
-// CHECK: sil hidden @$s31lifetime_dependence_scope_fixup10BufferViewV5start5count9dependsOnACyxGAA0eF5IndexVyxGYls_Siqd__htclufC : $@convention(method) <Element><Owner> (BufferViewIndex<Element>, Int, @in_guaranteed Owner, @thin BufferView<Element>.Type) -> _scope(1) @owned BufferView<Element> {
+// CHECK: sil hidden @$s36lifetime_dependence_buffer_view_test10BufferViewV5start5count9dependsOnACyxGAA0fG5IndexVyxG_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (BufferViewIndex<Element>, Int, @in_guaranteed Owner, @thin BufferView<Element>.Type) -> _inherit(2) @owned BufferView<Element> {
   init<Owner: ~Copyable & ~Escapable>(
     start index: BufferViewIndex<Element>,
     count: Int,
@@ -122,7 +121,7 @@ extension BufferView {
     }
   }
  
-// CHECK: sil @$s31lifetime_dependence_scope_fixup10BufferViewVyACyxGAA9FakeRangeVyAA0eF5IndexVyxGGcig : $@convention(method) <Element> (FakeRange<BufferViewIndex<Element>>, @guaranteed BufferView<Element>) -> _scope(0) @owned BufferView<Element> {
+ // CHECK: sil @$s36lifetime_dependence_buffer_view_test10BufferViewVyACyxGAA9FakeRangeVyAA0fG5IndexVyxGGcig : $@convention(method) <Element> (FakeRange<BufferViewIndex<Element>>, @guaranteed BufferView<Element>) -> _inherit(1) @owned BufferView<Element> {
   public subscript(bounds: FakeRange<BufferViewIndex<Element>>) -> Self {
     get {
       BufferView(

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -2,6 +2,8 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes | %FileCheck %s
 
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
 
 protocol P {
   associatedtype E: ~Escapable

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
-// REQUIRES: nonescapable_types
 
 struct AnotherBufferView : ~Escapable, BitwiseCopyable {
   let ptr: UnsafeRawBufferPointer

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -145,8 +145,6 @@ if "@SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY@" == "TRUE":
     config.available_features.add('concurrency')
 if "@SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED@" == "TRUE":
     config.available_features.add('distributed')
-if "@SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES@" == "TRUE":
-    config.available_features.add('nonescapable_types')
 if "@SWIFT_STDLIB_STATIC_PRINT@" == "TRUE":
     config.available_features.add('stdlib_static_print')
 if "@SWIFT_STDLIB_ENABLE_UNICODE_DATA" == "TRUE":

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -60,9 +60,6 @@ class Swift(product.Product):
         # Add experimental distributed flag.
         self.cmake_options.extend(self._enable_experimental_distributed)
 
-        # Add experimental NonescapableTypes flag.
-        self.cmake_options.extend(self._enable_experimental_nonescapable_types)
-
         # Add backtracing flag.
         self.cmake_options.extend(self._enable_backtracing)
 
@@ -207,11 +204,6 @@ updated without updating swift.py?")
     def _enable_experimental_distributed(self):
         return [('SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED:BOOL',
                  self.args.enable_experimental_distributed)]
-
-    @property
-    def _enable_experimental_nonescapable_types(self):
-        return [('SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES:BOOL',
-                 self.args.enable_experimental_nonescapable_types)]
 
     @property
     def _enable_backtracing(self):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -108,7 +108,6 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP:BOOL=FALSE',
             '-DSWIFT_ENABLE_CXX_INTEROP_SWIFT_BRIDGING_HEADER:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED:BOOL=FALSE',
-            '-DSWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_OBSERVATION:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION:BOOL=FALSE',
             '-DSWIFT_ENABLE_BACKTRACING:BOOL=FALSE',
@@ -143,7 +142,6 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP:BOOL=FALSE',
             '-DSWIFT_ENABLE_CXX_INTEROP_SWIFT_BRIDGING_HEADER:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED:BOOL=FALSE',
-            '-DSWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_OBSERVATION:BOOL=FALSE',
             '-DSWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION:BOOL=FALSE',
             '-DSWIFT_ENABLE_BACKTRACING:BOOL=FALSE',
@@ -420,19 +418,6 @@ class SwiftTestCase(unittest.TestCase):
              'TRUE'],
             [x for x in swift.cmake_options
              if 'DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED' in x])
-
-    def test_experimental_nonescapable_types_flags(self):
-        self.args.enable_experimental_nonescapable_types = True
-        swift = Swift(
-            args=self.args,
-            toolchain=self.toolchain,
-            source_dir='/path/to/src',
-            build_dir='/path/to/build')
-        self.assertEqual(
-            ['-DSWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES:BOOL='
-             'TRUE'],
-            [x for x in swift.cmake_options
-             if 'DSWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES' in x])
 
     def test_experimental_observation_flags(self):
         self.args.enable_experimental_observation = True

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -130,8 +130,6 @@ if "@SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY@" == "TRUE":
     config.available_features.add('concurrency')
 if "@SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED@" == "TRUE":
     config.available_features.add('distributed')
-if "@SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES@" == "TRUE":
-    config.available_features.add('nonescapable_types')
 if "@SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING@" == "TRUE":
     config.available_features.add('string_processing')
 if "@SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE@" == "TRUE":


### PR DESCRIPTION
NonEscapableTypes are enabled on the standard library, so we don't need  `SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES` build flag anymore