### PR TITLE
Continue migration from SolverScope to SolverTrail

### DIFF
--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -69,6 +69,8 @@ public:
     RecordedOpenedTypes,
     /// Recorded the opening of an existential type at a locator.
     RecordedOpenedExistentialType,
+    /// Recorded the opening of a pack existential type.
+    RecordedOpenedPackExpansionType,
   };
 
   /// A change made to the constraint system.
@@ -134,6 +136,7 @@ public:
       } FixedRequirement;
 
       ConstraintLocator *Locator;
+      PackExpansionType *ExpansionTy;
     };
 
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
@@ -196,6 +199,9 @@ public:
 
     /// Create a change that recorded the opening of an existential type.
     static Change recordedOpenedExistentialType(ConstraintLocator *locator);
+
+    /// Create a change that recorded the opening of a pack expansion type.
+    static Change recordedOpenedPackExpansionType(PackExpansionType *expansion);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -59,6 +59,8 @@ public:
     AddedFix,
     /// Recorded a fixed requirement.
     AddedFixedRequirement,
+    /// Recorded a disjunction choice.
+    RecordedDisjunctionChoice,
   };
 
   /// A change made to the constraint system.
@@ -122,6 +124,8 @@ public:
         GenericTypeParamType *GP;
         Type ReqTy;
       } FixedRequirement;
+
+      ConstraintLocator *Locator;
     };
 
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
@@ -168,6 +172,10 @@ public:
     static Change addedFixedRequirement(GenericTypeParamType *GP,
                                         unsigned reqKind,
                                         Type requirementTy);
+
+    /// Create a change that recorded a disjunction choice.
+    static Change recordedDisjunctionChoice(ConstraintLocator *locator,
+                                            unsigned index);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -55,6 +55,8 @@ public:
     UpdatedTypeVariable,
     /// Recorded a conversion restriction kind.
     AddedConversionRestriction,
+    /// Recorded a fix.
+    AddedFix,
   };
 
   /// A change made to the constraint system.
@@ -111,6 +113,8 @@ public:
         /// The destination type.
         Type DstType;
       } Restriction;
+
+      ConstraintFix *Fix;
     };
 
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
@@ -149,6 +153,9 @@ public:
 
     /// Create a change that recorded a restriction.
     static Change addedConversionRestriction(Type srcType, Type dstType);
+
+    /// Create a change that recorded a fix.
+    static Change addedFix(ConstraintFix *fix);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -65,6 +65,8 @@ public:
     RecordedAppliedDisjunction,
     /// Recorded an argument matching choice.
     RecordedMatchCallArgumentResult,
+    /// Recorded a list of opened types at a locator.
+    RecordedOpenedTypes,
   };
 
   /// A change made to the constraint system.
@@ -186,6 +188,9 @@ public:
 
     /// Create a change that recorded an applied disjunction.
     static Change recordedMatchCallArgumentResult(ConstraintLocator *locator);
+
+    /// Create a change that recorded a list of opened types.
+    static Change recordedOpenedTypes(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -76,6 +76,8 @@ public:
     /// Recorded the mapping from a pack element expression to its parent
     /// pack expansion expression.
     RecordedPackEnvironment,
+    /// Record a defaulted constraint at a locator.
+    RecordedDefaultedConstraint,
   };
 
   /// A change made to the constraint system.
@@ -215,6 +217,9 @@ public:
     /// Create a change that recorded a mapping from a pack element expression
     /// to its parent expansion expression.
     static Change recordedPackEnvironment(PackElementExpr *packElement);
+
+    /// Create a change that recorded a defaulted constraint at a locator.
+    static Change recordedDefaultedConstraint(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -73,6 +73,9 @@ public:
     RecordedOpenedPackExpansionType,
     /// Recorded the creation of a generic environment for a pack expansion expression.
     RecordedPackExpansionEnvironment,
+    /// Recorded the mapping from a pack element expression to its parent
+    /// pack expansion expression.
+    RecordedPackEnvironment,
   };
 
   /// A change made to the constraint system.
@@ -139,6 +142,7 @@ public:
 
       ConstraintLocator *Locator;
       PackExpansionType *ExpansionTy;
+      PackElementExpr *ElementExpr;
     };
 
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
@@ -207,6 +211,10 @@ public:
 
     /// Create a change that recorded the opening of a pack expansion type.
     static Change recordedPackExpansionEnvironment(ConstraintLocator *locator);
+
+    /// Create a change that recorded a mapping from a pack element expression
+    /// to its parent expansion expression.
+    static Change recordedPackEnvironment(PackElementExpr *packElement);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -71,6 +71,8 @@ public:
     RecordedOpenedExistentialType,
     /// Recorded the opening of a pack existential type.
     RecordedOpenedPackExpansionType,
+    /// Recorded the creation of a generic environment for a pack expansion expression.
+    RecordedPackExpansionEnvironment,
   };
 
   /// A change made to the constraint system.
@@ -202,6 +204,9 @@ public:
 
     /// Create a change that recorded the opening of a pack expansion type.
     static Change recordedOpenedPackExpansionType(PackExpansionType *expansion);
+
+    /// Create a change that recorded the opening of a pack expansion type.
+    static Change recordedPackExpansionEnvironment(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -61,6 +61,8 @@ public:
     AddedFixedRequirement,
     /// Recorded a disjunction choice.
     RecordedDisjunctionChoice,
+    /// Recorded an applied disjunction.
+    RecordedAppliedDisjunction,
   };
 
   /// A change made to the constraint system.
@@ -176,6 +178,9 @@ public:
     /// Create a change that recorded a disjunction choice.
     static Change recordedDisjunctionChoice(ConstraintLocator *locator,
                                             unsigned index);
+
+    /// Create a change that recorded an applied disjunction.
+    static Change recordedAppliedDisjunction(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -57,6 +57,8 @@ public:
     AddedConversionRestriction,
     /// Recorded a fix.
     AddedFix,
+    /// Recorded a fixed requirement.
+    AddedFixedRequirement,
   };
 
   /// A change made to the constraint system.
@@ -115,6 +117,11 @@ public:
       } Restriction;
 
       ConstraintFix *Fix;
+
+      struct {
+        GenericTypeParamType *GP;
+        Type ReqTy;
+      } FixedRequirement;
     };
 
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
@@ -156,6 +163,11 @@ public:
 
     /// Create a change that recorded a fix.
     static Change addedFix(ConstraintFix *fix);
