### PR TITLE
Sema: Continue unwinding SolverScope

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -223,6 +223,9 @@ struct PotentialBindings {
 
   TypeVariableType *TypeVar;
 
+  /// The set of all constraints that have been added via infer().
+  llvm::SmallPtrSet<Constraint *, 2> Constraints;
+
   /// The set of potential bindings.
   llvm::SmallVector<PotentialBinding, 4> Bindings;
 

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -49,6 +49,10 @@ public:
     RelatedTypeVariables,
     /// Introduced a type variable's fixed type to inference.
     IntroducedToInference,
+    /// Inferred potential bindings from a constraint.
+    InferredBindings,
+    /// Retracted potential bindings from a constraint.
+    RetractedBindings,
     /// Set the fixed type or parent and flags for a type variable.
     UpdatedTypeVariable,
   };
@@ -131,6 +135,14 @@ public:
 
     /// Create a change that introduced a type variable to inference.
     static Change introducedToInference(TypeVariableType *typeVar, Type fixed);
+
+    /// Create a change that inferred bindings from a constraint.
+    static Change inferredBindings(TypeVariableType *typeVar,
+                                   Constraint *constraint);
+
+    /// Create a change that retracted bindings from a constraint.
+    static Change retractedBindings(TypeVariableType *typeVar,
+                                    Constraint *constraint);
 
     /// Create a change that updated a type variable.
     static Change updatedTypeVariable(

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -47,8 +47,6 @@ public:
     ExtendedEquivalenceClass,
     /// Added a new edge in the constraint graph.
     RelatedTypeVariables,
-    /// Introduced a type variable's fixed type to inference.
-    IntroducedToInference,
     /// Inferred potential bindings from a constraint.
     InferredBindings,
     /// Retracted potential bindings from a constraint.
@@ -94,14 +92,6 @@ public:
       } Relation;
 
       struct {
-        /// The type variable being bound to a fixed type.
-        TypeVariableType *TypeVar;
-
-        /// The fixed type to which the type variable was bound.
-        TypeBase *FixedType;
-      } Binding;
-
-      struct {
         /// The type variable being updated.
         TypeVariableType *TypeVar;
 
@@ -132,9 +122,6 @@ public:
     /// a type variable pair.
     static Change relatedTypeVariables(TypeVariableType *typeVar,
                                        TypeVariableType *otherTypeVar);
-
-    /// Create a change that introduced a type variable to inference.
-    static Change introducedToInference(TypeVariableType *typeVar, Type fixed);
 
     /// Create a change that inferred bindings from a constraint.
     static Change inferredBindings(TypeVariableType *typeVar,

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -37,7 +37,7 @@ public:
 
   /// The kind of change made to the graph.
   enum class ChangeKind {
-    /// Added a type variable to the constraint graph.
+    /// Added a new vertex to the constraint graph.
     AddedTypeVariable,
     /// Added a new constraint to the constraint graph.
     AddedConstraint,
@@ -45,8 +45,8 @@ public:
     RemovedConstraint,
     /// Extended the equivalence class of a type variable in the constraint graph.
     ExtendedEquivalenceClass,
-    /// Added a fixed binding for a type variable in the constraint graph.
-    BoundTypeVariable,
+    /// Added a new edge in the constraint graph.
+    RelatedTypeVariables,
     /// Introduced a type variable's fixed type to inference.
     IntroducedToInference,
     /// Set the fixed type or parent and flags for a type variable.
@@ -73,6 +73,14 @@ public:
         /// The previous size of the equivalence class.
         unsigned PrevSize;
       } EquivClass;
+
+      struct {
+        /// The first type variable.
+        TypeVariableType *TypeVar;
+
+        /// The second type variable.
+        TypeVariableType *OtherTypeVar;
+      } Relation;
 
       struct {
         /// The type variable being bound to a fixed type.
@@ -109,8 +117,10 @@ public:
     static Change extendedEquivalenceClass(TypeVariableType *typeVar,
                                            unsigned prevSize);
 
-    /// Create a change that bound a type variable to a fixed type.
-    static Change boundTypeVariable(TypeVariableType *typeVar, Type fixed);
+    /// Create a change that updated the references/referenced by sets of
+    /// a type variable pair.
+    static Change relatedTypeVariables(TypeVariableType *typeVar,
+                                       TypeVariableType *otherTypeVar);
 
     /// Create a change that introduced a type variable to inference.
     static Change introducedToInference(TypeVariableType *typeVar, Type fixed);

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -64,7 +64,14 @@ public:
 
     union {
       TypeVariableType *TypeVar;
-      Constraint *TheConstraint;
+
+      struct {
+        /// The type variable we're adding or removing a constraint from.
+        TypeVariableType *TypeVar;
+
+        /// The constraint.
+        Constraint *Constraint;
+      } TheConstraint;
 
       struct {
         /// The type variable whose equivalence class was extended.
@@ -108,10 +115,10 @@ public:
     static Change addedTypeVariable(TypeVariableType *typeVar);
 
     /// Create a change that added a constraint.
-    static Change addedConstraint(Constraint *constraint);
+    static Change addedConstraint(TypeVariableType *typeVar, Constraint *constraint);
 
     /// Create a change that removed a constraint.
-    static Change removedConstraint(Constraint *constraint);
+    static Change removedConstraint(TypeVariableType *typeVar, Constraint *constraint);
 
     /// Create a change that extended an equivalence class.
     static Change extendedEquivalenceClass(TypeVariableType *typeVar,

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -259,8 +259,14 @@ public:
   /// Add a new constraint to the graph.
   void addConstraint(Constraint *constraint);
 
+  /// Primitive form for SolverTrail::Change::undo().
+  void addConstraint(TypeVariableType *typeVar, Constraint *constraint);
+
   /// Remove a constraint from the graph.
   void removeConstraint(Constraint *constraint);
+
+  /// Primitive form for SolverTrail::Change::undo().
+  void removeConstraint(TypeVariableType *typeVar, Constraint *constraint);
 
   /// Merge the two nodes for the two given type variables.
   ///
@@ -416,25 +422,23 @@ public:
 private:
   /// Remove the node corresponding to the given type variable.
   ///
-  /// This operation assumes that the any constraints that refer to
-  /// this type variable have been or will be removed before other
-  /// graph queries are performed.
+  /// This operation assumes that the any constraints that refer to this type
+  /// variable have been or will be removed before other graph queries are
+  /// performed.
   ///
-  /// Note that this change is not recorded and cannot be undone. Use with
-  /// caution.
+  /// Note that this it only meant to be called by SolverTrail::Change::undo().
   void removeNode(TypeVariableType *typeVar);
 
   /// Remove an edge from the constraint graph.
   ///
-  /// Note that this change is not recorded and cannot be undone. Use with
-  /// caution.
+  ///
+  /// Note that this it only meant to be called by SolverTrail::Change::undo().
   void unrelateTypeVariables(TypeVariableType *typeVar,
                              TypeVariableType *otherTypeVar);
 
   /// Retract the given type variable from inference.
   ///
-  /// Note that this change is not recorded and cannot be undone. Use with
-  /// caution.
+  /// Note that this it only meant to be called by SolverTrail::Change::undo().
   void retractFromInference(TypeVariableType *typeVar, Type fixedType);
 
   /// Perform edge contraction on the constraint graph, merging equivalence

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -153,10 +153,6 @@ private:
   /// type variable has been bound to a valid type and solver can make progress.
   void introduceToInference(Type fixedType);
 
-  /// Drop all previously collected bindings and re-infer based on the
-  /// current set constraints associated with this equivalence class.
-  void resetBindingSet();
-
   /// Notify all of the type variables that have this one (or any member of
   /// its equivalence class) referenced in their fixed type.
   ///

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -436,6 +436,16 @@ private:
   void unrelateTypeVariables(TypeVariableType *typeVar,
                              TypeVariableType *otherTypeVar);
 
+  /// Infer bindings from the given constraint.
+  ///
+  /// Note that this it only meant to be called by SolverTrail::Change::undo().
+  void inferBindings(TypeVariableType *typeVar, Constraint *constraint);
+
+  /// Retract bindings from the given constraint.
+  ///
+  /// Note that this it only meant to be called by SolverTrail::Change::undo().
+  void retractBindings(TypeVariableType *typeVar, Constraint *constraint);
+
   /// Retract the given type variable from inference.
   ///
   /// Note that this it only meant to be called by SolverTrail::Change::undo().

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -424,11 +424,12 @@ private:
   /// caution.
   void removeNode(TypeVariableType *typeVar);
 
-  /// Unbind the given type variable from the given fixed type.
+  /// Remove an edge from the constraint graph.
   ///
   /// Note that this change is not recorded and cannot be undone. Use with
   /// caution.
-  void unbindTypeVariable(TypeVariableType *typeVar, Type fixedType);
+  void unrelateTypeVariables(TypeVariableType *typeVar,
+                             TypeVariableType *otherTypeVar);
 
   /// Retract the given type variable from inference.
   ///

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -153,9 +153,6 @@ private:
   /// type variable has been bound to a valid type and solver can make progress.
   void introduceToInference(Type fixedType);
 
-  /// Opposite of \c introduceToInference(Type)
-  void retractFromInference(Type fixedType);
-
   /// Drop all previously collected bindings and re-infer based on the
   /// current set constraints associated with this equivalence class.
   void resetBindingSet();
@@ -445,11 +442,6 @@ private:
   ///
   /// Note that this it only meant to be called by SolverTrail::Change::undo().
   void retractBindings(TypeVariableType *typeVar, Constraint *constraint);
-
-  /// Retract the given type variable from inference.
-  ///
-  /// Note that this it only meant to be called by SolverTrail::Change::undo().
-  void retractFromInference(TypeVariableType *typeVar, Type fixedType);
 
   /// Perform edge contraction on the constraint graph, merging equivalence
   /// classes until a fixed point is reached.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1772,6 +1772,10 @@ void PotentialBindings::infer(Constraint *constraint) {
   if (!Constraints.insert(constraint).second)
     return;
 
+  // Record the change, if there are active scopes.
+  if (CS.isRecordingChanges())
+    CS.recordChange(SolverTrail::Change::inferredBindings(TypeVar, constraint));
+
   switch (constraint->getKind()) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
@@ -1942,6 +1946,10 @@ void PotentialBindings::infer(Constraint *constraint) {
 void PotentialBindings::retract(Constraint *constraint) {
   if (!Constraints.erase(constraint))
     return;
+
+  // Record the change, if there are active scopes.
+  if (CS.isRecordingChanges())
+    CS.recordChange(SolverTrail::Change::retractedBindings(TypeVar, constraint));
 
   Bindings.erase(
       llvm::remove_if(Bindings,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1769,6 +1769,9 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.
 void PotentialBindings::infer(Constraint *constraint) {
+  if (!Constraints.insert(constraint).second)
+    return;
+
   switch (constraint->getKind()) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
@@ -1937,6 +1940,9 @@ void PotentialBindings::infer(Constraint *constraint) {
 }
 
 void PotentialBindings::retract(Constraint *constraint) {
+  if (!Constraints.erase(constraint))
+    return;
+
   Bindings.erase(
       llvm::remove_if(Bindings,
                       [&constraint](const PotentialBinding &binding) {

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -76,12 +76,12 @@ SolverTrail::Change::extendedEquivalenceClass(TypeVariableType *typeVar,
 }
 
 SolverTrail::Change
-SolverTrail::Change::boundTypeVariable(TypeVariableType *typeVar,
-                                       Type fixed) {
+SolverTrail::Change::relatedTypeVariables(TypeVariableType *typeVar,
+                                          TypeVariableType *otherTypeVar) {
   Change result;
-  result.Kind = ChangeKind::BoundTypeVariable;
-  result.Binding.TypeVar = typeVar;
-  result.Binding.FixedType = fixed.getPointer();
+  result.Kind = ChangeKind::RelatedTypeVariables;
+  result.Relation.TypeVar = typeVar;
+  result.Relation.OtherTypeVar = otherTypeVar;
   return result;
 }
 
@@ -130,8 +130,8 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
     break;
    }
 
-  case ChangeKind::BoundTypeVariable:
-    cg.unbindTypeVariable(Binding.TypeVar, Binding.FixedType);
+  case ChangeKind::RelatedTypeVariables:
+    cg.unrelateTypeVariables(Relation.TypeVar, Relation.OtherTypeVar);
     break;
 
   case ChangeKind::IntroducedToInference:
@@ -179,11 +179,11 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     break;
    }
 
-  case ChangeKind::BoundTypeVariable:
-    out << "(bound type variable ";
-    Binding.TypeVar->print(out, PO);
-    out << " to fixed type ";
-    Binding.FixedType->print(out, PO);
+  case ChangeKind::RelatedTypeVariables:
+    out << "(related type variable ";
+    Relation.TypeVar->print(out, PO);
+    out << " with ";
+    Relation.OtherTypeVar->print(out, PO);
     out << ")\n";
     break;
 

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -50,18 +50,22 @@ SolverTrail::Change::addedTypeVariable(TypeVariableType *typeVar) {
 }
 
 SolverTrail::Change
-SolverTrail::Change::addedConstraint(Constraint *constraint) {
+SolverTrail::Change::addedConstraint(TypeVariableType *typeVar,
+                                     Constraint *constraint) {
   Change result;
   result.Kind = ChangeKind::AddedConstraint;
-  result.TheConstraint = constraint;
+  result.TheConstraint.TypeVar = typeVar;
+  result.TheConstraint.Constraint = constraint;
   return result;
 }
 
 SolverTrail::Change
-SolverTrail::Change::removedConstraint(Constraint *constraint) {
+SolverTrail::Change::removedConstraint(TypeVariableType *typeVar,
+                                       Constraint *constraint) {
   Change result;
   result.Kind = ChangeKind::RemovedConstraint;
-  result.TheConstraint = constraint;
+  result.TheConstraint.TypeVar = typeVar;
+  result.TheConstraint.Constraint = constraint;
   return result;
 }
 
@@ -117,11 +121,11 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
     break;
 
   case ChangeKind::AddedConstraint:
-    cg.removeConstraint(TheConstraint);
+    cg.removeConstraint(TheConstraint.TypeVar, TheConstraint.Constraint);
     break;
 
   case ChangeKind::RemovedConstraint:
-    cg.addConstraint(TheConstraint);
+    cg.addConstraint(TheConstraint.TypeVar, TheConstraint.Constraint);
     break;
 
   case ChangeKind::ExtendedEquivalenceClass: {
@@ -162,13 +166,19 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::AddedConstraint:
     out << "(added constraint ";
-    TheConstraint->print(out, &cs.getASTContext().SourceMgr, indent + 2);
+    TheConstraint.Constraint->print(out, &cs.getASTContext().SourceMgr,
+                         indent + 2);
+    out << " to type variable ";
+    TheConstraint.TypeVar->print(out, PO);
     out << ")\n";
     break;
 
   case ChangeKind::RemovedConstraint:
     out << "(removed constraint ";
-    TheConstraint->print(out, &cs.getASTContext().SourceMgr, indent + 2);
+    TheConstraint.Constraint->print(out, &cs.getASTContext().SourceMgr,
+                                    indent + 2);
+    out << " from type variable ";
+    TheConstraint.TypeVar->print(out, PO);
     out << ")\n";
     break;
 

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -90,16 +90,6 @@ SolverTrail::Change::relatedTypeVariables(TypeVariableType *typeVar,
 }
 
 SolverTrail::Change
-SolverTrail::Change::introducedToInference(TypeVariableType *typeVar,
-                                           Type fixed) {
-  Change result;
-  result.Kind = ChangeKind::IntroducedToInference;
-  result.Binding.TypeVar = typeVar;
-  result.Binding.FixedType = fixed.getPointer();
-  return result;
-}
-
-SolverTrail::Change
 SolverTrail::Change::inferredBindings(TypeVariableType *typeVar,
                                      Constraint *constraint) {
   Change result;
@@ -156,10 +146,6 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RelatedTypeVariables:
     cg.unrelateTypeVariables(Relation.TypeVar, Relation.OtherTypeVar);
-    break;
-
-  case ChangeKind::IntroducedToInference:
-    cg.retractFromInference(Binding.TypeVar, Binding.FixedType);
     break;
 
   case ChangeKind::InferredBindings:
@@ -223,14 +209,6 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     out << " with ";
     Relation.OtherTypeVar->print(out, PO);
     out << ")\n";
-    break;
-
-  case ChangeKind::IntroducedToInference:
-    out << "(introduced type variable ";
-    Binding.TypeVar->print(out, PO);
-    out << " with fixed type ";
-    Binding.FixedType->print(out, PO);
-    out << " to inference)\n";
     break;
 
   case ChangeKind::InferredBindings:

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -376,18 +376,6 @@ void ConstraintGraphNode::introduceToInference(Type fixedType) {
   }
 }
 
-void ConstraintGraphNode::resetBindingSet() {
-  assert(forRepresentativeVar());
-
-  Bindings.reset();
-
-  auto &bindings = getCurrentBindings();
-  for (auto *constraint : CG.gatherConstraints(
-           TypeVar, ConstraintGraph::GatheringKind::EquivalenceClass)) {
-    bindings.infer(constraint);
-  }
-}
-
 #pragma mark Graph mutation
 
 void ConstraintGraph::removeNode(TypeVariableType *typeVar) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -559,29 +559,24 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
 
     otherNode.addReferencedBy(typeVar);
     node.addReferencedVar(otherTypeVar);
-  }
 
-  // Record the change, if there are active scopes.
-  if (CS.isRecordingChanges())
-    CS.recordChange(SolverTrail::Change::boundTypeVariable(typeVar, fixed));
+    // Record the change, if there are active scopes.
+    if (CS.isRecordingChanges())
+      CS.recordChange(SolverTrail::Change::relatedTypeVariables(typeVar, otherTypeVar));
+  }
 }
 
 void ConstraintGraph::introduceToInference(TypeVariableType *typeVar, Type fixed) {
   (*this)[typeVar].introduceToInference(fixed);
 }
 
-void ConstraintGraph::unbindTypeVariable(TypeVariableType *typeVar, Type fixed) {
+void ConstraintGraph::unrelateTypeVariables(TypeVariableType *typeVar,
+                                            TypeVariableType *otherTypeVar) {
   auto &node = (*this)[typeVar];
+  auto &otherNode = (*this)[otherTypeVar];
 
-  llvm::SmallPtrSet<TypeVariableType *, 4> referencedVars;
-  fixed->getTypeVariables(referencedVars);
-
-  for (auto otherTypeVar : referencedVars) {
-    auto &otherNode = (*this)[otherTypeVar];
-
-    otherNode.removeReferencedBy(typeVar);
-    node.removeReference(otherTypeVar);
-  }
+  otherNode.removeReferencedBy(typeVar);
+  node.removeReference(otherTypeVar);
 }
 
 void ConstraintGraph::retractFromInference(TypeVariableType *typeVar, Type fixed) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -276,26 +276,8 @@ void ConstraintGraphNode::addToEquivalenceClass(
 }
 
 void ConstraintGraphNode::truncateEquivalenceClass(unsigned prevSize) {
-  llvm::SmallSetVector<TypeVariableType *, 4> disconnectedVars;
-  for (auto disconnected = EquivalenceClass.begin() + prevSize;
-       disconnected != EquivalenceClass.end();
-       ++disconnected) {
-    disconnectedVars.insert(*disconnected);
-  }
-
   EquivalenceClass.erase(EquivalenceClass.begin() + prevSize,
                          EquivalenceClass.end());
-
-  // We need to re-introduce each constraint associated with
-  // "disconnected" member itself and to this representative.
-  {
-    // Re-infer bindings for the current representative.
-    resetBindingSet();
-
-    // Re-infer bindings all of the newly made representatives.
-    for (auto *typeVar : disconnectedVars)
-      CG[typeVar].notifyReferencingVars();
-  }
 }
 
 void ConstraintGraphNode::addReferencedVar(TypeVariableType *typeVar) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -609,7 +609,17 @@ void ConstraintGraph::unrelateTypeVariables(TypeVariableType *typeVar,
 }
 
 void ConstraintGraph::retractFromInference(TypeVariableType *typeVar, Type fixed) {
-  return (*this)[typeVar].retractFromInference(fixed);
+  (*this)[typeVar].retractFromInference(fixed);
+}
+
+void ConstraintGraph::inferBindings(TypeVariableType *typeVar,
+                                    Constraint *constraint) {
+  (*this)[typeVar].getCurrentBindings().infer(constraint);
+}
+
+void ConstraintGraph::retractBindings(TypeVariableType *typeVar,
+                                      Constraint *constraint) {
+  (*this)[typeVar].getCurrentBindings().retract(constraint);
 }
 
 #pragma mark Algorithms

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -239,11 +239,6 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
     }
   }
 
-  // FIXME: This is totally the wrong place to do it. We should do this in
-  // introduceToInference().
-  if (isRecordingChanges())
-    recordChange(SolverTrail::Change::introducedToInference(typeVar, type));
-
   // Notify the constraint graph.
   CG.bindTypeVariable(typeVar, type);
 


### PR DESCRIPTION
This refactors the ConstraintGraph-related changes to make them more fine-grained. It also fixes a performance issue where PotentialBindings::infer() and ::retract() calls were not balanced, and we'd get thousands of duplicate bindings in some circumstances.