### PR TITLE
Revert "CI: Include stdlib build for Wasm in the Linux buildbot"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -870,9 +870,6 @@ build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 build-embedded-stdlib-cross-compiling
 
-wasmkit
-build-wasm-stdlib
-
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
 


### PR DESCRIPTION
Reverts swiftlang/swift#72010, which causes a 1 hour regression in Linux build times. This is significantly higher than the original March numbers (~15 minutes). We should investigate where the extra time is coming from - possibly from the foundation and testing additions?