### PR TITLE
[Parse] Restrict parsing integer types in certain contexts

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1435,6 +1435,11 @@ public:
   ParserResult<TypeRepr> parseTypeSimple(
       Diag<> MessageID, ParseTypeReason reason);
 
+  ParserResult<TypeRepr> parseTypeOrValue();
+  ParserResult<TypeRepr> parseTypeOrValue(Diag<> MessageID,
+                          ParseTypeReason reason = ParseTypeReason::Unspecified,
+                          bool fromASTGen = false);
+
   /// Parse layout constraint.
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4116,7 +4116,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
      
-      auto countType = parseType(diag::expected_type);
+      auto countType = parseTypeOrValue(diag::expected_type);
       if (countType.isNull()) {
         return makeParserSuccess();
       }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -317,7 +317,9 @@ ParserStatus Parser::parseGenericWhereClause(
 
     // Parse the leading type. It doesn't necessarily have to be just a type
     // identifier if we're dealing with a same-type constraint.
-    ParserResult<TypeRepr> FirstType = parseType();
+    //
+    // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
+    ParserResult<TypeRepr> FirstType = parseTypeOrValue();
 
     if (FirstType.hasCodeCompletion()) {
       Status.setHasCodeCompletionAndIsError();
@@ -377,7 +379,9 @@ ParserStatus Parser::parseGenericWhereClause(
       SourceLoc EqualLoc = consumeToken();
 
       // Parse the second type.
-      ParserResult<TypeRepr> SecondType = parseType();
+      //
+      // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
+      ParserResult<TypeRepr> SecondType = parseTypeOrValue();
       Status |= SecondType;
       if (SecondType.isNull())
         SecondType = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1060,6 +1060,42 @@ bool SILParser::parseASTType(CanType &result,
   return false;
 }
 
+bool SILParser::parseASTTypeOrValue(CanType &result,
+                                    GenericSignature genericSig,
+                                    GenericParamList *genericParams,
+                                    bool forceContextualType) {
+  auto parsedType = P.parseTypeOrValue();
+  if (parsedType.isNull()) return true;
+
+  // If we weren't given a specific generic context to resolve the type
+  // within, use the contextual generic parameters and always produce
+  // a contextual type.  Otherwise, produce a contextual type only if
+  // we were asked for one.
+  bool wantContextualType = forceContextualType;
+  if (!genericSig) {
+    genericSig = ContextGenericSig;
+    wantContextualType = true;
+  }
+  if (genericParams == nullptr)
+    genericParams = ContextGenericParams;
+
+  bindSILGenericParams(parsedType.get());
+
+  auto resolvedType = performTypeResolution(
+      parsedType.get(), /*isSILType=*/false, genericSig, genericParams);
+  if (wantContextualType && genericSig) {
+    resolvedType = genericSig.getGenericEnvironment()
+        ->mapTypeIntoContext(resolvedType);
+  }
+
+  if (resolvedType->hasError())
+    return true;
+
+  result = resolvedType->getCanonicalType();
+
+  return false;
+}
+
 void SILParser::bindSILGenericParams(TypeRepr *TyR) {
   // Resolve the generic environments for parsed generic function and box types.
   class HandleSILGenericParamsWalker : public ASTWalker {
@@ -3097,7 +3133,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     CanType paramType;
     if (parseSILType(Ty) ||
         parseVerbatim("for") ||
-        parseASTType(paramType))
+        parseASTTypeOrValue(paramType))
       return true;
 
     ResultVal = B.createTypeValue(InstLoc, Ty, paramType);

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -235,6 +235,11 @@ public:
     return false;
   }
 
+  bool parseASTTypeOrValue(CanType &result,
+                           GenericSignature genericSig = GenericSignature(),
+                           GenericParamList *genericParams = nullptr,
+                           bool forceContextualType = false);
+
   std::optional<StringRef>
   parseOptionalAttribute(ArrayRef<StringRef> expected) {
     // We parse here @ <identifier>.

--- a/test/Parse/integer_types.swift
+++ b/test/Parse/integer_types.swift
@@ -1,8 +1,12 @@
 // RUN: %target-typecheck-verify-swift
 
-let a: 123 // expected-error {{integer unexpectedly used in a type position}}
+let a: 123 // expected-error {{consecutive statements on a line must be separated by ';'}}
+           // expected-error@-1 {{expected type}}
+           // expected-warning@-2 {{integer literal is unused}}
 
-let b: -123 // expected-error {{integer unexpectedly used in a type position}}
+let b: -123 // expected-error {{consecutive statements on a line must be separated by ';'}}
+           // expected-error@-1 {{expected type}}
+           // expected-warning@-2 {{integer literal is unused}}
 
 let c: -Int // expected-error {{expected type}}
             // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
@@ -30,3 +34,19 @@ let f = Generic<-Int>.self // expected-error {{generic parameter 'T' could not b
                            // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
                            // expected-error@-2 {{'>' is not a postfix unary operator}}
                            // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}
+
+let g: 123.Type // expected-error {{consecutive statements on a line must be separated by ';'}}
+                // expected-error@-1 {{expected type}}
+                // expected-error@-2 {{value of type 'Int' has no member 'Type'}}
+
+let h: 123.Protocol // expected-error {{consecutive statements on a line must be separated by ';'}}
+                    // expected-error@-1 {{expected type}}
+                    // expected-error@-2 {{value of type 'Int' has no member 'Protocol'}}
+
+let i: 123? // expected-error {{consecutive statements on a line must be separated by ';'}}
+            // expected-error@-1 {{expected type}}
+            // expected-error@-2 {{cannot use optional chaining on non-optional value of type 'Int'}}
+
+let j: 123! // expected-error {{consecutive statements on a line must be separated by ';'}}
+            // expected-error@-1 {{expected type}}
+            // expected-error@-2 {{cannot force unwrap value of non-optional type 'Int'}}

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -49,18 +49,21 @@ struct Generic<T: ~Copyable & ~Escapable> {}
 struct GenericWithIntParam<T: ~Copyable & ~Escapable, let N: Int> {}
 
 extension Generic where T == 123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
-extension Generic where T == 123.Type {} // expected-error {{integer unexpectedly used in a type position}}
+extension Generic where T == 123.Type {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+                                         // expected-error@-1 {{expected '{' in extension}}
+extension Generic where T == 123? {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+                                     // expected-error@-1 {{expected '{' in extension}}
 
 func f(_: Generic<123>) {} // expected-error {{integer unexpectedly used in a type position}}
 func g<let N: Int>(_: Generic<N>) {} // expected-error {{cannot use value type 'N' for generic argument 'T'}}
-func h(_: (Int, 123)) {} // expected-error {{integer unexpectedly used in a type position}}
-func i(_: () -> 123) {} // expected-error {{integer unexpectedly used in a type position}}
+func h(_: (Int, 123)) {} // expected-error {{expected type}}
+func i(_: () -> 123) {} // expected-error {{expected type}}
 func j(_: (A<123>) -> ()) {} // OK
-func k(_: some 123) {} // expected-error {{integer unexpectedly used in a type position}}
+func k(_: some 123) {} // expected-error {{expected parameter type following ':'}}
 func l(_: GenericWithIntParam<123, Int>) {} // expected-error {{cannot pass type 'Int' as a value for generic value 'N'}}
 func m(_: GenericWithIntParam<Int, 123>) {} // OK
 
-typealias One = 1 // expected-error {{integer unexpectedly used in a type position}}
+typealias One = 1 // expected-error {{expected type in type alias declaration}}
 
 struct B<let N: UInt8> {} // expected-error {{'UInt8' is not a supported value type for 'N'}}
 

--- a/test/attr/attr_implements_bad_parse.swift
+++ b/test/attr/attr_implements_bad_parse.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -parse -verify %s
 
 struct S0 {
-  @_implements(1, Foo) // OK. We can parse integers as types now, so this is fine. We will diagnose its incorrect usage during type checking.
+  @_implements(1, Foo) // expected-error {{expected type}}
   func f() { }
 }
 

--- a/test/expr/postfix/init/unqualified.swift
+++ b/test/expr/postfix/init/unqualified.swift
@@ -62,7 +62,7 @@ class Theodosia: Aaron {
 
     // FIXME: We could optimistically parse this as an expression instead
     // expected-error@+2 {{initializers may only be declared within a type}}
-    // expected-error@+1 {{integer unexpectedly used in a type position}}
+    // expected-error@+1 {{expected parameter type following ':'}}
     init(z: 0)
   }
 
@@ -98,7 +98,7 @@ struct AaronStruct {
 
     // FIXME: We could optimistically parse this as an expression instead
     // expected-error@+2 {{initializers may only be declared within a type}}
-    // expected-error@+1 {{integer unexpectedly used in a type position}}
+    // expected-error@+1 {{expected parameter type following ':'}}
     init(y: 1)
   }
 


### PR DESCRIPTION
Previously, we would unconditionally parse integers as types in all contexts that were expecting to parse types. This patch changes that behavior so that we only parse integers as types in the contexts where we expect to see valid usages of these types, namely as generic arguments and as either the LHS or RHS of a same type generic constraint.