### PR TITLE
[Macro] Precise macro plugin dependency during scanning

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -127,6 +127,9 @@ ERROR(error_no_source_location_scope_map,none,
 ERROR(error_load_plugin_executable,none,
       "invalid value '%0' in '-load-plugin-executable'; "
       "make sure to use format '<plugin path>#<module names>'", (StringRef))
+ERROR(error_load_resolved_plugin,none,
+      "invalid value '%0' in '-load-resolved-plugin'; "
+      "make sure to use format '<library path>#<plugin path>#<module names>' where library and plugin path can't both be empty", (StringRef))
 
 NOTE(note_valid_swift_versions, none,
      "valid arguments to '-swift-version' are %0", (StringRef))

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -214,17 +214,24 @@ public:
     std::string SearchPath;
     std::string ServerPath;
   };
+  struct ResolvedPluginConfig {
+    std::string LibraryPath;
+    std::string ExecutablePath;
+    std::vector<std::string> ModuleNames;
+  };
 
   enum class Kind : uint8_t {
     LoadPluginLibrary,
     LoadPluginExecutable,
     PluginPath,
     ExternalPluginPath,
+    ResolvedPluginConfig,
   };
 
 private:
-  using Members = ExternalUnionMembers<LoadPluginLibrary, LoadPluginExecutable,
-                                       PluginPath, ExternalPluginPath>;
+  using Members =
+      ExternalUnionMembers<LoadPluginLibrary, LoadPluginExecutable, PluginPath,
+                           ExternalPluginPath, ResolvedPluginConfig>;
   static Members::Index getIndexForKind(Kind kind) {
     switch (kind) {
     case Kind::LoadPluginLibrary:
@@ -235,6 +242,8 @@ private:
       return Members::indexOf<PluginPath>();
     case Kind::ExternalPluginPath:
       return Members::indexOf<ExternalPluginPath>();
+    case Kind::ResolvedPluginConfig:
+      return Members::indexOf<ResolvedPluginConfig>();
     }
   };
   using Storage = ExternalUnion<Kind, Members, getIndexForKind>;
