### PR TITLE
[cxx-interop] Fix swift::Type to clang::QualType conversion to correctly handle foreign reference types

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -839,7 +839,11 @@ clang::QualType ClangTypeConverter::convert(Type type) {
     if (auto clangDecl = decl->getClangDecl()) {
       auto &ctx = ClangASTContext;
       if (auto clangTypeDecl = dyn_cast<clang::TypeDecl>(clangDecl)) {
-        return ctx.getTypeDeclType(clangTypeDecl).getUnqualifiedType();
+        auto qualType = ctx.getTypeDeclType(clangTypeDecl);
+        if (type->isForeignReferenceType()) {
+          qualType = ctx.getPointerType(qualType);
+        }
+        return qualType.getUnqualifiedType();
       } else if (auto ifaceDecl = dyn_cast<clang::ObjCInterfaceDecl>(clangDecl)) {
         auto clangType  = ctx.getObjCInterfaceType(ifaceDecl);
         return ctx.getObjCObjectPointerType(clangType);

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// A wrapper around C++'s static_cast(), which allows Swift to get around interop's current lack of support for inheritance.
+template <class I, class O> O cxxCast(I i) { return static_cast<O>(i); }
+
+// A minimal foreign reference type.
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+BaseT {
+public:
+    bool isBase;
+    BaseT() { isBase = true; }
+    BaseT(const BaseT &) = delete;
+    static BaseT &getBaseT() { static BaseT singleton; return singleton; }
+};
+
+// A foreign reference type that is a subclass of BaseT.
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+SubT : BaseT {
+public:
+    SubT() { isBase = false; }
+    SubT(const SubT &) = delete;
+    static SubT &getSubT() { static SubT singleton; return singleton; }
+};

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -18,6 +18,11 @@ module Nullable {
   requires cplusplus
 }
 
+module Inheritance {
+  header "inheritance.h"
+  requires cplusplus
+}
+
 module WitnessTable {
   header "witness-table.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/inheritance-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-typechecker.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
+
+import Inheritance
+
+// A function whose explicit type annotations specializes the cxxCast function.
+//
+// In Swift, the generic type parameters of cxxCast I and O should be respectively instantiated to SubT and BaseT.
+// However, since these are foreign reference types, this instantiates (and calls) cxxCast<SubT *, BaseT *> in C++.
+func cast(_ s: SubT) -> BaseT {
+    return cxxCast(s)
+}
+
+let s: SubT = SubT.getSubT()
+assert(!s.isBase)
+let sc: BaseT = cast(s)
+assert(!sc.isBase)
+let sx: BaseT = cxxCast(s)      // should instantiate I to SubT and O to BaseT
+assert(!sc.isBase)
+
+let b: BaseT = BaseT.getBaseT()
+assert(b.isBase)
+let bc: BaseT = cxxCast(b)      // should instantiate I and O both to BaseT
+assert(bc.isBase)

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -1,0 +1,33 @@
+// REQUIRES: executable_test
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs)
+
+import StdlibUnittest
+import Inheritance
+
+// A function whose explicit type annotations specializes the cxxCast function.
+//
+// In Swift, the generic type parameters of cxxCast I and O should be respectively instantiated to SubT and BaseT.
+// However, since these are foreign reference types, this instantiates (and calls) cxxCast<SubT *, BaseT *> in C++.
+func cast(_ s: SubT) -> BaseT {
+    return cxxCast(s)
+}
+
+var TemplatingTestSuite = TestSuite("Foreign references work with templates")
+
+TemplatingTestSuite.test("SubT") {
+    let s: SubT = SubT.getSubT()
+    assert(!s.isBase)
+    let sc: BaseT = cast(s)
+    assert(!sc.isBase)
+    let sx: BaseT = cxxCast(s)      // should instantiate I to SubT and O to BaseT
+    assert(!sc.isBase)
+}
+
+TemplatingTestSuite.test("BaseT") {
+    let b: BaseT = BaseT.getBaseT()
+    assert(b.isBase)
+    let bc: BaseT = cxxCast(b)      // should instantiate I and O both to BaseT
+    assert(bc.isBase)
+}
+
+runAllTests()


### PR DESCRIPTION
For types imported from C++, the original `clang::TypeDecl` is saved in the `swift::Type` and reused for conversions back to `clang::QualType`. However, the conversion did not account for foreign reference types,   which should be mapped to a pointer to the C++ record type, rather than    the record type itself.

This bug first appeared as a function template instantiation failure    due to a sanity check performed by `SwiftDeclConverter::foreignReferenceTypePassedByRef()`    but may also affect other round-tripping type conversions.    The added test case demonstrates the template instantiation scenario,    where templates were being used to overcome Swift/C++ interop's current    lack of support for class inheritance.

rdar://134979343