### PR TITLE
IRGen: Split async funclets need to be marked noinline to not loose async_entry/return metadata

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2526,6 +2526,7 @@ void IRGenSILFunction::emitSILFunction() {
 
     if (IGM.getOptions().EmitAsyncFramePushPopMetadata) {
       CurFn->addFnAttr("async_entry");
+      CurFn->addFnAttr(llvm::Attribute::NoInline);
     }
   }
   if (isAsyncFn) {

--- a/test/IRGen/async_frame_entry_return_metadata.swift
+++ b/test/IRGen/async_frame_entry_return_metadata.swift
@@ -9,6 +9,12 @@
 // ENABLED: @__swift_async_entry_functlets = internal constant [2 x i32] [i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6calleeyyYaF" to i64), i64 ptrtoint (ptr @__swift_async_entry_functlets to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6callerySiSbYaF" to i64), i64 ptrtoint (ptr getelementptr inbounds ([2 x i32], ptr @__swift_async_entry_functlets, i32 0, i32 1) to i64)) to i32)], section "__TEXT,__swift_as_entry, coalesced, no_dead_strip", no_sanitize_address, align 4
 // ENABLED: @__swift_async_ret_functlets = internal constant [1 x i32] [i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6callerySiSbYaFTQ1_" to i64), i64 ptrtoint (ptr @__swift_async_ret_functlets to i64)) to i32)], section "__TEXT,__swift_as_ret, coalesced, no_dead_strip", no_sanitize_address, align 4
 
+// ENABLED: define{{.*}} swifttailcc void @"$s5async6callerySiSbYaF"{{.*}} [[CALLER_FUNCLET_ATTRS:#[0-9]+]]
+// ENABLED: define{{.*}} internal swifttailcc void @"$s5async6callerySiSbYaFTY0_"{{.*}} [[CALLER_FUNCLET_ATTRS2:#[0-9]+]]
+
+// ENABLED: attributes [[CALLER_FUNCLET_ATTRS2]] = { {{.*}}noinline
+// ENABLED: attributes [[CALLER_FUNCLET_ATTRS]] = { {{.*}}noinline
+
 // DISABLED-NOT: @__swift_async_entry_functlets
 // DISABLED-NOT: @__swift_async_ret_functlets
 // DISABLED-NOT: s5async6calleeyyYaF.0


### PR DESCRIPTION
rdar://134460666