### PR TITLE
[Glibc] Remove WASI gyb logic from the modulemap

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -49,10 +49,8 @@ module SwiftGlibc [system] {
   export *
 }
 
-% if CMAKE_SDK != "WASI":
 module CUUID [system] {
   header "uuid/uuid.h"
   link "uuid"
   export *
 }
-% end


### PR DESCRIPTION
This is a minor cleanup of the generated Glibc modulemap.

WASI no longer uses the Glibc modulemap since 902d75e6.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
