### PR TITLE
[CMake] Reorganize CMakeLists.txt for ASTGen

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -80,24 +80,7 @@ add_pure_swift_host_library(swiftIDEUtilsBridging
     swiftASTGen
 )
 
-set(c_include_paths
-  # LLVM modules and headers.
-  "${LLVM_MAIN_INCLUDE_DIR}"
-  # Generated LLVM headers.
-  "${LLVM_INCLUDE_DIR}"
-  # Clang modules and headers.
-  ${CLANG_INCLUDE_DIRS}
-  # Bridging modules and headers.
-  "${SWIFT_MAIN_INCLUDE_DIR}"
-  # Generated C headers.
-  "${CMAKE_CURRENT_BINARY_DIR}/../../include")
-set(c_include_paths_args)
-foreach(c_include_path ${c_include_paths})
-  list(APPEND c_include_paths_args "SHELL: -Xcc -I -Xcc ${c_include_path}")
-endforeach()
-
 set(compile_options
-  ${c_include_paths_args}
   "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT"
 
   # FIXME: Needed to work around an availability issue with CxxStdlib

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(ASTGen_Swift_dependencies)
+add_subdirectory(Sources)
 
 # If requested, build the regular expression parser into the compiler itself.
 if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
@@ -14,69 +14,7 @@ if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   add_pure_swift_host_library(_CompilerRegexParser STATIC
     "${COMPILER_REGEX_PARSER_SOURCES}"
   )
-
-  list(APPEND ASTGen_Swift_dependencies _CompilerRegexParser)
+else()
+  # Dummy target for dependencies
+  add_custom_target(_CompilerRegexParser)
 endif()
-
-add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
-  Sources/ASTGen/ASTGen.swift
-  Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
-  Sources/ASTGen/Bridge.swift
-  Sources/ASTGen/CompilerBuildConfiguration.swift
-  Sources/ASTGen/DeclAttrs.swift
-  Sources/ASTGen/Decls.swift
-  Sources/ASTGen/Diagnostics.swift
-  Sources/ASTGen/DiagnosticsBridge.swift
-  Sources/ASTGen/Exprs.swift
-  Sources/ASTGen/Generics.swift
-  Sources/ASTGen/LegacyParse.swift
-  Sources/ASTGen/Literals.swift
-  Sources/ASTGen/ParameterClause.swift
-  Sources/ASTGen/Patterns.swift
-  Sources/ASTGen/Regex.swift
-  Sources/ASTGen/SourceFile.swift
-  Sources/ASTGen/Stmts.swift
-  Sources/ASTGen/TypeAttrs.swift
-  Sources/ASTGen/Types.swift
-
-  DEPENDENCIES
-    swiftAST
-  SWIFT_DEPENDENCIES
-    _CompilerSwiftSyntax
-    _CompilerSwiftIfConfig
-    _CompilerSwiftOperators
-    _CompilerSwiftSyntaxBuilder
-    _CompilerSwiftParser
-    _CompilerSwiftParserDiagnostics
-    _CompilerSwiftDiagnostics
-    ${ASTGen_Swift_dependencies}
-)
-
-add_pure_swift_host_library(swiftMacros STATIC CXX_INTEROP
-  Sources/Macros/Macros.swift
-  Sources/Macros/PluginHost.swift
-  Sources/Macros/SourceManager.swift
-
-  DEPENDENCIES
-    swiftAST
-  SWIFT_DEPENDENCIES
-    _CompilerSwiftCompilerPluginMessageHandling
-    _CompilerSwiftDiagnostics
-    _CompilerSwiftOperators
-    _CompilerSwiftParser
-    _CompilerSwiftSyntax
-    _CompilerSwiftSyntaxMacroExpansion
-    swiftASTGen
-)
-
-add_pure_swift_host_library(swiftIDEUtilsBridging CXX_INTEROP
-  Sources/SwiftIDEUtilsBridging/NameMatcherBridging.swift
-  
-  DEPENDENCIES
-    swiftAST
-  SWIFT_DEPENDENCIES
-    _CompilerSwiftIDEUtils
-    _CompilerSwiftSyntax
-    _CompilerSwiftIDEUtils
-    swiftASTGen
-)

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -18,7 +18,7 @@ if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   list(APPEND ASTGen_Swift_dependencies _CompilerRegexParser)
 endif()
 
