### PR TITLE
Fix instrumenting print and debugPrint for Swift 6.

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -461,7 +461,14 @@ public:
           }
         } else if (auto *AE = dyn_cast<ApplyExpr>(E)) {
           bool Handled = false;
-          if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn())) {
+          DeclRefExpr *DRE = nullptr;
+          // With Swift 6 the print() function decl is a sub expression
+          // of a function conversion expression.
+          if (auto *FCE = dyn_cast<FunctionConversionExpr>(AE->getFn()))
+            DRE = dyn_cast<DeclRefExpr>(FCE->getSubExpr());
+          else
+            DRE = dyn_cast<DeclRefExpr>(AE->getFn());
+          if (DRE) {
             auto *FnD = dyn_cast<AbstractFunctionDecl>(DRE->getDecl());
             if (FnD && FnD->getModuleContext() == Context.TheStdlibModule) {
               DeclBaseName FnName = FnD->getBaseName();

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -1,12 +1,22 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+//
+// Default Swift version
 // RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 
 // RUN: %target-codesign %t/main2
 // RUN: %target-run %t/main2 | %FileCheck %s
+//
+// Swift version 6
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main3 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main3
+// RUN: %target-run %t/main3 | %FileCheck %s
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main4 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main4
+// RUN: %target-run %t/main4 | %FileCheck %s
 // REQUIRES: executable_test
 
 import PlaygroundSupport


### PR DESCRIPTION
With Swift language mode 6 `print()`/`debugPrint()` calls were not being instrumented with `-playground`.

The cause was a change to the decl tree when compiled for Swift 6. `print()`/`debugPrint()` function decls are now sub expressions of a function conversion expression. This PR updates the instrumenter logic to account for the change.

Added tests for print() capture with -swift-version 6.

rdar://136858280
