### PR TITLE
IRGen: Prefer memcpy for initWithTake of single/mulipayload enums where possible over an outlined copy function

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3312,6 +3312,14 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined,
                             bool zeroizeIfSensitive) const override {
+      if (TI->isBitwiseTakable(ResilienceExpansion::Maximal)) {
+        IGF.Builder.CreateMemCpy(
+          dest.getAddress(), llvm::MaybeAlign(dest.getAlignment().getValue()),
+          src.getAddress(), llvm::MaybeAlign(src.getAlignment().getValue()),
+          TI->getSize(IGF, T));
+        return;
+      }
+
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
       } else if (isOutlined || T.hasParameterizedExistential()) {
@@ -5227,6 +5235,14 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined,
                             bool zeroizeIfSensitive) const override {
+      if (TI->isBitwiseTakable(ResilienceExpansion::Maximal)) {
+        IGF.Builder.CreateMemCpy(
+          dest.getAddress(), llvm::MaybeAlign(dest.getAlignment().getValue()),
+          src.getAddress(), llvm::MaybeAlign(src.getAlignment().getValue()),
+          TI->getSize(IGF, T));
+        return;
+      }
+
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
       } else if (isOutlined || T.hasParameterizedExistential()) {

--- a/test/IRGen/enum_copy_init_with_take_memcpy.swift
+++ b/test/IRGen/enum_copy_init_with_take_memcpy.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -I %t -primary-file %s -O -emit-ir | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+enum MyEnum {
+  case one
+  case four
+}
+
+struct HasAnEnum {
+  var s1: String
+  var s2: String
+  var s3: String
+  var s4: String
+  var s5: String
+  var s6: String
+  var s7: String
+  var s8: String
+  var s9: String
+  var s10: String
+  var value: MyEnum?
+
+  func readValue() -> Int {
+    let x = value
+    if case .four = x { return 4 }
+    return -1
+  }
+
+
+// CHECK: define{{.*}} hidden swiftcc i64 @"$s31enum_copy_init_with_take_memcpy9HasAnEnumV9readValueSiyF"(ptr {{.*}} %0)
+// CHECK:   [[T0:%.*]] = getelementptr inbounds %T31enum_copy_init_with_take_memcpy9HasAnEnumV, ptr %0
+// CHECK:   [[T1:%.*]] = load i8, ptr [[T0]]
+// CHECK:   [[T2:%.*]] = and i8 [[T1]], 1
+// CHECK:   [[T3:%.*]] = icmp eq i8 [[T2]], 0
+// CHECK:   [[T4:%.*]] = select i1 [[T3]], i64 -1, i64 4
+// CHECK:   ret i64 [[T4]]
+// CHECK: }
+
+}


### PR DESCRIPTION

rdar://83297558
https://github.com/swiftlang/swift/issues/57537
