### PR TITLE
[cxx-interop] Add rules to recognize escapability of aggregates

### DIFF
--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -42,3 +42,6 @@ SWIFT_REQUEST(ClangImporter, IsSafeUseOfCxxDecl,
 SWIFT_REQUEST(ClangImporter, CustomRefCountingOperation,
               CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
+              CxxEscapability(EscapabilityLookupDescriptor), Cached,
+              NoLocationInfo)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -52,7 +52,9 @@
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/IdentifierTable.h"
@@ -5016,6 +5018,74 @@ TinyPtrVector<ValueDecl *> CXXNamespaceMemberLookup::evaluate(
   }
 
   return result;
+}
+
+CxxEscapability
+ClangTypeEscapability::evaluate(Evaluator &evaluator,
+                                EscapabilityLookupDescriptor desc) const {
+  auto desugared = desc.type->getUnqualifiedDesugaredType();
+  if (const auto *recordType = desugared->getAs<clang::RecordType>()) {
+    if (importer::hasNonEscapableAttr(recordType->getDecl()))
+      return CxxEscapability::NonEscapable;
+    if (importer::hasEscapableAttr(recordType->getDecl()))
+      return CxxEscapability::Escapable;
+    auto recordDecl = recordType->getDecl();
+    auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
+    if (!cxxRecordDecl || cxxRecordDecl->isAggregate()) {
+      bool hadUnknown = false;
+      auto evaluateEscapability = [&](const clang::Type *type) {
+        auto escapability = evaluateOrDefault(
+            evaluator, ClangTypeEscapability({type}), CxxEscapability::Unknown);
+        if (escapability == CxxEscapability::Unknown)
+          hadUnknown = true;
+        return escapability;
+      };
+
+      if (cxxRecordDecl) {
+        for (auto base : cxxRecordDecl->bases()) {
+          auto baseEscapability = evaluateEscapability(
+              base.getType()->getUnqualifiedDesugaredType());
+          if (baseEscapability == CxxEscapability::NonEscapable)
+            return CxxEscapability::NonEscapable;
+        }
+      }
+
+      for (auto field : recordDecl->fields()) {
+        auto fieldEscapability = evaluateEscapability(
+            field->getType()->getUnqualifiedDesugaredType());
+        if (fieldEscapability == CxxEscapability::NonEscapable)
+          return CxxEscapability::NonEscapable;
+      }
+
+      return hadUnknown ? CxxEscapability::Unknown : CxxEscapability::Escapable;
+    }
+  }
+  if (desugared->isArrayType()) {
+    auto elemTy = cast<clang::ArrayType>(desugared)
+                      ->getElementType()
+                      ->getUnqualifiedDesugaredType();
+    return evaluateOrDefault(evaluator, ClangTypeEscapability({elemTy}),
+                             CxxEscapability::Unknown);
+  }
+
+  // Base cases
+  if (desugared->isAnyPointerType() || desugared->isBlockPointerType() ||
+      desugared->isMemberPointerType() || desugared->isReferenceType())
+    return CxxEscapability::NonEscapable;
+  if (desugared->isScalarType())
+    return CxxEscapability::Escapable;
+  return CxxEscapability::Unknown;
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           EscapabilityLookupDescriptor desc) {
+  out << "Computing escapability for type '";
+  out << clang::QualType(desc.type, 0).getAsString();
+  out << "'";
+}
+
+SourceLoc swift::extractNearestSourceLoc(EscapabilityLookupDescriptor) {
+  return SourceLoc();
 }
 
 // Just create a specialized function decl for "__swift_interopStaticCast"

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8155,8 +8155,7 @@ bool swift::importer::isMutabilityAttr(const clang::SwiftAttrAttr *swiftAttr) {
          swiftAttr->getAttribute() == "nonmutating";
 }
 
-static bool importAsUnsafe(const ASTContext &context,
-                           const clang::RecordDecl *decl,
+static bool importAsUnsafe(ASTContext &context, const clang::RecordDecl *decl,
                            const Decl *MappedDecl) {
   if (!context.LangOpts.hasFeature(Feature::SafeInterop) ||
       !context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute) || !decl)
@@ -8165,9 +8164,9 @@ static bool importAsUnsafe(const ASTContext &context,
   if (isa<ClassDecl>(MappedDecl))
     return false;
 
-  // TODO: Add logic to cover structural rules.
-  return !importer::hasNonEscapableAttr(decl) &&
-         !importer::hasEscapableAttr(decl);
+  return evaluateOrDefault(
+             context.evaluator, ClangTypeEscapability({decl->getTypeForDecl()}),
+             CxxEscapability::Unknown) == CxxEscapability::Unknown;
 }
 
 void

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -26,9 +26,21 @@ private:
 
 struct SWIFT_ESCAPABLE Owner {};
 
-struct Unannotated {};
+struct Unannotated {
+    Unannotated();
+};
 
 struct SWIFT_UNSAFE_REFERENCE UnsafeReference {};
+
+struct SafeEscapableAggregate {
+    int a;
+    float b[5];
+};
+
+struct UnknownEscapabilityAggregate {
+    SafeEscapableAggregate agg;
+    Unannotated unann;
+};
 
 //--- test.swift
 
@@ -42,7 +54,10 @@ func useUnsafeParam(x: Unannotated) { // expected-warning{{reference to unsafe s
 func useUnsafeParam2(x: UnsafeReference) { // expected-warning{{reference to unsafe class 'UnsafeReference'}}
 }
 
-func useSafeParams(x: Owner, y: View) {
+func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-warning{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
+}
+
+func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate) {
 }
 
 func useCfType(x: CFArray) {


### PR DESCRIPTION
For now, this logic is used for importing fewer unannotated types as unsafe. In the future, this logic will be used by escapability inference for other (non-aggregate) types.