### PR TITLE
Add validation to `CollectionDifference` decoder

### DIFF
--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -63,6 +63,12 @@ public struct CollectionDifference<ChangeElement> {
         }
       }
     }
+    internal var _isRemoval: Bool {
+      switch self {
+      case .insert: false
+      case .remove: true
+      }
+    }
   }
 
   /// The insertions contained by this difference, from lowest offset to 
@@ -404,13 +410,7 @@ extension CollectionDifference.Change: Codable where ChangeElement: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: _CodingKeys.self)
-    switch self {
-    case .remove(_, _, _):
-      try container.encode(true, forKey: .isRemove)
-    case .insert(_, _, _):
-      try container.encode(false, forKey: .isRemove)
-    }
-    
+    try container.encode(_isRemoval, forKey: .isRemove)
     try container.encode(_offset, forKey: .offset)
     try container.encode(_element, forKey: .element)
     try container.encode(_associatedOffset, forKey: .associatedOffset)
@@ -418,7 +418,37 @@ extension CollectionDifference.Change: Codable where ChangeElement: Codable {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension CollectionDifference: Codable where ChangeElement: Codable {}
+extension CollectionDifference: Codable where ChangeElement: Codable {
+  private enum _CodingKeys: String, CodingKey {
+    case insertions
+    case removals
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: _CodingKeys.self)
+    var changes = try container.decode([Change].self, forKey: .removals)
+    let removalCount = changes.count
+    try changes.append(contentsOf: container.decode([Change].self, forKey: .insertions))
+
+    guard changes[..<removalCount].allSatisfy({ $0._isRemoval }),
+          changes[removalCount...].allSatisfy({ !$0._isRemoval }),
+          Self._validateChanges(changes)
+    else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Cannot decode an invalid collection difference"))
+    }
+
+    self.init(_validatedChanges: changes)
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: _CodingKeys.self)
+    try container.encode(insertions, forKey: .insertions)
+    try container.encode(removals, forKey: .removals)
+  }
+}
 
 @available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Sendable where ChangeElement: Sendable { }

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -943,13 +943,6 @@ class TestCodable : TestCodableSuper {
         }
     }
     
-    func test_TimeZone_JSON_Errors() {
-        expectDecodingErrorViaJSON(
-            type: TimeZone.self,
-            json: #"{"identifier": "invalid-time-zone"}"#,
-            errorKind: .dataCorrupted)
-    }
-
     // MARK: - URL
     lazy var urlValues: [Int : URL] = {
         var values: [Int : URL] = [
@@ -987,13 +980,6 @@ class TestCodable : TestCodableSuper {
         }
     }
     
-    func test_URL_JSON_Errors() {
-        expectDecodingErrorViaJSON(
-            type: URL.self,
-            json: "http://swîft.org",
-            errorKind: .dataCorrupted)
-    }
-
     // MARK: - URLComponents
     lazy var urlComponentsValues: [Int : URLComponents] = [
         #line : URLComponents(),
@@ -1193,10 +1179,8 @@ var tests = [
     "test_Range_JSON_Errors" : TestCodable.test_Range_JSON_Errors,
     "test_TimeZone_JSON" : TestCodable.test_TimeZone_JSON,
     "test_TimeZone_Plist" : TestCodable.test_TimeZone_Plist,
-    "test_TimeZone_JSON_Errors": TestCodable.test_TimeZone_JSON_Errors,
     "test_URL_JSON" : TestCodable.test_URL_JSON,
     "test_URL_Plist" : TestCodable.test_URL_Plist,
-    "test_URL_JSON_Errors" : TestCodable.test_URL_JSON_Errors,
     "test_UUID_JSON" : TestCodable.test_UUID_JSON,
     "test_UUID_Plist" : TestCodable.test_UUID_Plist,
 ]


### PR DESCRIPTION
The `CollectionDifference` type has a few different invariants that were not being validated when initializing using the type's `Decodable` conformance, since the type was using the autogenerated `Codable` implementation. This change provides manual implementations of the `Encodable` and `Decodable` requirements, and adds tests that validate the failure when trying to decode invalid JSON for CollectionDifference (and a few other types).
