### PR TITLE
Option to emit mangled names for public symbols into the .swiftinterface

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -217,9 +217,6 @@ public:
                                    bool isStatic,
                                    SymbolKind SKind);
 
-  std::string mangleGlobalGetterEntity(const ValueDecl *decl,
-                                       SymbolKind SKind = SymbolKind::Default);
-
   std::string mangleDefaultArgumentEntity(const DeclContext *func,
                                           unsigned index,
                                           SymbolKind SKind = SymbolKind::Default);

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -520,6 +520,10 @@ struct PrintOptions {
   /// with types sharing a name with a module.
   bool AliasModuleNames = false;
 
+  /// Print some ABI details for public symbols as comments that can be
+  /// parsed by another tool.
+  bool PrintABIComments = false;
+
   /// Name of the modules that have been aliased in AliasModuleNames mode.
   /// Ideally we would use something other than a string to identify a module,
   /// but since one alias can apply to more than one module, strings happen
@@ -707,7 +711,8 @@ struct PrintOptions {
                                               bool useExportedModuleNames,
                                               bool aliasModuleNames,
                                               llvm::SmallSet<StringRef, 4>
-                                                *aliasModuleNamesTargets
+                                                *aliasModuleNamesTargets,
+                                              bool abiComments
                                               );
 
   /// Retrieve the set of options suitable for "Generated Interfaces", which

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -42,6 +42,10 @@ struct ModuleInterfaceOptions {
   /// [TODO: Clang-type-plumbing] This check should go away.
   bool PrintFullConvention = false;
 
+  /// Print some ABI details for public symbols as comments that can be
+  /// parsed by another tool.
+  bool ABIComments = false;
+
   struct InterfaceFlags {
     /// Copy of all the command-line flags passed at .swiftinterface
     /// generation time, re-applied to CompilerInvocation when reading

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1049,6 +1049,9 @@ def disable_alias_module_names_in_module_interface :
   Flag<["-"], "disable-alias-module-names-in-module-interface">,
   HelpText<"When emitting a module interface, disable disambiguating modules "
            "using distinct alias names">;
+def abi_comments_in_module_interface :
+  Flag<["-"], "abi-comments-in-module-interface">,
+  HelpText<"When emitting a module interface, emit comments with ABI details">;
 
 def experimental_spi_imports :
   Flag<["-"], "experimental-spi-imports">,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -171,17 +171,6 @@ std::string ASTMangler::mangleAccessorEntity(AccessorKind kind,
   return finalize();
 }
 
-std::string ASTMangler::mangleGlobalGetterEntity(const ValueDecl *decl,
-                                                 SymbolKind SKind) {
-  assert(isa<VarDecl>(decl) && "Only variables can have global getters");
-  llvm::SaveAndRestore X(AllowInverses, inversesAllowed(decl));
-  beginMangling();
-  BaseEntitySignature base(decl);
-  appendEntity(decl, base, "vG", /*isStatic*/false);
-  appendSymbolKind(SKind);
-  return finalize();
-}
-
 std::string ASTMangler::mangleDefaultArgumentEntity(const DeclContext *func,
                                                     unsigned index,
                                                     SymbolKind SKind) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -525,6 +525,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_debug_emit_invalid_swiftinterface_syntax);
   Opts.PrintMissingImports =
     !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
+  Opts.ABIComments = Args.hasArg(OPT_abi_comments_in_module_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -914,7 +914,7 @@ bool swift::emitSwiftInterface(raw_ostream &out,
       M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention,
       Opts.InterfaceContentMode,
       useExportedModuleNames,
-      Opts.AliasModuleNames, &aliasModuleNamesTargets);
+      Opts.AliasModuleNames, &aliasModuleNamesTargets, Opts.ABIComments);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;

--- a/test/ModuleInterface/abi-comments.swift
+++ b/test/ModuleInterface/abi-comments.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/ABIComments.swiftinterface -module-name ABIComments -abi-comments-in-module-interface %s
+
+// RUN: %FileCheck %s < %t/ABIComments.swiftinterface
+
+// CHECK: // MANGLED NAME: $s11ABIComments11intToStringySSSiF
+// CHECK-NEXT: public func intToString(_ value: Swift.Int) -> Swift.String
+public func intToString(_ value: Int) -> String { "\(value)" }
+
+// CHECK: // MANGLED NAME: $s11ABIComments8MyStructVMa
+// CHECK-NEXT: public struct MyStruct {
+public struct MyStruct {
+  // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV6methodSiyF
+  // CHECK-NEXT: public func method() -> Swift.Int
+  public func method() -> Int { 5 }
+}


### PR DESCRIPTION
When the frontend option `-abi-comments-in-module-interface` is provided during interface printing, the printed interface will contain additional comments that provide the mangled names for public symbols.

This is an experiment in seeing how much information we can meaningfully extract from a printed Swift interface for the purpose of bridging with other languages.