### PR TITLE
[Concurrency] Fix racy test, too sensitive on println ordering

### DIFF
--- a/test/Concurrency/Runtime/async_task_executor_unstructured_task_ownership.swift
+++ b/test/Concurrency/Runtime/async_task_executor_unstructured_task_ownership.swift
@@ -80,7 +80,6 @@ nonisolated func nonisolatedFunc(expectedQueue queue: DispatchQueue) async {
     }
 
     executor = nil
-    print("In main: executor = nil")
 
     await task.value
     // The executor is ONLY released after the task has completed,


### PR DESCRIPTION
The test only checks Task done and then "deinit" happening, however there is another print that may happen in between. Since it's racy which one comes first, on slower instances -- like simulators, it could get in the way.

Remove the println we're not even checking for but that breaks the CHECK-NEXT

Resolves rdar://137221764

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
