### PR TITLE
[Concurrency] Enable TaskGroup/DiscardingTaskGroup in Embedded Swift

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2792,6 +2792,10 @@ public:
     /// Request the TaskGroup to immediately release completed tasks,
     /// and not store their results. This also effectively disables `next()`.
     TaskGroup_DiscardResults = 8,
+    /// The `Metadata *T` in swift_taskGroup_initialize and in
+    /// swift_taskGroup_initializeWithFlags pointer is actually a
+    /// TaskOptionRecord pointer. Used only in Embedded Swift.
+    TaskGroup_MetadataAsOptionRecord = 9,
   };
 
   explicit TaskGroupFlags(uint32_t bits) : FlagSet(bits) {}
@@ -2800,6 +2804,10 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(TaskGroup_DiscardResults,
                                 isDiscardResults,
                                 setIsDiscardResults)
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(TaskGroup_MetadataAsOptionRecord,
+                                isMetadataAsOptionRecord,
+                                setIsMetadataAsOptionRecord)
 };
 
 /// Flags for cancellation records.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2792,10 +2792,6 @@ public:
     /// Request the TaskGroup to immediately release completed tasks,
     /// and not store their results. This also effectively disables `next()`.
     TaskGroup_DiscardResults = 8,
-    /// The `Metadata *T` in swift_taskGroup_initialize and in
-    /// swift_taskGroup_initializeWithFlags pointer is actually a
-    /// TaskOptionRecord pointer. Used only in Embedded Swift.
-    TaskGroup_MetadataAsOptionRecord = 9,
   };
 
   explicit TaskGroupFlags(uint32_t bits) : FlagSet(bits) {}
@@ -2804,10 +2800,6 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(TaskGroup_DiscardResults,
                                 isDiscardResults,
                                 setIsDiscardResults)
-
-  FLAGSET_DEFINE_FLAG_ACCESSORS(TaskGroup_MetadataAsOptionRecord,
-                                isMetadataAsOptionRecord,
-                                setIsMetadataAsOptionRecord)
 };
 
 /// Flags for cancellation records.

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -800,18 +800,6 @@ BUILTIN_MISC_OPERATION(ResumeThrowingContinuationReturning,
 BUILTIN_MISC_OPERATION(ResumeThrowingContinuationThrowing,
                        "resumeThrowingContinuationThrowing", "", Special)
 
-/// Create a task group.
-BUILTIN_MISC_OPERATION(CreateTaskGroup,
-                       "createTaskGroup", "", Special)
-
-/// Create a task group, with options.
-BUILTIN_MISC_OPERATION(CreateTaskGroupWithFlags,
-                       "createTaskGroupWithFlags", "", Special)
-
-/// Destroy a task group.
-BUILTIN_MISC_OPERATION(DestroyTaskGroup,
-                       "destroyTaskGroup", "", Special)
-
 /// Unchecked pointer alignment assertion. Allows the compiler to assume
 /// alignment of the pointer to emit more efficient code.
 ///
@@ -1053,6 +1041,15 @@ BUILTIN_SIL_OPERATION(CreateAsyncDiscardingTaskInGroupWithExecutor,
 /// reference.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(BuildOrdinaryTaskExecutorRef,
     "buildOrdinaryTaskExecutorRef", "n", Special)
+
+/// Create a task group.
+BUILTIN_MISC_OPERATION_WITH_SILGEN(CreateTaskGroup, "createTaskGroup", "", Special)
+
+/// Create a task group, with options.
+BUILTIN_MISC_OPERATION_WITH_SILGEN(CreateTaskGroupWithFlags, "createTaskGroupWithFlags", "", Special)
+
+/// Destroy a task group.
+BUILTIN_MISC_OPERATION(DestroyTaskGroup, "destroyTaskGroup", "", Special)
 
 /// globalStringTablePointer has type String -> Builtin.RawPointer.
 /// It returns an immortal, global string table pointer for strings constructed

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -215,6 +215,17 @@ void swift_taskGroup_initialize(TaskGroup *group, const Metadata *T);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_taskGroup_initializeWithFlags(size_t flags, TaskGroup *group, const Metadata *T);
 
+/// Initialize a `TaskGroup` in the passed `group` memory location.
+/// The caller is responsible for retaining and managing the group's lifecycle.
+///
+/// Its Swift signature is
+///
+/// \code
+/// func swift_taskGroup_initialize(flags: Int, group: Builtin.RawPointer)
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_taskGroup_initializeWithOptions(size_t flags, TaskGroup *group, const Metadata *T, TaskOptionRecord *options);
+
 /// Attach a child task to the parent task's task group record.
 ///
 /// This function MUST be called from the AsyncTask running the task group.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2555,7 +2555,7 @@ FUNCTION(TaskRunInline,
          EFFECT(NoEffect),
          UNKNOWN_MEMEFFECTS)
 
