### PR TITLE
[Test] Add asserts req to experimental tests.

### DIFF
--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -6,6 +6,8 @@
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Rock
 
+// REQUIRES: asserts
+
 var _i: Int = 0
 
 // CHECK:      #if compiler(>=5.3) && $CoroutineAccessors

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -6,6 +6,8 @@
 // RUN:     -verify-additional-prefix disabled- \
 // RUN:     -debug-diagnostic-names
 
+// REQUIRES: asserts
+
 var _i: Int = 0
 
 // Order of accessor kinds:

--- a/test/Parse/coroutine_accessors_ambiguity.swift
+++ b/test/Parse/coroutine_accessors_ambiguity.swift
@@ -6,6 +6,8 @@
 // RUN:     -verify-additional-prefix disabled- \
 // RUN:     -debug-diagnostic-names
 
+// REQUIRES: asserts
+
 // Properties with implicit getters which call functions named modify.
 
 func modify<T>(_ c : () -> T) -> T { c() }

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -3,6 +3,8 @@
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s
 
+// REQUIRES: asserts
+
 public struct S {
 public var o: any AnyObject
 public var _i: Int = 0

--- a/test/Sema/coroutine_accessors.swift
+++ b/test/Sema/coroutine_accessors.swift
@@ -3,6 +3,7 @@
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN:     -debug-diagnostic-names
 
+// REQUIRES: asserts
 
 struct S {
 var i: Int


### PR DESCRIPTION
The CoroutineAccessors experimental feature requires asserts.
