### PR TITLE
[CMake] Enable CMP0157 NEW if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,13 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+# Enable Swift_COMPILATION_MODE property.
+set(CMP0157_IS_NEW FALSE)
+if(POLICY CMP0157)
+  cmake_policy(SET CMP0157 NEW)
+  set(CMP0157_IS_NEW TRUE)
+endif()
+
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -1,6 +1,5 @@
 include(macCatalystUtils)
 
-# Workaround a cmake bug, see the corresponding function in swift-syntax
 function(force_add_dependencies TARGET)
   foreach(DEPENDENCY ${ARGN})
     string(REGEX REPLACE [<>:\"/\\|?*] _ sanitized ${DEPENDENCY})
@@ -16,12 +15,18 @@ endfunction()
 function(force_target_link_libraries TARGET)
   target_link_libraries(${TARGET} ${ARGN})
 
-  cmake_parse_arguments(ARGS "PUBLIC;PRIVATE;INTERFACE" "" "" ${ARGN})
-  force_add_dependencies(${TARGET} ${ARGS_UNPARSED_ARGUMENTS})
+  if(NOT CMP0157_IS_NEW)
+    # Workaround a cmake bug, see the corresponding function in swift-syntax
+    cmake_parse_arguments(ARGS "PUBLIC;PRIVATE;INTERFACE" "" "" ${ARGN})
+    force_add_dependencies(${TARGET} ${ARGS_UNPARSED_ARGUMENTS})
+  endif()
 endfunction()
 
 # Add compile options shared between libraries and executables.
 function(_add_host_swift_compile_options name)
+  set_property(TARGET ${name} PROPERTY
+    Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release,RelWithDebInfo>,wholemodule,incremental>")
+
   # Avoid introducing an implicit dependency on the string-processing library.
   if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
     target_compile_options(${name} PRIVATE
@@ -296,14 +301,16 @@ function(add_pure_swift_host_library name)
     # NOTE: workaround for CMake not setting up include flags.
     INTERFACE_INCLUDE_DIRECTORIES ${module_dir})
 
-  # Workaround to touch the library and its objects so that we don't
-  # continually rebuild (again, see corresponding change in swift-syntax).
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}> "${module_file}"
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of library outputs workaround")
+  if(NOT CMP0157_IS_NEW)
+    # Workaround to touch the library and its objects so that we don't
+    # continually rebuild (again, see corresponding change in swift-syntax).
+    add_custom_command(
+        TARGET ${name}
+        POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}> "${module_file}"
+        COMMAND_EXPAND_LISTS
+        COMMENT "Update mtime of library outputs workaround")
+  endif()
 
   # Downstream linking should include the swiftmodule in debug builds to allow lldb to
   # work correctly. Only do this on Darwin since neither gold (currently used by default
@@ -439,24 +446,26 @@ function(add_pure_swift_host_tool name)
       "SHELL:-Xlinker --build-id=sha1")
   endif()
 
-  # Workaround to touch the library and its objects so that we don't
-  # continually rebuild (again, see corresponding change in swift-syntax).
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}>
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of executable outputs workaround")
+  if(NOT CMP0157_IS_NEW)
+    # Workaround to touch the library and its objects so that we don't
+    # continually rebuild (again, see corresponding change in swift-syntax).
+    add_custom_command(
+        TARGET ${name}
+        POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}>
+        COMMAND_EXPAND_LISTS
+        COMMENT "Update mtime of executable outputs workaround")
 
-  # Even worse hack - ${name}.swiftmodule is added as an output, even though
-  # this is an executable target. Just touch it all the time to avoid having
-  # to rebuild it every time.
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/${name}.swiftmodule"
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of executable outputs workaround")
+    # Even worse hack - ${name}.swiftmodule is added as an output, even though
+    # this is an executable target. Just touch it all the time to avoid having
+    # to rebuild it every time.
+    add_custom_command(
+        TARGET ${name}
+        POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/${name}.swiftmodule"
+        COMMAND_EXPAND_LISTS
+        COMMENT "Update mtime of executable outputs workaround")
+  endif()
 
   if(NOT APSHT_SWIFT_COMPONENT STREQUAL no_component)
     add_dependencies(${APSHT_SWIFT_COMPONENT} ${name})

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -9,6 +9,10 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     PACKAGE_NAME Toolchain
   )
 
+  # 'swift-plugin-server' is not a valid module name.
+  set_target_properties(swift-plugin-server PROPERTIES
+    Swift_MODULE_NAME SwiftPluginServer)
+
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
   add_pure_swift_host_library(SwiftInProcPluginServer SHARED


### PR DESCRIPTION
Use new CMake Swift compilation mode if possible.
Disable sowe workaround when CMP0157 is enabled.
