### PR TITLE
[concurrency] UnspecifiedMeansMainActorIsolated tests as require asserts

### DIFF
--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -swift-version 6 -emit-silgen -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s | %FileCheck %s
 // RUN: %target-swift-frontend -swift-version 6 -emit-sil -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s -verify
 
+// REQUIRES: asserts
+
 // READ THIS! This test is meant to FileCheck the specific isolation when
 // UnspecifiedMeansMainActorIsolated is enabled. Please do not put other types
 // of tests in here.

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -swift-version 6 -emit-sil -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s -verify
 
+// REQUIRES: asserts
+
 // READ THIS! This test is meant to check the specific isolation when
 // UnspecifiedMeansMainActorIsolated is enabled in combination with validating
 // behavior around explicitly non-Sendable types that trigger type checker


### PR DESCRIPTION
Two test using an experimental feature UnspecifiedMeansMainActorIsolated are not marked as `REQUIRES: asserts` and are failing when asserts are disabled.

Introduced in #76558
