### PR TITLE
[CMake] Don't enable library evolution for package CMO clients

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -153,29 +153,32 @@ function(_set_pure_swift_profile_flags target_name)
   endif()
 endfunction()
 
-function(_set_pure_swift_package_options target_name package_name)
+function(_set_pure_swift_package_options target_name package_name emit_module)
   if(NOT package_name OR NOT Swift_COMPILER_PACKAGE_CMO_SUPPORT)
     return()
   endif()
 
-  # Enable package CMO if possible.
-  # NOTE: '-enable-library-evolution' is required for package CMO even when we
-  # don't need '.swiftinterface'. E.g. executables.
-  if(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
-    target_compile_options("${target_name}" PRIVATE
-      "-enable-library-evolution"
-      "SHELL:-package-name ${package_name}"
-      "SHELL:-Xfrontend -package-cmo"
-      "SHELL:-Xfrontend -allow-non-resilient-access"
-    )
-  elseif(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
-    target_compile_options("${target_name}" PRIVATE
-      "-enable-library-evolution"
-      "SHELL:-package-name ${package_name}"
-      "SHELL:-Xfrontend -experimental-package-cmo"
-      "SHELL:-Xfrontend -experimental-allow-non-resilient-access"
-      "SHELL:-Xfrontend -experimental-package-bypass-resilience"
-    )
+  # Packge CMO clients need to be in the same package as the libraries..
+  target_compile_options("${target_name}" PRIVATE
+    "SHELL:-package-name ${package_name}"
+  )
+
+  if(emit_module)
+    # Enable package CMO if possible.
+    if(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
+      target_compile_options("${target_name}" PRIVATE
+        "-enable-library-evolution"
+        "SHELL:-Xfrontend -package-cmo"
+        "SHELL:-Xfrontend -allow-non-resilient-access"
+      )
+    elseif(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
+      target_compile_options("${target_name}" PRIVATE
+        "-enable-library-evolution"
+        "SHELL:-package-name ${package_name}"
+        "SHELL:-Xfrontend -experimental-package-cmo"
+        "SHELL:-Xfrontend -experimental-allow-non-resilient-access"
+      )
+    endif()
   endif()
 endfunction()
 
@@ -259,7 +262,7 @@ function(add_pure_swift_host_library name)
   # Create the library.
   add_library(${name} ${libkind} ${APSHL_SOURCES})
   _add_host_swift_compile_options(${name})
-  _set_pure_swift_package_options(${name} "${APSHL_PACKAGE_NAME}")
+  _set_pure_swift_package_options(${name} "${APSHL_PACKAGE_NAME}" "${APSHL_EMIT_MODULE}")
   if(APSHL_CXX_INTEROP)
     _set_swift_cxx_interop_options(${name})
   endif()
@@ -423,7 +426,7 @@ function(add_pure_swift_host_tool name)
   add_executable(${name} ${APSHT_SOURCES})
   _add_host_swift_compile_options(${name})
   _set_pure_swift_link_flags(${name} "../lib/")
-  _set_pure_swift_package_options(${name} "${APSHT_PACKAGE_NAME}")
+  _set_pure_swift_package_options(${name} "${APSHT_PACKAGE_NAME}" FALSE)
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
     set_property(TARGET ${name}


### PR DESCRIPTION
Clients of package CMO enabled libraies that doesn't provide `.swiftinterface` don't need to be built with library evolution. They just need to be in the same package.

TODO:
- [ ]  Test with 6.1-dev toolchain