### PR TITLE
utils: do not allow the compiler mismatch for the STL

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1421,7 +1421,7 @@ function Build-Compilers() {
     # of Clang. If bootstrapping with an older toolchain, we need to relax to relax this requirement with
     # ALLOW_COMPILER_AND_STL_VERSION_MISMATCH.
     $SwiftFlags = @();
-    if ([System.Version](Get-PinnedToolchainVersion) -lt [System.Version]"6.0") {
+    if ([System.Version](Get-PinnedToolchainVersion) -lt [System.Version]"6.0" -and [System.Version](Get-PinnedToolchainVersion) -ne [System.Version]"0.0.0") {
       $SwiftFlags += @("-Xcc", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
     }
 


### PR DESCRIPTION
When using a development toolchain or the 6.0 toolchain, do not allow the mismatch of the compiler as we have a new enough compiler.