### PR TITLE
Sema: Move the availability macros cache to the ASTContext

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -69,6 +69,7 @@ namespace swift {
   class AbstractFunctionDecl;
   class ASTContext;
   enum class Associativity : unsigned char;
+  class AvailabilityMacroMap;
   class AvailabilityRange;
   class BoundGenericType;
   class BuiltinTupleDecl;
@@ -986,6 +987,12 @@ public:
     // This didn't fit the pattern, so needed renaming
     return getMultiPayloadEnumTagSinglePayloadAvailability();
   }
+
+  /// Cache of the availability macros parsed from the command line arguments.
+  ///
+  /// This is an implementation detail, access via
+  /// \c Parser::parseAllAvailabilityMacroArguments.
+  AvailabilityMacroMap &getAvailabilityMacroCache() const;
 
   /// Test support utility for loading a platform remap file
   /// in case an SDK is not specified to the compilation.

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -215,6 +215,19 @@ public:
   }
 };
 
+/// Maps of macro name and version to availability specifications.
+/// Organized as two nested \c DenseMap keyed first on the macro name then
+/// the macro version. This structure allows to peek at macro names before
+/// parsing a version tuple.
+class AvailabilityMacroMap {
+public:
+  typedef llvm::DenseMap<llvm::VersionTuple,
+                         SmallVector<AvailabilitySpec *, 4>> VersionEntry;
+
+  bool WasParsed = false;
+  llvm::DenseMap<StringRef, VersionEntry> Impl;
+};
+
 } // end namespace swift
 
 #endif

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -346,22 +346,6 @@ public:
   /// This vector is managed by \c StructureMarkerRAII objects.
   llvm::SmallVector<StructureMarker, 16> StructureMarkers;
 
-  /// Maps of macro name and version to availability specifications.
-  typedef llvm::DenseMap<llvm::VersionTuple,
-                         SmallVector<AvailabilitySpec *, 4>>
-                        AvailabilityMacroVersionMap;
-  typedef llvm::DenseMap<StringRef, AvailabilityMacroVersionMap>
-                        AvailabilityMacroMap;
-
-  /// Cache of the availability macros parsed from the command line arguments.
-  /// Organized as two nested \c DenseMap keyed first on the macro name then
-  /// the macro version. This structure allows to peek at macro names before
-  /// parsing a version tuple.
-  AvailabilityMacroMap AvailabilityMacros;
-
-  /// Has \c AvailabilityMacros been computed?
-  bool AvailabilityMacrosComputed = false;
-
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
          SILParserStateBase *SIL, PersistentParserState *PersistentState);
@@ -2080,7 +2064,7 @@ public:
   parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   /// Parse the availability macros definitions passed as arguments.
-  void parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap &parseAllAvailabilityMacroArguments();
 
   /// Result of parsing an availability macro definition.
   struct AvailabilityMacroDefinition {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -426,6 +426,9 @@ struct ASTContext::Implementation {
   /// Singleton used to cache the import graph.
   swift::namelookup::ImportCache TheImportCache;
 
+  /// Cache of availability macros parsed from the command line.
+  AvailabilityMacroMap TheAvailabilityMacroCache;
+
   /// The module loader used to load Clang modules.
   ClangModuleLoader *TheClangModuleLoader = nullptr;
 
@@ -2279,6 +2282,10 @@ void ASTContext::verifyAllLoadedModules() const {
 
 swift::namelookup::ImportCache &ASTContext::getImportCache() const {
   return getImpl().TheImportCache;
+}
+
+AvailabilityMacroMap &ASTContext::getAvailabilityMacroCache() const {
+  return getImpl().TheAvailabilityMacroCache;
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {

--- a/test/Sema/availability_define_multi_file.swift
+++ b/test/Sema/availability_define_multi_file.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: not %target-swift-frontend -typecheck -diagnostic-style llvm \
+// RUN:   %t/FileA.swift %t/FileB.swift \
+// RUN:   -define-availability "_justAName" \
+// RUN:   2>&1 | %FileCheck %s
+
+// CHECK: -define-availability argument:1:11: error: expected ':' after '_justAName' in availability macro definition
+// CHECK-NEXT: _justAName
+
+/// It's parsed once so the diagnostic is produced once as well.
+// CHECK-NOT: _justAName
+
+//--- FileA.swift
+
+@available(_triggerParsingMacros)
+public func brokenPlatforms() {}
+
+//--- FileB.swift
+
+@available(_triggerParsingMacros)
+public func brokenPlatforms() {}


### PR DESCRIPTION
The availability macros definitions are parsed from the command line and stored in a cache. The cache was in the Parser, which would have it be computed for each file using availability attributes. Let's move it to the ASTContext instead where it can generally be computed once per invocation and used across the module, speeding up the compilation process.

Also optimize how we register the buffer holding the macro definitions. Registering all of them before starting to parse their content avoids sorting them repeatedly which caused a noticeable slowdown on high usage of availability macros.

rdar://134797088