### PR TITLE
LargeTypesReg2Mem: Map `undef` SIL values to an undefined address on the stack

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3510,7 +3510,7 @@ public:
     auto it = valueToAddressMap.find(v);
 
     // This can happen if we deem a container type small but a contained type
-    // big.
+    // big or we have an undef operand.
     if (it == valueToAddressMap.end()) {
       if (auto *sv = dyn_cast<SingleValueInstruction>(v)) {
         auto addr = createAllocStack(v->getType());
@@ -3520,6 +3520,12 @@ public:
         mapValueToAddress(v, addr);
         return addr;
       }
+      if (isa<SILUndef>(v)) {
+        auto undefAddr = createAllocStack(v->getType());
+        mapValueToAddress(v, undefAddr);
+        return undefAddr;
+      }
+
     }
     assert(it != valueToAddressMap.end());
 

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -364,3 +364,36 @@ bb0(%0 : $*X):
   dealloc_stack %1 : $*X
   throw %3 : $X
 }
+
+// CHECK: sil @test15
+// CHECK:  cond_br %1, bb1, bb2
+
+// CHECK: bb1:
+// CHECK:   copy_addr [take] {{.*}} to [init] [[PHI:%[0-9]+]] : $*X
+// CHECK:   br bb3
+
+// CHECK: bb2:
+// CHECK:   [[UNDEF:%.*]] = alloc_stack $X
+// CHECK:   copy_addr [take] [[UNDEF]] to [init] [[PHI]] : $*X
+// CHECK:   dealloc_stack [[UNDEF]] : $*X
+// CHECK:   br bb3
+// CHECK:} // end sil function 'test15'
+
+sil @test15 : $@convention(thin) (X, Builtin.Int1) -> () {
+bb0(%0: $X, %1: $Builtin.Int1):
+  %2 = alloc_stack $X
+cond_br %1, bb1, bb2
+
+bb1:
+ br bb3(%0 : $X)
+
+bb2:
+ br bb3(undef : $X)
+
+bb3(%4 : $X):
+  store %4 to %2: $*X
+
+  dealloc_stack %2 : $*X
+  %t = tuple ()
+  return %t : $()
+}


### PR DESCRIPTION
SIL can have undefined values along some path (which dynamically is never executed).

rdar://136600129