### PR TITLE
Adds SelectiveTransform playground option with @_PlaygroundTransformed

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -513,7 +513,11 @@ DECL_ATTR(lifetime, Lifetime,
   OnAccessor | OnConstructor | OnFunc | OnSubscript | LongAttribute | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | AllowMultipleAttributes,
   161)
 
-LAST_DECL_ATTR(Lifetime)
+SIMPLE_DECL_ATTR(_PlaygroundTransformed, PlaygroundTransformed,
+  OnFunc | OnConstructor | OnDestructor | OnAccessor | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  162)
+
+LAST_DECL_ATTR(PlaygroundTransformed)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/Basic/PlaygroundOptions.def
+++ b/include/swift/Basic/PlaygroundOptions.def
@@ -37,4 +37,7 @@ PLAYGROUND_OPTION(ScopeEvents, "Scope entry/exit events",
 PLAYGROUND_OPTION(FunctionParameters, "Values of function parameters",
   /* enabled by default */ true, /* enabled in high-perf mode */ false)
 
+PLAYGROUND_OPTION(SelectiveTransform, "Only transform explicitly annotated code",
+  /* enabled by default */ false, /* enabled in high-perf mode */ false)
+
 #undef PLAYGROUND_OPTION

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -243,6 +243,7 @@ extension ASTGenVisitor {
         .nsManaged,
         .objCMembers,
         .objCNonLazyRealization,
+        .playgroundTransformed,
         .preconcurrency,
         .preInverseGenerics,
         .propertyWrapper,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -185,6 +185,7 @@ public:
   IGNORED_ATTR(LexicalLifetimes)
   IGNORED_ATTR(AllowFeatureSuppression)
   IGNORED_ATTR(PreInverseGenerics)
+  IGNORED_ATTR(PlaygroundTransformed)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1731,6 +1731,7 @@ namespace  {
     UNINTERESTING_ATTR(StaticExclusiveOnly)
     UNINTERESTING_ATTR(PreInverseGenerics)
     UNINTERESTING_ATTR(Lifetime)
+    UNINTERESTING_ATTR(PlaygroundTransformed)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/test/PlaygroundTransform/Inputs/TestMacro1.swift
+++ b/test/PlaygroundTransform/Inputs/TestMacro1.swift
@@ -1,0 +1,9 @@
+import PlaygroundSupport
+import TestMacro1
+
+#StructMacro
+
+func macroTesting() {
+  let r = MacroStruct.f()
+}
+

--- a/test/PlaygroundTransform/Inputs/TestMacro1Definition.swift
+++ b/test/PlaygroundTransform/Inputs/TestMacro1Definition.swift
@@ -1,0 +1,20 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StructMacro: DeclarationMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext) throws -> [DeclSyntax] {
+        return [
+        """
+        struct MacroStruct {
+            @_PlaygroundTransformed
+            static func f() -> [Int] {
+                print(#function)
+                return [1, 2, 3, 4]
+            }
+        }
+        """]
+    }
+}

--- a/test/PlaygroundTransform/Inputs/TestMacro1Freestanding.swift
+++ b/test/PlaygroundTransform/Inputs/TestMacro1Freestanding.swift
@@ -1,0 +1,2 @@
+@freestanding(declaration, names: named(MacroStruct))
+public macro StructMacro() = #externalMacro(module: "TestMacro1Macros", type: "StructMacro")

--- a/test/PlaygroundTransform/playgroundtransformed_no_transform.swift
+++ b/test/PlaygroundTransform/playgroundtransformed_no_transform.swift
@@ -1,0 +1,23 @@
+// Tests the `@_PlaygroundTransformed` function annotation
+// without any Playground transform enabled.
+// The annotation shouldn't have any affect in this case.
+//
+// REQUIRES: executable_test
+//
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+//
+// - Normal compilation, no transform
+// RUN: %target-build-swift -o %t/main -I=%t %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// Annotated function - silently ignored
+@_PlaygroundTransformed
+func f(x: Int, _ y: Float = 7.62) -> Int {
+    return x + Int(y)
+}
+let foo = f(x: 42)
+print("foo=\(foo)")
+
+// CHECK:      foo=49

--- a/test/PlaygroundTransform/playgroundtransformed_with_selective_transform.swift
+++ b/test/PlaygroundTransform/playgroundtransformed_with_selective_transform.swift
@@ -1,0 +1,225 @@
+// Tests the `-playground-option SelectiveTransform` flag and
+// the `@_PlaygroundTransformed` function annotation.
+//
+// REQUIRES: executable_test
+//
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+//
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-option -Xfrontend SelectiveTransform -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+//
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-option -Xfrontend SelectiveTransform -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+
+import PlaygroundSupport
+
+// This function won't be transformed and so won't generate any logging
+func g(w: Int, h: Int) -> Int {
+    return w * h
+}
+let goo = g(w: 10, h: 20)
+
+// Only this function will be transformed and generate logging
+@_PlaygroundTransformed
+func f(x: Int, _ y: Float = 7.62) -> Int {
+    return x + Int(y)
+}
+let foo = f(x: 42)
+
+// CHECK:      {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='42']
+// CHECK-NEXT: {{.*}} __builtin_log[y='7.62']
+// CHECK-NEXT: {{.*}} __builtin_log[='49']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+struct S {
+  // Non-annotated method
+  func func0(i0: Int) -> Int {
+    return i0 + 0
+  }
+
+  // Annotated method
+  @_PlaygroundTransformed
+  func func1(i1: Int) -> Int {
+    return i1 + 1
+  }
+
+  // Annotated static method
+  @_PlaygroundTransformed
+  static func func2(i2: Int) -> Int {
+    return i2 + 2
+  }
+}
+let s = S()
+s.func0(i0: 0)
+
+s.func1(i1: 1)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i1='1']
+// CHECK-NEXT: {{.*}} __builtin_log[='2']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+S.func2(i2: 2)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i2='2']
+// CHECK-NEXT: {{.*}} __builtin_log[='4']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+class C {
+  // Non-annotated method
+  func func0(i0: Int) -> Int {
+    return i0 + 0
+  }
+
+  // Annotated method
+  @_PlaygroundTransformed
+  func func1(i1: Int) -> Int {
+    return i1 + 1
+  }
+
+  // Annotated static method
+  @_PlaygroundTransformed
+  static func func2(i2: Int) -> Int {
+    return i2 + 2
+  }
+
+  // Annotated class method
+  @_PlaygroundTransformed
+  static func func3(i3: Int) -> Int {
+    return i3 + 3
+  }
+}
+
+let c = C()
+c.func0(i0: 0)
+
+c.func1(i1: 1)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i1='1']
+// CHECK-NEXT: {{.*}} __builtin_log[='2']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+C.func2(i2: 2)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i2='2']
+// CHECK-NEXT: {{.*}} __builtin_log[='4']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+C.func3(i3: 3)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i3='3']
+// CHECK-NEXT: {{.*}} __builtin_log[='6']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+extension C {
+  // Annotated func on extension
+  @_PlaygroundTransformed
+  func func4(i4: Int) -> Int {
+    return i4 + 4
+  }
+}
+
+c.func4(i4: 4)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[i4='4']
+// CHECK-NEXT: {{.*}} __builtin_log[='8']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+func quadrupled(x: Int) -> Int {
+    @_PlaygroundTransformed
+    func double(xx: Int) -> Int {
+        return xx * 2
+    }
+
+    return double(xx: double(xx: x))
+}
+quadrupled(x: 4)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[xx='4']
+// CHECK-NEXT: {{.*}} __builtin_log[='8']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[xx='8']
+// CHECK-NEXT: {{.*}} __builtin_log[='16']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+@_PlaygroundTransformed
+func tripled(t: Int) -> Int {
+    func _triple(tt: Int) -> Int {
+        return tt * 3
+    }
+
+    return _triple(tt: t)
+}
+tripled(t: 4)
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[t='4']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[tt='4']
+// CHECK-NEXT: {{.*}} __builtin_log[='12']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[='12']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+
+// @_PlaygroundTransformed can be used on init/deinit
+// and get/set/didSet for vars.
+class D {
+    var _negative: Int {
+        @_PlaygroundTransformed
+        didSet {
+            let actualValue = -_negative
+            print(actualValue)
+        }
+    }
+    var foo: Int {
+        @_PlaygroundTransformed
+        get {
+            let getValue = -_negative
+            return getValue
+        }
+        @_PlaygroundTransformed
+        set {
+            let setValue = -newValue
+            _negative = setValue
+        }
+    }
+    @_PlaygroundTransformed
+    init() {
+        let init_value = 0
+        _negative = 0
+    }
+    @_PlaygroundTransformed
+    deinit {
+        let deinit_value = 0
+        _negative = deinit_value
+    }
+}
+var d: D? = D()
+d!.foo = 42
+d!.foo
+d = nil
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[init_value='0']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[newValue='42']
+// CHECK-NEXT: {{.*}} __builtin_log[setValue='-42']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[actualValue='42']
+// CHECK-NEXT: 42
+// CHECK-NEXT: {{.*}} __builtin_postPrint
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[self='main{{.?}}.D']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[getValue='42']
+// CHECK-NEXT: {{.*}} __builtin_log[='42']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[deinit_value='0']
+// CHECK-NEXT: {{.*}} __builtin_log[self='main{{.?}}.D']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit

--- a/test/PlaygroundTransform/playgroundtransformed_with_selective_transform_macros.swift
+++ b/test/PlaygroundTransform/playgroundtransformed_with_selective_transform_macros.swift
@@ -1,0 +1,27 @@
+// Tests the `-playground-option SelectiveTransform` flag and the
+// `@_PlaygroundTransformed` function annotation in a Swift declaration macro.
+//
+// REQUIRES: executable_test
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/plugins)
+//
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/plugins/%target-library-name(TestMacro1Macros) -module-name=TestMacro1Macros %S/Inputs/TestMacro1Definition.swift -g -no-toolchain-stdlib-rpath
+//
+// XRUN: %target-build-swift -swift-version 5 -emit-module -o %t/TestMacro1.swiftmodule %S/Inputs/TestMacro1Freestanding.swift -module-name TestMacro1 -enable-library-evolution -emit-module-interface -load-plugin-library %t/plugins/%target-library-name(TestMacro1Macros)
+//
+// XRUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+//
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-option -Xfrontend SelectiveTransform -load-plugin-library %t/plugins/%target-library-name(TestMacro1Macros) -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift %S/Inputs/TestMacro1.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// Calls the function in Inputs/TestMacro1.swoft
+macroTesting()
+
+// CHECK:      {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: f()
+// CHECK-NEXT: {{.*}} __builtin_postPrint
+// CHECK-NEXT: {{.*}} __builtin_log[='[1, 2, 3, 4]']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit

