### PR TITLE
[embedded] Support default arguments with metatypes-as-type-hints in Embedded Swift

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1280,28 +1280,6 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
   F->verifyIncompleteOSSA();
 
   emitDifferentiabilityWitnessesForFunction(constant, F);
-
-  // To support using metatypes as type hints in Embedded Swift. A default
-  // argument generator might be returning a metatype, which we normally don't
-  // support in Embedded Swift, but to still allow metatypes as type hints, we
-  // make the generator always inline to the callee by marking it transparent.
-  if (M.getOptions().EmbeddedSwift) {
-    if (constant.isDefaultArgGenerator()) {
-      bool isReturningMetatype = false;
-      if (F->getLoweredFunctionType()->getNumResults() == 1) {
-        if (F->getLoweredFunctionType()
-                ->getSingleResult()
-                .getSILStorageInterfaceType()
-                .isMetatype()) {
-          isReturningMetatype = true;
-        }
-      }
-
-      if (isReturningMetatype) {
-        F->setTransparent(IsTransparent);
-      }
-    }
-  }
 }
 
 void SILGenModule::emitDifferentiabilityWitnessesForFunction(

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1280,6 +1280,28 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
   F->verifyIncompleteOSSA();
 
   emitDifferentiabilityWitnessesForFunction(constant, F);
+
+  // To support using metatypes as type hints in Embedded Swift. A default
+  // argument generator might be returning a metatype, which we normally don't
+  // support in Embedded Swift, but to still allow metatypes as type hints, we
+  // make the generator always inline to the callee by marking it transparent.
+  if (M.getOptions().EmbeddedSwift) {
+    if (constant.isDefaultArgGenerator()) {
+      bool isReturningMetatype = false;
+      if (F->getLoweredFunctionType()->getNumResults() == 1) {
+        if (F->getLoweredFunctionType()
+                ->getSingleResult()
+                .getSILStorageInterfaceType()
+                .isMetatype()) {
+          isReturningMetatype = true;
+        }
+      }
+
+      if (isReturningMetatype) {
+        F->setTransparent(IsTransparent);
+      }
+    }
+  }
 }
 
 void SILGenModule::emitDifferentiabilityWitnessesForFunction(

--- a/test/embedded/metatype-type-hint.swift
+++ b/test/embedded/metatype-type-hint.swift
@@ -1,0 +1,45 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -O) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -Osize) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public struct AsyncStream2<Element> {
+  var x: Int
+  var y: Int
+}
+
+extension AsyncStream2 {
+  public static func makeStream2(of elementType: Element.Type = Element.self) -> AsyncStream2<Element> {
+    return AsyncStream2<Element>()
+  }
+
+  public init(
+    _ elementType: Element.Type = Element.self
+  ) {
+    fatalError()
+  }
+}
+
+struct MyStruct<T> {
+  static func makeStruct(of t: T.Type = T.self) -> MyStruct<T> {
+    var s = MyStruct.init()
+    return s
+  }
+  public init(_ t: T.Type = T.self) {
+    print("x")
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    _ = MyStruct<String>.makeStruct()
+    _ = MyStruct.makeStruct(of: String.self)
+    print("OK!")
+    // CHECK: OK!
+  }
+}

--- a/test/embedded/metatype-type-hint2.swift
+++ b/test/embedded/metatype-type-hint2.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -o %t/Main.o -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// BEGIN MyModule.swift
+
+public struct MyStruct<T> {
+  var x: Int
+}
+
+extension MyStruct {
+  public static func makeStruct(of: T.Type) -> MyStruct<T> {
+    return MyStruct<T>()
+  }
+
+  public init(_: T.Type = T.self) {
+    self.x = 42
+  }
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+@main
+struct Main {
+  static func main() {
+    _ = MyStruct.makeStruct(of: String.self)
+  }
+}


### PR DESCRIPTION
Materializing metatypes is not allowed in Embedded Swift, but it's still useful to use metatype functions arguments as type hints (unused in the function body). This change enables such function arguments to have default values, and achieves that by marking metatype-returning default arg generators as @_transparent. When the default arg generator is force-inlined into the caller, the metatype value will be unused and removed by mandatory optimizations.

It's done in SILGen, because after SILGen there doesn't seem to be a reliable way to know whether a function is a default arg generator or not.