### PR TITLE
[embedded] Force deserialization of wtables when needed to support class-bound existentials

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -161,7 +161,7 @@ bool SILLinkerVisitor::processFunction(SILFunction *F) {
 }
 
 bool SILLinkerVisitor::processConformance(ProtocolConformanceRef conformanceRef) {
-  visitProtocolConformance(conformanceRef);
+  visitProtocolConformance(conformanceRef, false);
   process();
   return Changed;
 }
@@ -247,12 +247,15 @@ static bool mustDeserializeProtocolConformance(SILModule &M,
     && conformance->isSynthesized();
 }
 
-void SILLinkerVisitor::visitProtocolConformance(ProtocolConformanceRef ref) {
+void SILLinkerVisitor::visitProtocolConformance(
+    ProtocolConformanceRef ref, bool referencedFromInitExistential) {
   // If an abstract protocol conformance was passed in, do nothing.
   if (ref.isAbstract())
     return;
   
-  bool mustDeserialize = mustDeserializeProtocolConformance(Mod, ref);
+  bool isEmbedded = Mod.getOptions().EmbeddedSwift;
+  bool mustDeserialize = (isEmbedded && referencedFromInitExistential) ||
+                         mustDeserializeProtocolConformance(Mod, ref);
 
   // Otherwise try and lookup a witness table for C.
   ProtocolConformance *C = ref.getConcrete();
@@ -305,7 +308,7 @@ void SILLinkerVisitor::visitProtocolConformance(ProtocolConformanceRef ref) {
     // However, we *must* pull in shared clang-importer-derived conformances
     // we potentially use, since we may not otherwise have a local definition.
     if (mustDeserializeProtocolConformance(Mod, c))
-      visitProtocolConformance(c);
+      visitProtocolConformance(c, referencedFromInitExistential);
   };
   
   // For each entry in the witness table...
@@ -355,7 +358,7 @@ void SILLinkerVisitor::visitApplySubstitutions(SubstitutionMap subs) {
     // However, we *must* pull in shared clang-importer-derived conformances
     // we potentially use, since we may not otherwise have a local definition.
     if (mustDeserializeProtocolConformance(Mod, conformance)) {
-      visitProtocolConformance(conformance);
+      visitProtocolConformance(conformance, false);
     }
   }
 }
@@ -371,7 +374,7 @@ void SILLinkerVisitor::visitInitExistentialAddrInst(
   // visiting the open_existential_addr/witness_method before the
   // init_existential_inst.
   for (ProtocolConformanceRef C : IEI->getConformances()) {
-    visitProtocolConformance(C);
+    visitProtocolConformance(C, true);
   }
 }
 
@@ -385,9 +388,10 @@ void SILLinkerVisitor::visitInitExistentialRefInst(
   // not going to be smart about this to enable avoiding any issues with
   // visiting the protocol_method before the init_existential_inst.
   for (ProtocolConformanceRef C : IERI->getConformances()) {
-    visitProtocolConformance(C);
+    visitProtocolConformance(C, true);
   }
 }
+
 void SILLinkerVisitor::visitAllocRefDynamicInst(AllocRefDynamicInst *ARI) {
   if (!isLinkAll())
     return;

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -119,10 +119,11 @@ public:
   void visitFunctionRefInst(FunctionRefInst *FRI);
   void visitDynamicFunctionRefInst(DynamicFunctionRefInst *FRI);
   void visitPreviousDynamicFunctionRefInst(PreviousDynamicFunctionRefInst *FRI);
-  void visitProtocolConformance(ProtocolConformanceRef C);
+  void visitProtocolConformance(ProtocolConformanceRef C,
+                                bool referencedFromInitExistential);
   void visitApplySubstitutions(SubstitutionMap subs);
   void visitWitnessMethodInst(WitnessMethodInst *WMI) {
-    visitProtocolConformance(WMI->getConformance());
+    visitProtocolConformance(WMI->getConformance(), false);
   }
   void visitInitExistentialAddrInst(InitExistentialAddrInst *IEI);
   void visitInitExistentialRefInst(InitExistentialRefInst *IERI);

--- a/test/embedded/existential-class-bound8.swift
+++ b/test/embedded/existential-class-bound8.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// BEGIN MyModule.swift
+
+public protocol ClassBound: AnyObject {
+    func foo()
+}
+
+class MyGenericClass<T> {
+    var typ: String
+    init(typ: String) { self.typ = typ }
+}
+extension MyGenericClass: ClassBound {
+    func foo() { print("MyGenericClass<\(typ)>.foo()") }
+}
+
+public func factory() -> any ClassBound {
+    return MyGenericClass<String>(typ: "String")
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+var arr: [any ClassBound] = [factory()]
+arr[0].foo()
+// CHECK: MyGenericClass<String>.foo()


### PR DESCRIPTION
We currently fail to deserialize wtables in some cases and crash the compiler, see the attached test case that demonstrates that. SILLinker needs to force deserialization of a wtable if it's needed by a InitExistentialRefInst in Embedde Swift mode.