### PR TITLE
[CAS] Full support for make-style dependencies file caching hit

### DIFF
--- a/include/swift/Frontend/CASOutputBackends.h
+++ b/include/swift/Frontend/CASOutputBackends.h
@@ -38,6 +38,9 @@ protected:
 private:
   file_types::ID getOutputFileType(llvm::StringRef Path) const;
 
+  /// Return true if the file type is stored into CAS Backend directly.
+  static bool isStoredDirectly(file_types::ID Kind);
+
 public:
   SwiftCASOutputBackend(llvm::cas::ObjectStore &CAS,
                         llvm::cas::ActionCache &Cache,
@@ -48,6 +51,9 @@ public:
 
   llvm::Error storeCachedDiagnostics(unsigned InputIndex,
                                      llvm::StringRef Bytes);
+
+  llvm::Error storeMakeDependenciesFile(StringRef OutputFilename,
+                                        llvm::StringRef Bytes);
 
   /// Store the MCCAS CASID \p ID as the object file output for the input
   /// that corresponds to the \p OutputFilename

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -40,11 +40,13 @@ createSwiftCachingOutputBackend(
 
 /// Replay the output of the compilation from cache.
 /// Return true if outputs are replayed, false otherwise.
-bool replayCachedCompilerOutputs(
-    llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
-    llvm::cas::ObjectRef BaseKey, DiagnosticEngine &Diag,
-    const FrontendInputsAndOutputs &InputsAndOutputs,
-    CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend);
+bool replayCachedCompilerOutputs(llvm::cas::ObjectStore &CAS,
+                                 llvm::cas::ActionCache &Cache,
+                                 llvm::cas::ObjectRef BaseKey,
+                                 DiagnosticEngine &Diag,
+                                 const FrontendOptions &Opts,
+                                 CachingDiagnosticsProcessor &CDP,
+                                 bool CacheRemarks, bool UseCASBackend);
 
 /// Load the cached compile result from cache.
 std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(

--- a/include/swift/Frontend/MakeStyleDependencies.h
+++ b/include/swift/Frontend/MakeStyleDependencies.h
@@ -1,0 +1,46 @@
+//===--- MakeStyleDependencies.h -- header for emitting dependency files --===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines interface for emitting Make Style Dependency Files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_MAKESTYLEDEPENDENCIES_H
+#define SWIFT_FRONTEND_MAKESTYLEDEPENDENCIES_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
+
+namespace swift {
+
+class CompilerInstance;
+class DiagnosticEngine;
+class FrontendOptions;
+class InputFile;
+
+/// Emit make style dependency file from compiler instance if needed.
+bool emitMakeDependenciesIfNeeded(CompilerInstance &instance,
+                                  const InputFile &input);
+
+/// Emit make style dependency file from a serialized buffer.
+bool emitMakeDependenciesFromSerializedBuffer(llvm::StringRef buffer,
+                                              llvm::raw_ostream &os,
+                                              const FrontendOptions &opts,
+                                              const InputFile &input,
+                                              DiagnosticEngine &diags);
+
+} // end namespace swift
+
+#endif

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_host_library(swiftFrontend STATIC
   Frontend.cpp
   FrontendInputsAndOutputs.cpp
   FrontendOptions.cpp
+  MakeStyleDependencies.cpp
   ModuleInterfaceBuilder.cpp
   ModuleInterfaceLoader.cpp
   ModuleInterfaceSupport.cpp

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -20,6 +20,7 @@
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/CompileJobCacheResult.h"
 #include "swift/Frontend/FrontendOptions.h"
+#include "swift/Frontend/MakeStyleDependencies.h"
 #include "swift/Option/Options.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/CAS/IncludeTree.h"
@@ -135,19 +136,21 @@ lookupCacheKey(ObjectStore &CAS, ActionCache &Cache, ObjectRef CacheKey) {
 
 bool replayCachedCompilerOutputs(
     ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
-    DiagnosticEngine &Diag, const FrontendInputsAndOutputs &InputsAndOutputs,
+    DiagnosticEngine &Diag, const FrontendOptions &Opts,
     CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend) {
   bool CanReplayAllOutput = true;
   struct OutputEntry {
     std::string Path;
     CASID Key;
+    file_types::ID Kind;
+    const InputFile &Input;
     ObjectProxy Proxy;
   };
   SmallVector<OutputEntry> OutputProxies;
   std::optional<OutputEntry> DiagnosticsOutput;
-  std::string ObjFile;
 
-  auto replayOutputsForInputFile = [&](const std::string &InputPath,
+  auto replayOutputsForInputFile = [&](const InputFile &Input,
+                                       const std::string &InputPath,
                                        unsigned InputIndex,
                                        const DenseMap<file_types::ID,
                                                       std::string> &Outputs) {
@@ -190,15 +193,13 @@ bool replayCachedCompilerOutputs(
           if (!Proxy)
             return Proxy.takeError();
 
-          if (Kind == file_types::ID::TY_Object && UseCASBackend)
-            ObjFile = OutputPath->second;
-
           if (Kind == file_types::ID::TY_CachedDiagnostics) {
             assert(!DiagnosticsOutput && "more than 1 diagnotics found");
-            DiagnosticsOutput = OutputEntry{OutputPath->second, OutID, *Proxy};
+            DiagnosticsOutput.emplace(
+                OutputEntry{OutputPath->second, OutID, Kind, Input, *Proxy});
           } else
             OutputProxies.emplace_back(
-                OutputEntry{OutputPath->second, OutID, *Proxy});
+                OutputEntry{OutputPath->second, OutID, Kind, Input, *Proxy});
           return Error::success();
         })) {
       Diag.diagnose(SourceLoc(), diag::error_cas, toString(std::move(Err)));
@@ -211,7 +212,7 @@ bool replayCachedCompilerOutputs(
     auto InputPath = Input.getFileName();
     DenseMap<file_types::ID, std::string> Outputs;
     if (!Input.outputFilename().empty())
-      Outputs.try_emplace(InputsAndOutputs.getPrincipalOutputType(),
+      Outputs.try_emplace(Opts.InputsAndOutputs.getPrincipalOutputType(),
                           Input.outputFilename());
 
     Input.getPrimarySpecificPaths()
@@ -233,15 +234,15 @@ bool replayCachedCompilerOutputs(
     Outputs.try_emplace(file_types::ID::TY_CachedDiagnostics,
                         "<cached-diagnostics>");
 
-    return replayOutputsForInputFile(InputPath, InputIndex, Outputs);
+    return replayOutputsForInputFile(Input, InputPath, InputIndex, Outputs);
   };
 
-  auto AllInputs = InputsAndOutputs.getAllInputs();
+  auto AllInputs = Opts.InputsAndOutputs.getAllInputs();
   // If there are primary inputs, look up only the primary input files.
   // Otherwise, prepare to do cache lookup for all inputs.
   for (unsigned Index = 0; Index < AllInputs.size(); ++Index) {
     const auto &Input = AllInputs[Index];
-    if (InputsAndOutputs.hasPrimaryInputs() && !Input.isPrimary())
+    if (Opts.InputsAndOutputs.hasPrimaryInputs() && !Input.isPrimary())
       continue;
 
     replayOutputFromInput(Input, Index);
@@ -255,8 +256,9 @@ bool replayCachedCompilerOutputs(
   // diagnostics from first file.
   if (!DiagnosticsOutput)
     replayOutputsForInputFile(
+        Opts.InputsAndOutputs.getFirstOutputProducingInput(),
         "<cached-diagnostics>",
-        InputsAndOutputs.getIndexOfFirstOutputProducingInput(),
+        Opts.InputsAndOutputs.getIndexOfFirstOutputProducingInput(),
         {{file_types::ID::TY_CachedDiagnostics, "<cached-diagnostics>"}});
 
   // Check again to make sure diagnostics is fetched successfully.
@@ -287,10 +289,16 @@ bool replayCachedCompilerOutputs(
       continue;
     }
 
-    if (UseCASBackend && Output.Path == ObjFile) {
+    if (UseCASBackend && Output.Kind == file_types::ID::TY_Object) {
       auto Schema = std::make_unique<llvm::mccasformats::v1::MCSchema>(CAS);
-      if (auto E = Schema->serializeObjectFile(Output.Proxy, *File))
+      if (auto E = Schema->serializeObjectFile(Output.Proxy, *File)) {
         Diag.diagnose(SourceLoc(), diag::error_mccas, toString(std::move(E)));
+        return false;
+      }
+    } else if (Output.Kind == file_types::ID::TY_Dependencies) {
+      if (emitMakeDependenciesFromSerializedBuffer(
+              Output.Proxy.getData(), *File, Opts, Output.Input, Diag))
+        return false;
     } else
       *File << Output.Proxy.getData();
 

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -3,7 +3,6 @@ add_swift_host_library(swiftFrontendTool STATIC
   FrontendTool.cpp
   ImportedModules.cpp
   LoadedModuleTrace.cpp
-  MakeStyleDependencies.cpp
   TBD.cpp)
 add_dependencies(swiftFrontendTool
   SwiftOptions)

--- a/lib/FrontendTool/Dependencies.h
+++ b/lib/FrontendTool/Dependencies.h
@@ -13,17 +13,13 @@
 #ifndef SWIFT_FRONTENDTOOL_DEPENDENCIES_H
 #define SWIFT_FRONTENDTOOL_DEPENDENCIES_H
 
-namespace llvm {
-namespace vfs {
+namespace llvm::vfs {
 class OutputBackend;
-}
-} // namespace llvm
+} // namespace llvm::vfs
 
 namespace swift {
 
-class ASTContext;
 class DependencyTracker;
-class DiagnosticEngine;
 class FrontendOptions;
 class InputFile;
 class ModuleDecl;
@@ -31,11 +27,6 @@ class ModuleDecl;
 /// Emit the names of the modules imported by \c mainModule.
 bool emitImportedModules(ModuleDecl *mainModule, const FrontendOptions &opts,
                          llvm::vfs::OutputBackend &backend);
-bool emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
-                                  DependencyTracker *depTracker,
-                                  const FrontendOptions &opts,
-                                  const InputFile &input,
-                                  llvm::vfs::OutputBackend &backend);
 bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
                                    DependencyTracker *depTracker,
                                    const FrontendOptions &opts,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -54,6 +54,7 @@
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/DiagnosticHelper.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/MakeStyleDependencies.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/IRGen/TBDGen.h"
@@ -107,15 +108,13 @@ static std::string displayName(StringRef MainExecutablePath) {
   return Name;
 }
 
-static void emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
-                                         DependencyTracker *depTracker,
-                                         const FrontendOptions &opts,
-                                         llvm::vfs::OutputBackend &backend) {
-  opts.InputsAndOutputs.forEachInputProducingSupplementaryOutput(
-      [&](const InputFile &f) -> bool {
-        return swift::emitMakeDependenciesIfNeeded(diags, depTracker, opts, f,
-                                                   backend);
-      });
+static void emitMakeDependenciesIfNeeded(CompilerInstance &instance) {
+  instance.getInvocation()
+      .getFrontendOptions()
+      .InputsAndOutputs.forEachInputProducingSupplementaryOutput(
+          [&](const InputFile &f) -> bool {
+            return swift::emitMakeDependenciesIfNeeded(instance, f);
+          });
 }
 
 static void
@@ -1056,9 +1055,7 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   emitSwiftdepsForAllPrimaryInputsIfNeeded(Instance);
 
   // Emit Make-style dependencies.
-  emitMakeDependenciesIfNeeded(Instance.getDiags(),
-                               Instance.getDependencyTracker(), opts,
-                               Instance.getOutputBackend());
+  emitMakeDependenciesIfNeeded(Instance);
 
   // Emit extracted constant values for every file in the batch
   emitConstValuesForAllPrimaryInputsIfNeeded(Instance);
@@ -1322,7 +1319,7 @@ static bool tryReplayCompilerResults(CompilerInstance &Instance) {
   bool replayed = replayCachedCompilerOutputs(
       Instance.getObjectStore(), Instance.getActionCache(),
       *Instance.getCompilerBaseKey(), Instance.getDiags(),
-      Instance.getInvocation().getFrontendOptions().InputsAndOutputs, *CDP,
+      Instance.getInvocation().getFrontendOptions(), *CDP,
       Instance.getInvocation().getCASOptions().EnableCachingRemarks,
       Instance.getInvocation().getIRGenOptions().UseCASBackend);
 

--- a/test/CAS/dependency_file.swift
+++ b/test/CAS/dependency_file.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+// RUN: %target-swift-frontend \
+// RUN:   -c -o %t/main.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/main.swift @%t/MyApp.cmd -emit-dependencies -emit-dependencies-path %t/main.d 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+
+// CACHE-MISS: remark: cache miss for input
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/main.d -DTMP=%t
+// DEPS: [[TMP]]{{/|\\}}main.o :
+
+// RUN: %target-swift-frontend \
+// RUN:   -c -o %t/main-2.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/main.swift @%t/MyApp.cmd -emit-dependencies -emit-dependencies-path %t/main-2.d 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}main-2.d': key 'llvmcas://{{.*}}'
+
+// RUN: %FileCheck %s --check-prefix=DEPS2 --input-file=%t/main-2.d -DTMP=%t
+// DEPS2: [[TMP]]{{/|\\}}main-2.o :
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/main.swift -o %t/deps-1.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk \
+// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-prefix-map %t/sdk=/^sdk
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json A > %t/A1.cmd
+// RUN: %swift_frontend_plain @%t/A1.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps-1.json > %t/map-1.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map-1.json > %t/map-1.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json Test > %t/MyApp-1.cmd
+
+// RUN: %target-swift-frontend \
+// RUN:   -c -o %t/main-3.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-3.d
+
+// RUN: %FileCheck %s --check-prefix=DEPS3 --input-file=%t/main-3.d -DTMP=%t
+// DEPS3: [[TMP]]{{/|\\}}main-3.o : [[TMP]]{{/|\\}}main.swift
+
+//--- main.swift
+import A
+
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func a() { }
+


### PR DESCRIPTION
Fully support make-style `.d` dependencies file output by making following improvements:
* All correct dependency file render when cache hit for a different output file location. The dependency file should list the correct output path, not the stale output path for the initial compilation
* When enable a path prefix mapper to canonicalize the path, the dependency file should render the input file correctly as the input file path on disk.

rdar://132250067

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
