### PR TITLE
[concurrency] Implement _runOnMainActor

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -958,6 +958,9 @@ JobPriority swift_task_getCurrentThreadPriority(void);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_startOnMainActor(AsyncTask* job);
 
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) bool swift_task_isOnMainActor();
+
 /// Donate this thread to the global executor until either the
 /// given condition returns true or we've run out of cooperative
 /// tasks to run.

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -413,6 +413,10 @@ OVERRIDE_TASK(task_startOnMainActor, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
               swift::, (AsyncTask *task), (task))
 
+OVERRIDE_TASK(task_isOnMainActor, bool,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::,,)
+
 #undef OVERRIDE
 #undef OVERRIDE_ACTOR
 #undef OVERRIDE_TASK

--- a/stdlib/public/Concurrency/TaskTrackingPrivate.h
+++ b/stdlib/public/Concurrency/TaskTrackingPrivate.h
@@ -1,0 +1,120 @@
+//===--- TaskTrackingPrivate.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_CONCURRENCY_TASKTRACKINGPRIVATE_H
+#define SWIFT_STDLIB_CONCURRENCY_TASKTRACKINGPRIVATE_H
+
+#include "VoucherSupport.h"
+#include "swift/ABI/Actor.h"
+#include "swift/ABI/Task.h"
+#include "swift/Threading/ThreadLocalStorage.h"
+
+namespace swift {
+namespace tasktracking {
+
+/// An extremely silly class which exists to make pointer
+/// default-initialization constexpr.
+template <class T>
+struct Pointer {
+  T *Value;
+  constexpr Pointer() : Value(nullptr) {}
+  constexpr Pointer(T *value) : Value(value) {}
+  operator T *() const { return Value; }
+  T *operator->() const { return Value; }
+};
+
+/// A class which encapsulates the information we track about
+/// the current thread and active executor.
+class ExecutorTrackingInfo {
+  /// A thread-local variable pointing to the active tracking
+  /// information about the current thread, if any.
+  ///
+  /// TODO: this is obviously runtime-internal and therefore not
+  /// reasonable to make ABI. We might want to also provide a way
+  /// for generated code to efficiently query the identity of the
+  /// current executor, in order to do a cheap comparison to avoid
+  /// doing all the work to suspend the task when we're already on
+  /// the right executor. It would make sense for that to be a
+  /// separate thread-local variable (or whatever is most efficient
+  /// on the target platform).
+  static SWIFT_THREAD_LOCAL_TYPE(Pointer<ExecutorTrackingInfo>,
+                                 tls_key::concurrency_executor_tracking_info)
+      ActiveInfoInThread;
+
+  /// The active executor.
+  SerialExecutorRef ActiveExecutor = SerialExecutorRef::generic();
+
+  /// The current task executor, if present, otherwise `undefined`.
+  /// The task executor should be used to execute code when the active executor
+  /// is `generic`.
+  TaskExecutorRef TaskExecutor = TaskExecutorRef::undefined();
+
+  /// Whether this context allows switching.  Some contexts do not;
+  /// for example, we do not allow switching from swift_job_run
+  /// unless the passed-in executor is generic.
+  bool AllowsSwitching = true;
+
+  VoucherManager voucherManager;
+
+  /// The tracking info that was active when this one was entered.
+  ExecutorTrackingInfo *SavedInfo;
+
+public:
+  ExecutorTrackingInfo() = default;
+
+  ExecutorTrackingInfo(const ExecutorTrackingInfo &) = delete;
+  ExecutorTrackingInfo &operator=(const ExecutorTrackingInfo &) = delete;
+
+  /// Unconditionally initialize a fresh tracking state on the
+  /// current state, shadowing any previous tracking state.
+  /// leave() must be called before the object goes out of scope.
+  void enterAndShadow(SerialExecutorRef currentExecutor,
+                      TaskExecutorRef taskExecutor) {
+    ActiveExecutor = currentExecutor;
+    TaskExecutor = taskExecutor;
+    SavedInfo = ActiveInfoInThread.get();
+    ActiveInfoInThread.set(this);
+  }
+
+  void swapToJob(Job *job) { voucherManager.swapToJob(job); }
+
+  void restoreVoucher(AsyncTask *task) { voucherManager.restoreVoucher(task); }
+
+  SerialExecutorRef getActiveExecutor() const { return ActiveExecutor; }
+  void setActiveExecutor(SerialExecutorRef newExecutor) {
+    ActiveExecutor = newExecutor;
+  }
+
+  TaskExecutorRef getTaskExecutor() const { return TaskExecutor; }
+
+  void setTaskExecutor(TaskExecutorRef newExecutor) {
+    TaskExecutor = newExecutor;
+  }
+
+  bool allowsSwitching() const { return AllowsSwitching; }
+
+  /// Disallow switching in this tracking context.  This should only
+  /// be set on a new tracking info, before any jobs are run in it.
+  void disallowSwitching() { AllowsSwitching = false; }
+
+  static ExecutorTrackingInfo *current() { return ActiveInfoInThread.get(); }
+
+  void leave() {
+    voucherManager.leave();
+    ActiveInfoInThread.set(SavedInfo);
+  }
+};
+
+} // namespace tasktracking
+} // namespace swift
+
+#endif // SWIFT_STDLIB_CONCURRENCY_TASKTRACKINGPRIVATE_H

