### PR TITLE
[cxx-interop] Workaround a modularization issue in benchmarks

### DIFF
--- a/benchmark/cxx-source/CxxSpanTests.swift
+++ b/benchmark/cxx-source/CxxSpanTests.swift
@@ -12,6 +12,7 @@
 
 import TestsUtils
 import CxxStdlibPerformance
+import CxxStdlib // FIXME(rdar://128520766): this import should be redundant
 
 let iterRepeatFactor = 7
 


### PR DESCRIPTION
`import CxxStdlib` should not be required, since `CxxStdlibPerformance` transitively imports the C++ stdlib, but having the explicit import works around a modularization issue (rdar://128520766).

rdar://136330247

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
