### PR TITLE
Better support CoreFoundation types in RemoteMirror

### DIFF
--- a/validation-test/Reflection/reflect_Enum_CF.swift
+++ b/validation-test/Reflection/reflect_Enum_CF.swift
@@ -1,0 +1,105 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_CF
+// RUN: %target-codesign %t/reflect_Enum_CF
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_CF | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK%target-ptrsize --dump-input=fail %add_num_extra_inhabitants
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// REQUIRES: reflection_test_support
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+import Foundation
+
+enum MyPair<T,U> {
+case a(T)
+case b(U)
+}
+
+reflect(enum: MyPair<Void,CFNumber>.b(kCFNumberPositiveInfinity))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_CF.MyPair
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT:   (foreign name=So11CFNumberRefa))
+
+// CHECK: Type info:
+// CHECK64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK64-NEXT:   (case name=a index=0 offset=0
+// CHECK64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK64-NEXT:   (case name=b index=1 offset=0
+// CHECK64-NEXT:     (reference kind=strong refcounting=unknown)))
+
+// CHECK: Mangled name: $s15reflect_Enum_CF6MyPairOyytSo11CFNumberRefaG
+// CHECK-NEXT: Demangled name: reflect_Enum_CF.MyPair<(), __C.CFNumberRef>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (foreign name=So11CFNumberRefa)
+// CHECK-NEXT: )
+
+struct StructA {
+  let field1 = MyPair<Void,CFNumber>.b(kCFNumberPositiveInfinity)
+  let field2 = 7
+}
+
+enum T {
+case a
+case b(MyPair<Void,CFNumber>)
+}
+
+reflect(enum: StructA().field1)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_CF.MyPair
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT:   (foreign name=So11CFNumberRefa))
+
+// CHECK: Type info:
+// CHECK-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-NEXT:   (case name=a index=0 offset=0
+// CHECK-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-NEXT:   (case name=b index=1 offset=0
+// CHECK-NEXT:     (reference kind=strong refcounting=unknown)))
+
+// CHECK: Mangled name: $s15reflect_Enum_CF6MyPairOyytSo11CFNumberRefaG
+// CHECK-NEXT: Demangled name: reflect_Enum_CF.MyPair<(), __C.CFNumberRef>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT: (foreign name=So11CFNumberRefa)
+// CHECK-NEXT: )
+
+reflect(enum: T.a)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_CF.T)
+
+// CHECK: Type info:
+// CHECK-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK-NEXT:   (case name=b index=0 offset=0
+// CHECK-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK-NEXT:       (case name=a index=0 offset=0
+// CHECK-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-NEXT:       (case name=b index=1 offset=0
+// CHECK-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK-NEXT:   (case name=a index=1))
+// CHECK-NEXT: Mangled name: $s15reflect_Enum_CF1TO
+// CHECK-NEXT: Demangled name: reflect_Enum_CF.T
+
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=1)
+
+doneReflecting()
+
+// CHECKALL: Done.
+

--- a/validation-test/Reflection/reflect_Enum_CF.swift
+++ b/validation-test/Reflection/reflect_Enum_CF.swift
@@ -62,11 +62,11 @@ reflect(enum: StructA().field1)
 // CHECK-NEXT:   (foreign name=So11CFNumberRefa))
 
 // CHECK: Type info:
-// CHECK-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
-// CHECK-NEXT:   (case name=a index=0 offset=0
-// CHECK-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
-// CHECK-NEXT:   (case name=b index=1 offset=0
-// CHECK-NEXT:     (reference kind=strong refcounting=unknown)))
+// CHECK64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK64-NEXT:   (case name=a index=0 offset=0
+// CHECK64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK64-NEXT:   (case name=b index=1 offset=0
+// CHECK64-NEXT:     (reference kind=strong refcounting=unknown)))
 
 // CHECK: Mangled name: $s15reflect_Enum_CF6MyPairOyytSo11CFNumberRefaG
 // CHECK-NEXT: Demangled name: reflect_Enum_CF.MyPair<(), __C.CFNumberRef>
@@ -84,17 +84,17 @@ reflect(enum: T.a)
 // CHECK-NEXT: (enum reflect_Enum_CF.T)
 
 // CHECK: Type info:
