### PR TITLE
[Test] Disable new parser validation in 3 tests

### DIFF
--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip'.
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithStaticMembers -disable-availability-checking -parse-stdlib -module-name keypaths %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithStaticMembers -disable-availability-checking -disable-experimental-parser-round-trip -parse-stdlib -module-name keypaths %s | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip'.
 
 // REQUIRES: asserts
 

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip'.
 // REQUIRES: asserts
 
 struct NE : ~Escapable {


### PR DESCRIPTION
These tests have syntax SwiftParser currently doesn't parse correctly.

* test/SILGen/keypaths.swift
   ```swift
  \M.Type.[2]
   ```
* test/SIL/lifetime_dependence_span_lifetime_attr.swift and test/Sema/lifetime_attr.swift
   ```swift
   @lifetime(borrow x)
   ```
