### PR TITLE
[Compile Time Constant Extraction] Extract listed Availability Attributes for buildLimitedAvailability in Result Builders

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/Attr.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -198,6 +199,15 @@ public:
   class ConditionalMember : public BuilderMember {
   public:
     ConditionalMember(MemberKind MemberKind,
+                      std::vector<PlatformVersionConstraintAvailabilitySpec>
+                          AvailabilityAttributes,
+                      std::vector<std::shared_ptr<BuilderMember>> IfElements,
+                      std::vector<std::shared_ptr<BuilderMember>> ElseElements)
+        : BuilderMember(MemberKind),
+          AvailabilityAttributes(AvailabilityAttributes),
+          IfElements(IfElements), ElseElements(ElseElements) {}
+
+    ConditionalMember(MemberKind MemberKind,
                       std::vector<std::shared_ptr<BuilderMember>> IfElements,
                       std::vector<std::shared_ptr<BuilderMember>> ElseElements)
         : BuilderMember(MemberKind), IfElements(IfElements),
@@ -210,6 +220,10 @@ public:
              (Kind == MemberKind::Optional);
     }
 
+    std::optional<std::vector<PlatformVersionConstraintAvailabilitySpec>>
+    getAvailabilityAttributes() const {
+      return AvailabilityAttributes;
+    }
     std::vector<std::shared_ptr<BuilderMember>> getIfElements() const {
       return IfElements;
     }
@@ -218,6 +232,8 @@ public:
     }
 
   private:
+    std::optional<std::vector<PlatformVersionConstraintAvailabilitySpec>>
+        AvailabilityAttributes;
     std::vector<std::shared_ptr<BuilderMember>> IfElements;
     std::vector<std::shared_ptr<BuilderMember>> ElseElements;
   };

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -108,7 +108,7 @@ public struct MyFooProviderInferred: FooProvider {
             Foo(name: "MyFooProviderInferred.foos.Optional")
         }
 
-        if #available(macOS 99, *) {
+        if #available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             Foo(name: "MyFooProviderInferred.foos.limitedAvailability.1")
             Foo(name: "MyFooProviderInferred.foos.limitedAvailability.2")
         } else {
@@ -430,6 +430,28 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "kind": "buildLimitedAvailability",
+// CHECK-NEXT:               "availabilityAttributes": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "platform": "iOS",
+// CHECK-NEXT:                   "minVersion": "18.0"
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "platform": "macOS",
+// CHECK-NEXT:                   "minVersion": "15.0"
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "platform": "watchOS",
+// CHECK-NEXT:                   "minVersion": "11.0"
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "platform": "tvOS",
+// CHECK-NEXT:                   "minVersion": "18.0"
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "platform": "visionOS",
+// CHECK-NEXT:                   "minVersion": "2.0"
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ],
 // CHECK-NEXT:               "ifElements": [
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {


### PR DESCRIPTION
This takes a `#available` usage in a result builder and adds the availability information to the `swiftconstvalues` files. 

An example usage is the following:

```
public struct MyFooProviderInferred: FooProvider {
    public static var foos: [Foo] {

        if #available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
            Foo(name: "Blah 1")
        } else {
            Foo(name: "Other Blah")
        }
    }
}
```

This adds the following to the existing `swiftconstvalues` file:

```
            "availabilityAttributes": [
              {
                "platform": "iOS",
                "minVersion": "18.0"
              },
              {
                "platform": "macOS",
                "minVersion": "15.0"
              },
              {
                "platform": "watchOS",
                "minVersion": "11.0"
              },
              {
                "platform": "tvOS",
                "minVersion": "18.0"
              },
              {
                "platform": "visionOS",
                "minVersion": "2.0"
              }
            ],

```

Resolves rdar://136763429