### PR TITLE
Two witness table related cleanups

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
@@ -134,16 +134,16 @@ struct FunctionUses {
 
     for witnessTable in context.witnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .method, let f = entry.methodFunction {
-          markUnknown(f)
+        if case .method(_, let witness) = entry, let witness {
+          markUnknown(witness)
         }
       }
     }
 
     for witnessTable in context.defaultWitnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .method, let f = entry.methodFunction {
-          markUnknown(f)
+        if case .method(_, let witness) = entry, let witness {
+          markUnknown(witness)
         }
       }
     }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -284,12 +284,12 @@ private func checkForGenericMethods(in witnessTable: WitnessTable,
                                     errorLocation: Location,
                                     _ context: ModulePassContext)
 {
-  for entry in witnessTable.entries where entry.kind == .method {
-    if let method = entry.methodFunction,
-       method.isGeneric
+  for entry in witnessTable.entries {
+    if case .method(let requirement, let witness) = entry,
+       let witness,
+       witness.isGeneric
     {
-      context.diagnosticEngine.diagnose(errorLocation.sourceLoc, .cannot_specialize_witness_method,
-                                        entry.methodRequirement)
+      context.diagnosticEngine.diagnose(errorLocation.sourceLoc, .cannot_specialize_witness_method, requirement)
       return
     }
   }
@@ -509,8 +509,9 @@ fileprivate struct FunctionWorklist {
   }
 
   mutating func addWitnessMethods(of witnessTable: WitnessTable) {
-    for entry in witnessTable.entries where entry.kind == .method {
-      if let method = entry.methodFunction,
+    for entry in witnessTable.entries {
+      if case .method(_, let witness) = entry,
+         let method = witness,
          // A new witness table can still contain a generic function if the method couldn't be specialized for
          // some reason and an error has been printed. Exclude generic functions to not run into an assert later.
          !method.isGeneric

--- a/SwiftCompilerSources/Sources/SIL/Declarations.swift
+++ b/SwiftCompilerSources/Sources/SIL/Declarations.swift
@@ -59,6 +59,22 @@ public struct NominalTypeDecl : Equatable, Hashable {
   public var isGenericAtAnyLevel: Bool { bridged.isGenericAtAnyLevel() }
 }
 
+public struct ProtocolDecl {
+  let bridged: BridgedProtocolDecl
+
+  public init(_bridged: BridgedProtocolDecl) {
+    self.bridged = _bridged
+  }
+}
+
+public struct AssociatedTypeDecl {
+  let bridged: BridgedAssociatedTypeDecl
+
+  public init(_bridged: BridgedAssociatedTypeDecl) {
+    self.bridged = _bridged
+  }
+}
+
 public struct DeclRef {
   public let bridged: BridgedDeclRef
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -279,6 +279,7 @@ struct BridgedType {
     SWIFT_IMPORT_UNSAFE BRIDGED_INLINE EnumElementIterator getNext() const;
   };
 
+  BRIDGED_INLINE BridgedType(); // for Optional<Type>.nil
   BRIDGED_INLINE BridgedType(swift::SILType t);
   BRIDGED_INLINE swift::SILType unbridged() const;
 
@@ -614,6 +615,8 @@ struct BridgedFunction {
 
 struct OptionalBridgedFunction {
   OptionalSwiftObject obj;
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE swift::SILFunction * _Nullable getFunction() const;
 };
 
 struct BridgedGlobalVar {
@@ -1169,9 +1172,30 @@ struct BridgedWitnessTableEntry {
   BridgedOwnedString getDebugDescription() const;
   BRIDGED_INLINE Kind getKind() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclRef getMethodRequirement() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedFunction getMethodFunction() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedFunction getMethodWitness() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedAssociatedTypeDecl getAssociatedTypeRequirement() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getAssociatedTypeWitness() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getAssociatedTypeProtocolRequirement() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedProtocolDecl getAssociatedTypeProtocolDecl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedProtocolConformance getAssociatedTypeProtocolWitness() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedProtocolDecl getBaseProtocolRequirement() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedProtocolConformance getBaseProtocolWitness() const;
+
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
-  static BridgedWitnessTableEntry createMethod(BridgedDeclRef requirement, BridgedFunction function);
+  static BridgedWitnessTableEntry createInvalid();
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  static BridgedWitnessTableEntry createMethod(BridgedDeclRef requirement,
+                                               OptionalBridgedFunction witness);
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  static BridgedWitnessTableEntry createAssociatedType(BridgedAssociatedTypeDecl requirement,
+                                                       BridgedType witness);
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  static BridgedWitnessTableEntry createAssociatedTypeProtocol(BridgedType requirement,
+                                                               BridgedProtocolDecl protocolDecl,
+                                                               BridgedProtocolConformance witness);
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  static BridgedWitnessTableEntry createBaseProtocol(BridgedProtocolDecl requirement,
+                                                     BridgedProtocolConformance witness);
 };
 
 struct BridgedWitnessTable {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2485,8 +2485,11 @@ IRGenModule::getConformanceInfo(const ProtocolDecl *protocol,
 
   const ConformanceInfo *info;
 
-  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
-    if (auto *sc = dyn_cast<SpecializedProtocolConformance>(conformance)) {
+  // If there is a specialized SILWitnessTable for the specialized conformance,
+  // directly use it.
+  if (auto *sc = dyn_cast<SpecializedProtocolConformance>(conformance)) {
+    SILWitnessTable *wt = getSILModule().lookUpWitnessTable(conformance);
+    if (wt && wt->getConformance() == sc) {
       info = new SpecializedConformanceInfo(sc);
       Conformances.try_emplace(conformance, info);
       return *info;


### PR DESCRIPTION
* SwiftCompilerSources: implement `WitnessTable.Entry` as enum. It is the complete and correct representation.
* IRGen: allow specialized witness tables also in regular swift. We don't do witness table specialization in regular swift yet (only in embedded swift). Therefore this is a NFC for now.