-add_pure_swift_host_library(swiftASTGen STATIC
+add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   Sources/ASTGen/ASTGen.swift
   Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
   Sources/ASTGen/Bridge.swift
@@ -52,7 +52,7 @@ add_pure_swift_host_library(swiftASTGen STATIC
     ${ASTGen_Swift_dependencies}
 )
 
-add_pure_swift_host_library(swiftMacros STATIC
+add_pure_swift_host_library(swiftMacros STATIC CXX_INTEROP
   Sources/Macros/Macros.swift
   Sources/Macros/PluginHost.swift
   Sources/Macros/SourceManager.swift
@@ -69,7 +69,7 @@ add_pure_swift_host_library(swiftMacros STATIC
     swiftASTGen
 )
 
-add_pure_swift_host_library(swiftIDEUtilsBridging
+add_pure_swift_host_library(swiftIDEUtilsBridging CXX_INTEROP
   Sources/SwiftIDEUtilsBridging/NameMatcherBridging.swift
   
   DEPENDENCIES
@@ -77,36 +77,6 @@ add_pure_swift_host_library(swiftIDEUtilsBridging
   SWIFT_DEPENDENCIES
     _CompilerSwiftIDEUtils
     _CompilerSwiftSyntax
+    _CompilerSwiftIDEUtils
     swiftASTGen
 )
-
-set(compile_options
-  "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT"
-
-  # FIXME: Needed to work around an availability issue with CxxStdlib
-  "SHELL: -Xfrontend -disable-target-os-checking"
-
-  # Necessary to avoid treating IBOutlet and IBAction as keywords
-  "SHELL:-Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable"
-)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  list(APPEND compile_options
-    # Make 'offsetof()' a const value.
-    "SHELL:-Xcc -D_CRT_USE_BUILTIN_OFFSETOF"
-    # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
-    "SHELL:-Xcc -Xclang -Xcc -fmodule-format=raw")
-endif()
-
-# Prior to 5.9, we have to use the experimental flag for C++ interop.
-if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.9)
-  list(APPEND compile_options "SHELL:-Xfrontend -enable-experimental-cxx-interop")
-else()
-  list(APPEND compile_options "-cxx-interoperability-mode=default")
-endif()
-
-if(SWIFT_BUILD_SWIFT_SYNTAX)
-  foreach(target swiftASTGen swiftIDEUtilsBridging swiftMacros)
-    target_compile_options(${target} PRIVATE ${compile_options})
-  endforeach()
-endif()

--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
+  ASTGen.swift
+  ASTGen+CompilerBuildConfiguration.swift
+  Bridge.swift
+  CompilerBuildConfiguration.swift
+  DeclAttrs.swift
+  Decls.swift
+  Diagnostics.swift
+  DiagnosticsBridge.swift
+  Exprs.swift
+  Generics.swift
+  LegacyParse.swift
+  Literals.swift
+  ParameterClause.swift
+  Patterns.swift
+  Regex.swift
+  SourceFile.swift
+  Stmts.swift
+  TypeAttrs.swift
+  Types.swift
+
+  DEPENDENCIES
+    swiftAST
+  SWIFT_DEPENDENCIES
+    _CompilerRegexParser
+    _CompilerSwiftSyntax
+    _CompilerSwiftIfConfig
+    _CompilerSwiftOperators
+    _CompilerSwiftSyntaxBuilder
+    _CompilerSwiftParser
+    _CompilerSwiftParserDiagnostics
+    _CompilerSwiftDiagnostics
+)

--- a/lib/ASTGen/Sources/CMakeLists.txt
+++ b/lib/ASTGen/Sources/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(ASTGen)
+add_subdirectory(Macros)
+add_subdirectory(SwiftIDEUtilsBridging)

--- a/lib/ASTGen/Sources/Macros/CMakeLists.txt
+++ b/lib/ASTGen/Sources/Macros/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_pure_swift_host_library(swiftMacros STATIC CXX_INTEROP
+  Macros.swift
+  PluginHost.swift
+  SourceManager.swift
+
+  DEPENDENCIES
+    swiftAST
+  SWIFT_DEPENDENCIES
+    _CompilerSwiftCompilerPluginMessageHandling
+    _CompilerSwiftDiagnostics
+    _CompilerSwiftOperators
+    _CompilerSwiftParser
+    _CompilerSwiftSyntax
+    _CompilerSwiftSyntaxMacroExpansion
+    swiftASTGen
+)

--- a/lib/ASTGen/Sources/SwiftIDEUtilsBridging/CMakeLists.txt
+++ b/lib/ASTGen/Sources/SwiftIDEUtilsBridging/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_pure_swift_host_library(swiftIDEUtilsBridging CXX_INTEROP
+  NameMatcherBridging.swift
+
+  DEPENDENCIES
+    swiftAST
+  SWIFT_DEPENDENCIES
+    _CompilerSwiftIDEUtils
+    _CompilerSwiftSyntax
+    _CompilerSwiftIDEUtils
+    swiftASTGen
+)


### PR DESCRIPTION
* Remove redundant `-Xcc -I -Xcc ${include_path}`. All required paths are provided by the dependencies, or `include_directories()`, and `swiftc -I` paths are propagated to ClangImporter. So no need to specify them explicitly.
* Sink C/C++ interop related options to `add_pure_swift_host_library()`, and add `CXX_INTEROP`  option to control them.
* Move `add_pure_swift_host_library()` to each source directory instead of doing everything in `lib/ASTGen/CMakeLists.txt`