### PR TITLE
[Macro][Dependencies] Properly model macro dependencies in the scanner

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -272,6 +272,10 @@ public:
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                      ModuleDecl::ImportFilter filter) const {}
 
+  /// Looks up which external macros are defined by this file.
+  virtual void
+  getExternalMacros(SmallVectorImpl<ExternalMacroPlugin> &macros) const {}
+
   /// Lists modules that are not imported from this file and used in API.
   virtual void getImplicitImportsForModuleInterface(
       SmallVectorImpl<ImportedModule> &imports) const {}

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -145,6 +145,19 @@ struct SourceFilePathInfo {
   }
 };
 
+/// This is used to idenfity an external macro definition.
+struct ExternalMacroPlugin {
+  std::string ModuleName;
+
+  enum Access {
+    Internal = 0,
+    Package,
+    Public,
+  };
+
+  Access MacroAccess;
+};
+
 /// Discriminator for resilience strategy.
 enum class ResilienceStrategy : unsigned {
   /// Public nominal types: fragile
@@ -968,6 +981,9 @@ public:
   /// in this list.
   void getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                           ImportFilter filter = ImportFilterKind::Exported) const;
+
+  /// Looks up which external macros are defined by this file.
+  void getExternalMacros(SmallVectorImpl<ExternalMacroPlugin> &macros) const;
 
   /// Lists modules that are not imported from a file and used in API.
   void getImplicitImportsForModuleInterface(

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -224,6 +224,9 @@ public:
   /// command-line), no need to be saved to reconstruct from cache.
   std::vector<std::string> auxiliaryFiles;
 
+  /// The macro dependencies.
+  std::map<std::string, MacroPluginDependency> macroDependencies;
+
   /// The direct dependency of the module is resolved by scanner.
   bool resolved;
   /// ModuleDependencyInfo is finalized (with all transitive dependencies
@@ -252,9 +255,6 @@ struct CommonSwiftTextualModuleDependencyDetails {
 
   /// (Clang) modules on which the bridging header depends.
   std::vector<std::string> bridgingModuleDependencies;
-
-  /// The macro dependencies.
-  std::map<std::string, MacroPluginDependency> macroDependencies;
 
   /// The Swift frontend invocation arguments to build the Swift module from the
   /// interface.
@@ -326,12 +326,6 @@ public:
   void updateCommandLine(const std::vector<std::string> &newCommandLine) {
     textualModuleDetails.buildCommandLine = newCommandLine;
   }
-
-  void addMacroDependency(StringRef macroModuleName, StringRef libraryPath,
-                          StringRef executablePath) {
-    textualModuleDetails.macroDependencies.insert(
-        {macroModuleName.str(), {libraryPath.str(), executablePath.str()}});
-  }
 };
 
 /// Describes the dependencies of a Swift module
@@ -381,12 +375,6 @@ public:
 
   void addTestableImport(ImportPath::Module module) {
     testableImports.insert(module.front().Item.str());
-  }
-
-  void addMacroDependency(StringRef macroModuleName, StringRef libraryPath,
-                          StringRef executablePath) {
-    textualModuleDetails.macroDependencies.insert(
-        {macroModuleName.str(), {libraryPath.str(), executablePath.str()}});
   }
 };
 
@@ -786,6 +774,16 @@ public:
     storage->auxiliaryFiles.emplace_back(file);
   }
 
+  void addMacroDependency(StringRef macroModuleName, StringRef libraryPath,
+                          StringRef executablePath) {
+    storage->macroDependencies.insert(
+        {macroModuleName.str(), {libraryPath.str(), executablePath.str()}});
+  }
+
+  std::map<std::string, MacroPluginDependency> &getMacroDependencies() const {
+    return storage->macroDependencies;
+  }
+
   void updateCASFileSystemRootID(const std::string &rootID) {
     if (isSwiftInterfaceModule())
       cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())
@@ -808,13 +806,6 @@ public:
 
   /// For a Source dependency, register a `Testable` import
   void addTestableImport(ImportPath::Module module);
-
-  /// For a Source/Textual dependency, register a macro dependency.
-  void addMacroDependency(StringRef macroModuleName, StringRef libraryPath,
-                          StringRef executablePath);
-
-  /// For a Source/Textual dependency, if it Has macro dependency.
-  bool hasMacroDependencies() const;
 
   /// Whether or not a queried module name is a `@Testable` import dependency
   /// of this module. Can only return `true` for Swift source modules.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -576,6 +576,9 @@ public:
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                      ModuleDecl::ImportFilter filter) const override;
 
