### PR TITLE
[SILIR] Fix compiler crash when building a swift project

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2864,7 +2864,7 @@ public:
   /// Convenience function for calling TypeLowering.emitDestroy on the type
   /// lowering for the non-address value.
   void emitDestroyValueOperation(SILLocation Loc, SILValue v) {
-    ASSERT(!v->getType().isAddress());
+    assert(!v->getType().isAddress());
     if (F->hasOwnership() && v->getOwnershipKind() == OwnershipKind::None)
       return;
     auto &lowering = getTypeLowering(v->getType());


### PR DESCRIPTION
Use lowercase assert to fix a crash when building a swift project.

Resolves #76631 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
