### PR TITLE
[6.0.1][Windows] Teach Build-Testing how to find Foundation

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1557,6 +1557,8 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
 }
 
 function Build-SwiftTesting([Platform]$Platform, $Arch, [switch]$Test = $false) {
+  $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
+  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
   $SwiftTestingBinaryCache = Get-TargetProjectBinaryCache $Arch SwiftTesting
 
   Isolate-EnvVars {
@@ -1579,6 +1581,8 @@ function Build-SwiftTesting([Platform]$Platform, $Arch, [switch]$Test = $false) 
       -Defines (@{
         BUILD_SHARED_LIBS = "YES";
         CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
+        dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
+        Foundation_DIR = "$FoundationBinaryCache\cmake\modules";
         SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
         # FIXME: Build the plugin for the builder and specify the path.
         SwiftTesting_MACRO = "NO";


### PR DESCRIPTION
Cherry-pick #76489 into `release/6.0.1`

* **Explanation**: Previously in Windows builds, `Testing` was not linked to `Foundation`. Because of that, `Testing` in Windows toolchains lacked the functionalities. Pass `Foundation_DIR` to `swift-testing` CMake configuration so it can find the `Foundation`'s  search and link paths.
* **Scope**: `swift-testing` build in Windows toolchains
* **Risk**: Low. Obvious `build.ps1` only changes
* **Testing**: Passes the current test suite. Also manually tested with a PR toolchain
* **Issues**: N/A
* **Reviewers**: @compnerd @bnbarham 