### PR TITLE
Set install dir correctly for libSwiftRemoteMirror

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -14,7 +14,7 @@ add_swift_target_library(swiftRemoteMirror
                            ${SWIFT_SOURCE_DIR}/include/swift/RemoteInspection/RuntimeHeaders
                          INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
                          SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-                         DARWIN_INSTALL_NAME_DIR "${SWIFTLIB_DARWIN_INSTALL_NAME_DIR}"
+                         DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR}"
                          INSTALL_IN_COMPONENT
                            swift-remote-mirror
 


### PR DESCRIPTION
### In This PR

* Include `libswiftRemoteMirror` in shared cache by ensuring the split segment info load command is included in the library. 

The linker only adds `LC_SEGMENT_SPLIT_INFO` if the install name of the library is in `/usr/lib`

Previously, `SWIFTLIB_DARWIN_INSTALL_NAME_DIR` was used incorrectly and not set, meaning the library would default install_name to @rpath/libswiftRemoteMirror.dylib