### PR TITLE
IRGen: Add the ability to mark certain generic entry points in back traces

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -492,6 +492,8 @@ public:
   // (LLVM's 'frame-pointer=all').
   unsigned AsyncFramePointerAll : 1;
 
+  unsigned UseProfilingMarkerThunks : 1;
+
   /// The number of threads for multi-threaded code generation.
   unsigned NumThreads = 0;
 
@@ -582,7 +584,7 @@ public:
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false), EnableHotColdSplit(false),
         EmitAsyncFramePushPopMetadata(false), EmitYieldOnce2AsYieldOnce(true),
-        AsyncFramePointerAll(false), CmdArgs(),
+        UseProfilingMarkerThunks(false), AsyncFramePointerAll(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1349,6 +1349,13 @@ def disable_new_llvm_pass_manager :
   Flag<["-"], "disable-new-llvm-pass-manager">,
   HelpText<"Disable the new llvm pass manager">;
 
+def enable_profiling_marker_thunks :
+  Flag<["-"], "enable-profiling-marker-thunks">,
+  HelpText<"Enable profiling marker thunks">;
+def disable_profiling_marker_thunks :
+  Flag<["-"], "disable-profiling-marker-thunks">,
+  HelpText<"Disable profiling marker thunks">;
+
 def enable_objective_c_protocol_symbolic_references :
   Flag<["-"], "enable-objective-c-protocol-symbolic-references">,
   HelpText<"Enable objective-c protocol symbolic references">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3473,6 +3473,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Args.hasFlag(OPT_enable_fragile_resilient_protocol_witnesses,
                  OPT_disable_fragile_resilient_protocol_witnesses,
                  Opts.UseFragileResilientProtocolWitnesses);
+  Opts.UseProfilingMarkerThunks =
+    Args.hasFlag(OPT_enable_profiling_marker_thunks,
+                 OPT_disable_profiling_marker_thunks,
+                 Opts.UseProfilingMarkerThunks);
   Opts.EmitYieldOnce2AsYieldOnce =
       !LangOpts.hasFeature(Feature::CoroutineAccessorsAllocateInCallee);
   Opts.EnableHotColdSplit =

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -77,6 +77,8 @@ protected:
   /// RemainingArgsForCallee, at least between calls.
   bool EmittedCall;
 
+  bool UseProfilingThunk = false;
+
   /// The basic block to which the call to a potentially throwing foreign
   /// function should jump to continue normal execution of the program.
   llvm::BasicBlock *invokeNormalDest = nullptr;
@@ -121,6 +123,10 @@ public:
 
   SubstitutionMap getSubstitutions() const {
     return CurCallee.getSubstitutions();
+  }
+
+  void useProfilingThunk() {
+    UseProfilingThunk = true;
   }
 
   virtual void begin();

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -374,6 +374,15 @@ namespace irgen {
     }
 
   public:
+
+    FunctionPointer withProfilingThunk(llvm::Function *thunk) const {
+      auto res = FunctionPointer(kind, thunk, nullptr/*secondaryValue*/,
+                                 AuthInfo, Sig);
+      res.useSignature = useSignature;
+      return res;
+    }
+
+
     FunctionPointer()
         : kind(FunctionPointer::Kind::Function), Value(nullptr),
           SecondaryValue(nullptr) {}

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1636,7 +1636,17 @@ public:
         if (Func->isAsync()) {
           witness = IGM.getAddrOfAsyncFunctionPointer(Func);
         } else {
-          witness = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+
+          auto *conformance = dyn_cast<NormalProtocolConformance>(&Conformance);
+          auto f = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+          if (IGM.getOptions().UseProfilingMarkerThunks &&
+              conformance &&
+              conformance->getDeclContext()->
+                getSelfNominalTypeDecl()->isGenericContext() &&
+                !Func->getLoweredFunctionType()->isCoroutine())
+            witness = IGM.getAddrOfWitnessTableProfilingThunk(f, *conformance);
+          else witness = f;
+
         }
       } else {
         // The method is removed by dead method elimination.
@@ -2013,11 +2023,18 @@ void ResilientWitnessTableBuilder::collectResilientWitnesses(
 
     SILFunction *Func = entry.getMethodWitness().Witness;
     llvm::Constant *witness;
+    bool isGenericConformance =
+      conformance.getDeclContext()->getSelfNominalTypeDecl()->isGenericContext();
     if (Func) {
       if (Func->isAsync())
         witness = IGM.getAddrOfAsyncFunctionPointer(Func);
-      else
-        witness = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+      else {
+        auto f = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+        if (isGenericConformance && IGM.getOptions().UseProfilingMarkerThunks &&
+            !Func->getLoweredFunctionType()->isCoroutine())
+          witness = IGM.getAddrOfWitnessTableProfilingThunk(f, conformance);
+        else witness = f;
+      }
     } else {
       // The method is removed by dead method elimination.
       // It should be never called. We add a null pointer.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1477,6 +1477,12 @@ void IRGenModule::setHasNoFramePointer(llvm::Function *F) {
   F->addFnAttrs(b);
 }
 
+void IRGenModule::setMustHaveFramePointer(llvm::Function *F) {
+  llvm::AttrBuilder b(getLLVMContext());
+  b.addAttribute("frame-pointer", "all");
+  F->addFnAttrs(b);
+}
+
 /// Construct initial function attributes from options.
 void IRGenModule::constructInitialFnAttributes(
     llvm::AttrBuilder &Attrs, OptimizationMode FuncOptMode,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1586,6 +1586,7 @@ public:
       StackProtectorMode stackProtect = StackProtectorMode::NoStackProtector);
   void setHasNoFramePointer(llvm::AttrBuilder &Attrs);
   void setHasNoFramePointer(llvm::Function *F);
+  void setMustHaveFramePointer(llvm::Function *F);
   llvm::AttributeList constructInitialAttributes();
   StackProtectorMode shouldEmitStackProtector(SILFunction *f);
 
@@ -1660,7 +1661,8 @@ public:
   llvm::Constant *getAddrOfMethodDescriptor(SILDeclRef declRef,
                                             ForDefinition_t forDefinition);
   void emitNonoverriddenMethodDescriptor(const SILVTable *VTable,
-                                         SILDeclRef declRef);
+                                         SILDeclRef declRef,
+                                         ClassDecl *classDecl);
 
   Address getAddrOfEnumCase(EnumElementDecl *Case,
                             ForDefinition_t forDefinition);
@@ -1820,6 +1822,16 @@ public:
   getAddrOfSILFunction(SILFunction *f, ForDefinition_t forDefinition,
                        bool isDynamicallyReplaceableImplementation = false,
                        bool shouldCallPreviousImplementation = false);
+
+  llvm::Function *
+  getAddrOfWitnessTableProfilingThunk(llvm::Function *witness,
+                                      const NormalProtocolConformance &C);
+
+  llvm::Function *
+  getAddrOfVTableProfilingThunk(llvm::Function *f, ClassDecl *decl);
+
+  llvm::Function *getOrCreateProfilingThunk(llvm::Function *f,
+                                            StringRef prefix);
 
   void emitDynamicReplacementOriginalFunctionThunk(SILFunction *f);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3835,6 +3835,15 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     SubstitutionMap subMap = site.getSubstitutionMap();
     emitPolymorphicArguments(*this, origCalleeType,
                              subMap, &witnessMetadata, llArgs);
+
+    // We currently only support non-async calls with profiling thunks.
+    if (IGM.getOptions().UseProfilingMarkerThunks &&
+        isa<FunctionRefInst>(site.getCallee()) &&
+        !site.getOrigCalleeType()->isAsync() &&
+        subMap.hasAnySubstitutableParams() &&
+        !subMap.getRecursiveProperties().hasPrimaryArchetype()) {
+      emission->useProfilingThunk();
+    }
   }
 
   if (calleeFP.shouldPassContinuationDirectly()) {

--- a/test/IRGen/profiling_marker_thunks.swift
+++ b/test/IRGen/profiling_marker_thunks.swift
@@ -1,0 +1,114 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/P.swiftmodule -module-name=P %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -module-name A -I %t -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name A -I %t -enable-library-evolution -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name A -I %t -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s --check-prefix=ATTRIBUTE
+// RUN: %target-swift-frontend -module-name A -I %t -disable-profiling-marker-thunks -emit-ir %s | %FileCheck %s --check-prefix=NOTHUNK
+// RUN: %target-swift-frontend -module-name A -I %t -emit-ir %s | %FileCheck %s --check-prefix=NOTHUNK
+
+// UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
+
+// NOTHUNK-NOT: __swift_prof_thunk
+
+import P
+
+open class GenericClass<T> {
+  var x: T
+  public init(_ t: T) {
+    x = t
+  }
+
+  public func someMethod() -> Int {
+    return 20
+  }
+}
+
+open class PlainClass {
+  var x: Int
+
+  public init() {
+    x = 10
+  }
+
+  public func someMethod() -> Int {
+    return 20
+  }
+}
+
+public protocol SomeProto {
+  associatedtype T
+
+  func retAssoc() -> T
+  func plain() throws
+}
+
+public struct Conformer<T> : SomeProto {
+  var x : T
+
+  public init( _ t: T) {
+    self.x = t
+  }
+
+  public func retAssoc() -> T {
+    return x
+  }
+
+  public func plain() throws { print(x) }
+}
+
+struct SomeGenericThing<T, V> {
+  init(_ t: T, _ v: V) {}
+}
+
+public struct ResilientConformer<T> : ResilientBaseProtocol {
+  var t : T
+
+  public func requirement() -> Int {
+    return 5
+  }
+}
+
+public func generic<T>(_ t: T) {
+  print(t)
+}
+public func test() {
+  generic(SomeGenericThing(1, 3.0))
+}
+
+// CHECK: @"$s1A9ConformerVyxGAA9SomeProtoAAWp" = {{.*}} @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP8retAssoc1TQzyFTW"
+// CHECK-SAME: @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"
+
+// CHECK: @"$s1A18ResilientConformerVyxG1P0A12BaseProtocolAAMc" = constant {{.*}} @"__swift_prof_thunk__generic_witness__$s1A18ResilientConformerVyxG1P0A12BaseProtocolAaeFP11requirementSiyFTW"
+
+// CHECK: @"$s1A12GenericClassCMn" = constant {{.*}} @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"
+// CHECK-SAME: @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC10someMethodSiyF"
+
+// CHECK: @"$s1A10PlainClassCMn" = {{.*}}@"$s1A10PlainClassC10someMethodSiyF"
+
+// CHECK: define swiftcc void @"$s1A4testyyF"()
+// CHECK:  call swiftcc void @"__swift_prof_thunk__generic_func__2__$sSiN___$sSdN___fun__$s1A16SomeGenericThingVyACyxq_Gx_q_tcfC"
+// CHECK:  call swiftcc void @"__swift_prof_thunk__generic_func__1__$s1A16SomeGenericThingVySiSdGN___fun__$s1A7genericyyxlF"
+// CHECK:  ret void
+
+// CHECK: define {{.*}} swiftcc void @"__swift_prof_thunk__generic_func__1__$s1A16SomeGenericThingVySiSdGN___fun__$s1A7genericyyxlF"(ptr noalias %0, ptr %1) #[[ATTR:[0-9]+]]
+// CHECK: call swiftcc void @"$s1A7genericyyxlF"(ptr noalias %0, ptr %1)
+// CHECK: ret
+
+// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"({{.*}}) #[[ATTR]] {
+// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"({{.*}}) #[[ATTR]] {
+
+// CHECK: attributes #[[ATTR]] = { noinline "frame-pointer"="all"
+
+
+// ATTRIBUTE: define {{.*}} ptr @"__swift_prof_thunk__generic_func__1__$sypN___fun__$ss27_finalizeUninitializedArrayySayxGABnlF"({{.*}}) #[[ATTR:[0-9]+]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_func__2__$sSiN___$sSdN___fun__$s1A16SomeGenericThingVyACyxq_Gx_q_tcfC"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_func__1__$s1A16SomeGenericThingVySiSdGN___fun__$s1A7genericyyxlF"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP8retAssoc1TQzyFTW"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} i64 @"__swift_prof_thunk__generic_witness__$s1A18ResilientConformerVyxG1P0A12BaseProtocolAaeFP11requirementSiyFTW"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvs"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} ptr @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassCyACyxGxcfC"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} i64 @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC10someMethodSiyF"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: #[[ATTR]] = { noinline "frame-pointer"="all"


### PR DESCRIPTION
Mark generic function calls with concrete parameters, generic v-table calls and generic witness table calls where self is generic.