### PR TITLE
[cxx-interop] Remove redundant `[extern_c]` in tests

### DIFF
--- a/test/Interop/Cxx/apinotes/Inputs/module.modulemap
+++ b/test/Interop/Cxx/apinotes/Inputs/module.modulemap
@@ -1,4 +1,4 @@
-module SomeModule [extern_c] {
+module SomeModule {
   requires objc
   header "SomeModule.h"
 }

--- a/test/Interop/Cxx/availability/Inputs/module.modulemap
+++ b/test/Interop/Cxx/availability/Inputs/module.modulemap
@@ -1,4 +1,4 @@
-module SomeModule [extern_c] {
+module SomeModule {
   requires objc
   header "SomeModule.h"
 }

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -1,4 +1,4 @@
-module ProtocolNamingConflict [extern_c] {
+module ProtocolNamingConflict {
   header "protocol-naming-conflict.h"
   requires objc
 }


### PR DESCRIPTION
`[extern_c]` module attribute has no effect in these tests.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
