### PR TITLE
IRGen: Set a "not bitwise borrowable" bit in value witnesses for `@_rawLayout` types.

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -900,11 +900,16 @@ class OpaqueExistentialTypeInfo final :
 
   OpaqueExistentialTypeInfo(ArrayRef<const ProtocolDecl *> protocols,
                             llvm::Type *ty, Size size,
+                            IsCopyable_t copyable,
                             SpareBitVector &&spareBits,
                             Alignment align)
     : super(protocols, ty, size,
             std::move(spareBits), align,
-            IsNotTriviallyDestroyable, IsBitwiseTakable, IsCopyable,
+            IsNotTriviallyDestroyable,
+            // Copyable existentials are bitwise-takable and borrowable.
+            // Noncopyable existentials are bitwise-takable only.
+            copyable ? IsBitwiseTakableAndBorrowable : IsBitwiseTakableOnly,
+            copyable,
             IsFixedSize, IsABIAccessible) {}
 
 public:
@@ -1649,14 +1654,19 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
   OpaqueExistentialLayout opaque(protosWithWitnessTables.size());
   Alignment align = opaque.getAlignment(IGM);
   Size size = opaque.getSize(IGM);
+  IsCopyable_t copyable = T->isNoncopyable() ? IsNotCopyable : IsCopyable;
+  
   // There are spare bits in the metadata pointer and witness table pointers
   // consistent with a native object reference.
-  // TODO: There are spare bits we could theoretically use in the type metadata
-  // and witness table pointers, but opaque existentials are currently address-
+  // NB: There are spare bits we could theoretically use in the type metadata
+  // and witness table pointers, but opaque existentials are address-
   // only, and we can't soundly take advantage of spare bits for in-memory
   // representations.