@@ -257,6 +266,10 @@ public:
   PluginSearchOption(const ExternalPluginPath &v)
       : kind(Kind::ExternalPluginPath) {
     storage.emplace<ExternalPluginPath>(kind, v);
+  }
+  PluginSearchOption(const ResolvedPluginConfig &v)
+      : kind(Kind::ResolvedPluginConfig) {
+    storage.emplace<ResolvedPluginConfig>(kind, v);
   }
   PluginSearchOption(const PluginSearchOption &o) : kind(o.kind) {
     storage.copyConstruct(o.kind, o.storage);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2095,6 +2095,14 @@ def load_plugin_executable:
            "of module names where the macro types are declared">,
   MetaVarName<"<path>#<module-names>">;
 
+def load_resolved_plugin:
+  Separate<["-"], "load-resolved-plugin">, Group<plugin_search_Group>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Path to resolved plugin configuration and a comma-separated list "
+           "of module names where the macro types are declared. Library path "
+           "and exectuable path can be empty if not used">,
+  MetaVarName<"<library-path>#<executable-path>#<module-names>">;
+
 def in_process_plugin_server_path : Separate<["-"], "in-process-plugin-server-path">,
   Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Path to dynamic library plugin server">;

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -160,25 +160,6 @@ parseBatchScanInputFile(ASTContext &ctx, StringRef batchInputPath,
   return result;
 }
 
-static void removeMacroSearchPaths(std::vector<std::string> &cmd) {
-  // Macro search path options.
-  static const llvm::StringSet<> macroSearchOptions = {
-      "-plugin-path",
-      "-external-plugin-path",
-      "-load-plugin-library",
-      "-load-plugin-executable",
-      "-in-process-plugin-server-path",
-  };
-
-  // Remove macro search path option and its argument.
-  for (auto it = cmd.begin(); it != cmd.end();) {
-    if (macroSearchOptions.contains(*it) && it + 1 != cmd.end())
-      it = cmd.erase(it, it + 2);
-    else
-      ++it;
-  }
-}
-
 class ExplicitModuleDependencyResolver {
 public:
   ExplicitModuleDependencyResolver(
@@ -301,6 +282,13 @@ private:
     for (auto &macro : macros)
       depInfo.addMacroDependency(
           macro.first(), macro.second.LibraryPath, macro.second.ExecutablePath);
+
+    for (auto &macro : depInfo.getMacroDependencies()) {
+      std::string arg = macro.second.LibraryPath + "#" +
+                        macro.second.ExecutablePath + "#" + macro.first;
+      commandline.push_back("-load-resolved-plugin");
+      commandline.push_back(arg);
+    }
 
     // Update CAS dependencies.
     if (auto err = collectCASDependencies(depInfo))
@@ -529,11 +517,6 @@ private:
     // Update build command line.
     if (resolvingDepInfo.isSwiftInterfaceModule() ||
         resolvingDepInfo.isSwiftSourceModule()) {
-      // If there are no external macro dependencies, drop all plugin search
-      // paths.
-      if (resolvingDepInfo.getMacroDependencies().empty() && macros.empty())
-        removeMacroSearchPaths(commandline);
-
       // Update with casfs option.
       for (auto rootID : rootIDs) {
         commandline.push_back("-cas-fs");

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1753,6 +1753,15 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
           ArgSaver.save(val.SearchPath + "#" + val.ServerPath));
       break;
     }
+    case PluginSearchOption::Kind::ResolvedPluginConfig: {
+      auto &val = entry.get<PluginSearchOption::ResolvedPluginConfig>();
+      for (auto &moduleName : val.ModuleNames) {
+        GenericArgs.push_back("-load-plugin-executable");
+        GenericArgs.push_back(ArgSaver.save(
+            val.LibraryPath + "#" + val.ExecutablePath + "#" + moduleName));
+      }
+      break;
+    }
     }
   }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1723,47 +1723,9 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.setPlatformAvailabilityInheritanceMapPath(*SearchPathOpts.PlatformAvailabilityInheritanceMapPath);
   }
 
-  for (auto &entry : SearchPathOpts.PluginSearchOpts) {
-    switch (entry.getKind()) {
-    case PluginSearchOption::Kind::LoadPluginLibrary: {
-      auto &val = entry.get<PluginSearchOption::LoadPluginLibrary>();
-      GenericArgs.push_back("-load-plugin-library");
-      GenericArgs.push_back(ArgSaver.save(val.LibraryPath));
-      break;
-    }
-    case PluginSearchOption::Kind::LoadPluginExecutable: {
-      auto &val = entry.get<PluginSearchOption::LoadPluginExecutable>();
-      for (auto &moduleName : val.ModuleNames) {
-        GenericArgs.push_back("-load-plugin-executable");
-        GenericArgs.push_back(
-            ArgSaver.save(val.ExecutablePath + "#" + moduleName));
-      }
-      break;
-    }
-    case PluginSearchOption::Kind::PluginPath: {
-      auto &val = entry.get<PluginSearchOption::PluginPath>();
-      GenericArgs.push_back("-plugin-path");
-      GenericArgs.push_back(ArgSaver.save(val.SearchPath));
-      break;
-    }
-    case PluginSearchOption::Kind::ExternalPluginPath: {
-      auto &val = entry.get<PluginSearchOption::ExternalPluginPath>();
-      GenericArgs.push_back("-external-plugin-path");
-      GenericArgs.push_back(
-          ArgSaver.save(val.SearchPath + "#" + val.ServerPath));
-      break;
-    }
-    case PluginSearchOption::Kind::ResolvedPluginConfig: {
-      auto &val = entry.get<PluginSearchOption::ResolvedPluginConfig>();
-      for (auto &moduleName : val.ModuleNames) {
-        GenericArgs.push_back("-load-plugin-executable");
-        GenericArgs.push_back(ArgSaver.save(
-            val.LibraryPath + "#" + val.ExecutablePath + "#" + moduleName));
-      }
-      break;
-    }
-    }
-  }
+  // Inherit the plugin search opts but do not inherit the arguments.
+  genericSubInvocation.getSearchPathOptions().PluginSearchOpts =
+      SearchPathOpts.PluginSearchOpts;
 
   genericSubInvocation.getFrontendOptions().InputMode
       = FrontendOptions::ParseInputMode::SwiftModuleInterface;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -148,6 +148,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       case PluginSearchOptionKind::LoadPluginExecutable:
         optKind = PluginSearchOption::Kind::LoadPluginExecutable;
         break;
