### PR TITLE
[wasm] Merge all wasi-sysroot into a single sysroot directory

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -74,7 +74,7 @@ class WASILibc(product.Product):
             '-C', self.source_dir,
             'OBJDIR=' + os.path.join(self.build_dir, 'obj-' + thread_model),
             'SYSROOT=' + sysroot_build_dir,
-            'INSTALL_DIR=' + WASILibc.sysroot_install_path(build_root, target_triple),
+            'INSTALL_DIR=' + WASILibc.sysroot_install_path(build_root),
             'CC=' + os.path.join(clang_tools_path, 'clang'),
             'AR=' + os.path.join(llvm_tools_path, 'llvm-ar'),
             'NM=' + os.path.join(llvm_tools_path, 'llvm-nm'),
@@ -97,12 +97,12 @@ class WASILibc(product.Product):
                             'sysroot', target_triple)
 
     @classmethod
-    def sysroot_install_path(cls, build_root, target_triple):
+    def sysroot_install_path(cls, build_root):
         """
         Returns the path to the sysroot install directory, which contains artifacts
         of wasi-libc and LLVM runtimes.
         """
-        return os.path.join(build_root, 'wasi-sysroot', target_triple)
+        return os.path.join(build_root, 'wasi-sysroot')
 
 
 class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
@@ -222,7 +222,7 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         self.build_with_cmake([], self.args.build_variant, [],
                               prefer_native_toolchain=True)
         self.install_with_cmake(
-            ["install"], WASILibc.sysroot_install_path(build_root, target_triple))
+            ["install"], WASILibc.sysroot_install_path(build_root))
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -67,7 +67,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define(
             'SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL', 'FALSE')
         self.cmake_options.define('SWIFT_WASI_SYSROOT_PATH:STRING',
-                                  self._wasi_sysroot_path(target_triple))
+                                  self._wasi_sysroot_path())
 
         # It's ok to use the host LLVM build dir just for CMake functionalities
         llvm_cmake_dir = os.path.join(self._host_llvm_build_dir(
@@ -128,7 +128,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         test_driver_options = [
             # compiler-rt is not installed in the final toolchain, so use one
             # in build dir
-            '-Xclang-linker', '-resource-dir=' + self._wasi_sysroot_path(target_triple),
+            '-Xclang-linker', '-resource-dir=' + self._wasi_sysroot_path(),
         ]
         # Leading space is needed to separate from other options
         self.cmake_options.define('SWIFT_DRIVER_TEST_OPTIONS:STRING',
@@ -180,9 +180,9 @@ class WasmStdlib(cmake_product.CMakeProduct):
         build_root = os.path.dirname(self.build_dir)
         return os.path.join('..', build_root, '%s-%s' % ('swift', host_target))
 
-    def _wasi_sysroot_path(self, target_triple):
+    def _wasi_sysroot_path(self):
         build_root = os.path.dirname(self.build_dir)
-        return wasisysroot.WASILibc.sysroot_install_path(build_root, target_triple)
+        return wasisysroot.WASILibc.sysroot_install_path(build_root)
 
     def should_install(self, host_target):
         return False

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -120,16 +120,16 @@ class WasmSwiftSDK(product.Product):
         #    and header paths from the sysroot
         #    https://github.com/llvm/llvm-project/blob/73ef397fcba35b7b4239c00bf3e0b4e689ca0add/clang/lib/Driver/ToolChains/WebAssembly.cpp#L29-L36
         # 3. short_triple: The triple used by build-script to name the build directory
-        for swift_host_triple, clang_multiarch_triple, short_triple, build_basename in [
-            ('wasm32-unknown-wasi', 'wasm32-wasi', 'wasi-wasm32', 'wasmstdlib'),
+        for swift_host_triple, short_triple, build_basename in [
+            ('wasm32-unknown-wasi', 'wasi-wasm32', 'wasmstdlib'),
             # TODO: Enable threads stdlib once sdk-generator supports multi-target SDK
-            # ('wasm32-unknown-wasip1-threads', 'wasm32-wasip1-threads',
+            # ('wasm32-unknown-wasip1-threads',
             #  'wasip1-threads-wasm32', 'wasmthreadsstdlib'),
         ]:
             stdlib_build_path = os.path.join(
                 build_root, '%s-%s' % (build_basename, host_target))
             wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
-                build_root, clang_multiarch_triple)
+                build_root)
             package_path = self._build_target_package(
                 swift_host_triple, short_triple, stdlib_build_path,
                 llvm_runtime_libs_build_path, wasi_sysroot)


### PR DESCRIPTION
This change merges all wasi-sysroot directories into a single sysroot directory to reuse header files across `wasm32-wasi` and `wasm32-wasip1-threads`. The resulted sysroot layout aligns with the layout in [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) distribution.
