### PR TITLE
[BlockList] Don't share the SourceManager in BlockListStore

### DIFF
--- a/lib/Basic/BlockList.cpp
+++ b/lib/Basic/BlockList.cpp
@@ -19,7 +19,7 @@
 #include "swift/Basic/SourceManager.h"
 
 struct swift::BlockListStore::Implementation {
-  SourceManager &SM;
+  SourceManager SM;
   llvm::StringMap<std::vector<BlockListAction>> ModuleActionDict;
   llvm::StringMap<std::vector<BlockListAction>> ProjectActionDict;
   void addConfigureFilePath(StringRef path);
@@ -45,7 +45,7 @@ struct swift::BlockListStore::Implementation {
     return std::string();
   }
 
-  Implementation(SourceManager &SM) : SM(SM) {}
+  Implementation(SourceManager &SM) : SM(SM.getFileSystem()) {}
 };
 
 swift::BlockListStore::BlockListStore(swift::SourceManager &SM)


### PR DESCRIPTION
BlockListStore doesn't need to keep the buffer after the block-list is parsed. Don't share the same source manager as the compilation so it doesn't need to make sure the buffer is valid during the entire duration of the compilation.

rdar://137448231

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
