### PR TITLE
[cxx-interop] Support importing value types exported from Swift

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -843,6 +843,8 @@ public:
   /// if applicable.
   const Decl *getSwiftDeclForExportedClangDecl(const clang::Decl *decl);
 
+  void registerExportedClangDecl(Decl *decl, const clang::Decl *clangDecl);
+
   /// General conversion method from Swift types -> Clang types.
   ///
   /// HACK: This method is only intended to be called from a specific place in

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -714,6 +714,8 @@ ValueDecl *getImportedMemberOperator(const DeclBaseName &name,
                                      NominalTypeDecl *selfType,
                                      std::optional<Type> parameterType);
 
+bool isSwiftType(const clang::CXXRecordDecl *decl);
+
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6239,6 +6239,14 @@ ASTContext::getSwiftDeclForExportedClangDecl(const clang::Decl *decl) {
   return impl.Converter->getSwiftDeclForExportedClangDecl(decl);
 }
 
+void ASTContext::registerExportedClangDecl(Decl *decl,
+                                           const clang::Decl *clangDecl) {
+  // Make sure we have a converter.
+  getClangTypeConverter();
+  auto &impl = getImpl();
+  impl.Converter->registerExportedClangDecl(decl, clangDecl);
+}
+
 const clang::Type *
 ASTContext::getClangTypeForIRGen(Type ty) {
   return getClangTypeConverter().convert(ty).getTypePtrOrNull();

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -33,7 +33,11 @@ class ClangTypeConverter :
   using super = TypeVisitor<ClangTypeConverter, clang::QualType>;
 
   llvm::DenseMap<Type, clang::QualType> Cache;
+
+  // Bidirectional mapping between types exported from Swift to their
+  // C family counterparts.
   llvm::DenseMap<const clang::Decl *, swift::Decl *> ReversedExportMap;
+  llvm::DenseMap<swift::Decl *, const clang::Decl *> ReversedExportMapBackwards;
 
   bool StdlibTypesAreCached = false;
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2279,8 +2279,8 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
               CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
-        if (auto *cd = dyn_cast<ClassDecl>(vd)) {
-          Type t = ClassType::get(cd, Type(), SwiftContext);
+        if (auto *ntd = dyn_cast<NominalTypeDecl>(vd)) {
+          Type t = NominalType::get(ntd, Type(), SwiftContext);
           return ImportedType(t, /*implicitlyUnwraps=*/false);
         }
       }
@@ -2527,11 +2527,8 @@ ClangImporter::Implementation::importParameterType(
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
               CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
-
-        if (auto *cd = dyn_cast<ClassDecl>(vd)) {
-
-          swiftParamTy = ClassType::get(cd, Type(), SwiftContext);
-        }
+        if (auto *ntd = dyn_cast<NominalTypeDecl>(vd))
+          swiftParamTy = NominalType::get(ntd, Type(), SwiftContext);
       }
     }
   }

--- a/test/Interop/SwiftToCxxToSwift/import-swift-stdlib-types-back-to-swift-execution.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-stdlib-types-back-to-swift-execution.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
+
+// RUN: %target-interop-build-swift %t/swiftMod.swift -o %t/swift-execution -module-name SwiftMod -I %t -g -DSECOND_PASS -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
+
+// RUN: %target-codesign %t/swift-execution
+// RUN: %target-run %t/swift-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- header.h
+#ifndef FIRSTPASS
+
+#include "swiftMod.h"
+
+inline swift::String createString() {
+    return swift::String("Foobar");
+}
+
+#endif
+
+//--- module.modulemap
+module SwiftToCxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- swiftMod.swift
+import SwiftToCxxTest
+
+public func f() -> String? { "" }
+
+#if SECOND_PASS
+
+let str = createString()
+print(str)
+
+#endif
+
+// CHECK: Foobar


### PR DESCRIPTION
Whenever a Swift type is exported to C++, we create a corresponding type on the
C++ side. However, we did not support importing value types back into Swift.
This PR addresses this problem.

Unfortunately, we cannot just set the C++ type as the ClangNode of
Swift's  type. Types with ClangNodes are using the foreign
representation, but in this case we want to use the native type whenever
possible (e.g., for codegen). To work this around, this PR updates
ClangTypeConverter to make sure we have the correct Clang types when we
emit function calls to C++ APIs. It also updates the importer to not
attempt to import types that are annotated with ExternalSourceSymbolAttr
attributes as Swift types.

rdar://136964764