### PR TITLE
[Index] Record references to global actors in closures and function types.

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -89,6 +89,9 @@ private:
 
   bool handleImports(ImportDecl *Import);
   bool handleCustomAttributes(Decl *D);
+  bool handleCustomTypeAttribute(const CustomAttr *customAttr);
+  bool handleClosureAttributes(ClosureExpr *E);
+  bool handleTypeAttributes(AttributedTypeRepr *T);
   bool passModulePathElements(ImportPath::Module Path,
                               const clang::Module *ClangMod);
 
@@ -603,6 +606,10 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
           return Action::Stop();
       }
     }
+  } else if (auto CE = dyn_cast<ClosureExpr>(E)) {
+    if (!handleClosureAttributes(CE))
+      return Action::Stop();
+    return Action::Continue(E);
   }
 
   return Action::Continue(E);
@@ -655,6 +662,9 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
                                     ST->getSourceRange(), Data);
       return Action::StopIf(!Continue);
     }
+  } else if (auto AT = dyn_cast<AttributedTypeRepr>(T)) {
+    auto Continue = handleTypeAttributes(AT);
+    return Action::StopIf(!Continue);
   }
 
   return Action::Continue();
@@ -757,6 +767,39 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
       if (!Args->walk(*this))
         return false;
     }
+  }
+
+  return true;
+}
+
+bool SemaAnnotator::handleCustomTypeAttribute(const CustomAttr *customAttr) {
+  if (auto *Repr = customAttr->getTypeRepr())
+    if (!Repr->walk(*this))
+      return false;
+
+  if (auto *Args = customAttr->getArgs())
+    if (!Args->walk(*this))
+      return false;
+
+  return true;
+}
+
+bool SemaAnnotator::handleClosureAttributes(ClosureExpr *E) {
+  for (auto *customAttr : E->getAttrs().getAttributes<CustomAttr, true>())
+    if (!handleCustomTypeAttribute(customAttr))
+      return false;
+
+  return true;
+}
+
+bool SemaAnnotator::handleTypeAttributes(AttributedTypeRepr *T) {
+  for (auto attr : T->getAttrs()) {
+    if (!attr.is<CustomAttr *>())
+      continue;
+
+    CustomAttr *customAttr = attr.get<CustomAttr *>();
+    if (!handleCustomTypeAttribute(customAttr))
+      return false;
   }
 
   return true;

--- a/test/Index/index_global_actors.swift
+++ b/test/Index/index_global_actors.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s | %FileCheck %s
+// REQUIRES: concurrency
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+// Closure attributes
+
+func f() {
+  _ = { @MainActor in }
+  // CHECK:      [[@LINE-1]]:10 | class/Swift | MainActor | s:ScM | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | function/Swift | f() | s:14swift_ide_test1fyyF
+  _ = { @CustomActor in }
+  // CHECK:      [[@LINE-1]]:10 | class/Swift | CustomActor | s:14swift_ide_test11CustomActorC | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | function/Swift | f() | s:14swift_ide_test1fyyF
+}
+
+// Function type attributes
+
+typealias MAIsolated = @MainActor (Int) -> ()
+// CHECK: [[@LINE-1]]:25 | class/Swift | MainActor | s:ScM | Ref | rel: 0
+// CHECK: [[@LINE-2]]:36 | struct/Swift | Int | s:Si | Ref | rel: 0
+typealias CAIsolated = @CustomActor () -> Int
+// CHECK: [[@LINE-1]]:25 | class/Swift | CustomActor | s:14swift_ide_test11CustomActorC | Ref | rel: 0
+// CHECK: [[@LINE-2]]:43 | struct/Swift | Int | s:Si | Ref | rel: 0
+
+// Declaration attributes
+
+@CustomActor
+// CHECK: [[@LINE-1]]:2 | class/Swift | CustomActor | s:14swift_ide_test11CustomActorC | Ref | rel: 0
+class CustomIsolated {
+  @CustomActor func customIsolated() {}
+  // CHECK:      [[@LINE-1]]:4 | class/Swift | CustomActor | s:14swift_ide_test11CustomActorC | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | instance-method/Swift | customIsolated() | s:14swift_ide_test14CustomIsolatedC06customE0yyF
+}


### PR DESCRIPTION
This fixes missing references to global actors in closures and function types. Without this patch, indexstore does not contain references to `MainActor` in the following:

```swift
_ = { @MainActor in }
typealias F = @MainActor () -> ()
```

This PR also adds tests for global actors as a declaration attributes, like `@MainActor struct S {}`. Those _do_ work without this patch (there are similar tests for result builder references), but I figured the additional tests can't hurt.
