### PR TITLE
Parser: Move availability macro definition cache to a request

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -69,7 +69,6 @@ namespace swift {
   class AbstractFunctionDecl;
   class ASTContext;
   enum class Associativity : unsigned char;
-  class AvailabilityMacroMap;
   class AvailabilityRange;
   class BoundGenericType;
   class BuiltinTupleDecl;
@@ -987,12 +986,6 @@ public:
     // This didn't fit the pattern, so needed renaming
     return getMultiPayloadEnumTagSinglePayloadAvailability();
   }
-
-  /// Cache of the availability macros parsed from the command line arguments.
-  ///
-  /// This is an implementation detail, access via
-  /// \c Parser::parseAllAvailabilityMacroArguments.
-  AvailabilityMacroMap &getAvailabilityMacroCache() const;
 
   /// Test support utility for loading a platform remap file
   /// in case an SDK is not specified to the compilation.

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -224,7 +224,6 @@ public:
   typedef llvm::DenseMap<llvm::VersionTuple,
                          SmallVector<AvailabilitySpec *, 4>> VersionEntry;
 
-  bool WasParsed = false;
   llvm::DenseMap<StringRef, VersionEntry> Impl;
 };
 

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -25,6 +25,7 @@
 namespace swift {
 
 struct ASTNode;
+class AvailabilityMacroMap;
 
 /// Report that a request of the given kind is being evaluated, so it
 /// can be recorded by the stats reporter.
@@ -191,6 +192,30 @@ private:
       Evaluator &evaluator, SourceFile *SF, SourceRange conditionRange,
       bool shouldEvaluate) const;
 };
