### PR TITLE
[Concurrency] Include more pieces of Concurrency in Embedded (AsyncStream, continuations)

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -263,39 +263,13 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       IS_STDLIB IS_FRAGILE
 
       ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
+      ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES}
       CooperativeGlobalExecutor.cpp
-
-      # TODO: Only a subset of Swift Concurrency .swift sources, for now.
-      Actor.swift
-      AsyncLet.swift
-      CheckedContinuation.swift
-      Errors.swift
-      Executor.swift
-      ExecutorAssertions.swift
-      AsyncCompactMapSequence.swift
-      AsyncDropFirstSequence.swift
-      AsyncDropWhileSequence.swift
-      AsyncFilterSequence.swift
-      AsyncFlatMapSequence.swift
-      AsyncIteratorProtocol.swift
-      AsyncMapSequence.swift
-      AsyncPrefixSequence.swift
-      AsyncPrefixWhileSequence.swift
-      AsyncSequence.swift
-      AsyncThrowingCompactMapSequence.swift
-      AsyncThrowingDropWhileSequence.swift
-      AsyncThrowingFilterSequence.swift
-      AsyncThrowingFlatMapSequence.swift
-      AsyncThrowingMapSequence.swift
-      AsyncThrowingPrefixWhileSequence.swift
-      GlobalActor.swift
-      PartialAsyncTask.swift
-      Task.swift
-      TaskCancellation.swift
 
       SWIFT_COMPILE_FLAGS
         ${extra_swift_compile_flags} -enable-experimental-feature Embedded
         -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
+        -Xfrontend -emit-empty-object-file
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
         ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
+#if !$Embedded
 /// A clock that measures time that always increments and does not stop 
 /// incrementing while the system is asleep. 
 ///
@@ -33,6 +34,7 @@ public struct ContinuousClock: Sendable {
 
   public init() { }
 }
+#endif
 
 @available(SwiftStdlib 5.7, *)
 extension Duration {
@@ -48,6 +50,8 @@ extension Duration {
     self.init(_high: high, low: low)
   }
 }
+
+#if !$Embedded
 
 @available(SwiftStdlib 5.7, *)
 extension Clock where Self == ContinuousClock {
@@ -189,3 +193,5 @@ extension ContinuousClock.Instant: InstantProtocol {
     rhs.duration(to: lhs)
   }
 }
+
+#endif

--- a/stdlib/public/Concurrency/Deque/Deque+Codable.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Codable.swift
@@ -14,6 +14,8 @@
 
 import Swift
 
+#if !$Embedded
+
 extension _Deque: Encodable where Element: Encodable {
   /// Encodes the elements of this deque into the given encoder in an unkeyed
   /// container.
@@ -50,3 +52,5 @@ extension _Deque: Decodable where Element: Decodable {
     }
   }
 }
+
+#endif

--- a/stdlib/public/Concurrency/Deque/Deque+CustomDebugStringConvertible.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+CustomDebugStringConvertible.swift
@@ -12,7 +12,8 @@
 /// This file is copied from swift-collections and should not be modified here.
 /// Rather all changes should be made to swift-collections and copied back.
 
-#if !SWIFT_STDLIB_STATIC_PRINT
+#if !SWIFT_STDLIB_STATIC_PRINT && !$Embedded
+
 import Swift
 
 extension _Deque: CustomDebugStringConvertible {
@@ -32,4 +33,5 @@ extension _Deque: CustomDebugStringConvertible {
     return result
   }
 }
+
 #endif

--- a/stdlib/public/Concurrency/Deque/Deque+CustomStringConvertible.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+CustomStringConvertible.swift
@@ -12,7 +12,8 @@
 /// This file is copied from swift-collections and should not be modified here.
 /// Rather all changes should be made to swift-collections and copied back.
 
-#if !SWIFT_STDLIB_STATIC_PRINT
+#if !SWIFT_STDLIB_STATIC_PRINT && !$Embedded
+
 import Swift
 
 extension _Deque: CustomStringConvertible {
@@ -32,4 +33,5 @@ extension _Deque: CustomStringConvertible {
     return result
   }
 }
