### PR TITLE
Revert "[build-script] Run LLDB tests with new redecl-completion sett…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2786,18 +2786,6 @@ for host in "${ALL_HOSTS[@]}"; do
                             --param dotest-args="${DOTEST_ARGS}" \
                             --filter=compat
                 fi
-
-                if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "FALSE" ]]; then
-                    echo "--- Rerun LLDB API tests (Config: Redecl completion) ---"
-                     with_pushd ${results_dir} \
-                        call "${llvm_build_dir}/bin/llvm-lit" \
-                             "${lldb_build_dir}/test/API" \
-                             ${LLVM_LIT_ARGS} \
-                             --param dotest-args="--setting plugin.typesystem.clang.experimental-redecl-completion=true" \
-                             --filter="lang|functionalities|types|commands"
-
-                    # FIXME: run shell-tests with new setting. LLDB doesn't support that yet.
-                 fi
                 continue
                 ;;
             llbuild)


### PR DESCRIPTION
…ing"

This reverts commit 885858567758fd61fdafce3629f30654d022334c.

This mode is not working well with rebranch, so we're disabling its testing to reduce the CI noise.