+
+/// Parse the availability macros definitions passed as arguments.
+class AvailabilityMacroArgumentsRequest
+    : public SimpleRequest<AvailabilityMacroArgumentsRequest,
+                           AvailabilityMacroMap(ASTContext *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  AvailabilityMacroMap evaluate(Evaluator &evaluator, ASTContext *ctx) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+
+  // Source location.
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+};
+
+void simple_display(llvm::raw_ostream &out, const ASTContext *state);
 
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -34,3 +34,6 @@ SWIFT_REQUEST(Parse, ExportedSourceFileRequest,
 SWIFT_REQUEST(Parse, EvaluateIfConditionRequest,
               (std::pair<bool, bool>)(SourceFile *, SourceRange, bool), Uncached,
               NoLocationInfo)
+SWIFT_REQUEST(Parse, AvailabilityMacroArgumentsRequest,
+              (AvailabilityMacroMap)(ASTContext *), Cached,
+              NoLocationInfo)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2064,7 +2064,7 @@ public:
   parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   /// Parse the availability macros definitions passed as arguments.
-  AvailabilityMacroMap &parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap parseAllAvailabilityMacroArguments();
 
   /// Result of parsing an availability macro definition.
   struct AvailabilityMacroDefinition {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -426,9 +426,6 @@ struct ASTContext::Implementation {
   /// Singleton used to cache the import graph.
   swift::namelookup::ImportCache TheImportCache;
 
-  /// Cache of availability macros parsed from the command line.
-  AvailabilityMacroMap TheAvailabilityMacroCache;
-
   /// The module loader used to load Clang modules.
   ClangModuleLoader *TheClangModuleLoader = nullptr;
 
@@ -2282,10 +2279,6 @@ void ASTContext::verifyAllLoadedModules() const {
 
 swift::namelookup::ImportCache &ASTContext::getImportCache() const {
   return getImpl().TheImportCache;
-}
-
-AvailabilityMacroMap &ASTContext::getAvailabilityMacroCache() const {
-  return getImpl().TheAvailabilityMacroCache;
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2063,7 +2063,7 @@ void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
 }
 
 bool Parser::peekAvailabilityMacroName() {
-  AvailabilityMacroMap &Map = parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap Map = parseAllAvailabilityMacroArguments();
 
   StringRef MacroName = Tok.getText();
   return Map.Impl.find(MacroName) != Map.Impl.end();
@@ -2072,7 +2072,7 @@ bool Parser::peekAvailabilityMacroName() {
 ParserStatus
 Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   // Get the macros from the compiler arguments.
-  AvailabilityMacroMap &Map = parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap Map = parseAllAvailabilityMacroArguments();
 
   StringRef MacroName = Tok.getText();
   auto NameMatch = Map.Impl.find(MacroName);
@@ -2112,13 +2112,19 @@ Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   return makeParserSuccess();
 }
 
-AvailabilityMacroMap &Parser::parseAllAvailabilityMacroArguments() {
-  AvailabilityMacroMap &Map = Context.getAvailabilityMacroCache();
-  if (Map.WasParsed)
-    return Map;
+AvailabilityMacroMap
+Parser::parseAllAvailabilityMacroArguments() {
+  return evaluateOrDefault(Context.evaluator,
+                           AvailabilityMacroArgumentsRequest{&Context},
+                           AvailabilityMacroMap());
+}
 
-  SourceManager &SM = Context.SourceMgr;
-  LangOptions LangOpts = Context.LangOpts;
+AvailabilityMacroMap
+AvailabilityMacroArgumentsRequest::evaluate(Evaluator &evaluator,
+                                            ASTContext *ctx) const {
+  AvailabilityMacroMap Map;
+  SourceManager &SM = ctx->SourceMgr;
+  LangOptions LangOpts = ctx->LangOpts;
 
   // Allocate all buffers in one go to avoid repeating the sorting in
   // findBufferContainingLocInternal.
@@ -2135,11 +2141,11 @@ AvailabilityMacroMap &Parser::parseAllAvailabilityMacroArguments() {
     swift::ParserUnit PU(SM, SourceFileKind::Main, bufferID, LangOpts,
                          TypeCheckerOptions(), SILOptions(), "unknown");
 
-    ForwardingDiagnosticConsumer PDC(Context.Diags);
+    ForwardingDiagnosticConsumer PDC(ctx->Diags);
     PU.getDiagnosticEngine().addConsumer(PDC);
 
     // Parse the argument.
-    AvailabilityMacroDefinition ParsedMacro;
+    Parser::AvailabilityMacroDefinition ParsedMacro;
     ParserStatus Status =
       PU.getParser().parseAvailabilityMacroDefinition(ParsedMacro);
     if (Status.isError())
@@ -2152,7 +2158,7 @@ AvailabilityMacroMap &Parser::parseAllAvailabilityMacroArguments() {
       if (auto *PlatformVersionSpec =
           dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec)) {
         auto SpecCopy =
-          new (Context) PlatformVersionConstraintAvailabilitySpec(
+          new (*ctx) PlatformVersionConstraintAvailabilitySpec(
                                                          *PlatformVersionSpec);
         SpecsCopy.push_back(SpecCopy);
       }
@@ -2170,8 +2176,11 @@ AvailabilityMacroMap &Parser::parseAllAvailabilityMacroArguments() {
     auto PreviousEntry =
       MacroDefinition.insert({ParsedMacro.Version, ParsedMacro.Specs});
     if (!PreviousEntry.second) {
-      diagnose(PU.getParser().PreviousLoc, diag::attr_availability_duplicate,
-               ParsedMacro.Name, ParsedMacro.Version.getAsString());
+      auto &Diags = ctx->Diags;
+      Diags.diagnose(PU.getParser().PreviousLoc,
+                     diag::attr_availability_duplicate,
+                     ParsedMacro.Name, ParsedMacro.Version.getAsString());
+
     }
 
     // Save back the macro spec.
@@ -2179,8 +2188,12 @@ AvailabilityMacroMap &Parser::parseAllAvailabilityMacroArguments() {
     Map.Impl.insert({ParsedMacro.Name, MacroDefinition});
   }
 
-  Map.WasParsed = true;
   return Map;
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const ASTContext *value) {
+  out << "ASTContext: " << value;
 }
 
 ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,


### PR DESCRIPTION
Update the availability macro definitions caching logic to use the request evaluator.

Follow up to https://github.com/swiftlang/swift/pull/76794.