+
+    /// Create a change that recorded a fixed requirement.
+    static Change addedFixedRequirement(GenericTypeParamType *GP,
+                                        unsigned reqKind,
+                                        Type requirementTy);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -67,6 +67,8 @@ public:
     RecordedMatchCallArgumentResult,
     /// Recorded a list of opened types at a locator.
     RecordedOpenedTypes,
+    /// Recorded the opening of an existential type at a locator.
+    RecordedOpenedExistentialType,
   };
 
   /// A change made to the constraint system.
@@ -191,6 +193,9 @@ public:
 
     /// Create a change that recorded a list of opened types.
     static Change recordedOpenedTypes(ConstraintLocator *locator);
+
+    /// Create a change that recorded the opening of an existential type.
+    static Change recordedOpenedExistentialType(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -63,6 +63,8 @@ public:
     RecordedDisjunctionChoice,
     /// Recorded an applied disjunction.
     RecordedAppliedDisjunction,
+    /// Recorded an argument matching choice.
+    RecordedMatchCallArgumentResult,
   };
 
   /// A change made to the constraint system.
@@ -181,6 +183,9 @@ public:
 
     /// Create a change that recorded an applied disjunction.
     static Change recordedAppliedDisjunction(ConstraintLocator *locator);
+
+    /// Create a change that recorded an applied disjunction.
+    static Change recordedMatchCallArgumentResult(ConstraintLocator *locator);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2394,7 +2394,7 @@ private:
   llvm::SmallDenseMap<ConstraintLocator *, OpenedArchetypeType *, 4>
       OpenedExistentialTypes;
 
-  llvm::SmallMapVector<PackExpansionType *, TypeVariableType *, 4>
+  llvm::SmallDenseMap<PackExpansionType *, TypeVariableType *, 4>
       OpenedPackExpansionTypes;
 
   llvm::SmallMapVector<ConstraintLocator *, std::pair<UUID, Type>, 4>
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c OpenedPackExpansionsTypes.
-    unsigned numOpenedPackExpansionTypes;
 
     /// The length of \c PackExpansionEnvironments.
     unsigned numPackExpansionEnvironments;
@@ -4334,6 +4331,16 @@ private:
   Type openPackExpansionType(PackExpansionType *expansion,
                              OpenedTypeMap &replacements,
                              ConstraintLocatorBuilder locator);
+
+  /// Update OpenedPackExpansionTypes and record a change in the trail.
+  void recordOpenedPackExpansionType(PackExpansionType *expansion,
+                                     TypeVariableType *expansionVar);
+
+  /// Undo the above change.
+  void removeOpenedPackExpansionType(PackExpansionType *expansion) {
+    bool erased = OpenedPackExpansionTypes.erase(expansion);
+    ASSERT(erased);
+  }
 
 public:
   /// Recurse over the given type and open any opaque archetype types.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1546,7 +1546,7 @@ public:
       PackExpansionEnvironments;
 
   /// The pack expansion environment that can open a given pack element.
-  llvm::MapVector<PackElementExpr *, PackExpansionExpr *>
+  llvm::DenseMap<PackElementExpr *, PackExpansionExpr *>
       PackEnvironments;
 
   /// The outer pack element generic environment to use when dealing with nested
@@ -2400,7 +2400,7 @@ private:
   llvm::SmallDenseMap<ConstraintLocator *, std::pair<UUID, Type>, 4>
       PackExpansionEnvironments;
 
-  llvm::SmallMapVector<PackElementExpr *, PackExpansionExpr *, 2>
+  llvm::SmallDenseMap<PackElementExpr *, PackExpansionExpr *, 2>
       PackEnvironments;
 
   llvm::SmallVector<GenericEnvironment *, 4> PackElementGenericEnvironments;
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c PackEnvironments.
-    unsigned numPackEnvironments;
 
     /// The length of \c PackElementGenericEnvironments.
     unsigned numPackElementGenericEnvironments;
@@ -3474,9 +3471,16 @@ public:
   /// Get the opened element generic environment for the given pack element.
   PackExpansionExpr *getPackEnvironment(PackElementExpr *packElement) const;
 
-  /// Associate an opened element generic environment to a pack element.
+  /// Associate an opened element generic environment to a pack element,
+  /// and record a change in the trail.
   void addPackEnvironment(PackElementExpr *packElement,
                           PackExpansionExpr *packExpansion);
+
+  /// Undo the above change.
+  void removePackEnvironment(PackElementExpr *packElement) {
+    bool erased = PackEnvironments.erase(packElement);
+    ASSERT(erased);
+  }
 
   /// Retrieve the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2328,7 +2328,7 @@ private:
 
   /// The set of remembered disjunction choices used to reach
   /// the current constraint system.
-  llvm::MapVector<ConstraintLocator *, unsigned> DisjunctionChoices;
+  llvm::SmallDenseMap<ConstraintLocator *, unsigned, 4> DisjunctionChoices;
 
   /// A map from applied disjunction constraints to the corresponding
   /// argument function type.
@@ -2878,9 +2878,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c DisjunctionChoices.
-    unsigned numDisjunctionChoices;
 
     /// The length of \c AppliedDisjunctions.
     unsigned numAppliedDisjunctions;
@@ -5319,14 +5316,15 @@ private:
   /// Collect the current inactive disjunction constraints.
   void collectDisjunctions(SmallVectorImpl<Constraint *> &disjunctions);
 
-  /// Record a particular disjunction choice of
-  void recordDisjunctionChoice(ConstraintLocator *disjunctionLocator,
-                               unsigned index) {
-    // We shouldn't ever register disjunction choices multiple times.
-    assert(!DisjunctionChoices.count(disjunctionLocator) ||
-           DisjunctionChoices[disjunctionLocator] == index);
-    DisjunctionChoices.insert({disjunctionLocator, index});
+  /// Record a particular disjunction choice and add a change to the trail.
+  void recordDisjunctionChoice(ConstraintLocator *locator, unsigned index);
+
+  /// Undo the above change.
+  void removeDisjunctionChoice(ConstraintLocator *locator) {
+    bool erased = DisjunctionChoices.erase(locator);
+    ASSERT(erased);
   }
+
 
   /// Filter the set of disjunction terms, keeping only those where the
   /// predicate returns \c true.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2362,7 +2362,7 @@ private:
 
   /// A mapping from constraint locators to the set of opened types associated
   /// with that locator.
-  llvm::SmallMapVector<ConstraintLocator *, ArrayRef<OpenedType>, 4>
+  llvm::SmallDenseMap<ConstraintLocator *, ArrayRef<OpenedType>, 4>
       OpenedTypes;
 
   /// A dictionary of all conformances that have been looked up by the solver.
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c OpenedTypes.
-    unsigned numOpenedTypes;
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
@@ -4392,6 +4389,13 @@ public:
                               bool skipProtocolSelfConstraint,
                               ConstraintLocatorBuilder locator,
                               llvm::function_ref<Type(Type)> subst);
