### PR TITLE
Remove symbols that are no longer part of ABI

### DIFF
--- a/test/abi/macOS/x86_64/stdlib-asserts.swift
+++ b/test/abi/macOS/x86_64/stdlib-asserts.swift
@@ -59,10 +59,5 @@ Added: _$ss20__StaticArrayStorageCfd
 Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
 Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
 
-Added: _$ss24_RuntimeFunctionCountersV03numabC0SivpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimeB11NameToIndexSDySSSiGvpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimeB5NamesSaySSGvpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimebC7OffsetsSPys6UInt16VGvpZMV
-
 // Runtime Symbols
 Added: _swift_clearSensitive

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -671,10 +671,6 @@ Added: _$ss20ManagedBufferPointerV13_headerOffsetSivpZMV
 Added: _$ss20ManagedBufferPointerV14_alignmentMaskSivpZMV
 Added: _$ss20ManagedBufferPointerV14_elementOffsetSivpZMV
 Added: _$ss22__RawDictionaryStorageC5emptys07__EmptyB9SingletonCvpZMV
-Added: _$ss24_RuntimeFunctionCountersV03numabC0SivpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimeB11NameToIndexSDySSSiGvpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimeB5NamesSaySSGvpZMV
-Added: _$ss24_RuntimeFunctionCountersV07runtimebC7OffsetsSPys6UInt16VGvpZMV
 Added: _$ss4Int8V8bitWidthSivpZMV
 Added: _$ss5Int16V8bitWidthSivpZMV
 Added: _$ss5Int32V8bitWidthSivpZMV


### PR DESCRIPTION
Originally added in https://github.com/swiftlang/swift/pull/73242. https://github.com/swiftlang/swift/pull/76826 was up to remove them but we took https://github.com/swiftlang/swift/pull/76824 instead.

Resolves rdar://136918801.