### PR TITLE
[6.0] Fix NSDecimal interpreter test

### DIFF
--- a/test/Interpreter/SDK/NSDecimal.swift
+++ b/test/Interpreter/SDK/NSDecimal.swift
@@ -121,6 +121,5 @@ print(twenty) // CHECK: 2
 twenty = NSDecimalNumber(mantissa: 2, exponent: 1, isNegative: false) as Decimal
 print(twenty.significand) // CHECK: 2
 print(twenty.exponent) // CHECK: 1
-print(twenty.ulp) // CHECK: 10
 
 print(Decimal(sign: .plus, exponent: -2, significand: 100)) // CHECK: 1


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/75886 to `release/6.0`

We fixed the behavior of Decimal.ulp with https://github.com/apple/swift-foundation/pull/741. We should remove this test with wrong expectations since we already test it in SwiftFoundation

resolves: rdar://137332735
