### PR TITLE
[Test] Remove timeout from Reflection.swift and Reflection_objc.swift.

### DIFF
--- a/test/stdlib/Reflection.swift
+++ b/test/stdlib/Reflection.swift
@@ -1,10 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %{python} %S/../Inputs/timeout.py 360 %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: reflection
-// FIXME: timeout wrapper is necessary because the ASan test runs for hours
 
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -5,8 +5,7 @@
 // and it is needed for conformances on macOS < 15.
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o -o %t/a.out -lswiftCoreGraphics
 // RUN: %target-codesign %t/a.out
-// RUN: %{python} %S/../Inputs/timeout.py 360 %target-run %t/a.out %S/Inputs/shuffle.jpg | %FileCheck %s
-// FIXME: timeout wrapper is necessary because the ASan test runs for hours
+// RUN: %target-run %t/a.out %S/Inputs/shuffle.jpg | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
The timeouts have a comment about ASan tests taking hours, but that comment is a decade old and that doesn't seem to be the case now. Reflection_objc.swift does take over a minute to build with an ASan compiler, but that's tolerable.

rdar://134405526