### PR TITLE
Disable AutoDiff/validation-test/modify_accessor.swift on arm64e

### DIFF
--- a/test/AutoDiff/validation-test/modify_accessor.swift
+++ b/test/AutoDiff/validation-test/modify_accessor.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// This test fails on arm64e with a pointer auth failure.
+// XFAIL: CPU=arm64e
+
 import _Differentiation
 import StdlibUnittest
 


### PR DESCRIPTION
We fail to sign a pointer and so this test currently fails on arm64e.

rdar://136835713