+
+  /// Update OpenedTypes and record a change in the trail.
+  void recordOpenedType(
+      ConstraintLocator *locator, ArrayRef<OpenedType> openedTypes);
+
+  /// Undo the above change.
+  void removeOpenedType(ConstraintLocator *locator);
 
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2391,7 +2391,7 @@ private:
 
   /// A mapping from constraint locators to the opened existential archetype
   /// used for the 'self' of an existential type.
-  llvm::SmallMapVector<ConstraintLocator *, OpenedArchetypeType *, 4>
+  llvm::SmallDenseMap<ConstraintLocator *, OpenedArchetypeType *, 4>
       OpenedExistentialTypes;
 
   llvm::SmallMapVector<PackExpansionType *, TypeVariableType *, 4>
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c OpenedExistentialTypes.
-    unsigned numOpenedExistentialTypes;
 
     /// The length of \c OpenedPackExpansionsTypes.
     unsigned numOpenedPackExpansionTypes;
@@ -3455,6 +3452,16 @@ public:
   /// constraint system and returning both it and the root opened archetype.
   std::pair<Type, OpenedArchetypeType *> openExistentialType(
       Type type, ConstraintLocator *locator);
+
+  /// Update OpenedExistentials and record a change in the trail.
+  void recordOpenedExistentialType(ConstraintLocator *locator,
+                                   OpenedArchetypeType *opened);
+
+  /// Undo the above change.
+  void removeOpenedExistentialType(ConstraintLocator *locator) {
+    bool erased = OpenedExistentialTypes.erase(locator);
+    ASSERT(erased);
+  }
 
   /// Get the opened element generic environment for the given locator.
   GenericEnvironment *getPackElementEnvironment(ConstraintLocator *locator,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1519,7 +1519,7 @@ public:
 
   /// For locators associated with call expressions, the trailing closure
   /// matching rule and parameter bindings that were applied.
-  llvm::MapVector<ConstraintLocator *, MatchCallArgumentResult>
+  llvm::DenseMap<ConstraintLocator *, MatchCallArgumentResult>
       argumentMatchingChoices;
 
   /// The set of disjunction choices used to arrive at this solution,
@@ -2341,7 +2341,7 @@ private:
 
   /// For locators associated with call expressions, the trailing closure
   /// matching rule and parameter bindings that were applied.
-  llvm::MapVector<ConstraintLocator *, MatchCallArgumentResult>
+  llvm::DenseMap<ConstraintLocator *, MatchCallArgumentResult>
       argumentMatchingChoices;
 
   /// The set of implicit value conversions performed by the solver on
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c argumentMatchingChoices.
-    unsigned numArgumentMatchingChoices;
 
     /// The length of \c OpenedTypes.
     unsigned numOpenedTypes;
@@ -3637,8 +3634,15 @@ public:
   /// \param type The type on which to holeify.
   void recordTypeVariablesAsHoles(Type type);
 
+  /// Add a MatchCallArgumentResult and record the change in the trail.
   void recordMatchCallArgumentResult(ConstraintLocator *locator,
                                      MatchCallArgumentResult result);
+
+  /// Undo the above change.
+  void removeMatchCallArgumentResult(ConstraintLocator *locator) {
+    bool erased = argumentMatchingChoices.erase(locator);
+    ASSERT(erased);
+  }
 
   /// Record implicitly generated `callAsFunction` with root at the
   /// given expression, located at \c locator.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1549,10 +1549,6 @@ public:
   llvm::DenseMap<PackElementExpr *, PackExpansionExpr *>
       PackEnvironments;
 
-  /// The outer pack element generic environment to use when dealing with nested
-  /// pack iteration (see \c getPackElementEnvironment).
-  llvm::SmallVector<GenericEnvironment *> PackElementGenericEnvironments;
-
   /// The locators of \c Defaultable constraints whose defaults were used.
   llvm::DenseSet<ConstraintLocator *> DefaultedConstraints;
 
@@ -2882,9 +2878,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c PackElementGenericEnvironments.
-    unsigned numPackElementGenericEnvironments;
 
     /// The length of \c DefaultedConstraints.
     unsigned numDefaultedConstraints;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2314,7 +2314,7 @@ private:
   /// there are multiple ways in which one type could convert to another, e.g.,
   /// given class types A and B, the solver might choose either a superclass
   /// conversion or a user-defined conversion.
-  llvm::MapVector<std::pair<TypeBase *, TypeBase *>, ConversionRestrictionKind>
+  llvm::DenseMap<std::pair<TypeBase *, TypeBase *>, ConversionRestrictionKind>
       ConstraintRestrictions;
 
   /// The set of fixes applied to make the solution work.
@@ -2857,9 +2857,6 @@ public:
 
     /// The length of \c Trail.
     unsigned numTrailChanges;
-
-    /// The length of \c ConstraintRestrictions.
-    unsigned numConstraintRestrictions;
 
     /// The length of \c Fixes.
     unsigned numFixes;
@@ -4217,6 +4214,13 @@ public:
   void assignFixedType(TypeVariableType *typeVar, Type type,
                        bool updateState = true,
                        bool notifyBindingInference = true);
+
+  /// Update ConstraintRestrictions and record a change in the trail.
+  void addConversionRestriction(Type srcType, Type dstType,
+                                ConversionRestrictionKind restriction);
+
+  /// Called to undo the above change.
+  void removeConversionRestriction(Type srcType, Type dstType);
 
   /// Determine whether the given type is a dictionary and, if so, provide the
   /// key and value types for the dictionary.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2397,7 +2397,7 @@ private:
   llvm::SmallDenseMap<PackExpansionType *, TypeVariableType *, 4>
       OpenedPackExpansionTypes;
 
-  llvm::SmallMapVector<ConstraintLocator *, std::pair<UUID, Type>, 4>
+  llvm::SmallDenseMap<ConstraintLocator *, std::pair<UUID, Type>, 4>
       PackExpansionEnvironments;
 
   llvm::SmallMapVector<PackElementExpr *, PackExpansionExpr *, 2>
@@ -2882,9 +2882,6 @@ public:
     ///
     /// FIXME: Remove this.
     unsigned numFixes;
-
-    /// The length of \c PackExpansionEnvironments.
-    unsigned numPackExpansionEnvironments;
 
     /// The length of \c PackEnvironments.
     unsigned numPackEnvironments;
@@ -3463,6 +3460,16 @@ public:
   /// Get the opened element generic environment for the given locator.
   GenericEnvironment *getPackElementEnvironment(ConstraintLocator *locator,
                                                 CanType shapeClass);
+
+  /// Update PackExpansionEnvironments and record a change in the trail.
+  void recordPackExpansionEnvironment(ConstraintLocator *locator,
+                                      std::pair<UUID, Type> uuidAndShape);
+
+  /// Undo the above change.
+  void removePackExpansionEnvironment(ConstraintLocator *locator) {
+    bool erased = PackExpansionEnvironments.erase(locator);
+    ASSERT(erased);
+  }
 
   /// Get the opened element generic environment for the given pack element.
   PackExpansionExpr *getPackEnvironment(PackElementExpr *packElement) const;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2859,6 +2859,8 @@ public:
     unsigned numTrailChanges;
 
     /// The length of \c Fixes.
+    ///
+    /// FIXME: Remove this.
     unsigned numFixes;
 
     /// The length of \c FixedRequirements.
@@ -4221,6 +4223,12 @@ public:
 
   /// Called to undo the above change.
   void removeConversionRestriction(Type srcType, Type dstType);
+
+  /// Update Fixes and record a change in the trail.
+  void addFix(ConstraintFix *fix);
+
+  /// Called to undo the above change.
+  void removeFix(ConstraintFix *fix);
 
   /// Determine whether the given type is a dictionary and, if so, provide the
   /// key and value types for the dictionary.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2747,7 +2747,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
   // If this was from a defaultable binding note that.
   if (Binding.isDefaultableBinding()) {
-    cs.DefaultedConstraints.insert(srcLocator);
+    cs.recordDefaultedConstraint(srcLocator);
 
     // Fail if hole reporting fails.
     if (type->isPlaceholder() && reportHole())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4945,6 +4945,7 @@ bool ConstraintSystem::generateConstraints(
     // Cache the outer generic environment, if it exists.
     if (target.getPackElementEnv()) {
       PackElementGenericEnvironments.push_back(target.getPackElementEnv());
+      ASSERT(!isRecordingChanges() && "Need to record a change");
     }
 
     // For a for-each statement, generate constraints for the pattern, where

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12823,7 +12823,7 @@ bool ConstraintSystem::simplifyAppliedOverloads(
   auto *applicableFn = result->first;
   auto *fnTypeVar = applicableFn->getSecondType()->castTo<TypeVariableType>();
   auto argFnType = applicableFn->getFirstType()->castTo<FunctionType>();
-  AppliedDisjunctions[disjunction->getLocator()] = argFnType;
+  recordAppliedDisjunction(disjunction->getLocator(), argFnType);
   return simplifyAppliedOverloadsImpl(disjunction, fnTypeVar, argFnType,
                                       /*numOptionalUnwraps*/ result->second,
                                       applicableFn->getLocator());
@@ -12843,7 +12843,7 @@ bool ConstraintSystem::simplifyAppliedOverloads(
   if (!disjunction)
     return false;
 
-  AppliedDisjunctions[disjunction->getLocator()] = argFnType;
+  recordAppliedDisjunction(disjunction->getLocator(), argFnType);
   return simplifyAppliedOverloadsImpl(disjunction, fnTypeVar, argFnType,
                                       numOptionalUnwraps, locator);
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14676,8 +14676,7 @@ ConstraintSystem::simplifyRestrictedConstraint(
       addFixConstraint(fix, matchKind, type1, type2, locator);
     }
 
-    ConstraintRestrictions.insert({
-        std::make_pair(type1.getPointer(), type2.getPointer()), restriction});
+    addConversionRestriction(type1, type2, restriction);
     return SolutionKind::Solved;
   }
   case SolutionKind::Unsolved:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14855,7 +14855,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
     return true;
 
   if (isAugmentingFix(fix)) {
-    Fixes.insert(fix);
+    addFix(fix);
     return false;
   }
 
@@ -14887,7 +14887,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   }
 
   if (!found)
-    Fixes.insert(fix);
+    addFix(fix);
 
   return false;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14925,7 +14925,11 @@ void ConstraintSystem::recordTypeVariablesAsHoles(Type type) {
 void ConstraintSystem::recordMatchCallArgumentResult(
     ConstraintLocator *locator, MatchCallArgumentResult result) {
   assert(locator->isLastElement<LocatorPathElt::ApplyArgument>());
-  argumentMatchingChoices.insert({locator, result});
+  bool inserted = argumentMatchingChoices.insert({locator, result}).second;
+  if (inserted) {
+    if (isRecordingChanges())
+      recordChange(SolverTrail::Change::recordedMatchCallArgumentResult(locator));
+  }
 }
 
 void ConstraintSystem::recordCallAsFunction(UnresolvedDotExpr *root,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -341,7 +341,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solutions's pack expansion environments.
   for (const auto &expansion : solution.PackExpansionEnvironments) {
-    PackExpansionEnvironments.insert(expansion);
+    recordPackExpansionEnvironment(expansion.first, expansion.second);
   }
 
   // Register the solutions's pack environments.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
   numPackEnvironments = cs.PackEnvironments.size();
   numPackElementGenericEnvironments = cs.PackElementGenericEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
@@ -730,9 +729,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any pack expansion environments.
-  truncate(cs.PackExpansionEnvironments, numPackExpansionEnvironments);
 
   // Remove any pack environments.
   truncate(cs.PackEnvironments, numPackEnvironments);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -317,7 +317,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Remember all of the argument/parameter matching choices we made.
   for (auto &argumentMatch : solution.argumentMatchingChoices) {
-    argumentMatchingChoices.insert(argumentMatch);
+    recordMatchCallArgumentResult(argumentMatch.first, argumentMatch.second);
   }
 
   // Remember implied results.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
@@ -734,9 +733,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any argument matching choices;
-  truncate(cs.argumentMatchingChoices, numArgumentMatchingChoices);
 
   // Remove any opened types.
   truncate(cs.OpenedTypes, numOpenedTypes);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -336,7 +336,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solution's opened pack expansion types.
   for (const auto &expansion : solution.OpenedPackExpansionTypes) {
-    OpenedPackExpansionTypes.insert(expansion);
+    recordOpenedPackExpansionType(expansion.first, expansion.second);
   }
 
   // Register the solutions's pack expansion environments.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
   numPackEnvironments = cs.PackEnvironments.size();
   numPackElementGenericEnvironments = cs.PackElementGenericEnvironments.size();
@@ -731,9 +730,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any opened pack expansion types.
-  truncate(cs.OpenedPackExpansionTypes, numOpenedPackExpansionTypes);
 
   // Remove any pack expansion environments.
   truncate(cs.PackExpansionEnvironments, numPackExpansionEnvironments);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -347,8 +347,8 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   }
 
   // Register the defaulted type variables.
-  DefaultedConstraints.insert(solution.DefaultedConstraints.begin(),
-                              solution.DefaultedConstraints.end());
+  for (auto *locator : solution.DefaultedConstraints)
+    recordDefaultedConstraint(locator);
 
   // Add the node types back.
   for (auto &nodeType : solution.nodeTypes) {
@@ -663,7 +663,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
   numAddedKeyPathComponentTypes = cs.addedKeyPathComponentTypes.size();
   numKeyPaths = cs.KeyPaths.size();
@@ -718,9 +717,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any defaulted type variables.
-  truncate(cs.DefaultedConstraints, numDefaultedConstraints);
 
   // Remove any node types we registered.
   for (unsigned i :

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -326,7 +326,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solution's opened types.
   for (const auto &opened : solution.OpenedTypes) {
-    OpenedTypes.insert(opened);
+    recordOpenedType(opened.first, opened.second);
   }
 
   // Register the solution's opened existential types.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
@@ -733,9 +732,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any opened types.
-  truncate(cs.OpenedTypes, numOpenedTypes);
 
   // Remove any opened existential types.
   truncate(cs.OpenedExistentialTypes, numOpenedExistentialTypes);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -146,6 +146,11 @@ Solution ConstraintSystem::finalize() {
     solution.DisjunctionChoices.insert(choice);
   }
 
+  // Remember all the applied disjunctions.
+  for (auto &choice : AppliedDisjunctions) {
+    solution.AppliedDisjunctions.insert(choice);
+  }
+
   // Remember all of the argument/parameter matching choices we made.
   for (auto &argumentMatch : argumentMatchingChoices) {
     auto inserted = solution.argumentMatchingChoices.insert(argumentMatch);
@@ -303,6 +308,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solution's disjunction choices.
   for (auto &choice : solution.DisjunctionChoices) {
     recordDisjunctionChoice(choice.first, choice.second);
+  }
+
+  // Register the solution's applied disjunctions.
+  for (auto &choice : solution.AppliedDisjunctions) {
+    recordAppliedDisjunction(choice.first, choice.second);
   }
 
   // Remember all of the argument/parameter matching choices we made.
@@ -662,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numAppliedDisjunctions = cs.AppliedDisjunctions.size();
   numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
@@ -725,9 +734,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any applied disjunctions.
-  truncate(cs.AppliedDisjunctions, numAppliedDisjunctions);
 
   // Remove any argument matching choices;
   truncate(cs.argumentMatchingChoices, numArgumentMatchingChoices);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -331,7 +331,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solution's opened existential types.
   for (const auto &openedExistential : solution.OpenedExistentialTypes) {
-    OpenedExistentialTypes.insert(openedExistential);
+    recordOpenedExistentialType(openedExistential.first, openedExistential.second);
   }
 
   // Register the solution's opened pack expansion types.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
   numPackEnvironments = cs.PackEnvironments.size();
@@ -732,9 +731,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any opened existential types.
-  truncate(cs.OpenedExistentialTypes, numOpenedExistentialTypes);
 
   // Remove any opened pack expansion types.
   truncate(cs.OpenedPackExpansionTypes, numOpenedPackExpansionTypes);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -419,7 +419,8 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   }
 
   // Register any fixes produced along this path.
-  Fixes.insert(solution.Fixes.begin(), solution.Fixes.end());
+  for (auto *fix : solution.Fixes)
+    addFix(fix);
 }
 bool ConstraintSystem::simplify() {
   // While we have a constraint in the worklist, process it.
@@ -718,9 +719,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any fixes.
-  truncate(cs.Fixes, numFixes);
 
   // Remove any disjunction choices.
   truncate(cs.DisjunctionChoices, numDisjunctionChoices);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -346,7 +346,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solutions's pack environments.
   for (auto &packEnvironment : solution.PackEnvironments) {
-    PackEnvironments.insert(packEnvironment);
+    addPackEnvironment(packEnvironment.first, packEnvironment.second);
   }
 
   // Register the solutions's pack element generic environments.
@@ -672,7 +672,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numPackEnvironments = cs.PackEnvironments.size();
   numPackElementGenericEnvironments = cs.PackElementGenericEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
@@ -729,9 +728,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any pack environments.
-  truncate(cs.PackEnvironments, numPackEnvironments);
 
   // Remove any pack element generic environments.
   truncate(cs.PackElementGenericEnvironments,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -264,9 +264,6 @@ Solution ConstraintSystem::finalize() {
   for (const auto &packEnv : PackEnvironments)
     solution.PackEnvironments.insert(packEnv);
 
-  for (const auto &packEltGenericEnv : PackElementGenericEnvironments)
-    solution.PackElementGenericEnvironments.push_back(packEltGenericEnv);
-
   for (const auto &synthesized : SynthesizedConformances) {
     solution.SynthesizedConformances.insert(synthesized);
   }
@@ -347,12 +344,6 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solutions's pack environments.
   for (auto &packEnvironment : solution.PackEnvironments) {
     addPackEnvironment(packEnvironment.first, packEnvironment.second);
-  }
-
-  // Register the solutions's pack element generic environments.
-  for (auto &packElementGenericEnvironment :
-       solution.PackElementGenericEnvironments) {
-    PackElementGenericEnvironments.push_back(packElementGenericEnvironment);
   }
 
   // Register the defaulted type variables.
@@ -672,7 +663,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numPackElementGenericEnvironments = cs.PackElementGenericEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
   numAddedKeyPathComponentTypes = cs.addedKeyPathComponentTypes.size();
@@ -728,10 +718,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any pack element generic environments.
-  truncate(cs.PackElementGenericEnvironments,
-           numPackElementGenericEnvironments);
 
   // Remove any defaulted type variables.
   truncate(cs.DefaultedConstraints, numDefaultedConstraints);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -302,7 +302,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Register the solution's disjunction choices.
   for (auto &choice : solution.DisjunctionChoices) {
-    DisjunctionChoices.insert(choice);
+    recordDisjunctionChoice(choice.first, choice.second);
   }
 
   // Remember all of the argument/parameter matching choices we made.
@@ -662,7 +662,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
-  numDisjunctionChoices = cs.DisjunctionChoices.size();
   numAppliedDisjunctions = cs.AppliedDisjunctions.size();
   numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
@@ -726,9 +725,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any disjunction choices.
-  truncate(cs.DisjunctionChoices, numDisjunctionChoices);
 
   // Remove any applied disjunctions.
   truncate(cs.AppliedDisjunctions, numAppliedDisjunctions);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -290,10 +290,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register constraint restrictions.
   // FIXME: Copy these directly into some kind of partial solution?
   for ( auto &restriction : solution.ConstraintRestrictions) {
-    auto *type1 = restriction.first.first.getPointer();
-    auto *type2 = restriction.first.second.getPointer();
+    auto type1 = restriction.first.first;
+    auto type2 = restriction.first.second;
 
-    ConstraintRestrictions.insert({{type1, type2}, restriction.second});
+    addConversionRestriction(type1, type2, restriction.second);
   }
 
   // Register the solution's disjunction choices.
@@ -652,7 +652,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numTrailChanges = cs.solverState->Trail.size();
 
   numTypeVariables = cs.TypeVariables.size();
-  numConstraintRestrictions = cs.ConstraintRestrictions.size();
   numFixes = cs.Fixes.size();
   numFixedRequirements = cs.FixedRequirements.size();
   numDisjunctionChoices = cs.DisjunctionChoices.size();
@@ -719,9 +718,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // e.g. add retired constraints back to the circulation and remove generated
   // constraints introduced by the current scope.
   cs.solverState->rollback(this);
-
-  // Remove any constraint restrictions.
-  truncate(cs.ConstraintRestrictions, numConstraintRestrictions);
 
   // Remove any fixes.
   truncate(cs.Fixes, numFixes);

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -185,6 +185,14 @@ SolverTrail::Change::recordedOpenedTypes(ConstraintLocator *locator) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedOpenedExistentialType(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedOpenedExistentialType;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -252,6 +260,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedOpenedTypes:
     cs.removeOpenedType(Locator);
+    break;
+
+  case ChangeKind::RecordedOpenedExistentialType:
+    cs.removeOpenedExistentialType(Locator);
     break;
   }
 }
@@ -385,6 +397,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::RecordedOpenedTypes:
     out << "(recorded list of opened types at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
+    break;
+
+  case ChangeKind::RecordedOpenedExistentialType:
+    out << "(recorded opened existential type at ";
     Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << ")\n";
     break;

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -151,6 +151,16 @@ SolverTrail::Change::addedFixedRequirement(GenericTypeParamType *GP,
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedDisjunctionChoice(ConstraintLocator *locator,
+                                               unsigned index) {
+  Change result;
+  result.Kind = ChangeKind::RecordedDisjunctionChoice;
+  result.Locator = locator;
+  result.Options = index;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -202,6 +212,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   case ChangeKind::AddedFixedRequirement:
     cs.removeFixedRequirement(FixedRequirement.GP, Options,
                               FixedRequirement.ReqTy);
+    break;
+
+  case ChangeKind::RecordedDisjunctionChoice:
+    cs.removeDisjunctionChoice(Locator);
     break;
   }
 }
@@ -312,6 +326,13 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     out << Options << " ";
     FixedRequirement.ReqTy->print(out, PO);
     out << ")\n";
+    break;
+
+  case ChangeKind::RecordedDisjunctionChoice:
+    out << "(recorded disjunction choice at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << " index ";
+    out << Options << ")\n";
     break;
   }
 }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -161,6 +161,14 @@ SolverTrail::Change::recordedDisjunctionChoice(ConstraintLocator *locator,
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedAppliedDisjunction(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedAppliedDisjunction;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -216,6 +224,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedDisjunctionChoice:
     cs.removeDisjunctionChoice(Locator);
+    break;
+
+  case ChangeKind::RecordedAppliedDisjunction:
+    cs.removeAppliedDisjunction(Locator);
     break;
   }
 }
@@ -333,6 +345,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << " index ";
     out << Options << ")\n";
+    break;
+
+  case ChangeKind::RecordedAppliedDisjunction:
+    out << "(recorded applied disjunction at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
     break;
   }
 }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -193,6 +193,14 @@ SolverTrail::Change::recordedOpenedExistentialType(ConstraintLocator *locator) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedOpenedPackExpansionType(PackExpansionType *expansionTy) {
+  Change result;
+  result.Kind = ChangeKind::RecordedOpenedPackExpansionType;
+  result.ExpansionTy = expansionTy;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -264,6 +272,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedOpenedExistentialType:
     cs.removeOpenedExistentialType(Locator);
+    break;
+
+  case ChangeKind::RecordedOpenedPackExpansionType:
+    cs.removeOpenedPackExpansionType(ExpansionTy);
     break;
   }
 }
@@ -404,6 +416,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
   case ChangeKind::RecordedOpenedExistentialType:
     out << "(recorded opened existential type at ";
     Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
+    break;
+
+  case ChangeKind::RecordedOpenedPackExpansionType:
+    out << "(recorded opened pack expansion type for ";
+    ExpansionTy->print(out, PO);
     out << ")\n";
     break;
   }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -201,6 +201,14 @@ SolverTrail::Change::recordedOpenedPackExpansionType(PackExpansionType *expansio
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedPackExpansionEnvironment(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedPackExpansionEnvironment;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -276,6 +284,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedOpenedPackExpansionType:
     cs.removeOpenedPackExpansionType(ExpansionTy);
+    break;
+
+  case ChangeKind::RecordedPackExpansionEnvironment:
+    cs.removePackExpansionEnvironment(Locator);
     break;
   }
 }
@@ -422,6 +434,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
   case ChangeKind::RecordedOpenedPackExpansionType:
     out << "(recorded opened pack expansion type for ";
     ExpansionTy->print(out, PO);
+    out << ")\n";
+    break;
+
+  case ChangeKind::RecordedPackExpansionEnvironment:
+    out << "(recorded pack expansion environment at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << ")\n";
     break;
   }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -139,6 +139,18 @@ SolverTrail::Change::addedFix(ConstraintFix *fix) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::addedFixedRequirement(GenericTypeParamType *GP,
+                                           unsigned reqKind,
+                                           Type reqTy) {
+  Change result;
+  result.Kind = ChangeKind::AddedFixedRequirement;
+  result.FixedRequirement.GP = GP;
+  result.FixedRequirement.ReqTy = reqTy;
+  result.Options = reqKind;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -185,6 +197,11 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::AddedFix:
     cs.removeFix(Fix);
+    break;
+
+  case ChangeKind::AddedFixedRequirement:
+    cs.removeFixedRequirement(FixedRequirement.GP, Options,
+                              FixedRequirement.ReqTy);
     break;
   }
 }
