### PR TITLE
Fix performance regression in ConstraintSystem::openType()

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4318,7 +4318,6 @@ public:
   Type openType(Type type, OpenedTypeMap &replacements,
                 ConstraintLocatorBuilder locator);
 
-private:
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
                       ConstraintLocatorBuilder locator);
@@ -4340,7 +4339,6 @@ private:
     ASSERT(erased);
   }
 
-public:
   /// Recurse over the given type and open any opaque archetype types.
   Type openOpaqueType(Type type, ContextualTypePurpose context,
                       ConstraintLocatorBuilder locator);

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -524,7 +524,8 @@ namespace {
 struct MapTypeIntoContext: TypeTransform<MapTypeIntoContext> {
   GenericEnvironment *env;
 
-  explicit MapTypeIntoContext(GenericEnvironment *env) : env(env) {}
+  explicit MapTypeIntoContext(GenericEnvironment *env, ASTContext &ctx)
+    : TypeTransform(ctx), env(env) {}
 
   std::optional<Type> transform(TypeBase *type, TypePosition pos) {
     if (!type->hasTypeParameter())
@@ -552,7 +553,10 @@ struct MapTypeIntoContext: TypeTransform<MapTypeIntoContext> {
 
 Type GenericEnvironment::mapTypeIntoContext(Type type) const {
   assert(!type->hasPrimaryArchetype() && "already have a contextual type");
-  return MapTypeIntoContext(const_cast<GenericEnvironment *>(this))
+  if (!type->hasTypeParameter())
+    return type;
+  return MapTypeIntoContext(const_cast<GenericEnvironment *>(this),
+                            type->getASTContext())
       .doIt(type, TypePosition::Invariant);
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4092,14 +4092,15 @@ Type Type::transformRec(
   class Transform : public TypeTransform<Transform> {
     llvm::function_ref<std::optional<Type>(TypeBase *)> fn;
   public:
-    explicit Transform(llvm::function_ref<std::optional<Type>(TypeBase *)> fn) : fn(fn) {}
+    explicit Transform(llvm::function_ref<std::optional<Type>(TypeBase *)> fn,
+                       ASTContext &ctx) : TypeTransform(ctx), fn(fn) {}
 
     std::optional<Type> transform(TypeBase *type, TypePosition position) {
       return fn(type);
     }
   };
 
-  return Transform(fn).doIt(*this, TypePosition::Invariant);
+  return Transform(fn, (*this)->getASTContext()).doIt(*this, TypePosition::Invariant);
 }
 
 Type Type::transformWithPosition(
@@ -4109,14 +4110,15 @@ Type Type::transformWithPosition(
   class Transform : public TypeTransform<Transform> {
     llvm::function_ref<std::optional<Type>(TypeBase *, TypePosition)> fn;
   public:
-    explicit Transform(llvm::function_ref<std::optional<Type>(TypeBase *, TypePosition)> fn) : fn(fn) {}
+    explicit Transform(llvm::function_ref<std::optional<Type>(TypeBase *, TypePosition)> fn,
+                       ASTContext &ctx) : TypeTransform(ctx), fn(fn) {}
 
     std::optional<Type> transform(TypeBase *type, TypePosition position) {
       return fn(type, position);
     }
   };
 
-  return Transform(fn).doIt(*this, pos);
+  return Transform(fn, (*this)->getASTContext()).doIt(*this, pos);
 }
 
 bool Type::findIf(llvm::function_ref<bool(Type)> pred) const {

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -388,8 +388,8 @@ class TypeSubstituter : public TypeTransform<TypeSubstituter> {
   InFlightSubstitution &IFS;
 
 public:
-  TypeSubstituter(unsigned level, InFlightSubstitution &IFS)
-    : level(level), IFS(IFS) {}
+  TypeSubstituter(ASTContext &ctx, unsigned level, InFlightSubstitution &IFS)
+    : TypeTransform(ctx), level(level), IFS(IFS) {}
 
   std::optional<Type> transform(TypeBase *type, TypePosition pos);
 
@@ -566,7 +566,7 @@ Type Type::subst(InFlightSubstitution &IFS) const {
   if (IFS.isInvariant(*this))
     return *this;
 
-  TypeSubstituter transform(/*level=*/0, IFS);
+  TypeSubstituter transform((*this)->getASTContext(), /*level=*/0, IFS);
   return transform.doIt(*this, TypePosition::Invariant);
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1240,6 +1240,10 @@ struct TypeOpener : public TypeTransform<TypeOpener> {
   bool shouldUnwrapVanishingTuples() const {
     return false;
   }
+
+  bool shouldDesugarTypeAliases() const {
+    return true;
+  }
 };
 
 }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1119,7 +1119,7 @@ func testLValueBaseTyOfSubscript() {
   var cache: [String: Codable] = [:]
   if let cached = cache[#^LVALUEBASETY^#
 
-  // LVALUEBASETY-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem: ['[']{#(position): Dictionary<String, any Codable>.Index#}[']'][#Dictionary<String, any Codable>.Element#];
+  // LVALUEBASETY-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem: ['[']{#(position): Dictionary<String, any Codable>.Index#}[']'][#(key: String, value: any Codable)#];
   // LVALUEBASETY-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem: ['[']{#(key): String#}[']'][#@lvalue (any Codable)?#];
 }
 

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -55,5 +55,5 @@ func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}
 // expected-error@+1{{only literals are permitted}}
 func testString(interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
 
-// expected-error@+1{{default argument value of type 'Stringified<Int>' (aka '(Int, String)') cannot be converted to type 'Int'}}
+// expected-error@+1{{default argument value of type '(Int, String)' cannot be converted to type 'Int'}}
 func testReturn(wrongType: Int = #stringify(0)) {}


### PR DESCRIPTION
This fixes a performance regression from 074684fe06e2a60c9bd658fac550008578406d9b.

My change to preserve type sugar in type transforms introduced a performance regression here, because openType() is called for every disjunction choice.

My hope is to optimize the TypeAliasType representation and remove this at some point, but for now, let's just restore the old desugaring behavior in this case.