### PR TITLE
AST: Sort TypeRefinementContexts for better lookup performance

### DIFF
--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -185,6 +185,8 @@ private:
     unsigned needsExpansion : 1;
   } LazyInfo = {};
 
+  void verify(const TypeRefinementContext *parent, ASTContext &ctx) const;
+
   TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
                         TypeRefinementContext *Parent, SourceRange SrcRange,
                         const AvailabilityRange &Info,
@@ -302,6 +304,10 @@ public:
   void setNeedsExpansion(bool needsExpansion) {
     LazyInfo.needsExpansion = needsExpansion;
   }
+
+  /// Recursively check the tree for integrity. If any errors are found, emits
+  /// diagnosticts to stderr and aborts.
+  void verify(ASTContext &ctx);
 
   SWIFT_DEBUG_DUMPER(dump(SourceManager &SrcMgr));
   void dump(raw_ostream &OS, SourceManager &SrcMgr) const;

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -290,10 +290,7 @@ public:
   }
 
   /// Adds a child refinement context.
-  void addChild(TypeRefinementContext *Child) {
-    assert(Child->getSourceRange().isValid());
-    Children.push_back(Child);
-  }
+  void addChild(TypeRefinementContext *Child, ASTContext &Ctx);
 
   /// Returns the inner-most TypeRefinementContext descendant of this context
   /// for the given source location.

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -55,6 +55,7 @@ public:
   enum Kind {
 #define MACRO_ROLE(Name, Description) Name##MacroExpansion,
 #include "swift/Basic/MacroRoles.def"
+#undef MACRO_ROLE
 
     /// A new function body that is replacing an existing function body.
     ReplacedFunctionBody,
@@ -65,6 +66,23 @@ public:
     /// The expansion of default argument at caller side
     DefaultArgument,
   } kind;
+
+  static StringRef kindToString(GeneratedSourceInfo::Kind kind) {
+    switch (kind) {
+#define MACRO_ROLE(Name, Description)                                          \
+  case Name##MacroExpansion:                                                   \
+    return #Name "MacroExpansion";
+#include "swift/Basic/MacroRoles.def"
+#undef MACRO_ROLE
+    case ReplacedFunctionBody:
+      return "ReplacedFunctionBody";
+    case PrettyPrinted:
+      return "PrettyPrinted";
+    case DefaultArgument:
+      return "DefaultArgument";
+    }
+    llvm_unreachable("Invalid kind");
+  }
 
   /// The source range in the enclosing buffer where this source was generated.
   ///

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -404,7 +404,24 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
   auto R = getSourceRange();
   if (R.isValid()) {
     OS << " src_range=";
-    R.print(OS, SrcMgr, /*PrintText=*/false);
+
+    if (getReason() != Reason::Root) {
+      R.print(OS, SrcMgr, /*PrintText=*/false);
+    } else if (auto info = SrcMgr.getGeneratedSourceInfo(
+                   Node.getAsSourceFile()->getBufferID())) {
+      info->originalSourceRange.print(OS, SrcMgr, /*PrintText=*/false);
+    } else {
+      OS << "<unknown>";
+    }
+  }
+
+  if (getReason() == Reason::Root) {
+    if (auto info = SrcMgr.getGeneratedSourceInfo(
+            Node.getAsSourceFile()->getBufferID())) {
+      OS << " generated_kind=" << GeneratedSourceInfo::kindToString(info->kind);
+    } else {
+      OS << " file=" << Node.getAsSourceFile()->getFilename().str();
+    }
   }
 
   if (!ExplicitAvailabilityInfo.isAlwaysAvailable())


### PR DESCRIPTION
Improve the performance of querying the `TypeRefinementContext` tree to look up the most refined context that contains a source location. By storing the child nodes of a parent context in sorted order, we can search for the child with a source range that contains the target location using a binary search.

To ensure the new sorted children invariant is preserved, the `ASTVerifier` has been extended to also verify the `TypeRefinementContext` hierarchy.