### PR TITLE
[Serialization] Don't filter out unextended-module-map VFS in explicit builds.

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1167,7 +1167,7 @@ void Serializer::writeHeader() {
         auto &Opts = Options.ExtraClangOptions;
         for (auto Arg = Opts.begin(), E = Opts.end(); Arg != E; ++Arg) {
           StringRef arg(*Arg);
-          if (arg.starts_with("-ivfsoverlay")) {
+          if (!Options.ExplicitModuleBuild && arg.starts_with("-ivfsoverlay")) {
             // FIXME: This is a hack and calls for a better design.
             //
             // Filter out any -ivfsoverlay options that include an
@@ -1175,6 +1175,11 @@ void Serializer::writeHeader() {
             // buildsystem uses these while *building* mixed Objective-C and
             // Swift frameworks; but they should never be used to *import* the
             // module defined in the framework.
+            //
+            // This is not done for explicit modules builds. In an explicit
+            // build LLDB needs to be able import the unmodified .pcms, so
+            // having the exact same flags matters there, and there is no risk
+            // of a recompilation failure, because nothing is recompiled.
             auto Next = std::next(Arg);
             if (Next != E &&
                 StringRef(*Next).ends_with("unextended-module-overlay.yaml")) {

--- a/test/Serialization/search-paths-relative.swift
+++ b/test/Serialization/search-paths-relative.swift
@@ -6,6 +6,7 @@
 
 // Output paths differ in the new driver, so force SWIFT_USE_OLD_DRIVER for now.
 // RUN: cd %t/secret && env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -emit-module -o %t/has_xref.swiftmodule -I . -F ../Frameworks -parse-as-library %S/Inputs/has_xref.swift %S/../Inputs/empty.swift -Xfrontend -serialize-debugging-options -Xcc -ivfsoverlay -Xcc %S/../Inputs/unextended-module-overlay.yaml -Xcc -DDUMMY
+// RUN: cd %t/secret && env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -emit-module -o %t/explicit.swiftmodule -parse-stdlib -parse-as-library %S/../Inputs/empty.swift -Xfrontend -disable-implicit-swift-modules -Xfrontend -serialize-debugging-options -Xcc -ivfsoverlay -Xcc %S/../Inputs/unextended-module-overlay.yaml -Xcc -DDUMMY
 // RUN: %target-swift-frontend %s -typecheck -I %t
 
 // Ensure that in Swift 6 mode we do not read out search paths, thus are no longer able to
@@ -15,8 +16,10 @@
 
 // Check the actual serialized search paths.
 // RUN: llvm-bcanalyzer -dump %t/has_xref.swiftmodule > %t/has_xref.swiftmodule.txt
+// RUN: llvm-bcanalyzer -dump %t/explicit.swiftmodule > %t/explicit.swiftmodule.txt
 // RUN: %FileCheck %s < %t/has_xref.swiftmodule.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/has_xref.swiftmodule.txt
+// RUN: %FileCheck -check-prefix=EXPLICIT %s < %t/explicit.swiftmodule.txt
 
 import has_xref
 
@@ -36,6 +39,10 @@ numeric(42)
 // NEGATIVE-NOT: '.'
 // NEGATIVE-NOT: '../Frameworks'
 // This should be filtered out.
-// NEGATIVE-NOT: -ivfsoverlay{{.*}}unextended-module-overlay.yaml
+// NEGATIVE-NOT: -ivfsoverlay
+// NEGATIVE-NOT: unextended-module-overlay.yaml
+// EXPLICIT: -ivfsoverlay
+// EXPLICIT: unextended-module-overlay.yaml
+// EXPLICIT: -DDUMMY
 
 // SWIFT6: error: missing required modules: 'has_alias', 'struct_with_operators'


### PR DESCRIPTION
…t builds.

In an explicit build LLDB needs to be able import the unmodified .pcms, so having the exact same flags matters there, and there is no risk of a recompilation failure, because nothing is recompiled.

rdar://136759808
