### PR TITLE
Fix syntax highlighting by changing how we include COMPATIBILITY_OVERRIDE_INCLUDE_PATH

### DIFF
--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.cpp
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.cpp
@@ -43,7 +43,7 @@ struct OverrideSection {
   
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "CompatibilityOverrideIncludePath.h"
 };
 
 static_assert(std::is_pod<OverrideSection>::value,
@@ -98,6 +98,6 @@ static OverrideSection *getOverrideSectionPtr() {
     Section->name;                                           \
   }
 
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "CompatibilityOverrideIncludePath.h"
 
 #endif // #ifdef SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
@@ -120,9 +120,9 @@ namespace swift {
 #define COMPATIBILITY_PAREN_PARAMS(...) (__VA_ARGS__)
 #define COMPATIBILITY_PAREN_COMPATIBILITY_PAREN2 ()
 
-// Include path computation. Code that includes this file can write
-// `#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH` to include the appropriate
-// .def file for the current library.
+// Include path computation. Code that includes this file can write `#include
+// "..CompatibilityOverride/CompatibilityOverrideIncludePath.h"` to include the
+// appropriate .def file for the current library.
 #define COMPATIBILITY_OVERRIDE_INCLUDE_PATH_swiftRuntime                       \
   "../CompatibilityOverride/CompatibilityOverrideRuntime.def"
 #define COMPATIBILITY_OVERRIDE_INCLUDE_PATH_swift_Concurrency                  \
@@ -173,18 +173,18 @@ namespace swift {
 // Create typedefs for function pointers to call the original implementation.
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs)   \
   ccAttrs typedef ret(*Original_##name) COMPATIBILITY_PAREN(typedArgs);
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "CompatibilityOverrideIncludePath.h"
 
 // Create typedefs for override function pointers.
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs)   \
   ccAttrs typedef ret (*Override_##name)(COMPATIBILITY_UNPAREN_WITH_COMMA(     \
       typedArgs) Original_##name originalImpl);
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "CompatibilityOverrideIncludePath.h"
 
 // Create declarations for getOverride functions.
-#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
-  Override_ ## name getOverride_ ## name();
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs)   \
+  Override_##name getOverride_##name();
+#include "CompatibilityOverrideIncludePath.h"
 
 /// Used to define an override point. The override point #defines the appropriate
 /// OVERRIDE macro from CompatibilityOverride.def to this macro, then includes

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideIncludePath.h
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideIncludePath.h
@@ -1,0 +1,24 @@
+//===--- CompatibilityOverrideIncludePath.h -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file should be included instead of including
+/// COMPATIBILITY_OVERRIDE_INCLUDE_PATH directly to ensure that syntax
+/// highlighting in certain errors is not broken. It is assumed that
+/// CompatibilityOverride.h is already included.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMPATIBILITY_OVERRIDE_H
+#error "Must define COMPATIBILITY_OVERRIDE_H before including this file"
+#endif
+
+#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2310,8 +2310,7 @@ void swift::swift_executor_escalate(SerialExecutorRef executor, AsyncTask *task,
 }
 
 #define OVERRIDE_ACTOR COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
-
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"
 
 /*****************************************************************************/
 /***************************** DISTRIBUTED ACTOR *****************************/

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -577,4 +577,4 @@ void AsyncLet::setDidAllocateFromParentTask(bool value) {
 // =============================================================================
 
 #define OVERRIDE_ASYNC_LET COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -233,4 +233,4 @@ bool SerialExecutorRef::isMainExecutor() const {
 }
 
 #define OVERRIDE_GLOBAL_EXECUTOR COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1832,4 +1832,4 @@ static void swift_task_startOnMainActorImpl(AsyncTask* task) {
   }
 #endif // #else SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
 
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -2084,4 +2084,4 @@ static bool swift_taskGroup_addPendingImpl(TaskGroup *_group, bool unconditional
 }
 
 #define OVERRIDE_TASK_GROUP COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -536,4 +536,4 @@ void TaskLocal::Storage::copyToOnlyOnlyFromCurrentGroup(AsyncTask *target) {
 }
 
 #define OVERRIDE_TASK_LOCAL COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -1118,4 +1118,4 @@ void TaskDependencyStatusRecord::performEscalationAction(JobPriority newPriority
 }
 
 #define OVERRIDE_TASK_STATUS COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1733,5 +1733,4 @@ HeapObject *_swift_bridgeToObjectiveCUsingProtocolIfPossible(
 #endif
 
 #define OVERRIDE_CASTING COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
-
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -2594,4 +2594,4 @@ swift_dynamicCastImpl(OpaqueValue *destLocation,
 }
 
 #define OVERRIDE_DYNAMICCASTING COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -7925,7 +7925,7 @@ const HeapObject *swift_getKeyPathImpl(const void *pattern,
 
 #define OVERRIDE_KEYPATH COMPATIBILITY_OVERRIDE
 #define OVERRIDE_WITNESSTABLE COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"
 
 // Autolink with libc++, for cases where libswiftCore is linked statically.
 #if defined(__MACH__)

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -3910,4 +3910,4 @@ void swift::swift_disableDynamicReplacementScope(
   DynamicReplacementLock.get().withLock([=] { scope->disable(); });
 }
 #define OVERRIDE_METADATALOOKUP COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -2023,4 +2023,4 @@ const Metadata *swift::findConformingSuperclass(
 }
 
 #define OVERRIDE_PROTOCOLCONFORMANCE COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1774,7 +1774,7 @@ const ClassMetadata *swift::getRootSuperclass() {
 }
 
 #define OVERRIDE_OBJC COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"
 
 #define OVERRIDE_FOREIGN COMPATIBILITY_OVERRIDE
-#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
+#include "../CompatibilityOverride/CompatibilityOverrideIncludePath.h"

--- a/stdlib/toolchain/Compatibility56/CompatibilityOverride.h
+++ b/stdlib/toolchain/Compatibility56/CompatibilityOverride.h
@@ -57,8 +57,13 @@ namespace swift {
 #define COMPATIBILITY_PAREN_COMPATIBILITY_PAREN2 ()
 
 // Include path computation. Code that includes this file can write
-// `#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH` to include the appropriate
+// `#include "CompatibilityOverrideIncludePath.h"` to include the appropriate
 // .def file for the current library.
+//
+// DISCUSSION: We do not use COMPATIBILITY_OVERRIDE_INCLUDE_PATH directly since
+// #including it can break syntax highlighting in certain editors. By using a
+// different file, we keep the broken-ness to that one file that only #include
+// COMPATIBILITY_OVERRIDE_INCLUDE_PATH.
 #define COMPATIBILITY_OVERRIDE_INCLUDE_PATH_swiftRuntime                       \
   "CompatibilityOverrideRuntime.def"
 #define COMPATIBILITY_OVERRIDE_INCLUDE_PATH_swift_Concurrency                  \


### PR DESCRIPTION
The way that we include COMPATIBILITY_OVERRIDE_INCLUDE_PATH freaks out the syntax highlighting of editors like emacs. It causes the whole file to be highlighted like it is part of the include string.

To work around this, this patch creates a separate file called CompatibilityOverrideIncludePath.h that just includes COMPATIBILITY_OVERRIDE_INCLUDE_PATH. So its syntax highlighting is borked, but at least in the actual files that contain real code, the syntax highlighting is restored.
