### PR TITLE
[utils][presets] Build libc++ for LLDB on linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3066,6 +3066,8 @@ mixin-preset=
     sourcekit_stress_test_mixin
 
 [preset: linux_lldb]
+# Build libcxx for tests
+libcxx
 lldb
 foundation
 libdispatch


### PR DESCRIPTION
We pass `-stdlib=libc++` in the test-suite to
Clang for many of our tests because we want to
explicilty test against libc++ type layouts.
However, if we don't do this against a newly built libc++ we risk testing against old/unexpected layouts or if libc++ isn't available on the system, falling back to the system libstdc++.

This patch adds libcxx as an explicit target in the preset so the tests build against a fresh libc++ (as we do for our other LLDB presets too).

Fixes the Ubuntu LLDB bots: https://ci.swift.org/view/LLDB/job/oss-lldb-linux-ubuntu-22_04/10806/execution/node/427/log/?consoleFull