### PR TITLE
[stdlib] Fix minor `TextOutputStreamable` issues

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -134,10 +134,14 @@ ${Availability(bits)}
 @_unavailableInEmbedded
 extension ${Self}: TextOutputStreamable {
   public func write<Target>(to target: inout Target) where Target: TextOutputStream {
-    var (buffer, length) = _float${bits}ToString(self, debug: true)
-    buffer.withBytes { (bufferPtr) in
-      let bufPtr = UnsafeBufferPointer(start: bufferPtr, count: length)
-      target._writeASCII(bufPtr)
+    if isNaN {
+      target.write("nan")
+    } else {
+      var (buffer, length) = _float${bits}ToString(self, debug: false)
+      buffer.withBytes { (bufferPtr) in
+        let bufPtr = UnsafeBufferPointer(start: bufferPtr, count: length)
+        target._writeASCII(bufPtr)
+      }
     }
   }
 }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -721,7 +721,8 @@ extension String {
   public init<Subject>(describing instance: Subject)
     where Subject: CustomStringConvertible & TextOutputStreamable
   {
-    self = instance.description
+    self.init()
+    instance.write(to: &self)
   }
 
   /// Creates a string with a detailed representation of the given value,

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -434,9 +434,27 @@ fileprivate func expectNaN<T>(_ expected: String, _ object: T,
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
-) where T: FloatingPoint & CustomDebugStringConvertible & CustomStringConvertible {
+) where T: FloatingPoint & CustomDebugStringConvertible &
+  LosslessStringConvertible & TextOutputStreamable
+{
   // Regular description always returns "nan"
   expectEqual("nan", object.description,
+    message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  expectEqual("nan", String(object),
+    message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+
+  // TextOutputStreamable always writes "nan"
+  var textOutputStream = ""
+  print(object, terminator: "", to: &textOutputStream)
+  expectEqual("nan", textOutputStream,
+    message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  expectEqual("nan", "\(object)",
+    message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  expectEqual("nan", String(describing: object),
     message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
 

--- a/test/stdlib/StringDescribing.swift
+++ b/test/stdlib/StringDescribing.swift
@@ -23,4 +23,13 @@ StringDescribingTestSuite.test("String(reflecting:) should include extra stuff i
   expectEqual(privateName.suffix(5), ").Foo")
 }
 
+StringDescribingTestSuite.test("String(describing:) for CustomStringConvertible & TextOutputStreamable types") {
+  expectEqual(String(describing: "abc" as String), "abc")
+  expectEqual(String(describing: "xyz" as Substring), "xyz")
+  expectEqual(String(describing: "a" as Character), "a")
+  expectEqual(String(describing: "z" as Unicode.Scalar), "z")
+  expectEqual(String(describing: -0.5 as Double), "-0.5")
+  expectEqual(String(describing: Double.nan), "nan")
+}
+
 runAllTests()


### PR DESCRIPTION
Update `FloatXX.write(to:)` and `String.init(describing:)` implementations.

See also: [equivalent property][1] and [related initializer][2].

[1]: <https://github.com/swiftlang/swift/blob/swift-6.0-RELEASE/stdlib/public/core/FloatingPointTypes.swift.gyb#L104-L114>
[2]: <https://github.com/swiftlang/swift/blob/swift-6.0-RELEASE/stdlib/public/core/Mirror.swift#L675-L678>

Closes #76618.
