### PR TITLE
[Runtime] Handle nil parameter to -[SwiftObject isEqual:]

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -431,6 +431,9 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
   if (self == other) {
     return YES;
   }
+  if (other == nil) {
+    return NO;
+  }
   if (runtime::bincompat::useLegacySwiftObjCHashing()) {
     // Legacy behavior: Don't proxy to Swift Hashable or Equatable
     return NO; // We know the ids are different

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -113,7 +113,7 @@ func CheckSwiftObjectNSObjectEquals(_: AnyObject, _: AnyObject) -> Bool
 @_silgen_name("TestSwiftObjectNSObjectEquals")
 func TestSwiftObjectNSObjectEquals(_: AnyObject, _: AnyObject)
 @_silgen_name("TestSwiftObjectNSObjectNotEquals")
-func TestSwiftObjectNSObjectNotEquals(_: AnyObject, _: AnyObject)
+func TestSwiftObjectNSObjectNotEquals(_: AnyObject, _: AnyObject?)
 @_silgen_name("TestSwiftObjectNSObjectHashValue")
 func TestSwiftObjectNSObjectHashValue(_: AnyObject, _: Int)
 @_silgen_name("TestSwiftObjectNSObjectDefaultHashValue")
@@ -263,6 +263,10 @@ if #available(OSX 10.12, iOS 10.0, *) {
   TestHashable(H(i:1))
   TestHashable(H(i:2))
   TestHashable(H(i:18))
+
+  // Verify that we correctly handle a nil argument to isEqual:
+  TestSwiftObjectNSObjectNotEquals(C(), nil)
+  TestSwiftObjectNSObjectNotEquals(E(i: 1), nil)
 
   TestSwiftObjectNSObjectAssertNoErrors()
 } else {


### PR DESCRIPTION
The parameter is nullable, and isEqual: should always return nil in that case. We need to check for nil before doing anything else.

rdar://136825667