### PR TITLE
🍒[cxx-interop] Modularize __msvc_bit_utils on Windows

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,6 +702,11 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
+    explicit module __msvc_bit_utils {
+      header "__msvc_bit_utils.hpp"
+      export *
+    }
+
     explicit module xhash {
       header "xhash"
       export *

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -1,3 +1,9 @@
+module StdNumeric {
+  header "std-numeric.h"
+  requires cplusplus
+  export *
+}
+
 module StdVector {
   header "std-vector.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-numeric.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-numeric.h
@@ -1,0 +1,5 @@
+#include <numeric>
+
+inline int64_t getGCD(int64_t a, int64_t b) {
+  return std::gcd(a, b);
+}

--- a/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20
+
+import StdNumeric
+
+let _ = getGCD(12, 15)


### PR DESCRIPTION
**Explanation**: `__msvc_bit_utils.hpp` was added in a recent version of MSVC, and it is causing build errors for SwiftCompilerSources:
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:12: error: function '_Select_countr_zero_impl<unsigned long long, (lambda at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\numeric:598:55)>' with deduced return type cannot be used before it is defined
    return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
```
This change references the `__msvc_bit_utils.hpp` header from the modulemap. Since we still need to support older versions of Visual Studio that do not provide `__msvc_bit_utils.hpp`, this also teaches ClangImporter to inject an empty header file named `__msvc_bit_utils.hpp` into the system include directory, unless it already exists.
**Scope**: ClangImporter logic that injects modulemaps into system headers on Windows was changed, along with the modulemap for Microsoft STL.
**Risk**: Low, this is a Windows-only change.
**Testing**: Added a compiler test.
**Issue**: rdar://137066642
**Reviewer**: @compnerd @Xazax-hun

Original PR: https://github.com/swiftlang/swift/pull/76823