### PR TITLE
[cxx-interop] Modularize __msvc_bit_utils on Windows

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -718,8 +718,13 @@ ValueDecl *getImportedMemberOperator(const DeclBaseName &name,
 } // namespace importer
 
 struct ClangInvocationFileMapping {
+  /// Mapping from a file name to an existing file path.
   SmallVector<std::pair<std::string, std::string>, 2> redirectedFiles;
+
+  /// Mapping from a file name to a string of characters that represents the
+  /// contents of the file.
   SmallVector<std::pair<std::string, std::string>, 1> overridenFiles;
+
   bool requiresBuiltinHeadersInSystemModules;
 };
 

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,6 +702,11 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
+    explicit module __msvc_bit_utils {
+      header "__msvc_bit_utils.hpp"
+      export *
+    }
+
     explicit module xatomic {
       header "xatomic.h"
       export *

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -1,3 +1,9 @@
+module StdNumeric {
+  header "std-numeric.h"
+  requires cplusplus
+  export *
+}
+
 module StdVector {
   header "std-vector.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-numeric.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-numeric.h
@@ -1,0 +1,5 @@
+#include <numeric>
+
+inline int64_t getGCD(int64_t a, int64_t b) {
+  return std::gcd(a, b);
+}

--- a/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20
+
+import StdNumeric
+
+let _ = getGCD(12, 15)


### PR DESCRIPTION
`__msvc_bit_utils.hpp` was added in a recent version of MSVC, and it is causing build errors for SwiftCompilerSources:
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:12: error: function '_Select_countr_zero_impl<unsigned long long, (lambda at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:55)>' with deduced return type cannot be used before it is defined
    return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
```

This change references the `__msvc_bit_utils.hpp` header from the modulemap. Since we still need to support older versions of Visual Studio that do not provide `__msvc_bit_utils.hpp`, this also teaches ClangImporter to inject an empty header file named `__msvc_bit_utils.hpp` into the system include directory, unless it already exists.

rdar://137066642