### PR TITLE
Add MemberImportVisibility tests for inherited members of classes.

### DIFF
--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -35,6 +35,7 @@ public enum EnumInA {
 }
 
 open class BaseClassInA {
+  public init() {}
   open func methodInA() {}
 }
 

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 import members_C
-// expected-member-visibility-note 15{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 16{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -93,3 +93,9 @@ class DerivedFromClassInC: DerivedClassInC {
 }
 
 struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}} expected-member-visibility-note {{add stubs for conformance}}
+
+func testDerivedMethodAccess() {
+  DerivedClassInC().methodInC()
+  DerivedClassInC().methodInB() // expected-member-visibility-error{{instance method 'methodInB()' is not available due to missing import of defining module 'members_B'}}
+  DerivedFromClassInC().methodInB()
+}


### PR DESCRIPTION
Create some test cases that demonstrate MemberImportVisibility behavior with respect referencing inherited members. There are already tests that demonstrate overrides, but nothing seemed to show the behavior when referencing an inherted member through a derived type. I wanted to verify this behavior so I wrote a test to demonstrate it. It seems reasonable to check-in the test to ensure the behavior remains consistent.

Based on experimental/upcoming feature: https://forums.swift.org/t/se-0444-member-import-visibility/74519

There's no functionality change here. I just wanted to add some tests to demonstrate and solidify the behavior.