### PR TITLE
[CS] Diagnose misuse of CheckedCastExpr with ~=

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1419,6 +1419,15 @@ ERROR(optional_chain_isnt_chaining,none,
       ())
 ERROR(pattern_in_expr,none,
       "%0 cannot appear in an expression", (DescriptivePatternKind))
+ERROR(conditional_cast_in_type_casting_pattern,none,
+      "cannot conditionally downcast in a type-casting pattern",
+      ())
+ERROR(force_cast_in_type_casting_pattern,none,
+      "cannot force downcast in a type-casting pattern",
+      ())
+ERROR(cannot_bind_value_with_is,none,
+      "use 'as' keyword to bind a matched value",
+      ())
 NOTE(note_call_to_operator,none,
      "in call to operator %0", (const ValueDecl *))
 NOTE(note_call_to_func,none,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2604,6 +2604,18 @@ public:
       : FailureDiagnostic(solution, locator), P(pattern) {}
 
   bool diagnoseAsError() override;
+
+private:
+  /// Diagnose situations where a type-casting pattern that binds a value
+  /// expects 'as' but is given 'as!', 'as?' or 'is' instead
+  /// e.g:
+  ///
+  /// \code
+  /// case let x as? Int = y
+  /// case let x as! Int = y
+  /// case let x is Int = y
+  /// \endcode
+  bool diagnoseInvalidCheckedCast() const;
 };
 
 /// Diagnose situations where there is no context to determine a

--- a/test/Constraints/rdar106598067.swift
+++ b/test/Constraints/rdar106598067.swift
@@ -3,10 +3,22 @@
 enum E: Error { case e }
 
 // rdar://106598067 – Make sure we don't crash.
-// FIXME: We ought to have a tailored diagnostic to change to 'as' instead of 'as?'
 let fn = {
   do {} catch let x as? E {}
-  // expected-error@-1 {{pattern variable binding cannot appear in an expression}}
+  // expected-error@-1 {{cannot conditionally downcast in a type-casting pattern}}{{23-24=}}
   // expected-error@-2 {{expression pattern of type 'E?' cannot match values of type 'any Error'}}
   // expected-warning@-3 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+}
+
+// https://github.com/swiftlang/swift/issues/44631
+let maybeInt: Any = 1
+switch maybeInt {
+case let intValue as? Int: _ = intValue
+  // expected-error@-1 {{cannot conditionally downcast in a type-casting pattern}}{{21-22=}}
+  // expected-error@-2 {{expression pattern of type 'Int?' cannot match values of type 'Any'}}
+case let intValue as! Int: _ = intValue
+  // expected-error@-1 {{cannot force downcast in a type-casting pattern}}{{21-22=}}
+case let intValue is Int: _ = intValue
+  // expected-error@-1 {{use 'as' keyword to bind a matched value}}{{19-21=as}}
+default: break
 }


### PR DESCRIPTION
### Issue
When applying unwrap operator to 'as' or using 'is' in a type-cast pattern (specifically one that binds a value), the diagnostic for the resulting error could provide more guidance and suggest a fix-it. 

Example with current diagnostic:
```swift
let maybeInt: Any = 1
if case let intValue as? Int = maybeInt {}
            `- error: pattern variable binding cannot appear in an expression
```
### Fix
1) Added diagnostic `invalid_cast_in_pattern` and an associated fix-it to remove !/? or replace 'is' with 'as'.
2) Modified test/Constraints/rdar106598067.swift to account for the new diagnostic.

Example with new diagnostic:
```swift
if case let intValue as? Int = maybeInt {}
            ~~~~~~~~ ^ ~~~~~ 
                   //`- error: cannot conditionally downcast in a type-casting pattern
                   // - fix-it: remove '?'
if case let intValue as! Int = maybeInt {}
            ~~~~~~~~ ^ ~~~~~ 
                   //`- error: cannot force downcast in a type-casting pattern
                   // - fix-it: remove '!'
if case let intValue is Int = maybeInt {}
            ~~~~~~~~ ^ ~~~~
                   //`- error: use 'as' keyword to bind a matched value
                   // - fix-it: replace 'is' with 'as'
```
Resolves https://github.com/swiftlang/swift/issues/44631.