### PR TITLE
[Blocklist] Make sure blocklist config is read through VFS

### DIFF
--- a/include/swift/Basic/BlockList.h
+++ b/include/swift/Basic/BlockList.h
@@ -23,6 +23,8 @@
 
 namespace swift {
 
+class SourceManager;
+
 enum class BlockListAction: uint8_t {
   Undefined = 0,
 #define BLOCKLIST_ACTION(NAME) NAME,
@@ -41,7 +43,7 @@ public:
   void addConfigureFilePath(StringRef path);
   bool hasBlockListAction(StringRef key, BlockListKeyKind keyKind,
                           BlockListAction action);
-  BlockListStore();
+  BlockListStore(SourceManager &SM);
   ~BlockListStore();
 private:
   Implementation &Impl;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -86,6 +86,11 @@ def primary_file : Separate<["-"], "primary-file">,
   Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
   HelpText<"Produce output for this file, not the whole module">;
 
+def block_list_file
+  : Separate<["-"], "blocklist-file">, MetaVarName<"<path>">,
+    Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
+    HelpText<"The path to a blocklist configuration file">;
+
 let Flags = [FrontendOption, NoDriverOption] in {
 
 def triple : Separate<["-"], "triple">, Alias<target>;
@@ -287,10 +292,6 @@ def Raccess_note : Separate<["-"], "Raccess-note">,
     HelpText<"Control access note remarks (default: all)">;
 def Raccess_note_EQ : Joined<["-"], "Raccess-note=">,
     Alias<Raccess_note>;
-
-def block_list_file
-  : Separate<["-"], "blocklist-file">, MetaVarName<"<path>">,
-    HelpText<"The path to a blocklist configuration file">;
 } // end let Flags = [FrontendOption, NoDriverOption]
 
 def debug_crash_Group : OptionGroup<"<automatic crashing options>">;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -58,6 +58,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/APIntMap.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/BlockList.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
@@ -779,6 +780,7 @@ ASTContext::ASTContext(
       evaluator(Diags, langOpts), TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
+      blockListConfig(SourceMgr),
       TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(
           *this, Type(), RecursiveTypeProperties::HasError)),
       TheUnresolvedType(new(*this, AllocationArena::Permanent)

--- a/lib/Basic/BlockList.cpp
+++ b/lib/Basic/BlockList.cpp
@@ -19,7 +19,7 @@
 #include "swift/Basic/SourceManager.h"
 
 struct swift::BlockListStore::Implementation {
-  SourceManager SM;
+  SourceManager &SM;
   llvm::StringMap<std::vector<BlockListAction>> ModuleActionDict;
   llvm::StringMap<std::vector<BlockListAction>> ProjectActionDict;
   void addConfigureFilePath(StringRef path);
@@ -44,9 +44,12 @@ struct swift::BlockListStore::Implementation {
     }
     return std::string();
   }
+
+  Implementation(SourceManager &SM) : SM(SM) {}
 };
 
-swift::BlockListStore::BlockListStore(): Impl(*new Implementation()) {}
+swift::BlockListStore::BlockListStore(swift::SourceManager &SM)
+    : Impl(*new Implementation(SM)) {}
 
 swift::BlockListStore::~BlockListStore() { delete &Impl; }
 

--- a/test/CAS/block-list.swift
+++ b/test/CAS/block-list.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -blocklist-file %t/blocklist.yml -blocklist-file %t/empty.yml \
+// RUN:   -scanner-prefix-map %t=/^tmp \
 // RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
@@ -25,10 +26,11 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -blocklist-file %t/blocklist.yml -blocklist-file %t/empty.yml \
+// RUN:   -blocklist-file /^tmp/blocklist.yml -blocklist-file /^tmp/empty.yml \
 // RUN:   -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation \
 // RUN:   -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation \
-// RUN:   %t/main.swift @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix CHECK-BLOCKED
+// RUN:   -cache-replay-prefix-map /^tmp=%t \
+// RUN:   /^tmp/main.swift @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix CHECK-BLOCKED
 
 // CHECK-BLOCKED: note: Layout string value witnesses have been disabled for module 'Test' through block list entry
 // CHECK-BLOCKED-NOT: type_layout_string

--- a/unittests/Basic/BlocklistTest.cpp
+++ b/unittests/Basic/BlocklistTest.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/BlockList.h"
+#include "swift/Basic/SourceManager.h"
 
 using namespace swift;
 
@@ -46,7 +47,8 @@ TEST(BlocklistTest, testYamlParsing) {
   ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
       "BlocklistTest.testYamlParsing", temp));
   SWIFT_DEFER { llvm::sys::fs::remove_directories(temp); };
-  BlockListStore store;
+  SourceManager sm;
+  BlockListStore store(sm);
   std::string path1, path2;
   ASSERT_FALSE(emitFileWithContents(temp, "block1.yaml",
                                     "---\n"


### PR DESCRIPTION
Make sure block-list file is read through VFS so CASFS can be used to read the configuration to ensure sound caching, and also the path of the blocklist can be canonicalized via path remapping.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
