### PR TITLE
AST: Re-enable ASTScope invariant check

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -682,7 +682,7 @@ void ASTScopeImpl::addChild(ASTScopeImpl *child, ASTContext &ctx) {
   child->parentAndWasExpanded.setPointer(this);
 
 #ifndef NDEBUG
-  // checkSourceRangeBeforeAddingChild(child, ctx);
+  checkSourceRangeBeforeAddingChild(child, ctx);
 #endif
 
   // If this is the first time we've added children, notify the ASTContext


### PR DESCRIPTION
Re-enables the check that children of ASTScope nodes are added in source range order. This seems to have been accidentally disabled permanently in https://github.com/swiftlang/swift/pull/63023.
