### PR TITLE
[Concurrency] Downgrade the isolated default argument error to a warning when the argument expression is `@preconcurrency`.

### DIFF
--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature InferSendableFromCaptures %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature InferSendableFromCaptures %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -317,3 +317,10 @@ struct Values {
   @MainActor var value: Int { 0 }
   @SomeGlobalActor var otherValue: Int { 0 }
 }
+
+class PreconcurrencyInit {
+  @preconcurrency @MainActor init() {}
+}
+
+// expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+func downgrade(_: PreconcurrencyInit = .init()) {}


### PR DESCRIPTION
If the isolation of a default argument expression is `@preconcurrency`, then the isolation mismatch diagnostic should be downgraded to a warning in Swift 5 mode with complete concurrency checking enabled. I observed this bug while migrating some code to Swift 6 by first enabling warnings via complete concurrency checking.