### PR TITLE
[CAS] Make CAS plugin options to be cache invariant

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1999,11 +1999,11 @@ def cas_path: Separate<["-"], "cas-path">,
   HelpText<"Path to CAS">, MetaVarName<"<path>">;
 
 def cas_plugin_path: Separate<["-"], "cas-plugin-path">,
-  Flags<[FrontendOption, NewDriverOnlyOption]>,
+  Flags<[FrontendOption, NewDriverOnlyOption, CacheInvariant]>,
   HelpText<"Path to CAS Plugin">, MetaVarName<"<path>">;
 
 def cas_plugin_option: Separate<["-"], "cas-plugin-option">,
-  Flags<[FrontendOption, NewDriverOnlyOption]>,
+  Flags<[FrontendOption, NewDriverOnlyOption, CacheInvariant]>,
   HelpText<"Option pass to CAS Plugin">, MetaVarName<"<name>=<option>">;
 
 def clang_scanner_module_cache_path : Separate<["-"], "clang-scanner-module-cache-path">,

--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -50,6 +50,14 @@
 // RUN: diff %t5.casid %t6.casid
 // RUN: not diff %t5.casid %t7.casid
 
+/// Check switching CAS plugin path.
+// RUN: %cache-tool -cas-path %t/cas -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -cas-path %t/cas -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext > %t8.casid
+// RUN: ln -s %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext %t/libCASPluginTest%llvm_plugin_ext
+// RUN: %cache-tool -cas-path %t/cas -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -cas-path %t/cas -cas-plugin-path %t/libCASPluginTest%llvm_plugin_ext > %t9.casid
+// RUN: diff %t8.casid %t9.casid
+
 /// Test output keys.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \


### PR DESCRIPTION
Do not add CAS configurations into cache key computation. This ensure if the cache keys are identical if two functionally equivalent plugins are used. This is safe to do because if any of the CAS configurations changes how the cache key is computed, they are going to be directly reflected in the cache key without adding its configuration into the key.

rdar://137091843

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
