### PR TITLE
Tiny optimization and cleanups

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7170,11 +7170,6 @@ public:
   Type substBaseType(Type base, LookupConformanceFn lookupConformance,
                      SubstOptions options);
 
-  /// Substitute the root generic type, looking up the chain of associated types.
-  /// Returns null if the member could not be found in the new root.
-  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance,
-                      SubstOptions options);
-
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::DependentMember;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7158,17 +7158,6 @@ public:
   AssociatedTypeDecl *getAssocType() const {
     return NameOrAssocType.dyn_cast<AssociatedTypeDecl *>();
   }
-  
-  /// Substitute the base type, looking up our associated type in it if it is
-  /// non-dependent. Returns null if the member could not be found in the new
-  /// base.
-  Type substBaseType(Type base);
-
-  /// Substitute the base type, looking up our associated type in it if it is
-  /// non-dependent. Returns null if the member could not be found in the new
-  /// base.
-  Type substBaseType(Type base, LookupConformanceFn lookupConformance,
-                     SubstOptions options);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -302,9 +302,8 @@ ConcreteContraction::substTypeParameterRec(Type type, Position position) const {
         return std::nullopt;
       }
 
-      return assocType->getDeclaredInterfaceType()
-                      ->castTo<DependentMemberType>()
-                      ->substBaseType(*substBaseType);
+      return conformance.getAssociatedType(
+          *substBaseType, assocType->getDeclaredInterfaceType());
     }
 
     // An unresolved DependentMemberType stores an identifier. Handle this

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -33,6 +33,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
@@ -332,6 +333,8 @@ bool RequirementMachine::isReducedType(Type type) const {
 /// Given a type parameter 'T.A1.A2...An', a suffix length m where m <= n,
 /// and a replacement type U, produce the type 'U.A(n-m)...An' by replacing
 /// 'T.A1...A(n-m-1)' with 'U'.
+///
+/// FIXME: Remove this.
 static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
                             GenericSignature sig) {
   if (suffixLength == 0)
@@ -340,9 +343,12 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
   auto *memberType = type->castTo<DependentMemberType>();
   auto substBaseType = substPrefixType(memberType->getBase(), suffixLength - 1,
                                        prefixType, sig);
-  return memberType->substBaseType(
-      substBaseType, LookUpConformanceInModule(),
-      std::nullopt);
+  auto *assocDecl = memberType->getAssocType();
+  auto *proto = assocDecl->getProtocol();
+  auto conformance = lookupConformance(substBaseType, proto);
+  return conformance.getAssociatedType(
+      substBaseType,
+      assocDecl->getDeclaredInterfaceType());
 }
 
 Type RequirementMachine::getReducedTypeParameter(
@@ -380,6 +386,8 @@ Type RequirementMachine::getReducedTypeParameter(
   //
   // Note that V can be empty if T is fully valid; we expect this to be
   // true most of the time.
+  //
+  // FIXME: Remove all of this.
   auto prefix = getLongestValidPrefix(term);
 
   // Get a type (concrete or dependent) for U.

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -150,6 +150,7 @@
 
 #include "RequirementLowering.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Requirement.h"
@@ -663,9 +664,9 @@ struct InferRequirementsWalker : public TypeWalker {
       if (differentiableProtocol && fnTy->isDifferentiable()) {
         auto addSameTypeConstraint = [&](Type firstType,
                                          AssociatedTypeDecl *assocType) {
-          auto secondType = assocType->getDeclaredInterfaceType()
-              ->castTo<DependentMemberType>()
-              ->substBaseType(firstType);
+          auto conformance = lookupConformance(firstType, differentiableProtocol);
+          auto secondType = conformance.getAssociatedType(
+              firstType, assocType->getDeclaredInterfaceType());
           reqs.push_back({Requirement(RequirementKind::SameType,
                                       firstType, secondType),
                           SourceLoc()});

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3746,12 +3746,13 @@ void ParameterizedProtocolType::getRequirements(
   auto argTypes = getArgs();
   assert(argTypes.size() <= assocTypes.size());
 
+  auto conformance = lookupConformance(baseType, protoDecl);
+
   for (unsigned i : indices(argTypes)) {
     auto argType = argTypes[i];
     auto *assocType = assocTypes[i];
-    auto subjectType = assocType->getDeclaredInterfaceType()
-        ->castTo<DependentMemberType>()
-        ->substBaseType(baseType);
+    auto subjectType = conformance.getAssociatedType(
+        baseType, assocType->getDeclaredInterfaceType());
     reqs.emplace_back(RequirementKind::SameType, subjectType, argType);
   }
 }
@@ -4457,14 +4458,13 @@ TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
   auto associatedTypeLookup =
       differentiableProtocol->lookupDirect(ctx.Id_TangentVector);
   assert(associatedTypeLookup.size() == 1);
-  auto *dependentType = DependentMemberType::get(
-      differentiableProtocol->getDeclaredInterfaceType(),
-      cast<AssociatedTypeDecl>(associatedTypeLookup[0]));
+  auto *assocDecl = cast<AssociatedTypeDecl>(associatedTypeLookup[0]);
 
   // Try to get the `TangentVector` associated type of `base`.
   // Return the associated type if it is valid.
-  auto assocTy =
-      dependentType->substBaseType(this, lookupConformance, std::nullopt);
+  auto conformance = swift::lookupConformance(this, differentiableProtocol);
+  auto assocTy = conformance.getAssociatedType(
+      this, assocDecl->getDeclaredInterfaceType());
   if (!assocTy->hasError())
     return cache(TangentSpace::getTangentVector(assocTy));
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -264,24 +264,6 @@ operator()(CanType dependentType, Type conformingReplacementType,
   return ProtocolConformanceRef(conformedProtocol);
 }
 
-Type DependentMemberType::substBaseType(Type substBase) {
-  return substBaseType(substBase, LookUpConformanceInModule(),
-                       std::nullopt);
-}
-
-Type DependentMemberType::substBaseType(Type substBase,
-                                        LookupConformanceFn lookupConformance,
-                                        SubstOptions options) {
-  if (substBase.getPointer() == getBase().getPointer() &&
-      substBase->hasTypeParameter())
-    return this;
-
-  InFlightSubstitution IFS(nullptr, lookupConformance, options);
-  return getMemberForBaseType(IFS, getBase(), substBase,
-                              getAssocType(), getName(),
-                              /*level=*/0);
-}
-
 static Type substGenericFunctionType(GenericFunctionType *genericFnType,
                                      InFlightSubstitution &IFS) {
   // Substitute into the function type (without generic signature).

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -282,20 +282,6 @@ Type DependentMemberType::substBaseType(Type substBase,
                               /*level=*/0);
 }
 
-Type DependentMemberType::substRootParam(Type newRoot,
-                                         LookupConformanceFn lookupConformance,
-                                         SubstOptions options) {
-  auto base = getBase();
-  if (base->is<GenericTypeParamType>()) {
-    return substBaseType(newRoot, lookupConformance, options);
-  }
-  if (auto depMem = base->getAs<DependentMemberType>()) {
-    return substBaseType(depMem->substRootParam(newRoot, lookupConformance, options),
-                         lookupConformance, options);
-  }
-  return Type();
-}
-
 static Type substGenericFunctionType(GenericFunctionType *genericFnType,
                                      InFlightSubstitution &IFS) {
   // Substitute into the function type (without generic signature).

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2685,10 +2685,8 @@ bool AssociatedTypeInference::simplifyCurrentTypeWitnesses() {
       abort();
     }
 
-    TypeSubstitutionMap substitutions;
-    auto selfTy = cast<SubstitutableType>(
-        proto->getSelfInterfaceType()->getCanonicalType());
-    substitutions[selfTy] = dc->mapTypeIntoContext(conformance->getType());
+    auto selfTy = proto->getSelfInterfaceType()->getCanonicalType();
+    auto substSelfTy = dc->mapTypeIntoContext(conformance->getType());
 
     for (auto assocType : proto->getAssociatedTypeMembers()) {
       if (conformance->hasTypeWitness(assocType))
@@ -2716,13 +2714,14 @@ bool AssociatedTypeInference::simplifyCurrentTypeWitnesses() {
           if (!type->isTypeParameter())
             return std::nullopt;
 
-          auto *rootParam = type->getRootGenericParam();
-          assert(rootParam->isEqual(selfTy));
-
           // Replace Self with the concrete conforming type.
-          auto substType = Type(type).subst(QueryTypeSubstitutionMap{substitutions},
-                                            LookUpConformanceInModule(),
-                                            options);
+          auto substType = Type(type).subst(
+              [&](SubstitutableType *type) -> Type {
+                ASSERT(type->isEqual(selfTy));
+                return substSelfTy;
+              },
+              LookUpConformanceInModule(),
+              options);
 
           // If we don't have enough type witnesses to substitute fully,
           // leave the original type parameter in place.
@@ -2914,12 +2913,12 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
 
 bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
   auto typeInContext = dc->mapTypeIntoContext(adoptee);
-  auto subs = typeInContext->getContextSubstitutions(ext);
+  auto subs = typeInContext->getContextSubstitutionMap(ext->getExtendedNominal());
 
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
   switch (checkRequirements(
       ext->getGenericSignature().getRequirements(),
-      QueryTypeSubstitutionMap{subs}, options)) {
+      QuerySubstitutionMap{subs}, options)) {
   case CheckRequirementsResult::Success:
   case CheckRequirementsResult::SubstitutionFailure:
     return false;

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1921,11 +1921,15 @@ static Type getWithoutProtocolTypeAliases(Type type) {
 /// Also see simplifyCurrentTypeWitnesses().
 static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
                                       ValueDecl *witness) {
-  if (witness->isRecursiveValidation())
+  if (witness->isRecursiveValidation()) {
+    LLVM_DEBUG(llvm::dbgs() << "Recursive validation\n";);
     return Type();
+  }
 
-  if (witness->isInvalid())
+  if (witness->isInvalid()) {
+    LLVM_DEBUG(llvm::dbgs() << "Invalid witness\n";);
     return Type();
+  }
 
   if (!witness->getDeclContext()->isTypeContext()) {
     // FIXME: Could we infer from 'Self' to make these work?

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1383,7 +1383,7 @@ getPropertyWrapperInformationFromOverload(
       VarDecl *memberDecl;
       std::tie(memberDecl, type) = *declInformation;
       if (Type baseType = resolvedOverload.choice.getBaseType()) {
-        type = baseType->getTypeOfMember(memberDecl, type);
+        type = baseType->getRValueType()->getTypeOfMember(memberDecl, type);
       }
       return std::make_pair(decl, type);
     }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -374,8 +374,9 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       Type newType;
       if (lookupType && !lookupType->isAnyObject()) {
-        newType = lookupType->getTypeOfMember(type,
-                                              type->getDeclaredInterfaceType());
+        newType = type->getDeclaredInterfaceType().subst(
+            lookupType->getContextSubstitutionMap(
+                type->getDeclContext()));
       } else {
         newType = type->getDeclaredInterfaceType();
       }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -643,9 +643,9 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
       noteLoc = loc;
   }
 
-  const auto subMap = parentTy->getContextSubstitutions(dc);
+  const auto subMap = parentTy->getContextSubstitutionMap(dc);
   const auto substitutions = [&](SubstitutableType *type) -> Type {
-    auto result = QueryTypeSubstitutionMap{subMap}(type);
+    auto result = QuerySubstitutionMap{subMap}(type);
     if (result->hasTypeParameter()) {
       if (contextSig) {
         // Avoid building this generic environment unless we need it.

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -677,3 +677,12 @@ func test_optional_chaining_with_function_conversion() {
     _ = data.compactMap(\.elements!.db)
   }
 }
+
+protocol HasAlias {
+  var id: Self.ID { get }
+  typealias ID = Int
+}
+
+func testHasAlias() {
+  _ = \HasAlias.id
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -77,10 +77,9 @@ deliverResults(SourceKit::ConformingMethodListConsumer &SKConsumer,
       Members.emplace_back();
       auto &memberElem = Members.back();
 
-      auto funcTy = cast<FuncDecl>(member)->getMethodInterfaceType();
-      funcTy = Result->Result->ExprType->getTypeOfMember(
-          member, funcTy);
-      auto resultTy = funcTy->castTo<FunctionType>()->getResult();
+      auto resultTy = cast<FuncDecl>(member)->getResultInterfaceType();
+      resultTy = resultTy.subst(
+        Result->Result->ExprType->getMemberSubstitutionMap(member));
 
       // Name.
       memberElem.DeclNameBegin = SS.size();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1229,9 +1229,9 @@ static int printConformingMethodList(
           llvm::outs() << " []";
         llvm::outs() << "\n";
         for (auto VD : Result->Members) {
-          auto funcTy = cast<FuncDecl>(VD)->getMethodInterfaceType();
-          funcTy = Result->ExprType->getTypeOfMember(VD, funcTy);
-          auto resultTy = funcTy->castTo<FunctionType>()->getResult();
+          auto resultTy = cast<FuncDecl>(VD)->getResultInterfaceType();
+          resultTy = resultTy.subst(
+                Result->ExprType->getMemberSubstitutionMap(VD));
 
           llvm::outs() << "   - Name: ";
           VD->getName().print(llvm::outs());


### PR DESCRIPTION
I found a project where we were spending more than 2% of total compile time in `getTypeOfMember()`. Most callers only passed in a `VarDecl` or `EnumElementDecl`, so now it only supports those and applies `getContextSubstitutionMap()`, which is cached.

Also clean up some older code that used `TypeSubstitutionMap`, which I'd like to get rid of because it's a `DenseMap` which is wasteful for just a handful of generic parameter keys.

Finally, remove `substRootParam()` and `substBaseType()` methods on `DependentMemberType`, which were only used in a few places. There are better ways of doing the same thing with existing primitives.