### PR TITLE
[Windows] Switch to 'PURE' bridging mode for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND BOOTSTRAPPING_MODE STREQUAL "HO
 endif()
 
 if(BRIDGING_MODE STREQUAL "DEFAULT" OR NOT BRIDGING_MODE)
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
     # In debug builds, to workaround a problem with LLDB's `po` command (rdar://115770255).
     # If the host Swift version is less than 5.8, use pure mode to workaround a C++ interop compiler crash.
     set(BRIDGING_MODE "PURE")


### PR DESCRIPTION
Partially revert #76754 

With newer llvm-project, importing 'llvm/include/llvm/ADT/DynamicAPInt.h' causes an error:

```
C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/llvm-project/llvm/include/llvm/ADT\ADL.h:12:2: note: in module 'std' imported from C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/llvm-project/llvm/include/llvm/ADT\ADL.h:12:
#include <type_traits>
 ^
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:12: error: function '_Select_countr_zero_impl<unsigned long long, (lambda at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:55)>' with deduced return type cannot be used before it is defined
    return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
           ^
C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/llvm-project/llvm/include/llvm/ADT\DynamicAPInt.h:392:30: note: in instantiation of function template specialization 'std::gcd<long long, long long>' requested here
    return DynamicAPInt(std::gcd(A.getSmall(), B.getSmall()));
                             ^
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\__msvc_bit_utils.hpp:374:26: note: '_Select_countr_zero_impl<unsigned long long, (lambda at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:55)>' declared here
constexpr decltype(auto) _Select_countr_zero_impl(_Fn _Callback) {
                         ^
<module-includes>:1:10: note: in file included from <module-includes>:1:
#include "swift/Basic/BasicBridging.h"
         ^
C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/swift/include/swift/Basic/BasicBridging.h:44:10: note: in file included from C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/swift/include/swift/Basic/BasicBridging.h:44:
#include "llvm/CAS/CASReference.h"
         ^
C:/Users/swift-ci/jenkins/workspace/swift-rebranch-windows-toolchain/llvm-project/llvm/include\llvm/CAS/CASReference.h:12:10: error: could not build module 'LLVM_Utils'
#include "llvm/ADT/ArrayRef.h"
         ^
C:\Users\swift-ci\jenkins\workspace\swift-rebranch-windows-toolchain\swift\SwiftCompilerSources\Sources\Basic\SourceLoc.swift:13:8: error: could not build C module 'BasicBridging'
import BasicBridging
       ^
```
