### PR TITLE
RemoteInspection: Handle ObjC typerefs in computeUnalignedFieldStartOffset

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1279,6 +1279,10 @@ public:
   std::optional<unsigned>
   computeUnalignedFieldStartOffset(const TypeRef *TR,
                                    remote::TypeInfoProvider *ExternalTypeInfo) {
+    if (auto *objcTR = dyn_cast<ObjCClassTypeRef>(TR))
+      if (auto objcTI = ExternalTypeInfo->getTypeInfo(objcTR->getName()))
+        return objcTI->getSize();
+
     size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
 
     const TypeRef *superclass = getBuilder().lookupSuperclass(TR);


### PR DESCRIPTION
This change is part of a fix for a regression that wasn't noticed because lldb has a fallback to using ASTContexts when type metadata resolution fails.

For any Swift class that directly or indirectly inherits from an ObjC class (such as `NSObject`, `NSView`, etc), the function `computeUnalignedFieldStartOffset` will fail to compute the start offset. To compute the start offset, it traverses the parent classes and uses their sizes. Once the traversal reaches an ObjC class, the RemoteInspection does not know the size. The fix here is to get the size from the `TypeInfo` returned by the external `TypeInfoProvider` (which in LLDB is `LLDBTypeInforProvider`).

Depended on by https://github.com/swiftlang/llvm-project/pull/9320