--- a/test/PlaygroundTransform/playgroundtransformed_with_transform.swift
+++ b/test/PlaygroundTransform/playgroundtransformed_with_transform.swift
@@ -1,0 +1,50 @@
+// Tests the `@_PlaygroundTransformed` function annotation
+// with Playground transforms enabled but without the
+// `SelectiveTransform` playground option enabled.
+// The annotation shouldn't have any affect in this case,
+// all the code will be transformed.
+//
+// REQUIRES: executable_test
+//
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+//
+// - Transformed, No SelectiveTransform
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main1b -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main1b
+// RUN: %target-run %t/main1b | %FileCheck %s
+//
+// - Transformed + PC-Macro, No SelectiveTransform
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2b -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2b
+// RUN: %target-run %t/main2b | %FileCheck %s
+
+import PlaygroundSupport
+
+// Non-annotated function
+func a(w: Int, h: Int) -> Int {
+    return w * h
+}
+let area = a(w: 10, h: 20)
+
+// CHECK:      {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[w='10']
+// CHECK-NEXT: {{.*}} __builtin_log[h='20']
+// CHECK-NEXT: {{.*}} __builtin_log[='200']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[area='200']
+
+// Annotated function
+@_PlaygroundTransformed
+func f(x: Int, _ y: Float = 7.62) -> Int {
+    return x + Int(y)
+}
+let foo = f(x: 42)
+
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='42']
+// CHECK-NEXT: {{.*}} __builtin_log[y='7.62']
+// CHECK-NEXT: {{.*}} __builtin_log[='49']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[foo='49']


### PR DESCRIPTION
### Overview

In cases where playground logging is only needed for very specific parts of a Swift file, it would be great to be able to selectively transform only the code of interest.  This change introduces just such a playground option, `SelectiveTransform`.  This option opts-out all code in a source file from being transformed by default, except for code explicitly annotated.

Transforming only the context of specific functions is the first area of interest for using this option.  A new function annotation, `@_PlaygroundTransformed`, is introduced by this change to explicitly target annotated functions for being selectively transformed.

The `@_PlaygroundTransformed` annotation is otherwise ignored if the new `SelectiveTransform` option is not used or the code is not being transformed at all.

### Future

Opting in other declaration types for being selectively transformed could be of interest in the future, but is out of scope for this change, in the interests of keeping the change and the test coverage manageable.

rdar://137088043
