### PR TITLE
[stdlib][android] ignore the -Wgnu-offsetof-extensions in ExecutorChe…

### DIFF
--- a/stdlib/public/Concurrency/ExecutorChecks.cpp
+++ b/stdlib/public/Concurrency/ExecutorChecks.cpp
@@ -23,6 +23,9 @@
 
 #include "ExecutorImpl.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-offsetof-extensions"
+
 // JobFlags
 static_assert(sizeof(swift::JobFlags) == sizeof(SwiftJobFlags));
 
@@ -65,3 +68,5 @@ static_assert((SwiftClockId)swift::swift_clock_id_continuous
               == SwiftContinuousClock);
 static_assert((SwiftClockId)swift::swift_clock_id_suspending
               == SwiftSuspendingClock);
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
…cks.cpp

ExecutorChecks.cpp no longer builds for android as -Wgnu -Werror is used for stdlib