@@ -285,6 +302,15 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
   case ChangeKind::AddedFix:
     out << "(added a fix ";
     Fix->print(out);
+    out << ")\n";
+    break;
+
+  case ChangeKind::AddedFixedRequirement:
+    out << "(added a fixed requirement ";
+    FixedRequirement.GP->print(out, PO);
+    out << " kind ";
+    out << Options << " ";
+    FixedRequirement.ReqTy->print(out, PO);
     out << ")\n";
     break;
   }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -169,6 +169,14 @@ SolverTrail::Change::recordedAppliedDisjunction(ConstraintLocator *locator) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedMatchCallArgumentResult(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedMatchCallArgumentResult;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -228,6 +236,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedAppliedDisjunction:
     cs.removeAppliedDisjunction(Locator);
+    break;
+
+  case ChangeKind::RecordedMatchCallArgumentResult:
+    cs.removeMatchCallArgumentResult(Locator);
     break;
   }
 }
@@ -349,6 +361,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::RecordedAppliedDisjunction:
     out << "(recorded applied disjunction at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
+    break;
+
+  case ChangeKind::RecordedMatchCallArgumentResult:
+    out << "(recorded argument matching choice at ";
     Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << ")\n";
     break;

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -131,6 +131,14 @@ SolverTrail::Change::addedConversionRestriction(Type srcType, Type dstType) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::addedFix(ConstraintFix *fix) {
+  Change result;
+  result.Kind = ChangeKind::AddedFix;
+  result.Fix = fix;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -173,6 +181,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   case ChangeKind::AddedConversionRestriction:
     cs.removeConversionRestriction(Restriction.SrcType,
                                    Restriction.DstType);
+    break;
+
+  case ChangeKind::AddedFix:
+    cs.removeFix(Fix);
     break;
   }
 }
