### PR TITLE
Sema: Check worseThanBestSolution() in a better place

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -751,6 +751,18 @@ public:
   }
 };
 
+class LocatorPathElt::ProtocolCompositionMemberType final : public StoredIntegerElement<1> {
+public:
+  ProtocolCompositionMemberType(unsigned index)
+      : StoredIntegerElement(ConstraintLocator::GenericArgument, index) {}
+
+  unsigned getIndex() const { return getValue(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ProtocolCompositionMemberType;
+  }
+};
+
 class LocatorPathElt::GenericArgument final : public StoredIntegerElement<1> {
 public:
   GenericArgument(unsigned index)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -76,7 +76,7 @@ CUSTOM_LOCATOR_PATH_ELT(ContextualType)
 SIMPLE_LOCATOR_PATH_ELT(DynamicLookupResult)
 
 /// The superclass of a protocol composition type.
-SIMPLE_LOCATOR_PATH_ELT(ProtocolCompositionSuperclassType)
+CUSTOM_LOCATOR_PATH_ELT(ProtocolCompositionMemberType)
 
 /// The constraint of an existential type.
 SIMPLE_LOCATOR_PATH_ELT(ExistentialConstraintType)

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -460,8 +460,18 @@ CanType TypeJoin::visitProtocolType(CanType second) {
   auto *secondDecl =
     cast<ProtocolDecl>(second->getNominalOrBoundGenericNominal());
 
-  if (firstDecl->getInheritedProtocols().empty() &&
-      secondDecl->getInheritedProtocols().empty())
+  SmallVector<Type, 4> firstMembers;
+  for (auto *decl : firstDecl->getInheritedProtocols())
+    if (!decl->getInvertibleProtocolKind())
+      firstMembers.push_back(decl->getDeclaredInterfaceType());
+
+  SmallVector<Type, 4> secondMembers;
+  for (auto *decl : secondDecl->getInheritedProtocols())
+    if (!decl->getInvertibleProtocolKind())
+      secondMembers.push_back(decl->getDeclaredInterfaceType());
+
+  if (firstMembers.empty() &&
+      secondMembers.empty())
     return TheAnyType;
 
   if (firstDecl->inheritsFrom(secondDecl))
@@ -473,14 +483,6 @@ CanType TypeJoin::visitProtocolType(CanType second) {
   // One isn't the supertype of the other, so instead, treat each as
   // if it's a protocol composition of its inherited members, and join
   // those.
-  SmallVector<Type, 4> firstMembers;
-  for (auto *decl : firstDecl->getInheritedProtocols())
-    firstMembers.push_back(decl->getDeclaredInterfaceType());
-
-  SmallVector<Type, 4> secondMembers;
-  for (auto *decl : secondDecl->getInheritedProtocols())
-    secondMembers.push_back(decl->getDeclaredInterfaceType());
-
   return computeProtocolCompositionJoin(firstMembers, secondMembers);
 }
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -319,7 +319,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   // One of the previous components created by "split"
   // failed, it means that we can't solve this component.
   if ((prevFailed && DependsOnPartialSolutions.empty()) ||
-      CS.isTooComplex(Solutions))
+      CS.isTooComplex(Solutions) || CS.worseThanBestSolution())
     return done(/*isSuccess=*/false);
 
   // Setup active scope, only if previous component didn't fail.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -925,6 +925,10 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   // Rewind back the constraint system information.
   ActiveChoice.reset();
 
+  // Reset the best score which was updated by `ConstraintSystem::finalize`
+  // while forming solution(s) for the current element.
+  CS.solverState->BestScore.reset();
+
   if (CS.isDebugMode())
     getDebugLogger() << ")\n";
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -58,7 +58,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::UnresolvedMember:
   case ConstraintLocator::ParentType:
   case ConstraintLocator::ExistentialConstraintType:
-  case ConstraintLocator::ProtocolCompositionSuperclassType:
+  case ConstraintLocator::ProtocolCompositionMemberType:
   case ConstraintLocator::LValueConversion:
   case ConstraintLocator::DynamicType:
   case ConstraintLocator::SubscriptMember:
@@ -278,9 +278,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     out << "existential constraint type";
     break;
 
-  case ConstraintLocator::ProtocolCompositionSuperclassType:
-    out << "protocol composition superclass type";
+  case ConstraintLocator::ProtocolCompositionMemberType: {
+    auto memberElt = elt.castTo<LocatorPathElt::ProtocolCompositionMemberType>();
+    out << "protocol composition member " << llvm::utostr(memberElt.getIndex());
     break;
+  }
 
   case ConstraintLocator::LValueConversion:
     out << "@lvalue-to-inout conversion";

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6145,7 +6145,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::SequenceElementType:
     case ConstraintLocator::ConstructorMemberType:
     case ConstraintLocator::ExistentialConstraintType:
-    case ConstraintLocator::ProtocolCompositionSuperclassType:
+    case ConstraintLocator::ProtocolCompositionMemberType:
       break;
 
     case ConstraintLocator::GenericArgument:


### PR DESCRIPTION
This change speeds up this test case, but it remains exponential:

```
let x: Int? = nil

func f<T>(_: T?, _: T) -> T {}
func f<T>(_: T?, _: T?) -> T? {}

let _ = [f(x, 0), f(x, 0), f(x, 0), f(x, 0), f(x, 0), f(x, 0), f(x, 0), f(x, 0)]
```

Also, clean up DeepEquality for protocol compositions. This is one of the blockers towards enabling protocol compositions that contain parameterized protocol types, like `any Sequence<Int> & Sendable`, etc.