### PR TITLE
Revert "[cxx-interop] Add test for lifetimebound annotation in ctor"

### DIFF
--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -18,15 +18,6 @@ struct SWIFT_NONESCAPABLE View {
     View(const View&) = default;
 private:
     const int *member;
-    friend struct OtherView;
-};
-
-struct SWIFT_NONESCAPABLE OtherView {
-    OtherView() : member(nullptr) {}
-    OtherView(View v [[clang::lifetimebound]]) : member(v.member) {}
-    OtherView(const OtherView&) = default;
-private:
-    const int *member;
 };
 
 struct Owner {
@@ -77,7 +68,7 @@ private:
     const int *member;
 };
 
-// CHECK: sil [clang makeOwner] {{.*}} : $@convention(c) () -> Owner
+// CHECK: sil [clang makeOwner] {{.*}}: $@convention(c) () -> Owner
 // CHECK: sil [clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> _scope(0) @autoreleased View
 // CHECK: sil [clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> _scope(0) @autoreleased View
 // CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> _scope(0, 1) @autoreleased View
@@ -85,7 +76,6 @@ private:
 // CHECK: sil [clang Owner.handOutView2] {{.*}} : $@convention(cxx_method) (View, @in_guaranteed Owner) -> _scope(1) @autoreleased View
 // CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@guaranteed View, @guaranteed View) -> _inherit(0, 1) @autoreleased View
 // CHECK: sil [clang View.init] {{.*}} : $@convention(c) () -> @out View
-// CHECK: sil [clang OtherView.init] {{.*}} : $@convention(c) (@guaranteed View) -> _inherit(0) @out OtherView
 
 //--- test.swift
 
@@ -101,5 +91,4 @@ public func test() {
     let _ = o.handOutView2(v1)
     let _ = getViewFromEither(v1, v2)
     let defaultView = View()
-    let _ = OtherView(defaultView)
 }


### PR DESCRIPTION
Reverts swiftlang/swift#76651

It's causing a CI failure in PR testing. E.g. https://ci.swift.org/job/swift-PR-Linux/17404/