+
 #endif

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -31,6 +31,7 @@ import Swift
 ///
 /// Customizing the global concurrent executor is currently not supported.
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
     _DefaultGlobalConcurrentExecutor.shared
@@ -43,6 +44,7 @@ public var globalConcurrentExecutor: any TaskExecutor {
 /// thread pool that is used as the default executor for Swift concurrency
 /// tasks.
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 internal final class _DefaultGlobalConcurrentExecutor: TaskExecutor {
   public static let shared: _DefaultGlobalConcurrentExecutor = .init()
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -12,6 +12,8 @@
 
 import Swift
 
+#if !$Embedded
+
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
@@ -156,4 +158,6 @@ extension MainActor {
     try assumeIsolated(operation, file: file, line: line)
   }
 }
+#endif
+
 #endif

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
+#if !$Embedded
+
 /// A clock that measures time that always increments but stops incrementing 
 /// while the system is asleep. 
 ///
@@ -179,3 +181,4 @@ extension SuspendingClock.Instant: InstantProtocol {
   }
 }
 
+#endif

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -190,6 +190,7 @@ public func _unsafeInheritExecutor_withTaskExecutorPreference<T: Sendable>(
 /// Task with specified executor -----------------------------------------------
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension Task where Failure == Never {
   /// Runs the given nonthrowing operation asynchronously
   /// as part of a new top-level task on behalf of the current actor.
@@ -257,6 +258,7 @@ extension Task where Failure == Never {
 }
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension Task where Failure == Error {
   /// Runs the given throwing operation asynchronously
   /// as part of a new top-level task on behalf of the current actor.
@@ -321,6 +323,7 @@ extension Task where Failure == Error {
 // ==== Detached tasks ---------------------------------------------------------
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension Task where Failure == Never {
   /// Runs the given nonthrowing operation asynchronously
   /// as part of a new top-level task.
@@ -379,6 +382,7 @@ extension Task where Failure == Never {
 }
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension Task where Failure == Error {
   /// Runs the given throwing operation asynchronously
   /// as part of a new top-level task.
@@ -441,6 +445,7 @@ extension Task where Failure == Error {
 // ==== Unsafe Current Task ----------------------------------------------------
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension UnsafeCurrentTask {
 
   /// The current ``TaskExecutor`` preference, if this task has one configured.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1402,6 +1402,7 @@ static LazyMutex ActiveContinuationsLock;
 static Lazy<std::unordered_set<AsyncTask *>> ActiveContinuations;
 
 static bool isEnabled() {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   auto state = CurrentState.load(std::memory_order_relaxed);
   if (state == State::Uninitialized) {
     bool enabled =
@@ -1410,6 +1411,9 @@ static bool isEnabled() {
     CurrentState.store(state, std::memory_order_relaxed);
   }
   return state == State::On;
+#else
+  return false;
+#endif
 }
 
 static void init(AsyncTask *task) {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -67,7 +67,9 @@ import Swift
 /// Therefore, if a cancellation handler must acquire a lock, other code should
 /// not cancel tasks or resume continuations while holding that lock.
 @available(SwiftStdlib 5.1, *)
+#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
+#endif
 public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void,

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -14,6 +14,7 @@ import Swift
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.1, *)
+@_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, renamed: "Task.sleep(nanoseconds:)")
   /// Suspends the current task for at least the given duration

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -14,6 +14,7 @@ import Swift
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(SwiftStdlib 5.7, *)
   internal static func _sleep(

--- a/test/embedded/concurrency-stream.swift
+++ b/test/embedded/concurrency-stream.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+import _Concurrency
+
+@main struct Main {
+    static func main() async {
+        let (stream, continuation) = AsyncStream.makeStream(of: String.self)
+        Task {
+            for i in 0 ..< 10 {
+                continuation.yield("\(i)")
+            }
+            continuation.finish()
+        }
+        for await value in stream {
+            print(value)
+        }
+        print("All done!")
+        // CHECK: 0
+        // CHECK: 1
+        // CHECK: 2
+        // CHECK: 3
+        // CHECK: 4
+        // CHECK: 5
+        // CHECK: 6
+        // CHECK: 7
+        // CHECK: 8
+        // CHECK: 9
+        // CHECK: All done!
+    }
+}

--- a/test/embedded/custom-executor.swift
+++ b/test/embedded/custom-executor.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o
-// RUN: %target-clang %t/a.o %t/print.o %t/executor.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-clang %t/a.o %t/executor.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -26,6 +26,7 @@
 // DEP: ___stack_chk_guard
 // DEP: ___stderrp
 // DEP: _abort
+// DEP: _clock_gettime
 // DEP: _exit
 // DEP: _fprintf
 // DEP: _free
@@ -38,6 +39,7 @@
 // DEP: _putchar
 // DEP: _strlen
 // DEP: _vfprintf
+// DEP: _vprintf
 // DEP: _vsnprintf
 // DEP: _write
 

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -1,0 +1,85 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -disable-availability-checking -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o
+// RUN: %target-clang %t/a.o %t/executor.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+
+// RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
+
+// RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort | tee %t/actual-dependencies.txt
+
+// Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
+// RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
+
+// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKc
+// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKcm
+// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6insertEmPKc
+// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED1Ev
+// DEP: __ZNSt3__16chrono12steady_clock3nowEv
+// DEP: __ZNSt3__19to_stringEj
+// DEP: __ZNSt3__19to_stringEy
+// DEP: __ZdlPv
+// DEP: __ZdlPvm
+// DEP: __Znwm
+// DEP: ___assert_rtn
+// DEP: ___error
+// DEP: ___stack_chk_fail
+// DEP: ___stack_chk_guard
+// DEP: ___stderrp
+// DEP: _abort
+// DEP: _exit
+// DEP: _fprintf
+// DEP: _free
+// DEP: _malloc
+// DEP: _memmove
+// DEP: _memset
+// DEP: _memset_s
+// DEP: _nanosleep
+// DEP: _posix_memalign
+// DEP: _putchar
+// DEP: _strlen
+// DEP: _vfprintf
+// DEP: _vsnprintf
+// DEP: _write
+
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+import _Concurrency
+
+public func test() async -> Int {
+  print("test")
+  let t = Task {
+    print("return 42")
+    return 42
+  }
+  print("await")
+  let v = await t.value
+  print("return")
+  return v
+}
+
+@main
+struct Main {
+  static func main() async {
+    print("main")
+    // CHECK: main
+    let t = Task {
+      print("task")
+      let x = await test()
+      print(x == 42 ? "42" : "???")
+    }
+    print("after task")
+    await t.value
+    // CHECK-NEXT: after task
+    // CHECK-NEXT: task
+    // CHECK-NEXT: test
+    // CHECK-NEXT: await
+    // CHECK-NEXT: return 42
+    // CHECK-NEXT: return
+    // CHECK-NEXT: 42
+  }
+}

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -76,12 +76,12 @@ struct Main {
     }
     print("after task")
     await t.value
-    // CHECK-NEXT: after task
-    // CHECK-NEXT: task
-    // CHECK-NEXT: test
-    // CHECK-NEXT: await
-    // CHECK-NEXT: return 42
-    // CHECK-NEXT: return
-    // CHECK-NEXT: 42
+    // CHECK: after task
+    // CHECK: task
+    // CHECK: test
+    // CHECK: await
+    // CHECK: return 42
+    // CHECK: return
+    // CHECK: 42
   }
 }


### PR DESCRIPTION
We have been only including a subset of files and functionality on Embedded Concurrency, let's instead include all the source files, and have a fine grained opt out on things that don't yet work. Namely, this is still avoiding clocks, task sleeping, main actor and custom executors.
    
Add a test for AsyncStream and continuations on Embedded Concurrency.

Enables:
- [x] withUnsafeContinuation, withCheckedContinuation, test added
- [x] AsyncStream, AsyncSequence, test added
- [x] Deque used as storage for AsyncStream

Left as follow-up:
- [ ] MainActor
- [ ] ContinuousClock, SuspendingClock, Task.sleep
- [ ] Custom Task executors