-// void swift_taskGroup_initialize(TaskGroup *group);
+// void swift_taskGroup_initialize(TaskGroup *group, const Metadata *T);
 FUNCTION(TaskGroupInitialize,
          swift_taskGroup_initialize, SwiftCC,
          ConcurrencyAvailability,
@@ -2565,7 +2565,7 @@ FUNCTION(TaskGroupInitialize,
          EFFECT(Concurrency),
          UNKNOWN_MEMEFFECTS)
 
-// void swift_taskGroup_initializeWithFlags(size_t flags, TaskGroup *group);
+// void swift_taskGroup_initializeWithFlags(size_t flags, TaskGroup *group, const Metadata *T);
 FUNCTION(TaskGroupInitializeWithFlags,
          swift_taskGroup_initializeWithFlags, SwiftCC,
          ConcurrencyDiscardingTaskGroupAvailability,
@@ -2573,6 +2573,20 @@ FUNCTION(TaskGroupInitializeWithFlags,
          ARGS(SizeTy,           // flags
               Int8PtrTy,        // group
               TypeMetadataPtrTy // T.Type
+         ),
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_taskGroup_initializeWithTaskOptions(size_t flags, TaskGroup *group, const Metadata *T, TaskOptionRecord *options);
+FUNCTION(TaskGroupInitializeWithOptions,
+         swift_taskGroup_initializeWithOptions, SwiftCC,
+         ConcurrencyDiscardingTaskGroupAvailability,
+         RETURNS(VoidTy),
+         ARGS(SizeTy,                     // flags
+              Int8PtrTy,                  // group
+              TypeMetadataPtrTy,          // T.Type
+              SwiftTaskOptionRecordPtrTy  // options
          ),
          ATTRS(NoUnwind),
          EFFECT(Concurrency),

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -295,20 +295,14 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
 
   if (Builtin.ID == BuiltinValueKind::CreateTaskGroup) {
     llvm::Value *groupFlags = nullptr;
-    // Claim metadata pointer.
-    (void)args.claimAll();
+    assert(args.size() == 0);
     out.add(emitCreateTaskGroup(IGF, substitutions, groupFlags));
     return;
   }
 
   if (Builtin.ID == BuiltinValueKind::CreateTaskGroupWithFlags) {
     auto groupFlags = args.claimNext();
-    // Claim the remaining metadata pointer.
-    if (args.size() == 1) {
-      (void)args.claimNext();
-    } else if (args.size() > 1) {
-      llvm_unreachable("createTaskGroupWithFlags expects 1 or 2 arguments");
-    }
+    assert(args.size() == 0);
     out.add(emitCreateTaskGroup(IGF, substitutions, groupFlags));
     return;
   }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1750,6 +1750,38 @@ static ManagedValue emitBuiltinCreateDiscardingTask(
         CreateTaskOptions::Discarding });
 }
 
+// Emit SIL for the named builtin: createTaskGroup.
+// These formally take a metatype argument that's never actually used, so
+// we ignore it.
+static ManagedValue emitBuiltinCreateTaskGroup(SILGenFunction &SGF,
+                                               SILLocation loc,
+                                               SubstitutionMap subs,
+                                               ArrayRef<ManagedValue> args,
+                                               SGFContext C) {
+  auto &ctx = SGF.getASTContext();
+  auto resultType = SILType::getRawPointerType(ctx);
+  auto value = SGF.B.createBuiltin(
+      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateTaskGroup)),
+      resultType, subs, {});
+  return ManagedValue::forObjectRValueWithoutOwnership(value);
+}
+
+// Emit SIL for the named builtin: createTaskGroupWithFlags.
+// These formally take a metatype argument that's never actually used, so
+// we ignore it.
+static ManagedValue emitBuiltinCreateTaskGroupWithFlags(
+    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
+    ArrayRef<ManagedValue> args, SGFContext C) {
+  auto &ctx = SGF.getASTContext();
+  auto resultType = SILType::getRawPointerType(ctx);
+  auto value = SGF.B.createBuiltin(
+      loc,
+      ctx.getIdentifier(
+          getBuiltinName(BuiltinValueKind::CreateTaskGroupWithFlags)),
+      resultType, subs, {args[0].getValue()});
+  return ManagedValue::forObjectRValueWithoutOwnership(value);
+}
+
 ManagedValue
 SILGenFunction::emitCreateAsyncMainTask(SILLocation loc, SubstitutionMap subs,
                                         ManagedValue flags,

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -300,6 +300,10 @@ OVERRIDE_TASK_GROUP(taskGroup_initializeWithFlags, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (size_t flags, TaskGroup *group, const Metadata *T), (flags, group, T))
 
+OVERRIDE_TASK_GROUP(taskGroup_initializeWithOptions, void,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                    swift::, (size_t flags, TaskGroup *group, const Metadata *T, TaskOptionRecord *options), (flags, group, T, options))
+
 OVERRIDE_TASK_STATUS(taskGroup_attachChild, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group, AsyncTask *child),

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -67,7 +67,9 @@ import Swift
 ///
 /// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
 @available(SwiftStdlib 5.9, *)
+#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
+#endif
 @inlinable
 public func withDiscardingTaskGroup<GroupResult>(
   returning returnType: GroupResult.Type = GroupResult.self,
@@ -609,7 +611,9 @@ extension DiscardingTaskGroup: Sendable { }
 /// }
 /// ```
 @available(SwiftStdlib 5.9, *)
+#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
+#endif
 @inlinable
 public func withThrowingDiscardingTaskGroup<GroupResult>(
     returning returnType: GroupResult.Type = GroupResult.self,

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -67,7 +67,7 @@ import Swift
 ///
 /// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
 @available(SwiftStdlib 5.9, *)
-#if !$Embedded
+#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
 #endif
 @inlinable
@@ -611,7 +611,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// }
 /// ```
 @available(SwiftStdlib 5.9, *)
-#if !$Embedded
+#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
 #endif
 @inlinable

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -63,7 +63,9 @@ import Swift
 /// For tasks that need to handle cancellation by throwing an error,
 /// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
+#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
+#endif
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type = ChildTaskResult.self,
@@ -198,7 +200,9 @@ public func _unsafeInheritExecutor_withTaskGroup<ChildTaskResult, GroupResult>(
 /// which gives you a chance to handle the individual error
 /// or to let the group rethrow the error.
 @available(SwiftStdlib 5.1, *)
+#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
+#endif
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type = ChildTaskResult.self,
@@ -592,7 +596,9 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///
   /// - Returns: The value returned by the next child task that completes.
   @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
@@ -610,7 +616,9 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// Await all of the pending tasks added this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
     while let _ = await next(isolation: isolation) {}
   }
@@ -750,7 +758,9 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// Await all the remaining tasks on this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
     while true {
       do {
@@ -1028,7 +1038,9 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - SeeAlso: `nextResult()`
   @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async throws -> ChildTaskResult? {
     return try await _taskGroupWaitNext(group: _group)
   }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -63,7 +63,7 @@ import Swift
 /// For tasks that need to handle cancellation by throwing an error,
 /// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
-#if !$Embedded
+#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
 #endif
 @inlinable
@@ -200,7 +200,7 @@ public func _unsafeInheritExecutor_withTaskGroup<ChildTaskResult, GroupResult>(
 /// which gives you a chance to handle the individual error
 /// or to let the group rethrow the error.
 @available(SwiftStdlib 5.1, *)
-#if !$Embedded
+#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
 #endif
 @inlinable
@@ -596,7 +596,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///
   /// - Returns: The value returned by the next child task that completes.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
   #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async -> ChildTaskResult? {
@@ -616,7 +616,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// Await all of the pending tasks added this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
   #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
@@ -758,7 +758,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// Await all the remaining tasks on this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
   #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
@@ -1038,7 +1038,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - SeeAlso: `nextResult()`
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
   #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async throws -> ChildTaskResult? {

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -322,8 +322,12 @@ public:
     fillWithError(future->getError());
   }
   void fillWithError(SwiftError *error) {
+    #if SWIFT_CONCURRENCY_EMBEDDED
+    swift_unreachable("untyped error used in embedded Swift");
+    #else
     errorResult = error;
     swift_errorRetain(error);
+    #endif
   }
 };
 

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -358,3 +358,5 @@ Added: _$ss15ContinuousClockV7InstantV3nowADvpZMV
 Added: _$ss15SuspendingClockV3nowAB7InstantVvpZMV
 Added: _$ss15SuspendingClockV7InstantV3nowADvpZMV
 Added: _$ss9TaskLocalC18_enclosingInstance7wrapped7storagexs5NeverO_s24ReferenceWritableKeyPathCyAGxGAIyAgByxGGtcipZMV
+
+Added: _swift_taskGroup_initializeWithOptions

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -359,3 +359,5 @@ Added: _$ss15ContinuousClockV7InstantV3nowADvpZMV
 Added: _$ss15SuspendingClockV3nowAB7InstantVvpZMV
 Added: _$ss15SuspendingClockV7InstantV3nowADvpZMV
 Added: _$ss9TaskLocalC18_enclosingInstance7wrapped7storagexs5NeverO_s24ReferenceWritableKeyPathCyAGxGAIyAgByxGGtcipZMV
+
+Added: _swift_taskGroup_initializeWithOptions

--- a/test/embedded/concurrency-taskgroup.swift
+++ b/test/embedded/concurrency-taskgroup.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+import _Concurrency
+
+protocol Go: Actor {
+  var name: String { get }
+  func go(times: Int) async -> Int
+}
+
+extension Go {
+  func go(times: Int) async -> Int {
+    for i in 0..<times {
+      print("\(name) @ \(i)")
+      await Task.yield()
+    }
+    return times
+  }
+}
+
+actor One: Go { var name = "One" }
+actor Two: Go { var name = "Two" }
+
+func yielding() async {
+  let one = One()
+  let two = Two()
+  await withTaskGroup(of: Int.self) { group in
+    group.addTask {
+      await one.go(times: 5)
+    }
+    group.addTask {
+      await two.go(times: 5)
+    }
+  }
+}
+
+@main struct Main {
+    static func main() async {
+        await yielding()
+        print("All done!")
+        // CHECK: One @ 0
+        // CHECK: Two @ 0
+        // CHECK: One @ 1
+        // CHECK: Two @ 1
+        // CHECK: One @ 2
+        // CHECK: Two @ 2
+        // CHECK: One @ 3
+        // CHECK: Two @ 3
+        // CHECK: One @ 4
+        // CHECK: Two @ 4
+        // CHECK: All done!
+    }
+}

--- a/test/embedded/concurrency-taskgroup2.swift
+++ b/test/embedded/concurrency-taskgroup2.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+import _Concurrency
+
+protocol Go: Actor {
+  var name: String { get }
+  func go(times: Int) async -> Int
+}
+
+extension Go {
+  func go(times: Int) async -> Int {
+    for i in 0..<times {
+      print("\(name) @ \(i)")
+      await Task.yield()
+    }
+    return times
+  }
+}
+
+actor One: Go { var name = "One" }
+actor Two: Go { var name = "Two" }
+
+func yielding() async {
+  let one = One()
+  let two = Two()
+  await withDiscardingTaskGroup(returning: Void.self) { group in
+    group.addTask {
+      await one.go(times: 5)
+    }
+    group.addTask {
+      await two.go(times: 5)
+    }
+  }
+}
+
+@main struct Main {
+    static func main() async {
+        await yielding()
+        print("All done!")
+        // CHECK: One @ 0
+        // CHECK: Two @ 0
+        // CHECK: One @ 1
+        // CHECK: Two @ 1
+        // CHECK: One @ 2
+        // CHECK: Two @ 2
+        // CHECK: One @ 3
+        // CHECK: Two @ 3
+        // CHECK: One @ 4
+        // CHECK: Two @ 4
+        // CHECK: All done!
+    }
+}


### PR DESCRIPTION
This is enabling TaskGroup and DiscardingTaskGroup to be used in Embedded Swift by:
- Using the same metadata-free approach we have for Builtin.createAsyncTask and applying it to Builtin.createTaskGroup and Builtin.createTaskGroupWithFlags. We discard the metatype argument in SILGen (we do that already for Builtin.createAsyncTask), and instead deduce it from the substitution map in IRGen.
- The runtime entry point (`swift_taskGroup_initializeWithFlags`) doesn't offer a convenient way to pass extra data (unlike `swift_task_create`). I'm avoiding adding a new entry for simplicity and instead using a bit in `groupFlags` that means that instead of `Metadata *` we receive the same format of arbitrary options that `swift_task_create` uses (TaskOptionRecord linked list).
- IRGen under Embedded Swift mode emits TaskOptionRecord instead of the metadata pointer, and sets the bit in `groupFlags`.
- Like task creation, task group creation does not support throwing in Embedded Swift yet.