### PR TITLE
Fix partial apply forwarder emission for coroutines that are methods of structs with type parameters

### DIFF
--- a/test/AutoDiff/validation-test/modify_accessor.swift
+++ b/test/AutoDiff/validation-test/modify_accessor.swift
@@ -39,5 +39,39 @@ ModifyAccessorTests.test("SimpleModifyAccessor") {
   expectEqual((100, 20), valueWithGradient(at: 10, of: modify_struct))
 }
 
+ModifyAccessorTests.test("GenericModifyAccessor") {
+  struct S<T : Differentiable & SignedNumeric & Comparable>: Differentiable {
+    private var _x : T
+
+    func _endMutation() {}
+
+    var x: T {
+      get{_x}
+      set(newValue) { _x = newValue }
+      _modify {
+        defer { _endMutation() }
+        if (x > -x) {
+          yield &_x
+        } else {
+          yield &_x
+        }
+      }
+    }
+
+    init(_ x : T) {
+      self._x = x
+    }
+  }
+
+  func modify_struct(_ x : Float) -> Float {
+    var s = S<Float>(x)
+    s.x *= s.x
+    return s.x
+  }
+
+  expectEqual((100, 20), valueWithGradient(at: 10, of: modify_struct))
+}
+
+
 runAllTests()
 


### PR DESCRIPTION
Simplify the code while here.

This refactors some implementation bits of https://github.com/swiftlang/swift/pull/71653 (and effectively reverts some parts of it). In particular, it implements the coroutine call in terms of CallEmission rather than relying on implementation details of CallEmission.