### PR TITLE
[cxx-interop] Conform `std::set` to `ExpressibleByArrayLiteral`

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -883,6 +883,8 @@ void swift::conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element,
                                valueType->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.Id_ArrayLiteralElement,
+                               valueType->getUnderlyingType());
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
                                sizeType->getUnderlyingType());
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("InsertionResult"),

--- a/stdlib/public/Cxx/CxxSet.swift
+++ b/stdlib/public/Cxx/CxxSet.swift
@@ -16,7 +16,7 @@
 /// `std::multiset` conform to this protocol.
 ///
 /// - SeeAlso: `CxxUniqueSet`
-public protocol CxxSet<Element> {
+public protocol CxxSet<Element>: ExpressibleByArrayLiteral {
   associatedtype Element
   associatedtype Size: BinaryInteger
 
@@ -45,6 +45,11 @@ extension CxxSet {
     for item in sequence {
       self.__insertUnsafe(item)
     }
+  }
+
+  @inlinable
+  public init(arrayLiteral elements: Element...) {
+    self.init(elements)
   }
 
   /// Returns a Boolean value that indicates whether the given element exists

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -75,6 +75,51 @@ StdSetTestSuite.test("UnorderedSetOfCInt.init()") {
     expectTrue(s.contains(3))
 }
 
+StdSetTestSuite.test("SetOfCInt as ExpressibleByArrayLiteral") {
+    let s: SetOfCInt = [1, 3, 5]
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+
+    func takesSetOfCInt(_ s: SetOfCInt) {
+        expectTrue(s.contains(1))
+        expectTrue(s.contains(2))
+        expectFalse(s.contains(3))
+    }
+
+    takesSetOfCInt([1, 2])
+}
+
+StdSetTestSuite.test("UnorderedSetOfCInt as ExpressibleByArrayLiteral") {
+    let s: UnorderedSetOfCInt = [1, 3, 5]
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+
+    func takesUnorderedSetOfCInt(_ s: UnorderedSetOfCInt) {
+        expectTrue(s.contains(1))
+        expectTrue(s.contains(2))
+        expectFalse(s.contains(3))
+    }
+
+    takesUnorderedSetOfCInt([1, 2])
+}
+
+StdSetTestSuite.test("MultisetOfCInt as ExpressibleByArrayLiteral") {
+    let s: MultisetOfCInt = [1, 1, 3]
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+
+    func takesMultisetOfCInt(_ s: MultisetOfCInt) {
+        expectTrue(s.contains(1))
+        expectTrue(s.contains(2))
+        expectFalse(s.contains(3))
+    }
+
+    takesMultisetOfCInt([1, 1, 2])
+}
+
 StdSetTestSuite.test("SetOfCInt.insert") {
     var s = SetOfCInt()
     expectFalse(s.contains(123))


### PR DESCRIPTION
Swift's own `Set` conforms to `ExpressibleByArrayLiteral`. This change conforms instantiations of C++ `std::set` to `ExpressibleByArrayLiteral` as well.

This makes it possible to pass an array literal as an argument to a function that takes a `std::set` as parameter.

rdar://137126325

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
