### PR TITLE
[cxx-interop] Add diagnostic notes when retain/release are not import…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2615,6 +2615,11 @@ namespace {
         Impl.diagnose(loc,
                       diag::foreign_reference_types_cannot_find_retain_release,
                       false, retainOperation.name, decl->getNameAsString());
+        if (!Impl.SwiftContext.LangOpts
+                 .DisableExperimentalClangImporterDiagnostics) {
+          Impl.diagnoseTopLevelValue(
+              DeclName(Impl.SwiftContext.getIdentifier(retainOperation.name)));
+        }
       } else if (retainOperation.kind ==
                  CustomRefCountingOperationResult::tooManyFound) {
         HeaderLoc loc(decl->getLocation());
@@ -2674,7 +2679,12 @@ namespace {
         Impl.diagnose(loc,
                       diag::foreign_reference_types_cannot_find_retain_release,
                       true, releaseOperation.name, decl->getNameAsString());
-      } else if (releaseOperation.kind ==
+        if (!Impl.SwiftContext.LangOpts
+                 .DisableExperimentalClangImporterDiagnostics) {
+          Impl.diagnoseTopLevelValue(
+              DeclName(Impl.SwiftContext.getIdentifier(releaseOperation.name)));
+        }
+      }else if (releaseOperation.kind ==
                  CustomRefCountingOperationResult::tooManyFound) {
         HeaderLoc loc(decl->getLocation());
         Impl.diagnose(loc,

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -204,6 +204,14 @@ void retain2(MultipleRetainReleaseAttrFRT *v);
 void release1(MultipleRetainReleaseAttrFRT *v);
 void release2(MultipleRetainReleaseAttrFRT *v);
 
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:Uretain")))
+    __attribute__((swift_attr("release:Urelease")))
+UnimportedRetainRelease {};
+void Uretain(UnimportedRetainRelease v);
+UnimportedRetainRelease Urelease(UnimportedRetainRelease* v);
+
 //--- test.swift
 
 import Test
@@ -284,3 +292,10 @@ public func testMultipleRetainRelease(x: MultipleRetainReleaseFRT) {}
 // CHECK: error: reference type 'MultipleRetainReleaseAttrFRT' must have only one 'release:' Swift attribute
 @available(macOS 13.3, *)
 public func testMultipleRetainRelease(x: MultipleRetainReleaseAttrFRT) {}
+
+// CHECK: error: cannot find retain function 'Uretain' for reference type 'UnimportedRetainRelease'
+// CHECK: note: function uses foreign reference type 'UnimportedRetainRelease' as a value in a parameter types which breaks 'swift_shared_reference' contract
+// CHECK: error: cannot find release function 'Urelease' for reference type 'UnimportedRetainRelease'
+// CHECK: note: function uses foreign reference type 'UnimportedRetainRelease' as a value in the return types which breaks 'swift_shared_reference' contract
+@available(macOS 13.3, *)
+public func test(x: UnimportedRetainRelease) {}


### PR DESCRIPTION
If the retain or release function of a C++ foreign reference type (or SWIFT_SHARED_REFERENCE type) was not imported into swift because of any reasons, then we were just emitting this error: 
cannot find retain/release function '<retain/release function name>' for reference type '<CXX-frt-name>'. 

This is confusing to a C++ developer because the retain/release function clearly exists on C++ side. It is just not imported into swift because it violated some contract. 

In this patch I am adding additional notes in such cases when retain/release functions are actually present on the C++ side, but are not imported into swift for whatever reason.

rdar://136834573