@@ -267,6 +279,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     Restriction.SrcType->print(out, PO);
     out << " and destination ";
     Restriction.DstType->print(out, PO);
+    out << ")\n";
+    break;
+
+  case ChangeKind::AddedFix:
+    out << "(added a fix ";
+    Fix->print(out);
     out << ")\n";
     break;
   }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -217,6 +217,14 @@ SolverTrail::Change::recordedPackEnvironment(PackElementExpr *packElement) {
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedDefaultedConstraint(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedDefaultedConstraint;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -300,6 +308,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedPackEnvironment:
     cs.removePackEnvironment(ElementExpr);
+    break;
+
+  case ChangeKind::RecordedDefaultedConstraint:
+    cs.removeDefaultedConstraint(Locator);
     break;
   }
 }
@@ -457,6 +469,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::RecordedPackEnvironment:
     out << "(recorded pack environment)\n";
+    break;
+
+  case ChangeKind::RecordedDefaultedConstraint:
+    out << "(recorded defaulted constraint at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
     break;
   }
 }

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -177,6 +177,14 @@ SolverTrail::Change::recordedMatchCallArgumentResult(ConstraintLocator *locator)
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedOpenedTypes(ConstraintLocator *locator) {
+  Change result;
+  result.Kind = ChangeKind::RecordedOpenedTypes;
+  result.Locator = locator;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -240,6 +248,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedMatchCallArgumentResult:
     cs.removeMatchCallArgumentResult(Locator);
+    break;
+
+  case ChangeKind::RecordedOpenedTypes:
+    cs.removeOpenedType(Locator);
     break;
   }
 }
