### PR TITLE
ASTGen/SIL: Suppress Swift 6.0 retroactive conformance warnings

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -104,20 +104,28 @@ public extension CollectionLikeSequence {
 
 // Also make the lazy sequences a CollectionLikeSequence if the underlying sequence is one.
 
-extension LazySequence : CollectionLikeSequence,
-                         FormattedLikeArray, CustomStringConvertible, CustomReflectable
+extension LazySequence : /*@retroactive*/ SIL.CollectionLikeSequence,
+                         /*@retroactive*/ SIL.FormattedLikeArray,
+                         /*@retroactive*/ Swift.CustomStringConvertible,
+                         /*@retroactive*/ Swift.CustomReflectable
                          where Base: CollectionLikeSequence {}
 
-extension FlattenSequence : CollectionLikeSequence,
-                            FormattedLikeArray, CustomStringConvertible, CustomReflectable
+extension FlattenSequence : /*@retroactive*/ SIL.CollectionLikeSequence,
+                            /*@retroactive*/ SIL.FormattedLikeArray,
+                            /*@retroactive*/ Swift.CustomStringConvertible,
+                            /*@retroactive*/ Swift.CustomReflectable
                             where Base: CollectionLikeSequence {}
 
-extension LazyMapSequence : CollectionLikeSequence,
-                            FormattedLikeArray, CustomStringConvertible, CustomReflectable
+extension LazyMapSequence : /*@retroactive*/ SIL.CollectionLikeSequence,
+                            /*@retroactive*/ SIL.FormattedLikeArray,
+                            /*@retroactive*/ Swift.CustomStringConvertible,
+                            /*@retroactive*/ Swift.CustomReflectable
                             where Base: CollectionLikeSequence {}
 
-extension LazyFilterSequence : CollectionLikeSequence,
-                               FormattedLikeArray, CustomStringConvertible, CustomReflectable
+extension LazyFilterSequence : /*@retroactive*/ SIL.CollectionLikeSequence,
+                               /*@retroactive*/ SIL.FormattedLikeArray,
+                               /*@retroactive*/ Swift.CustomStringConvertible,
+                               /*@retroactive*/ Swift.CustomReflectable
                                where Base: CollectionLikeSequence {}
 
 //===----------------------------------------------------------------------===//

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -24,18 +24,18 @@ extension BridgedNullable {
   }
 }
 
-extension BridgedSourceLoc: BridgedNullable {}
-extension BridgedIdentifier: BridgedNullable {}
-extension BridgedNullableExpr: BridgedNullable {}
-extension BridgedNullableStmt: BridgedNullable {}
-extension BridgedNullableTypeRepr: BridgedNullable {}
-extension BridgedNullablePattern: BridgedNullable {}
-extension BridgedNullableGenericParamList: BridgedNullable {}
-extension BridgedNullableTrailingWhereClause: BridgedNullable {}
-extension BridgedNullableParameterList: BridgedNullable {}
-extension BridgedNullablePatternBindingInitializer: BridgedNullable {}
+extension BridgedSourceLoc: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedIdentifier: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableExpr: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableStmt: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableTypeRepr: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullablePattern: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableGenericParamList: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableTrailingWhereClause: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullableParameterList: /*@retroactive*/ swiftASTGen.BridgedNullable {}
+extension BridgedNullablePatternBindingInitializer: /*@retroactive*/ swiftASTGen.BridgedNullable {}
 
-extension BridgedIdentifier: Equatable {
+extension BridgedIdentifier: /*@retroactive*/ Swift.Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.raw == rhs.raw
   }
@@ -91,7 +91,7 @@ public extension BridgedSourceLoc {
   }
 }
 
-extension BridgedLabeledStmtInfo: ExpressibleByNilLiteral {
+extension BridgedLabeledStmtInfo: /*@retroactive*/ Swift.ExpressibleByNilLiteral {
   public init(nilLiteral: ()) {
     self.init()
   }
@@ -149,7 +149,7 @@ extension BridgedStringRef {
   }
 }
 
-extension BridgedStringRef: ExpressibleByStringLiteral {
+extension BridgedStringRef: /*@retroactive*/ Swift.ExpressibleByStringLiteral {
   public init(stringLiteral str: StaticString) {
     self.init(data: str.utf8Start, count: str.utf8CodeUnitCount)
   }


### PR DESCRIPTION
When building ASTGen and SIL using the Swift 6.0 compiler the compiler emits diagnostics about various retroactive conformances. Since Swift code in the compiler needs to remain compatible with the Swift 5.10 compiler for now, use module qualification syntax to suppress the warning. I've also included the `@retroactive` attribute in a comment to document the retroactive conformance acknowledgement more explicitly.

NFC.
