### PR TITLE
[Tests] Add a test for accessing globally-isolated Sendable mutable storage of a Sendable value type from outside of the module.

### DIFF
--- a/test/Concurrency/nonisolated_access.swift
+++ b/test/Concurrency/nonisolated_access.swift
@@ -3,13 +3,13 @@
 
 /// Build the library A
 // RUN: %target-swift-frontend -emit-module %t/src/A.swift \
-// RUN: -disable-availability-checking \
+// RUN: -disable-availability-checking -verify \
 // RUN: -module-name A -swift-version 6 \
 // RUN: -emit-module-path %t/A.swiftmodule
 
 // Build the client
 // RUN: %target-swift-frontend -emit-module %t/src/Client.swift \
-// RUN: -disable-availability-checking \
+// RUN: -disable-availability-checking -verify \
 // RUN: -module-name Client -I %t -swift-version 6 \
 // RUN: -emit-module-path %t/Client.swiftmodule
 
@@ -28,6 +28,7 @@ public struct ImplicitlySendable {
 
 public struct S: P {
   nonisolated public var x: Int = 0
+  public var y: Int = 1
 
   nonisolated public init() {}
 }
@@ -39,6 +40,8 @@ actor A {
   func test() {
     var s = S()
     s.x += 0 // okay
+    // expected-error@+1 {{main actor-isolated property 'y' can not be mutated on a nonisolated actor instance}}
+    s.y += 1
     var sendable = ImplicitlySendable()
     sendable.prop = false // okay
   }


### PR DESCRIPTION
Resolves rdar://136761737.