### PR TITLE
Remove Copyable requirement from RandomNumberGenerator protocol

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -109,11 +109,20 @@ public struct Bool: Sendable {
   ///   the new random value.
   /// - Returns: Either `true` or `false`, randomly chosen with equal
   ///   probability.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     using generator: inout T
   ) -> Bool {
-    return (generator.next() >> 17) & 1 == 0
+    generator.next() >> 17 & 1 == 0
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSb6random5usingSbxz_tSGRzlFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> Bool {
+    random(using: &generator)
   }
   
   /// Returns a random Boolean value.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -922,14 +922,23 @@ extension Collection {
   ///   the same sequence of elements each time you run your program, that
   ///   sequence may change when your program is compiled using a different
   ///   version of Swift.
-  @inlinable
-  public func randomElement<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public func randomElement<T: RandomNumberGenerator & ~Copyable>(
     using generator: inout T
   ) -> Element? {
     guard !isEmpty else { return nil }
     let random = Int.random(in: 0 ..< count, using: &generator)
     let idx = index(startIndex, offsetBy: random)
     return self[idx]
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSlsE13randomElement5using0B0QzSgqd__z_tSGRd__lF")
+  @usableFromInline
+  internal func __abi_randomElement<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> Element? {
+    randomElement(using: &generator)
   }
 
   /// Returns a random element of the collection.

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -546,13 +546,22 @@ extension Sequence {
   ///   same shuffled order each time you run your program, that sequence may
   ///   change when your program is compiled using a different version of
   ///   Swift.
-  @inlinable
-  public func shuffled<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public func shuffled<T: RandomNumberGenerator & ~Copyable>(
     using generator: inout T
   ) -> [Element] {
     var result = ContiguousArray(self)
     result.shuffle(using: &generator)
     return Array(result)
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSTsE8shuffled5usingSay7ElementQzGqd__z_tSGRd__lF")
+  @usableFromInline
+  internal func __abi_shuffled<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> [Element] {
+    shuffled(using: &generator)
   }
   
   /// Returns the elements of the sequence, shuffled.
@@ -598,8 +607,8 @@ extension MutableCollection where Self: RandomAccessCollection {
   ///   same shuffled order each time you run your program, that sequence may
   ///   change when your program is compiled using a different version of
   ///   Swift.
-  @inlinable
-  public mutating func shuffle<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public mutating func shuffle<T: RandomNumberGenerator & ~Copyable>(
     using generator: inout T
   ) {
     guard count > 1 else { return }
@@ -614,6 +623,15 @@ extension MutableCollection where Self: RandomAccessCollection {
       )
       formIndex(after: &currentIndex)
     }
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSMsSkRzrlE7shuffle5usingyqd__z_tSGRd__lF")
+  @usableFromInline
+  internal mutating func __abi_shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) {
+    shuffle(using: &generator)
   }
   
   /// Shuffles the collection in place.

--- a/stdlib/public/core/FloatingPointRandom.swift
+++ b/stdlib/public/core/FloatingPointRandom.swift
@@ -44,8 +44,8 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
   /// - Returns: A random value within the bounds of `range`.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: Range<Self>,
     using generator: inout T
   ) -> Self {
@@ -80,6 +80,16 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
       return Self.random(in: range, using: &generator)
     }
     return randFloat
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSBss17FixedWidthInteger14RawSignificandRpzrlE6random2in5usingxSnyxG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: Range<Self>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
 
   /// Returns a random value within the specified range.
@@ -144,8 +154,8 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
   /// - Returns: A random value within the bounds of `range`.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: ClosedRange<Self>,
     using generator: inout T
   ) -> Self {
@@ -181,6 +191,16 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
     let unitRandom = Self.init(rand) * (Self.ulpOfOne / 2)
     let randFloat = delta * unitRandom + range.lowerBound
     return randFloat
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSBss17FixedWidthInteger14RawSignificandRpzrlE6random2in5usingxSNyxG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: ClosedRange<Self>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a random value within the specified range.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2461,8 +2461,8 @@ extension FixedWidthInteger {
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
   /// - Returns: A random value within the bounds of `range`.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: Range<Self>,
     using generator: inout T
   ) -> Self {
@@ -2485,6 +2485,16 @@ extension FixedWidthInteger {
       Magnitude(truncatingIfNeeded: range.lowerBound) &+
       generator.next(upperBound: delta)
     )
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss17FixedWidthIntegerPsE6random2in5usingxSnyxG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: Range<Self>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a random value within the specified range.
@@ -2530,8 +2540,8 @@ extension FixedWidthInteger {
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
   /// - Returns: A random value within the bounds of `range`.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: ClosedRange<Self>,
     using generator: inout T
   ) -> Self {
@@ -2559,6 +2569,17 @@ extension FixedWidthInteger {
       generator.next(upperBound: delta)
     )
   }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss17FixedWidthIntegerPsE6random2in5usingxSNyxG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: ClosedRange<Self>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
+  }
+    
   
   /// Returns a random value within the specified range.
   ///
@@ -2955,8 +2976,8 @@ extension FixedWidthInteger {
 }
 
 extension FixedWidthInteger {
-  @inlinable
-  public static func _random<R: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func _random<R: RandomNumberGenerator & ~Copyable>(
     using generator: inout R
   ) -> Self {
     if bitWidth <= UInt64.bitWidth {
@@ -2972,6 +2993,15 @@ extension FixedWidthInteger {
       tmp += Self(truncatingIfNeeded: next) &<< (UInt64.bitWidth * i)
     }
     return tmp
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss17FixedWidthIntegerPsE7_random5usingxqd__z_tSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<R: RandomNumberGenerator>(
+    using generator: inout R
+  ) -> Self {
+    _random(using: &generator)
   }
 }
 

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -51,7 +51,7 @@ import SwiftShims
 ///
 /// Types that conform to `RandomNumberGenerator` should specifically document
 /// the thread safety and quality of the generator.
-public protocol RandomNumberGenerator {
+public protocol RandomNumberGenerator: ~Copyable {
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
   /// Use this method when you need random binary data to generate another
@@ -63,7 +63,7 @@ public protocol RandomNumberGenerator {
   mutating func next() -> UInt64
 }
 
-extension RandomNumberGenerator {
+extension RandomNumberGenerator where Self: ~Copyable {
   
   // An unavailable default implementation of next() prevents types that do
   // not implement the RandomNumberGenerator interface from conforming to the
@@ -83,7 +83,7 @@ extension RandomNumberGenerator {
   ///
   /// - Returns: A random value of `T`. Bits are randomly distributed so that
   ///   every value of `T` is equally likely to be returned.
-  @inlinable
+  @_alwaysEmitIntoClient
   public mutating func next<T: FixedWidthInteger & UnsignedInteger>() -> T {
     return T._random(using: &self)
   }
@@ -99,7 +99,7 @@ extension RandomNumberGenerator {
   ///   Must be non-zero.
   /// - Returns: A random value of `T` in the range `0..<upperBound`. Every
   ///   value in the range `0..<upperBound` is equally likely to be returned.
-  @inlinable
+  @_alwaysEmitIntoClient
   public mutating func next<T: FixedWidthInteger & UnsignedInteger>(
     upperBound: T
   ) -> T {
@@ -117,6 +117,24 @@ extension RandomNumberGenerator {
       }
     }
     return m.high
+  }
+}
+
+extension RandomNumberGenerator {
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSGsE4nextqd__ys17FixedWidthIntegerRd__SURd__lF")
+  @usableFromInline
+  internal mutating func __abi_next<T: FixedWidthInteger & UnsignedInteger>() -> T {
+    return T._random(using: &self)
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$sSGsE4next10upperBoundqd__qd___ts17FixedWidthIntegerRd__SURd__lF")
+  @usableFromInline
+  internal mutating func __abi_next<T: FixedWidthInteger & UnsignedInteger>(
+    upperBound: T
+  ) -> T {
+    next()
   }
 }
 

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -565,8 +565,8 @@ extension SIMD where Scalar: FixedWidthInteger {
   
   /// Returns a vector with random values from within the specified range in
   /// all lanes, using the given generator as a source for randomness.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: Range<Scalar>,
     using generator: inout T
   ) -> Self {
@@ -575,6 +575,16 @@ extension SIMD where Scalar: FixedWidthInteger {
       result[i] = Scalar.random(in: range, using: &generator)
     }
     return result
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss4SIMDPss17FixedWidthInteger6ScalarRpzrlE6random2in5usingxSnyAEG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: Range<Scalar>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a vector with random values from within the specified range in
@@ -587,8 +597,8 @@ extension SIMD where Scalar: FixedWidthInteger {
 
   /// Returns a vector with random values from within the specified range in
   /// all lanes, using the given generator as a source for randomness.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: ClosedRange<Scalar>,
     using generator: inout T
   ) -> Self {
@@ -597,6 +607,16 @@ extension SIMD where Scalar: FixedWidthInteger {
       result[i] = Scalar.random(in: range, using: &generator)
     }
     return result
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss4SIMDPss17FixedWidthInteger6ScalarRpzrlE6random2in5usingxSNyAEG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: ClosedRange<Scalar>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a vector with random values from within the specified range in
@@ -637,8 +657,8 @@ extension SIMD
 where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
   /// Returns a vector with random values from within the specified range in
   /// all lanes, using the given generator as a source for randomness.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: Range<Scalar>,
     using generator: inout T
   ) -> Self {
@@ -647,6 +667,16 @@ where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
       result[i] = Scalar.random(in: range, using: &generator)
     }
     return result
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss4SIMDPsSB6ScalarRpzs17FixedWidthIntegerAC_14RawSignificandSBRPzrlE6random2in5usingxSnyADG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: Range<Scalar>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a vector with random values from within the specified range in
@@ -659,8 +689,8 @@ where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
   
   /// Returns a vector with random values from within the specified range in
   /// all lanes, using the given generator as a source for randomness.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
     in range: ClosedRange<Scalar>,
     using generator: inout T
   ) -> Self {
@@ -669,6 +699,16 @@ where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
       result[i] = Scalar.random(in: range, using: &generator)
     }
     return result
+  }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss4SIMDPsSB6ScalarRpzs17FixedWidthIntegerAC_14RawSignificandSBRPzrlE6random2in5usingxSNyADG_qd__ztSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    in range: ClosedRange<Scalar>,
+    using generator: inout T
+  ) -> Self {
+    random(in: range, using: &generator)
   }
   
   /// Returns a vector with random values from within the specified range in
@@ -725,12 +765,24 @@ extension SIMDMask: Sendable where Storage: Sendable {}
 extension SIMDMask {
   /// Returns a vector mask with `true` or `false` randomly assigned in each
   /// lane, using the given generator as a source for randomness.
-  @inlinable
-  public static func random<T: RandomNumberGenerator>(using generator: inout T) -> SIMDMask {
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator & ~Copyable>(
+    using generator: inout T
+  ) -> SIMDMask {
     var result = SIMDMask()
     for i in result.indices { result[i] = Bool.random(using: &generator) }
     return result
   }
+  
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss8SIMDMaskV6random5usingAByxGqd__z_tSGRd__lFZ")
+  @usableFromInline
+  internal static func __abi_random<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> SIMDMask {
+    random(using: &generator)
+  }
+  
   
   /// Returns a vector mask with `true` or `false` randomly assigned in each
   /// lane.

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -262,7 +262,6 @@ Protocol OptionSet has added inherited protocol Copyable
 Protocol OptionSet has added inherited protocol Escapable
 Protocol RandomAccessCollection has added inherited protocol Copyable
 Protocol RandomAccessCollection has added inherited protocol Escapable
-Protocol RandomNumberGenerator has added inherited protocol Copyable
 Protocol RandomNumberGenerator has added inherited protocol Escapable
 Protocol RangeExpression has added inherited protocol Copyable
 Protocol RangeExpression has added inherited protocol Escapable
@@ -816,5 +815,19 @@ Func _SliceBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __abi_wit
 Func _SliceBuffer.withUnsafeBufferPointer(_:) has mangled name changing from 'Swift._SliceBuffer.withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._SliceBuffer.__abi_withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1'
 Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
 Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift._SliceBuffer.withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._SliceBuffer.__abi_withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
+
+// RNG: ~Copyable
+Func BinaryFloatingPoint.random(in:using:) has generic signature change from <Self, T where Self : Swift.BinaryFloatingPoint, T : Swift.RandomNumberGenerator, Self.RawSignificand : Swift.FixedWidthInteger> to <Self, T where Self : Swift.BinaryFloatingPoint, T : Swift.RandomNumberGenerator, Self.RawSignificand : Swift.FixedWidthInteger, T : ~Copyable>
+Func Bool.random(using:) has generic signature change from <T where T : Swift.RandomNumberGenerator> to <T where T : Swift.RandomNumberGenerator, T : ~Copyable>
+Func Collection.randomElement(using:) has generic signature change from <Self, T where Self : Swift.Collection, T : Swift.RandomNumberGenerator> to <Self, T where Self : Swift.Collection, T : Swift.RandomNumberGenerator, T : ~Copyable>
+Func FixedWidthInteger.random(in:using:) has generic signature change from <Self, T where Self : Swift.FixedWidthInteger, T : Swift.RandomNumberGenerator> to <Self, T where Self : Swift.FixedWidthInteger, T : Swift.RandomNumberGenerator, T : ~Copyable>
+Func MutableCollection.shuffle(using:) has generic signature change from <Self, T where Self : Swift.MutableCollection, Self : Swift.RandomAccessCollection, T : Swift.RandomNumberGenerator> to <Self, T where Self : Swift.MutableCollection, Self : Swift.RandomAccessCollection, T : Swift.RandomNumberGenerator, T : ~Copyable>
+Func RandomNumberGenerator.next() has generic signature change from <Self where Self : Swift.RandomNumberGenerator> to <Self where Self : Swift.RandomNumberGenerator, Self : ~Copyable>
+Func RandomNumberGenerator.next() has generic signature change from <Self, T where Self : Swift.RandomNumberGenerator, T : Swift.FixedWidthInteger, T : Swift.UnsignedInteger> to <Self, T where Self : Swift.RandomNumberGenerator, T : Swift.FixedWidthInteger, T : Swift.UnsignedInteger, Self : ~Copyable>
+Func RandomNumberGenerator.next(upperBound:) has generic signature change from <Self, T where Self : Swift.RandomNumberGenerator, T : Swift.FixedWidthInteger, T : Swift.UnsignedInteger> to <Self, T where Self : Swift.RandomNumberGenerator, T : Swift.FixedWidthInteger, T : Swift.UnsignedInteger, Self : ~Copyable>
+Func SIMD.random(in:using:) has generic signature change from <Self, T where Self : Swift.SIMD, T : Swift.RandomNumberGenerator, Self.Scalar : Swift.BinaryFloatingPoint, Self.Scalar.RawSignificand : Swift.FixedWidthInteger> to <Self, T where Self : Swift.SIMD, T : Swift.RandomNumberGenerator, Self.Scalar : Swift.BinaryFloatingPoint, Self.Scalar.RawSignificand : Swift.FixedWidthInteger, T : ~Copyable>
+Func SIMD.random(in:using:) has generic signature change from <Self, T where Self : Swift.SIMD, T : Swift.RandomNumberGenerator, Self.Scalar : Swift.FixedWidthInteger> to <Self, T where Self : Swift.SIMD, T : Swift.RandomNumberGenerator, Self.Scalar : Swift.FixedWidthInteger, T : ~Copyable>
+Func SIMDMask.random(using:) has generic signature change from <Storage, T where Storage : Swift.SIMD, T : Swift.RandomNumberGenerator, Storage.Scalar : Swift.FixedWidthInteger, Storage.Scalar : Swift.SignedInteger> to <Storage, T where Storage : Swift.SIMD, T : Swift.RandomNumberGenerator, Storage.Scalar : Swift.FixedWidthInteger, Storage.Scalar : Swift.SignedInteger, T : ~Copyable>
+Func Sequence.shuffled(using:) has generic signature change from <Self, T where Self : Swift.Sequence, T : Swift.RandomNumberGenerator> to <Self, T where Self : Swift.Sequence, T : Swift.RandomNumberGenerator, T : ~Copyable>
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
We should allow RNGs to be ~Copyable. For one thing, they simply don't need to be copyable. For another, it's entirely plausible that it would be desirable to bind an RNG to a unique resource. It's entirely arguable that the SystemRNG should be ~Copyable, but I'll consider that under a separate PR.