### PR TITLE
[NFC] Small cleanup in stdlib/public/runtime.

### DIFF
--- a/stdlib/public/runtime/Exception.cpp
+++ b/stdlib/public/runtime/Exception.cpp
@@ -31,7 +31,7 @@
 
 using namespace swift;
 
-extern "C" void __cxa_begin_catch(void *);
+extern "C" void *__cxa_begin_catch(void *);
 
 SWIFT_RUNTIME_STDLIB_API _Unwind_Reason_Code
 _swift_exceptionPersonality(int version,

--- a/stdlib/public/runtime/Leaks.mm
+++ b/stdlib/public/runtime/Leaks.mm
@@ -228,5 +228,5 @@ static void _swift_leaks_stopTrackingObjCObject(id Object) {
 }
 
 #else
-static char DummyDecl = '';
+static char DummyDecl = '\0';
 #endif


### PR DESCRIPTION
These changes fix minor issues that cause compilation errors with our C++ toolchain's stricter default settings:

* `Exception.cpp`: The return type of `__cxa_begin_catch` should be `void *`, not `void` (see https://libcxxabi.llvm.org/spec.html).
* `Leaks.mm`: `''` is not a valid C char literal; use `'\0'` instead.
