### PR TITLE
[cxx-interop] Build benchmarks with modern C++ interop flag

### DIFF
--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.9
 
 import PackageDescription
 import Foundation
@@ -127,11 +127,9 @@ targets.append(
     dependencies: swiftBenchDeps,
     path: "utils",
     sources: ["main.swift"],
-    swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
-                                  "-I",
-                                  "utils/CxxTests",
-                                  // FIXME(rdar://136138941): these flags should be redundant because of cxxLanguageStandard
-                                  "-Xcc", "-std=c++20"])]))
+    swiftSettings: [.interoperabilityMode(.Cxx),
+                    .unsafeFlags(["-I",
+                                  "utils/CxxTests"])]))
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 targets.append(
@@ -167,11 +165,9 @@ targets += cxxSingleSourceLibraries.map { name in
     dependencies: singleSourceDeps,
     path: "cxx-source",
     sources: ["\(name).swift"],
-    swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
-                                  "-I",
+    swiftSettings: [.interoperabilityMode(.Cxx),
+                    .unsafeFlags(["-I",
                                   "utils/CxxTests",
-                                  // FIXME(rdar://136138941): these flags should be redundant because of cxxLanguageStandard
-                                  "-Xcc", "-std=c++20",
                                   // FIXME: https://github.com/apple/swift/issues/61453
                                   "-Xfrontend", "-validate-tbd-against-ir=none"])])
 }


### PR DESCRIPTION
To build benchmarks that use C++ `std::span`, we need to use C++20 standard.

SwiftPM supports `.interoperabilityMode(.Cxx)` build setting starting from version 5.9. In more recent versions, SwiftPM is also able to correctly propagate the C++ standard version (e.g. `-Xcc -std=c++20`) to the Swift compiler invocation, when C++ interop is enabled. The C++ standard version is only propagated if the modern build setting is used. This has caused Linux CI failures in the past.

This change switches the package manifest to use the modern build setting to enable C++ interop.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
