### PR TITLE
[cmake] Add missing dependency between component and its targets

### DIFF
--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -55,3 +55,4 @@ swift_install_in_component(TARGETS ${compiler_swiftsyntax_libs}
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   RUNTIME DESTINATION "bin" COMPONENT compiler-swift-syntax-lib)
+add_dependencies(compiler-swift-syntax-lib ${compiler_swiftsyntax_libs})


### PR DESCRIPTION
`swift_install_in_component` does not create a dependency between its `TARGETS` and the `COMPONENT`, so one has to be created manually. The missing dependency might cause invocations to CMake/Ninja for the `install-*` targets to not build the required files before the installation is performed. Because the normal `build-script` builds the `all` target, this kind of missing dependencies like this are common.

This bit of code appeared in #76497 some days ago.
