### PR TITLE
[ClangImporter] Update the error condition when delayed inputs are used

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1501,8 +1501,8 @@ ClangImporter::create(ASTContext &ctx,
     return importer;
 
   instance.initializeDelayedInputFileFromCAS();
-  if (instance.getDiagnostics().hasErrorOccurred())
-    return nullptr;
+  if (instance.getFrontendOpts().Inputs.empty())
+    return nullptr; // no inputs available.
 
   bool canBegin = action->BeginSourceFile(instance,
                                           instance.getFrontendOpts().Inputs[0]);


### PR DESCRIPTION
Return error only when no inputs are available, instead of relying on checking no errors occured in diagnostics.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
