### PR TITLE
Reimplement ModuleDecl::getSourceFileContainingLocation() using SourceManager

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -162,10 +162,6 @@ enum class ResilienceStrategy : unsigned {
 
 class OverlayFile;
 
-/// A mapping used to find the source file that contains a particular source
-/// location.
-class ModuleSourceFileLocationMap;
-
 /// A unit that allows grouping of modules by a package name.
 ///
 /// PackageUnit is treated as an enclosing scope of ModuleDecl. Unlike other
@@ -302,13 +298,6 @@ private:
 
   SmallVector<FileUnit *, 2> Files;
 
-  /// Mapping used to find the source file associated with a given source
-  /// location.
-  ModuleSourceFileLocationMap *sourceFileLocationMap = nullptr;
-
-  /// The set of auxiliary source files build as part of this module.
-  SmallVector<SourceFile *, 2> AuxiliaryFiles;
-
   llvm::SmallDenseMap<Identifier, SmallVector<OverlayFile *, 1>>
     declaredCrossImports;
 
@@ -409,9 +398,6 @@ public:
   /// a file in the middle of e.g. semantic analysis, use a \c
   /// SynthesizedFileUnit instead.
   void addFile(FileUnit &newFile);
-
-  /// Add an auxiliary source file, introduced as part of the translation.
-  void addAuxiliaryFile(SourceFile &sourceFile);
 
   /// Produces the source file that contains the given source location, or
   /// \c nullptr if the source location isn't in this module.
@@ -565,9 +551,6 @@ private:
   /// along with the name of the required bystander module. Used by tooling to
   /// present overlays as if they were part of their underlying module.
   std::pair<ModuleDecl *, Identifier> getDeclaringModuleAndBystander();
-
-  /// Update the source-file location map to make it current.
-  void updateSourceFileLocationMap();
 
 public:
   ///  If this is a traditional (non-cross-import) overlay, get its underlying

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -156,9 +156,7 @@ private:
   std::optional<StableHasher> InterfaceHasher;
 
   /// The ID for the memory buffer containing this file's source.
-  ///
-  /// May be -1, to indicate no association with a buffer.
-  int BufferID;
+  unsigned BufferID;
 
   /// The parsing options for the file.
   ParsingOptions ParsingOpts;
@@ -370,7 +368,7 @@ public:
   /// \c #sourceLocation(file:) declarations.
   llvm::StringMap<SourceFilePathInfo> getInfoForUsedFilePaths() const;
 
-  SourceFile(ModuleDecl &M, SourceFileKind K, std::optional<unsigned> bufferID,
+  SourceFile(ModuleDecl &M, SourceFileKind K, unsigned bufferID,
              ParsingOptions parsingOpts = {}, bool isPrimary = false);
 
   ~SourceFile();
@@ -590,9 +588,7 @@ public:
 
   /// The buffer ID for the file that was imported, or None if there
   /// is no associated buffer.
-  std::optional<unsigned> getBufferID() const {
-    if (BufferID == -1)
-      return std::nullopt;
+  unsigned getBufferID() const {
     return BufferID;
   }
 

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -18,15 +18,34 @@
 #include "clang/Basic/FileManager.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/SourceMgr.h"
 #include <map>
 #include <optional>
 #include <vector>
 
 namespace swift {
+  class SourceFile;
+}
+
+namespace llvm {
+  template <> struct PointerLikeTypeTraits<swift::SourceFile *> {
+  public:
+    static inline swift::SourceFile *getFromVoidPointer(void *P) {
+      return (swift::SourceFile *)P;
+    }
+    static inline void *getAsVoidPointer(swift::SourceFile *S) {
+      return (void *)S;
+    }
+    enum { NumLowBitsAvailable = /*swift::DeclContextAlignInBits=*/ 3 };
+  };
+}
+
+namespace swift {
 
 class CustomAttr;
 class DeclContext;
+class SourceFile;
 
 /// Augments a buffer that was created specifically to hold generated source
 /// code with the reasons for it being generated.
@@ -122,6 +141,13 @@ private:
   /// The starting source locations of regex literals written in source. This
   /// is an unfortunate hack needed to allow for correct re-lexing.
   llvm::DenseSet<SourceLoc> RegexLiteralStartLocs;
+
+  /// Mapping from each buffer ID to the source files that describe it
+  /// semantically.
+  llvm::DenseMap<
+    unsigned,
+    llvm::TinyPtrVector<SourceFile *>
+  > bufferIDToSourceFiles;
 
   std::map<const char *, VirtualFile> VirtualFiles;
   mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
@@ -322,6 +348,13 @@ public:
 
   /// Adds a memory buffer to the SourceManager, taking ownership of it.
   unsigned addNewSourceBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer);
+
+  /// Record the source file as having the given buffer ID.
+  void recordSourceFile(unsigned bufferID, SourceFile *sourceFile);
+
+  /// Retrieve the source files for the given buffer ID.
+  llvm::TinyPtrVector<SourceFile *>
+  getSourceFilesForBufferID(unsigned bufferID) const;
 
   /// Add a \c #sourceLocation-defined virtual file region of \p Length.
   void createVirtualFile(SourceLoc Loc, StringRef Name, int LineOffset,

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -789,7 +789,7 @@ private:
   /// Creates a new source file for the main module.
   SourceFile *createSourceFileForMainModule(ModuleDecl *mod,
                                             SourceFileKind FileKind,
-                                            std::optional<unsigned> BufferID,
+                                            unsigned BufferID,
                                             bool isMainBuffer = false) const;
 
   /// Creates all the files to be added to the main module, appending them to

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -50,7 +50,7 @@ struct CursorInfoOwner {
     return !(lhs == rhs);
   }
   bool isValid() const {
-    return File && File->getBufferID() && Loc.isValid();
+    return File && Loc.isValid();
   }
 };
 
@@ -110,7 +110,7 @@ struct RangeInfoOwner {
   }
 
   bool isValid() const {
-    return File && File->getBufferID() && StartLoc.isValid() && EndLoc.isValid();
+    return File && StartLoc.isValid() && EndLoc.isValid();
   }
 };
 

--- a/include/swift/Migrator/ASTMigratorPass.h
+++ b/include/swift/Migrator/ASTMigratorPass.h
@@ -41,7 +41,7 @@ protected:
   ASTMigratorPass(EditorAdapter &Editor, SourceFile *SF,
                   const MigratorOptions &Opts)
     : Editor(Editor), SF(SF), Opts(Opts), Filename(SF->getFilename()),
-      BufferID(SF->getBufferID().value()),
+      BufferID(SF->getBufferID()),
       SM(SF->getASTContext().SourceMgr), Diags(SF->getASTContext().Diags) {}
 };
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6622,9 +6622,8 @@ void VarDecl::setOriginalWrappedProperty(VarDecl *originalProperty) {
 static bool isSourceLocInOrignalBuffer(const Decl *D, SourceLoc Loc) {
   assert(Loc.isValid());
   auto bufferID = D->getDeclContext()->getParentSourceFile()->getBufferID();
-  assert(bufferID.has_value() && "Source buffer ID must be set");
   auto &SM = D->getASTContext().SourceMgr;
-  return SM.getRangeForBuffer(*bufferID).contains(Loc);
+  return SM.getRangeForBuffer(bufferID).contains(Loc);
 }
 #endif
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -272,7 +272,7 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
 
     if (SF->Kind == SourceFileKind::DefaultArgument) {
       auto genInfo = *SF->getASTContext().SourceMgr.getGeneratedSourceInfo(
-          *SF->getBufferID());
+          SF->getBufferID());
       parentLoc = ASTNode::getFromOpaqueValue(genInfo.astNode).getStartLoc();
       if (auto parentScope =
               findStartingScopeForLookup(enclosingSF, parentLoc)) {

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -43,13 +43,8 @@ void ASTScopeImpl::dump() const { print(llvm::errs(), 0, false); }
 void ASTScopeImpl::dumpOneScopeMapLocation(
     std::pair<unsigned, unsigned> lineColumn) {
   auto bufferID = getSourceFile()->getBufferID();
-  if (!bufferID) {
-    llvm::errs() << "***No buffer, dumping all scopes***";
-    print(llvm::errs());
-    return;
-  }
   SourceLoc loc = getSourceManager().getLocForLineCol(
-      *bufferID, lineColumn.first, lineColumn.second);
+      bufferID, lineColumn.first, lineColumn.second);
   if (loc.isInvalid())
     return;
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -203,17 +203,9 @@ SourceRange GenericParamScope::getSourceRangeOfThisASTNode(
 
 SourceRange ASTSourceFileScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  if (auto bufferID = SF->getBufferID()) {
-    auto charRange = getSourceManager().getRangeForBuffer(*bufferID);
-    return SourceRange(charRange.getStart(), charRange.getEnd());
-  }
-
-  if (SF->getTopLevelItems().empty())
-    return SourceRange();
-
-  // Use the source ranges of the declarations in the file.
-  return SourceRange(SF->getTopLevelItems().front().getStartLoc(),
-                     SF->getTopLevelItems().back().getEndLoc());
+  auto bufferID = SF->getBufferID();
+  auto charRange = getSourceManager().getRangeForBuffer(bufferID);
+  return SourceRange(charRange.getStart(), charRange.getEnd());
 }
 
 SourceRange GenericTypeOrExtensionScope::getSourceRangeOfThisASTNode(

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1759,9 +1759,7 @@ BufferIndirectlyCausingDiagnosticRAII::BufferIndirectlyCausingDiagnosticRAII(
     const SourceFile &SF)
     : Diags(SF.getASTContext().Diags) {
   auto id = SF.getBufferID();
-  if (!id)
-    return;
-  auto loc = SF.getASTContext().SourceMgr.getLocForBufferStart(*id);
+  auto loc = SF.getASTContext().SourceMgr.getLocForBufferStart(id);
   if (loc.isValid())
     Diags.setBufferIndirectlyCausingDiagnosticToInput(loc);
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3434,7 +3434,7 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
                        ParsingOptions parsingOpts, bool isPrimary)
     : FileUnit(FileUnitKind::Source, M), BufferID(bufferID),
       ParsingOpts(parsingOpts), IsPrimary(isPrimary), Kind(K) {
-  assert(BufferID != ~0);
+  assert(BufferID != (unsigned)~0);
   M.getASTContext().addDestructorCleanup(*this);
 
   assert(!IsPrimary || M.isMainModule() &&

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3446,6 +3446,8 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
     (void)problem;
   }
 
+  M.getASTContext().SourceMgr.recordSourceFile(bufferID, this);
+
   if (Kind == SourceFileKind::MacroExpansion ||
       Kind == SourceFileKind::DefaultArgument)
     M.addAuxiliaryFile(*this);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3434,6 +3434,7 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
                        ParsingOptions parsingOpts, bool isPrimary)
     : FileUnit(FileUnitKind::Source, M), BufferID(bufferID),
       ParsingOpts(parsingOpts), IsPrimary(isPrimary), Kind(K) {
+  assert(BufferID != ~0);
   M.getASTContext().addDestructorCleanup(*this);
 
   assert(!IsPrimary || M.isMainModule() &&

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -58,7 +58,7 @@ TypeRefinementContext::createForSourceFile(SourceFile *SF,
     // root context should be nested under.
     if (auto parentTRC =
             SF->getEnclosingSourceFile()->getTypeRefinementContext()) {
-      auto charRange = Ctx.SourceMgr.getRangeForBuffer(*SF->getBufferID());
+      auto charRange = Ctx.SourceMgr.getRangeForBuffer(SF->getBufferID());
       range = SourceRange(charRange.getStart(), charRange.getEnd());
       auto originalNode = SF->getNodeInEnclosingSourceFile();
       parentContext =

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -215,6 +215,19 @@ SourceManager::getIDForBufferIdentifier(StringRef BufIdentifier) const {
   return It->second;
 }
 
+void SourceManager::recordSourceFile(unsigned bufferID, SourceFile *sourceFile){
+  bufferIDToSourceFiles[bufferID].push_back(sourceFile);
+}
+
+llvm::TinyPtrVector<SourceFile *>
+SourceManager::getSourceFilesForBufferID(unsigned bufferID) const {
+  auto found = bufferIDToSourceFiles.find(bufferID);
+  if (found == bufferIDToSourceFiles.end())
+    return { };
+
+  return found->second;
+}
+
 SourceManager::~SourceManager() {
   for (auto &generated : GeneratedSourceInfos) {
     free((void*)generated.second.onDiskBufferCopyFileName.data());

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8072,9 +8072,6 @@ SourceFile &ClangImporter::Implementation::getClangSwiftAttrSourceFile(
       SourceFile(module, SourceFileKind::Library, bufferID);
   ClangSwiftAttrSourceFiles.insert({&module, sourceFile});
 
-  // Record this attribute in the module.
-  module.addAuxiliaryFile(*sourceFile);
-
   return *sourceFile;
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8063,14 +8063,18 @@ unsigned ClangImporter::Implementation::getClangSwiftAttrSourceBuffer(
 }
 
 SourceFile &ClangImporter::Implementation::getClangSwiftAttrSourceFile(
-    ModuleDecl &module) {
+    ModuleDecl &module, unsigned bufferID) {
   auto known = ClangSwiftAttrSourceFiles.find(&module);
   if (known != ClangSwiftAttrSourceFiles.end())
     return *known->second;
 
   auto sourceFile = new (SwiftContext)
-      SourceFile(module, SourceFileKind::Library, std::nullopt);
+      SourceFile(module, SourceFileKind::Library, bufferID);
   ClangSwiftAttrSourceFiles.insert({&module, sourceFile});
+
+  // Record this attribute in the module.
+  module.addAuxiliaryFile(*sourceFile);
+
   return *sourceFile;
 }
 
@@ -8228,7 +8232,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
 
       // Dig out a source file we can use for parsing.
       auto &sourceFile = getClangSwiftAttrSourceFile(
-          *MappedDecl->getDeclContext()->getParentModule());
+          *MappedDecl->getDeclContext()->getParentModule(), bufferID);
 
       // Spin up a parser.
       swift::Parser parser(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1062,7 +1062,7 @@ public:
 
   /// Retrieve the placeholder source file for use in parsing Swift attributes
   /// in the given module.
-  SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module);
+  SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module, unsigned bufferID);
 
   /// Utility function to import Clang attributes from a source Swift decl to
   /// synthesized Swift decl.

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -324,13 +324,7 @@ private:
 
 bool DependencyVerifier::parseExpectations(
     const SourceFile *SF, std::vector<Expectation> &Expectations) {
-  const auto MaybeBufferID = SF->getBufferID();
-  if (!MaybeBufferID) {
-    llvm::errs() << "source file has no buffer: " << SF->getFilename();
-    return true;
-  }
-
-  const auto BufferID = MaybeBufferID.value();
+  const auto BufferID = SF->getBufferID();
   const CharSourceRange EntireRange = SM.getRangeForBuffer(BufferID);
   const StringRef InputFile = SM.extractText(EntireRange);
 
@@ -484,7 +478,7 @@ bool DependencyVerifier::verifyNegativeExpectations(
 
 bool DependencyVerifier::diagnoseUnfulfilledObligations(
     const SourceFile *SF, ObligationMap &Obligations) {
-  CharSourceRange EntireRange = SM.getRangeForBuffer(*SF->getBufferID());
+  CharSourceRange EntireRange = SM.getRangeForBuffer(SF->getBufferID());
   StringRef InputFile = SM.extractText(EntireRange);
   auto &diags = SF->getASTContext().Diags;
   auto &Ctx = SF->getASTContext();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1743,9 +1743,9 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
 }
 
 SourceFile *CompilerInstance::createSourceFileForMainModule(
-    ModuleDecl *mod, SourceFileKind fileKind, std::optional<unsigned> bufferID,
+    ModuleDecl *mod, SourceFileKind fileKind, unsigned bufferID,
     bool isMainBuffer) const {
-  auto isPrimary = bufferID && isPrimaryInput(*bufferID);
+  auto isPrimary = isPrimaryInput(bufferID);
   auto opts = getSourceFileParsingOptions(isPrimary);
 
   auto *inputFile = new (*Context)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -238,11 +238,8 @@ static void countStatsOfSourceFile(UnifiedStatsReporter &Stats,
   SF->getPrecedenceGroups(groups);
   C.NumPrecedenceGroups += groups.size();
 
-  auto bufID = SF->getBufferID();
-  if (bufID.has_value()) {
-    C.NumSourceLines +=
-      SM.getEntireTextForBuffer(bufID.value()).count('\n');
-  }
+  C.NumSourceLines +=
+    SM.getEntireTextForBuffer(SF->getBufferID()).count('\n');
 }
 
 static void countASTStats(UnifiedStatsReporter &Stats,

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -3040,7 +3040,7 @@ std::pair<LineRange, std::string> swift::ide::reformat(LineRange Range,
     // default value.
     Options.TabWidth = Options.IndentWidth ? Options.IndentWidth : 4;
   }
-  auto SourceBufferID = SF.getBufferID().value();
+  auto SourceBufferID = SF.getBufferID();
   StringRef Text = SM.getLLVMSourceMgr()
     .getMemoryBuffer(SourceBufferID)->getBuffer();
   size_t Offset = getOffsetOfLine(Range.startLine(), Text, /*Trim*/true);

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -431,7 +431,7 @@ void swift::simple_display(llvm::raw_ostream &out, const CursorInfoOwner &owner)
   if (!owner.isValid())
     return;
   auto &SM = owner.File->getASTContext().SourceMgr;
-  out << SM.getIdentifierForBuffer(*owner.File->getBufferID());
+  out << SM.getIdentifierForBuffer(owner.File->getBufferID());
   auto LC = SM.getLineAndColumnInBuffer(owner.Loc);
   out << ":" << LC.first << ":" << LC.second;
 }
@@ -442,7 +442,7 @@ void swift::ide::simple_display(llvm::raw_ostream &out,
     return;
   out << "Resolved cursor info at ";
   auto &SM = info->getSourceFile()->getASTContext().SourceMgr;
-  out << SM.getIdentifierForBuffer(*info->getSourceFile()->getBufferID());
+  out << SM.getIdentifierForBuffer(info->getSourceFile()->getBufferID());
   auto LC = SM.getLineAndColumnInBuffer(info->getLoc());
   out << ":" << LC.first << ":" << LC.second;
 }
@@ -1178,7 +1178,7 @@ void swift::simple_display(llvm::raw_ostream &out,
   if (!owner.isValid())
     return;
   auto &SM = owner.File->getASTContext().SourceMgr;
-  out << SM.getIdentifierForBuffer(*owner.File->getBufferID());
+  out << SM.getIdentifierForBuffer(owner.File->getBufferID());
   auto SLC = SM.getLineAndColumnInBuffer(owner.StartLoc);
   auto ELC = SM.getLineAndColumnInBuffer(owner.EndLoc);
   out << ": (" << SLC.first << ":" << SLC.second << ", "
@@ -1188,7 +1188,7 @@ void swift::simple_display(llvm::raw_ostream &out,
 RangeInfoOwner::RangeInfoOwner(SourceFile *File, unsigned Offset,
                                unsigned Length): File(File) {
   SourceManager &SM = File->getASTContext().SourceMgr;
-  unsigned BufferId = File->getBufferID().value();
+  unsigned BufferId = File->getBufferID();
   StartLoc = SM.getLocForOffset(BufferId, Offset);
   EndLoc = SM.getLocForOffset(BufferId, Offset + Length);
 }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -729,7 +729,7 @@ public:
       std::vector<ExpressionTypeInfo> &Results, bool FullyQualified,
       bool CanonicalType, llvm::raw_ostream &OS)
       : SM(SF.getASTContext().SourceMgr),
-        BufferId(*SF.getBufferID()), Results(Results), OS(OS),
+        BufferId(SF.getBufferID()), Results(Results), OS(OS),
         InterestedProtocols(InterestedProtocols),
         FullyQualified(FullyQualified), CanonicalType(CanonicalType) {}
   bool walkToExprPre(Expr *E) override {
@@ -843,7 +843,7 @@ public:
                         bool FullyQualified,
                         std::vector<VariableTypeInfo> &Results,
                         llvm::raw_ostream &OS)
-      : SM(SF.getASTContext().SourceMgr), BufferId(*SF.getBufferID()),
+      : SM(SF.getASTContext().SourceMgr), BufferId(SF.getBufferID()),
         TotalRange(Range), FullyQualified(FullyQualified), Results(Results),
         OS(OS) {}
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -751,9 +751,7 @@ static SourceLoc getDeclStartPosition(SourceFile &File) {
 }
 
 static void printUntilFirstDeclStarts(SourceFile &File, ASTPrinter &Printer) {
-  if (!File.getBufferID().has_value())
-    return;
-  auto BufferID = *File.getBufferID();
+  auto BufferID = File.getBufferID();
 
   auto &SM = File.getASTContext().SourceMgr;
   CharSourceRange TextRange = SM.getRangeForBuffer(BufferID);

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -366,7 +366,7 @@ public:
       : AllTokensInFile(File.getAllTokens()),
         LangOpts(File.getASTContext().LangOpts),
         SM(File.getASTContext().SourceMgr),
-        BufferID(File.getBufferID().value()),
+        BufferID(File.getBufferID()),
         Ctx(File.getASTContext()),
         Walker(Walker) { }
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -708,9 +708,8 @@ void swift::ide::SourceEditConsumer::acceptMacroExpansionBuffer(
       containingSF->getParentModule()->getSourceFileContainingLocation(
           originalSourceRange.getStart());
   StringRef originalPath;
-  if (originalFile->getBufferID().has_value() &&
-      containingSF->getBufferID() != originalFile->getBufferID()) {
-    originalPath = SM.getIdentifierForBuffer(*originalFile->getBufferID());
+  if (containingSF->getBufferID() != originalFile->getBufferID()) {
+    originalPath = SM.getIdentifierForBuffer(originalFile->getBufferID());
   }
 
   StringRef bufferName;

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -140,7 +140,6 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   auto tmpBufferID = tmpSM.addNewSourceBuffer(std::move(*tmpBuffer));
   SourceFile *tmpSF = new (tmpCtx)
       SourceFile(*tmpM, SF.Kind, tmpBufferID, SF.getParsingOptions());
-  tmpM->addAuxiliaryFile(*tmpSF);
 
   // If the top-level code has been changed, we can't do anything.
   if (SF.getInterfaceHash() != tmpSF->getInterfaceHash())

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -200,7 +200,6 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
     return false;
 
   auto *oldSF = CachedCI->getIDEInspectionFile();
-  assert(oldSF->getBufferID());
 
   auto *oldState = oldSF->getDelayedParserState();
   assert(oldState->hasIDEInspectionDelayedDeclState());
@@ -208,7 +207,7 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
 
   auto &SM = CachedCI->getSourceMgr();
   auto bufferName = ideInspectionTargetBuffer->getBufferIdentifier();
-  if (SM.getIdentifierForBuffer(*oldSF->getBufferID()) != bufferName)
+  if (SM.getIdentifierForBuffer(oldSF->getBufferID()) != bufferName)
     return false;
 
   if (shouldCheckDependencies()) {
@@ -223,7 +222,7 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
     }
 
     if (areAnyDependentFilesInvalidated(
-            *CachedCI, *FileSystem, *oldSF->getBufferID(),
+            *CachedCI, *FileSystem, oldSF->getBufferID(),
             DependencyCheckedTimestamp, InMemoryDependencyHash))
       return false;
     DependencyCheckedTimestamp = std::chrono::system_clock::now();

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -254,7 +254,6 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
   ModuleDecl *tmpM = ModuleDecl::create(Identifier(), *tmpCtx);
   SourceFile *tmpSF = new (*tmpCtx)
       SourceFile(*tmpM, oldSF->Kind, tmpBufferID, oldSF->getParsingOptions());
-  tmpM->addAuxiliaryFile(*tmpSF);
 
   // FIXME: Since we don't setup module loaders on the temporary AST context,
   // 'canImport()' conditional compilation directive always fails. That causes

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -231,7 +231,7 @@ expandFreestandingMacro(MacroDecl *macro,
   SourceFile *expandedSource =
       swift::evaluateFreestandingMacro(expansion, discriminator);
   if (expandedSource)
-    bufferIDs.push_back(*expandedSource->getBufferID());
+    bufferIDs.push_back(expandedSource->getBufferID());
 
   return bufferIDs;
 }
@@ -254,7 +254,7 @@ expandAttachedMacro(MacroDecl *macro, CustomAttr *attr, Decl *attachedDecl) {
     SourceFile *expandedSource = swift::evaluateAttachedMacro(
         macro, target, attr, passParent, role, discriminator);
     if (expandedSource)
-      bufferIDs.push_back(*expandedSource->getBufferID());
+      bufferIDs.push_back(expandedSource->getBufferID());
   };
 
   MacroRoles roles = macro->getMacroRoles();
@@ -430,7 +430,7 @@ void SyntacticMacroExpansionInstance::expand(
   // Find the expansion at 'expansion.offset'.
   MacroExpansionFinder expansionFinder(
       SourceMgr,
-      SourceMgr.getLocForOffset(*SF->getBufferID(), expansion.offset));
+      SourceMgr.getLocForOffset(SF->getBufferID(), expansion.offset));
   SF->walk(expansionFinder);
   auto expansionNode = expansionFinder.getResult();
   if (!expansionNode)

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -590,7 +590,7 @@ public:
   IndexSwiftASTWalker(IndexDataConsumer &IdxConsumer, ASTContext &Ctx,
                       SourceFile *SF = nullptr)
       : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr),
-        BufferID(SF ? SF->getBufferID().value_or(-1) : -1),
+        BufferID(SF ? SF->getBufferID() : -1),
         enableWarnings(IdxConsumer.enableWarnings()) {}
 
   ~IndexSwiftASTWalker() override {
@@ -1164,7 +1164,7 @@ void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod) {
   for (auto File : Mod.getFiles()) {
     if (auto SF = dyn_cast<SourceFile>(File)) {
       auto BufID = SF->getBufferID();
-      if (BufID.has_value() && *BufID == BufferID) {
+      if (BufID == BufferID) {
         SrcFile = SF;
         break;
       }

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -218,7 +218,7 @@ bool Migrator::performSyntacticPasses(SyntacticPassOptions Opts) {
   RewriteBufferEditsReceiver Rewriter {
     ClangSourceManager,
     Editor.getClangFileIDForSwiftBufferID(
-      StartInstance->getPrimarySourceFile()->getBufferID().value()),
+      StartInstance->getPrimarySourceFile()->getBufferID()),
     InputState->getOutputText()
   };
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -257,10 +257,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
   // Perform round-trip and/or validation checking.
   if (parsingOpts.contains(ParsingFlags::RoundTrip) &&
       swift_ASTGen_roundTripCheck(exportedSourceFile)) {
-    SourceLoc loc;
-    if (auto bufferID = SF.getBufferID()) {
-      loc = Context.SourceMgr.getLocForBufferStart(*bufferID);
-    }
+    SourceLoc loc = Context.SourceMgr.getLocForBufferStart(SF.getBufferID());
     diagnose(loc, diag::parser_round_trip_error);
     return;
   }
@@ -277,10 +274,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
       // which case we still have `hadAnyError() == false`. To avoid
       // emitting the same warnings from SwiftParser, only emit errors from
       // SwiftParser
-      SourceLoc loc;
-      if (auto bufferID = SF.getBufferID()) {
-          loc = Context.SourceMgr.getLocForBufferStart(*bufferID);
-      }
+      SourceLoc loc = Context.SourceMgr.getLocForBufferStart(SF.getBufferID());
       diagnose(loc, diag::parser_new_parser_errors);
     }
   }
@@ -298,10 +292,7 @@ void *ExportedSourceFileRequest::evaluate(Evaluator &evaluator,
   auto &SM = ctx.SourceMgr;
 
   auto bufferID = SF->getBufferID();
-  if (!bufferID)
-    return nullptr;
-
-  StringRef contents = SM.extractText(SM.getRangeForBuffer(*bufferID));
+  StringRef contents = SM.extractText(SM.getRangeForBuffer(bufferID));
 
   // Parse the source file.
   auto exportedSourceFile = swift_ASTGen_parseSourceFile(

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -70,7 +70,7 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
     return FingerprintAndMembers{fp, ctx.AllocateCopy(members)};
   }
 
-  unsigned bufferID = *sf->getBufferID();
+  unsigned bufferID = sf->getBufferID();
 
   // Lexer diagnostics have been emitted during skipping, so we disable lexer's
   // diagnostic engine here.
@@ -140,10 +140,6 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   auto &ctx = SF->getASTContext();
   auto bufferID = SF->getBufferID();
 
-  // If there's no buffer, there's nothing to parse.
-  if (!bufferID)
-    return {};
-
   // If we've been asked to silence warnings, do so now. This is needed for
   // secondary files, which can be parsed multiple times.
   auto &diags = ctx.Diags;
@@ -161,13 +157,13 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     SF->setDelayedParserState({state, &deletePersistentParserState});
   }
 
-  Parser parser(*bufferID, *SF, /*SIL*/ nullptr, state);
+  Parser parser(bufferID, *SF, /*SIL*/ nullptr, state);
   PrettyStackTraceParser StackTrace(parser);
 
   // If the buffer is generated source information, we might have more
   // context that we need to set up for parsing.
   SmallVector<ASTNode, 128> items;
-  if (auto generatedInfo = ctx.SourceMgr.getGeneratedSourceInfo(*bufferID)) {
+  if (auto generatedInfo = ctx.SourceMgr.getGeneratedSourceInfo(bufferID)) {
     if (generatedInfo->declContext)
       parser.CurDeclContext = generatedInfo->declContext;
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1144,7 +1144,6 @@ struct ParserUnit::Implementation {
 
     auto *M = ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx);
     SF = new (Ctx) SourceFile(*M, SFKind, BufferID, parsingOpts);
-    M->addAuxiliaryFile(*SF);
   }
 
   ~Implementation() {

--- a/lib/Refactoring/ExtractFunction.cpp
+++ b/lib/Refactoring/ExtractFunction.cpp
@@ -96,7 +96,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name) {
   if (Instance->setup(Invocation, InstanceSetupError))
     llvm_unreachable(InstanceSetupError.c_str());
 
-  unsigned BufferId = Instance->getPrimarySourceFile()->getBufferID().value();
+  unsigned BufferId = Instance->getPrimarySourceFile()->getBufferID();
   SourceManager &SM = Instance->getSourceMgr();
   SourceLoc NameLoc = SM.getLocForOffset(BufferId, NameOffset);
   auto LineAndCol = SM.getLineAndColumnInBuffer(NameLoc);

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -49,7 +49,7 @@ collectRefactoringsAtCursor(SourceFile *SF, unsigned Line, unsigned Column,
   DiagnosticEngine DiagEngine(SM);
   std::for_each(DiagConsumers.begin(), DiagConsumers.end(),
                 [&](DiagnosticConsumer *Con) { DiagEngine.addConsumer(*Con); });
-  SourceLoc Loc = SM.getLocForLineCol(SF->getBufferID().value(), Line, Column);
+  SourceLoc Loc = SM.getLocForLineCol(SF->getBufferID(), Line, Column);
   if (Loc.isInvalid())
     return {};
 

--- a/lib/Refactoring/SyntacticRename.cpp
+++ b/lib/Refactoring/SyntacticRename.cpp
@@ -28,7 +28,7 @@ swift::ide::resolveRenameLocations(ArrayRef<RenameLoc> RenameLocs,
                                    StringRef NewName, SourceFile &SF,
                                    DiagnosticEngine &Diags) {
   SourceManager &SM = SF.getASTContext().SourceMgr;
-  unsigned BufferID = SF.getBufferID().value();
+  unsigned BufferID = SF.getBufferID();
 
   std::vector<SourceLoc> UnresolvedLocs;
   for (const RenameLoc &RenameLoc : RenameLocs) {

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -108,7 +108,7 @@ static bool shouldProfile(SILDeclRef Constant) {
     auto *M = DC->getParentModule();
     if (auto *SF = M->getSourceFileContainingLocation(N.getStartLoc())) {
       auto &SM = M->getASTContext().SourceMgr;
-      if (SM.hasGeneratedSourceInfo(*SF->getBufferID())) {
+      if (SM.hasGeneratedSourceInfo(SF->getBufferID())) {
         LLVM_DEBUG(llvm::dbgs() << "Skipping ASTNode: generated code\n");
         return false;
       }
@@ -1183,7 +1183,7 @@ public:
     if (SourceRegions.empty())
       return nullptr;
 
-    auto FileSourceRange = SM.getRangeForBuffer(*SF->getBufferID());
+    auto FileSourceRange = SM.getRangeForBuffer(SF->getBufferID());
     auto isLocInFile = [&](SourceLoc Loc) {
       return FileSourceRange.contains(Loc) || FileSourceRange.getEnd() == Loc;
     };

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -101,12 +101,10 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   assert(SF);
 
   auto bufferID = SF->getBufferID();
-  assert(bufferID);
-
   auto silMod = SILModule::createEmptyModule(desc.context, desc.conv,
                                              desc.opts);
   SILParserState parserState(*silMod.get());
-  Parser parser(*bufferID, *SF, &parserState);
+  Parser parser(bufferID, *SF, &parserState);
   PrettyStackTraceParser StackTrace(parser);
 
   if (ParseSerializedSIL) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
@@ -54,7 +54,6 @@ class DiagnoseUnnecessaryPreconcurrencyImports : public SILModuleTransform {
       }
 
       data.push_back(sf);
-      assert(sf->getBufferID() != -1 && "Must have a buffer id");
     }
 
     // Sort unique by filename so our diagnostics are deterministic.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -128,7 +128,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
   // FIXME: When we migrate to SwiftParser, use the parsed syntax tree.
   auto &SM = ctx.SourceMgr;
   StringRef sourceFileText =
-      SM.getEntireTextForBuffer(*sourceFile->getBufferID());
+      SM.getEntireTextForBuffer(sourceFile->getBufferID());
   StringRef macroDeclText =
       SM.extractText(Lexer::getCharSourceRangeFromSourceRange(
           SM, macro->getSourceRangeIncludingAttrs()));
@@ -1199,7 +1199,7 @@ std::optional<unsigned> swift::expandMacroExpr(MacroExpansionExpr *mee) {
   ASTContext &ctx = dc->getASTContext();
   SourceManager &sourceMgr = ctx.SourceMgr;
 
-  auto macroBufferID = *macroSourceFile->getBufferID();
+  auto macroBufferID = macroSourceFile->getBufferID();
   auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
 
   // Handle builtin macro definitions by producing the expression we
@@ -1302,7 +1302,7 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
     if (auto *decl = item.dyn_cast<Decl *>())
       decl->setDeclContext(dc);
   }
-  return *macroSourceFile->getBufferID();
+  return macroSourceFile->getBufferID();
 }
 
 static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
@@ -1681,8 +1681,7 @@ ArrayRef<unsigned> ExpandPreambleMacroRequest::evaluate(
         if (!macroSourceFile)
           return;
 
-        if (auto bufferID = macroSourceFile->getBufferID())
-          bufferIDs.push_back(*bufferID);
+        bufferIDs.push_back(macroSourceFile->getBufferID());
       });
 
   std::reverse(bufferIDs.begin(), bufferIDs.end());

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -226,7 +226,6 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
         SourceFile::ParsingOptions parsingOpts;
         auto sourceFile = new (Ctx) SourceFile(
             *moduleDecl, SourceFileKind::Interface, bufferID, parsingOpts);
-        moduleDecl->addAuxiliaryFile(*sourceFile);
         std::vector<StringRef> ArgsRefs(Args.begin(), Args.end());
         std::vector<StringRef> compiledCandidatesRefs(compiledCandidates.begin(),
                                                       compiledCandidates.end());

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1044,7 +1044,7 @@ static void addParameterEntities(CompilerInstance &CI,
     auto SF = dyn_cast<SourceFile>(Unit);
     if (!SF)
       continue;
-    FuncWalker Walker(CI.getSourceMgr(), *SF->getBufferID(), FuncEnts);
+    FuncWalker Walker(CI.getSourceMgr(), SF->getBufferID(), FuncEnts);
     SF->walk(Walker);
   }
 }
@@ -1058,7 +1058,7 @@ static void reportSourceAnnotations(const SourceTextInfo &IFaceInfo,
       continue;
 
     SyntaxModelContext SyntaxContext(*SF);
-    DocSyntaxWalker SyntaxWalker(CI.getSourceMgr(), *SF->getBufferID(),
+    DocSyntaxWalker SyntaxWalker(CI.getSourceMgr(), SF->getBufferID(),
                                  IFaceInfo.References, Consumer);
     SyntaxContext.walk(SyntaxWalker);
     SyntaxWalker.finished();
@@ -1428,7 +1428,7 @@ void SwiftLangSupport::findLocalRenameRanges(
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &SF = AstUnit->getPrimarySourceFile();
-      swift::ide::RangeConfig Range{*SF.getBufferID(), Line, Column, Length};
+      swift::ide::RangeConfig Range{SF.getBufferID(), Line, Column, Length};
       SourceManager &SM = SF.getASTContext().SourceMgr;
       auto SyntacticRenameRanges =
           swift::ide::findLocalRenameRanges(&SF, Range);
@@ -1481,7 +1481,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
   unsigned BufferID = ParseCI.getInputBufferIDs().back();
   for (auto Unit : ParseCI.getMainModule()->getFiles()) {
     if (auto Current = dyn_cast<SourceFile>(Unit)) {
-      if (Current->getBufferID().value() == BufferID) {
+      if (Current->getBufferID() == BufferID) {
         SF = Current;
         break;
       }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1102,11 +1102,7 @@ public:
       return;
     }
 
-    if (!AstUnit->getPrimarySourceFile().getBufferID().has_value()) {
-      LOG_WARN_FUNC("Primary SourceFile is expected to have a BufferID");
-      return;
-    }
-    unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().value();
+    unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID();
 
     SemanticAnnotator Annotator(CompIns.getSourceMgr(), BufferID);
     Annotator.walk(AstUnit->getPrimarySourceFile());
@@ -2388,7 +2384,7 @@ void SwiftEditorDocument::reportDocumentStructure(SourceFile &SrcFile,
                                                   EditorConsumer &Consumer) {
   ide::SyntaxModelContext ModelContext(SrcFile);
   SwiftDocumentStructureWalker Walker(SrcFile.getASTContext().SourceMgr,
-                                      *SrcFile.getBufferID(),
+                                      SrcFile.getBufferID(),
                                       Consumer);
   ModelContext.walk(Walker);
 }
@@ -2612,7 +2608,7 @@ void SwiftLangSupport::getSemanticTokens(
             "Unable to find input file"));
         return;
       }
-      SemanticAnnotator Annotator(CompIns.getSourceMgr(), *SF->getBufferID());
+      SemanticAnnotator Annotator(CompIns.getSourceMgr(), SF->getBufferID());
       Annotator.walk(SF);
       Receiver(
           RequestResult<SemanticTokensResult>::fromResult(Annotator.SemaToks));

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -247,7 +247,7 @@ static void reportSyntacticAnnotations(CompilerInstance &CI,
                                        EditorConsumer &Consumer) {
   auto SF = dyn_cast<SourceFile>(CI.getMainModule()->getFiles()[0]);
   SyntaxModelContext SyntaxContext(*SF);
-  DocSyntaxWalker SyntaxWalker(CI.getSourceMgr(), *SF->getBufferID(),
+  DocSyntaxWalker SyntaxWalker(CI.getSourceMgr(), SF->getBufferID(),
                                Consumer);
   SyntaxContext.walk(SyntaxWalker);
 }
@@ -654,7 +654,7 @@ SwiftInterfaceGenContext::resolveEntityForOffset(unsigned Offset) const {
 
   SourceManager &SM = Impl.TextCI.getSourceMgr();
   auto SF = dyn_cast<SourceFile>(Impl.TextCI.getMainModule()->getFiles()[0]);
-  unsigned BufferID = *SF->getBufferID();
+  unsigned BufferID = SF->getBufferID();
   SourceLoc Loc = Lexer::getLocForStartOfToken(SM, BufferID, Offset);
   Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1628,7 +1628,7 @@ static void resolveCursor(
       }
 
       SourceManager &SM = CompIns.getSourceMgr();
-      unsigned BufferID = SF->getBufferID().value();
+      unsigned BufferID = SF->getBufferID();
       SourceLoc Loc =
         Lexer::getLocForStartOfToken(SM, BufferID, Offset);
       if (Loc.isInvalid()) {
@@ -1802,7 +1802,7 @@ static void computeDiagnostics(
         : Receiver(Receiver) {}
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      unsigned BufferID = *AstUnit->getPrimarySourceFile().getBufferID();
+      unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID();
       auto &DiagConsumer = AstUnit->getEditorDiagConsumer();
       auto Diagnostics = DiagConsumer.getDiagnosticsForBuffer(BufferID);
       Receiver(RequestResult<DiagnosticsResult>::fromResult(Diagnostics));
@@ -1863,7 +1863,7 @@ static void resolveName(
       }
 
       SourceLoc Loc = Lexer::getLocForStartOfToken(CompIns.getSourceMgr(),
-                                                   *SF->getBufferID(), Offset);
+                                                   SF->getBufferID(), Offset);
       if (Loc.isInvalid()) {
         Receiver(RequestResult<NameTranslatingInfo>::fromError(
           "Unable to resolve the start of the token."));
@@ -2548,7 +2548,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
     // FIXME: Don't silently eat errors here.
     RelatedIdentsResult getRelatedIdents(SourceFile *SrcFile,
                                          CompilerInstance &CompInst) {
-      unsigned BufferID = SrcFile->getBufferID().value();
+      unsigned BufferID = SrcFile->getBufferID();
       SourceLoc Loc = Lexer::getLocForStartOfToken(CompInst.getSourceMgr(),
                                                    BufferID, Offset);
       if (Loc.isInvalid())
@@ -2722,7 +2722,7 @@ void SwiftLangSupport::findActiveRegionsInFile(
       }
 
       auto &SM = SF->getASTContext().SourceMgr;
-      auto BufferID = *SF->getBufferID();
+      auto BufferID = SF->getBufferID();
 
       SmallVector<IfConfigInfo> Configs;
       for (auto &range : SF->getIfConfigClauseRanges()) {
@@ -2812,7 +2812,7 @@ void SwiftLangSupport::semanticRefactoring(
         return;
       }
 
-      Opts.Range.BufferID = *SF->getBufferID();
+      Opts.Range.BufferID = SF->getBufferID();
       Opts.Range.Line = Info.Line;
       Opts.Range.Column = Info.Column;
       Opts.Range.Length = Info.Length;
@@ -2963,7 +2963,7 @@ void SwiftLangSupport::collectVariableTypes(
       SourceRange Range;
       if (Offset.has_value() && Length.has_value()) {
         auto &SM = CompInst.getSourceMgr();
-        unsigned BufferID = SF->getBufferID().value();
+        unsigned BufferID = SF->getBufferID();
         SourceLoc Start = Lexer::getLocForStartOfToken(SM, BufferID, *Offset);
         SourceLoc End =
             Lexer::getLocForStartOfToken(SM, BufferID, *Offset + *Length);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1761,8 +1761,9 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
   importInfo.StdlibKind = ImplicitStdlibKind::Stdlib;
   auto *M = ModuleDecl::create(ctx.getIdentifier(Invocation.getModuleName()),
                                ctx, importInfo);
+  auto bufferID = ctx.SourceMgr.addMemBufferCopy("// nothing\n");
   auto *SF =
-      new (ctx) SourceFile(*M, SourceFileKind::Main, /*BufferID*/ std::nullopt);
+      new (ctx) SourceFile(*M, SourceFileKind::Main, bufferID);
   M->addFile(*SF);
   performImportResolution(*SF);
 
@@ -2618,7 +2619,7 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   llvm::SmallString<256> TypeBuffer;
   llvm::raw_svector_ostream OS(TypeBuffer);
   SourceFile &SF = *CI.getPrimarySourceFile();
-  auto Source = SF.getASTContext().SourceMgr.getRangeForBuffer(*SF.getBufferID()).str();
+  auto Source = SF.getASTContext().SourceMgr.getRangeForBuffer(SF.getBufferID()).str();
   std::vector<std::pair<unsigned, std::string>> SortedTags;
 
   std::vector<const char*> Usrs;
@@ -4003,9 +4004,8 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
       break;
   }
   assert(SF && "no source file?");
-  assert(SF->getBufferID().has_value() && "no buffer id?");
   SourceManager &SM = SF->getASTContext().SourceMgr;
-  unsigned bufferID = SF->getBufferID().value();
+  unsigned bufferID = SF->getBufferID();
   SourceLoc StartLoc = SM.getLocForLineCol(bufferID, StartLineCol.first,
                                            StartLineCol.second);
   SourceLoc EndLoc = SM.getLocForLineCol(bufferID, EndLineCol.first,
@@ -4109,7 +4109,6 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
       break;
   }
   assert(SF && "no source file?");
-  assert(SF->getBufferID().has_value() && "no buffer id?");
 
   llvm::outs() << llvm::sys::path::filename(SF->getFilename()) << '\n';
   llvm::outs() << "------------\n";

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -401,7 +401,7 @@ int main(int argc, char *argv[]) {
   assert(SF && "no source file?");
 
   SourceManager &SM = SF->getASTContext().SourceMgr;
-  unsigned BufferID = SF->getBufferID().value();
+  unsigned BufferID = SF->getBufferID();
   std::string Buffer = SM.getRangeForBuffer(BufferID).str().str();
 
   auto Start = getLocsByLabelOrPosition(options::LineColumnPair, Buffer);

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -44,8 +44,9 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
   auto *module = ModuleDecl::create(stdlibID, Ctx);
   Ctx.addLoadedModule(module);
 
+  auto bufferID = Ctx.SourceMgr.addMemBufferCopy("// nothing\n");
   FileForLookups = new (Ctx) SourceFile(*module, SourceFileKind::Library,
-                                        /*buffer*/ std::nullopt);
+                                        bufferID);
   module->addFile(*FileForLookups);
 
   if (optionals == DeclareOptionalTypes) {

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -47,8 +47,9 @@ SemaTest::SemaTest()
   auto *module =
       ModuleDecl::create(Context.getIdentifier("SemaTests"), Context);
 
+  auto bufferID = Context.SourceMgr.addMemBufferCopy("// nothing\n");
   MainFile = new (Context) SourceFile(*module, SourceFileKind::Main,
-                                      /*buffer=*/std::nullopt);
+                                      bufferID);
 
   AttributedImport<ImportedModule> stdlibImport{{ImportPath::Access(), stdlib},
                                                 /*options=*/{}};


### PR DESCRIPTION
ModuleDecl kept track of all of the source files in the module so that it could find the source file containing a given location, which relied on a sorted array all of these source files. SourceManager has its own similar data structure for a similar query mapping the locations to buffer IDs.

Replace ModuleDecl's dats structure with a use of the SourceManager's location -> buffer ID mapping. Augment SourceManager with a bufferID -> SourceFile mapping so we can do this.