### PR TITLE
[NFC] rewrite PredictableMemOpts dead allocation elimination

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -442,7 +442,7 @@ class AvailableValueAggregator {
   SILModule &M;
   SILBuilderWithScope B;
   SILLocation Loc;
-  MutableArrayRef<AvailableValue> AvailableValueList;
+  ArrayRef<AvailableValue> AvailableValueList;
   SmallVectorImpl<PMOMemoryUse> &Uses;
   DeadEndBlocks &deadEndBlocks;
   AvailableValueExpectedOwnership expectedOwnership;
@@ -463,7 +463,7 @@ class AvailableValueAggregator {
 
 public:
   AvailableValueAggregator(SILInstruction *Inst,
-                           MutableArrayRef<AvailableValue> AvailableValueList,
+                           ArrayRef<AvailableValue> AvailableValueList,
                            SmallVectorImpl<PMOMemoryUse> &Uses,
                            DeadEndBlocks &deadEndBlocks,
                            AvailableValueExpectedOwnership expectedOwnership)
@@ -2273,117 +2273,85 @@ bool OptimizeAllocLoads::optimize() {
 
 namespace {
 
-struct TakePromotionState {
-  ArrayRef<SILInstruction *> takeInsts;
-  SmallVector<unsigned, 8> takeInstIndices;
-  SmallVector<AvailableValue, 32> availableValueList;
+class PromotableInstructions {
+  // All promotable instructions share a vector of available values.
+  SmallVectorImpl<AvailableValue> &allAvailableValues;
+
+  SmallVector<SILInstruction *> promotableInsts;
   SmallVector<unsigned, 8> availableValueStartOffsets;
 
-  TakePromotionState(ArrayRef<SILInstruction *> takeInsts)
-      : takeInsts(takeInsts) {}
+public:
+  PromotableInstructions(SmallVectorImpl<AvailableValue> &allAvailableValues)
+      : allAvailableValues(allAvailableValues) {}
 
-  unsigned size() const { return takeInstIndices.size(); }
+  unsigned size() const { return promotableInsts.size(); }
 
-  void verify() {
-#ifndef NDEBUG
-    for (unsigned i : range(size())) {
-      SILInstruction *inst;
-      MutableArrayRef<AvailableValue> data;
-      std::tie(inst, data) = getData(i);
-      assert(inst);
-      inst->verifyOperandOwnership();
-      assert(!data.empty() && "Value without any available values?!");
-    }
-#endif
+  void push(SILInstruction *instruction) {
+    promotableInsts.push_back(instruction);
   }
 
-  void verify(unsigned startOffset) {
-#ifndef NDEBUG
-    assert(startOffset < size());
-    for (unsigned i : range(startOffset, size())) {
-      SILInstruction *inst;
-      MutableArrayRef<AvailableValue> data;
-      std::tie(inst, data) = getData(i);
-      assert(inst);
-      inst->verifyOperandOwnership();
-      assert(!data.empty() && "Value without any available values?!");
-    }
-#endif
+  // Available values must be initialized in the same order that the
+  // instructions are pushed. Return the instruction's index.
+  unsigned
+  initializeAvailableValues(SILInstruction *instruction,
+                            SmallVectorImpl<AvailableValue> &&availableValues) {
+
+    unsigned nextInstIdx = availableValueStartOffsets.size();
+    assert(instruction == promotableInsts[nextInstIdx]);
+    availableValueStartOffsets.push_back(allAvailableValues.size());
+    std::move(availableValues.begin(), availableValues.end(),
+              std::back_inserter(allAvailableValues));
+    return nextInstIdx;
   }
 
-  void initializeForTakeInst(unsigned takeInstIndex) {
-    availableValueStartOffsets.push_back(availableValueList.size());
-    takeInstIndices.push_back(takeInstIndex);
+  ArrayRef<SILInstruction *> instructions() const { return promotableInsts; }
+
+  ArrayRef<AvailableValue> availableValues(unsigned index) {
+    return mutableAvailableValues(index);
   }
 
-  std::pair<SILInstruction *, MutableArrayRef<AvailableValue>>
-  getData(unsigned index) {
-    unsigned takeInstIndex = takeInstIndices[index];
+  MutableArrayRef<AvailableValue> mutableAvailableValues(unsigned index) {
     unsigned startOffset = availableValueStartOffsets[index];
-    unsigned count;
-
-    if ((availableValueStartOffsets.size() - 1) != index) {
-      count = availableValueStartOffsets[index + 1] - startOffset;
-    } else {
-      count = availableValueList.size() - startOffset;
+    unsigned endOffset = allAvailableValues.size();
+    if (index + 1 < size()) {
+      endOffset = availableValueStartOffsets[index + 1];
     }
-
-    auto values = MutableArrayRef<AvailableValue>(availableValueList);
-    return {takeInsts[takeInstIndex], values.slice(startOffset, count)};
+    return {allAvailableValues.begin() + startOffset,
+            allAvailableValues.begin() + endOffset};
   }
+
+#ifndef NDEBUG
+  void verify() {
+    for (unsigned i : range(promotableInsts.size())) {
+      promotableInsts[i]->verifyOperandOwnership();
+      assert(!availableValues(i).empty()
+             && "Value without any available values?!");
+    }
+  }
+#endif
 };
 
 } // end anonymous namespace
 
-// Check if our use list has any non store, non take uses that keep the value
-// alive. Returns nullptr on success and the user that prevents removal on
-// failure.
-//
-// NOTE: This also gathers up any takes that we need to process.
-static SILInstruction *
-checkForNonStoreNonTakeUses(ArrayRef<PMOMemoryUse> uses,
-                            SmallVectorImpl<SILInstruction *> &loadTakeList) {
-  for (auto &u : uses) {
-    // Ignore removed instructions.
-    if (u.Inst == nullptr)
-      continue;
+namespace {
 
-    switch (u.Kind) {
-    case PMOUseKind::Assign:
-      // Until we can promote the value being destroyed by the assign, we can
-      // not remove deallocations with such assigns.
-      return u.Inst;
-    case PMOUseKind::InitOrAssign:
-      continue; // These don't prevent removal.
-    case PMOUseKind::Load:
-      // For now only handle takes from alloc_stack.
-      //
-      // TODO: It should be implementable, but it has not been needed yet.
-      if (auto *li = dyn_cast<LoadInst>(u.Inst)) {
-        if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
-          loadTakeList.push_back(li);
-          continue;
-        }
-      }
-      return u.Inst;
-    case PMOUseKind::Initialization:
-      if (!isa<ApplyInst>(u.Inst) &&
-          // A copy_addr that is not a take affects the retain count
-          // of the source.
-          (!isa<CopyAddrInst>(u.Inst) ||
-           cast<CopyAddrInst>(u.Inst)->isTakeOfSrc()))
-        continue;
-      // FALL THROUGH.
-      LLVM_FALLTHROUGH;
-    case PMOUseKind::IndirectIn:
-    case PMOUseKind::InOutUse:
-    case PMOUseKind::Escape:
-      return u.Inst; // These do prevent removal.
-    }
+struct Promotions {
+  SmallVector<AvailableValue, 32> allAvailableValues;
+  PromotableInstructions loadTakes;
+  PromotableInstructions destroys;
+
+  Promotions()
+      : loadTakes(allAvailableValues), destroys(allAvailableValues) {}
+
+#ifndef NDEBUG
+  void verify() {
+    loadTakes.verify();
+    destroys.verify();
   }
+#endif
+};
 
-  return nullptr;
-}
+} // end anonymous namespace
 
 namespace {
 
@@ -2415,7 +2383,15 @@ class OptimizeDeadAlloc {
   /// A structure that we use to compute our available values.
   AvailableValueDataflowContext DataflowContext;
 
+  Promotions promotions;
+
+  SmallBlotSetVector<SILValue, 32> valuesNeedingLifetimeCompletion;
+
 public:
+  SILFunction *getFunction() const { return TheMemory->getFunction(); }
+
+  bool isTrivial() const { return MemoryType.isTrivial(getFunction()); }
+
   OptimizeDeadAlloc(AllocationInst *memory,
                     SmallVectorImpl<PMOMemoryUse> &uses,
                     SmallVectorImpl<SILInstruction *> &releases,
@@ -2434,8 +2410,13 @@ public:
   bool tryToRemoveDeadAllocation();
 
 private:
+  SILInstruction *collectUsesForPromotion();
+
+  /// Return true if a load [take] or destroy_addr can be promoted. If so, this
+  /// initializes the available values in promotions.
   bool canPromoteTake(SILInstruction *i,
-                      SmallVectorImpl<AvailableValue> &availableValues);
+                      PromotableInstructions &promotableInsts);
+
   /// Promote a load take cleaning up everything except for RAUWing the
   /// instruction with the aggregated result. The routine returns the new
   /// aggregated result to the caller and expects the caller to eventually RAUW
@@ -2445,9 +2426,11 @@ private:
   ///
   /// \returns the value that the caller will RAUW with \p inst.
   SILValue promoteLoadTake(LoadInst *inst,
-                           MutableArrayRef<AvailableValue> values);
+                           ArrayRef<AvailableValue> availableValues);
   void promoteDestroyAddr(DestroyAddrInst *dai,
-                          MutableArrayRef<AvailableValue> values);
+                          ArrayRef<AvailableValue> availableValues);
+
+  void removeDeadAllocation();
 };
 
 } // end anonymous namespace
@@ -2474,70 +2457,29 @@ bool OptimizeDeadAlloc::tryToRemoveDeadAllocation() {
   if (!isRemovableAutogeneratedAllocation(TheMemory))
     return false;
 
-  SmallVector<SILInstruction *, 8> loadTakeList;
   // Check the uses list to see if there are any non-store uses left over after
   // load promotion and other things PMO does.
-  if (auto *badUser = checkForNonStoreNonTakeUses(Uses, loadTakeList)) {
+  if (auto *badUser = collectUsesForPromotion()) {
     LLVM_DEBUG(llvm::dbgs() << "*** Failed to remove autogenerated alloc: "
                                "kept alive by: "
                             << *badUser);
     return false;
   }
 
-  // If our memory is trivially typed, we can just remove it without needing to
-  // consider if the stored value needs to be destroyed. So at this point,
-  // delete the memory!
-  if (MemoryType.isTrivial(*TheMemory->getFunction())) {
-    LLVM_DEBUG(llvm::dbgs() << "*** Removing autogenerated trivial allocation: "
-                            << *TheMemory);
-
-    // If it is safe to remove, do it.  Recursively remove all instructions
-    // hanging off the allocation instruction, then return success.  Let the
-    // caller remove the allocation itself to avoid iterator invalidation.
-    deleter.forceDeleteWithUsers(TheMemory);
+  if (isTrivial()) {
+    removeDeadAllocation();
     return true;
   }
-
-  // Now make sure we can promote all load [take] and prepare state for each of
-  // them.
-  TakePromotionState loadTakeState(loadTakeList);
-  for (auto p : llvm::enumerate(loadTakeList)) {
-    loadTakeState.initializeForTakeInst(p.index());
-    if (!canPromoteTake(p.value(), loadTakeState.availableValueList))
+  for (auto *load : promotions.loadTakes.instructions()) {
+    if (!canPromoteTake(load, promotions.loadTakes))
       return false;
   }
-
-  // Otherwise removing the deallocation will drop any releases.  Check that
-  // there is nothing preventing removal.
-  TakePromotionState destroyAddrState(Releases);
-  for (auto p : llvm::enumerate(Releases)) {
-    auto *r = p.value();
-    if (r == nullptr)
-      continue;
-
-    // We stash all of the destroy_addr that we see.
-    if (auto *dai = dyn_cast<DestroyAddrInst>(r)) {
-      destroyAddrState.initializeForTakeInst(p.index() /*destroyAddrIndex*/);
-      // Make sure we can actually promote this destroy addr. If we can not,
-      // then we must bail. In order to not gather available values twice, we
-      // gather the available values here that we will use to promote the
-      // values.
-      if (!canPromoteTake(dai, destroyAddrState.availableValueList))
-        return false;
-      continue;
-    }
-
-    LLVM_DEBUG(llvm::dbgs()
-               << "*** Failed to remove autogenerated non-trivial alloc: "
-                  "kept alive by release: "
-               << *r);
-    return false;
+  for (auto *destroy : promotions.destroys.instructions()) {
+    if (!canPromoteTake(destroy, promotions.destroys))
+      return false;
   }
-
-  // If we reached this point, we can promote all of our destroy_addr and load
-  // take. Before we begin, gather up all found available values before we do
-  // anything so we can fix up lifetimes later if we need to.
-  SmallBlotSetVector<SILValue, 32> valuesNeedingLifetimeCompletion;
+  // Gather up all found available values before promoting anything so we can
+  // fix up lifetimes later if we need to.
   for (auto pmoMemUse : Uses) {
     if (pmoMemUse.Inst && pmoMemUse.Kind == PMOUseKind::Initialization) {
       // Today if we promote, this is always a store, since we would have
@@ -2559,41 +2501,180 @@ bool OptimizeDeadAlloc::tryToRemoveDeadAllocation() {
       valuesNeedingLifetimeCompletion.insert(src);
     }
   }
+  removeDeadAllocation();
+  return true;
+}
+
+// Collect all uses that require promotion before this allocation can be
+// eliminated. Returns nullptr on success. Upon failure, return the first
+// instruction corresponding to a use that cannot be promoted.
+//
+// Populates 'loadTakeList'.
+SILInstruction *OptimizeDeadAlloc::collectUsesForPromotion() {
+  for (auto &u : Uses) {
+    // Ignore removed instructions.
+    if (u.Inst == nullptr)
+      continue;
+
+    switch (u.Kind) {
+    case PMOUseKind::Assign:
+      // Until we can promote the value being destroyed by the assign, we can
+      // not remove deallocations with such assigns.
+      return u.Inst;
+    case PMOUseKind::InitOrAssign:
+      continue; // These don't prevent removal.
+    case PMOUseKind::Load:
+      // For now only handle takes from alloc_stack.
+      //
+      // TODO: It should be implementable, but it has not been needed yet.
+      if (auto *li = dyn_cast<LoadInst>(u.Inst)) {
+        if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
+          promotions.loadTakes.push(li);
+          continue;
+        }
+      }
+      return u.Inst;
+    case PMOUseKind::Initialization:
+      if (!isa<ApplyInst>(u.Inst) &&
+          // A copy_addr that is not a take affects the retain count
+          // of the source.
+          (!isa<CopyAddrInst>(u.Inst)
+           || cast<CopyAddrInst>(u.Inst)->isTakeOfSrc())) {
+        continue;
+      }
+      LLVM_FALLTHROUGH;
+    case PMOUseKind::IndirectIn:
+    case PMOUseKind::InOutUse:
+    case PMOUseKind::Escape:
+      return u.Inst; // These do prevent removal.
+    }
+  }
+  // Ignore destroys of trivial values. They are destroy_value instructions
+  // that only destroy the dead box itself.
+  if (!isTrivial()) {
+    // Non-trivial allocations require ownership cleanup. We only promote
+    // alloc_stack in that case--all releases must be destroy_addr.
+    for (auto *release : Releases) {
+      // We stash all of the destroy_addr that we see.
+      if (auto *dai = dyn_cast_or_null<DestroyAddrInst>(release)) {
+        promotions.destroys.push(dai);
+        continue;
+      }
+      return release;
+    }
+  }
+  return nullptr;
+}
+
+/// Return true if we can promote the given destroy.
+bool OptimizeDeadAlloc::canPromoteTake(
+    SILInstruction *inst, PromotableInstructions &promotableInsts) {
+
+  SILValue address = inst->getOperand(0);
+
+  // We cannot promote destroys of address-only types, because we can't expose
+  // the load.
+  SILType loadTy = address->getType().getObjectType();
+  if (loadTy.isAddressOnly(*inst->getFunction()))
+    return false;
+
+  // If the box has escaped at this instruction, we can't safely promote the
+  // load.
+  if (DataflowContext.hasEscapedAt(inst))
+    return false;
+
+  // Compute the access path down to the field so we can determine precise
+  // def/use behavior.
+  unsigned firstElt = computeSubelement(address, TheMemory);
+  assert(firstElt != ~0U && "destroy within enum projection is not valid");
+  auto expansionContext = TypeExpansionContext(*inst->getFunction());
+  unsigned numLoadSubElements =
+      getNumSubElements(loadTy, Module, expansionContext);
+
+  // Find out if we have any available values.  If no bits are demanded, we
+  // trivially succeed. This can happen when there is a load of an empty struct.
+  if (numLoadSubElements == 0)
+    return true;
+
+  // Set up the bitvector of elements being demanded by the load.
+  SmallBitVector requiredElts(NumMemorySubElements);
+  requiredElts.set(firstElt, firstElt + numLoadSubElements);
+
+  // Compute our available values. If we do not have any available values,
+  // return false. We have nothing further to do.
+  SmallVector<AvailableValue, 8> availableValues;
+  availableValues.resize(NumMemorySubElements);
+  if (!DataflowContext.computeAvailableValues(
+          inst, firstElt, numLoadSubElements, requiredElts, availableValues))
+    return false;
+
+  // Now check that we can perform a take upon our available values. This
+  // implies today that our value is fully available. If the value is not fully
+  // available, we would need to split stores to promote this destroy_addr. We
+  // do not support that yet.
+  AvailableValueAggregator agg(inst, availableValues, Uses, deadEndBlocks,
+                               AvailableValueExpectedOwnership::Take);
+  if (!agg.canTake(loadTy, firstElt))
+    return false;
+
+  // As a final check, make sure that we have an available value for each value,
+  // if not bail.
+  for (const auto &av : availableValues)
+    if (!av.Value)
+      return false;
+
+  // Ok, we can promote this destroy_addr... move the temporary lists contents
+  // into the final AvailableValues list.
+  promotableInsts.initializeAvailableValues(inst, std::move(availableValues));
+
+  return true;
+}
+
+void OptimizeDeadAlloc::removeDeadAllocation() {
+  // If our memory is trivially typed, we can just remove it without needing to
+  // consider if the stored value needs to be destroyed. So at this point,
+  // delete the memory!
+  if (isTrivial()) {
+    LLVM_DEBUG(llvm::dbgs() << "*** Removing autogenerated trivial allocation: "
+                            << *TheMemory);
+
+    // If it is safe to remove, do it.  Recursively remove all instructions
+    // hanging off the allocation instruction, then return success.  Let the
+    // caller remove the allocation itself to avoid iterator invalidation.
+    deleter.forceDeleteWithUsers(TheMemory);
+    return;
+  }
 
   // Since our load [take] may be available values for our
   // destroy_addr/load [take], we promote the destroy_addr first and then handle
   // load [take] with extra rigour later to handle that possibility.
-  for (unsigned i : range(destroyAddrState.size())) {
-    SILInstruction *dai;
-    MutableArrayRef<AvailableValue> values;
-    std::tie(dai, values) = destroyAddrState.getData(i);
-    promoteDestroyAddr(cast<DestroyAddrInst>(dai), values);
+  for (auto idxVal : llvm::enumerate(promotions.destroys.instructions())) {
+    auto *dai = cast<DestroyAddrInst>(idxVal.value());
+    auto vals = promotions.destroys.availableValues(idxVal.index());
+    promoteDestroyAddr(dai, vals);
     // We do not need to unset releases, since we are going to exit here.
   }
 
   llvm::SmallMapVector<LoadInst *, SILValue, 32> loadsToDelete;
-  for (unsigned i : range(loadTakeState.size())) {
-    SILInstruction *li;
-    MutableArrayRef<AvailableValue> values;
-    std::tie(li, values) = loadTakeState.getData(i);
-
-    for (unsigned i : indices(values)) {
-      auto v = values[i].Value;
-      auto *li = dyn_cast<LoadInst>(v);
-      if (!li)
+  for (auto idxVal : llvm::enumerate(promotions.loadTakes.instructions())) {
+    for (auto &availableVal :
+         promotions.loadTakes.mutableAvailableValues(idxVal.index())) {
+      auto *availableLoad = dyn_cast<LoadInst>(availableVal.Value);
+      if (!availableLoad)
         continue;
 
-      auto iter = loadsToDelete.find(li);
+      auto iter = loadsToDelete.find(availableLoad);
       if (iter == loadsToDelete.end())
         continue;
 
       SILValue newValue = iter->second;
       assert(newValue && "We should neer store a nil SILValue into this map");
-      values[i].Value = newValue;
+      availableVal.Value = newValue;
     }
 
-    auto *liCast = cast<LoadInst>(li);
-    SILValue result = promoteLoadTake(liCast, values);
+    auto *loadTake = cast<LoadInst>(idxVal.value());
+    auto vals = promotions.loadTakes.availableValues(idxVal.index());
+    SILValue result = promoteLoadTake(loadTake, vals);
     assert(result);
 
     // We need to erase liCast here before we erase it since a load [take] that
@@ -2610,8 +2691,8 @@ bool OptimizeDeadAlloc::tryToRemoveDeadAllocation() {
     //
     // In such a case, we are going to delete %0 here, but %0 is an available
     // value for %1, so we will
-    auto insertIter = loadsToDelete.insert({liCast, result});
-    valuesNeedingLifetimeCompletion.erase(liCast);
+    auto insertIter = loadsToDelete.insert({loadTake, result});
+    valuesNeedingLifetimeCompletion.erase(loadTake);
     (void)insertIter;
     assert(insertIter.second && "loadTakeState doesn't have unique loads?!");
   }
@@ -2654,76 +2735,11 @@ bool OptimizeDeadAlloc::tryToRemoveDeadAllocation() {
     LLVM_DEBUG(v->dump());
     completion.completeOSSALifetime(v, boundary);
   }
-
-  return true;
 }
 
-/// Return true if we can promote the given destroy.
-bool OptimizeDeadAlloc::canPromoteTake(
-    SILInstruction *inst, SmallVectorImpl<AvailableValue> &availableValues) {
-  SILValue address = inst->getOperand(0);
-
-  // We cannot promote destroys of address-only types, because we can't expose
-  // the load.
-  SILType loadTy = address->getType().getObjectType();
-  if (loadTy.isAddressOnly(*inst->getFunction()))
-    return false;
-  
-  // If the box has escaped at this instruction, we can't safely promote the
-  // load.
-  if (DataflowContext.hasEscapedAt(inst))
-    return false;
-  
-  // Compute the access path down to the field so we can determine precise
-  // def/use behavior.
-  unsigned firstElt = computeSubelement(address, TheMemory);
-  assert(firstElt != ~0U && "destroy within enum projection is not valid");
-  auto expansionContext = TypeExpansionContext(*inst->getFunction());
-  unsigned numLoadSubElements =
-      getNumSubElements(loadTy, Module, expansionContext);
-
-  // Find out if we have any available values.  If no bits are demanded, we
-  // trivially succeed. This can happen when there is a load of an empty struct.
-  if (numLoadSubElements == 0)
-    return true;
-
-  // Set up the bitvector of elements being demanded by the load.
-  SmallBitVector requiredElts(NumMemorySubElements);
-  requiredElts.set(firstElt, firstElt + numLoadSubElements);
-
-  // Compute our available values. If we do not have any available values,
-  // return false. We have nothing further to do.
-  SmallVector<AvailableValue, 8> tmpList;
-  tmpList.resize(NumMemorySubElements);
-  if (!DataflowContext.computeAvailableValues(
-          inst, firstElt, numLoadSubElements, requiredElts, tmpList))
-    return false;
-
-  // Now check that we can perform a take upon our available values. This
-  // implies today that our value is fully available. If the value is not fully
-  // available, we would need to split stores to promote this destroy_addr. We
-  // do not support that yet.
-  AvailableValueAggregator agg(inst, tmpList, Uses, deadEndBlocks,
-                               AvailableValueExpectedOwnership::Take);
-  if (!agg.canTake(loadTy, firstElt))
-    return false;
-
-  // As a final check, make sure that we have an available value for each value,
-  // if not bail.
-  for (const auto &av : tmpList)
-    if (!av.Value)
-      return false;
-
-  // Ok, we can promote this destroy_addr... move the temporary lists contents
-  // into the final AvailableValues list.
-  std::move(tmpList.begin(), tmpList.end(),
-            std::back_inserter(availableValues));
-
-  return true;
-}
-
-SILValue OptimizeDeadAlloc::promoteLoadTake(
-    LoadInst *li, MutableArrayRef<AvailableValue> availableValues) {
+SILValue
+OptimizeDeadAlloc::promoteLoadTake(LoadInst *li,
+                                   ArrayRef<AvailableValue> availableValues) {
   assert(li->getOwnershipQualifier() == LoadOwnershipQualifier::Take &&
          "load [copy], load [trivial], load should be handled by "
          "promoteLoadCopy");
@@ -2759,7 +2775,7 @@ SILValue OptimizeDeadAlloc::promoteLoadTake(
 // Note that we handle the general case of a destroy_addr of a piece of the
 // memory object, not just destroy_addrs of the entire thing.
 void OptimizeDeadAlloc::promoteDestroyAddr(
-    DestroyAddrInst *dai, MutableArrayRef<AvailableValue> availableValues) {
+    DestroyAddrInst *dai, ArrayRef<AvailableValue> availableValues) {
   SILValue address = dai->getOperand();
   SILType loadTy = address->getType().getObjectType();
 


### PR DESCRIPTION
Generalize the code that promotes the remaining uses of an allocation to make it
readable and extensible. We need to be able to promote allocations with more
interesting uses, namely mark_dependence.