### PR TITLE
Sema: generalize `findSyntacticErrorForConsume`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6534,7 +6534,8 @@ ForcedCheckedCastExpr *findForcedDowncast(ASTContext &ctx, Expr *expr);
 /// can I add `consume` around this expression?
 ///
 /// \param module represents the module in which the expr appears
-bool canAddExplicitConsume(ModuleDecl *module, Expr *expr);
+bool canAddExplicitConsume(constraints::Solution &sol,
+                           ModuleDecl *module, Expr *expr);
 
 // Count the number of overload sets present
 // in the expression and all of the children.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5620,18 +5620,18 @@ namespace {
 
       /// Check if it needs an explicit consume, due to this being a cast.
       auto *module = dc->getParentModule();
-      auto origType = cs.getType(injection->getSubExpr());
+      auto origType = solution.getResolvedType(injection->getSubExpr());
       if (willHaveConfusingConsumption(origType, locator, cs) &&
-          canAddExplicitConsume(module, injection->getSubExpr()))
+          canAddExplicitConsume(solution, module, injection->getSubExpr()))
         ConsumingCoercions.push_back(injection);
     }
 
     void diagnoseExistentialErasureOf(Expr *fromExpr, Expr *toExpr,
                                       ConstraintLocatorBuilder locator) {
       auto *module = dc->getParentModule();
-      auto fromType = cs.getType(fromExpr);
+      auto fromType = solution.getResolvedType(fromExpr);
       if (willHaveConfusingConsumption(fromType, locator, cs) &&
-          canAddExplicitConsume(module, fromExpr)) {
+          canAddExplicitConsume(solution, module, fromExpr)) {
         ConsumingCoercions.push_back(toExpr);
       }
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1478,12 +1478,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 }
 
 DeferredDiags swift::findSyntacticErrorForConsume(
-    ModuleDecl *module, SourceLoc loc, Expr *subExpr) {
+    ModuleDecl *module, SourceLoc loc, Expr *subExpr,
+    llvm::function_ref<Type(Expr *)> getType) {
   assert(!isa<ConsumeExpr>(subExpr) && "operates on the sub-expr of a consume");
 
   DeferredDiags result;
   const bool noncopyable =
-      subExpr->getType()->getCanonicalType()->isNoncopyable();
+      getType(subExpr)->isNoncopyable();
 
   bool partial = false;
   Expr *current = subExpr;

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include <optional>
 
 namespace swift {
@@ -162,10 +163,18 @@ namespace swift {
   /// \param loc corresponds to the location of the 'consume' for which
   ///            diagnostics should be collected, if any.
   ///
+  /// \param getType is a function that can correctly determine the type of
+  ///                an expression. This is to support calls from the
+  ///                constraint solver.
+  ///
   /// \returns an empty collection if there are no errors.
-  DeferredDiags findSyntacticErrorForConsume(ModuleDecl *module,
-                                             SourceLoc loc,
-                                             Expr *subExpr);
+  DeferredDiags findSyntacticErrorForConsume(
+                     ModuleDecl *module,
+                     SourceLoc loc,
+                     Expr *subExpr,
+                     llvm::function_ref<Type(Expr *)> getType = [](Expr *E) {
+                       return E->getType();
+                     });
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2338,7 +2338,9 @@ ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   return nullptr;
 }
 
-bool swift::canAddExplicitConsume(ModuleDecl *module, Expr *expr) {
+bool swift::canAddExplicitConsume(constraints::Solution &sol,
+                                  ModuleDecl *module,
+                                  Expr *expr) {
   expr = expr->getSemanticsProvidingExpr();
 
   // Is it already wrapped in a `consume`?
@@ -2346,7 +2348,8 @@ bool swift::canAddExplicitConsume(ModuleDecl *module, Expr *expr) {
     return false;
 
   // Is this expression valid to wrap inside a `consume`?
-  auto diags = findSyntacticErrorForConsume(module, SourceLoc(), expr);
+  auto diags = findSyntacticErrorForConsume(module, SourceLoc(), expr,
+                            [&](Expr *e) { return sol.getResolvedType(e); });
   return diags.empty();
 }
 

--- a/test/Sema/moveonly_casts.swift
+++ b/test/Sema/moveonly_casts.swift
@@ -131,3 +131,12 @@ struct ImplicitInit: ~Copyable {
 func test(_ nc: consuming NC) -> ImplicitInit {
   return .init(x: nc)
 }
+
+
+// rdar://134371893 (optional chaining on ~Copyable type)
+struct NonCopyable: ~Copyable {
+    var shared: Self { .init() }
+}
+func f() {
+    _ = (Optional<NonCopyable>.none)?.shared
+}


### PR DESCRIPTION
Since this function is being called from the constraint solver now, we need to generalize the way it obtains the Type of an Expression, as the expression itself may not know its own type, only the solver does.

resolves rdar://134371893 / https://github.com/swiftlang/swift/issues/75999