### PR TITLE
[cxx-interop] Use macosx paths when searching modulemaps for macCatalyst

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -30,7 +30,11 @@ static std::optional<Path> getActualModuleMapPath(
     StringRef name, SearchPathOptions &Opts, const llvm::Triple &triple,
     bool isArchSpecific,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs) {
-  StringRef platform = swift::getPlatformNameForTriple(triple);
+  StringRef platform;
+  if (swift::tripleIsMacCatalystEnvironment(triple))
+    platform = "macosx";
+  else
+    platform = swift::getPlatformNameForTriple(triple);
   StringRef arch = swift::getMajorArchitectureName(triple);
 
   Path result;


### PR DESCRIPTION
The existing code will use paths for "iphoneos" because the triples for macCatalyst are in the form "<arch>-apple-iosXX.yy-macabi", which the code interprets as an iPhone triple. This seems to work in Xcode because the "iphoneos" folder is always there. When building in open source, this seems to work because it is also normal to have the iPhone SDK configured. This is not the case if you want to build the macOS SDK in isolation.

The code changes detect the macCatalyst environment from the triple and use the "macosx" paths instead, otherwise it follows the same code path as before. This matches many places in the CMakeLists.txt files in which macCatalyst support pieces are only enabled when the SDK is macOS.

The modified function is also used for the libc modulemap of non-Darwin platforms, but for those triples, the macCatalyst environment should not be detected, so the libc modulemap should not be affected by this change.

This is a followup to #76260 and #74994.