### PR TITLE
[cxx-interop] Re-enable a test for C foreign reference types

### DIFF
--- a/test/Interop/C/struct/foreign-reference.swift
+++ b/test/Interop/C/struct/foreign-reference.swift
@@ -1,9 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Xfrontend -experimental-c-foreign-reference-types)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Xfrontend -experimental-c-foreign-reference-types -Onone -D NO_OPTIMIZATIONS)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Xfrontend -experimental-c-foreign-reference-types -O)
 //
 // REQUIRES: executable_test
 // TODO: This should work without ObjC interop in the future rdar://97497120
 // REQUIRES: objc_interop
-// REQUIRES: rdar101790203
 
 import StdlibUnittest
 import ForeignReference
@@ -15,24 +15,32 @@ public func blackHole<T>(_ _: T) {  }
 
 ReferenceCountedTestSuite.test("Local") {
     var x = createLocalCount()
+#if NO_OPTIMIZATIONS
     expectEqual(x.value, 6) // This is 6 because of "var x" "x.value" * 2 and "(x, x, x)".
+#endif
 
     let t = (x, x, x)
+#if NO_OPTIMIZATIONS
     expectEqual(x.value, 5)
+#endif
 }
 
 @inline(never)
 func globalTest1() {
     var x = createGlobalCount()
     let t = (x, x, x)
+#if NO_OPTIMIZATIONS
     expectEqual(globalCount, 4)
+#endif
     blackHole(t)
 }
 
 @inline(never)
 func globalTest2() {
     var x = createGlobalCount()
+#if NO_OPTIMIZATIONS
     expectEqual(globalCount, 1)
+#endif
 }
 
 ReferenceCountedTestSuite.test("Global") {


### PR DESCRIPTION
This test has been disabled since 2022.

This re-enables the test in order to have  some test coverage of the `-experimental-c-foreign-reference-types` compiler flag.

See `test/Interop/Cxx/foreign-reference/reference-counted.swift` for a very similar test that enables C++ interop.

rdar://101790203

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
