### PR TITLE
Use "resilient conformance" logic for deciding protocol dependencies involving Sendable

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -960,11 +960,11 @@ namespace {
 /// Return true if the witness table requires runtime instantiation to
 /// handle resiliently-added requirements with default implementations.
 ///
-/// If ignoreGenericity is true, skip the optimization for non-generic
-/// conformances are considered non-resilient.
+/// If disableOptimizations is true, skip optimizations that treat
+/// formally-resilient conformances as non-resilient.
 bool IRGenModule::isResilientConformance(
     const NormalProtocolConformance *conformance,
-    bool ignoreGenericity
+    bool disableOptimizations
 ) {
   // If the protocol is not resilient, the conformance is not resilient
   // either.
@@ -998,7 +998,7 @@ bool IRGenModule::isResilientConformance(
   // resiliently become dependent.
   if (!conformance->getDeclContext()->isGenericContext() &&
       conformanceModule == conformance->getProtocol()->getParentModule() &&
-      !ignoreGenericity)
+      !disableOptimizations)
     return false;
 
   // We have a resilient conformance.
@@ -1006,9 +1006,9 @@ bool IRGenModule::isResilientConformance(
 }
 
 bool IRGenModule::isResilientConformance(const RootProtocolConformance *root,
-                                         bool ignoreGenericity) {
+                                         bool disableOptimizations) {
   if (auto normal = dyn_cast<NormalProtocolConformance>(root))
-    return isResilientConformance(normal, ignoreGenericity);
+    return isResilientConformance(normal, disableOptimizations);
   // Self-conformances never require this.
   return false;
 }
@@ -1193,7 +1193,7 @@ bool IRGenModule::isDependentConformance(
   llvm::SmallPtrSet<const NormalProtocolConformance *, 4> visited;
   return ::isDependentConformance(
       *this, conformance,
-      isResilientConformance(conformance, /*ignoreGenericity=*/true),
+      isResilientConformance(conformance, /*disableOptimizations=*/true),
       visited);
 }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -959,8 +959,13 @@ namespace {
 
 /// Return true if the witness table requires runtime instantiation to
 /// handle resiliently-added requirements with default implementations.
+///
+/// If ignoreGenericity is true, skip the optimization for non-generic
+/// conformances are considered non-resilient.
 bool IRGenModule::isResilientConformance(
-    const NormalProtocolConformance *conformance) {
+    const NormalProtocolConformance *conformance,
+    bool ignoreGenericity
+) {
   // If the protocol is not resilient, the conformance is not resilient
   // either.
   bool shouldTreatProtocolNonResilient =
@@ -992,16 +997,18 @@ bool IRGenModule::isResilientConformance(
   // This is an optimization -- a conformance of a non-generic type cannot
   // resiliently become dependent.
   if (!conformance->getDeclContext()->isGenericContext() &&
-      conformanceModule == conformance->getProtocol()->getParentModule())
+      conformanceModule == conformance->getProtocol()->getParentModule() &&
+      !ignoreGenericity)
     return false;
 
   // We have a resilient conformance.
   return true;
 }
 
-bool IRGenModule::isResilientConformance(const RootProtocolConformance *root) {
+bool IRGenModule::isResilientConformance(const RootProtocolConformance *root,
+                                         bool ignoreGenericity) {
   if (auto normal = dyn_cast<NormalProtocolConformance>(root))
-    return isResilientConformance(normal);
+    return isResilientConformance(normal, ignoreGenericity);
   // Self-conformances never require this.
   return false;
 }
@@ -1185,7 +1192,9 @@ bool IRGenModule::isDependentConformance(
     const RootProtocolConformance *conformance) {
   llvm::SmallPtrSet<const NormalProtocolConformance *, 4> visited;
   return ::isDependentConformance(
-      *this, conformance, conformance->getProtocol()->isResilient(), visited);
+      *this, conformance,
+      isResilientConformance(conformance, /*ignoreGenericity=*/true),
+      visited);
 }
 
 static llvm::Value *

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1119,8 +1119,10 @@ public:
 
   TypeExpansionContext getMaximalTypeExpansionContext() const;
 
-  bool isResilientConformance(const NormalProtocolConformance *conformance);
-  bool isResilientConformance(const RootProtocolConformance *root);
+  bool isResilientConformance(const NormalProtocolConformance *conformance,
+                              bool ignoreGenericity = false);
+  bool isResilientConformance(const RootProtocolConformance *root,
+                              bool ignoreGenericity = false);
   bool isDependentConformance(const RootProtocolConformance *conformance);
 
   Alignment getCappedAlignment(Alignment alignment);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1120,9 +1120,9 @@ public:
   TypeExpansionContext getMaximalTypeExpansionContext() const;
 
   bool isResilientConformance(const NormalProtocolConformance *conformance,
-                              bool ignoreGenericity = false);
+                              bool disableOptimizations = false);
   bool isResilientConformance(const RootProtocolConformance *root,
-                              bool ignoreGenericity = false);
+                              bool disableOptimizations = false);
   bool isDependentConformance(const RootProtocolConformance *conformance);
 
   Alignment getCappedAlignment(Alignment alignment);

--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -6,10 +6,36 @@
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
 
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 -enable-library-evolution | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 -enable-library-evolution | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
+
 // REQUIRES: OS=macosx
 
 import resilient_protocol
 import non_resilient_protocol
+
+// CHECK-USAGE: @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolAAWP" = hidden constant [3 x ptr] [
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolAAMc",
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D8ProtocolAAWP",
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolA2aDP9subMethodyyFTW"
+public protocol LocalProtocol: Sendable {
+  func method()
+}
+
+protocol LocalSubProtocol: Sendable, LocalProtocol {
+  func subMethod()
+}
+
+struct LocalType: Sendable, LocalSubProtocol {
+  func method() { }
+  func subMethod() { }
+}
+
+func acceptLocalProtocol<T: LocalProtocol>(_: T.Type) { }
+func testLocalType() {
+  acceptLocalProtocol(LocalType.self)
+}
+
 
 func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
 


### PR DESCRIPTION
When compiling with library evolution and a pre-Swift 6.0 deployment target, a mismatch between the notion of resilience used for determining whether a protocol that inherits Sendable might need to be treated as "dependent" differed from how other parts of IR generation decided whether to conformance should be considered as resilient. The difference came when both the protocol and its conforming type are in the same module as the user.

Switch over to the "is this conformance resilient?" query that takes into account such conformances.

Fixes rdar://136586922.