### PR TITLE
Improve code generation for arrays of classes.

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -30,6 +30,7 @@ public class Decl: CustomStringConvertible, Hashable {
 public class ValueDecl: Decl {
   final public var nameLoc: SourceLoc? { SourceLoc(bridged: bridged.Value_getNameLoc()) }
   final public var userFacingName: StringRef { StringRef(bridged: bridged.Value_getUserFacingName()) }
+  final public var isObjC: Bool { bridged.Value_isObjC() }
 }
 
 public class TypeDecl: ValueDecl {

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -14,6 +14,7 @@ swift_compiler_sources(Optimizer
   SimplifyBranch.swift
   SimplifyBuiltin.swift
   SimplifyCheckedCast.swift
+  SimplifyClassifyBridgeObject.swift
   SimplifyCondBranch.swift
   SimplifyCondFail.swift
   SimplifyConvertEscapeToNoEscape.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyClassifyBridgeObject.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyClassifyBridgeObject.swift
@@ -1,0 +1,50 @@
+//===--- SimplifyClassifyBridgeObject.swift -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AST
+import SIL
+
+extension ClassifyBridgeObjectInst : OnoneSimplifyable, SILCombineSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    // Constant fold `classify_bridge_object` to `(false, false)` if the operand is known
+    // to be a swift class.
+    var walker = CheckForSwiftClasses();
+    if walker.walkUp(value: operand.value, path: UnusedWalkingPath()) == .abortWalk {
+      return
+    }
+
+    let builder = Builder(before: self, context)
+    let falseLiteral = builder.createIntegerLiteral(0, type: context.getBuiltinIntegerType(bitWidth: 1))
+    let tp = builder.createTuple(type: self.type, elements: [falseLiteral, falseLiteral])
+    uses.replaceAll(with: tp, context)
+    context.erase(instruction: self)
+  }
+}
+
+private struct CheckForSwiftClasses: ValueUseDefWalker {
+  mutating func walkUp(value: Value, path: UnusedWalkingPath) -> WalkResult {
+    if let nominal = value.type.nominal,
+       let classDecl = nominal as? ClassDecl,
+       !classDecl.isObjC
+    {
+      // Stop this use-def walk if the value is known to be a swift class.
+      return .continueWalk
+    }
+    return walkUpDefault(value: value, path: path)
+  }
+
+  mutating func rootDef(value: Value, path: UnusedWalkingPath) -> WalkResult {
+    return .abortWalk
+  }
+
+  var walkUpCache = WalkerCache<UnusedWalkingPath>()
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -111,6 +111,7 @@ private func registerSwiftPasses() {
   registerForSILCombine(DestructureStructInst.self, { run(DestructureStructInst.self, $0) })
   registerForSILCombine(DestructureTupleInst.self, { run(DestructureTupleInst.self, $0) })
   registerForSILCombine(TypeValueInst.self, { run(TypeValueInst.self, $0) })
+  registerForSILCombine(ClassifyBridgeObjectInst.self, { run(ClassifyBridgeObjectInst.self, $0) })
 
   // Test passes
   registerPass(aliasInfoDumper, { aliasInfoDumper.run($0) })

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -317,6 +317,7 @@ struct BridgedDeclObj {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef Type_getName() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef Value_getUserFacingName() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSourceLoc Value_getNameLoc() const;
+  BRIDGED_INLINE bool Value_isObjC() const;
   BRIDGED_INLINE bool GenericType_isGenericAtAnyLevel() const;
   BRIDGED_INLINE bool NominalType_isGlobalActor() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj NominalType_getValueTypeDestructor() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -52,6 +52,10 @@ BridgedSourceLoc BridgedDeclObj::Value_getNameLoc() const {
   return BridgedSourceLoc(getAs<swift::ValueDecl>()->getNameLoc().getOpaquePointerValue());
 }
 
+bool BridgedDeclObj::Value_isObjC() const {
+  return getAs<swift::ValueDecl>()->isObjC();
+}
+
 bool BridgedDeclObj::GenericType_isGenericAtAnyLevel() const {
   return getAs<swift::GenericTypeDecl>()->isGenericContext();
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -517,6 +517,7 @@ PASS(PruneVTables, "prune-vtables",
 PASS_RANGE(AllPasses, AliasInfoDumper, PruneVTables)
 
 SWIFT_SILCOMBINE_PASS(BeginCOWMutationInst)
+SWIFT_SILCOMBINE_PASS(ClassifyBridgeObjectInst)
 SWIFT_SILCOMBINE_PASS(GlobalValueInst)
 SWIFT_SILCOMBINE_PASS(StrongRetainInst)
 SWIFT_SILCOMBINE_PASS(StrongReleaseInst)

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -292,7 +292,6 @@ public:
   SILInstruction *visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI);
       
   SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
-  SILInstruction *visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2006,24 +2006,6 @@ SILInstruction *SILCombiner::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   return nullptr;
 }
 
-SILInstruction *
-SILCombiner::visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *cboi) {
-  auto *urc = dyn_cast<UncheckedRefCastInst>(cboi->getOperand());
-  if (!urc)
-    return nullptr;
-
-  auto type = urc->getOperand()->getType().getASTType();
-  if (ClassDecl *cd = type->getClassOrBoundGenericClass()) {
-    if (!cd->isObjC()) {
-      auto int1Ty = SILType::getBuiltinIntegerType(1, Builder.getASTContext());
-      SILValue zero = Builder.createIntegerLiteral(cboi->getLoc(), int1Ty, 0);
-      return Builder.createTuple(cboi->getLoc(), {zero, zero});
-    }
-  }
-
-  return nullptr;
-}
-
 /// Returns true if reference counting and debug_value users of a global_value
 /// can be deleted.
 static bool checkGlobalValueUsers(SILValue val,

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2982,6 +2982,13 @@ static bool usePrespecialized(
   if (refF->getSpecializeAttrs().empty())
     return false;
 
+  // `Array._endMutation` was added for pre-specialization by mistake. But we
+  // cannot remove the specialize-attributes anymore because the pre-specialized
+  // functions are now part of the stdlib's ABI.
+  // Therefore make an exception for `Array._endMutation` here.
+  if (refF->getName() == "$sSa12_endMutationyyF")
+    return false;
+
   SmallVector<std::tuple<unsigned, ReabstractionInfo, AvailabilityRange>, 4>
       layoutMatches;
 

--- a/test/SILOptimizer/simplify_classify_bridge_object.sil
+++ b/test/SILOptimizer/simplify_classify_bridge_object.sil
@@ -1,0 +1,35 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=classify_bridge_object | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+struct MyArray {
+  let o: Builtin.BridgeObject
+}
+
+// CHECK-LABEL: sil @test_swift_class :
+// CHECK:         %1 = integer_literal $Builtin.Int1, 0
+// CHECK:         %2 = tuple (%1 : $Builtin.Int1, %1 : $Builtin.Int1)
+// CHECK:         return %2
+// CHECK:       } // end sil function 'test_swift_class'
+sil @test_swift_class : $@convention(thin) (@guaranteed _ContiguousArrayStorage<Int>) -> (Builtin.Int1, Builtin.Int1) {
+bb0(%0 : $_ContiguousArrayStorage<Int>):
+  %1 = unchecked_ref_cast %0 : $_ContiguousArrayStorage<Int> to $Builtin.BridgeObject
+  %2 = classify_bridge_object %1 : $Builtin.BridgeObject
+  return %2 : $(Builtin.Int1, Builtin.Int1)
+}
+
+// CHECK-LABEL: sil @test_unknown_class :
+// CHECK:         %1 = struct_extract %0
+// CHECK:         %2 = classify_bridge_object %1
+// CHECK:         return %2
+// CHECK:       } // end sil function 'test_unknown_class'
+sil @test_unknown_class : $@convention(thin) (@guaranteed MyArray) -> (Builtin.Int1, Builtin.Int1) {
+bb0(%0 : $MyArray):
+  %1 = struct_extract %0 : $MyArray, #MyArray.o
+  %2 = classify_bridge_object %1 : $Builtin.BridgeObject
+  return %2 : $(Builtin.Int1, Builtin.Int1)
+}
+

--- a/test/SILOptimizer/static_arrays.swift
+++ b/test/SILOptimizer/static_arrays.swift
@@ -267,12 +267,12 @@ func takeUnsafePointer(ptr : UnsafePointer<SwiftClass>, len: Int) {
 // This should be a single basic block, and the array should end up being stack
 // allocated.
 //
-// CHECK-LABEL: sil [noinline] @{{.*passArrayOfClasses.*}} : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> () {
+// CHECK-LABEL: sil [noinline] @$s4test18passArrayOfClasses1a1b1cyAA10SwiftClassC_A2GtF : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> () {
 // CHECK:       bb0(%0 : $SwiftClass, %1 : $SwiftClass, %2 : $SwiftClass):
-// CHECK-NOT:   bb1(
-// CHECK:         alloc_ref{{(_dynamic)?}} {{.*}}[tail_elems $SwiftClass *
-// CHECK-NOT:   bb1(
-// CHECK:       } // end sil function '{{.*passArrayOfClasses.*}}'
+// CHECK-NOT:   bb1
+// CHECK:         alloc_ref{{.*}}[stack] [tail_elems $SwiftClass *
+// CHECK-NOT:   bb1
+// CHECK:       } // end sil function '$s4test18passArrayOfClasses1a1b1cyAA10SwiftClassC_A2GtF'
 @inline(never)
 public func passArrayOfClasses(a: SwiftClass, b: SwiftClass, c: SwiftClass) {
   let arr = [a, b, c]


### PR DESCRIPTION
* Constant fold `classify_bridge_object` to `(false, false)` if the operand is known to be a swift class.

We already had this optimization in the SILCombiner. But it didn't handle all the cases. Now it's implemented as instruction simplification (in swift) using a ValueUseDefWalker.

* Don't use pre-specialization for `Array._endMutation`.

Pre-specialization of `Array._endMutation` (for AnyObject) prevents inlining this function and that results in sub-optimal code. This function is basically a no-op. So it should be inlined.
Unfortunately we cannot remove the specialize-attributes anymore because the pre-specialized function(s) are now part of the stdlib's ABI. Therefore make an exception for `Array._endMutation` in the generic specializer.

rdar://137243595