### PR TITLE
[embedded] Skip C++ stdlib for unicode stubs

### DIFF
--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -23,7 +23,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
       set(extra_c_compile_flags -D__MACH__ -D__APPLE__ -ffreestanding)
     endif()
-    
+    list(APPEND extra_c_compile_flags -nostdinc++)
+
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")


### PR DESCRIPTION
`stdint.h` should be picked up from `clang/lib/Headers`, but is instead being picked up by the system libc++. There's no C++ stdlib being used here, so just exclude it.

Resolves rdar://134584685.