### PR TITLE
[CAS] Use IncludeTreeFileList instead of full CASFS for caching

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -35,7 +35,7 @@
 
 namespace llvm {
 class FileCollectorBase;
-class TreePathPrefixMapper;
+class PrefixMapper;
 namespace vfs {
 class OutputBackend;
 }
@@ -376,7 +376,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
-                        llvm::TreePathPrefixMapper *mapper = nullptr,
+                        llvm::PrefixMapper *mapper = nullptr,
                         bool isTestableImport = false) = 0;
 };
 

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -43,6 +43,9 @@ public:
   /// Clang Include Trees.
   std::vector<std::string> ClangIncludeTrees;
 
+  /// Clang Include Tree FileList.
+  std::vector<std::string> ClangIncludeTreeFileList;
+
   /// CacheKey for input file.
   std::string InputFileKey;
 
@@ -60,7 +63,8 @@ public:
   bool requireCASFS() const {
     return EnableCaching &&
            (!CASFSRootIDs.empty() || !ClangIncludeTrees.empty() ||
-            !InputFileKey.empty() || !BridgingHeaderPCHCacheKey.empty());
+            !ClangIncludeTreeFileList.empty() || !InputFileKey.empty() ||
+            !BridgingHeaderPCHCacheKey.empty());
   }
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -484,7 +484,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
-                        llvm::TreePathPrefixMapper *mapper,
+                        llvm::PrefixMapper *mapper,
                         bool isTestableImport = false) override;
 
   void recordBridgingHeaderOptions(

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -54,7 +54,8 @@ std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(
 
 llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createCASFileSystem(llvm::cas::ObjectStore &CAS, ArrayRef<std::string> FSRoots,
-                    ArrayRef<std::string> IncludeTreeRoots);
+                    ArrayRef<std::string> IncludeTreeRoots,
+                    ArrayRef<std::string> IncludeTreeFileList);
 
 std::vector<std::string> remapPathsFromCommandLine(
     ArrayRef<std::string> Args,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1386,7 +1386,8 @@ def cas_fs: Separate<["-"], "cas-fs">,
 
 def clang_include_tree_root: Separate<["-"], "clang-include-tree-root">,
   HelpText<"Clang Include Tree CASID">, MetaVarName<"<cas-id>">;
-
+def clang_include_tree_filelist: Separate<["-"], "clang-include-tree-filelist">,
+  HelpText<"Clang Include Tree FileList CASID">, MetaVarName<"<cas-id>">;
 
 def experimental_spi_only_imports :
   Flag<["-"], "experimental-spi-only-imports">,

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -103,7 +103,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
-                        llvm::TreePathPrefixMapper *mapper,
+                        llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;
 };
 }

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -265,7 +265,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
-                        llvm::TreePathPrefixMapper *mapper,
+                        llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;
 };
 

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -424,7 +424,7 @@ ClangImporter::getModuleDependencies(Identifier moduleName,
                                      const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                                      clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                                      InterfaceSubContextDelegate &delegate,
-                                     llvm::TreePathPrefixMapper *mapper,
+                                     llvm::PrefixMapper *mapper,
                                      bool isTestableImport) {
   auto &ctx = Impl.SwiftContext;
   // Determine the command-line arguments for dependency scanning.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -729,6 +729,8 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
     Opts.CASFSRootIDs.emplace_back(A);
   for (const auto &A : Args.getAllArgValues(OPT_clang_include_tree_root))
     Opts.ClangIncludeTrees.emplace_back(A);
+  for (const auto &A : Args.getAllArgValues(OPT_clang_include_tree_filelist))
+    Opts.ClangIncludeTreeFileList.emplace_back(A);
 
   if (const Arg *A = Args.getLastArg(OPT_input_file_key))
     Opts.InputFileKey = A->getValue();
@@ -736,7 +738,8 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   if (const Arg*A = Args.getLastArg(OPT_bridging_header_pch_key))
     Opts.BridgingHeaderPCHCacheKey = A->getValue();
 
-  if (!Opts.CASFSRootIDs.empty() || !Opts.ClangIncludeTrees.empty())
+  if (!Opts.CASFSRootIDs.empty() || !Opts.ClangIncludeTrees.empty() ||
+      !Opts.ClangIncludeTreeFileList.empty())
     Opts.HasImmutableFileSystem = true;
 
   return false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -623,10 +623,12 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
   }
 
   if (Invocation.getCASOptions().requireCASFS()) {
-    if (!CASOpts.CASFSRootIDs.empty() || !CASOpts.ClangIncludeTrees.empty()) {
+    if (!CASOpts.CASFSRootIDs.empty() || !CASOpts.ClangIncludeTrees.empty() ||
+        !CASOpts.ClangIncludeTreeFileList.empty()) {
       // Set up CASFS as BaseFS.
       auto FS = createCASFileSystem(*CAS, CASOpts.CASFSRootIDs,
-                                    CASOpts.ClangIncludeTrees);
+                                    CASOpts.ClangIncludeTrees,
+                                    CASOpts.ClangIncludeTreeFileList);
       if (!FS) {
         Diagnostics.diagnose(SourceLoc(), diag::error_cas,
                              toString(FS.takeError()));

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -160,7 +160,7 @@ SourceLoader::getModuleDependencies(Identifier moduleName,
                                     const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                                     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                                     InterfaceSubContextDelegate &delegate,
-                                    llvm::TreePathPrefixMapper* mapper,
+                                    llvm::PrefixMapper* mapper,
                                     bool isTestableImport) {
   // FIXME: Implement?
   return {};

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -314,7 +314,7 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenClangModules,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-    InterfaceSubContextDelegate &delegate, llvm::TreePathPrefixMapper *mapper,
+    InterfaceSubContextDelegate &delegate, llvm::PrefixMapper *mapper,
     bool isTestableDependencyLookup) {
   ImportPath::Module::Builder builder(moduleName);
   auto modulePath = builder.get();

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -13,7 +13,7 @@
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t#%swift-plugin-server
 
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
-// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/fs.casid | %FileCheck %s --check-prefix=FS
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
 
 // FS: MacroDefinition
 // RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd

--- a/test/CAS/deps_cas_fs.swift
+++ b/test/CAS/deps_cas_fs.swift
@@ -13,11 +13,11 @@
 
 /// check cas-fs content
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json E casFSRootID > %t/E_fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json F casFSRootID > %t/F_fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/F_fs.casid | %FileCheck %s -check-prefix FS_ROOT_F
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/F_fs.casid | %FileCheck %s -check-prefix FS_ROOT_F
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/Test_fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/Test_fs.casid | %FileCheck %s -check-prefix FS_ROOT_TEST
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/Test_fs.casid | %FileCheck %s -check-prefix FS_ROOT_TEST
 
 // FS_ROOT_E-DAG: layouts-x86_64.yaml
 // FS_ROOT_E-DAG: E.swiftinterface

--- a/test/CAS/macro_option_set.swift
+++ b/test/CAS/macro_option_set.swift
@@ -7,7 +7,7 @@
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -plugin-path %swift-plugin-dir
 
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
-// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/fs.casid | %FileCheck %s --check-prefix=FS
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
 
 // FS: SwiftMacros
 

--- a/test/CAS/macro_plugin.swift
+++ b/test/CAS/macro_plugin.swift
@@ -20,7 +20,7 @@
 // RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -load-plugin-library %t/plugins/%target-library-name(MacroDefinition)
 
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
-// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/fs.casid | %FileCheck %s --check-prefix=FS
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
 
 // FS: MacroDefinition
 

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -21,7 +21,7 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/nomacro.swift -o %t/deps1.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t/plugins#%swift-plugin-server
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps1.json MyApp casFSRootID > %t/no_macro_fs.casid
-// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/no_macro_fs.casid | %FileCheck %s --check-prefix=NO-MACRO
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/no_macro_fs.casid | %FileCheck %s --check-prefix=NO-MACRO
 // NO-MACRO-NOT: MacroDefinition
 
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
@@ -29,7 +29,7 @@
 // RUN:   %t/macro.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t/plugins#%swift-plugin-server
 
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
-// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/fs.casid | %FileCheck %s --check-prefix=FS
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
 
 // FS: MacroDefinition
 

--- a/test/CAS/module_deps.swift
+++ b/test/CAS/module_deps.swift
@@ -27,7 +27,7 @@
 
 /// check cas-fs content
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json E casFSRootID > %t/E_fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F casFSRootID > %t/F_fs.casid
 // RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/F_fs.casid | %FileCheck %s -check-prefix FS_ROOT_F
 

--- a/test/CAS/module_deps_clang_extras.swift
+++ b/test/CAS/module_deps_clang_extras.swift
@@ -13,7 +13,7 @@
 // RUN: %validate-json %t/deps.json &>/dev/null
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/fs.casid | %FileCheck %s -DDIR=%basename_t -check-prefix FS_ROOT
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s -DDIR=%basename_t -check-prefix FS_ROOT
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:Dummy clangIncludeTree > %t/tree.casid
 // RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/tree.casid | %FileCheck %s -DDIR=%basename_t -check-prefix INCLUDE_TREE
 

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -27,7 +27,7 @@
 
 /// check cas-fs content
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json E casFSRootID > %t/E_fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/F_tree.casid
 // RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/F_tree.casid | %FileCheck %s -check-prefix INCLUDE_TREE_F
@@ -49,8 +49,8 @@
 // INCLUDE_TREE_F-NEXT: CHeaders/F.h
 
 // MAIN_CMD: -direct-clang-cc1-module-build
-// MAIN_CMD: -cas-fs
 // MAIN_CMD: -clang-include-tree-root
+// MAIN_CMD: -clang-include-tree-filelist
 
 import C
 import E

--- a/test/CAS/module_path_remap.swift
+++ b/test/CAS/module_path_remap.swift
@@ -10,18 +10,18 @@
 // RUN:  -cas-path %t/cas -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/deps.fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/deps.fs.casid | %FileCheck %s -check-prefix DEPS-FS
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/deps.fs.casid | %FileCheck %s -check-prefix DEPS-FS
 // DEPS-FS: /^src/test/CAS/module_path_remap.swift
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps bridgingHeader | %FileCheck %s -check-prefix DEPS-BRIDGING
 // DEPS-BRIDGING: -fmodule-file=F=/^tmp/clang-module-cache/F-{{.*}}.pcm
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json F casFSRootID > %t/F.fs.casid
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/F.fs.casid | %FileCheck %s -check-prefix F-FS
-// F-FS: /^src/test/ScanDependencies/Inputs/Swift/F.swiftinterface
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/F.fs.casid | %FileCheck %s -check-prefix F-FS
+// F-FS: /^src/test/CAS/../ScanDependencies/Inputs/Swift/F.swiftinterface
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json F commandLine | %FileCheck %s -check-prefix F-CMD
-// F-CMD: /^src/test/ScanDependencies/Inputs/Swift/F.swiftinterface
+// F-CMD: /^src/test/CAS/../ScanDependencies/Inputs/Swift/F.swiftinterface
 // F-CMD: -fmodule-file=SwiftShims=/^tmp/clang-module-cache/SwiftShims-{{.*}}.pcm
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/tree.casid

--- a/test/CAS/simlink_inputs.swift
+++ b/test/CAS/simlink_inputs.swift
@@ -1,0 +1,65 @@
+// UNSUPPORTED: OS=windows-msvc
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: cd %t && ln -s private src
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/src/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/src/include
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json B > %t/B.cmd
+// RUN: %swift_frontend_plain @%t/B.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/src/main.swift @%t/MyApp.cmd
+
+/// Test the same build but remapping the path.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t/src=/^tmp -scanner-prefix-map %t/sdk=/^sdk \
+// RUN:   %t/src/main.swift -o %t/deps-1.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/src/include
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json clang:A > %t/A-1.cmd
+// RUN: %swift_frontend_plain @%t/A-1.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json B > %t/B-1.cmd
+// RUN: %swift_frontend_plain @%t/B-1.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps-1.json > %t/map-1.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map-1.json > %t/map-1.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json Test > %t/MyApp-1.cmd
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map-1.casid \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t/src -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   /^tmp/main.swift @%t/MyApp-1.cmd
+
+//--- private/main.swift
+import A
+import B
+
+//--- private/include/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- private/include/A.h
+void notused(void);
+
+//--- private/include/B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func c() { }
+


### PR DESCRIPTION
Use IncludeTreeFileList instead of full feature CASFS for swift dependency filesystem. This allows smaller CAS based VFS that is smaller and faster. This is enabled by the CAS enabled compilation does not need to iterate file system.

rdar://136787368

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
