### PR TITLE
Use xpc_dictionary_create_empty to create empty dictionaries

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
@@ -130,10 +130,10 @@ sourcekitd_response_t sourcekitd_send_request_sync(sourcekitd_object_t req) {
   }
 
   xpc_connection_t Conn = getGlobalConnection();
-  xpc_object_t contents = xpc_array_create(nullptr, 0);
+  xpc_object_t contents = xpc_array_create_empty();
   xpc_array_append_value(contents, req);
 
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr,  0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(msg, xpc::KeyMsg, contents);
   xpc_release(contents);
 
@@ -179,10 +179,10 @@ void sourcekitd_send_request(sourcekitd_object_t req,
   }
 
   xpc_connection_t Conn = getGlobalConnection();
-  xpc_object_t contents = xpc_array_create(nullptr, 0);
+  xpc_object_t contents = xpc_array_create_empty();
   xpc_array_append_value(contents, req);
 
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr,  0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(msg, xpc::KeyMsg, contents);
   if (request_handle) {
     xpc_dictionary_set_uint64(msg, xpc::KeyCancelToken,
@@ -218,7 +218,7 @@ void sourcekitd_send_request(sourcekitd_object_t req,
 
 void sourcekitd_cancel_request(sourcekitd_request_handle_t handle) {
   xpc_connection_t conn = getGlobalConnection();
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_uint64(msg, xpc::KeyCancelRequest,
                             reinterpret_cast<uint64_t>(handle));
 
@@ -229,7 +229,7 @@ void sourcekitd_cancel_request(sourcekitd_request_handle_t handle) {
 
 void sourcekitd_request_handle_dispose(sourcekitd_request_handle_t handle) {
   xpc_connection_t conn = getGlobalConnection();
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_uint64(msg, xpc::KeyDisposeRequestHandle,
                             reinterpret_cast<uint64_t>(handle));
 
@@ -367,7 +367,7 @@ static xpc_connection_t getGlobalConnection() {
 static void pingService(xpc_connection_t ping_conn) {
   LOG_WARN_FUNC("pinging service");
 
-  xpc_object_t ping_msg = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_object_t ping_msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_bool(ping_msg, "ping", true);
 
   dispatch_queue_t queue

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -41,12 +41,12 @@ static void postNotification(sourcekitd_response_t Notification) {
     goto done;
 
   {
-    xpc_object_t contents = xpc_array_create(nullptr, 0);
+    xpc_object_t contents = xpc_array_create_empty();
     xpc_array_set_uint64(contents, XPC_ARRAY_APPEND,
                          (uint64_t)xpc::Message::Notification);
     xpc_array_set_value(contents, XPC_ARRAY_APPEND, Notification);
 
-    xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr, 0);
+    xpc_object_t msg = xpc_dictionary_create_empty();
     xpc_dictionary_set_value(msg, xpc::KeyInternalMsg, contents);
     xpc_release(contents);
 
@@ -85,12 +85,12 @@ static sourcekitd_uid_t xpcSKDUIDFromUIdent(UIdent UID) {
   if (!peer)
     return nullptr;
 
-  xpc_object_t contents = xpc_array_create(nullptr, 0);
+  xpc_object_t contents = xpc_array_create_empty();
   xpc_array_set_uint64(contents, XPC_ARRAY_APPEND,
                        (uint64_t)xpc::Message::UIDSynchronization);
   xpc_array_set_string(contents, XPC_ARRAY_APPEND, UID.c_str());
 
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr,  0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(msg, xpc::KeyInternalMsg, contents);
   xpc_release(contents);
 
@@ -122,12 +122,12 @@ static UIdent xpcUIdentFromSKDUID(sourcekitd_uid_t SKDUID) {
   if (!Peer)
     return UIdent();
 
-  xpc_object_t contents = xpc_array_create(nullptr, 0);
+  xpc_object_t contents = xpc_array_create_empty();
   xpc_array_set_uint64(contents, XPC_ARRAY_APPEND,
                        (uint64_t)xpc::Message::UIDSynchronization);
   xpc_array_set_uint64(contents, XPC_ARRAY_APPEND, uintptr_t(SKDUID));
 
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr,  0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(msg, xpc::KeyInternalMsg, contents);
   xpc_release(contents);
 
@@ -324,11 +324,11 @@ static void sourcekitdServer_peer_event_handler(xpc_connection_t peer,
 }
 
 static void getInitializationInfo(xpc_connection_t peer) {
-  xpc_object_t contents = xpc_array_create(nullptr, 0);
+  xpc_object_t contents = xpc_array_create_empty();
   xpc_array_set_uint64(contents, XPC_ARRAY_APPEND,
                        (uint64_t)xpc::Message::Initialization);
 
-  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr,  0);
+  xpc_object_t msg = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(msg, xpc::KeyInternalMsg, contents);
   xpc_release(contents);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -166,7 +166,7 @@ void sourcekitd::printRequestObject(sourcekitd_object_t Obj, raw_ostream &OS) {
 //===----------------------------------------------------------------------===//
 
 ResponseBuilder::ResponseBuilder() {
-  Impl = xpc_dictionary_create(nullptr, nullptr, 0);
+  Impl = xpc_dictionary_create_empty();
 }
 
 ResponseBuilder::~ResponseBuilder() {
@@ -220,7 +220,7 @@ void ResponseBuilder::Dictionary::set(UIdent Key, int64_t val) {
 void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
                                       ArrayRef<StringRef> Strs) {
   llvm::SmallString<128> Buf;
-  xpc_object_t arr = xpc_array_create(nullptr, 0);
+  xpc_object_t arr = xpc_array_create_empty();
   for (auto Str : Strs) {
     Buf = Str;
     xpc_array_set_string(arr, XPC_ARRAY_APPEND, Buf.c_str());
@@ -231,7 +231,7 @@ void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
 
 void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
                                       ArrayRef<std::string> Strs) {
-  xpc_object_t arr = xpc_array_create(nullptr, 0);
+  xpc_object_t arr = xpc_array_create_empty();
   for (auto Str : Strs) {
     xpc_array_set_string(arr, XPC_ARRAY_APPEND, Str.c_str());
   }
@@ -241,7 +241,7 @@ void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
 
 void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
                                       ArrayRef<SourceKit::UIdent> UIDs) {
-  xpc_object_t arr = xpc_array_create(nullptr, 0);
+  xpc_object_t arr = xpc_array_create_empty();
   for (auto UID : UIDs) {
     xpc_array_set_uint64(arr, XPC_ARRAY_APPEND, uintptr_t(SKDUIDFromUIdent(UID)));
   }
@@ -255,7 +255,7 @@ void ResponseBuilder::Dictionary::setBool(UIdent Key, bool val) {
 
 ResponseBuilder::Array
 ResponseBuilder::Dictionary::setArray(UIdent Key) {
-  xpc_object_t arr = xpc_array_create(nullptr, 0);
+  xpc_object_t arr = xpc_array_create_empty();
   xpc_dictionary_set_value(Impl, Key.c_str(), arr);
   xpc_release(arr);
   return Array(arr);
@@ -263,7 +263,7 @@ ResponseBuilder::Dictionary::setArray(UIdent Key) {
 
 ResponseBuilder::Dictionary
 ResponseBuilder::Dictionary::setDictionary(UIdent Key) {
-  xpc_object_t dict = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_object_t dict = xpc_dictionary_create_empty();
   xpc_dictionary_set_value(Impl, Key.c_str(), dict);
   xpc_release(dict);
   return Dictionary(dict);
@@ -278,7 +278,7 @@ void ResponseBuilder::Dictionary::setCustomBuffer(
 }
 
 ResponseBuilder::Dictionary ResponseBuilder::Array::appendDictionary() {
-  xpc_object_t dict = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_object_t dict = xpc_dictionary_create_empty();
   xpc_array_append_value(Impl, dict);
   xpc_release(dict);
   return Dictionary(dict);


### PR DESCRIPTION
xpc_dictionary_create has Nonnull annotated for some of its parameters. We should just do xpc_dictionary_create_empty to avoid warnings and be safe.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
