### PR TITLE
[Embedded] Enable RangeSet for embedded targets

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -129,8 +129,8 @@ split_embedded_sources(
   EMBEDDED RandomAccessCollection.swift
   EMBEDDED Range.swift
   EMBEDDED RangeReplaceableCollection.swift
-    NORMAL RangeSet.swift
-    NORMAL RangeSetRanges.swift
+  EMBEDDED RangeSet.swift
+  EMBEDDED RangeSetRanges.swift
     NORMAL ReflectionMirror.swift
   EMBEDDED Repeat.swift
     NORMAL REPL.swift

--- a/stdlib/public/core/RangeSet.swift
+++ b/stdlib/public/core/RangeSet.swift
@@ -398,6 +398,7 @@ extension RangeSet {
 }
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension RangeSet: CustomStringConvertible {
   public var description: String {
     return _ranges.description

--- a/stdlib/public/core/RangeSetRanges.swift
+++ b/stdlib/public/core/RangeSetRanges.swift
@@ -420,6 +420,7 @@ extension RangeSet.Ranges: Hashable where Bound: Hashable {
 extension RangeSet.Ranges: Sendable where Bound: Sendable {}
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension RangeSet.Ranges: CustomStringConvertible {
   public var description: String {
     _makeCollectionDescription()


### PR DESCRIPTION
This enables `RangeSet` to be used in embedded targets. Modulo the description.