### PR TITLE
Sema: Small fixes for result builder inference

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -153,6 +153,13 @@ public:
     llvm_unreachable("autoclosures don't have statement bodies");
   }
 
+  /// Returns a boolean value indicating whether the body, if any, contains
+  /// an explicit `return` statement.
+  ///
+  /// \returns `true` if the body contains an explicit `return` statement,
+  /// `false` otherwise.
+  bool bodyHasExplicitReturnStmt() const;
+
   DeclContext *getAsDeclContext() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD;

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -160,6 +160,11 @@ public:
   /// `false` otherwise.
   bool bodyHasExplicitReturnStmt() const;
 
+  /// Finds occurrences of explicit `return` statements within the body, if any.
+  ///
+  /// \param results An out container to which the results are added.
+  void getExplicitReturnStmts(SmallVectorImpl<ReturnStmt *> &results) const;
+
   DeclContext *getAsDeclContext() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7675,6 +7675,13 @@ public:
   /// parsed.
   bool hasBody() const;
 
+  /// Returns a boolean value indicating whether the body, if any, contains
+  /// an explicit `return` statement.
+  ///
+  /// \returns `true` if the body contains an explicit `return` statement,
+  /// `false` otherwise.
+  bool bodyHasExplicitReturnStmt() const;
+
   /// Returns true if the text of this function's body can be retrieved either
   /// by extracting the text from the source buffer or reading the inlinable
   /// body from a deserialized swiftmodule.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -109,6 +109,7 @@ namespace swift {
   class ProtocolType;
   struct RawComment;
   enum class ResilienceExpansion : unsigned;
+  class ReturnStmt;
   enum class EffectKind : uint8_t;
   enum class PolymorphicEffectKind : uint8_t;
   class TrailingWhereClause;
@@ -7681,6 +7682,11 @@ public:
   /// \returns `true` if the body contains an explicit `return` statement,
   /// `false` otherwise.
   bool bodyHasExplicitReturnStmt() const;
+
+  /// Finds occurrences of explicit `return` statements within the body, if any.
+  ///
+  /// \param results An out container to which the results are added.
+  void getExplicitReturnStmts(SmallVectorImpl<ReturnStmt *> &results) const;
 
   /// Returns true if the text of this function's body can be retrieved either
   /// by extracting the text from the source buffer or reading the inlinable

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4051,6 +4051,13 @@ public:
   /// returns nullptr if the closure doesn't have a body
   BraceStmt *getBody() const;
 
