### PR TITLE
[Windows] Enable "INLINE" bridging mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,9 +434,8 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND BOOTSTRAPPING_MODE STREQUAL "HO
 endif()
 
 if(BRIDGING_MODE STREQUAL "DEFAULT" OR NOT BRIDGING_MODE)
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
     # In debug builds, to workaround a problem with LLDB's `po` command (rdar://115770255).
-    # On Windows, to workaround a build problem.
     # If the host Swift version is less than 5.8, use pure mode to workaround a C++ interop compiler crash.
     set(BRIDGING_MODE "PURE")
   else()

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -177,6 +177,8 @@ function(add_swift_compiler_modules_library name)
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     list(APPEND swift_compile_options "-static")
     list(APPEND sdk_option "-sdk" "${SWIFT_PATH_TO_SWIFT_SDK}")
+    # For "swift/shims/*.h".
+    list(APPEND sdk_option "-I" "${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib")
 
     # Workaround a crash in the LoadableByAddress pass
     # https://github.com/apple/swift/issues/73254
@@ -188,6 +190,12 @@ function(add_swift_compiler_modules_library name)
     if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 6.0)
       list(APPEND swift_compile_options "-Xcc" "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
     endif()
+
+    # Make 'offsetof()' a const value.
+    list(APPEND swift_compile_options "-Xcc" "-D_CRT_USE_BUILTIN_OFFSETOF")
+
+    # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
+    list(APPEND swift_compile_options "-Xcc" "-Xclang" "-Xcc" "-fmodule-format=raw")
   else()
     list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
   endif()

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -93,13 +93,19 @@ set(compile_options
 
   # Necessary to avoid treating IBOutlet and IBAction as keywords
   "SHELL:-Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable"
-
-  "SHELL:-Xcc -D_CRT_USE_BUILTIN_OFFSETOF"
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  list(APPEND compile_options
+    # Make 'offsetof()' a const value.
+    "SHELL:-Xcc -D_CRT_USE_BUILTIN_OFFSETOF"
+    # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
+    "SHELL:-Xcc -Xclang -Xcc -fmodule-format=raw")
+endif()
 
 # Prior to 5.9, we have to use the experimental flag for C++ interop.
 if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.9)
-  list(APPEND compile_options "-Xfrontend" "-enable-experimental-cxx-interop")
+  list(APPEND compile_options "SHELL:-Xfrontend -enable-experimental-cxx-interop")
 else()
   list(APPEND compile_options "-cxx-interoperability-mode=default")
 endif()


### PR DESCRIPTION
* Workaround for https://github.com/swiftlang/llvm-project/issues/7172
* `-D_CRT_USE_BUILTIN_OFFSETOF` to make `offsetof()` a constant
* Pass `swift/shims` search path in `SwiftCompilerSources`