### PR TITLE
[CMake] Give a dedicated component to compiler swift-syntax libraries

### DIFF
--- a/cmake/caches/Linux-x86_64.cmake
+++ b/cmake/caches/Linux-x86_64.cmake
@@ -142,12 +142,14 @@ set(LLDB_TOOLS
 set(SWIFT_INSTALL_COMPONENTS
       autolink-driver
       compiler
+      compiler-swift-syntax-lib
       clang-builtin-headers
       editor-integration
       tools
       sourcekit-inproc
       swift-remote-mirror
       swift-remote-mirror-headers
+      swift-syntax-lib
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS

--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -149,6 +149,7 @@ set(LLDB_TOOLS
 set(SWIFT_INSTALL_COMPONENTS
       autolink-driver
       compiler
+      compiler-swift-syntax-lib
       clang-builtin-headers
       editor-integration
       tools

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -189,6 +189,7 @@ set(LLDB_TOOLS
 set(SWIFT_INSTALL_COMPONENTS
       autolink-driver
       compiler
+      compiler-swift-syntax-lib
       clang-builtin-headers
       editor-integration
       tools

--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -48,6 +48,7 @@
 # * autolink-driver -- the Swift driver support tools
 # * back-deployment -- Swift back-deployment libraries
 # * compiler -- the Swift compiler and (on supported platforms) the REPL.
+# * compiler-swift-syntax-lib -- install swift-syntax libraries for the compiler.
 # * clang-builtin-headers -- install a copy of Clang builtin headers under
 #   'lib/swift/clang'.  This is useful when Swift compiler is installed in
 #   isolation.
@@ -70,7 +71,7 @@
 # * llvm-toolchain-dev-tools -- install LLVM development tools useful in a shared toolchain
 # * dev -- headers and libraries required to use Swift compiler as a library.
 set(_SWIFT_DEFINED_COMPONENTS
-  "autolink-driver;back-deployment;compiler;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;libexec;stdlib;stdlib-experimental;sdk-overlay;static-mirror-lib;swift-syntax-lib;editor-integration;tools;testsuite-tools;toolchain-tools;toolchain-dev-tools;llvm-toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
+  "autolink-driver;back-deployment;compiler;compiler-swift-syntax-lib;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;libexec;stdlib;stdlib-experimental;sdk-overlay;static-mirror-lib;swift-syntax-lib;editor-integration;tools;testsuite-tools;toolchain-tools;toolchain-dev-tools;llvm-toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
 
 # The default install components include all of the defined components, except
 # for the following exceptions.
@@ -97,10 +98,10 @@ macro(swift_configure_components)
   set(SWIFT_INSTALL_COMPONENTS "${_SWIFT_DEFAULT_COMPONENTS}" CACHE STRING
     "A semicolon-separated list of components to install from the set ${_SWIFT_DEFINED_COMPONENTS}")
 
-  # 'compiler' depends on 'swift-syntax-lib' component.
+  # 'compiler' depends on 'compiler-swift-syntax-lib' component.
   if ("compiler" IN_LIST SWIFT_INSTALL_COMPONENTS AND
-      NOT "swift-syntax-lib" IN_LIST SWIFT_INSTALL_COMPONENTS)
-    list(APPEND SWIFT_INSTALL_COMPONENTS "swift-syntax-lib")
+      NOT "compiler-swift-syntax-lib" IN_LIST SWIFT_INSTALL_COMPONENTS)
+    list(APPEND SWIFT_INSTALL_COMPONENTS "compiler-swift-syntax-lib")
   endif()
 
   foreach(component ${_SWIFT_DEFINED_COMPONENTS})

--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -103,6 +103,12 @@ macro(swift_configure_components)
       NOT "compiler-swift-syntax-lib" IN_LIST SWIFT_INSTALL_COMPONENTS)
     list(APPEND SWIFT_INSTALL_COMPONENTS "compiler-swift-syntax-lib")
   endif()
+  # 'compiler' depends on 'swift-syntax-lib' component.
+  # FIXME: Remove this. Clients should specify the components explicitly.
+  if ("compiler" IN_LIST SWIFT_INSTALL_COMPONENTS AND
+      NOT "swift-syntax-lib" IN_LIST SWIFT_INSTALL_COMPONENTS)
+    list(APPEND SWIFT_INSTALL_COMPONENTS "swift-syntax-lib")
+  endif()
 
   foreach(component ${_SWIFT_DEFINED_COMPONENTS})
     add_custom_target(${component})

--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -52,6 +52,6 @@ foreach(lib ${compiler_swiftsyntax_libs})
 endforeach()
 
 swift_install_in_component(TARGETS ${compiler_swiftsyntax_libs}
-  ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler
-  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler
-  RUNTIME DESTINATION "bin" COMPONENT compiler)
+  ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
+  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
+  RUNTIME DESTINATION "bin" COMPONENT compiler-swift-syntax-lib)


### PR DESCRIPTION
'compiler-swift-syntax-lib' so projects statically link to compiler libraries (libswiftAST etc) can use the required shared libraries.
