### PR TITLE
[docs] FirstPullRequest: Turn CEWG team handle into a link

### DIFF
--- a/docs/HowToGuides/FirstPullRequest.md
+++ b/docs/HowToGuides/FirstPullRequest.md
@@ -139,7 +139,10 @@ Reviews are automatically requested from code owners per the
 [CODEOWNERS](/.github/CODEOWNERS) file upon opening a non-draft pull request.
 If this doesn't happen, @mention and ask a suggested person under **Reviewers**
 to review your changes in a comment. If no suggestions are shown either, please
-ask @swiftlang/contributor-experience to sort out review requests for you.
+ask [@swiftlang/contributor-experience][contributor-experience-team] to sort out
+review requests for you.
+
+[contributor-experience-team]: https://github.com/orgs/swiftlang/teams/contributor-experience
 
 You are welcome to invite other people for review as well — say, someone you
 had an active discussion with on how to implement your change.


### PR DESCRIPTION
GitHub handles do not work automatically in files.
