### PR TITLE
Revert "[utils][presets] Build libc++ for LLDB on linux"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3066,8 +3066,6 @@ mixin-preset=
     sourcekit_stress_test_mixin
 
 [preset: linux_lldb]
-# Build libcxx for tests
-libcxx
 lldb
 foundation
 libdispatch


### PR DESCRIPTION
This reverts commit a7d01a1ef76c5b46a71256a1a18793b83b3857c9.

We need to upgrade the bots toolchain before this can be enabled.
