### PR TITLE
Do not prefix relative SDK paths twice

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1798,7 +1798,7 @@ bool ModuleFileSharedCore::hasSourceInfo() const {
 std::string ModuleFileSharedCore::resolveModuleDefiningFilePath(const StringRef SDKPath) const {
   if (!ModuleInterfacePath.empty()) {
     std::string interfacePath = ModuleInterfacePath.str();
-    if (llvm::sys::path::is_relative(interfacePath)) {
+    if (llvm::sys::path::is_relative(interfacePath) && !ModuleInterfacePath.starts_with(SDKPath)) {
       SmallString<128> absoluteInterfacePath(SDKPath);
       llvm::sys::path::append(absoluteInterfacePath, interfacePath);
       return absoluteInterfacePath.str().str();

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target arm64-apple-macosx15.0 -module-name OtherModule -O
+
+import Swift
+
+public struct OtherStruct {
+    var x : Int
+    public init()
+}

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -enable-experimental-concise-pound-file -target-min-inlining-version min -module-name Swift
+
+public struct Int {}

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/SwiftOnoneSupport.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/SwiftOnoneSupport.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-link-name swiftSwiftOnoneSupport -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -module-name SwiftOnoneSupport
+
+import Swift
+
+public let x: Swift.Int

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-link-name swift_Concurrency -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -module-name _Concurrency
+
+import Swift
+
+@frozen public enum Task {}
+
+public let x: Swift.Int

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_StringProcessing.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_StringProcessing.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-link-name swift_StringProcessing -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -module-name _StringProcessing
+
+import Swift
+
+public let x: Swift.Int

--- a/test/ModuleInterface/relative-sdk-path.swift
+++ b/test/ModuleInterface/relative-sdk-path.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t.relative_sdk_path)
+// RUN: %empty-directory(%t.mcp)
+
+// RUN: cp -R %S/Inputs/stdlib_rebuild %t.relative_sdk_path/
+// RUN: cd %t.relative_sdk_path
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk stdlib_rebuild -module-cache-path %t.mcp) -target arm64-apple-macosx15.0 -resource-dir /dev/null -o %t.relative_sdk_path -emit-object %s
+
+// REQUIRES: OS=macosx
+
+import OtherModule
+
+func fn(_: Int) {
+    let _ = OtherStruct()
+}


### PR DESCRIPTION
When using relative SDK paths, do not prefix the SDK path again in `resolveModuleDefiningFilePath`.