+  virtual void getExternalMacros(
+      SmallVectorImpl<ExternalMacroPlugin> &macros) const override;
+
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 

--- a/include/swift/DependencyScan/DependencyScanImpl.h
+++ b/include/swift/DependencyScan/DependencyScanImpl.h
@@ -167,6 +167,9 @@ typedef struct {
   /// A flag that indicates this dependency is associated with a static archive
   bool is_static;
 
+  /// Macro dependecies.
+  swiftscan_macro_dependency_set_t *macro_dependencies;
+
   /// ModuleCacheKey
   swiftscan_string_ref_t module_cache_key;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ModuleDependencies.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -190,6 +191,9 @@ protected:
                                         StringRef packageName,
                                         llvm::vfs::FileSystem *fileSystem,
                                         PathObfuscator &recoverer);
+
+  std::optional<MacroPluginDependency>
+  resolveMacroPlugin(const ExternalMacroPlugin &macro, StringRef packageName);
 
 public:
   virtual ~SerializedModuleLoaderBase();
@@ -513,6 +517,9 @@ public:
   virtual void
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                      ModuleDecl::ImportFilter filter) const override;
+
+  virtual void getExternalMacros(
+      SmallVectorImpl<ExternalMacroPlugin> &macros) const override;
 
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -30,6 +31,7 @@
 #include "swift/AST/ImportCache.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
+#include "swift/AST/MacroDefinition.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -1614,6 +1616,11 @@ void ModuleDecl::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
   FORWARD(getImportedModules, (modules, filter));
 }
 
+void ModuleDecl::getExternalMacros(
+    SmallVectorImpl<ExternalMacroPlugin> &macros) const {
+  FORWARD(getExternalMacros, (macros));
+}
+
 void ModuleDecl::getImplicitImportsForModuleInterface(
     SmallVectorImpl<ImportedModule> &imports) const {
   FORWARD(getImplicitImportsForModuleInterface, (imports));
@@ -1702,6 +1709,29 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
 
     if (filter.contains(requiredFilter))
       modules.push_back(desc.module);
+  }
+}
+
+void SourceFile::getExternalMacros(
+    SmallVectorImpl<ExternalMacroPlugin> &macros) const {
+  for (auto *D : getTopLevelDecls()) {
+    auto macroDecl = dyn_cast<MacroDecl>(D);
+    if (!macroDecl)
+      continue;
+
+    auto macroDef = macroDecl->getDefinition();
+    if (macroDef.kind != MacroDefinition::Kind::External)
+      continue;
+
+    auto formalAccess = macroDecl->getFormalAccess();
+    ExternalMacroPlugin::Access access = ExternalMacroPlugin::Access::Internal;
+    if (formalAccess >= AccessLevel::Public)
+      access = ExternalMacroPlugin::Access::Public;
+    else if (formalAccess >= AccessLevel::Package)
+      access = ExternalMacroPlugin::Access::Package;
+
+    auto external = macroDef.getExternalMacro();
+    macros.push_back({external.moduleName.str().str(), access});
   }
 }
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/MacroDefinition.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Frontend/Frontend.h"
@@ -103,33 +104,6 @@ ModuleDependencyInfo::getAsPlaceholderDependencyModule() const {
 void ModuleDependencyInfo::addTestableImport(ImportPath::Module module) {
   assert(getAsSwiftSourceModule() && "Expected source module for addTestableImport.");
   dyn_cast<SwiftSourceModuleDependenciesStorage>(storage.get())->addTestableImport(module);
-}
-
-void ModuleDependencyInfo::addMacroDependency(StringRef macroModuleName,
-                                              StringRef libraryPath,
-                                              StringRef executablePath) {
-  if (auto swiftSourceStorage =
-          dyn_cast<SwiftSourceModuleDependenciesStorage>(storage.get()))
-    swiftSourceStorage->addMacroDependency(macroModuleName, libraryPath,
-                                           executablePath);
-  else if (auto swiftInterfaceStorage =
-               dyn_cast<SwiftInterfaceModuleDependenciesStorage>(storage.get()))
-    swiftInterfaceStorage->addMacroDependency(macroModuleName, libraryPath,
-                                              executablePath);
-  else
-    llvm_unreachable("Unexpected dependency kind");
-}
-
-bool ModuleDependencyInfo::hasMacroDependencies() const {
-  if (auto sourceModule =
-          dyn_cast<SwiftSourceModuleDependenciesStorage>(storage.get()))
-    return !sourceModule->textualModuleDetails.macroDependencies.empty();
-
-  if (auto interfaceModule =
-          dyn_cast<SwiftInterfaceModuleDependenciesStorage>(storage.get()))
-    return !interfaceModule->textualModuleDetails.macroDependencies.empty();
-
-  llvm_unreachable("Unexpected dependency kind");
 }
 
 bool ModuleDependencyInfo::isTestableImport(StringRef moduleName) const {

--- a/lib/DependencyScan/DependencyScanJSON.cpp
+++ b/lib/DependencyScan/DependencyScanJSON.cpp
@@ -601,6 +601,8 @@ void writeJSON(llvm::raw_ostream &out,
                           /*trailingComma=*/true);
       }
 
+      writeMacroDependencies(out, swiftBinaryDeps->macro_dependencies, 5,
+                             /*trailingComma=*/true);
       writeJSONSingleField(out, "isFramework", swiftBinaryDeps->is_framework,
                            5, /*trailingComma=*/false);
     } else {

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/AST/ModuleLoader.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
@@ -180,6 +181,10 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       workerCompilerInvocation->getSymbolGraphOptions(),
                       workerCompilerInvocation->getCASOptions(),
                       ScanASTContext.SourceMgr, Diagnostics));
