### PR TITLE
[6.0] [test] Remove a test for linking against libraries in the resource dir

### DIFF
--- a/validation-test/execution/interpret-with-dependencies.swift
+++ b/validation-test/execution/interpret-with-dependencies.swift
@@ -8,16 +8,6 @@
 // RUN: %swift_driver -I %S/Inputs/custom-modules -L%t %s | %FileCheck %s
 // CHECK: {{okay}}
 
-// Now test a dependency on a library in the compiler's resource directory.
-// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
-// RUN: ln -s %t/libabc.dylib %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/* %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/../shims %t/rsrc/
-// RUN: %empty-directory(%t/other)
-// RUN: ln -s %t/libfoo.dylib %t/other
-
-// RUN: %swift_driver -I %S/Inputs/custom-modules -L%t/other -resource-dir %t/rsrc/ %s | %FileCheck %s
-
 import foo
 
 if test() == 42 {


### PR DESCRIPTION
*6.0 cherry-pick of https://github.com/swiftlang/swift/pull/76640/commits/345619e9cb183eee0cb79fdce5be6eb5d4b513a4*

- Explanation: Disables a test for a behavior not supported by the new driver
- Scope: Test-only change
- Issue: rdar://136683245
- Risk: None
- Testing: Tested as part of the Swift test suite
- Reviewer: Ben Langmuir