### PR TITLE
[Test] Mark additional tests with REQUIRES: asserts for KeyPathWithStaticMembers flag.

### DIFF
--- a/test/SILOptimizer/access_wmo_diagnose.swift
+++ b/test/SILOptimizer/access_wmo_diagnose.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithStaticMembers -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
 
+// REQUIRES: asserts
+
 // AccessEnforcementWMO assumes that the only way to address a global or static
 // property is via a formal begin_access. If we ever allow keypaths for static
 // properties, which I think is conceivable, then this test will fail to produce

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature KeyPathWithStaticMembers
 
+// REQUIRES: asserts
+
 var global = 42
 
 @dynamicMemberLookup

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -enable-experimental-feature KeyPathWithStaticMembers -parse-as-library %s -verify
 
+// REQUIRES: asserts
+
 struct Sub: Hashable {
   static func ==(_: Sub, _: Sub) -> Bool { return true }
   func hash(into hasher: inout Hasher) {}


### PR DESCRIPTION
This adds `REQUIRES: asserts` to all Sema/SIL tests with the [KeyPathWithStaticMembers experimental flag](https://github.com/swiftlang/swift/pull/73242) to resolve failures in a noassert build.