### PR TITLE
[gardening] remove obsolete annotations

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -78,7 +78,6 @@ extension Result {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
@@ -147,7 +146,6 @@ extension Result where Success: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result {
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
@@ -220,7 +218,6 @@ extension Result {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -549,7 +549,6 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Unsafe${Mutable}BufferPointer {
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -287,7 +287,6 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
@@ -317,7 +316,6 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it
@@ -845,7 +843,6 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
@@ -1303,7 +1300,6 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it


### PR DESCRIPTION
This removes the `@_disallowFeatureSuppression(NoncopyableGenerics)` annotations, since "NoncopyableGenerics" is now turned on, and isn't explicitly mentioned in swiftinterface files.