+  // Maybe an ABI break that made opaque existentials loadable could use those
+  // bits, though.
   auto spareBits = SpareBitVector::getConstant(size.getValueInBits(), false);
   return OpaqueExistentialTypeInfo::create(protosWithWitnessTables, type, size,
+                                           copyable,
                                            std::move(spareBits),
                                            align);
 }

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -579,7 +579,7 @@ const TypeInfo *TypeConverter::convertBlockStorageType(SILBlockStorageType *T) {
 
     size = captureOffset + fixedCapture->getFixedSize();
     pod = fixedCapture->isTriviallyDestroyable(ResilienceExpansion::Maximal);
-    bt = fixedCapture->isBitwiseTakable(ResilienceExpansion::Maximal);
+    bt = fixedCapture->getBitwiseTakable(ResilienceExpansion::Maximal);
   }
 
   llvm::Type *storageElts[] = {

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1144,7 +1144,7 @@ public:
 
     auto alignment = ti->getFixedAlignment().getValue();
     unsigned bitwiseTakable =
-      (ti->isBitwiseTakable(ResilienceExpansion::Minimal) == IsBitwiseTakable
+      (ti->getBitwiseTakable(ResilienceExpansion::Minimal) >= IsBitwiseTakableOnly
        ? 1 : 0);
     B.addInt32(alignment | (bitwiseTakable << 16));
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -236,7 +236,7 @@ llvm::Value *FixedTypeInfo::getIsTriviallyDestroyable(IRGenFunction &IGF, SILTyp
 }
 llvm::Value *FixedTypeInfo::getIsBitwiseTakable(IRGenFunction &IGF, SILType T) const {
   return llvm::ConstantInt::get(IGF.IGM.Int1Ty,
-                                isBitwiseTakable(ResilienceExpansion::Maximal) == IsBitwiseTakable);
+      getBitwiseTakable(ResilienceExpansion::Maximal) >= IsBitwiseTakableOnly);
 }
 llvm::Constant *FixedTypeInfo::getStaticStride(IRGenModule &IGM) const {
   return IGM.getSize(getFixedStride());

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -849,12 +849,22 @@ ValueWitnessFlags getValueWitnessFlags(const TypeInfo *TI, SILType concreteType,
     bool isInline = packing == FixedPacking::OffsetZero;
     bool isBitwiseTakable =
         fixedTI->isBitwiseTakable(ResilienceExpansion::Maximal);
+    bool isBitwiseBorrowable =
+        fixedTI->isBitwiseBorrowable(ResilienceExpansion::Maximal);
     assert(isBitwiseTakable || !isInline);
     flags = flags.withAlignment(fixedTI->getFixedAlignment().getValue())
                 .withPOD(fixedTI->isTriviallyDestroyable(ResilienceExpansion::Maximal))
                 .withCopyable(fixedTI->isCopyable(ResilienceExpansion::Maximal))
                 .withInlineStorage(isInline)
-                .withBitwiseTakable(isBitwiseTakable);
+                .withBitwiseTakable(isBitwiseTakable)
+                // the IsNotBitwiseBorrowable bit only needs to be set if the
+                // type is bitwise-takable but not bitwise-borrowable, since
+                // a type must be bitwise-takable to be bitwise-borrowable.
+                //
+                // Swift prior to version 6 didn't have the
+                // IsNotBitwiseBorrowable bit, so to avoid unnecessary variation
+                // in metadata output, we only set the bit when needed.
+                .withBitwiseBorrowable(!isBitwiseTakable || isBitwiseBorrowable);
   } else {
     flags = flags.withIncomplete(true);
   }
@@ -1532,12 +1542,12 @@ llvm::Constant *IRGenModule::emitFixedTypeLayout(CanType t,
   unsigned align = ti.getFixedAlignment().getValue();
 
   bool pod = ti.isTriviallyDestroyable(ResilienceExpansion::Maximal);
-  bool bt = ti.isBitwiseTakable(ResilienceExpansion::Maximal);
+  IsBitwiseTakable_t bt = ti.getBitwiseTakable(ResilienceExpansion::Maximal);
   unsigned numExtraInhabitants = ti.getFixedExtraInhabitantCount(*this);
 
   // Try to use common type layouts exported by the runtime.
   llvm::Constant *commonValueWitnessTable = nullptr;
-  if (pod && bt && numExtraInhabitants == 0) {
+  if (pod && bt == IsBitwiseTakableAndBorrowable && numExtraInhabitants == 0) {
     if (size == 0)
       commonValueWitnessTable =
         getAddrOfValueWitnessTable(Context.TheEmptyTupleType);
@@ -1562,7 +1572,7 @@ llvm::Constant *IRGenModule::emitFixedTypeLayout(CanType t,
 
   // Otherwise, see if a layout has been emitted with these characteristics
   // already.
-  FixedLayoutKey key{size, numExtraInhabitants, align, pod, bt};
+  FixedLayoutKey key{size, numExtraInhabitants, align, pod, unsigned(bt)};
 
   auto found = PrivateFixedLayouts.find(key);
   if (found != PrivateFixedLayouts.end())
@@ -1578,16 +1588,29 @@ llvm::Constant *IRGenModule::emitFixedTypeLayout(CanType t,
     addValueWitness(*this, witnesses, witness, packing, t, silTy, ti);
   }
 
+  auto pod_bt_string = [](bool pod, IsBitwiseTakable_t bt) -> StringRef {
+    if (pod) {
+      return "_pod";
+    }
+    switch (bt) {
+    case IsNotBitwiseTakable:
+      return "";
+    case IsBitwiseTakableOnly:
+      return "_bt_nbb";
+    case IsBitwiseTakableAndBorrowable:
+      return "_bt";
+    }
+  };
+
   auto layoutVar
     = witnesses.finishAndCreateGlobal(
         "type_layout_" + llvm::Twine(size)
                        + "_" + llvm::Twine(align)
                        + "_" + llvm::Twine::utohexstr(numExtraInhabitants)
-                       + (pod ? "_pod" :
-                          bt  ? "_bt"  : ""),
-                                      getPointerAlignment(),
-                                      /*constant*/ true,
-                                      llvm::GlobalValue::PrivateLinkage);
+                       + pod_bt_string(pod, bt),
+        getPointerAlignment(),
+        /*constant*/ true,
+        llvm::GlobalValue::PrivateLinkage);
 
   // Cast to the standard currency type for type layouts.
   auto layout = llvm::ConstantExpr::getBitCast(layoutVar, Int8PtrPtrTy);

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -80,9 +80,15 @@ inline IsLoadable_t &operator&=(IsLoadable_t &l, IsLoadable_t r) {
   return (l = (l & r));
 }
 
-enum IsBitwiseTakable_t : bool { IsNotBitwiseTakable, IsBitwiseTakable };
+enum IsBitwiseTakable_t : uint8_t {
+  IsNotBitwiseTakable = 0,
+  // The type is bitwise-takable, but borrows are pinned to memory.
+  IsBitwiseTakableOnly = 1,
+  // The type is bitwise-takable and -borrowable.
+  IsBitwiseTakableAndBorrowable = 3,
+};
 inline IsBitwiseTakable_t operator&(IsBitwiseTakable_t l, IsBitwiseTakable_t r) {
-  return IsBitwiseTakable_t(unsigned(l) & unsigned(r));
+  return IsBitwiseTakable_t(std::min(unsigned(l), unsigned(r)));
 }
 inline IsBitwiseTakable_t &operator&=(IsBitwiseTakable_t &l, IsBitwiseTakable_t r) {
   return (l = (l & r));

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1368,7 +1368,7 @@ private:
     unsigned numExtraInhabitants;
     unsigned align: 16;
     unsigned pod: 1;
-    unsigned bitwiseTakable: 1;
+    unsigned bitwiseTakable: 2;
   };
   friend struct ::llvm::DenseMapInfo<swift::irgen::IRGenModule::FixedLayoutKey>;
   llvm::DenseMap<FixedLayoutKey, llvm::Constant *> PrivateFixedLayouts;

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -65,8 +65,9 @@ protected:
                    IsABIAccessible_t isABIAccessible,
                    SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, spareBits, align, pod,
-                      // All currently implemented loadable types are bitwise-takable.
-                      IsBitwiseTakable,
+                      // All currently implemented loadable types are
+                      // bitwise-takable and -borrowable.
+                      IsBitwiseTakableAndBorrowable,
                       copy, alwaysFixedSize, isABIAccessible, stik) {
     assert(isLoadable());
   }
@@ -80,8 +81,9 @@ protected:
                    IsABIAccessible_t isABIAccessible,
                    SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, std::move(spareBits), align, pod,
-                      // All currently implemented loadable types are bitwise-takable.
-                      IsBitwiseTakable,
+                      // All currently implemented loadable types are
+                      // bitwise-takable and borrowable.
+                      IsBitwiseTakableAndBorrowable,
                       copy, alwaysFixedSize, isABIAccessible, stik) {
     assert(isLoadable());
   }

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -72,7 +72,7 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = (decl && !decl->canBeCopyable())
     ? IsNotCopyable : IsCopyable;
-  IsBitwiseTakable_t bitwiseTakable = IsBitwiseTakable;
+  IsBitwiseTakable_t bitwiseTakable = IsBitwiseTakableAndBorrowable;
 
   if (decl && decl->getAttrs().hasAttribute<SensitiveAttr>()) {
     triviallyDestroyable = IsNotTriviallyDestroyable;
@@ -87,7 +87,8 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
   if (rawLayout && type) {
     auto sd = cast<StructDecl>(decl);
     IsKnownTriviallyDestroyable = triviallyDestroyable;
-    IsKnownBitwiseTakable = bitwiseTakable;
+    // Raw layout types are never bitwise-borrowable.
+    IsKnownBitwiseTakable = bitwiseTakable & IsBitwiseTakableOnly;
     SpareBits.clear();
     assert(!copyable);
     IsKnownCopyable = copyable;
@@ -168,7 +169,9 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
         // type its like.
         if (rawLayout->shouldMoveAsLikeType()) {
           IsKnownTriviallyDestroyable = likeFixedType->isTriviallyDestroyable(ResilienceExpansion::Maximal);
-          IsKnownBitwiseTakable = likeFixedType->isBitwiseTakable(ResilienceExpansion::Maximal);
+          // Raw layout types are still never bitwise-borrowable.
+          IsKnownBitwiseTakable = likeFixedType->getBitwiseTakable(ResilienceExpansion::Maximal)
+            & IsBitwiseTakableOnly;
         }
       } else {
         MinimumSize = Size(0);
@@ -417,7 +420,7 @@ bool StructLayoutBuilder::addField(ElementLayout &elt,
                                   LayoutStrategy strategy) {
   auto &eltTI = elt.getType();
   IsKnownTriviallyDestroyable &= eltTI.isTriviallyDestroyable(ResilienceExpansion::Maximal);
-  IsKnownBitwiseTakable &= eltTI.isBitwiseTakable(ResilienceExpansion::Maximal);
+  IsKnownBitwiseTakable &= eltTI.getBitwiseTakable(ResilienceExpansion::Maximal);
   IsKnownAlwaysFixedSize &= eltTI.isFixedSize(ResilienceExpansion::Minimal);
   IsLoadable &= eltTI.isLoadable();
   IsKnownCopyable &= eltTI.isCopyable(ResilienceExpansion::Maximal);

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -285,7 +285,7 @@ private:
   bool IsFixedLayout = true;
   bool IsLoadable = true;
   IsTriviallyDestroyable_t IsKnownTriviallyDestroyable = IsTriviallyDestroyable;
-  IsBitwiseTakable_t IsKnownBitwiseTakable = IsBitwiseTakable;
+  IsBitwiseTakable_t IsKnownBitwiseTakable = IsBitwiseTakableAndBorrowable;
   IsCopyable_t IsKnownCopyable = IsCopyable;
   IsFixedSize_t IsKnownAlwaysFixedSize = IsFixedSize;
 public:

--- a/test/IRGen/existential-bitwise-borrowability.swift
+++ b/test/IRGen/existential-bitwise-borrowability.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/existential-bitwise-borrowability.swift
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -enable-experimental-feature ValueGenerics -emit-ir -disable-availability-checking -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %t/existential-bitwise-borrowability.swift | %FileCheck %t/existential-bitwise-borrowability.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Copyable existentials are bitwise-borrowable (because copyable types are
+// always bitwise-borrowable if they're bitwise-takable, and only bitwise-takable
+// values are stored inline in existentials). Noncopyable existentials are
+// not (since types like Atomic and Mutex can be stored inline in their
+// buffers).
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}3FooVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-64-SAME:  , {{i64|i32}} 32
+// CHECK-32-SAME:  , {{i64|i32}} 16
+// stride
+// CHECK-64-SAME:  , {{i64|i32}} 32
+// CHECK-32-SAME:  , {{i64|i32}} 16
+// flags: word alignment, noncopyable, non-POD, non-inline-storage
+// CHECK-64-SAME:  , <i32 0x830007>
+// CHECK-32-SAME:  , <i32 0x830003>
+struct Foo: ~Copyable {
+    var x: Any
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}3BarVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-64-SAME:  , {{i64|i32}} 32
+// CHECK-32-SAME:  , {{i64|i32}} 16
+// stride
+// CHECK-64-SAME:  , {{i64|i32}} 32
+// CHECK-32-SAME:  , {{i64|i32}} 16
+// flags: word alignment, non-bitwise-borrowable, noncopyable, non-POD, non-inline-storage
+// CHECK-64-SAME:  , <i32 0x1830007>
+// CHECK-32-SAME:  , <i32 0x1830003>
+struct Bar: ~Copyable {
+    var x: any ~Copyable
+}
+

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -11,8 +11,8 @@ import RawLayoutCXX
 // CHECK-SAME:  , {{i64|i32}} 4
 // stride
 // CHECK-SAME:  , {{i64|i32}} 4
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 
 @_rawLayout(size: 4, alignment: 4)
 struct Lock: ~Copyable { }
@@ -27,8 +27,8 @@ struct PaddedStride {
 // CHECK-SAME:  , {{i64|i32}} 5
 // stride
 // CHECK-SAME:  , {{i64|i32}} 8
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 @_rawLayout(like: PaddedStride)
 struct LikePaddedStride: ~Copyable {}
 
@@ -37,8 +37,8 @@ struct LikePaddedStride: ~Copyable {}
 // CHECK-SAME:  , {{i64|i32}} 8
 // stride
 // CHECK-SAME:  , {{i64|i32}} 8
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 @_rawLayout(likeArrayOf: PaddedStride, count: 1)
 struct LikePaddedStrideArray1: ~Copyable {}
 
@@ -47,9 +47,9 @@ struct LikePaddedStrideArray1: ~Copyable {}
 // CHECK-SAME:  , {{i64|i32}} 16
 // stride
 // CHECK-SAME:  , {{i64|i32}} 16
-// flags: alignment 3, noncopyable, (on 32-bit platforms) not storable inline
-// CHECK-64-SAME:  , <i32 0x800003>
-// CHECK-32-SAME:  , <i32 0x820003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable, (on 32-bit platforms) not storable inline
+// CHECK-64-SAME:  , <i32 0x1800003>
+// CHECK-32-SAME:  , <i32 0x1820003>
 @_rawLayout(likeArrayOf: PaddedStride, count: 2)
 struct LikePaddedStrideArray2: ~Copyable {}
 
@@ -58,8 +58,8 @@ struct LikePaddedStrideArray2: ~Copyable {}
 // CHECK-SAME:  , {{i64|i32}} 12
 // stride
 // CHECK-SAME:  , {{i64|i32}} 12
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 struct Keymaster: ~Copyable {
     let lock1: Lock
     let lock2: Lock
@@ -125,8 +125,8 @@ struct Vector<T, let N: Int>: ~Copyable {}
 // CHECK-SAME:  , {{i64|i32}} 8
 // stride
 // CHECK-SAME:  , {{i64|i32}} 8
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 struct UsesCell: ~Copyable {
     let someCondition: Bool
     let specialInt: Cell<Int32>
@@ -137,8 +137,8 @@ struct UsesCell: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 3
 // stride
 // CHECK-SAME:  , {{i64|i32}} 3
-// flags: alignment 0, noncopyable
-// CHECK-SAME:  , <i32 0x800000>
+// flags: alignment 0, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800000>
 struct BufferOf3Bool: ~Copyable {
     let buffer: SmallVectorOf3<Bool>
 }
@@ -148,8 +148,8 @@ struct BufferOf3Bool: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 48
 // stride
 // CHECK-SAME:  , {{i64|i32}} 48
-// flags: alignment 7, noncopyable, is not inline
-// CHECK-SAME:  , <i32 0x820007>
+// flags: alignment 7, noncopyable, non-bitwise-borrowable, is not inline
+// CHECK-SAME:  , <i32 0x1820007>
 struct BadBuffer: ~Copyable {
     let buffer: SmallVectorOf3<Int64?>
 }
@@ -159,8 +159,8 @@ struct BadBuffer: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 2
 // stride
 // CHECK-SAME:  , {{i64|i32}} 2
-// flags: alignment 0, noncopyable
-// CHECK-SAME:  , <i32 0x800000>
+// flags: alignment 0, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800000>
 struct UsesVector: ~Copyable {
     let buffer: Vector<UInt8, 2>
 }
@@ -170,8 +170,8 @@ struct UsesVector: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 48
 // stride
 // CHECK-SAME:  , {{i64|i32}} 48
-// flags: alignment 7, noncopyable, is not inline
-// CHECK-SAME:  , <i32 0x820007>
+// flags: alignment 7, noncopyable, non-bitwise-borrowable, is not inline
+// CHECK-SAME:  , <i32 0x1820007>
 struct BadBuffer2: ~Copyable {
     let buffer: Vector<Int64?, 3>
 }
@@ -222,8 +222,8 @@ struct ConcreteMoveAsLike: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 4
 // stride
 // CHECK-SAME:  , {{i64|i32}} 4
-// flags: alignment 3, not copyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, not copyable, not bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 struct ConcreteIntMoveAsLike: ~Copyable {
   let cell: CellThatMovesAsLike<Int32>
 }
@@ -272,8 +272,8 @@ struct ConcreteSmallVectorMovesAsLike: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 8
 // stride
 // CHECK-SAME:  , {{i64|i32}} 8
-// flags: alignment 3, not copyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, not copyable, not bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 struct ConcreteSmallVectorIntMovesAsLike: ~Copyable {
   let vector: SmallVectorOf2MovesAsLike<Int32>
 }
@@ -322,9 +322,9 @@ struct ConcreteVectorMovesAsLike: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 16
 // stride
 // CHECK-SAME:  , {{i64|i32}} 16
-// flags: alignment 3, not copyable, (on 32-bit platforms) not storable inline
-// CHECK-64-SAME:  , <i32 0x800003>
-// CHECK-32-SAME:  , <i32 0x820003>
+// flags: alignment 3, not copyable, not bitwise-borrowable, (on 32-bit platforms) not storable inline
+// CHECK-64-SAME:  , <i32 0x1800003>
+// CHECK-32-SAME:  , <i32 0x1820003>
 struct ConcreteVectorIntMovesAsLike: ~Copyable {
   let vector: VectorMovesAsLike<Int32, 4>
 }

--- a/test/IRGen/raw_layout_multifile.swift
+++ b/test/IRGen/raw_layout_multifile.swift
@@ -10,8 +10,8 @@ public struct Foo<T>: ~Copyable {}
 // CHECK-SAME:  , {{i64|i32}} 4
 // stride
 // CHECK-SAME:  , {{i64|i32}} 4
-// flags: alignment 3, noncopyable
-// CHECK-SAME:  , <i32 0x800003>
+// flags: alignment 3, noncopyable, non-bitwise-borrowable
+// CHECK-SAME:  , <i32 0x1800003>
 struct MyInt: ~Copyable {
   let x: Int32Fake
 }
@@ -21,8 +21,8 @@ struct MyInt: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 48
 // stride
 // CHECK-SAME:  , {{i64|i32}} 48
-// flags: alignment 7, noncopyable, is not inline
-// CHECK-SAME:  , <i32 0x820007>
+// flags: alignment 7, noncopyable, non-bitwise-borrowable, is not inline
+// CHECK-SAME:  , <i32 0x1820007>
 struct BadBuffer: ~Copyable {
   let buf = SmallVectorOf3<Int64?>()
 }
@@ -32,10 +32,10 @@ struct BadBuffer: ~Copyable {
 // CHECK-SAME:  , {{i64|i32}} 8
 // stride
 // CHECK-SAME:  , {{i64|i32}} 8
-// flags-32: alignment 7, noncopyable, is not inline
-// CHECK-SAME-32:  , <i32 0x820007>
-// flags-64: alignment 7, noncopyable
-// CHECK-SAME-64:  , <i32 0x800007>
+// flags-32: alignment 7, noncopyable, non-bitwise-borrowable, is not inline
+// CHECK-SAME-32:  , <i32 0x1820007>
+// flags-64: alignment 7, noncopyable, non-bitwise-borrowable
+// CHECK-SAME-64:  , <i32 0x1800007>
 struct Weird: ~Copyable {
   let value = UnsafeCell<Int64>()
 }


### PR DESCRIPTION
For types like `Atomic` and `Mutex`, we want to know that even though they are technically bitwise-takable, they differ from other bitwise-takable types until this point because they are not also "bitwise-borrowable"; while borrowed, they are pinned in memory, so they cannot be passed by value as a borrowed parameter, unlike copyable bitwise-takable types. Add a bit to the value witness table flags to record this.

Note that this patch does not include any accompanying runtime support for propagating the flag into runtime-instantiated type metadata. There isn't yet any runtime functionality that varies based on this flag, so that can be implemented separately.

rdar://136396806