@@ -367,6 +379,12 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::RecordedMatchCallArgumentResult:
     out << "(recorded argument matching choice at ";
+    Locator->dump(&cs.getASTContext().SourceMgr, out);
+    out << ")\n";
+    break;
+
+  case ChangeKind::RecordedOpenedTypes:
+    out << "(recorded list of opened types at ";
     Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << ")\n";
     break;

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -209,6 +209,14 @@ SolverTrail::Change::recordedPackExpansionEnvironment(ConstraintLocator *locator
   return result;
 }
 
+SolverTrail::Change
+SolverTrail::Change::recordedPackEnvironment(PackElementExpr *packElement) {
+  Change result;
+  result.Kind = ChangeKind::RecordedPackEnvironment;
+  result.ElementExpr = packElement;
+  return result;
+}
+
 void SolverTrail::Change::undo(ConstraintSystem &cs) const {
   auto &cg = cs.getConstraintGraph();
 
@@ -288,6 +296,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RecordedPackExpansionEnvironment:
     cs.removePackExpansionEnvironment(Locator);
+    break;
+
+  case ChangeKind::RecordedPackEnvironment:
+    cs.removePackEnvironment(ElementExpr);
     break;
   }
 }
@@ -441,6 +453,10 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
     out << "(recorded pack expansion environment at ";
     Locator->dump(&cs.getASTContext().SourceMgr, out);
     out << ")\n";
