### PR TITLE
SE-0444: Promote MemberImportVisibility to an upcoming feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 ## Swift (next)
 
+* [SE-0444][]:
+  When the upcoming feature `MemberImportVisibility` is enabled, Swift will
+  require that a module be directly imported in a source file when resolving
+  member declarations from that module:
+  
+  ```swift
+  let recipe = "2 slices of bread, 1.5 tbs peanut butter".parse()
+  // error: instance method 'parse()' is inaccessible due to missing import of
+  //        defining module 'RecipeKit'
+  // note:  add import of module 'RecipeKit'
+  ```
+  
+  This new behavior prevents ambiguities from arising when a transitively
+  imported module declares a member that conflicts with a member of a directly
+  imported module.
+
 * Syntactic SourceKit queries no longer attempt to provide information
   within the inactive `#if` regions. For example, given:
 
@@ -10629,6 +10645,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 [SE-0428]: https://github.com/apple/swift-evolution/blob/main/proposals/0428-resolve-distributed-actor-protocols.md
 [SE-0431]: https://github.com/apple/swift-evolution/blob/main/proposals/0431-isolated-any-functions.md
 [SE-0442]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0442-allow-taskgroup-childtaskresult-type-to-be-inferred.md
+[SE-0444]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
 [#64927]: <https://github.com/apple/swift/issues/64927>
 [#42697]: <https://github.com/apple/swift/issues/42697>
 [#42728]: <https://github.com/apple/swift/issues/42728>

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -223,6 +223,7 @@ UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
+UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
@@ -375,9 +376,6 @@ EXPERIMENTAL_FEATURE(GroupActorErrors, true)
 
 // Enable explicit isolation of closures.
 EXPERIMENTAL_FEATURE(ClosureIsolation, true)
-
-// Whether lookup of members respects the enclosing file's imports.
-EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(MemberImportVisibility, true)
 
 // Enable @implementation on extensions of ObjC classes with non-fixed layout
 // due to resilient stored properties. Requires OS support; this flag exists for

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -68,6 +68,7 @@ UNINTERESTING_FEATURE(FullTypedThrows)
 UNINTERESTING_FEATURE(ExistentialAny)
 UNINTERESTING_FEATURE(InferSendableFromCaptures)
 UNINTERESTING_FEATURE(ImplicitOpenExistentials)
+UNINTERESTING_FEATURE(MemberImportVisibility)
 
 // ----------------------------------------------------------------------------
 // MARK: - Experimental Features
@@ -275,7 +276,6 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
   });
 }
 
-UNINTERESTING_FEATURE(MemberImportVisibility)
 UNINTERESTING_FEATURE(IsolatedAny2)
 UNINTERESTING_FEATURE(GlobalActorIsolatedTypesUsability)
 UNINTERESTING_FEATURE(ObjCImplementation)

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_C.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -verify-additional-prefix ambiguity-
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 6 -package-name TestPackage -verify-additional-prefix ambiguity-
-// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -enable-upcoming-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 import members_C
 // expected-member-visibility-note 15{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}

--- a/test/NameLookup/members_transitive_multifile.swift
+++ b/test/NameLookup/members_transitive_multifile.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_C.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 5
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 5 -enable-upcoming-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 //--- main.swift
 

--- a/test/NameLookup/members_transitive_multifile_access_level.swift
+++ b/test/NameLookup/members_transitive_multifile_access_level.swift
@@ -19,7 +19,7 @@
 // RUN:   -primary-file %t/extensions.swift \
 // RUN:   %t/imports.swift \
 // RUN:   -I %t -package-name Package \
-// RUN:   -enable-experimental-feature MemberImportVisibility \
+// RUN:   -enable-upcoming-feature MemberImportVisibility \
 // RUN:   -verify-additional-prefix public-by-default-
 
 // RUN: %target-swift-frontend -typecheck -verify -swift-version 5 \
@@ -29,7 +29,7 @@
 // RUN:   -primary-file %t/extensions.swift \
 // RUN:   %t/imports.swift \
 // RUN:   -I %t -package-name Package \
-// RUN:   -enable-experimental-feature MemberImportVisibility \
+// RUN:   -enable-upcoming-feature MemberImportVisibility \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
 // RUN:   -verify-additional-prefix internal-by-default-
 

--- a/test/NameLookup/members_transitive_objc.swift
+++ b/test/NameLookup/members_transitive_objc.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/MemberImportVisibility -o %t %S/Inputs/MemberImportVisibility/Categories_E.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5
 // RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5 -enable-upcoming-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 // REQUIRES: objc_interop
 

--- a/test/NameLookup/members_transitive_underlying_clang.swift
+++ b/test/NameLookup/members_transitive_underlying_clang.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5
 // RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility
+// RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5 -enable-upcoming-feature MemberImportVisibility
 
 //--- Other.swift
 @_exported import Underlying


### PR DESCRIPTION
The proposal has been [accepted](https://forums.swift.org/t/accepted-se-0444-member-import-visibility/74966/1), so `MemberImportVisibility` is no longer experimental.

Resolves rdar://126284512.
