### PR TITLE
[Concurrency] Fix warning about implicit conversion in ActorIsolation.h

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -100,11 +100,11 @@ public:
         silParsed(isSILParsed), parameterIndex(0) {}
 
   static ActorIsolation forUnspecified() {
-    return ActorIsolation(Unspecified, nullptr);
+    return ActorIsolation(Unspecified);
   }
 
   static ActorIsolation forNonisolated(bool unsafe) {
-    return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated, nullptr);
+    return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated);
   }
 
   static ActorIsolation forActorInstanceSelf(ValueDecl *decl);


### PR DESCRIPTION
To get rid of this warning:
```
In file included from /Users/kuba/swift-github-main/swift/lib/IRGen/IRGen.cpp:17:
In file included from /Users/kuba/swift-github-main/swift/lib/IRGen/../Serialization/ModuleFormat.h:22:
In file included from /Users/kuba/swift-github-main/swift/include/swift/AST/Decl.h:27:
In file included from /Users/kuba/swift-github-main/swift/include/swift/AST/DiagnosticEngine.h:21:
/Users/kuba/swift-github-main/swift/include/swift/AST/ActorIsolation.h:103:40: warning: implicit conversion of nullptr constant to 'bool' [-Wnull-conversion]
  103 |     return ActorIsolation(Unspecified, nullptr);
      |            ~~~~~~~~~~~~~~              ^~~~~~~
      |                                        false
/Users/kuba/swift-github-main/swift/include/swift/AST/ActorIsolation.h:107:69: warning: implicit conversion of nullptr constant to 'bool' [-Wnull-conversion]
  107 |     return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated, nullptr);
      |            ~~~~~~~~~~~~~~                                           ^~~~~~~
      |                                                                     false
2 warnings generated.
```