+  auto loader = std::make_unique<PluginLoader>(
+      *workerASTContext, /*DepTracker=*/nullptr,
+      workerCompilerInvocation->getFrontendOptions().DisableSandbox);
+  workerASTContext->setPluginLoader(std::move(loader));
 
   // Configure the interface scanning AST delegate.
   auto ClangModuleCachePath = getModuleCachePathFromClang(

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -265,6 +265,19 @@ static llvm::Error resolveExplicitModuleInputs(
 
   std::vector<std::string> commandLine = resolvingDepInfo.getCommandline();
   auto dependencyInfoCopy = resolvingDepInfo;
+  auto &directDeps = resolvingDepInfo.getDirectModuleDependencies();
+
+  // Helper to the macro dependencies from direct module dependencies.
+  auto addMacroDependencies = [&](ModuleDependencyID moduleID,
+                                  const ModuleDependencyInfo &dep) {
+    if (llvm::find(directDeps, moduleID) == directDeps.end())
+      return;
+
+    for (auto &entry: dep.getMacroDependencies())
+      dependencyInfoCopy.addMacroDependency(
+          entry.first, entry.second.LibraryPath, entry.second.ExecutablePath);
+  };
+
   for (const auto &depModuleID : dependencies) {
     const auto &depInfo = cache.findKnownDependency(depModuleID);
     switch (depModuleID.Kind) {
@@ -276,6 +289,7 @@ static llvm::Error resolveExplicitModuleInputs(
                        : interfaceDepDetails->moduleCacheKey;
       commandLine.push_back("-swift-module-file=" + depModuleID.ModuleName + "=" +
                             path);
+      addMacroDependencies(depModuleID, depInfo);
     } break;
     case swift::ModuleDependencyKind::SwiftBinary: {
       auto binaryDepDetails = depInfo.getAsSwiftBinaryModule();
@@ -299,6 +313,7 @@ static llvm::Error resolveExplicitModuleInputs(
             "-fmodule-map-file=" +
             remapPath(bridgingHeaderDepModuleDetails->moduleMapFile));
       }
+      addMacroDependencies(depModuleID, depInfo);
     } break;
     case swift::ModuleDependencyKind::SwiftPlaceholder: {
       auto placeholderDetails = depInfo.getAsPlaceholderDependencyModule();
@@ -364,7 +379,7 @@ static llvm::Error resolveExplicitModuleInputs(
       llvm::for_each(
           sourceDep->auxiliaryFiles,
           [&tracker](const std::string &file) { tracker->trackFile(file); });
-      llvm::for_each(sourceDep->textualModuleDetails.macroDependencies,
+      llvm::for_each(sourceDep->macroDependencies,
                      [&tracker](const auto &entry) {
                        tracker->trackFile(entry.second.LibraryPath);
                      });
@@ -382,7 +397,7 @@ static llvm::Error resolveExplicitModuleInputs(
       llvm::for_each(
           textualDep->auxiliaryFiles,
           [&tracker](const std::string &file) { tracker->trackFile(file); });
-      llvm::for_each(textualDep->textualModuleDetails.macroDependencies,
+      llvm::for_each(textualDep->macroDependencies,
                      [&tracker](const auto &entry) {
                        tracker->trackFile(entry.second.LibraryPath);
                      });
@@ -402,7 +417,7 @@ static llvm::Error resolveExplicitModuleInputs(
 
       // If there are no external macro dependencies, drop all plugin search
       // paths.
-      if (!resolvingDepInfo.hasMacroDependencies())
+      if (dependencyInfoCopy.getMacroDependencies().empty())
         removeMacroSearchPaths(newCommandLine);
 
       // Update with casfs option.
@@ -726,7 +741,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
                              .CASBridgingHeaderIncludeTreeRootID.c_str()),
             create_clone(swiftTextualDeps->moduleCacheKey.c_str()),
             createMacroDependencySet(
-                swiftTextualDeps->textualModuleDetails.macroDependencies),
+                swiftTextualDeps->macroDependencies),
             create_clone(swiftTextualDeps->userModuleVersion.c_str())};
       } else if (swiftSourceDeps) {
         swiftscan_string_ref_t moduleInterfacePath = create_null();
@@ -764,7 +779,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
                              .CASBridgingHeaderIncludeTreeRootID.c_str()),
             /*CacheKey*/ create_clone(""),
             createMacroDependencySet(
-                swiftSourceDeps->textualModuleDetails.macroDependencies),
+                swiftSourceDeps->macroDependencies),
             /*userModuleVersion*/ create_clone("")};
       } else if (swiftPlaceholderDeps) {
         details->kind = SWIFTSCAN_DEPENDENCY_INFO_SWIFT_PLACEHOLDER;
@@ -788,6 +803,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
             create_set(swiftBinaryDeps->headerSourceFiles),
             swiftBinaryDeps->isFramework,
             swiftBinaryDeps->isStatic,
+            createMacroDependencySet(swiftBinaryDeps->macroDependencies),
             create_clone(swiftBinaryDeps->moduleCacheKey.c_str()),
             create_clone(swiftBinaryDeps->userModuleVersion.c_str())};
       } else {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -629,6 +629,7 @@ static swiftscan_macro_dependency_set_t *createMacroDependencySet(
         create_clone(entry.second.LibraryPath.c_str());
     set->macro_dependencies[SI]->executablePath =
         create_clone(entry.second.ExecutablePath.c_str());
+    ++ SI;
   }
   return set;
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -115,6 +115,8 @@ ModuleFile::ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core)
     Dependencies.emplace_back(coreDep);
   }
 
