### PR TITLE
[Windows] Run swift-format tests from build.ps1

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,swift,dispatch,foundation,xctest,
+set TestArg=-Test lld,swift,dispatch,foundation,xctest,swift-format,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 


### PR DESCRIPTION
The basic idea is that we build all libraries for the executable that will be included in the toolchain using CMake. swift-format then has a mode in its Package manifest that allows it to build just the test and test support targets, requiring all search paths to find those libraries to be passed in. We use that to only build swift-format's test using SwiftPM and re-use all the libraries that were already built using CMake.

Building the test targets and running the tests takes about 1 minute locally on my machine.