+    break;
+
+  case ChangeKind::RecordedPackEnvironment:
+    out << "(recorded pack environment)\n";
     break;
   }
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -310,6 +310,18 @@ void ConstraintSystem::recordDisjunctionChoice(
   }
 }
 
+void ConstraintSystem::recordAppliedDisjunction(
+    ConstraintLocator *locator, FunctionType *fnType) {
+  // We shouldn't ever register disjunction choices multiple times.
+  auto inserted = AppliedDisjunctions.insert(
+      std::make_pair(locator, fnType));
+  if (inserted.second) {
+    if (isRecordingChanges()) {
+      recordChange(SolverTrail::Change::recordedAppliedDisjunction(locator));
+    }
+  }
+}
+
 /// Retrieve a dynamic result signature for the given declaration.
 static std::tuple<char, ObjCSelector, CanType>
 getDynamicResultSignature(ValueDecl *decl) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -910,11 +910,12 @@ ConstraintSystem::getPackEnvironment(PackElementExpr *packElement) const {
 
 void ConstraintSystem::addPackEnvironment(PackElementExpr *packElement,
                                           PackExpansionExpr *packExpansion) {
-  assert(packElement);
-  assert(packExpansion);
-  [[maybe_unused]] const auto inserted =
+  bool inserted =
       PackEnvironments.insert({packElement, packExpansion}).second;
-  assert(inserted && "Mapping already defined?");
+  if (inserted) {
+    if (isRecordingChanges())
+      recordChange(SolverTrail::Change::recordedPackEnvironment(packElement));
+  }
 }
 
 /// Extend the given depth map by adding depths for all of the subexpressions

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -279,6 +279,20 @@ void ConstraintSystem::removeConversionRestriction(
   ASSERT(erased);
 }
 
+void ConstraintSystem::addFix(ConstraintFix *fix) {
+  bool inserted = Fixes.insert(fix);
+  if (!inserted)
+    return;
+
+  if (isRecordingChanges())
+    recordChange(SolverTrail::Change::addedFix(fix));
+}
+
+void ConstraintSystem::removeFix(ConstraintFix *fix) {
+  ASSERT(Fixes.back() == fix);
+  Fixes.pop_back();
+}
+
 /// Retrieve a dynamic result signature for the given declaration.
 static std::tuple<char, ObjCSelector, CanType>
 getDynamicResultSignature(ValueDecl *decl) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4473,7 +4473,6 @@ size_t Solution::getTotalMemory() const {
          OpenedPackExpansionTypes.getMemorySize() +
          PackExpansionEnvironments.getMemorySize() +
          size_in_bytes(PackEnvironments) +
-         PackElementGenericEnvironments.size() +
          (DefaultedConstraints.size() * sizeof(void *)) +
          nodeTypes.getMemorySize() +
          keyPathComponentTypes.getMemorySize() +

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -293,6 +293,23 @@ void ConstraintSystem::removeFix(ConstraintFix *fix) {
   Fixes.pop_back();
 }
 
+void ConstraintSystem::recordDisjunctionChoice(
+    ConstraintLocator *locator,
+    unsigned index) {
+  // We shouldn't ever register disjunction choices multiple times.
+  auto inserted = DisjunctionChoices.insert(
+      std::make_pair(locator, index));
+  if (!inserted.second) {
+    ASSERT(inserted.first->second == index);
+    return;
+  }
+
+  if (isRecordingChanges()) {
+    recordChange(SolverTrail::Change::recordedDisjunctionChoice(
+      locator, index));
+  }
+}
+
 /// Retrieve a dynamic result signature for the given declaration.
 static std::tuple<char, ObjCSelector, CanType>
 getDynamicResultSignature(ValueDecl *decl) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -868,7 +868,7 @@ ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator,
   auto result = PackExpansionEnvironments.find(locator);
   if (result == PackExpansionEnvironments.end()) {
     uuidAndShape = std::make_pair(UUID::fromTime(), shapeClass);
-    PackExpansionEnvironments[locator] = uuidAndShape;
+    recordPackExpansionEnvironment(locator, uuidAndShape);
   } else {
     uuidAndShape = result->second;
   }
@@ -889,6 +889,17 @@ ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator,
   auto contextSubs = contextEnv->getForwardingSubstitutionMap();
   return GenericEnvironment::forOpenedElement(elementSig, uuidAndShape.first,
                                               shapeParam, contextSubs);
+}
+
+void ConstraintSystem::recordPackExpansionEnvironment(
+    ConstraintLocator *locator, std::pair<UUID, Type> uuidAndShape) {
+  bool inserted = PackExpansionEnvironments.insert({locator, uuidAndShape}).second;
+  if (inserted) {
+    if (isRecordingChanges()) {
+      recordChange(
+        SolverTrail::Change::recordedPackExpansionEnvironment(locator));
+    }
+  }
 }
 
 PackExpansionExpr *

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -257,6 +257,28 @@ void ConstraintSystem::addTypeVariableConstraintsToWorkList(
       activateConstraint(constraint);
 }
 
+void ConstraintSystem::addConversionRestriction(
+    Type srcType, Type dstType,
+    ConversionRestrictionKind restriction) {
+  auto key = std::make_pair(srcType.getPointer(), dstType.getPointer());
+  bool inserted = ConstraintRestrictions.insert(
+      std::make_pair(key, restriction)).second;
+  if (!inserted)
+    return;
+
+  if (isRecordingChanges()) {
+    recordChange(SolverTrail::Change::addedConversionRestriction(
+      srcType, dstType));
+  }
+}
+
+void ConstraintSystem::removeConversionRestriction(
+    Type srcType, Type dstType) {
+  auto key = std::make_pair(srcType.getPointer(), dstType.getPointer());
+  bool erased = ConstraintRestrictions.erase(key);
+  ASSERT(erased);
+}
+
 /// Retrieve a dynamic result signature for the given declaration.
 static std::tuple<char, ObjCSelector, CanType>
 getDynamicResultSignature(ValueDecl *decl) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1263,6 +1263,15 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
   return expansionVar;
 }
 
+void ConstraintSystem::recordOpenedPackExpansionType(PackExpansionType *expansion,
+                                                     TypeVariableType *expansionVar) {
+  bool inserted = OpenedPackExpansionTypes.insert({expansion, expansionVar}).second;
+  if (inserted) {
+    if (isRecordingChanges())
+      recordChange(SolverTrail::Change::recordedOpenedPackExpansionType(expansion));
+  }
+}
+
 Type ConstraintSystem::openOpaqueType(OpaqueTypeArchetypeType *opaque,
                                       ConstraintLocatorBuilder locator) {
   auto opaqueDecl = opaque->getDecl();


### PR DESCRIPTION
The SolverTrail::Change kinds are getting a bit verbose. I'm going to write them all out first and then factor out the commonality with xmacros.