### PR TITLE
[build.ps1] ensure the compiler is using UTF-8

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -958,6 +958,10 @@ function Build-CMakeProject {
     switch ($Platform) {
       Windows {
         $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/Zc:inline")
+        # If the current code page is not UTF-8, add "/utf-8" option to ensure the compiler is using it
+        if (65001 -ne [Console]::OutputEncoding.CodePage) {
+          $CFlags.Add("/utf-8")
+        }
       }
       Android {
         $CFlags = @("--sysroot=$(Get-AndroidNDKPath)\toolchains\llvm\prebuilt\windows-x86_64\sysroot")


### PR DESCRIPTION
I am (again) proposing to add this flag because anyone who's not using 65001 code page could meet unexpected situations without it. Although it should have no effect with code page 65001 or `clang-cl`, I added a conditional check to eliminate the flag when unncessary.