### PR TITLE
SE-0444: Fix interactions with Cxx interop

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -147,7 +147,7 @@ public:
   virtual void dumpSwiftLookupTables() const = 0;
 
   /// Returns the module that contains imports and declarations from all loaded
-  /// Objective-C header files.
+  /// header files.
   virtual ModuleDecl *getImportedHeaderModule() const = 0;
 
   /// Retrieves the Swift wrapper for the given Clang module, creating

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -979,6 +979,12 @@ public:
   LLVM_READONLY
   ModuleDecl *getModuleContext() const;
 
+  /// Retrieve the module in which this declaration would be found by name
+  /// lookup queries. The result can differ from that of `getModuleContext()`
+  /// when the decl was imported via Cxx interop.
+  LLVM_READONLY
+  ModuleDecl *getModuleContextForNameLookup() const;
+
   /// getASTContext - Return the ASTContext that this decl lives in.
   LLVM_READONLY
   ASTContext &getASTContext() const {

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -614,6 +614,9 @@ public:
   void findDeclaredCrossImportOverlaysTransitive(
       SmallVectorImpl<ModuleDecl *> &overlays);
 
+  /// Returns true if this module is the Clang header import module.
+  bool isClangHeaderImportModule() const;
+
   /// Convenience accessor for clients that know what kind of file they're
   /// dealing with.
   SourceFile &getMainSourceFile() const;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2471,6 +2471,14 @@ bool ModuleDecl::getRequiredBystandersIfCrossImportOverlay(
   return false;
 }
 
+bool ModuleDecl::isClangHeaderImportModule() const {
+  auto importer = getASTContext().getClangModuleLoader();
+  if (!importer)
+    return false;
+
+  return this == importer->getImportedHeaderModule();
+}
+
 namespace {
 struct OverlayFileContents {
   struct Module {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2504,7 +2504,7 @@ bool DeclContext::lookupQualified(Type type,
 }
 
 bool DeclContext::isDeclImported(const Decl *decl) const {
-  auto declModule = decl->getDeclContext()->getParentModule();
+  auto declModule = decl->getModuleContextForNameLookup();
   return getASTContext().getImportCache().isImportedBy(declModule, this);
 }
 

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -404,9 +404,7 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
     if (bridgingHeader.empty())
       return import != &M && import->getName() == M.getName();
 
-    auto importer = static_cast<ClangImporter *>(
-        import->getASTContext().getClangModuleLoader());
-    return import == importer->getImportedHeaderModule();
+    return import->isClangHeaderImportModule();
   };
 
   clang::FileSystemOptions fileSystemOptions;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -744,11 +744,7 @@ IdentifierID Serializer::addContainingModuleRef(const DeclContext *DC,
     return CURRENT_MODULE_ID;
   if (M == this->M->getASTContext().TheBuiltinModule)
     return BUILTIN_MODULE_ID;
-
-  auto clangImporter =
-    static_cast<ClangImporter *>(
-      this->M->getASTContext().getClangModuleLoader());
-  if (M == clangImporter->getImportedHeaderModule())
+  if (M->isClangHeaderImportModule())
     return OBJC_HEADER_MODULE_ID;
 
   auto exportedModuleName = file->getExportedModuleName();

--- a/test/Interop/Cxx/namespace/Inputs/members-direct.h
+++ b/test/Interop/Cxx/namespace/Inputs/members-direct.h
@@ -1,0 +1,24 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_DIRECT_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_DIRECT_H
+
+#include <members-transitive.h>
+
+namespace DirectNamespace { }
+
+namespace CommonNamespace {
+
+struct DirectStruct {
+  int memberVar;
+};
+
+} // namespace CommonNamespace
+
+CommonNamespace::TransitiveStruct returnsTransitiveStruct() {
+  return CommonNamespace::TransitiveStruct{};
+}
+
+TopLevelTransitiveStruct returnsTopLevelTransitiveStruct() {
+  return TopLevelTransitiveStruct{};
+}
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_DIRECT_H

--- a/test/Interop/Cxx/namespace/Inputs/members-transitive.h
+++ b/test/Interop/Cxx/namespace/Inputs/members-transitive.h
@@ -1,0 +1,18 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_TRANSITIVE_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_TRANSITIVE_H
+
+namespace TransitiveNamespace { }
+
+namespace CommonNamespace {
+
+struct TransitiveStruct {
+  bool memberVar;
+};
+
+} // namespace CommonNamespace
+
+struct TopLevelTransitiveStruct {
+  bool memberVar;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERS_TRANSITIVE_H

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -59,3 +59,13 @@ module Enums {
   header "enums.h"
   requires cplusplus
 }
+
+module MembersDirect {
+  header "members-direct.h"
+  requires cplusplus
+}
+
+module MembersTransitive {
+  header "members-transitive.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/namespace/member-import-visibility.swift
+++ b/test/Interop/Cxx/namespace/member-import-visibility.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -enable-upcoming-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+
+import MembersDirect
+
+// expected-member-visibility-note@-1 4 {{add import of module 'MembersTransitive'}}
+
+extension DirectNamespace { }
+extension TransitiveNamespace { } // expected-error {{cannot find type 'TransitiveNamespace' in scope}}
+
+extension CommonNamespace.DirectStruct {
+  func extensionMethod() -> Int32 {
+    return memberVar
+  }
+}
+
+extension CommonNamespace.TransitiveStruct { // expected-member-visibility-error {{struct 'TransitiveStruct' is not available due to missing import of defining module 'MembersTransitive'}}
+  func extensionMethod() -> Bool {
+    return memberVar // expected-member-visibility-error {{property 'memberVar' is not available due to missing import of defining module 'MembersTransitive'}}
+  }
+}
+
+func test() {
+  let _: Bool = returnsTransitiveStruct().memberVar // expected-member-visibility-error {{property 'memberVar' is not available due to missing import of defining module 'MembersTransitive'}}
+  let _: Bool = returnsTopLevelTransitiveStruct().memberVar // expected-member-visibility-error {{property 'memberVar' is not available due to missing import of defining module 'MembersTransitive'}}
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1043,8 +1043,6 @@ static void collectModuleDependencies(ModuleDecl *TopMod,
   if (!TopMod)
     return;
 
-  auto ClangModuleLoader = TopMod->getASTContext().getClangModuleLoader();
-
   ModuleDecl::ImportFilter ImportFilter = {
       ModuleDecl::ImportFilterKind::Exported,
       ModuleDecl::ImportFilterKind::Default};
@@ -1061,8 +1059,7 @@ static void collectModuleDependencies(ModuleDecl *TopMod,
     if (Mod->isSystemModule())
       continue;
     // FIXME: Setup dependencies on the included headers.
-    if (ClangModuleLoader &&
-        Mod == ClangModuleLoader->getImportedHeaderModule())
+    if (Mod->isClangHeaderImportModule())
       continue;
     bool NewVisit = Visited.insert(Mod).second;
     if (!NewVisit)


### PR DESCRIPTION
With the upcoming `MemberImportVisibility` feature enabled, code built with Cxx interop also enabled could be rejected by the compiler with cryptic errors about the `__ObjC` module not being imported. This is the result of a surprising implementation detail of Cxx interop. When importing C++ namespaces and their members, the Clang importer puts these declarations in the Clang header import module (a.k.a. the bridging header module, `__ObjC`). C++ namespaces don't have a logical modular home in the Swift AST because they can span multiple modules, so it's understandable why this implementation was chosen. However, the concrete members of namespaces also get placed in the `__ObjC` module too, and this really confuses things.

To work around this idiosyncrasy of Cxx interop, I've introduced `Decl::getModuleContextForNameLookup()` which returns the module that a declaration would ideally belong to if Cxx interop didn't have this behavior. This alternative to `Decl::getModuleContext()` is now used everywhere that `MemberImportVisibility` rules are enforced to provide consistency.

Additionally, I found that I also had to further special-case the header import module for Cxx interop because it turns out that there are some additional declarations, beyond imported namespaces, that also live there and need to be implicitly visible in every source file. The `__ObjC` module is not implicitly imported in source files when Cxx interop is enabled, so these declarations are not deemed visible under normal name lookup rules. When I tried to add an implicit import of `__ObjC` when Cxx interop is enabled, it broke a bunch tests. So for now, when a decl really belongs to the `__ObjC` module in Cxx interop mode, we just always allow it to be referenced.

This Cxx interop behavior really needs a re-think in my opinion, but that will require larger discussions.

Resolves rdar://136600598.