### PR TITLE
[cxx-interop] import static operator call from C++23 as member callAs…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3735,6 +3735,18 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
+      // The static `operator ()` introduced in C++ 23 is still callable as an
+      // instance operator in C++, and we want to preserve the ability to call
+      // it as an instance method in Swift as well for source compatibility.
+      // Therefore, we synthesize a C++ instance member that invokes the
+      // operator and import it instead.
+      if (decl->getOverloadedOperator() ==
+              clang::OverloadedOperatorKind::OO_Call &&
+          decl->isStatic()) {
+        auto result = synthesizer.makeInstanceToStaticOperatorCallMethod(decl);
+        if (result)
+          return result;
+      }
       auto method = VisitFunctionDecl(decl);
 
       // Do not expose constructors of abstract C++ classes.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2149,6 +2149,11 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
     thisExpr = conv.get();
   }
 
+  auto memberExprTy =
+      (method->isStatic() && method->getOverloadedOperator() ==
+                                 clang::OverloadedOperatorKind::OO_Call)
+          ? method->getType()
+          : clangCtx.BoundMemberTy;
   auto memberExpr = clangSema.BuildMemberExpr(
       thisExpr, /*isArrow=*/true, clang::SourceLocation(),
       clang::NestedNameSpecifierLoc(), clang::SourceLocation(),
@@ -2156,7 +2161,7 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
       clang::DeclAccessPair::make(const_cast<clang::CXXMethodDecl *>(method),
                                   clang::AS_public),
       /*HadMultipleCandidates=*/false, method->getNameInfo(),
-      clangCtx.BoundMemberTy, clang::VK_PRValue, clang::OK_Ordinary);
+      memberExprTy, clang::VK_PRValue, clang::OK_Ordinary);
   llvm::SmallVector<clang::Expr *, 4> args;
   for (size_t i = 0; i < newMethod->getNumParams(); ++i) {
     auto *param = newMethod->getParamDecl(i);
@@ -2167,7 +2172,7 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
         clangCtx, param, false, type, clang::ExprValueKind::VK_LValue,
         clang::SourceLocation()));
   }
-  auto memberCall = clangSema.BuildCallToMemberFunction(
+  auto memberCall = clangSema.BuildCallExpr(
       nullptr, memberExpr, clang::SourceLocation(), args,
       clang::SourceLocation());
   if (!memberCall.isUsable())

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -319,6 +319,9 @@ public:
   /// method that dispatches the call dynamically.
   FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl);
 
+  FuncDecl *makeInstanceToStaticOperatorCallMethod(
+      const clang::CXXMethodDecl *clangMethodDecl);
+
   VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                               FuncDecl *setter);
 

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -72,4 +72,8 @@ struct HasVirtualMethod {
   virtual int return42() { return 42; } 
 };
 
+struct HasStaticOperatorCall {
+  static int operator()(int x) { return x * 2; }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -49,3 +49,9 @@ protocol HasOperatorPlusEqualProtocol {
 }
 
 extension HasOperatorPlusEqualInt : HasOperatorPlusEqualProtocol {}
+
+protocol HasOperatorCall {
+  func callAsFunction(_ x: Int32) -> Int32
+}
+
+extension HasStaticOperatorCall : HasOperatorCall {}

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -477,4 +477,19 @@ struct HasOperatorCallWithDefaultArg {
   int operator()(int x = 0) const { return value + x; }
 };
 
+class HasStaticOperatorCallBase {
+public:
+  static int operator()(int x) { return x + 42; }
+};
+
+class HasStaticOperatorCallDerived : public HasStaticOperatorCallBase {};
+
+class HasStaticOperatorCallWithConstOperator {
+public:
+  inline int operator()(int x, int y) const { return x + y; }
+  static int operator()(int x) {
+        return x - 1;
+   }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -482,6 +482,15 @@ public:
   static int operator()(int x) { return x + 42; }
 };
 
+class HasStaticOperatorCallBaseNonTrivial: public NonTrivial {
+public:
+  HasStaticOperatorCallBaseNonTrivial() {}
+  HasStaticOperatorCallBaseNonTrivial(const HasStaticOperatorCallBaseNonTrivial &self) : NonTrivial(self) {}
+  HasStaticOperatorCallBaseNonTrivial(HasStaticOperatorCallBaseNonTrivial &&self) : NonTrivial(self) {}
+
+  static int operator()(const NonTrivial &arg) { return arg.f + 42; }
+};
+
 class HasStaticOperatorCallDerived : public HasStaticOperatorCallBase {};
 
 class HasStaticOperatorCallWithConstOperator {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -294,3 +294,16 @@
 // CHECK: struct HasOperatorCallWithDefaultArg {
 // CHECK:   func callAsFunction(_ x: Int32 = cxxDefaultArg) -> Int32
 // CHECK: }
+
+// CHECK: struct HasStaticOperatorCallBase {
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasStaticOperatorCallDerived {
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasStaticOperatorCallWithConstOperator {
+// CHECK:   func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -437,4 +437,24 @@ OperatorsTestSuite.test("HasOperatorCallWithDefaultArg.call") {
   expectEqual(444, res)
 }
 
+OperatorsTestSuite.test("HasStaticOperatorCallBase.call") {
+  let h = HasStaticOperatorCallBase()
+  let res = h(1)
+  expectEqual(43, res)
+}
+
+OperatorsTestSuite.test("HasStaticOperatorCallDerived.call") {
+  let h = HasStaticOperatorCallDerived()
+  let res = h(0)
+  expectEqual(42, res)
+}
+
+OperatorsTestSuite.test("HasStaticOperatorCallWithConstOperator.call") {
+  let h = HasStaticOperatorCallWithConstOperator()
+  let res = h(10)
+  expectEqual(9, res)
+  let res2 = h(3, 5)
+  expectEqual(8, res2)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -443,6 +443,13 @@ OperatorsTestSuite.test("HasStaticOperatorCallBase.call") {
   expectEqual(43, res)
 }
 
+OperatorsTestSuite.test("HasStaticOperatorCallBase2.call") {
+  let m = NonTrivial()
+  let h = HasStaticOperatorCallBaseNonTrivial()
+  let res = h(m)
+  expectEqual(48, res)
+}
+
 OperatorsTestSuite.test("HasStaticOperatorCallDerived.call") {
   let h = HasStaticOperatorCallDerived()
   let res = h(0)


### PR DESCRIPTION
…Function functions in Swift to preserve source compatibility