### PR TITLE
stdlib: Enable upcoming `MemberImportVisibility` feature

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -270,8 +270,10 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_dynamic_actor_isolation);
   inputArgs.AddLastArg(arguments, options::OPT_warn_concurrency);
   inputArgs.AddLastArg(arguments, options::OPT_strict_concurrency);
-  inputArgs.AddAllArgs(arguments, options::OPT_enable_experimental_feature);
-  inputArgs.AddAllArgs(arguments, options::OPT_enable_upcoming_feature);
+  inputArgs.addAllArgs(arguments, {options::OPT_enable_experimental_feature,
+                                   options::OPT_disable_experimental_feature,
+                                   options::OPT_enable_upcoming_feature,
+                                   options::OPT_disable_upcoming_feature});
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -633,10 +633,8 @@ function(_compile_swift_files
   list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypes")
   list(APPEND swift_flags "-enable-experimental-feature" "SE427NoInferenceOnExtension")
   list(APPEND swift_flags "-enable-experimental-feature" "AllowUnsafeAttribute")
-
   list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
-
-  list(APPEND swift_flags "-enable-experimental-feature" "ExtensionImportVisiblity")
+  list(APPEND swift_flags "-enable-upcoming-feature" "MemberImportVisibility")
 
   if (SWIFT_STDLIB_ENABLE_STRICT_CONCURRENCY_COMPLETE)
     list(APPEND swift_flags "-strict-concurrency=complete")

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -52,6 +52,11 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     -Xfrontend -module-interface-preserve-types-as-written
     -enable-experimental-feature AssumeResilientCxxTypes
 
+    # The varying modularization of the C++ standard library on different
+    # platforms makes it difficult to enable MemberImportVisibility for this
+    # module
+    -disable-upcoming-feature MemberImportVisibility
+
     SWIFT_COMPILE_FLAGS_LINUX
     ${SWIFT_SDK_LINUX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS}
 

--- a/test/Driver/features.swift
+++ b/test/Driver/features.swift
@@ -1,0 +1,18 @@
+// RUN: %swiftc_driver -emit-executable -o %t.exe %s \
+// RUN:   -enable-upcoming-feature MemberImportVisibility \
+// RUN:   -enable-experimental-feature ParserValidation \
+// RUN:   -disable-upcoming-feature MemberImportVisibility \
+// RUN:   -disable-experimental-feature ParserValidation \
+// RUN:   -disallow-use-new-driver -driver-print-jobs 2>&1 | %FileCheck %s
+
+// The new driver has its own test for this
+
+// REQUIRES: cplusplus_driver
+// REQUIRES: swift_feature_ParserValidation
+// REQUIRES: swift_feature_MemberImportVisibility
+
+// CHECK: {{.*}}swift{{c|-frontend}}{{(.exe)?"?}} -frontend
+// CHECK-SAME: -enable-upcoming-feature MemberImportVisibility
+// CHECK-SAME: -enable-experimental-feature ParserValidation
+// CHECK-SAME: -disable-upcoming-feature MemberImportVisibility
+// CHECK-SAME: -disable-experimental-feature ParserValidation


### PR DESCRIPTION
It was already supposed to be enabled, but I forgot to update the CMake when I renamed the feature from `ExtensionImportVisibility` to `MemberImportVisibility`.

However, leave it disabled on the CxxStdlib module since the C++ standard library's modularization varies a lot by platform, making it difficult to add the right conditional imports.