### PR TITLE
[Concurrency] Allow properties with `@Sendable` function types witnes…

### DIFF
--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -187,3 +187,20 @@ actor MyActor {
   // expected-warning@+1 {{non-final class 'Nested' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode}}
   class Nested: Sendable {}
 }
+
+@Sendable func globalFn() {}
+
+protocol NoSendableReqs {
+  var prop: () -> Void { get }
+  static var staticProp: () -> Void { get }
+}
+
+public struct TestSendableWitnesses1 : NoSendableReqs {
+  var prop: @Sendable () -> Void // Ok (no warnings)
+  static let staticProp: @Sendable () -> Void = { } // Ok (no warnings)
+}
+
+public struct TestSendableWitnesses2 : NoSendableReqs {
+  var prop = globalFn // Ok (no warnings)
+  static let staticProp = globalFn // Ok (no warnings)
+}


### PR DESCRIPTION
…s non-Sendable requirements

This is already supported for method and subscript witnesses that get their types decomposed.

```
protocol P {
  var test: () -> Void { get }
}

extension S : P {
  let test: @Sendable () -> Void // no concurrency warnings
}
```

Resolves: rdar://133403333

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
