### PR TITLE
[cxx-interop] Use the name of the typedef when an unnamed class is used as a template argument

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -66,6 +66,8 @@ struct TemplateInstantiationNamePrinter
   std::string VisitRecordType(const clang::RecordType *type) {
     auto tagDecl = type->getAsTagDecl();
     if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(tagDecl)) {
+      if (auto typeDefDecl = tagDecl->getTypedefNameForAnonDecl())
+        namedArg = typeDefDecl;
       llvm::SmallString<128> storage;
       llvm::raw_svector_ostream buffer(storage);
       nameImporter->importName(namedArg, version, clang::DeclarationName())

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -76,4 +76,21 @@ struct HasStaticOperatorCall {
   static int operator()(int x) { return x * 2; }
 };
 
+typedef struct {
+  int a;
+} Anon0;
+
+typedef struct {
+  int a;
+} Anon1;
+
+template <class T>
+struct S {
+  ~S() {}
+  int method0();
+};
+
+using AnonType0 = S<Anon0>;
+using AnonType1 = S<Anon1>;
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -11,9 +11,39 @@ protocol HasReturn42 {
 // CHECK: [[OUT:%.*]] = call i32 @{{_ZN18ConformsToProtocol8return42Ev|"\?return42@ConformsToProtocol@@QEAAHXZ"}}(ptr
 // CHECK: ret i32 [[OUT]]
 
+// CHECK: define hidden swiftcc i32 @"$sSo0014SAnon0_wuJCavaV4mainE7method0s5Int32VyF"(
+// CHECK: ret i32 123
+
+// CHECK: define internal swiftcc i32 @"$sSo0014SAnon0_wuJCavaV4main1PA2cDP7method0s5Int32VyFTW"(
+// CHECK: %[[V1:.*]] = call swiftcc i32 @"$sSo0014SAnon0_wuJCavaV4mainE7method0s5Int32VyF"(
+// CHECK: ret i32 %[[V1]]
+
+// CHECK: define hidden swiftcc i32 @"$sSo0014SAnon1_wuJCavaV4mainE7method0s5Int32VyF"(
+// CHECK: ret i32 234
+
+// CHECK: define internal swiftcc i32 @"$sSo0014SAnon1_wuJCavaV4main1PA2cDP7method0s5Int32VyFTW"(
+// CHECK: %[[V1:.*]] = call swiftcc i32 @"$sSo0014SAnon1_wuJCavaV4mainE7method0s5Int32VyF"(
+// CHECK: ret i32 %[[V1]]
+
 // CHECK: define {{.*}}%swift.metadata_response @"$sSo18ConformsToProtocolVMa"({{i64|i32}} [[ARG:%.*]])
 // CHECK: load ptr, ptr @"$sSo18ConformsToProtocolVML"
 // CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata({{i64|i32}} [[ARG]]
 // CHECK: ret %swift.metadata_response
 
 extension ConformsToProtocol : HasReturn42 {}
+
+protocol P {
+  func method0() -> Int32
+}
+
+extension AnonType0 : P {
+  func method0() -> Int32 {
+    return 123
+  }
+}
+
+extension AnonType1 : P {
+  func method0() -> Int32 {
+    return 234
+  }
+}


### PR DESCRIPTION
This fixes a bug where IRGen would try to use the same name for two different protocol witness methods.

rdar://134149098