### PR TITLE
Add support for borrow lifetime dependence

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7958,9 +7958,15 @@ ERROR(lifetime_dependence_immortal_conflict_name, none,
 ERROR(lifetime_dependence_function_type, none,
       "lifetime dependencies on function types are not supported",
       ())
-
 ERROR(lifetime_dependence_immortal_alone, none,
       "cannot specify any other dependence source along with immortal", ())
+ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
+      "invalid lifetime dependence on a source of Escapable type, use borrow "
+      "dependence instead",
+      ())
+ERROR(lifetime_dependence_cannot_use_parsed_borrow_consuming, none,
+      "invalid use of borrow dependence with consuming ownership",
+      ())
 
 //===----------------------------------------------------------------------===//
 //                             MARK: Sending

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -230,6 +230,7 @@ getLifetimeDependenceKind(LifetimeEntry specifier, AbstractFunctionDecl *afd,
           loc, diag::lifetime_dependence_cannot_use_inferred_scoped_consuming);
       return std::nullopt;
     }
+    return lifetimeKind;
   }
 
   // For dependsOn type modifier, we check if we had a "scoped" modifier, if not

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -218,19 +218,26 @@ getLifetimeDependenceKind(LifetimeEntry specifier, AbstractFunctionDecl *afd,
   auto ownership = decl->getValueOwnership();
   auto type = decl->getTypeInContext();
 
-  // For @lifetime attribute, we determine lifetime dependence kind based on
-  // type.
+  // For @lifetime attribute, we check if we had a "borrow" modifier, if not
+  // we infer inherit dependence.
   if (afd->getAttrs().hasAttribute<LifetimeAttr>()) {
-    auto lifetimeKind = getLifetimeDependenceKindFromType(type);
-    bool isCompatible = isLifetimeDependenceCompatibleWithOwnership(
-        lifetimeKind, type, ownership, afd);
-    if (!isCompatible) {
-      assert(lifetimeKind == LifetimeDependenceKind::Scope);
-      diags.diagnose(
-          loc, diag::lifetime_dependence_cannot_use_inferred_scoped_consuming);
+    auto parsedLifetimeKind = specifier.getParsedLifetimeDependenceKind();
+    if (parsedLifetimeKind == ParsedLifetimeDependenceKind::Scope) {
+      bool isCompatible = isLifetimeDependenceCompatibleWithOwnership(
+          LifetimeDependenceKind::Scope, type, ownership, afd);
+      if (!isCompatible) {
+        diags.diagnose(
+            loc, diag::lifetime_dependence_cannot_use_parsed_borrow_consuming);
+        return std::nullopt;
+      }
+      return LifetimeDependenceKind::Scope;
+    }
+    if (type->isEscapable()) {
+      diags.diagnose(loc,
+                     diag::lifetime_dependence_invalid_inherit_escapable_type);
       return std::nullopt;
     }
-    return lifetimeKind;
+    return LifetimeDependenceKind::Inherit;
   }
 
   // For dependsOn type modifier, we check if we had a "scoped" modifier, if not

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2819,6 +2819,15 @@ ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
       diag::expected_rparen_after_lifetime_dependence, [&]() -> ParserStatus {
         ParserStatus listStatus;
         foundParamId = true;
+
+        auto lifetimeDependenceKind = ParsedLifetimeDependenceKind::Default;
+        if (Tok.isContextualKeyword("borrow") &&
+            peekToken().isAny(tok::identifier, tok::integer_literal,
+                              tok::kw_self)) {
+          lifetimeDependenceKind = ParsedLifetimeDependenceKind::Scope;
+          consumeToken();
+        }
+
         switch (Tok.getKind()) {
         case tok::identifier: {
           Identifier paramName;
@@ -2828,8 +2837,8 @@ ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
             lifetimeEntries.push_back(
                 LifetimeEntry::getImmortalLifetimeEntry(paramLoc));
           } else {
-            lifetimeEntries.push_back(
-                LifetimeEntry::getNamedLifetimeEntry(paramLoc, paramName));
+            lifetimeEntries.push_back(LifetimeEntry::getNamedLifetimeEntry(
+                paramLoc, paramName, lifetimeDependenceKind));
           }
           break;
         }
@@ -2842,14 +2851,14 @@ ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
             listStatus.setIsParseError();
             return listStatus;
           }
-          lifetimeEntries.push_back(
-              LifetimeEntry::getOrderedLifetimeEntry(paramLoc, paramNum));
+          lifetimeEntries.push_back(LifetimeEntry::getOrderedLifetimeEntry(
+              paramLoc, paramNum, lifetimeDependenceKind));
           break;
         }
         case tok::kw_self: {
           auto paramLoc = consumeToken(tok::kw_self);
-          lifetimeEntries.push_back(
-              LifetimeEntry::getSelfLifetimeEntry(paramLoc));
+          lifetimeEntries.push_back(LifetimeEntry::getSelfLifetimeEntry(
+              paramLoc, lifetimeDependenceKind));
           break;
         }
         default:

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -1,13 +1,21 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes 
 // REQUIRES: asserts
 
-struct NE : ~Escapable {
+struct E {}
 
-}
+struct NE : ~Escapable {}
 
 @lifetime(ne)
 func derive(_ ne: NE) -> NE {
   ne
+}
+
+@lifetime(borrow ne1, ne2)
+func derive(_ ne1: NE, _ ne2: NE) -> NE {
+  if (Int.random(in: 1..<100) < 50) {
+    return ne1
+  }
+  return ne2
 }
 
 @lifetime // expected-error{{expected '(' after lifetime dependence specifier}} 
@@ -20,3 +28,7 @@ func testMissingDependence(_ ne: NE) -> NE {
   ne
 }
 
+@lifetime(borrow borrow)
+func testNameConflict(_ borrow: E) -> NE {
+  NE()
+}

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -160,7 +160,7 @@ extension Span {
 
 extension ContiguousArray {
   public var view: Span<Element> {
-    @lifetime(self)
+    @lifetime(borrow self)
     borrowing _read {
       yield Span(
         baseAddress: _baseAddressIfContiguous!, count: count, dependsOn: self

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -28,7 +28,7 @@ func invalidDuplicateLifetimeDependence1(_ ne: borrowing NE) -> NE {
 
 class Klass {}
 
-@lifetime(x) // expected-error{{invalid use of lifetime dependence on an Escapable parameter with consuming ownership}}
+@lifetime(borrow x) // expected-error{{invalid use of borrow dependence with consuming ownership}}
 func invalidDependence(_ x: consuming Klass) -> NE {
   NE()
 }


### PR DESCRIPTION
Add support for `@lifetime(borrow source)` to represent lifetime dependence on an `Escapable` source.