-// CHECK-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
-// CHECK-NEXT:   (case name=b index=0 offset=0
-// CHECK-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
-// CHECK-NEXT:       (case name=a index=0 offset=0
-// CHECK-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
-// CHECK-NEXT:       (case name=b index=1 offset=0
-// CHECK-NEXT:         (reference kind=strong refcounting=unknown))))
-// CHECK-NEXT:   (case name=a index=1))
-// CHECK-NEXT: Mangled name: $s15reflect_Enum_CF1TO
-// CHECK-NEXT: Demangled name: reflect_Enum_CF.T
+// CHECK64-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// CHECK64-NEXT:   (case name=b index=0 offset=0
+// CHECK64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// CHECK64-NEXT:       (case name=a index=0 offset=0
+// CHECK64-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK64-NEXT:       (case name=b index=1 offset=0
+// CHECK64-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK64-NEXT:   (case name=a index=1))
 
+// CHECK: Mangled name: $s15reflect_Enum_CF1TO
+// CHECK-NEXT: Demangled name: reflect_Enum_CF.T
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=a index=1)

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SingleCaseCFPayload
 // RUN: %target-codesign %t/reflect_Enum_SingleCaseCFPayload
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseCFPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseCFPayload | %FileCheck %s --check-prefix=CHECK%target-ptrsize
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -29,42 +29,41 @@ class ClassWithSingleCaseCFPayloadEnum {
 
 reflect(object: ClassWithSingleCaseCFPayloadEnum())
 
-// CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
-// CHECK-64: Type info:
-// CHECK-64: <null type info>
+// CHECK: Reflecting an object.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 
-// CHECK-32: Reflecting an object.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
-// CHECK-32: Type info:
-// CHECK-32: <null type info>
+// CHECK: Type reference:
+// CHECK-NEXT: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
+
+// CHECK64: Type info:
+// CHECK64-NEXT: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1 
+// CHECK64-NEXT:  (field name=e1 offset=16 
+// CHECK64-NEXT:   (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1 
+// CHECK64-NEXT:    (case name=some index=0 offset=0 
+// CHECK64-NEXT:    (reference kind=strong refcounting=unknown)) 
+
+// CHECK32: Type info:
 
 reflect(enum: SingleCaseCFPayloadEnum.only(cfs1))
 
-// CHECK-64: Reflecting an enum.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
-// CHECK-64: Type info:
-// CHECK-64: <null type info>
-// CHECK-64: Enum value:
-// CHECK-64: <null type info>
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 
-// CHECK-32: Reflecting an enum.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
-// CHECK-32: Type info:
-// CHECK-32: <null type info>
-// CHECK-32: Enum value:
-// CHECK-32: <null type info>
+// CHECK: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
+
+// CHECK: Type info:
+// CHECK-NEXT: (reference kind=strong refcounting=unknown) 
+
+// CHECK: Mangled name: $s32reflect_Enum_SingleCaseCFPayload0cdeB0O 
+// CHECK-NEXT: Demangled name: reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum 
+
+// CHECK: Enum value:
+// CHECK-NEXT: (reference kind=strong refcounting=unknown)
+
+// CHECK: Mangled name: $s32reflect_Enum_SingleCaseCFPayload0cdeB0O 
+// CHECK-NEXT: Demangled name: reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum 
 
 doneReflecting()
 
-// CHECK-64: Done.
-
-// CHECK-32: Done.
+// CHECK: Done.


### PR DESCRIPTION
This plugs a hole where we failed to recognize a CF type when it appeared as the payload of an enum stored as a property.  Curiously, RemoteMirror is able to reflect this when the enum appears by itself, just not when it's stored as a property.

The simplest fix is to hook into the calculation which computes a TypeInfo (basically, the tree of fields) from a TypeRef (basically, the name of the type, including generic context). Specifically, we sometimes end up here with a "type alias" that none of the lookup support seems to be able to handle.  Fortunately, these aliases demangle into a pretty predictable shape, so this just pattern-matches the specific demangle tree shape to recognize these as "type aliases in the `__C` module whose name starts with `CF` and ends with `Ref`".

Resolves rdar://82465109