### PR TITLE
[Runtime] Properly compute offset for unmanaged properties in generic…

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2852,11 +2852,12 @@ void swift::swift_initStructMetadataWithLayoutString(
 
         auto tagAndOffset = ((uint64_t)tag << 56) | offset;
         writer.writeBytes(tagAndOffset);
+        previousFieldOffset = fieldType->size - sizeof(uintptr_t);
+      } else {
+        previousFieldOffset += fieldType->size;
       }
 
       fullOffset += fieldType->size;
-      previousFieldOffset = fieldType->size - sizeof(uintptr_t);
-
       continue;
     }
 

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -19,6 +19,17 @@ public struct GenericResilient<C, T> {
     }
 }
 
+public struct GenericResilientWithUnmanagedAndWeak<T> {
+    public let x: T
+    public unowned(unsafe) var y: AnyObject?
+    public let z: Int = 500
+    public weak var w: AnyObject?
+
+    public init(x: T) {
+        self.x = x
+    }
+}
+
 public enum ResilientSinglePayloadEnumGeneric<T> {
     case empty0
     case empty1

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1209,6 +1209,34 @@ func testWeakRefOptionalNative() {
 
 testWeakRefOptionalNative()
 
+func testGenericResilientWithUnmanagedAndWeak() {
+    let ptr = allocateInternalGenericPtr(of: GenericResilientWithUnmanagedAndWeak<TestClass>.self)
+
+    do {
+        let x = GenericResilientWithUnmanagedAndWeak<TestClass>(x: TestClass())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = GenericResilientWithUnmanagedAndWeak<TestClass>(x: TestClass())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: TestClass deinitialized!
+    testGenericDestroy(ptr, of: GenericResilientWithUnmanagedAndWeak<TestClass>.self)
+
+    ptr.deallocate()
+}
+
+testGenericResilientWithUnmanagedAndWeak()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
… CVW instantiation

rdar://137066879

An unmanaged property does not map to an operation in CVW, instead it will be copied like primitive values. When instantiating the layout string, we correctly do not emit an operation, but we compute the offset to the next field as if we did. This is causing the offset to be incorrect and subsequent operations to be executed on the wrong address, causing crashes or other misbehavior.