### PR TITLE
[cxx-interop] Conform `std::map` to `ExpressibleByDictionaryLiteral`

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -14,9 +14,9 @@
 ///
 /// C++ standard library types such as `std::map` and `std::unordered_map`
 /// conform to this protocol.
-public protocol CxxDictionary<Key, Value> {
-  associatedtype Key
-  associatedtype Value
+public protocol CxxDictionary<Key, Value>: ExpressibleByDictionaryLiteral {
+  override associatedtype Key
+  override associatedtype Value
   associatedtype Element: CxxPair<Key, Value>
   associatedtype RawIterator: UnsafeCxxInputIterator
     where RawIterator.Pointee == Element
@@ -61,6 +61,14 @@ extension CxxDictionary {
   public init(_ dictionary: Dictionary<Key, Value>) where Key: Hashable {
     self.init()
     for (key, value) in dictionary {
+      self[key] = value
+    }
+  }
+
+  @inlinable
+  public init(dictionaryLiteral elements: (Key, Value)...) {
+    self.init()
+    for (key, value) in elements {
       self[key] = value
     }
   }

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -71,6 +71,35 @@ StdMapTestSuite.test("MapStrings.init(_: Dictionary<std.string, std.string>)") {
   expectEqual(emptyM.size(), 0)
 }
 
+StdMapTestSuite.test("Map as ExpressibleByDictionaryLiteral") {
+  let m: Map = [-1 : 2, 2 : 3, 33 : 44]
+  expectEqual(m.size(), 3)
+
+  func takesMap(_ m: Map) {
+    expectEqual(m[-1], 2)
+    expectEqual(m[2], 3)
+    expectEqual(m[33], 44)
+  }
+
+  takesMap(m)
+  takesMap([-1 : 2, 2 : 3, 33 : 44])
+}
+
+/// Same as above, but for std::unordered_map.
+StdMapTestSuite.test("UnorderedMap as ExpressibleByDictionaryLiteral") {
+  let m: UnorderedMap = [-1 : 2, 2 : 3, 33 : 44]
+  expectEqual(m.size(), 3)
+
+  func takesUnorderedMap(_ m: UnorderedMap) {
+    expectEqual(m[-1], 2)
+    expectEqual(m[2], 3)
+    expectEqual(m[33], 44)
+  }
+
+  takesUnorderedMap(m)
+  takesUnorderedMap([-1 : 2, 2 : 3, 33 : 44])
+}
+
 StdMapTestSuite.test("Map.subscript") {
   // This relies on the `std::map` conformance to `CxxDictionary` protocol.
   var m = initMap()


### PR DESCRIPTION
This adds an automatic conformance for `std::map` and `std::unordered_map` to Swift's `ExpressibleByDictionaryLiteral` protocol.

This makes it possible to pass a dictionary literal as an argument to a function that takes a `std::map` as parameter.

rdar://137126474

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
