### PR TITLE
Embedded: specialized witness tables, part2: support remaining cases of class existentials

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Conformance.swift
+++ b/SwiftCompilerSources/Sources/AST/Conformance.swift
@@ -47,6 +47,16 @@ public struct Conformance: CustomStringConvertible, NoReflectionChildren {
     return bridged.getGenericConformance().conformance
   }
 
+  public var isInherited: Bool {
+    assert(isConcrete)
+    return bridged.isInheritedConformance()
+  }
+
+  public var inheritedConformance: Conformance {
+    assert(isInherited)
+    return bridged.getInheritedConformance().conformance
+  }
+
   public var specializedSubstitutions: SubstitutionMap {
     assert(isSpecialized)
     return SubstitutionMap(bridged: bridged.getSpecializedSubstitutions())

--- a/SwiftCompilerSources/Sources/AST/SubstitutionMap.swift
+++ b/SwiftCompilerSources/Sources/AST/SubstitutionMap.swift
@@ -18,7 +18,7 @@ import ASTBridging
 ///
 /// Substitution maps are primarily used when performing substitutions into any entity that
 /// can reference type parameters and conformances.
-public struct SubstitutionMap {
+public struct SubstitutionMap: CustomStringConvertible {
   public let bridged: BridgedSubstitutionMap
 
   public init(bridged: BridgedSubstitutionMap) {
@@ -27,6 +27,10 @@ public struct SubstitutionMap {
   
   public init() {
     self.bridged = BridgedSubstitutionMap()
+  }
+
+  public var description: String {
+    return String(taking: bridged.getDebugDescription())
   }
 
   public var isEmpty: Bool { bridged.isEmpty() }

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -37,6 +37,10 @@ public struct Type: CustomStringConvertible, NoReflectionChildren {
   public var isEscapable: Bool { bridged.isEscapable() }
   public var isNoEscape: Bool { bridged.isNoEscape() }
   public var isInteger: Bool { bridged.isInteger() }
+
+  public func subst(with substitutionMap: SubstitutionMap) -> Type {
+    return Type(bridged: bridged.subst(substitutionMap.bridged))
+  }
 }
 
 /// A Type that is statically known to be canonical.
@@ -55,4 +59,8 @@ public struct CanonicalType: CustomStringConvertible, NoReflectionChildren {
   public var isEscapable: Bool { type.isEscapable }
   public var isNoEscape: Bool { type.isNoEscape }
   public var isInteger: Bool { type.isInteger }
+
+  public func subst(with substitutionMap: SubstitutionMap) -> CanonicalType {
+    return type.subst(with: substitutionMap).canonical
+  }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -271,8 +271,9 @@ private func specializeWitnessTables(for initExRef: InitExistentialRefInst, _ co
     let origWitnessTable = context.lookupWitnessTable(for: conformance)
     if conformance.isSpecialized {
       if origWitnessTable == nil {
-        let wt = specializeWitnessTable(forConformance: conformance, errorLocation: initExRef.location, context)
-        worklist.addWitnessMethods(of: wt)
+        specializeWitnessTable(forConformance: conformance, errorLocation: initExRef.location, context) {
+          worklist.addWitnessMethods(of: $0)
+        }
       }
     } else if let origWitnessTable {
       checkForGenericMethods(in: origWitnessTable, errorLocation: initExRef.location, context)

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -116,6 +116,10 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         if context.options.enableEmbeddedSwift {
           _ = context.specializeClassMethodInst(classMethod)
         }
+      case let witnessMethod as WitnessMethodInst:
+        if context.options.enableEmbeddedSwift {
+          _ = context.specializeWitnessMethodInst(witnessMethod)
+        }
 
       case let initExRef as InitExistentialRefInst:
         if context.options.enableEmbeddedSwift {

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -271,7 +271,8 @@ private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlined
 private func specializeWitnessTables(for initExRef: InitExistentialRefInst, _ context: ModulePassContext,
                                      _ worklist: inout FunctionWorklist)
 {
-  for conformance in initExRef.conformances where conformance.isConcrete {
+  for c in initExRef.conformances where c.isConcrete {
+    let conformance = c.isInherited ? c.inheritedConformance : c
     let origWitnessTable = context.lookupWitnessTable(for: conformance)
     if conformance.isSpecialized {
       if origWitnessTable == nil {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -74,6 +74,14 @@ extension Context {
     return _bridged.lookupSpecializedVTable(classType.bridged).vTable
   }
 
+  func getSpecializedConformance(of genericConformance: Conformance,
+                                 for type: AST.`Type`,
+                                 substitutions: SubstitutionMap) -> Conformance
+  {
+    let c = _bridged.getSpecializedConformance(genericConformance.bridged, type.bridged, substitutions.bridged)
+    return Conformance(bridged: c)
+  }
+
   func notifyNewFunction(function: Function, derivedFrom: Function) {
     _bridged.addFunctionToPassManagerWorklist(function.bridged, derivedFrom.bridged)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -357,6 +357,15 @@ struct FunctionPassContext : MutatingContext {
     return false
   }
 
+  func specializeWitnessMethodInst(_ wm: WitnessMethodInst) -> Bool {
+    if _bridged.specializeWitnessMethodInst(wm.bridged) {
+      notifyInstructionsChanged()
+      notifyCallsChanged()
+      return true
+    }
+    return false
+  }
+
   func specializeApplies(in function: Function, isMandatory: Bool) -> Bool {
     if _bridged.specializeAppliesInFunction(function.bridged, isMandatory) {
       notifyInstructionsChanged()

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -78,7 +78,8 @@ func specializeVTablesOfSuperclasses(_ moduleContext: ModulePassContext) {
 
 func specializeWitnessTable(forConformance conformance: Conformance,
                             errorLocation: Location,
-                            _ context: ModulePassContext) -> WitnessTable
+                            _ context: ModulePassContext,
+                            _ notifyNewWitnessTable: (WitnessTable) -> ())
 {
   let genericConformance = conformance.genericConformance
   guard let witnessTable = context.lookupWitnessTable(for: genericConformance) else {
@@ -107,5 +108,7 @@ func specializeWitnessTable(forConformance conformance: Conformance,
     }
     return origEntry
   }
-  return context.createWitnessTable(entries: newEntries, conformance: conformance, linkage: .shared, serialized: false)
+  let newWT = context.createWitnessTable(entries: newEntries,conformance: conformance,
+                                         linkage: .shared, serialized: false)
+  notifyNewWitnessTable(newWT)
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -102,11 +102,16 @@ func specializeWitnessTable(forConformance conformance: Conformance,
         return origEntry
       }
       return .method(requirement: requirement, witness: specializedMethod)
+    case .baseProtocol(let requirement, let witness):
+      let baseConf = context.getSpecializedConformance(of: witness,
+                                                       for: conformance.type,
+                                                       substitutions: conformance.specializedSubstitutions)
+      specializeWitnessTable(forConformance: baseConf, errorLocation: errorLocation, context, notifyNewWitnessTable)
+      return .baseProtocol(requirement: requirement, witness: baseConf)
     default:
       // TODO: handle other witness table entry kinds
       fatalError("unsupported witness table etnry")
     }
-    return origEntry
   }
   let newWT = context.createWitnessTable(entries: newEntries,conformance: conformance,
                                          linkage: .shared, serialized: false)

--- a/docs/EmbeddedSwift/ABI.md
+++ b/docs/EmbeddedSwift/ABI.md
@@ -20,13 +20,30 @@ The compiler respects the ABIs and calling conventions of C and C++ when interop
 
 ## Metadata ABI of Embedded Swift
 
-Embedded Swift eliminates almost all metadata compared to full Swift. However, class metadata is still used, because those serve as vtables for dynamic dispatch of methods to implement runtime polymorphism. The layout of Embedded Swift's class metadata is *different* from full Swift:
+Embedded Swift eliminates almost all metadata compared to full Swift. However, class and existential metadata are still used, because those serve as vtables and witness tables for dynamic dispatch of methods to implement runtime polymorphism with classes and existentials.
+
+### Class Metadata ABI
+
+The layout of Embedded Swift's class metadata is *different* from full Swift:
 
 - The **super pointer** pointing to the class metadata record for the superclass is stored at **offset 0**. If the class is a root class, it is null.
 - The **destructor pointer** is stored at **offset 1**. This function is invoked by Swift's deallocator when the class instance is destroyed.
 - The **ivar destroyer** is stored at **offset 2**. This function is invoked to destroy instance members when creation of the object is cancelled (e.g. in a failable initializer).
 - Lastly, the **vtable** is stored at **offset 3**: For each Swift class in the class's inheritance hierarchy, in order starting
   from the root class and working down to the most derived class, the function pointers to the implementation of every method of the class in declaration order in stored.
+
+### Witness Tables ABI
+
+The layout of Embedded Swift's witness tables is *different* from full Swift:
+
+- The first word is always a null pointer (TODO: it can be eliminated)
+- The following words are witness table entries which can be one of the following:
+  - A method witness: a pointer to the witness function.
+  - An associated conformance witness: a pointer to the witness table of the associated conformance
+
+Note that witness tables in Embedded Swift do not contain associated type entries.
+
+Witness functions are always specialized for concrete types. This also means that parameters and return values are passed directly (if possible).
 
 ## Heap object layout in Embedded Swift
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2070,6 +2070,7 @@ struct BridgedSubstitutionMap {
   BRIDGED_INLINE BridgedSubstitutionMap(swift::SubstitutionMap map);
   BRIDGED_INLINE swift::SubstitutionMap unbridged() const;
   BRIDGED_INLINE BridgedSubstitutionMap();
+  BridgedOwnedString getDebugDescription() const;
   BRIDGED_INLINE bool isEmpty() const;
   BRIDGED_INLINE bool hasAnySubstitutableParams() const;
   BRIDGED_INLINE SwiftInt getNumConformances() const;

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2014,6 +2014,7 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isEscapable() const;
   BRIDGED_INLINE bool isNoEscape() const;
   BRIDGED_INLINE bool isInteger() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedSubstitutionMap substMap) const;
 };
 
 class BridgedCanType {

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2042,8 +2042,10 @@ struct BridgedConformance {
   BRIDGED_INLINE bool isConcrete() const;
   BRIDGED_INLINE bool isValid() const;
   BRIDGED_INLINE bool isSpecializedConformance() const;
+  BRIDGED_INLINE bool isInheritedConformance() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getGenericConformance() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getInheritedConformance() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getSpecializedSubstitutions() const;
 };
 

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -126,6 +126,10 @@ bool BridgedASTType::isInteger() const {
   return unbridged()->is<swift::IntegerType>();
 }
 
+BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
+  return {unbridged().subst(substMap.unbridged()).getPointer()};
+}
+
 //===----------------------------------------------------------------------===//
 // MARK: BridgedCanType
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -163,6 +163,10 @@ bool BridgedConformance::isSpecializedConformance() const {
   return swift::isa<swift::SpecializedProtocolConformance>(unbridged().getConcrete());
 }
 
+bool BridgedConformance::isInheritedConformance() const {
+  return swift::isa<swift::InheritedProtocolConformance>(unbridged().getConcrete());
+}
+
 BridgedASTType BridgedConformance::getType() const {
   return {unbridged().getConcrete()->getType().getPointer()};
 }
@@ -170,6 +174,11 @@ BridgedASTType BridgedConformance::getType() const {
 BridgedConformance BridgedConformance::getGenericConformance() const {
   auto *specPC = swift::cast<swift::SpecializedProtocolConformance>(unbridged().getConcrete());
   return {swift::ProtocolConformanceRef(specPC->getGenericConformance())};
+}
+
+BridgedConformance BridgedConformance::getInheritedConformance() const {
+  auto *inheritedConf = swift::cast<swift::InheritedProtocolConformance>(unbridged().getConcrete());
+  return {swift::ProtocolConformanceRef(inheritedConf->getInheritedConformance())};
 }
 
 BridgedSubstitutionMap BridgedConformance::getSpecializedSubstitutions() const {

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -120,6 +120,8 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
 
   /// Swift protocol witness table associated conformance witness table
   /// access functions.
+  /// In Embedded Swift used for associated conformance witness table
+  /// pointers.
   PointerAuthSchema ProtocolAssociatedTypeWitnessTableAccessFunctions;
 
   /// Swift class v-table functions.

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -15,7 +15,7 @@
 
 #include "swift/SIL/InstWrappers.h"
 #include "swift/SIL/RuntimeEffect.h"
-#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
 
 namespace swift {
 
@@ -232,6 +232,9 @@ bool visitExplodedTupleType(SILType type,
 /// visited all of the tuple elements without the visitor returing false.
 bool visitExplodedTupleValue(SILValue value,
                              llvm::function_ref<SILValue(SILValue, std::optional<unsigned>)> callback);
+
+std::pair<SILFunction *, SILWitnessTable *>
+lookUpFunctionInWitnessTable(WitnessMethodInst *wmi, SILModule::LinkingMode linkingMode);
 
 } // end namespace swift
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2682,7 +2682,7 @@ SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
   recordClonedInstruction(Inst,
                           getBuilder().createWitnessMethod(
                               getOpLocation(Inst->getLoc()), newLookupType,
-                              conformance, Inst->getMember(), Inst->getType()));
+                              conformance, Inst->getMember(), getOpType(Inst->getType())));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7715,6 +7715,13 @@ public:
     return getMember().getDecl()->getDeclContext()->getSelfProtocolDecl();
   }
 
+  // Returns true if it's expected that the witness method is looked up up from
+  // a specialized witness table.
+  // This is the case in Embedded Swift.
+  bool isSpecialized() const {
+    return !getType().castTo<SILFunctionType>()->isPolymorphic();
+  }
+
   ProtocolConformanceRef getConformance() const { return Conformance; }
 };
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -853,6 +853,7 @@ public:
   std::pair<SILFunction *, SILWitnessTable *>
   lookUpFunctionInWitnessTable(ProtocolConformanceRef C,
                                SILDeclRef Requirement,
+                               bool lookupInSpecializedWitnessTable,
                                SILModule::LinkingMode linkingMode);
 
   /// Look up the SILDefaultWitnessTable representing the default witnesses

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -256,6 +256,7 @@ struct BridgedPassContext {
                                                                  BridgedSubstitutionMap substitutions) const;
   void deserializeAllCallees(BridgedFunction function, bool deserializeAll) const;
   bool specializeClassMethodInst(BridgedInstruction cm) const;
+  bool specializeWitnessMethodInst(BridgedInstruction wm) const;
   bool specializeAppliesInFunction(BridgedFunction function, bool isMandatory) const;
   BridgedOwnedString mangleOutlinedVariable(BridgedFunction function) const;
   BridgedOwnedString mangleAsyncRemoved(BridgedFunction function) const;

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -332,6 +332,10 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   OptionalBridgedVTable lookupSpecializedVTable(BridgedType classType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedConformance getSpecializedConformance(BridgedConformance genericConformance,
+                                                       BridgedASTType type,
+                                                       BridgedSubstitutionMap substitutions) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   OptionalBridgedWitnessTable lookupWitnessTable(BridgedConformance conformance) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedWitnessTable createWitnessTable(BridgedLinkage linkage,
                                                                             bool serialized,

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -417,6 +417,16 @@ OptionalBridgedVTable BridgedPassContext::lookupSpecializedVTable(BridgedType cl
   return {mod->lookUpSpecializedVTable(classType.unbridged())};
 }
 
+BridgedConformance BridgedPassContext::getSpecializedConformance(
+                                                     BridgedConformance genericConformance,
+                                                     BridgedASTType type,
+                                                     BridgedSubstitutionMap substitutions) const {
+  auto &ctxt = invocation->getPassManager()->getModule()->getASTContext();
+  auto *genConf = llvm::cast<swift::NormalProtocolConformance>(genericConformance.unbridged().getConcrete());
+  auto *c = ctxt.getSpecializedConformance(type.unbridged(), genConf, substitutions.unbridged());
+  return swift::ProtocolConformanceRef(c);
+}
+
 OptionalBridgedWitnessTable BridgedPassContext::lookupWitnessTable(BridgedConformance conformance) const {
   swift::ProtocolConformanceRef ref = conformance.unbridged();
   if (!ref.isConcrete()) {

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -607,6 +607,7 @@ bool optimizeMemoryAccesses(SILFunction *fn);
 bool eliminateDeadAllocations(SILFunction *fn, DominanceInfo *domInfo);
 
 bool specializeClassMethodInst(ClassMethodInst *cm);
+bool specializeWitnessMethodInst(WitnessMethodInst *wm);
 
 bool specializeAppliesInFunction(SILFunction &F,
                                  SILTransform *transform,

--- a/lib/AST/Bridging/MiscBridging.cpp
+++ b/lib/AST/Bridging/MiscBridging.cpp
@@ -51,6 +51,10 @@ void BridgedTypeRepr_dump(void *type) { static_cast<TypeRepr *>(type)->dump(); }
 
 #pragma clang diagnostic pop
 
+//===----------------------------------------------------------------------===//
+// MARK: Conformance
+//===----------------------------------------------------------------------===//
+
 BridgedOwnedString BridgedConformance::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
@@ -58,5 +62,17 @@ BridgedOwnedString BridgedConformance::getDebugDescription() const {
   return str;
 }
 
+//===----------------------------------------------------------------------===//
+// MARK: SubstitutionMap
+//===----------------------------------------------------------------------===//
+
 static_assert(sizeof(BridgedSubstitutionMap) >= sizeof(swift::SubstitutionMap),
               "BridgedSubstitutionMap has wrong size");
+
+BridgedOwnedString BridgedSubstitutionMap::getDebugDescription() const {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  unbridged().dump(os);
+  return str;
+}
+

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2504,10 +2504,14 @@ IRGenModule::getConformanceInfo(const ProtocolDecl *protocol,
 
   const ConformanceInfo *info;
 
+  auto *specConf = conformance;
+  if (auto *inheritedC = dyn_cast<InheritedProtocolConformance>(conformance))
+    specConf = inheritedC->getInheritedConformance();
+
   // If there is a specialized SILWitnessTable for the specialized conformance,
   // directly use it.
-  if (auto *sc = dyn_cast<SpecializedProtocolConformance>(conformance)) {
-    SILWitnessTable *wt = getSILModule().lookUpWitnessTable(conformance);
+  if (auto *sc = dyn_cast<SpecializedProtocolConformance>(specConf)) {
+    SILWitnessTable *wt = getSILModule().lookUpWitnessTable(specConf);
     if (wt && wt->getConformance() == sc) {
       info = new SpecializedConformanceInfo(sc);
       Conformances.try_emplace(conformance, info);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2485,8 +2485,11 @@ IRGenModule::getConformanceInfo(const ProtocolDecl *protocol,
 
   const ConformanceInfo *info;
 
-  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
-    if (auto *sc = dyn_cast<SpecializedProtocolConformance>(conformance)) {
+  // If there is a specialized SILWitnessTable for the specialized conformance,
+  // directly use it.
+  if (auto *sc = dyn_cast<SpecializedProtocolConformance>(conformance)) {
+    SILWitnessTable *wt = getSILModule().lookUpWitnessTable(conformance);
+    if (wt && wt->getConformance() == sc) {
       info = new SpecializedConformanceInfo(sc);
       Conformances.try_emplace(conformance, info);
       return *info;

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -73,6 +73,10 @@ namespace irgen {
                                          SILDeclRef member,
                                          ProtocolConformanceRef conformance);
 
+  llvm::Value *emitAssociatedConformanceValue(IRGenFunction &IGF,
+                                              llvm::Value *wtable,
+                                              const AssociatedConformance &conf);
+
   /// Compute the index into a witness table for a resilient protocol given
   /// a reference to a descriptor of one of the requirements in that witness
   /// table.

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -541,6 +541,9 @@ SILModule::lookUpFunctionInWitnessTable(ProtocolConformanceRef C,
     linker.processConformance(C);
   }
   ProtocolConformance *conf = C.getConcrete();
+  if (auto *inheritedC = dyn_cast<InheritedProtocolConformance>(conf))
+    conf = inheritedC->getInheritedConformance();
+
   if (!isa<SpecializedProtocolConformance>(conf) || !lookupInSpecializedWitnessTable) {
     conf = conf->getRootConformance();
   }

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -531,6 +531,7 @@ SerializedSILLoader *SILModule::getSILLoader() {
 std::pair<SILFunction *, SILWitnessTable *>
 SILModule::lookUpFunctionInWitnessTable(ProtocolConformanceRef C,
                                         SILDeclRef Requirement,
+                                        bool lookupInSpecializedWitnessTable,
                                         SILModule::LinkingMode linkingMode) {
   if (!C.isConcrete())
     return {nullptr, nullptr};
@@ -539,7 +540,12 @@ SILModule::lookUpFunctionInWitnessTable(ProtocolConformanceRef C,
     SILLinkerVisitor linker(*this, linkingMode);
     linker.processConformance(C);
   }
-  SILWitnessTable *wt = lookUpWitnessTable(C.getConcrete()->getRootConformance());
+  ProtocolConformance *conf = C.getConcrete();
+  if (!isa<SpecializedProtocolConformance>(conf) || !lookupInSpecializedWitnessTable) {
+    conf = conf->getRootConformance();
+  }
+
+  SILWitnessTable *wt = lookUpWitnessTable(conf);
 
   if (!wt) {
     LLVM_DEBUG(llvm::dbgs() << "        Failed speculative lookup of "

--- a/lib/SIL/Utils/CalleeCache.cpp
+++ b/lib/SIL/Utils/CalleeCache.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SIL/CalleeCache.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
 #include "llvm/Support/Compiler.h"
@@ -256,8 +257,7 @@ CalleeCache::getSingleCalleeForWitnessMethod(WitnessMethodInst *WMI) const {
   SILWitnessTable *WT;
 
   // Attempt to find a specific callee for the given conformance and member.
-  std::tie(CalleeFn, WT) = WMI->getModule().lookUpFunctionInWitnessTable(
-      WMI->getConformance(), WMI->getMember(), SILModule::LinkingMode::LinkNormal);
+  std::tie(CalleeFn, WT) = lookUpFunctionInWitnessTable(WMI, SILModule::LinkingMode::LinkNormal);
 
   return CalleeFn;
 }

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1389,3 +1389,11 @@ bool swift::visitExplodedTupleValue(
 
   return true;
 }
+
+std::pair<SILFunction *, SILWitnessTable *>
+swift::lookUpFunctionInWitnessTable(WitnessMethodInst *wmi,
+                                    SILModule::LinkingMode linkingMode) {
+  SILModule &mod = wmi->getModule();
+  return mod.lookUpFunctionInWitnessTable(wmi->getConformance(), wmi->getMember(),
+                                          wmi->isSpecialized(), linkingMode);
+}

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4114,29 +4114,31 @@ public:
               == F.getModule().Types.getProtocolWitnessRepresentation(protocol),
             "result of witness_method must have correct representation for protocol");
 
-    require(methodType->isPolymorphic(),
-            "result of witness_method must be polymorphic");
+    if (methodType->isPolymorphic()) {
+      require(methodType->isPolymorphic(),
+              "result of witness_method must be polymorphic");
 
-    auto genericSig = methodType->getInvocationGenericSignature();
+      auto genericSig = methodType->getInvocationGenericSignature();
 
-    auto selfGenericParam = genericSig.getGenericParams()[0];
-    require(selfGenericParam->getDepth() == 0
-            && selfGenericParam->getIndex() == 0,
-            "method should be polymorphic on Self parameter at depth 0 index 0");
-    std::optional<Requirement> selfRequirement;
-    for (auto req : genericSig.getRequirements()) {
-      if (req.getKind() != RequirementKind::SameType) {
-        selfRequirement = req;
-        break;
+      auto selfGenericParam = genericSig.getGenericParams()[0];
+      require(selfGenericParam->getDepth() == 0
+              && selfGenericParam->getIndex() == 0,
+              "method should be polymorphic on Self parameter at depth 0 index 0");
+      std::optional<Requirement> selfRequirement;
+      for (auto req : genericSig.getRequirements()) {
+        if (req.getKind() != RequirementKind::SameType) {
+          selfRequirement = req;
+          break;
+        }
       }
-    }
 
-    require(selfRequirement &&
-            selfRequirement->getKind() == RequirementKind::Conformance,
-            "first non-same-typerequirement should be conformance requirement");
-    const auto protos = genericSig->getRequiredProtocols(selfGenericParam);
-    require(std::find(protos.begin(), protos.end(), protocol) != protos.end(),
-            "requirement Self parameter must conform to called protocol");
+      require(selfRequirement &&
+              selfRequirement->getKind() == RequirementKind::Conformance,
+              "first non-same-typerequirement should be conformance requirement");
+      const auto protos = genericSig->getRequiredProtocols(selfGenericParam);
+      require(std::find(protos.begin(), protos.end(), protocol) != protos.end(),
+              "requirement Self parameter must conform to called protocol");
+    }
 
     auto lookupType = AMI->getLookupType();
     if (getLocalArchetypeOf(lookupType) || lookupType->hasDynamicSelfType()) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -122,8 +122,7 @@ static bool isRecursiveCall(FullApplySite applySite) {
   }
 
   if (auto *WMI = dyn_cast<WitnessMethodInst>(callee)) {
-    auto funcAndTable = parentFunc->getModule().lookUpFunctionInWitnessTable(
-        WMI->getConformance(), WMI->getMember(), SILModule::LinkingMode::LinkNormal);
+    auto funcAndTable = lookUpFunctionInWitnessTable(WMI, SILModule::LinkingMode::LinkNormal);
     return funcAndTable.first == parentFunc;
   }
   return false;

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1771,6 +1771,10 @@ bool BridgedPassContext::specializeClassMethodInst(BridgedInstruction cm) const 
   return ::specializeClassMethodInst(cm.getAs<ClassMethodInst>());
 }
 
+bool BridgedPassContext::specializeWitnessMethodInst(BridgedInstruction wm) const {
+  return ::specializeWitnessMethodInst(wm.getAs<WitnessMethodInst>());
+}
+
 bool BridgedPassContext::specializeAppliesInFunction(BridgedFunction function, bool isMandatory) const {
   return ::specializeAppliesInFunction(*function.getFunction(), invocation->getTransform(), isMandatory);
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1134,8 +1134,6 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
     FullApplySite Apply,
     const llvm::SmallDenseMap<unsigned, ConcreteOpenedExistentialInfo> &COAIs,
     SILBuilderContext &BuilderCtx) {
-  // Ensure that the callee is polymorphic.
-  assert(Apply.getOrigCalleeType()->isPolymorphic());
 
   // Create the new set of arguments to apply including their substitutions.
   SubstitutionMap NewCallSubs = Apply.getSubstitutionMap();

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -433,7 +433,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
                         UnknownReason::UnknownWitnessMethodConformance);
     auto &module = wmi->getModule();
     SILFunction *fn =
-        module.lookUpFunctionInWitnessTable(conf, wmi->getMember(),
+        module.lookUpFunctionInWitnessTable(conf, wmi->getMember(), wmi->isSpecialized(),
             SILModule::LinkingMode::LinkAll).first;
     // If we were able to resolve it, then we can proceed.
     if (fn)

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1239,8 +1239,7 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite, bool isMandatory) 
     }
   }
 
-  std::tie(f, wt) = applySite.getModule().lookUpFunctionInWitnessTable(
-      wmi->getConformance(), wmi->getMember(), SILModule::LinkingMode::LinkAll);
+  std::tie(f, wt) = lookUpFunctionInWitnessTable(wmi, SILModule::LinkingMode::LinkAll);
 
   if (!f)
     return false;
@@ -1351,8 +1350,7 @@ swift::tryDevirtualizeWitnessMethod(SILPassManager *pm, ApplySite applySite,
 
   auto *wmi = cast<WitnessMethodInst>(applySite.getCallee());
 
-  std::tie(f, wt) = applySite.getModule().lookUpFunctionInWitnessTable(
-      wmi->getConformance(), wmi->getMember(), SILModule::LinkingMode::LinkAll);
+  std::tie(f, wt) = lookUpFunctionInWitnessTable(wmi, SILModule::LinkingMode::LinkAll);
 
   return devirtualizeWitnessMethod(pm, applySite, f, wmi->getConformance(), ore);
 }

--- a/test/embedded/existential-class-bound1.swift
+++ b/test/embedded/existential-class-bound1.swift
@@ -29,6 +29,61 @@ func test(existential: any ClassBound) {
     existential.bar()
 }
 
+public protocol ProtoWithAssocType<T>: AnyObject {
+  associatedtype T
+  func foo(t: T)
+}
+
+final public class GenClass<T: BinaryInteger>: ProtoWithAssocType {
+  public func foo(t: T) {
+    print(t)
+  }
+}
+
+public func createExWithAssocType() -> any ProtoWithAssocType<Int> {
+  return GenClass<Int>()
+}
+
+public func callExWithAssocType(_ p: any ProtoWithAssocType<Int>) {
+  p.foo(t: 27)
+}
+
+public protocol Q: AnyObject {
+  func bar()
+}
+
+public protocol ProtoWithAssocConf: AnyObject {
+  associatedtype A: Q
+  func foo() -> A
+}
+
+public class GenClass2<T>: Q {
+  var t: T
+
+  init(t : T) { self.t = t }
+
+  public func bar() {
+    print("bar")
+  }
+}
+
+final public class GenClass3<V>: ProtoWithAssocConf {
+  public func foo() -> GenClass2<Int> {
+    print("foo")
+    return GenClass2(t: 27)
+  }
+}
+
+
+public func createExWithAssocConf() -> any ProtoWithAssocConf {
+  return GenClass3<Int>()
+}
+
+public func callExWithAssocConf(_ p: any ProtoWithAssocConf) {
+  let x = p.foo()
+  x.bar()
+}
+
 @main
 struct Main {
     static func main() {
@@ -38,6 +93,11 @@ struct Main {
         test(existential: MyOtherClass())
         // CHECK: MyOtherClass.foo()
         // CHECK: MyOtherClass.bar()
+        callExWithAssocType(createExWithAssocType())
+        // CHECK: 27
+        callExWithAssocConf(createExWithAssocConf())
+        // CHECK: foo
+        // CHECK: bar
     }
 }
 

--- a/test/embedded/existential-class-bound4.swift
+++ b/test/embedded/existential-class-bound4.swift
@@ -5,8 +5,11 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-protocol ClassBound: AnyObject {
+public protocol Base: AnyObject {
     func foo()
+}
+
+protocol ClassBound: Base {
     func bar()
 }
 


### PR DESCRIPTION
This is part 2 of https://github.com/swiftlang/swift/pull/76669

This PR adds support for
* existential of protocols with associated types and conformances.
* base-protocols: inheritance of protocols
* inherited conformanes: derived classes where the base conforms to a protocol

rdar://135311381