--- a/test/Concurrency/Runtime/Inputs/RunOnMainActor.h
+++ b/test/Concurrency/Runtime/Inputs/RunOnMainActor.h
@@ -1,0 +1,6 @@
+
+struct dispatch_queue_s;
+
+extern struct dispatch_queue_s _dispatch_main_q;
+
+static inline void *getDispatchMain() { return (void *)&_dispatch_main_q; }

--- a/test/Concurrency/Runtime/isOnMainActor.swift
+++ b/test/Concurrency/Runtime/isOnMainActor.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: asserts
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+@usableFromInline
+@_silgen_name("swift_task_isOnMainActor")
+internal func _isOnMainActor() -> Bool
+
+@MainActor
+func main() async {
+  precondition(_isOnMainActor())
+
+  nonisolated func test() async {
+    precondition(!_isOnMainActor())
+  }
+
+  await test()
+
+  precondition(_isOnMainActor())
+}
+
+await main()

--- a/test/Concurrency/Runtime/runOnMainActor.swift
+++ b/test/Concurrency/Runtime/runOnMainActor.swift
@@ -1,0 +1,60 @@
+// RUN: %target-run-simple-swift( -import-objc-header %S/Inputs/RunOnMainActor.h )
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: libdispatch
+// REQUIRES: asserts
+
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+import Dispatch
+
+// MARK: Test runOnMainActor in all modes. We use the one future proof API in
+// dispatch: dispatch_assert_queue.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@_silgen_name("dispatch_assert_queue")
+func dispatch_assertQueue(_ ptr: UnsafeRawPointer)
+
+func checkIfOnMainQueue() {
+  dispatch_assertQueue(getDispatchMain())
+}
+
+actor Custom {
+}
+
+@globalActor
+struct CustomActor {
+  static var shared: Custom {
+    return Custom()
+  }
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+let tests = TestSuite("RunOnMainActor")
+
+tests.test("RunOnMainActor on MainActor") {
+  Task { @MainActor in
+    try _runOnMainActor { @MainActor in
+      checkIfOnMainQueue()
+    }
+  }
+}
+
+tests.test("RunOnMainActor off MainActor") {
+  Task { @CustomActor in
+    try _runOnMainActor { @MainActor in
+      checkIfOnMainQueue()
+    }
+  }
+}
+
+await runAllTestsAsync()

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -330,6 +330,10 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_startOnMainActorImpl) {
   swift_task_startOnMainActor(nullptr);
 }
 
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_isOnMainActor) {
+  swift_task_isOnMainActor();
+}
+
 #if RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_asyncMainDrainQueue) {
 


### PR DESCRIPTION
This PR implements the new runtime routine swift_task_isOnMainActor() which returns true if one is on the main actor. It does this by in non-Swift Concurrency code checking for the main thread and in swift concurrency mode returns true if the current executor is the main executor. I backwards deploy it back to Swift 5.1 on Darwin by using swift runtime APIs and dispatch APIs.