### PR TITLE
[ClangImporter][ModuleWrap] Turn off libc warnings.

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -727,9 +727,13 @@ struct ClangInvocationFileMapping {
 /// On Linux, some platform libraries (glibc, libstdc++) are not modularized.
 /// We inject modulemaps for those libraries into their include directories
 /// to allow using them from Swift.
+///
+/// `suppressDiagnostic` prevents us from emitting warning messages when we
+/// are unable to find headers.
 ClangInvocationFileMapping getClangInvocationFileMapping(
     ASTContext &ctx,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr,
+    bool suppressDiagnostic = false);
 
 } // end namespace swift
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -188,7 +188,8 @@ public:
   static std::unique_ptr<ClangImporter>
   create(ASTContext &ctx,
          std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
-         DWARFImporterDelegate *dwarfImporterDelegate = nullptr);
+         DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
+         bool ignoreFileMapping = false);
 
   static std::vector<std::string>
   getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget = false);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1275,7 +1275,8 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
 std::unique_ptr<ClangImporter>
 ClangImporter::create(ASTContext &ctx,
                       std::string swiftPCHHash, DependencyTracker *tracker,
-                      DWARFImporterDelegate *dwarfImporterDelegate) {
+                      DWARFImporterDelegate *dwarfImporterDelegate,
+                      bool ignoreFileMapping) {
   std::unique_ptr<ClangImporter> importer{
       new ClangImporter(ctx, tracker, dwarfImporterDelegate)};
   auto &importerOpts = ctx.ClangImporterOpts;
@@ -1296,7 +1297,11 @@ ClangImporter::create(ASTContext &ctx,
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
       ctx.SourceMgr.getFileSystem();
 
-  auto fileMapping = getClangInvocationFileMapping(ctx);
+  ClangInvocationFileMapping fileMapping;
+
+  if (!ignoreFileMapping)
+    fileMapping = getClangInvocationFileMapping(ctx);
+
   // Avoid creating indirect file system when using include tree.
   if (!ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
     // Wrap Swift's FS to allow Clang to override the working directory

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1297,10 +1297,8 @@ ClangImporter::create(ASTContext &ctx,
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
       ctx.SourceMgr.getFileSystem();
 
-  ClangInvocationFileMapping fileMapping;
-
-  if (!ignoreFileMapping)
-    fileMapping = getClangInvocationFileMapping(ctx);
+  ClangInvocationFileMapping fileMapping =
+    getClangInvocationFileMapping(ctx, nullptr, ignoreFileMapping);
 
   // Avoid creating indirect file system when using include tree.
   if (!ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -189,7 +189,8 @@ ClangImporter::createClangArgs(const ClangImporterOptions &ClangImporterOpts,
 static SmallVector<std::pair<std::string, std::string>, 2>
 getLibcFileMapping(ASTContext &ctx, StringRef modulemapFileName,
                    std::optional<ArrayRef<StringRef>> maybeHeaderFileNames,
-                   const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs) {
+                   const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs,
+                   bool suppressDiagnostic) {
   const llvm::Triple &triple = ctx.LangOpts.Target;
 
   // Extract the libc path from Clang driver.
@@ -213,7 +214,8 @@ getLibcFileMapping(ASTContext &ctx, StringRef modulemapFileName,
           parsedIncludeArgs, {"inttypes.h", "unistd.h", "stdint.h"}, vfs)) {
     libcDir = dir.value();
   } else {
-    ctx.Diags.diagnose(SourceLoc(), diag::libc_not_found, triple.str());
+    if (!suppressDiagnostic)
+      ctx.Diags.diagnose(SourceLoc(), diag::libc_not_found, triple.str());
     return {};
   }
 
@@ -251,7 +253,8 @@ getLibcFileMapping(ASTContext &ctx, StringRef modulemapFileName,
 
 static void getLibStdCxxFileMapping(
     ClangInvocationFileMapping &fileMapping, ASTContext &ctx,
-    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs) {
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs,
+    bool suppressDiagnostic) {
   assert(ctx.LangOpts.EnableCXXInterop &&
          "libstdc++ is only injected if C++ interop is enabled");
 
@@ -286,7 +289,8 @@ static void getLibStdCxxFileMapping(
                                      {"cstdlib", "string", "vector"}, vfs)) {
     cxxStdlibDir = dir.value();
   } else {
-    ctx.Diags.diagnose(SourceLoc(), diag::libstdcxx_not_found, triple.str());
+    if (!suppressDiagnostic)
+      ctx.Diags.diagnose(SourceLoc(), diag::libstdcxx_not_found, triple.str());
     return;
   }
 
@@ -541,7 +545,8 @@ SmallVector<std::pair<std::string, std::string>, 2> GetWindowsFileMappings(
 } // namespace
 
 ClangInvocationFileMapping swift::getClangInvocationFileMapping(
-    ASTContext &ctx, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
+  ASTContext &ctx, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+  bool suppressDiagnostic) {
   ClangInvocationFileMapping result;
   if (!vfs)
     vfs = llvm::vfs::getRealFileSystem();
@@ -571,18 +576,21 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
   if (triple.isOSWASI()) {
     // WASI Mappings
     libcFileMapping =
-        getLibcFileMapping(ctx, "wasi-libc.modulemap", std::nullopt, vfs);
+      getLibcFileMapping(ctx, "wasi-libc.modulemap", std::nullopt, vfs,
+                         suppressDiagnostic);
 
     // WASI's module map needs fixing
     result.requiresBuiltinHeadersInSystemModules = true;
   } else if (triple.isMusl()) {
     libcFileMapping =
-        getLibcFileMapping(ctx, "musl.modulemap", StringRef("SwiftMusl.h"), vfs);
+      getLibcFileMapping(ctx, "musl.modulemap", StringRef("SwiftMusl.h"), vfs,
+                         suppressDiagnostic);
   } else if (triple.isAndroid()) {
     // Android uses the android-specific module map that overlays the NDK.
     StringRef headerFiles[] = {"SwiftAndroidNDK.h", "SwiftBionic.h"};
     libcFileMapping =
-        getLibcFileMapping(ctx, "android.modulemap", headerFiles, vfs);
+      getLibcFileMapping(ctx, "android.modulemap", headerFiles, vfs,
+                         suppressDiagnostic);
 
     if (!libcFileMapping.empty()) {
       sysroot = libcFileMapping[0].first;
@@ -592,7 +600,8 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
              triple.isOSFreeBSD()) {
     // BSD/Linux Mappings
     libcFileMapping = getLibcFileMapping(ctx, "glibc.modulemap",
-                                         StringRef("SwiftGlibc.h"), vfs);
+                                         StringRef("SwiftGlibc.h"), vfs,
+                                         suppressDiagnostic);
 
     // glibc.modulemap needs fixing
     result.requiresBuiltinHeadersInSystemModules = true;
@@ -600,7 +609,7 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
   result.redirectedFiles.append(libcFileMapping);
 
   if (ctx.LangOpts.EnableCXXInterop)
-    getLibStdCxxFileMapping(result, ctx, vfs);
+    getLibStdCxxFileMapping(result, ctx, vfs, suppressDiagnostic);
 
   result.redirectedFiles.append(GetWindowsFileMappings(
       ctx, vfs, result.requiresBuiltinHeadersInSystemModules));

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -196,8 +196,11 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
       llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
-  
-  ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, ""), true);
+
+  ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, "",
+                                               nullptr, nullptr,
+                                               true),
+                         true);
   ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
   std::unique_ptr<Lowering::TypeConverter> TC(
       new Lowering::TypeConverter(*M, ASTCtx.SILOpts.EnableSILOpaqueValues));


### PR DESCRIPTION
`swift-modulewrap` uses the `ClangImporter` to obtain a module loader, but it doesn't take an SDK argument (nor does anything bother to pass one), which means that when cross-compiling you get warnings about not being able to find the C library.

Suppress the warning by telling the `ClangImporter` that we don't care about the C library here.

rdar://115918181
