### PR TITLE
[Tests] NFC: Disable `Interop/Cxx/class/safe-interop-mode.swift` due …

### DIFF
--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://136620623
+// REQUIRES: rdar136620623
+
 //--- Inputs/module.modulemap
 module Test {
     header "nonescapable.h"


### PR DESCRIPTION
…to failures on iphonesimulator

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