+  /// Returns a boolean value indicating whether the body, if any, contains
+  /// an explicit `return` statement.
+  ///
+  /// \returns `true` if the body contains an explicit `return` statement,
+  /// `false` otherwise.
+  bool bodyHasExplicitReturnStmt() const;
+
   ActorIsolation getActorIsolation() const {
     return actorIsolation;
   }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -71,6 +71,7 @@ namespace swift {
   class KeyPathExpr;
   class CaptureListExpr;
   class ThenStmt;
+  class ReturnStmt;
 
 enum class ExprKind : uint8_t {
 #define EXPR(Id, Parent) Id,
@@ -4057,6 +4058,11 @@ public:
   /// \returns `true` if the body contains an explicit `return` statement,
   /// `false` otherwise.
   bool bodyHasExplicitReturnStmt() const;
+
+  /// Finds occurrences of explicit `return` statements within the body, if any.
+  ///
+  /// \param results An out container to which the results are added.
+  void getExplicitReturnStmts(SmallVectorImpl<ReturnStmt *> &results) const;
 
   ActorIsolation getActorIsolation() const {
     return actorIsolation;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3050,9 +3050,9 @@ public:
   void cacheResult(ProtocolConformanceRef value) const;
 };
 
-class BraceHasReturnRequest
-    : public SimpleRequest<BraceHasReturnRequest, bool(const BraceStmt *),
-                           RequestFlags::Cached> {
+class BraceHasExplicitReturnStmtRequest
+    : public SimpleRequest<BraceHasExplicitReturnStmtRequest,
+                           bool(const BraceStmt *), RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -383,7 +383,7 @@ SWIFT_REQUEST(TypeChecker, HasUserDefinedDesignatedInitRequest,
               bool(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasMemberwiseInitRequest,
               bool(StructDecl *), Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, BraceHasReturnRequest,
+SWIFT_REQUEST(TypeChecker, BraceHasExplicitReturnStmtRequest,
               bool(const BraceStmt *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9361,6 +9361,12 @@ bool AbstractFunctionDecl::bodyHasExplicitReturnStmt() const {
       .bodyHasExplicitReturnStmt();
 }
 
+void AbstractFunctionDecl::getExplicitReturnStmts(
+    SmallVectorImpl<ReturnStmt *> &results) const {
+  AnyFunctionRef(const_cast<AbstractFunctionDecl *>(this))
+      .getExplicitReturnStmts(results);
+}
+
 /// Expand all preamble macros attached to the given function declaration.
 static std::vector<ASTNode> expandPreamble(AbstractFunctionDecl *func) {
   std::vector<ASTNode> preamble;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9356,6 +9356,11 @@ bool AbstractFunctionDecl::hasBody() const {
   }
 }
 
+bool AbstractFunctionDecl::bodyHasExplicitReturnStmt() const {
+  return AnyFunctionRef(const_cast<AbstractFunctionDecl *>(this))
+      .bodyHasExplicitReturnStmt();
+}
+
 /// Expand all preamble macros attached to the given function declaration.
 static std::vector<ASTNode> expandPreamble(AbstractFunctionDecl *func) {
   std::vector<ASTNode> preamble;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1962,6 +1962,11 @@ BraceStmt * AbstractClosureExpr::getBody() const {
   llvm_unreachable("Unknown closure expression");
 }
 
+bool AbstractClosureExpr::bodyHasExplicitReturnStmt() const {
+  return AnyFunctionRef(const_cast<AbstractClosureExpr *>(this))
+      .bodyHasExplicitReturnStmt();
+}
+
 Type AbstractClosureExpr::getResultType(
     llvm::function_ref<Type(Expr *)> getType) const {
   auto *E = const_cast<AbstractClosureExpr *>(this);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1967,6 +1967,12 @@ bool AbstractClosureExpr::bodyHasExplicitReturnStmt() const {
       .bodyHasExplicitReturnStmt();
 }
 
+void AbstractClosureExpr::getExplicitReturnStmts(
+    SmallVectorImpl<ReturnStmt *> &results) const {
+  AnyFunctionRef(const_cast<AbstractClosureExpr *>(this))
+      .getExplicitReturnStmts(results);
+}
+
 Type AbstractClosureExpr::getResultType(
     llvm::function_ref<Type(Expr *)> getType) const {
   auto *E = const_cast<AbstractClosureExpr *>(this);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1266,8 +1266,8 @@ public:
 };
 } // end anonymous namespace
 
-bool BraceHasReturnRequest::evaluate(Evaluator &evaluator,
-                                     const BraceStmt *BS) const {
+bool BraceHasExplicitReturnStmtRequest::evaluate(Evaluator &evaluator,
+                                                 const BraceStmt *BS) const {
   return !ReturnStmtFinder::find(BS).empty();
 }
 
@@ -1278,7 +1278,8 @@ bool AnyFunctionRef::bodyHasExplicitReturnStmt() const {
   }
 
   auto &ctx = getAsDeclContext()->getASTContext();
-  return evaluateOrDefault(ctx.evaluator, BraceHasReturnRequest{body}, false);
+  return evaluateOrDefault(ctx.evaluator,
+                           BraceHasExplicitReturnStmtRequest{body}, false);
 }
 
 std::vector<ReturnStmt *> TypeChecker::findReturnStatements(AnyFunctionRef fn) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8862,7 +8862,8 @@ bool ReferenceToInvalidDeclaration::diagnoseAsError() {
 bool InvalidReturnInResultBuilderBody::diagnoseAsError() {
   auto *closure = castToExpr<ClosureExpr>(getAnchor());
 
-  auto returnStmts = TypeChecker::findReturnStatements(closure);
+  SmallVector<ReturnStmt *> returnStmts;
+  closure->getExplicitReturnStmts(returnStmts);
   assert(!returnStmts.empty());
 
   auto loc = returnStmts.front()->getReturnLoc();

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -263,7 +263,7 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
   // the result of inferring for 'x' will be considered when inferring for 'y'
   // either way.
   if (!funcDecl->hasBody() || !dc->getParentSourceFile() ||
-      !TypeChecker::findReturnStatements(funcDecl).empty()) {
+      funcDecl->bodyHasExplicitReturnStmt()) {
     return Type();
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -468,9 +468,6 @@ void typeCheckASTNode(ASTNode &node, DeclContext *DC,
 std::optional<BraceStmt *> applyResultBuilderBodyTransform(FuncDecl *func,
                                                            Type builderType);
 
-/// Find the return statements within the body of the given function.
-std::vector<ReturnStmt *> findReturnStatements(AnyFunctionRef fn);
-
 bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);
 
 Type typeCheckParameterDefault(Expr *&defaultValue, DeclContext *DC,

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -113,13 +113,11 @@ extension Test1 {
   var replacement_property1: Result { 1 }
   @_dynamicReplacement(for: property2)
   var replacement_property2: Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert return expression}}
 
   @_dynamicReplacement(for: subscript(subscript1:))
   subscript(replacement_subscript1 _: Int) -> Result { 1 }
   @_dynamicReplacement(for: subscript(subscript2:))
   subscript(replacement_subscript2 _: Int) -> Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert return expression}}
 }
 
 // Edge case: context is a protocol extension.
@@ -498,7 +496,6 @@ extension Test9 {
 
   @_dynamicReplacement(for: property1)
   var replacement_property1: Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
   @_dynamicReplacement(for: property2)
   var replacement_property2: Result { 1 }
 
@@ -506,7 +503,6 @@ extension Test9 {
   subscript(replacement_subscript1 _: Int) -> Result { 1 }
   @_dynamicReplacement(for: subscript(subscript2:))
   subscript(replacement_subscript2 _: Int) -> Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
 }
 
 struct Test10: P_Builder_Int1, P_Builder_String {
@@ -648,13 +644,11 @@ extension Test13 {
   var replacement_property1: Result { 1 }
   @_dynamicReplacement(for: property2)
   var replacement_property2: Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert return expression}}
 
   @_dynamicReplacement(for: subscript(subscript1:))
   subscript(replacement_subscript1 _: Int) -> Result { 1 }
   @_dynamicReplacement(for: subscript(subscript2:))
   subscript(replacement_subscript2 _: Int) -> Result { 1 }
-  // FIXME: expected-error@-1 {{cannot convert return expression}}
 }
 
 struct Test14: P_Builder_Int1 {

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -1,286 +1,792 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// First, test everything together.
+//
+// RUN: %target-typecheck-verify-swift
 
-enum Either<T,U> {
-  case first(T)
-  case second(U)
+// Now to the cross-module test. The result builder and protocols go to the
+// module, the rest to the importing file.
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+//
+// RUN: %target-swift-frontend -emit-module -module-name M -emit-module-path %t/M.swiftmodule %t/src/M.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t -D CROSS_MODULE %t/src/test.swift
+
+//--- M.swift
+
+public struct Result {
+  public init() {}
 }
 
 @resultBuilder
-struct TupleBuilder {
-  static func buildBlock() -> () {
-    return ()
-  }
-
-  static func buildBlock<T1>(_ t1: T1) -> (T1) {
-    return (t1)
-  }
-  
-  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
-    return (t1, t2)
-  }
-  
-  static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
-      -> (T1, T2, T3) {
-    return (t1, t2, t3)
-  }
-
-  static func buildBlock<T1, T2, T3, T4>(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4)
-      -> (T1, T2, T3, T4) {
-    return (t1, t2, t3, t4)
-  }
-
-  static func buildBlock<T1, T2, T3, T4, T5>(
-    _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5
-  ) -> (T1, T2, T3, T4, T5) {
-    return (t1, t2, t3, t4, t5)
-  }
-
-  static func buildDo<T>(_ value: T) -> T { return value }
-  static func buildIf<T>(_ value: T?) -> T? { return value }
-
-  static func buildEither<T,U>(first value: T) -> Either<T,U> {
-    return .first(value)
-  }
-  static func buildEither<T,U>(second value: U) -> Either<T,U> {
-    return .second(value)
-  }
+public enum Builder<T> {
+  public static func buildBlock(_: T...) -> Result { Result() }
 }
 
-protocol Tupled {
-  associatedtype TupleType
-  
-  @TupleBuilder var tuple: TupleType { get }
+public protocol P_Builder_Int1 {
+  @Builder<Int>
+  func function() -> Result
+
+  @Builder<Int>
+  var property1: Result { get }
+  var property2: Result { @Builder<Int> get }
+
+  @Builder<Int>
+  subscript(subscript1 _: Int) -> Result { get }
+  subscript(subscript2 _: Int) -> Result { @Builder<Int> get }
 }
 
-struct TupleMe: Tupled {
-  var condition: Bool
+public protocol P_Builder_Int2 {
+  @Builder<Int>
+  func function() -> Result
 
-  // Okay: applies the result builder @TupleBuilder.
-  var tuple: some Any {
-    "hello"
-    if condition {
-      "nested"
-    }
-    3.14159
-    "world"
-  }
+  @Builder<Int>
+  var property1: Result { get }
+  var property2: Result { @Builder<Int> get }
+
+  @Builder<Int>
+  subscript(subscript1 _: Int) -> Result { get }
+  subscript(subscript2 _: Int) -> Result { @Builder<Int> get }
 }
 
-// Witness is separated from the context declaring conformance, so don't infer
-// the result builder.
-struct DoNotTupleMe {
-  var condition: Bool
+public protocol P_Builder_String {
+  @Builder<String>
+  func function() -> Result
 
-  var tuple: some Any { // expected-error{{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
-    "hello" // expected-warning{{string literal is unused}}
-    "world" // expected-warning{{string literal is unused}}
-    // expected-note@-1 {{did you mean to return the last expression?}} {{5-5=return }}
-  }
+  @Builder<String>
+  var property1: Result { get }
+  var property2: Result { @Builder<String> get }
+
+  @Builder<String>
+  subscript(subscript1 _: Int) -> Result { get }
+  subscript(subscript2 _: Int) -> Result { @Builder<String> get }
 }
 
-extension DoNotTupleMe: Tupled { }
+public protocol P_Builder_Bool {
+  @Builder<Bool>
+  func function() -> Result
 
-@resultBuilder
-struct OtherTupleBuilder {
-  static func buildBlock() -> () {
-    return ()
-  }
+  @Builder<Bool>
+  var property1: Result { get }
+  var property2: Result { @Builder<Bool> get }
 
-  static func buildBlock<T1>(_ t1: T1) -> (T1) {
-    return (t1)
-  }
-  
-  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
-    return (t1, t2)
-  }
-  
-  static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
-      -> (T1, T2, T3) {
-    return (t1, t2, t3)
-  }
-
-  static func buildBlock<T1, T2, T3, T4>(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4)
-      -> (T1, T2, T3, T4) {
-    return (t1, t2, t3, t4)
-  }
-
-  static func buildBlock<T1, T2, T3, T4, T5>(
-    _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5
-  ) -> (T1, T2, T3, T4, T5) {
-    return (t1, t2, t3, t4, t5)
-  }
-
-  static func buildDo<T>(_ value: T) -> T { return value }
-  static func buildIf<T>(_ value: T?) -> T? { return value }
-
-  static func buildEither<T,U>(first value: T) -> Either<T,U> {
-    return .first(value)
-  }
-  static func buildEither<T,U>(second value: U) -> Either<T,U> {
-    return .second(value)
-  }
+  @Builder<Bool>
+  subscript(subscript1 _: Int) -> Result { get }
+  subscript(subscript2 _: Int) -> Result { @Builder<Bool> get }
 }
 
-protocol Tupled2 {
-  associatedtype TupleType
-  
-  @TupleBuilder var tuple: TupleType { get }
-}
+//--- test.swift
 
-struct TupleMe2: Tupled, Tupled2 {
-  var condition: Bool
+#if CROSS_MODULE
+import M
+#endif
 
-  // Okay: applies the result builder @TupleBuilder, even though it satisfies
-  // two requirements. (They have the same result builder)
-  var tuple: some Any {
-    "hello"
-    if condition {
-      "nested"
-    }
-    3.14159
-    "world"
-  }
-}
-
-protocol Tupled3 {
-  associatedtype TupleType
-
-  var tuple: TupleType { @TupleBuilder get }
-}
-
-struct TupleMe3: Tupled3 {
-  var condition: Bool
-
-  var tuple: some Any {
-    "hello"
-    if condition {
-      "nested"
-    }
-    3.14159
-    "world"
-  }
-}
-
-protocol OtherTupled {
-  associatedtype OtherTupleType
-  
-  @OtherTupleBuilder var tuple: OtherTupleType { get }
-}
-
-struct AmbigTupleMe: Tupled, OtherTupled {
-  var condition: Bool
-
-  // Ambiguous
-  // expected-note@+4{{add an explicit 'return' statement to not use a result builder}}{{+3:3-3=return <#expr#>\n}}
-  // expected-note@+3{{apply result builder 'TupleBuilder' (inferred from protocol 'Tupled')}}{{-1:3-3=@TupleBuilder }}
-  // expected-note@+2{{apply result builder 'OtherTupleBuilder' (inferred from protocol 'OtherTupled')}}{{-1:3-3=@OtherTupleBuilder }}
-  internal
-  var tuple: Void { // expected-error{{ambiguous result builder inferred for 'tuple': 'TupleBuilder' or 'OtherTupleBuilder'}}
-    "hello" // expected-warning{{string literal is unused}}
-    "world" // expected-warning{{string literal is unused}}
-  }
-}
-
-// Separating the conformances resolves the ambiguity.
-struct TupleMeResolvedSeparate: Tupled {
-  var condition: Bool
-
-  var tuple: some Any {
-    "hello"
-    if condition {
-      "nested"
-    }
-    3.14159
-    "world"
-  }
-}
-
-extension TupleMeResolvedSeparate: OtherTupled { }
-
-struct TupleMeResolvedExplicit: Tupled, OtherTupled {
-  var condition: Bool
-
-  var tuple: some Any {
-    return "hello"
-  }
-}
-
-// Inference through dynamic replacement
-struct DynamicTupled: Tupled {
-  dynamic var tuple: some Any {
-    return "hello"
-  }
-}
-
-extension DynamicTupled {
-  @_dynamicReplacement(for: tuple)
-  var replacementTuple: some Any {
-    1
-    3.14159
-    "hello"
-  }
-}
-
-struct DynamicTupled2: Tupled, OtherTupled {
-  dynamic var tuple: some Any {
-    return "hello"
-  }
-}
-
-extension DynamicTupled2 {
-  @_dynamicReplacement(for: tuple)
-  var replacementTuple: some Any { // expected-error{{ambiguous result builder inferred for 'replacementTuple': 'TupleBuilder' or 'OtherTupleBuilder'}}
-    // expected-note@-1{{add an explicit 'return' statement to not use a result builder}}
-    // expected-note@-2{{apply result builder 'TupleBuilder' (inferred from protocol 'Tupled')}}
-    // expected-note@-3{{apply result builder 'OtherTupleBuilder' (inferred from protocol 'OtherTupled')}}
-    1
-  }
-}
-
-struct DynamicTupled3 {
-  @TupleBuilder dynamic var dynamicTuple: some Any {
-    0
-  }
-}
-
-extension DynamicTupled3: OtherTupled {
-  @_dynamicReplacement(for: dynamicTuple)
-  var tuple: some Any { // expected-error{{ambiguous result builder inferred for 'tuple': 'OtherTupleBuilder' or 'TupleBuilder'}}
-    // expected-note@-1{{add an explicit 'return' statement to not use a result builder}}
-    // expected-note@-2{{apply result builder 'OtherTupleBuilder' (inferred from protocol 'OtherTupled')}}
-    // expected-note@-3{{apply result builder 'TupleBuilder' (inferred from dynamic replacement of 'dynamicTuple')}}
-    0
-  }
-}
-
+// Result builder cannot be inferred from overridden declaration.
 do {
-  @resultBuilder
-  enum BuildBoolFrom<T> {
-    static func buildBlock(_ t: T...) -> Bool {}
+  class Super {
+    @Builder<Int> func function() -> Result { 1 }
   }
+  class Sub: Super {
+    override public func function() -> Result { Result() }
+  }
+}
 
+// Result builder of dynamic replacement can be inferred from the replaced
+// declaration.
+struct Test1 {
+  @Builder<Int>
+  dynamic func function() -> Result { 1 }
+
+  @Builder<Int>
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { @Builder<Int> get { 1 } }
+
+  @Builder<Int>
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { @Builder<Int> get { 1 } }
+}
+extension Test1 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert return expression}}
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert return expression}}
+}
+
+// Edge case: context is a protocol extension.
+protocol Test1_1 {}
+extension Test1_1 {
+  @Builder<Int>
+  dynamic func function() -> Result { 1 }
+
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+}
+
+// Result builders can be inferred from protocol requirements.
+do {
+  struct Test: P_Builder_Int1 {
+    func function() -> Result { 1 }
+
+    var property1: Result { 1 }
+    var property2: Result { 1 }
+
+    subscript(subscript1 _: Int) -> Result { 1 }
+    subscript(subscript2 _: Int) -> Result { 1 }
+  }
+}
+
+// Exception: inference does not support function parameters.
+do {
   protocol P {
-    @BuildBoolFrom<String>
-    var property: Bool { get }
+    func function(@Builder<Int> _: () -> Result)
+  }
+  struct Test: P {
+    func function(_: () -> Result) {}
   }
 
-  struct Conformer1: P {
-    @BuildBoolFrom<Int>
-    var property: Bool {
-      // OK, explicit result builder disables inference through protocol.
-      1
-      2
+  Test().function { Result() }
+}
+
+// Result builder of a dynamic replacement can be
+// inferred from a protocol requirement that is witnessed by the replaced
+// declaration.
+struct Test2: P_Builder_Int1 {
+  dynamic func function() -> Result { 1 }
+
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { 1 }
+
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { 1 }
+}
+extension Test2 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+}
+
+// Inference from multiple conflicting sources with matching result builder
+// types is unambiguous.
+
+struct Test3: P_Builder_Int1, P_Builder_Int2 {
+  dynamic func function() -> Result { 1 }
+
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { 1 }
+
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { 1 }
+}
+extension Test3 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+}
+
+struct Test4 {
+  @Builder<Int> dynamic func replaced_function() -> Result { 1 }
+
+  @Builder<Int> dynamic var replaced_property1: Result { 1 }
+  @Builder<Int> dynamic var replaced_property2: Result { 1 }
+
+  @Builder<Int> dynamic subscript(replaced_subscript1 _: Int) -> Result { 1 }
+  @Builder<Int> dynamic subscript(replaced_subscript2 _: Int) -> Result { 1 }
+}
+extension Test4: P_Builder_Int1 {
+  @_dynamicReplacement(for: replaced_function)
+  func function() -> Result { 1 }
+
+  @_dynamicReplacement(for: replaced_property1)
+  var property1: Result { 1 }
+  @_dynamicReplacement(for: replaced_property2)
+  var property2: Result { 1 }
+
+  @_dynamicReplacement(for: subscript(replaced_subscript1:))
+  subscript(subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(replaced_subscript2:))
+  subscript(subscript2 _: Int) -> Result { 1 }
+}
+
+// Ambiguous inference.
+
+struct Test5: P_Builder_Int1, P_Builder_Int2, P_Builder_String {
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'function()': 'Builder<Int>' or 'Builder<String>'}}
+  internal dynamic
+  func function() -> Result {
+  }
+
+  // FIXME: 'return' will be inserted without semicolon.
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{13-13=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'property1': 'Builder<Int>' or 'Builder<String>'}}
+  dynamic var property1: Result {
+    get { 1 } // expected-error {{cannot convert return expression}}
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{10-10=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'property2': 'Builder<Int>' or 'Builder<String>'}}
+  dynamic var property2: Result {
+    get {}
+  }
+
+  // expected-note@+5{{add an explicit 'return' statement to not use a result builder}}{{51-51=return <#expr#>\n}}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+2{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{3-3=@Builder<String> }}
+  // expected-error@+1{{ambiguous result builder inferred for 'subscript(subscript1:)': 'Builder<Int>' or 'Builder<String>'}}
+  dynamic subscript(subscript1 _: Int) -> Result {}
+
+  // expected-note@+5{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+2{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{3-3=@Builder<String> }}
+  // expected-error@+1{{ambiguous result builder inferred for 'subscript(subscript2:)': 'Builder<Int>' or 'Builder<String>'}}
+  dynamic subscript(subscript2 _: Int) -> Result {
+  }
+}
+extension Test5 {
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'replacement_function()': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'replacement_property1': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'replacement_property2': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'subscript(replacement_subscript1:)': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int2')}}{{-1:3-3=@Builder<Int> }} // FIXME: This is redundant; we already suggested Builder<Int>.
+  // expected-note@+3{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'subscript(replacement_subscript2:)': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result {
+  }
+}
+
+struct Test6 {}
+extension Test6: P_Builder_Int1, P_Builder_String {
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Bool>' (inferred from dynamic replacement of 'replaced_function()')}}{{-1:3-3=@Builder<Bool> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'function()': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: replaced_function)
+  func function() -> Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Bool>' (inferred from dynamic replacement of 'replaced_property1')}}{{-1:3-3=@Builder<Bool> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'property1': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: replaced_property1)
+  var property1: Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Bool>' (inferred from dynamic replacement of 'replaced_property2')}}{{-1:3-3=@Builder<Bool> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'property2': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: replaced_property2)
+  var property2: Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Bool>' (inferred from dynamic replacement of 'subscript(replaced_subscript1:)')}}{{-1:3-3=@Builder<Bool> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'subscript(subscript1:)': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: subscript(replaced_subscript1:))
+  subscript(subscript1 _: Int) -> Result {
+  }
+
+  // expected-note@+6{{add an explicit 'return' statement to not use a result builder}}{{+1:3-3=return <#expr#>\n}}
+  // expected-note@+5{{apply result builder 'Builder<String>' (inferred from protocol 'P_Builder_String')}}{{-1:3-3=@Builder<String> }}
+  // expected-note@+4{{apply result builder 'Builder<Int>' (inferred from protocol 'P_Builder_Int1')}}{{-1:3-3=@Builder<Int> }}
+  // expected-note@+3{{apply result builder 'Builder<Bool>' (inferred from dynamic replacement of 'subscript(replaced_subscript2:)')}}{{-1:3-3=@Builder<Bool> }}
+  // expected-error@+2{{ambiguous result builder inferred for 'subscript(subscript2:)': 'Builder<Int>' or 'Builder<String>'}}
+  @_dynamicReplacement(for: subscript(replaced_subscript2:))
+  subscript(subscript2 _: Int) -> Result {
+  }
+}
+extension Test6 {
+  @Builder<Bool> dynamic func replaced_function() -> Result { true }
+
+  @Builder<Bool> dynamic var replaced_property1: Result { true }
+  @Builder<Bool> dynamic var replaced_property2: Result { true }
+
+  @Builder<Bool> dynamic subscript(replaced_subscript1 _: Int) -> Result { true }
+  @Builder<Bool> dynamic subscript(replaced_subscript2 _: Int) -> Result { true }
+}
+
+// (?) Overridden result builders in protocol hierarchies still contribute to
+// ambiguities.
+do {
+  protocol P1 {
+    @Builder<Int>
+    func function() -> Result
+  }
+  protocol P2: P1 {
+    @Builder<String>
+    func function() -> Result
+  }
+  protocol P3: P2 {
+    @Builder<Bool>
+    func function() -> Result
+  }
+
+  struct S: P3 {
+    // expected-note@+5{{add an explicit 'return' statement to not use a result builder}}{{+1:5-5=return <#expr#>\n}}
+    // expected-note@+4{{apply result builder 'Builder<Bool>' (inferred from protocol 'P3')}}{{5-5=@Builder<Bool> }}
+    // expected-note@+3{{apply result builder 'Builder<Int>' (inferred from protocol 'P1')}}{{5-5=@Builder<Int> }}
+    // expected-note@+2{{apply result builder 'Builder<String>' (inferred from protocol 'P2')}}{{5-5=@Builder<String> }}
+    // expected-error@+1{{ambiguous result builder inferred for 'function()': 'Builder<Bool>' or 'Builder<String>'}}
+    func function() -> Result {
+    }
+  }
+}
+
+//==============================================================================
+// Inference suppression: explicit result builder.
+//==============================================================================
+
+struct Test7 {
+  @Builder<Int> dynamic func function() -> Result { 1 }
+
+  @Builder<Int> 
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { @Builder<Int> get { 1 } }
+
+  @Builder<Int> 
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { @Builder<Int> get { 1 } }
+}
+extension Test7 {
+  @Builder<Bool>
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { true }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { true }
+
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result {
+    @Builder<Bool> get { true }
+  }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result {
+    @Builder<Bool> get { true }
+  }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { true }
+}
+
+struct Test8: P_Builder_Int1 {
+  dynamic func function() -> Result { 1 }
+
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { 1 }
+
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { 1 }
+}
+extension Test8 {
+  @Builder<Bool>
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { true }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { true }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { @Builder<Bool> get { true } }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { true }
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { @Builder<Bool> get { true } }
+}
+
+// Inference from dynamically replaced declaration is prioritized
+// above inference from protocol requirements that are witnessed by it.
+struct Test9: P_Builder_String {
+  @Builder<Int>
+  dynamic func function() -> Result { 1 }
+
+  @Builder<Int>
+  dynamic var property2: Result { 1 }
+  dynamic var property1: Result { @Builder<Int> get { 1 } }
+
+  @Builder<Int>
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { @Builder<Int> get { 1 } }
+}
+extension Test9 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+}
+
+struct Test10: P_Builder_Int1, P_Builder_String {
+  @Builder<Int> dynamic func function() -> Result { 1 }
+
+  @Builder<Int>
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { @Builder<Int> get { 1 } }
+
+  @Builder<Int>
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { @Builder<Int> get { 1 } }
+}
+extension Test10 {
+  @Builder<Bool>
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { true }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { true }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { @Builder<Bool> get { true } }
+
+  @Builder<Bool>
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { true }
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { @Builder<Bool> get { true } }
+}
+
+//==============================================================================
+// Inference suppression: return statements.
+//==============================================================================
+
+struct Test11 {
+  @Builder<Int>
+  dynamic func function() -> Result { 1 }
+
+  @Builder<Int>
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { @Builder<Int> get { 1 } }
+
+  @Builder<Int>
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { @Builder<Int> get { 1 } }
+}
+extension Test11 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result {
+    do { if true { while true { return Result() } } }
+  }
+
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { return Result() }
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { get { return Result() } }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { return Result() }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { get { return Result() } }
+}
+
+struct Test12: P_Builder_Int1 {
+  dynamic func function() -> Result { 1 }
+
+  dynamic var property1: Result { 1 }
+  dynamic var property2: Result { 1 }
+
+  dynamic subscript(subscript1 _: Int) -> Result { 1 }
+  dynamic subscript(subscript2 _: Int) -> Result { 1 }
+}
+extension Test12 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { return Result() }
+
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { return Result() }
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { get { return Result() } }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { return Result() }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { get { return Result() } }
+}
+
+// Return statement in dynamically replaced declaration does not prevent the
+// replacement from using it to infer a result builder.
+
+struct Test13 {
+  // @expected-note@+1 {{remove the attribute to explicitly disable the result builder}}
+  @Builder<Int>
+  dynamic func function() -> Result {
+    return Result()
+    // @expected-warning@-1 {{application of result builder 'Builder<Int>' disabled by explicit 'return' statement}}
+    // @expected-note@-2 {{remove 'return' statements to apply the result builder}}
+  }
+
+  // @expected-note@+1 {{remove the attribute to explicitly disable the result builder}}
+  @Builder<Int>
+  dynamic var property1: Result {
+    return Result()
+    // @expected-warning@-1 {{application of result builder 'Builder<Int>' disabled by explicit 'return' statement}}
+    // @expected-note@-2 {{remove 'return' statements to apply the result builder}}
+  }
+  dynamic var property2: Result {
+    // @expected-note@+1 {{remove the attribute to explicitly disable the result builder}}
+    @Builder<Int>
+    get {
+      return Result()
+      // @expected-warning@-1 {{application of result builder 'Builder<Int>' disabled by explicit 'return' statement}}
+      // @expected-note@-2 {{remove 'return' statements to apply the result builder}}
     }
   }
 
-  struct Conformer2: P {
-    var property: Bool {
-      @BuildBoolFrom<Int>
-      get {
-        // OK, explicit result builder disables inference through protocol.
-        1
-        2
-      }
+  // @expected-note@+1 {{remove the attribute to explicitly disable the result builder}}
+  @Builder<Int>
+  dynamic subscript(subscript1 _: Int) -> Result {
+    return Result()
+    // @expected-warning@-1 {{application of result builder 'Builder<Int>' disabled by explicit 'return' statement}}
+    // @expected-note@-2 {{remove 'return' statements to apply the result builder}}
+  }
+  dynamic subscript(subscript2 _: Int) -> Result {
+    // @expected-note@+1 {{remove the attribute to explicitly disable the result builder}}
+    @Builder<Int> get {
+      return Result()
+      // @expected-warning@-1 {{application of result builder 'Builder<Int>' disabled by explicit 'return' statement}}
+      // @expected-note@-2 {{remove 'return' statements to apply the result builder}}
     }
   }
+}
+extension Test13 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert return expression}}
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+  // FIXME: expected-error@-1 {{cannot convert return expression}}
+}
+
+struct Test14: P_Builder_Int1 {
+  dynamic func function() -> Result { return Result() }
+
+  dynamic var property1: Result { return Result() }
+  dynamic var property2: Result { get { return Result() } }
+
+  dynamic subscript(subscript1 _: Int) -> Result { return Result() }
+  dynamic subscript(subscript2 _: Int) -> Result { get { return Result() } }
+}
+extension Test14 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { 1 }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { 1 }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { 1 }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+}
+
+struct Test15: P_Builder_Int1, P_Builder_String {
+  dynamic func function() -> Result { return Result() }
+
+  dynamic var property1: Result { return Result() }
+  dynamic var property2: Result { get { return Result() } }
+
+  dynamic subscript(subscript1 _: Int) -> Result { return Result() }
+  dynamic subscript(subscript2 _: Int) -> Result { get { return Result() } }
+}
+extension Test15 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { return Result() }
+
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { return Result() }
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { get { return Result() } }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { return Result() }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { get { return Result() } }
+}
+
+//==============================================================================
+// Inference suppression: separation of conformance context & witness context.
+// Only conformances declared on the witness context are considered in
+// inference from protocol requirements.
+//==============================================================================
+
+struct Test16 {
+  dynamic func function() -> Result { Result() }
+
+  dynamic var property1: Result { Result() }
+  dynamic var property2: Result { Result() }
+
+  dynamic subscript(subscript1 _: Int) -> Result { Result() }
+  dynamic subscript(subscript2 _: Int) -> Result { Result() }
+}
+extension Test16: P_Builder_Int1 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { Result() }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { Result() }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { Result() }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { Result() }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { Result() }
+}
+
+struct Test17 {
+  dynamic func function() -> Result { Result() }
+}
+extension Test17: P_Builder_Int1 {
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { Result() }
+
+  dynamic var property1: Result { 1 }
+}
+extension Test17: P_Builder_String {
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { 1 }
+
+  dynamic var property2: Result { "1" }
+}
+extension Test17: P_Builder_Bool {
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { "1" }
+
+  dynamic subscript(subscript1 _: Int) -> Result { true }
+}
+extension Test17: P_Builder_Int2 {
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { true }
+
+  dynamic subscript(subscript2 _: Int) -> Result { 1 }
+}
+extension Test17 {
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { 1 }
+}
+
+struct Test18: P_Builder_Int1, P_Builder_String, P_Builder_Bool {}
+extension Test18 {
+  dynamic func function() -> Result { Result() }
+
+  dynamic var property1: Result { Result() }
+  dynamic var property2: Result { Result() }
+
+  dynamic subscript(subscript1 _: Int) -> Result { Result() }
+  dynamic subscript(subscript2 _: Int) -> Result { Result() }
+
+  @_dynamicReplacement(for: function)
+  func replacement_function() -> Result { Result() }
+
+  @_dynamicReplacement(for: property1)
+  var replacement_property1: Result { Result() }
+  @_dynamicReplacement(for: property2)
+  var replacement_property2: Result { Result() }
+
+  @_dynamicReplacement(for: subscript(subscript1:))
+  subscript(replacement_subscript1 _: Int) -> Result { Result() }
+  @_dynamicReplacement(for: subscript(subscript2:))
+  subscript(replacement_subscript2 _: Int) -> Result { Result() }
 }

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -151,16 +151,13 @@ protocol Tupled3 {
 struct TupleMe3: Tupled3 {
   var condition: Bool
 
-  // FIXME: Not inferred from getter requirement
-  // expected-error@+1 {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
   var tuple: some Any {
-    "hello" // expected-warning{{literal is unused}}
+    "hello"
     if condition {
-      "nested" // expected-warning{{literal is unused}}
+      "nested"
     }
-    3.14159 // expected-warning{{literal is unused}}
-    "world" // expected-warning{{literal is unused}}
-    // expected-note@-1 {{did you mean to return the last expression?}}
+    3.14159
+    "world"
   }
 }
 

--- a/test/Constraints/result_builder_infer.swiftinterface
+++ b/test/Constraints/result_builder_infer.swiftinterface
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift
+
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution
+
+import Swift
+
+public struct Result {}
+
+@resultBuilder public enum Builder<T> {
+  public static func buildBlock(_: T...) -> Result
+}
+
+public protocol P_Builder_Int {
+  @Builder<Int> func function() -> Result
+  @Builder<Int> var property: Result { get }
+  @Builder<Int> subscript(_: Int) -> Result { get }
+}
+public protocol P_Builder_String {
+  @Builder<String> func function() -> Result
+  @Builder<String> var property: Result { get }
+  @Builder<String> subscript(_: Int) -> Result { get }
+}
+
+// Do not call out ambiguous result builder inference if the inferred-for
+// function has no body.
+
+public struct Test : P_Builder_Int, P_Builder_String {
+  dynamic public func function() -> Result
+  dynamic public var property: Result {
+    get
+  }
+  dynamic public subscript(_: Int) -> Result {
+    get
+  }
+}
+extension Test {
+  @_dynamicReplacement(for: function)
+  public func replacement_function() -> Result
+  @_dynamicReplacement(for: property)
+  public var replacement_property: Result {
+    get
+  }
+  @_dynamicReplacement(for: subscript(_:))
+  public subscript(replacement_subscript _: Int) -> Result {
+    get
+  }
+}


### PR DESCRIPTION
Fixes #76362, fixes #76746, fixes #76747. 

These are technically source breaking, but the cases in which they break source are quite niche.