+  MacroModuleNames = core->MacroModuleNames;
+
   // `ModuleFileSharedCore` has immutable data, we copy these into `ModuleFile`
   // so we can mutate the arrays and replace the offsets with AST object
   // pointers as we lazily deserialize them.
@@ -531,6 +533,11 @@ void ModuleFile::getImportedModules(SmallVectorImpl<ImportedModule> &results,
     assert(dep.isLoaded());
     results.push_back(*(dep.Import));
   }
+}
+
+void ModuleFile::getExternalMacros(
+    SmallVectorImpl<ExternalMacroPlugin> &macros) {
+  macros = MacroModuleNames;
 }
 
 void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -127,6 +127,9 @@ private:
   /// All modules this module depends on.
   SmallVector<Dependency, 8> Dependencies;
 
+  /// External macro modules.
+  SmallVector<ExternalMacroPlugin, 4> MacroModuleNames;
+
 public:
   template <typename T>
   class Serialized {
@@ -783,6 +786,8 @@ public:
   /// Adds any imported modules to the given vector.
   void getImportedModules(SmallVectorImpl<ImportedModule> &results,
                           ModuleDecl::ImportFilter filter);
+
+  void getExternalMacros(SmallVectorImpl<ExternalMacroPlugin> &macros);
 
   void getImportDecls(SmallVectorImpl<Decl *> &Results);
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -184,6 +184,9 @@ private:
   /// modules.
   std::vector<serialization::SearchPath> SearchPaths;
 
+  /// The external macro plugins from the macro definition inside the module.
+  SmallVector<ExternalMacroPlugin, 4> MacroModuleNames;
+
   /// Info for the (lone) imported header for this module.
   struct {
     off_t fileSize;
@@ -632,6 +635,11 @@ public:
 
   llvm::VersionTuple getUserModuleVersion() const {
     return UserModuleVersion;
+  }
+
+  /// Get external macro names.
+  ArrayRef<ExternalMacroPlugin> getExternalMacros() const {
+    return MacroModuleNames;
   }
 
   /// If the module-defining `.swiftinterface` file is an SDK-relative path,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 890; // @lifetime attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 891; // external macro
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1077,6 +1077,7 @@ namespace input_block {
     DEPENDENCY_DIRECTORY,
     MODULE_INTERFACE_PATH,
     IMPORTED_MODULE_SPIS,
+    EXTERNAL_MACRO,
   };
 
   using ImportedModuleLayout = BCRecordLayout<
@@ -1092,6 +1093,12 @@ namespace input_block {
   using ImportedModuleLayoutSPI = BCRecordLayout<
     IMPORTED_MODULE_SPIS,
     BCBlob // SPI names, separated by \0s
+  >;
+
+  using ExternalMacroLayout = BCRecordLayout<
+    EXTERNAL_MACRO,
+    ImportControlField, // import kind
+    BCBlob // ModuleName, Library Path, Executable Path, separated by \0s
   >;
 
   using LinkLibraryLayout = BCRecordLayout<

--- a/test/Serialization/external_macros.swift
+++ b/test/Serialization/external_macros.swift
@@ -1,0 +1,73 @@
+// REQUIRES: swift_swift_parser
+
+/// Test loading dependencies that has macros.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build macros.
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroOne) -module-name=MacroOne %t/macro-1.swift
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroTwo) -module-name=MacroTwo %t/macro-2.swift
+
+// RUN: %target-swift-frontend -emit-module %t/test.swift -module-name Test -o %t/Test.swiftmodule \
+// RUN:   -swift-version 5 -external-plugin-path %t#%swift-plugin-server
+// RUN: llvm-bcanalyzer -dump %t/Test.swiftmodule | %FileCheck %s
+
+// CHECK-COUNT-1: <EXTERNAL_MACRO abbrevid=13 op0=4/> blob data = 'MacroOne'
+// CHECK-COUNT-1: <EXTERNAL_MACRO abbrevid=13 op0=4/> blob data = 'MacroTwo'
+
+// RUN: %target-swift-frontend -emit-module %t/test2.swift -module-name Test2 -o %t/Test2.swiftmodule \
+// RUN:   -swift-version 5 -external-plugin-path %t#%swift-plugin-server -package-name Test
+// RUN: llvm-bcanalyzer -dump %t/Test2.swiftmodule | %FileCheck %s --check-prefix CHECK2
+
+// CHECK2-COUNT-1: <EXTERNAL_MACRO abbrevid=13 op0=4/> blob data = 'MacroOne'
+// CHECK2-COUNT-1: <EXTERNAL_MACRO abbrevid=13 op0=3/> blob data = 'MacroTwo'
+
+//--- macro-1.swift
+import SwiftSyntax
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+
+public struct AssertMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.arguments.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "assert(\(argument))"
+  }
+}
+
+//--- macro-2.swift
+import SwiftSyntax
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.arguments.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "(\(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+}
+
+//--- test.swift
+import Swift
+@freestanding(expression) public macro assert(_: Bool) = #externalMacro(module: "MacroOne", type: "AssertMacro")
+@freestanding(expression) public macro assert_2(_: Bool) = #externalMacro(module: "MacroOne", type: "AssertMacro")
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroTwo", type: "StringifyMacro")
+@freestanding(expression) public macro stringify_2<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroTwo", type: "StringifyMacro")
+
+//--- test2.swift
+import Swift
+@freestanding(expression) public macro assert(_: Bool) = #externalMacro(module: "MacroOne", type: "AssertMacro")
+@freestanding(expression) package macro assertPackage(_: Bool) = #externalMacro(module: "MacroOne", type: "AssertMacro")
+@freestanding(expression) macro assertInternal(_: Bool) = #externalMacro(module: "MacroOne", type: "AssertMacro")
+
+@freestanding(expression) macro stringifyPackage<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroTwo", type: "StringifyMacro")
+@freestanding(expression) package macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroTwo", type: "StringifyMacro")


### PR DESCRIPTION
Add function to handle all macro dependencies kinds in the scanner, including taking care of the macro definitions in the module interface for its client to use. The change involves:
  * Encode the macro definition inside the binary module
  * Resolve macro modules in the dependencies scanners, including those
    declared inside the dependency modules.
  * Propagate the macro defined from the direct dependencies to track
    all the potentially available modules inside a module compilation.
