### PR TITLE
[cxx-interop] Increase the size of `std::string`s in benchmarks

### DIFF
--- a/benchmark/cxx-source/CxxStringConversion.swift
+++ b/benchmark/cxx-source/CxxStringConversion.swift
@@ -15,7 +15,7 @@ import CxxStdlibPerformance
 import CxxStdlib
 
 let cxxStringSize = 1_000_000
-let swiftStringSize = 25_000
+let swiftStringSize = 1_000_000
 
 var cxxString: std.string? = nil
 var swiftString: String? = nil


### PR DESCRIPTION
Since https://github.com/swiftlang/swift/pull/75608, the performance of `std::string` <=> `Swift.String` conversions improved significantly. To make sure the workload is significant enough for the benchmark results to be noise-free, this bumps the size of Swift strings that are being tested.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
