### PR TITLE
[cxx-interop] Implement annotating escapability for class template specs

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7387,11 +7387,11 @@ static bool hasNonCopyableAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, "~Copyable");
 }
 
-bool importer::hasNonEscapableAttr(const clang::RecordDecl *decl) {
+bool importer::hasNonEscapableAttr(const clang::Decl *decl) {
   return hasSwiftAttribute(decl, "~Escapable");
 }
 
-bool importer::hasEscapableAttr(const clang::RecordDecl *decl) {
+bool importer::hasEscapableAttr(const clang::Decl *decl) {
   return hasSwiftAttribute(decl, "Escapable");
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1506,6 +1506,9 @@ namespace {
         // bridging, i.e. if the imported typealias should name a bridged type
         // or the original C type.
         clang::QualType ClangType = Decl->getUnderlyingType();
+        if (importer::hasNonEscapableAttr(Decl))
+          Impl.nonEscapableTypes.insert(
+              ClangType->getCanonicalTypeUnqualified()->getTypePtr());
         SwiftType = Impl.importTypeIgnoreIUO(
             ClangType, ImportTypeKind::Typedef,
             ImportDiagnosticAdder(Impl, Decl, Decl->getLocation()),
@@ -2204,7 +2207,10 @@ namespace {
       }
 
       if (Impl.SwiftContext.LangOpts.hasFeature(Feature::NonescapableTypes) &&
-          importer::hasNonEscapableAttr(decl)) {
+          (importer::hasNonEscapableAttr(decl) ||
+           Impl.nonEscapableTypes.contains(decl->getTypeForDecl()
+                                               ->getCanonicalTypeUnqualified()
+                                               ->getTypePtr()))) {
         result->getAttrs().add(new (Impl.SwiftContext)
                                    NonEscapableAttr(/*Implicit=*/true));
       }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -552,6 +552,10 @@ public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
 
+  // Types that should be imported as non-escapable. This is collected from
+  // the using declarations and used when importing template specializations.
+  llvm::DenseSet<const clang::Type *> nonEscapableTypes;
+
   /// The set of "special" typedef-name declarations, which are
   /// mapped to specific Swift types.
   ///
@@ -2029,9 +2033,9 @@ inline std::string getPrivateOperatorName(const std::string &OperatorToken) {
 
 bool hasUnsafeAPIAttr(const clang::Decl *decl);
 
-bool hasNonEscapableAttr(const clang::RecordDecl *decl);
+bool hasNonEscapableAttr(const clang::Decl *decl);
 
-bool hasEscapableAttr(const clang::RecordDecl *decl);
+bool hasEscapableAttr(const clang::Decl *decl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);
 

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -10,6 +10,7 @@ module Test {
 
 //--- Inputs/nonescapable.h
 #include "swift/bridging"
+#include <vector>
 
 struct SWIFT_NONESCAPABLE View {
     View() : member(nullptr) {}
@@ -19,11 +20,19 @@ private:
     const int *member;
 };
 
+using VecOfPtr SWIFT_NONESCAPABLE = std::vector<int*>;
+
 //--- test.swift
 
+import CxxStdlib
 import Test
 
 // CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
 public func noAnnotations() -> View {
     View()
+}
+
+// CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+public func noAnnotations2() -> VecOfPtr {
+    VecOfPtr()
 }


### PR DESCRIPTION
We import class template specializations via type alias declarations. This patch adds logic to look for declaration attributes on the type alias declarations to mark the underlying class template specialization type as non-escapable.
