### PR TITLE
docs: Update links to section on commit access

### DIFF
--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -33,7 +33,7 @@ In order for the Swift project to be able to advance quickly, it is important th
 
 ### @swift-ci
 
-Users with [commit access](https://swift.org/contributing/#commit-access) can trigger pull request testing by writing a comment on a PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment used. The current test types are:
+Users with [commit access](/CONTRIBUTING.md#commit-access) can trigger pull request testing by writing a comment on a PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment used. The current test types are:
 
 1. Smoke Testing
 2. Validation Testing

--- a/docs/HowToGuides/FirstPullRequest.md
+++ b/docs/HowToGuides/FirstPullRequest.md
@@ -198,4 +198,4 @@ Once you've made multiple substantial contributions, you can
 trigger the CI bot and merge changes upon approval.
 
 [good-first-issues]: https://github.com/swiftlang/swift/contribute
-[write-access]: https://swift.org/contributing/#commit-access
+[write-access]: /CONTRIBUTING.md#commit-access


### PR DESCRIPTION
Follow-up to #76667. Missed these.