### PR TITLE
Concurrency: Reject nonisolated lazy properties

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5810,6 +5810,9 @@ ERROR(nonisolated_actor_sync_init,none,
 ERROR(nonisolated_wrapped_property,none,
       "'nonisolated' is not supported on properties with property wrappers",
       ())
+ERROR(nonisolated_lazy,none,
+      "'nonisolated' is not supported on lazy properties",
+      ())
 
 ERROR(non_sendable_from_deinit,none,
         "cannot access %1 %2 with a non-sendable type %0 from nonisolated deinit",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7224,11 +7224,18 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
-    // Using 'nonisolated' with wrapped properties is unsupported, because
-    // backing storage is a stored 'var' that is part of the internal state
-    // of the actor which could only be accessed in actor's isolation context.
+    // Using 'nonisolated' with lazy properties and wrapped properties is
+    // unsupported, because backing storage is a stored 'var' that is part
+    // of the internal state of the actor which could only be accessed in
+    // actor's isolation context.
     if (var->hasAttachedPropertyWrapper()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property)
+        .warnUntilSwiftVersionIf(attr->isImplicit(), 6);
+      return;
+    }
+
+    if (var->getAttrs().hasAttribute<LazyAttr>()) {
+      diagnoseAndRemoveAttr(attr, diag::nonisolated_lazy)
         .warnUntilSwiftVersionIf(attr->isImplicit(), 6);
       return;
     }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -834,21 +834,29 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
+    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
+    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
+    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
     nonisolated lazy var l41: Int = { l }()
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l42: Int = l
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l43: Int = { self.l }()
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l44: Int = self.l
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
     nonisolated lazy var l45: Int = { [unowned self] in self.l }()
+    // expected-error@-1 {{'nonisolated' is not supported on lazy properties}}
 }
 
 // Infer global actors from context only for instance members.

--- a/test/Concurrency/mutable_storage_nonisolated.swift
+++ b/test/Concurrency/mutable_storage_nonisolated.swift
@@ -2,26 +2,67 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
 
 // REQUIRES: concurrency
-// REQUIRES: asserts
+
+@propertyWrapper struct P {
+  var wrappedValue = 0
+}
 
 class NonSendable {}
 
 struct ImplicitlySendable {
-  var x: Int
-  nonisolated var y: Int // okay
+  var a: Int
+
+  // always okay
+  nonisolated let b = 0
+  nonisolated var c: Int { 0 }
+
+  // okay
+  nonisolated var d = 0
+
+  // never okay
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
 }
 
 struct ImplicitlyNonSendable {
-  let x: NonSendable
-  // expected-note@+1 {{convert 'y' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
-  nonisolated var y: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  let a: NonSendable
+
+  // always okay
+  nonisolated let b = 0
+  nonisolated var c: Int { 0 }
+
+  // not okay
+  nonisolated var d = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  // expected-note@-1 {{convert 'd' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+
+  // never okay
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
 }
 
 public struct PublicSendable: Sendable {
-  nonisolated var x: Int // okay
+  // always okay
+  nonisolated let b = 0
+  nonisolated var c: Int { 0 }
+
+  // okay
+  nonisolated var d = 0
+
+  // never okay
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
 }
 
 public struct PublicNonSendable {
-  // expected-note@+1 {{convert 'x' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
-  nonisolated var x: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  // always okay
+  nonisolated let b = 0
+  nonisolated var c: Int { 0 }
+
+  // not okay
+  nonisolated var d = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  // expected-note@-1 {{convert 'd' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+
+  // never okay
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
 }


### PR DESCRIPTION
We already banned nonisolated property wrappers, and 'lazy' is conceptually similar, so it makes sense to disallow it also.

Fixes https://github.com/swiftlang/swift/issues/76513.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
