### PR TITLE
[6.0.2] Use "resilient conformance" logic for deciding protocol dependencies involving Sendable

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1114,8 +1114,10 @@ public:
 
   TypeExpansionContext getMaximalTypeExpansionContext() const;
 
-  bool isResilientConformance(const NormalProtocolConformance *conformance);
-  bool isResilientConformance(const RootProtocolConformance *root);
+  bool isResilientConformance(const NormalProtocolConformance *conformance,
+                              bool ignoreGenericity = false);
+  bool isResilientConformance(const RootProtocolConformance *root,
+                              bool ignoreGenericity = false);
   bool isDependentConformance(const RootProtocolConformance *conformance);
 
   Alignment getCappedAlignment(Alignment alignment);

--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -6,10 +6,36 @@
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
 // RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
 
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 -enable-library-evolution | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 -enable-library-evolution | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
+
 // REQUIRES: OS=macosx
 
 import resilient_protocol
 import non_resilient_protocol
+
+// CHECK-USAGE: @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolAAWP" = hidden constant [3 x ptr] [
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolAAMc",
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D8ProtocolAAWP",
+// CHECK-USAGE-SAME: ptr @"$s28protocol_resilience_sendable9LocalTypeVAA0D11SubProtocolA2aDP9subMethodyyFTW"
+public protocol LocalProtocol: Sendable {
+  func method()
+}
+
+protocol LocalSubProtocol: Sendable, LocalProtocol {
+  func subMethod()
+}
+
+struct LocalType: Sendable, LocalSubProtocol {
+  func method() { }
+  func subMethod() { }
+}
+
+func acceptLocalProtocol<T: LocalProtocol>(_: T.Type) { }
+func testLocalType() {
+  acceptLocalProtocol(LocalType.self)
+}
+
 
 func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
 


### PR DESCRIPTION
- **Explanation**: When compiling with library evolution and a pre-Swift 6.0 deployment target, a mismatch between the notion of resilience used for determining whether a protocol that inherits Sendable might need to be treated as "dependent" differed from how other parts of IR generation decided whether to conformance should be considered as resilient. The difference came when both the protocol and its conforming type are in the same module as the user. Switch over to the "is this conformance resilient?" query that takes into account such conformances.
- **Scope**: Affects binaries that use conformances of `Sendable`-conforming protocols, use library evolution, and are buil for deployment targets that predate Swift 6.0. 
- **Issues**: rdar://136586922
- **Original PRs**: https://github.com/swiftlang/swift/pull/76707
- **Risk**: Low. This is further narrowing from https://github.com/swiftlang/swift/pull/76384.
- **Testing**: Tested against an affected project, plus new tests
- **Reviewer**: @aschwaighofer 