+      case PluginSearchOptionKind::ResolvedPluginConfig:
+        optKind = PluginSearchOption::Kind::ResolvedPluginConfig;
+        break;
       }
       extendedInfo.addPluginSearchOption({optKind, blobData});
       break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -694,6 +694,7 @@ enum class PluginSearchOptionKind : uint8_t {
   ExternalPluginPath,
   LoadPluginLibrary,
   LoadPluginExecutable,
+  ResolvedPluginConfig,
 };
 using PluginSearchOptionKindField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1245,6 +1245,18 @@ void Serializer::writeHeader() {
                 uint8_t(PluginSearchOptionKind::LoadPluginExecutable), optStr);
             continue;
           }
+          case PluginSearchOption::Kind::ResolvedPluginConfig: {
+            auto &opt = elem.get<PluginSearchOption::ResolvedPluginConfig>();
+            std::string optStr =
+                opt.LibraryPath + "#" + opt.ExecutablePath + "#";
+            llvm::interleave(
+                opt.ModuleNames, [&](auto &name) { optStr += name; },
+                [&]() { optStr += ","; });
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::ResolvedPluginConfig), optStr);
+            continue;
+          }
           }
         }
       }

--- a/test/CAS/macro_deps.swift
+++ b/test/CAS/macro_deps.swift
@@ -44,6 +44,10 @@
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
+// RUN: %FileCheck %s --check-prefix=PLUGIN_SEARCH --check-prefix=RESOLVED --input-file=%t/MyApp.cmd
+// PLUGIN_SEARCH-NOT: -external-plugin-path
+// RESOLVED-COUNT-2: -load-resolved-plugin
+
 // RUN: %target-swift-frontend -diagnostic-style=swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -31,6 +31,26 @@
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 
+/// Create file with matching name in alt directories and test
+/// `-load-resolved-plugin` takes the priority over other options.
+// RUN: %empty-directory(%t/alt)
+// RUN: touch %t/alt/%target-library-name(MacroDefinition)
+
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -external-plugin-path %t/alt#%swift-plugin-server \
+// RUN:   -load-resolved-plugin lib-do-not-exist.dylib##MacroDefinition \
+// RUN:   -load-resolved-plugin %t/plugins/%target-library-name(MacroDefinition)#%swift-plugin-server#MacroDefinition \
+// RUN:   -load-resolved-plugin %t/plugins/%target-library-name(EvilMacros)#%swift-plugin-server#EvilMacros \
+// RUN:   -external-plugin-path %t/alt#%swift-plugin-server \
+// RUN:   -Rmacro-loading -verify-ignore-unknown \
+// RUN:   -module-name MyApp \
+// RUN:   %s \
+// RUN:   2>&1 | tee %t/macro-expansions-2.txt
+
+// RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions-2.txt
+
 // RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 \

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -105,6 +105,9 @@ static bool validateModule(
       case swift::PluginSearchOption::Kind::LoadPluginExecutable:
         optStr = "-load-plugin-executable";
         break;
+      case swift::PluginSearchOption::Kind::ResolvedPluginConfig:
+        optStr = "-load-resolved-plugin";
+        break;
       }
       llvm::outs() << "    " << optStr << " " << opt.second << "\n";
     }


### PR DESCRIPTION
Teach dependency scanner to track precise dependencies for macro plugin:
* Read the available public external macro module name from swift modules dependencies
* Resolve the macro plugin in the dependency scanner using the search path option
* Pass resolved plugin configuration to swift-frontend so no searching is needed during compilation

This also means if a macro plugin search path is not used, it will not cause an additional module variants due to the search path difference.

rdar://136682810