### PR TITLE
[Test] Mark unsupported for OS stdlib.

### DIFF
--- a/validation-test/SILOptimizer/rdar133969821.swift
+++ b/validation-test/SILOptimizer/rdar133969821.swift
@@ -4,6 +4,7 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: use_os_stdlib
 
 class C {
   init() {}


### PR DESCRIPTION
The test verifies a stdlib behavior whose fix is not present in all OSes.  It was already marked unsupported for `back_deployment_runtime`, but this similar configuration (`use_os_stdlib`) was missed.

rdar://136943907
