### PR TITLE
[Dependency Scanning] Parallelize Clang module queries

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -90,6 +90,9 @@ class SwiftLookupTable;
 class TypeDecl;
 class ValueDecl;
 class VisibleDeclConsumer;
+using ModuleDependencyIDSetVector =
+    llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
+                    std::set<ModuleDependencyID>>;
 enum class SelectorSplitKind;
 
 /// Kinds of optional types.
@@ -492,7 +495,11 @@ public:
       ModuleDependencyInfo &MDI,
       const clang::tooling::dependencies::TranslationUnitDeps &deps);
 
-  /// Add dependency information for header dependencies
+  void getBridgingHeaderOptions(
+      const clang::tooling::dependencies::TranslationUnitDeps &deps,
+      std::vector<std::string> &swiftArgs);
+
+  /// Query dependency information for header dependencies
   /// of a binary Swift module.
   ///
   /// \param moduleID the name of the Swift module whose dependency
@@ -505,10 +512,14 @@ public:
   /// about new Clang modules discovered along the way.
   ///
   /// \returns \c true if an error occurred, \c false otherwise
-  bool addHeaderDependencies(
+  bool getHeaderDependencies(
       ModuleDependencyID moduleID,
       clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-      ModuleDependenciesCache &cache);
+      ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &headerClangModuleDependencies,
+      std::vector<std::string> &headerFileInputs,
+      std::vector<std::string> &bridgingHeaderCommandLine,
+      std::optional<std::string> &includeTreeID);
 
   clang::TargetInfo &getModuleAvailabilityTarget() const override;
   clang::ASTContext &getClangASTContext() const override;

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -49,7 +49,8 @@ private:
   /// Retrieve the module dependencies for the Swift module with the given name.
   ModuleDependencyVector
   scanFilesystemForSwiftModuleDependency(Identifier moduleName,
-                                         const ModuleDependenciesCache &cache);
+                                         const ModuleDependenciesCache &cache,
+                                         bool isTestableImport = false);
 
   // Worker-specific instance of CompilerInvocation
   std::unique_ptr<CompilerInvocation> workerCompilerInvocation;
@@ -82,14 +83,15 @@ public:
   /// Resolve module dependencies of the given module, computing a full
   /// transitive closure dependency graph.
   std::vector<ModuleDependencyID>
-  getModuleDependencies(ModuleDependencyID moduleID,
+  performDependencyScan(ModuleDependencyID rootModuleID,
                         ModuleDependenciesCache &cache);
 
   /// Query the module dependency info for the Clang module with the given name.
   /// Explicit by-name lookups are useful for batch mode scanning.
   std::optional<const ModuleDependencyInfo *>
   getNamedClangModuleDependencyInfo(StringRef moduleName,
-                                    ModuleDependenciesCache &cache);
+                                    ModuleDependenciesCache &cache,
+                                    ModuleDependencyIDSetVector &discoveredClangModules);
 
   /// Query the module dependency info for the Swift module with the given name.
   /// Explicit by-name lookups are useful for batch mode scanning.
@@ -98,34 +100,50 @@ public:
                                     ModuleDependenciesCache &cache);
 
 private:
-  /// Resolve the direct dependencies of the given module.
-  std::vector<ModuleDependencyID>
-  resolveDirectModuleDependencies(ModuleDependencyID moduleID,
-                                  ModuleDependenciesCache &cache);
-
-  /// Resolve imported module names of a given module to concrete
-  /// modules. If `ParallelScan` is enabled, this operation is multithreaded.
+  /// Main routine that computes imported module dependency transitive
+  /// closure for the given module.
+  /// 1. Swift modules imported directly or via another Swift dependency
+  /// 2. Clang modules imported directly or via a Swift dependency
+  /// 3. Clang modules imported via textual header inputs to Swift modules (bridging headers)
+  /// 4. Swift overlay modules of all of the transitively imported Clang modules that have one
+  ModuleDependencyIDSetVector
+  resolveImportedModuleDependencies(const ModuleDependencyID &rootModuleID,
+                                    ModuleDependenciesCache &cache);
   void
-  resolveImportDependencies(const ModuleDependencyID &moduleID,
+  resolveSwiftModuleDependencies(const ModuleDependencyID &rootModuleID,
+                                 ModuleDependenciesCache &cache,
+                                 ModuleDependencyIDSetVector &discoveredSwiftModules);
+  void
+  resolveAllClangModuleDependencies(ArrayRef<ModuleDependencyID> swiftModules,
+                                    ModuleDependenciesCache &cache,
+                                    ModuleDependencyIDSetVector &discoveredClangModules);
+  void
+  resolveHeaderDependencies(ArrayRef<ModuleDependencyID> swiftModules,
                             ModuleDependenciesCache &cache,
-                            ModuleDependencyIDSetVector &directDependencies);
+                            ModuleDependencyIDSetVector &discoveredHeaderDependencyClangModules);
+  void
+  resolveSwiftOverlayDependencies(ArrayRef<ModuleDependencyID> swiftModules,
+                                  ModuleDependenciesCache &cache,
+                                  ModuleDependencyIDSetVector &discoveredDependencies);
+
+  /// Resolve all of a given module's imports to a Swift module, if one exists.
+  void
+  resolveSwiftImportsForModule(const ModuleDependencyID &moduleID,
+                               ModuleDependenciesCache &cache,
+                               ModuleDependencyIDSetVector &importedSwiftDependencies);
 
   /// If a module has a bridging header or other header inputs, execute a dependency scan
   /// on it and record the dependencies.
-  void resolveHeaderDependencies(
+  void resolveHeaderDependenciesForModule(
       const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
-      std::vector<std::string> &allClangModules,
-      llvm::StringSet<> &alreadyKnownModules,
-      ModuleDependencyIDSetVector &directDependencies);
+      ModuleDependencyIDSetVector &headerClangModuleDependencies);
 
   /// Resolve all module dependencies comprised of Swift overlays
   /// of this module's Clang module dependencies.
-  void resolveSwiftOverlayDependencies(
+  void resolveSwiftOverlayDependenciesForModule(
       const ModuleDependencyID &moduleID,
-      const std::vector<std::string> &clangDependencies,
       ModuleDependenciesCache &cache,
-      ModuleDependencyIDSetVector &swiftOverlayDependencies,
-      ModuleDependencyIDSetVector &directDependencies);
+      ModuleDependencyIDSetVector &swiftOverlayDependencies);
 
   /// Identify all cross-import overlay modules of the specified
   /// dependency set and apply an action for each.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -270,7 +270,7 @@ def dependency_scan_cache_remarks : Flag<["-"], "Rdependency-scan-cache">,
 
 def parallel_scan : Flag<["-"], "parallel-scan">,
    HelpText<"Perform dependency scanning in-parallel.">;
-def no_parallel_scan : Flag<["-"], "-no-parallel-scan">,
+def no_parallel_scan : Flag<["-"], "no-parallel-scan">,
    HelpText<"Perform dependency scanning in a single-threaded fashion.">;
 
 def enable_copy_propagation : Flag<["-"], "enable-copy-propagation">,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -114,10 +114,6 @@ bool ModuleDependencyInfo::isTestableImport(StringRef moduleName) const {
     return false;
 }
 
-void ModuleDependencyInfo::addModuleDependency(ModuleDependencyID dependencyID) {
-  storage->resolvedDirectModuleDependencies.push_back(dependencyID);
-}
-
 void ModuleDependencyInfo::addOptionalModuleImport(
     StringRef module, llvm::StringSet<> *alreadyAddedModules) {
   if (!alreadyAddedModules || alreadyAddedModules->insert(module).second)
@@ -447,38 +443,6 @@ void ModuleDependencyInfo::addSourceFile(StringRef sourceFile) {
     auto swiftSourceStorage =
         cast<SwiftSourceModuleDependenciesStorage>(storage.get());
     swiftSourceStorage->sourceFiles.push_back(sourceFile.str());
-    break;
-  }
-  default:
-    llvm_unreachable("Unexpected dependency kind");
-  }
-}
-
-/// Add (Clang) module on which the bridging header depends.
-void ModuleDependencyInfo::addHeaderInputModuleDependency(
-    StringRef module, llvm::StringSet<> &alreadyAddedModules) {
-  switch (getKind()) {
-  case swift::ModuleDependencyKind::SwiftInterface: {
-    auto swiftInterfaceStorage =
-        cast<SwiftInterfaceModuleDependenciesStorage>(storage.get());
-    if (alreadyAddedModules.insert(module).second)
-      swiftInterfaceStorage->textualModuleDetails.bridgingModuleDependencies
-          .push_back(module.str());
-    break;
-  }
-  case swift::ModuleDependencyKind::SwiftSource: {
-    auto swiftSourceStorage =
-        cast<SwiftSourceModuleDependenciesStorage>(storage.get());
-    if (alreadyAddedModules.insert(module).second)
-      swiftSourceStorage->textualModuleDetails.bridgingModuleDependencies
-          .push_back(module.str());
-    break;
-  }
-  case swift::ModuleDependencyKind::SwiftBinary: {
-    auto swiftBinaryStorage =
-        cast<SwiftBinaryModuleDependencyStorage>(storage.get());
-    if (alreadyAddedModules.insert(module).second)
-      swiftBinaryStorage->headerModuleDependencies.push_back(module.str());
     break;
   }
   default:
@@ -916,6 +880,19 @@ ModuleDependenciesCache::findDependency(StringRef moduleName) const {
   return std::nullopt;
 }
 
+std::optional<const ModuleDependencyInfo *>
+ModuleDependenciesCache::findSwiftDependency(StringRef moduleName) const {
+  if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftInterface))
+    return found;
+  if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftBinary))
+    return found;
+  if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftSource))
+    return found;
+  if (auto found = findDependency(moduleName, ModuleDependencyKind::SwiftPlaceholder))
+    return found;
+  return std::nullopt;
+}
+
 const ModuleDependencyInfo &ModuleDependenciesCache::findKnownDependency(
     const ModuleDependencyID &moduleID) const {
   auto dep = findDependency(moduleID);
@@ -939,6 +916,10 @@ bool ModuleDependenciesCache::hasDependency(StringRef moduleName) const {
       return true;
   }
   return false;
+}
+
+bool ModuleDependenciesCache::hasSwiftDependency(StringRef moduleName) const {
+  return findSwiftDependency(moduleName).has_value();
 }
 
 void ModuleDependenciesCache::recordDependency(
@@ -977,52 +958,147 @@ void ModuleDependenciesCache::updateDependency(
   map.insert({moduleID.ModuleName, updatedDependencies});
 }
 
-void ModuleDependenciesCache::resolveDependencyImports(ModuleDependencyID moduleID,
-                                                       const ArrayRef<ModuleDependencyID> dependencyIDs) {
-  auto optionalDependencyInfo = findDependency(moduleID);
-  assert(optionalDependencyInfo.has_value() && "Resolving unknown dependency");
-  // Copy the existing info to a mutable one we can then replace it with, after resolving its dependencies.
-  auto dependencyInfo = *(optionalDependencyInfo.value());
-  dependencyInfo.resolveDirectDependencies(dependencyIDs);
-  updateDependency(moduleID, dependencyInfo);
+void
+ModuleDependenciesCache::setImportedSwiftDependencies(ModuleDependencyID moduleID,
+                                                      const ArrayRef<ModuleDependencyID> dependencyIDs) {
+  auto dependencyInfo = findKnownDependency(moduleID);
+  assert(dependencyInfo.getImportedSwiftDependencies().empty());
+#ifndef NDEBUG
+  for (const auto &depID : dependencyIDs)
+    assert(depID.Kind != ModuleDependencyKind::Clang);
+#endif
+  // Copy the existing info to a mutable one we can then replace it with, after setting its overlay dependencies.
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.setImportedSwiftDependencies(dependencyIDs);
+  updateDependency(moduleID, updatedDependencyInfo);
 }
-
+void
+ModuleDependenciesCache::setImportedClangDependencies(ModuleDependencyID moduleID,
+                                                      const ArrayRef<ModuleDependencyID> dependencyIDs) {
+  auto dependencyInfo = findKnownDependency(moduleID);
+  assert(dependencyInfo.getImportedClangDependencies().empty());
+#ifndef NDEBUG
+  for (const auto &depID : dependencyIDs)
+    assert(depID.Kind == ModuleDependencyKind::Clang);
+#endif
+  // Copy the existing info to a mutable one we can then replace it with, after setting its overlay dependencies.
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.setImportedClangDependencies(dependencyIDs);
+  updateDependency(moduleID, updatedDependencyInfo);
+}
+void
+ModuleDependenciesCache::setHeaderClangDependencies(ModuleDependencyID moduleID,
+                                                    const ArrayRef<ModuleDependencyID> dependencyIDs) {
+  auto dependencyInfo = findKnownDependency(moduleID);
+  assert(dependencyInfo.getHeaderClangDependencies().empty());
+#ifndef NDEBUG
+  for (const auto &depID : dependencyIDs)
+    assert(depID.Kind == ModuleDependencyKind::Clang);
+#endif
+  // Copy the existing info to a mutable one we can then replace it with, after setting its overlay dependencies.
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.setHeaderClangDependencies(dependencyIDs);
+  updateDependency(moduleID, updatedDependencyInfo);
+}
 void ModuleDependenciesCache::setSwiftOverlayDependencies(ModuleDependencyID moduleID,
                                                           const ArrayRef<ModuleDependencyID> dependencyIDs) {
-  auto optionalDependencyInfo = findDependency(moduleID);
-  assert(optionalDependencyInfo.has_value() && "Resolving unknown dependency");
+  auto dependencyInfo = findKnownDependency(moduleID);
+  assert(dependencyInfo.getSwiftOverlayDependencies().empty());
+#ifndef NDEBUG
+  for (const auto &depID : dependencyIDs)
+    assert(depID.Kind != ModuleDependencyKind::Clang);
+#endif
   // Copy the existing info to a mutable one we can then replace it with, after setting its overlay dependencies.
-  auto dependencyInfo = *(optionalDependencyInfo.value());
-  dependencyInfo.setOverlayDependencies(dependencyIDs);
-  updateDependency(moduleID, dependencyInfo);
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.setSwiftOverlayDependencies(dependencyIDs);
+  updateDependency(moduleID, updatedDependencyInfo);
+}
+void
+ModuleDependenciesCache::setCrossImportOverlayDependencies(ModuleDependencyID moduleID,
+                                                           const ArrayRef<ModuleDependencyID> dependencyIDs) {
+  auto dependencyInfo = findKnownDependency(moduleID);
+  assert(dependencyInfo.getCrossImportOverlayDependencies().empty());
+  // Copy the existing info to a mutable one we can then replace it with, after setting its overlay dependencies.
+  auto updatedDependencyInfo = dependencyInfo;
+  updatedDependencyInfo.setCrossImportOverlayDependencies(dependencyIDs);
+  updateDependency(moduleID, updatedDependencyInfo);
 }
 
-std::vector<ModuleDependencyID>
+ModuleDependencyIDSetVector
 ModuleDependenciesCache::getAllDependencies(const ModuleDependencyID &moduleID) const {
-  const auto &moduleInfo = findDependency(moduleID);
-  assert(moduleInfo.has_value());
-  auto directDependenciesRef =
-      moduleInfo.value()->getDirectModuleDependencies();
-  auto overlayDependenciesRef =
-      moduleInfo.value()->getSwiftOverlayDependencies();
-  std::vector<ModuleDependencyID> result;
-  result.insert(std::end(result), directDependenciesRef.begin(),
-                directDependenciesRef.end());
-  result.insert(std::end(result), overlayDependenciesRef.begin(),
-                overlayDependenciesRef.end());
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  ModuleDependencyIDSetVector result;
+  if (moduleInfo.isSwiftModule()) {
+    auto swiftImportedDepsRef = moduleInfo.getImportedSwiftDependencies();
+    auto headerClangDepsRef = moduleInfo.getHeaderClangDependencies();
+    auto overlayDependenciesRef = moduleInfo.getSwiftOverlayDependencies();
+    result.insert(swiftImportedDepsRef.begin(),
+                  swiftImportedDepsRef.end());
+    result.insert(headerClangDepsRef.begin(),
+                  headerClangDepsRef.end());
+    result.insert(overlayDependenciesRef.begin(),
+                  overlayDependenciesRef.end());
+  }
+
+  if (moduleInfo.isSwiftSourceModule()) {
+    auto crossImportOverlayDepsRef = moduleInfo.getCrossImportOverlayDependencies();
+    result.insert(crossImportOverlayDepsRef.begin(),
+                  crossImportOverlayDepsRef.end());
+  }
+
+  auto clangImportedDepsRef = moduleInfo.getImportedClangDependencies();
+  result.insert(clangImportedDepsRef.begin(),
+                clangImportedDepsRef.end());
+
   return result;
 }
 
-ArrayRef<ModuleDependencyID>
-ModuleDependenciesCache::getOnlyOverlayDependencies(const ModuleDependencyID &moduleID) const {
-  const auto &moduleInfo = findDependency(moduleID);
-  assert(moduleInfo.has_value());
-  return moduleInfo.value()->getSwiftOverlayDependencies();
+ModuleDependencyIDSetVector
+ModuleDependenciesCache::getClangDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  ModuleDependencyIDSetVector result;
+  auto clangImportedDepsRef = moduleInfo.getImportedClangDependencies();
+  result.insert(clangImportedDepsRef.begin(),
+                clangImportedDepsRef.end());
+  if (moduleInfo.isSwiftSourceModule()) {
+    auto headerClangDepsRef = moduleInfo.getHeaderClangDependencies();
+    result.insert(headerClangDepsRef.begin(),
+                  headerClangDepsRef.end());
+  }
+  return result;
 }
 
-ArrayRef<ModuleDependencyID>
-ModuleDependenciesCache::getOnlyDirectDependencies(const ModuleDependencyID &moduleID) const {
-  const auto &moduleInfo = findDependency(moduleID);
-  assert(moduleInfo.has_value());
-  return moduleInfo.value()->getDirectModuleDependencies();
+llvm::ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getImportedSwiftDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  assert(moduleInfo.isSwiftModule());
+  return moduleInfo.getImportedSwiftDependencies();
 }
+
+llvm::ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getImportedClangDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  return moduleInfo.getImportedClangDependencies();
+}
+
+llvm::ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getHeaderClangDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  assert(moduleInfo.isSwiftModule());
+  return moduleInfo.getHeaderClangDependencies();
+}
+
+llvm::ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getSwiftOverlayDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  assert(moduleInfo.isSwiftModule());
+  return moduleInfo.getSwiftOverlayDependencies();
+}
+
+llvm::ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getCrossImportOverlayDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  assert(moduleInfo.isSwiftSourceModule());
+  return moduleInfo.getCrossImportOverlayDependencies();
+}
+

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -300,14 +300,14 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
         clangModuleDep.ID.ContextHash, swiftArgs, fileDeps, capturedPCMArgs,
         LinkLibraries, RootID, IncludeTree, /*module-cache-key*/ "",
         clangModuleDep.IsSystem);
+
+    std::vector<ModuleDependencyID> directDependencyIDs;
     for (const auto &moduleName : clangModuleDep.ClangModuleDeps) {
       dependencies.addModuleImport(moduleName.ModuleName, &alreadyAddedModules);
       // It is safe to assume that all dependencies of a Clang module are Clang modules.
-      // Doing this allows us to skip "resolving" Clang modules down the line.
-      dependencies.addModuleDependency({moduleName.ModuleName, ModuleDependencyKind::Clang});
+      directDependencyIDs.push_back({moduleName.ModuleName, ModuleDependencyKind::Clang});
     }
-    dependencies.setIsResolved(true);
-
+    dependencies.setImportedClangDependencies(directDependencyIDs);
     result.push_back(std::make_pair(ModuleDependencyID{clangModuleDep.ID.ModuleName,
                                                        ModuleDependencyKind::Clang},
                                     dependencies));
@@ -318,9 +318,16 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
 void ClangImporter::recordBridgingHeaderOptions(
     ModuleDependencyInfo &MDI,
     const clang::tooling::dependencies::TranslationUnitDeps &deps) {
+  std::vector<std::string> swiftArgs;
+  getBridgingHeaderOptions(deps, swiftArgs);
+  MDI.updateBridgingHeaderCommandLine(swiftArgs);
+}
+
+void ClangImporter::getBridgingHeaderOptions(
+    const clang::tooling::dependencies::TranslationUnitDeps &deps,
+    std::vector<std::string> &swiftArgs) {
   auto &ctx = Impl.SwiftContext;
 
-  std::vector<std::string> swiftArgs;
   auto addClangArg = [&](Twine arg) {
     swiftArgs.push_back("-Xcc");
     swiftArgs.push_back(arg.str());
@@ -384,8 +391,6 @@ void ClangImporter::recordBridgingHeaderOptions(
     swiftArgs.push_back("-cas-fs");
     swiftArgs.push_back(*CASFS);
   }
-
-  MDI.updateBridgingHeaderCommandLine(swiftArgs);
 }
 
 // The Swift compiler does not have a concept of a working directory.
@@ -465,20 +470,21 @@ ClangImporter::getModuleDependencies(Identifier moduleName,
                                        });
 }
 
-bool ClangImporter::addHeaderDependencies(
+bool ClangImporter::getHeaderDependencies(
     ModuleDependencyID moduleID,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-    ModuleDependenciesCache &cache) {
-  auto optionalTargetModule = cache.findDependency(moduleID);
-  assert(optionalTargetModule.has_value());
-  auto targetModule = *(optionalTargetModule.value());
+    ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &headerClangModuleDependencies,
+    std::vector<std::string> &headerFileInputs,
+    std::vector<std::string> &bridgingHeaderCommandLine,
+    std::optional<std::string> &includeTreeID) {
+  auto targetModuleInfo = cache.findKnownDependency(moduleID);
   // If we've already recorded bridging header dependencies, we're done.
-  if (!targetModule.getHeaderDependencies().empty() ||
-      !targetModule.getHeaderInputSourceFiles().empty())
+  if (!targetModuleInfo.getHeaderClangDependencies().empty() ||
+      !targetModuleInfo.getHeaderInputSourceFiles().empty())
     return false;
 
-  // Scan the specified textual header file and record its dependencies
-  // into the cache
+  // Scan the specified textual header file and collect its dependencies
   auto scanHeaderDependencies =
       [&](StringRef headerPath) -> llvm::Expected<TranslationUnitDeps> {
     auto &ctx = Impl.SwiftContext;
@@ -514,25 +520,22 @@ bool ClangImporter::addHeaderDependencies(
         });
     cache.recordDependencies(bridgedDeps);
 
-    // Record dependencies for the source files the bridging header includes.
-    for (const auto &fileDep : dependencies->FileDeps)
-      targetModule.addHeaderSourceFile(fileDep);
-
-    // ... and all module dependencies.
-    llvm::StringSet<> alreadyAddedModules;
-    for (const auto &moduleDep : dependencies->ClangModuleDeps)
-      targetModule.addHeaderInputModuleDependency(moduleDep.ModuleName,
-                                                  alreadyAddedModules);
-
+    llvm::copy(dependencies->FileDeps, std::back_inserter(headerFileInputs));
+    auto bridgedDependencyIDs =
+        llvm::map_range(dependencies->ClangModuleDeps, [](auto &input) {
+          return ModuleDependencyID{input.ModuleName, ModuleDependencyKind::Clang};
+        });
+    headerClangModuleDependencies.insert(bridgedDependencyIDs.begin(),
+                                         bridgedDependencyIDs.end());
     return dependencies;
   };
 
   // - Textual module dependencies require us to process their bridging header.
   // - Binary module dependnecies may have arbitrary header inputs.
-  if (targetModule.isTextualSwiftModule() &&
-      !targetModule.getBridgingHeader()->empty()) {
+  if (targetModuleInfo.isTextualSwiftModule() &&
+      !targetModuleInfo.getBridgingHeader()->empty()) {
     auto clangModuleDependencies =
-        scanHeaderDependencies(*targetModule.getBridgingHeader());
+        scanHeaderDependencies(*targetModuleInfo.getBridgingHeader());
     if (!clangModuleDependencies) {
       // FIXME: Route this to a normal diagnostic.
       llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
@@ -543,19 +546,22 @@ bool ClangImporter::addHeaderDependencies(
       return true;
     }
     if (auto TreeID = clangModuleDependencies->IncludeTreeID)
-      targetModule.addBridgingHeaderIncludeTree(*TreeID);
-    recordBridgingHeaderOptions(targetModule, *clangModuleDependencies);
-    // Update the cache with the new information for the module.
-    cache.updateDependency(moduleID, targetModule);
-  } else if (targetModule.isSwiftBinaryModule()) {
-    auto swiftBinaryDeps = targetModule.getAsSwiftBinaryModule();
+      includeTreeID = TreeID;
+
+    getBridgingHeaderOptions(*clangModuleDependencies, bridgingHeaderCommandLine);
+  } else if (targetModuleInfo.isSwiftBinaryModule()) {
+    auto swiftBinaryDeps = targetModuleInfo.getAsSwiftBinaryModule();
     if (!swiftBinaryDeps->headerImport.empty()) {
       auto clangModuleDependencies = scanHeaderDependencies(swiftBinaryDeps->headerImport);
-      if (!clangModuleDependencies)
+      if (!clangModuleDependencies) {
+        // FIXME: Route this to a normal diagnostic.
+        llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
+                                    llvm::errs());
+        Impl.SwiftContext.Diags.diagnose(
+            SourceLoc(), diag::clang_dependency_scan_error,
+            "failed to scan header dependencies");
         return true;
-      // TODO: CAS will require a header include tree for this.
-      // Update the cache with the new information for the module.
-      cache.updateDependency(moduleID, targetModule);
+      }
     }
   }
 

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -162,6 +162,13 @@ diagnoseScannerFailure(const ScannerImportStatementInfo &moduleImport,
   }
 }
 
+static bool isSwiftDependencyKind(ModuleDependencyKind Kind) {
+  return Kind == ModuleDependencyKind::SwiftInterface ||
+         Kind == ModuleDependencyKind::SwiftSource ||
+         Kind == ModuleDependencyKind::SwiftBinary ||
+         Kind == ModuleDependencyKind::SwiftPlaceholder;
+}
+
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     SwiftDependencyScanningService &globalScanningService,
     const CompilerInvocation &ScanCompilerInvocation,
@@ -239,11 +246,12 @@ ModuleDependencyScanningWorker::scanFilesystemForModuleDependency(
 
 ModuleDependencyVector
 ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
-    Identifier moduleName, const ModuleDependenciesCache &cache) {
+    Identifier moduleName, const ModuleDependenciesCache &cache,
+    bool isTestableImport) {
   return swiftScannerModuleLoader->getModuleDependencies(
       moduleName, cache.getModuleOutputPath(),
       cache.getAlreadySeenClangModules(), clangScanningTool,
-      *scanningASTDelegate, cache.getScanService().getPrefixMapper(), false);
+      *scanningASTDelegate, cache.getScanService().getPrefixMapper(), isTestableImport);
 }
 
 ModuleDependencyVector
@@ -309,34 +317,6 @@ ModuleDependencyScanner::ModuleDependencyScanner(
         DependencyTracker, Diagnostics));
 }
 
-std::vector<ModuleDependencyID>
-ModuleDependencyScanner::getModuleDependencies(ModuleDependencyID moduleID,
-                                               ModuleDependenciesCache &cache) {
-  ModuleDependencyIDSetVector allModules;
-  allModules.insert(moduleID);
-  for (unsigned currentModuleIdx = 0; currentModuleIdx < allModules.size();
-       ++currentModuleIdx) {
-    auto module = allModules[currentModuleIdx];
-    auto discoveredModules = resolveDirectModuleDependencies(module, cache);
-
-    // Do not need to resolve Clang modules, as they come fully-resolved
-    // from the Clang dependency scanner.
-    for (const auto &moduleID : discoveredModules)
-      if (moduleID.Kind != ModuleDependencyKind::Clang)
-        allModules.insert(moduleID);
-
-    allModules.insert(discoveredModules.begin(), discoveredModules.end());
-  }
-
-  // Resolve cross-import overlays.
-  if (ScanCompilerInvocation.getLangOptions().EnableCrossImportOverlays)
-    discoverCrossImportOverlayDependencies(
-        moduleID.ModuleName, allModules.getArrayRef().slice(1), cache,
-        [&](ModuleDependencyID id) { allModules.insert(id); });
-
-  return allModules.takeVector();
-}
-
 /// Find all of the imported Clang modules starting with the given module name.
 static void findAllImportedClangModules(StringRef moduleName,
                                         ModuleDependenciesCache &cache,
@@ -345,16 +325,13 @@ static void findAllImportedClangModules(StringRef moduleName,
   if (!knownModules.insert(moduleName).second)
     return;
   allModules.push_back(moduleName.str());
-  auto optionalDependencies =
-      cache.findDependency(moduleName, ModuleDependencyKind::Clang);
+  auto moduleID = ModuleDependencyID{moduleName.str(),
+                                     ModuleDependencyKind::Clang};
+  auto optionalDependencies = cache.findDependency(moduleID);
   if (!optionalDependencies.has_value())
     return;
 
-  auto dependencies = optionalDependencies.value();
-  for (const auto &dep : dependencies->getDirectModuleDependencies())
-    findAllImportedClangModules(dep.ModuleName, cache, allModules,
-                                knownModules);
-  for (const auto &dep : dependencies->getSwiftOverlayDependencies())
+  for (const auto &dep : cache.getClangDependencies(moduleID))
     findAllImportedClangModules(dep.ModuleName, cache, allModules,
                                 knownModules);
 }
@@ -496,11 +473,29 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
 /// Retrieve the module dependencies for the Clang module with the given name.
 std::optional<const ModuleDependencyInfo *>
 ModuleDependencyScanner::getNamedClangModuleDependencyInfo(
-    StringRef moduleName, ModuleDependenciesCache &cache) {
+    StringRef moduleName, ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &discoveredClangModules) {
   // Check whether we've cached this result.
-  if (auto found =
-          cache.findDependency(moduleName, ModuleDependencyKind::Clang))
+  auto moduleID = ModuleDependencyID{moduleName.str(),
+                                     ModuleDependencyKind::Clang};
+  if (auto found = cache.findDependency(moduleID)) {
+    discoveredClangModules.insert(moduleID);
+    auto directClangDeps = cache.getImportedClangDependencies(moduleID);
+    ModuleDependencyIDSetVector reachableClangModules;
+    reachableClangModules.insert(directClangDeps.begin(),
+                                 directClangDeps.end());
+    for (unsigned currentModuleIdx = 0;
+         currentModuleIdx < reachableClangModules.size();
+         ++currentModuleIdx) {
+      auto moduleID = reachableClangModules[currentModuleIdx];
+      auto dependencies =
+        cache.findKnownDependency(moduleID).getImportedClangDependencies();
+      reachableClangModules.insert(dependencies.begin(), dependencies.end());
+    }
+    discoveredClangModules.insert(reachableClangModules.begin(),
+                                  reachableClangModules.end());
     return found;
+  }
 
   // Otherwise perform filesystem scan
   auto moduleIdentifier = getModuleImportIdentifier(moduleName);
@@ -511,9 +506,13 @@ ModuleDependencyScanner::getNamedClangModuleDependencyInfo(
       });
   if (moduleDependencies.empty())
     return std::nullopt;
+  
+  discoveredClangModules.insert(moduleID);
+  for (const auto &dep : moduleDependencies)
+    discoveredClangModules.insert(dep.first);
 
   cache.recordDependencies(moduleDependencies);
-  return cache.findDependency(moduleDependencies[0].first);
+  return cache.findDependency(moduleID);
 }
 
 /// Retrieve the module dependencies for the Swift module with the given name.
@@ -545,243 +544,539 @@ ModuleDependencyScanner::getNamedSwiftModuleDependencyInfo(
     return std::nullopt;
 
   cache.recordDependencies(moduleDependencies);
-  return cache.findDependency(moduleDependencies[0].first);
+  return cache.findDependency(moduleName);
+}
+
+static void discoverCrossImportOverlayFiles(
+    StringRef mainModuleName, ArrayRef<ModuleDependencyID> allDependencies,
+    ModuleDependenciesCache &cache, ASTContext &scanASTContext,
+    llvm::SetVector<Identifier> &newOverlays,
+    std::vector<std::pair<std::string, std::string>> &overlayFiles) {
+  for (auto moduleID : allDependencies) {
+    auto moduleName = moduleID.ModuleName;
+    // Do not look for overlays of main module under scan
+    if (moduleName == mainModuleName)
+      continue;
+
+    auto dependencies = cache.findDependency(moduleName, moduleID.Kind).value();
+    // Collect a map from secondary module name to cross-import overlay names.
+    auto overlayMap = dependencies->collectCrossImportOverlayNames(
+        scanASTContext, moduleName, overlayFiles);
+    if (overlayMap.empty())
+      continue;
+    for (const auto &dependencyId : allDependencies) {
+      auto moduleName = dependencyId.ModuleName;
+      // Do not look for overlays of main module under scan
+      if (moduleName == mainModuleName)
+        continue;
+      // check if any explicitly imported modules can serve as a
+      // secondary module, and add the overlay names to the
+      // dependencies list.
+      for (auto overlayName : overlayMap[moduleName]) {
+        if (overlayName.str() != mainModuleName &&
+            std::find_if(allDependencies.begin(), allDependencies.end(),
+                         [&](ModuleDependencyID Id) {
+                           return moduleName == overlayName.str();
+                         }) == allDependencies.end()) {
+          newOverlays.insert(overlayName);
+        }
+      }
+    }
+  }
 }
 
 std::vector<ModuleDependencyID>
-ModuleDependencyScanner::resolveDirectModuleDependencies(
-    ModuleDependencyID moduleID, ModuleDependenciesCache &cache) {
-  PrettyStackTraceStringAction trace("Resolving dependencies of: ",
-                                     moduleID.ModuleName);
-  auto optionalModuleDependencyInfo = cache.findDependency(moduleID);
-  assert(optionalModuleDependencyInfo.has_value());
-  auto moduleDependencyInfo = optionalModuleDependencyInfo.value();
-
-  // If this dependency has already been resolved, return the result.
-  if (moduleDependencyInfo->isResolved() &&
-      moduleDependencyInfo->getKind() != ModuleDependencyKind::SwiftSource)
-    return cache.getAllDependencies(moduleID);
-
-  // Find the dependencies of every module this module directly depends on.
-  ModuleDependencyIDSetVector directDependencies;
-  ModuleDependencyIDSetVector swiftOverlayDependencies;
-  resolveImportDependencies(moduleID, cache, directDependencies);
-
-  // A record of all of the Clang modules referenced from this Swift module.
-  std::vector<std::string> allClangModules;
-  llvm::StringSet<> knownModules;
-
-  // Find and add all header header dependencies.
-  resolveHeaderDependencies(moduleID, cache, allClangModules, knownModules,
-                            directDependencies);
-
-  // Find all of the discovered Clang modules that this module depends on.
-  for (const auto &dep : directDependencies) {
-    if (dep.Kind != ModuleDependencyKind::Clang)
-      continue;
-    findAllImportedClangModules(dep.ModuleName, cache, allClangModules,
-                                knownModules);
+ModuleDependencyScanner::performDependencyScan(
+    ModuleDependencyID rootModuleID, ModuleDependenciesCache &cache) {
+  PrettyStackTraceStringAction trace("Performing dependency scan of: ",
+                                     rootModuleID.ModuleName);
+  // If scanning for an individual Clang module, simply resolve its imports
+  if (rootModuleID.Kind == ModuleDependencyKind::Clang) {
+    ModuleDependencyIDSetVector discoveredClangModules;
+    resolveAllClangModuleDependencies({},
+                                      cache, discoveredClangModules);
+    return discoveredClangModules.takeVector();
   }
+  
+  // Resolve all, direct and transitive, imported module dependencies:
+  // 1. Imported Swift modules
+  // 2. Imported Clang modules
+  // 3. Clang module dependencies of bridging headers
+  // 4. Swift Overlay modules of imported Clang modules
+  //    This may call into 'resolveImportedModuleDependencies'
+  //    for the newly-added Swift overlay dependencies.
+  ModuleDependencyIDSetVector allModules =
+    resolveImportedModuleDependencies(rootModuleID, cache);
 
-  // Find all Swift overlays that this module depends on.
-  resolveSwiftOverlayDependencies(moduleID, allClangModules, cache,
-                                  swiftOverlayDependencies, directDependencies);
+  // 5. Resolve cross-import overlays
+  // This must only be done for the main source module, since textual and
+  // binary Swift modules already encode their dependencies on cross-import overlays
+  // with explicit imports.
+  if (ScanCompilerInvocation.getLangOptions().EnableCrossImportOverlays)
+    discoverCrossImportOverlayDependencies(
+        rootModuleID.ModuleName, allModules.getArrayRef().slice(1), cache,
+        [&](ModuleDependencyID id) { allModules.insert(id); });
 
-  // Resolve the dependency info with dependency module information.
-  cache.resolveDependencyImports(moduleID, directDependencies.getArrayRef());
-  // Resolve the dependency info with Swift overlay dependency information.
-  if (!swiftOverlayDependencies.empty())
-    cache.setSwiftOverlayDependencies(moduleID,
-                                      swiftOverlayDependencies.getArrayRef());
-
-  ModuleDependencyIDSetVector result = directDependencies;
-  result.insert(swiftOverlayDependencies.begin(),
-                swiftOverlayDependencies.end());
-  return result.takeVector();
+  return allModules.takeVector();
 }
 
-void ModuleDependencyScanner::resolveImportDependencies(
-    const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
-    ModuleDependencyIDSetVector &directDependencies) {
-  auto optionalModuleDependencyInfo = cache.findDependency(moduleID);
-  assert(optionalModuleDependencyInfo.has_value());
-  auto moduleDependencyInfo = optionalModuleDependencyInfo.value();
+ModuleDependencyIDSetVector
+ModuleDependencyScanner::resolveImportedModuleDependencies(
+    const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache) {
+  PrettyStackTraceStringAction trace("Resolving transitive closure of dependencies of: ",
+                                     rootModuleID.ModuleName);
+  ModuleDependencyIDSetVector allModules;
 
+  // Resolve all imports for which a Swift module can be found,
+  // transitively, starting at 'rootModuleID'.
+  ModuleDependencyIDSetVector discoveredSwiftModules;
+  resolveSwiftModuleDependencies(rootModuleID, cache, discoveredSwiftModules);
+  allModules.insert(discoveredSwiftModules.begin(),
+                    discoveredSwiftModules.end());
+  
+  ModuleDependencyIDSetVector discoveredClangModules;
+  resolveAllClangModuleDependencies(discoveredSwiftModules.getArrayRef(),
+                                    cache, discoveredClangModules);
+  allModules.insert(discoveredClangModules.begin(),
+                    discoveredClangModules.end());
+  
+  ModuleDependencyIDSetVector discoveredHeaderDependencyClangModules;
+  resolveHeaderDependencies(discoveredSwiftModules.getArrayRef(), cache,
+                            discoveredHeaderDependencyClangModules);
+  allModules.insert(discoveredHeaderDependencyClangModules.begin(),
+                    discoveredHeaderDependencyClangModules.end());
+  
+  ModuleDependencyIDSetVector discoveredSwiftOverlayDependencyModules;
+  resolveSwiftOverlayDependencies(discoveredSwiftModules.getArrayRef(), cache,
+                                  discoveredSwiftOverlayDependencyModules);
+  allModules.insert(discoveredSwiftOverlayDependencyModules.begin(),
+                    discoveredSwiftOverlayDependencyModules.end());
+
+  return allModules;
+}
+
+void
+ModuleDependencyScanner::resolveSwiftModuleDependencies(
+    const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &allDiscoveredSwiftModules) {
+  PrettyStackTraceStringAction trace("Resolving transitive closure of Swift dependencies of: ",
+                                     rootModuleID.ModuleName);
+  // Clang modules cannot have Swift module dependencies
+  if (!isSwiftDependencyKind(rootModuleID.Kind))
+    return;
+
+  allDiscoveredSwiftModules.insert(rootModuleID);
+  for (unsigned currentModuleIdx = 0;
+       currentModuleIdx < allDiscoveredSwiftModules.size();
+       ++currentModuleIdx) {
+    auto moduleID = allDiscoveredSwiftModules[currentModuleIdx];
+    auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+
+    // If this dependency module's Swift imports are already resolved,
+    // we do not need to scan it.
+    if (!moduleDependencyInfo.getImportedSwiftDependencies().empty()) {
+      for (const auto &dep : moduleDependencyInfo.getImportedSwiftDependencies())
+        allDiscoveredSwiftModules.insert(dep);
+    } else {
+      // Find the Swift dependencies of every module this module directly depends on.
+      ModuleDependencyIDSetVector importedSwiftDependencies;
+      resolveSwiftImportsForModule(moduleID, cache, importedSwiftDependencies);
+      allDiscoveredSwiftModules.insert(importedSwiftDependencies.begin(),
+                                       importedSwiftDependencies.end());
+    }
+  }
+  return;
+}
+
+void
+ModuleDependencyScanner::resolveAllClangModuleDependencies(
+    ArrayRef<ModuleDependencyID> swiftModuleDependents,
+    ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &allDiscoveredClangModules) {
+  // Gather all unresolved imports which must correspond to
+  // Clang modules (since no Swift module for them was found).
+  llvm::StringSet<> unresolvedImportIdentifiers;
+  llvm::StringSet<> unresolvedOptionalImportIdentifiers;
+  std::unordered_map<ModuleDependencyID, std::vector<ScannerImportStatementInfo>> unresolvedImportsMap;
+  std::unordered_map<ModuleDependencyID, std::vector<ScannerImportStatementInfo>> unresolvedOptionalImportsMap;
+
+  for (const auto &moduleID : swiftModuleDependents) {
+    auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+    auto unresolvedImports = &unresolvedImportsMap.emplace(moduleID, std::vector<ScannerImportStatementInfo>()).first->second;
+    auto unresolvedOptionalImports = &unresolvedOptionalImportsMap.emplace(moduleID, std::vector<ScannerImportStatementInfo>()).first->second;
+
+    // If we have already resolved Clang dependencies for this module,
+    // then we have the entire dependency sub-graph already computed for
+    // it and ready to be added to 'allDiscoveredClangModules' without
+    // additional scanning.
+    if (!moduleDependencyInfo.getImportedClangDependencies().empty()) {
+      auto directClangDeps = cache.getImportedClangDependencies(moduleID);
+      ModuleDependencyIDSetVector reachableClangModules;
+      reachableClangModules.insert(directClangDeps.begin(),
+                                   directClangDeps.end());
+      for (unsigned currentModuleIdx = 0;
+           currentModuleIdx < reachableClangModules.size();
+           ++currentModuleIdx) {
+        auto moduleID = reachableClangModules[currentModuleIdx];
+        auto dependencies =
+          cache.findKnownDependency(moduleID).getImportedClangDependencies();
+        reachableClangModules.insert(dependencies.begin(), dependencies.end());
+      }
+      allDiscoveredClangModules.insert(reachableClangModules.begin(),
+                                       reachableClangModules.end());
+      continue;
+    } else {
+      // We need to query the Clang dependency scanner for this module's
+      // unresolved imports
+      auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+
+      // Figure out which imports have already been resolved to module dependencies
+      llvm::StringSet<> resolvedImportIdentifiers;
+      for (const auto &resolvedDep : moduleDependencyInfo.getImportedSwiftDependencies())
+        resolvedImportIdentifiers.insert(resolvedDep.ModuleName);
+
+      for (const auto &depImport : moduleDependencyInfo.getModuleImports())
+        if (!resolvedImportIdentifiers.contains(depImport.importIdentifier)) {
+          unresolvedImports->push_back(depImport);
+          unresolvedImportIdentifiers.insert(depImport.importIdentifier);
+        }
+      for (const auto &depImport : moduleDependencyInfo.getOptionalModuleImports())
+        if (!resolvedImportIdentifiers.contains(depImport.importIdentifier)) {
+          unresolvedOptionalImports->push_back(depImport);
+          unresolvedOptionalImportIdentifiers.insert(depImport.importIdentifier);
+        }
+    }
+  }
+
+  // Prepare the module lookup result collection
   llvm::StringMap<std::optional<ModuleDependencyVector>> moduleLookupResult;
-  // ACTDOO: Import refactor
-  for (const auto &dependsOn : moduleDependencyInfo->getModuleImports())
-    moduleLookupResult.insert(std::make_pair(dependsOn.importIdentifier, std::nullopt));
+  for (const auto &unresolvedIdentifier : unresolvedImportIdentifiers)
+    moduleLookupResult.insert(
+        std::make_pair(unresolvedIdentifier.getKey(), std::nullopt));
+
+  std::mutex CacheAccessLock;
+  auto scanForClangModuleDependency =
+      [this, &cache, &moduleLookupResult, &CacheAccessLock](Identifier moduleIdentifier) {
+        auto moduleName = moduleIdentifier.str();
+        {
+          std::lock_guard<std::mutex> guard(CacheAccessLock);
+          if (cache.hasDependency(moduleName, ModuleDependencyKind::Clang))
+            return;
+        }
+
+        auto moduleDependencies = withDependencyScanningWorker(
+            [&cache,
+             moduleIdentifier](ModuleDependencyScanningWorker *ScanningWorker) {
+              return ScanningWorker->scanFilesystemForClangModuleDependency(
+                  moduleIdentifier, cache);
+            });
+
+        // Update the `moduleLookupResult` and cache all discovered dependencies
+        // so that subsequent queries do not have to call into the scanner
+        // if looking for a module that was discovered as a transitive dependency
+        // in this scan.
+        {
+          std::lock_guard<std::mutex> guard(CacheAccessLock);
+          moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
+          if (!moduleDependencies.empty())
+            cache.recordDependencies(moduleDependencies);
+        }
+      };
+
+  // Enque asynchronous lookup tasks
+  for (const auto &unresolvedIdentifier : unresolvedImportIdentifiers)
+    ScanningThreadPool.async(
+        scanForClangModuleDependency,
+        getModuleImportIdentifier(unresolvedIdentifier.getKey()));
+  for (const auto &unresolvedIdentifier : unresolvedOptionalImportIdentifiers)
+    ScanningThreadPool.async(
+        scanForClangModuleDependency,
+        getModuleImportIdentifier(unresolvedIdentifier.getKey()));
+  ScanningThreadPool.wait();
+
+  // Use the computed scan results to update the dependency info
+  for (const auto &moduleID : swiftModuleDependents) {
+    std::vector<ScannerImportStatementInfo> failedToResolveImports;
+    ModuleDependencyIDSetVector importedClangDependencies;
+    auto recordResolvedClangModuleImport =
+        [&moduleLookupResult, &importedClangDependencies,
+         &allDiscoveredClangModules, moduleID,
+         &failedToResolveImports](const ScannerImportStatementInfo &moduleImport,
+                                  bool optionalImport) {
+          auto lookupResult = moduleLookupResult[moduleImport.importIdentifier];
+          // The imported module was found in the cache
+          if (lookupResult == std::nullopt) {
+            importedClangDependencies.insert(
+                {moduleImport.importIdentifier, ModuleDependencyKind::Clang});
+          } else {
+            // Cache discovered module dependencies.
+            if (!lookupResult.value().empty()) {
+              importedClangDependencies.insert(
+                  {moduleImport.importIdentifier, ModuleDependencyKind::Clang});
+              // Add the full transitive dependency set
+              for (const auto &dep : lookupResult.value())
+                allDiscoveredClangModules.insert(dep.first);
+            } else if (!optionalImport) {
+              // Otherwise, we failed to resolve this dependency. We will try
+              // again using the cache after all other imports have been resolved.
+              // If that fails too, a scanning failure will be diagnosed.
+              failedToResolveImports.push_back(moduleImport);
+            }
+          }
+        };
+
+    for (const auto &unresolvedImport : unresolvedImportsMap[moduleID])
+      recordResolvedClangModuleImport(unresolvedImport, false);
+    for (const auto &unresolvedImport : unresolvedOptionalImportsMap[moduleID])
+      recordResolvedClangModuleImport(unresolvedImport, true);
+
+    // It is possible that a specific import resolution failed because we are attempting to
+    // resolve a module which can only be brought in via a modulemap of a
+    // different Clang module dependency which is not otherwise on the current
+    // search paths. For example, suppose we are scanning a `.swiftinterface` for
+    // module `Foo`, which contains:
+    // -----
+    // @_exported import Foo
+    // import Bar
+    // ...
+    // -----
+    // Where `Foo` is the underlying Framework clang module whose .modulemap
+    // defines an auxiliary module `Bar`. Because Foo is a framework, its
+    // modulemap is under
+    // `<some_framework_search_path>/Foo.framework/Modules/module.modulemap`.
+    // Which means that lookup of `Bar` alone from Swift will not be able to
+    // locate the module in it. However, the lookup of Foo will itself bring in
+    // the auxiliary module becuase the Clang scanner instance scanning for clang
+    // module Foo will be able to find it in the corresponding framework module's
+    // modulemap and register it as a dependency which means it will be registered
+    // with the scanner's cache in the step above. To handle such cases, we
+    // first add all successfully-resolved modules and (for Clang modules) their
+    // transitive dependencies to the cache, and then attempt to re-query imports
+    // for which resolution originally failed from the cache. If this fails, then
+    // the scanner genuinely failed to resolve this dependency.
+    for (const auto &unresolvedImport : failedToResolveImports) {
+      auto unresolvedModuleID = ModuleDependencyID{unresolvedImport.importIdentifier,
+                                                   ModuleDependencyKind::Clang};
+      auto optionalCachedModuleInfo =
+        cache.findDependency(unresolvedModuleID);
+      if (optionalCachedModuleInfo.has_value())
+        importedClangDependencies.insert(unresolvedModuleID);
+      else
+        diagnoseScannerFailure(unresolvedImport, Diagnostics, cache, moduleID);
+    }
+
+    if (!importedClangDependencies.empty())
+      cache.setImportedClangDependencies(moduleID, importedClangDependencies.takeVector());
+  }
+
+  return;
+}
+
+void
+ModuleDependencyScanner::resolveHeaderDependencies(
+    ArrayRef<ModuleDependencyID> allSwiftModules,
+    ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &allDiscoveredHeaderDependencyClangModules) {
+  for (const auto &moduleID : allSwiftModules) {
+    auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+    if (!moduleDependencyInfo.getHeaderClangDependencies().empty()) {
+      allDiscoveredHeaderDependencyClangModules.insert(moduleDependencyInfo.getImportedSwiftDependencies().begin(),
+                                                       moduleDependencyInfo.getImportedSwiftDependencies().end());
+    } else {
+      ModuleDependencyIDSetVector headerClangModuleDependencies;
+      resolveHeaderDependenciesForModule(moduleID, cache, headerClangModuleDependencies);
+      allDiscoveredHeaderDependencyClangModules.insert(headerClangModuleDependencies.begin(),
+                                                       headerClangModuleDependencies.end());
+    }
+  }
+}
+
+void
+ModuleDependencyScanner::resolveSwiftOverlayDependencies(
+    ArrayRef<ModuleDependencyID> allSwiftModules,
+    ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &allDiscoveredDependencies) {
+  ModuleDependencyIDSetVector discoveredSwiftOverlays;
+  for (const auto &moduleID : allSwiftModules) {
+    auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+    if (!moduleDependencyInfo.getSwiftOverlayDependencies().empty()) {
+      allDiscoveredDependencies.insert(moduleDependencyInfo.getSwiftOverlayDependencies().begin(),
+                                       moduleDependencyInfo.getSwiftOverlayDependencies().end());
+    } else {
+      ModuleDependencyIDSetVector swiftOverlayDependencies;
+      resolveSwiftOverlayDependenciesForModule(moduleID, cache, swiftOverlayDependencies);
+      discoveredSwiftOverlays.insert(swiftOverlayDependencies.begin(),
+                                     swiftOverlayDependencies.end());
+    }
+  }
+
+  // For each additional Swift overlay dependency, ensure we perform a full scan
+  // in case it itself has unresolved module dependencies.
+  for (const auto &overlayDepID : discoveredSwiftOverlays) {
+    ModuleDependencyIDSetVector allNewModules =
+      resolveImportedModuleDependencies(overlayDepID, cache);
+    allDiscoveredDependencies.insert(allNewModules.begin(),
+                                     allNewModules.end());
+  }
+
+  allDiscoveredDependencies.insert(discoveredSwiftOverlays.begin(),
+                                   discoveredSwiftOverlays.end());
+}
+
+void ModuleDependencyScanner::resolveSwiftImportsForModule(
+    const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &importedSwiftDependencies) {
+  PrettyStackTraceStringAction trace("Resolving Swift imports of: ",
+                                     moduleID.ModuleName);
+  if (!isSwiftDependencyKind(moduleID.Kind))
+    return;
+
+  auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
+  llvm::StringMap<std::optional<ModuleDependencyVector>> moduleLookupResult;
+  for (const auto &dependsOn : moduleDependencyInfo.getModuleImports())
+    moduleLookupResult.insert(
+        std::make_pair(dependsOn.importIdentifier, std::nullopt));
 
   // A scanning task to query a module by-name. If the module already exists
   // in the cache, do nothing and return.
-  auto scanForModuleDependency = [this, &cache, &moduleLookupResult](
-                                  Identifier moduleIdentifier, bool onlyClangModule,
-                                  bool isTestable) {
-    auto moduleName = moduleIdentifier.str();
-    // If this is already in the cache, no work to do here
-    if (onlyClangModule) {
-      if (cache.hasDependency(moduleName, ModuleDependencyKind::Clang))
-        return;
-    } else {
-      if (cache.hasDependency(moduleName))
-        return;
-    }
+  auto scanForSwiftModuleDependency =
+      [this, &cache, &moduleLookupResult](Identifier moduleIdentifier,
+                                          bool isTestable) {
+        auto moduleName = moduleIdentifier.str().str();
+        // If this is already in the cache, no work to do here
+        if (cache.hasSwiftDependency(moduleName))
+          return;
 
-    auto moduleDependencies = withDependencyScanningWorker(
-        [&cache, moduleIdentifier, onlyClangModule,
-         isTestable](ModuleDependencyScanningWorker *ScanningWorker) {
-          return onlyClangModule
-                     ? ScanningWorker->scanFilesystemForClangModuleDependency(
-                           moduleIdentifier, cache)
-                     : ScanningWorker->scanFilesystemForModuleDependency(
-                           moduleIdentifier, cache, isTestable);
-        });
-    moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
-  };
+        auto moduleDependencies = withDependencyScanningWorker(
+            [&cache, moduleIdentifier,
+             isTestable](ModuleDependencyScanningWorker *ScanningWorker) {
+              return ScanningWorker->scanFilesystemForSwiftModuleDependency(
+                  moduleIdentifier, cache, isTestable);
+            });
+        moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
+      };
 
-  // ACTDOO: Import refactor
   // Enque asynchronous lookup tasks
-  for (const auto &dependsOn : moduleDependencyInfo->getModuleImports()) {
-    bool underlyingClangModuleLookup = moduleID.ModuleName == dependsOn.importIdentifier;
-    bool isTestable = moduleDependencyInfo->isTestableImport(dependsOn.importIdentifier);
-    ScanningThreadPool.async(scanForModuleDependency, getModuleImportIdentifier(dependsOn.importIdentifier),
-                             underlyingClangModuleLookup, isTestable);
+  for (const auto &dependsOn : moduleDependencyInfo.getModuleImports()) {
+    // Avoid querying the underlying Clang module here
+    if (moduleID.ModuleName == dependsOn.importIdentifier)
+      continue;
+    ScanningThreadPool.async(
+        scanForSwiftModuleDependency,
+        getModuleImportIdentifier(dependsOn.importIdentifier),
+        moduleDependencyInfo.isTestableImport(dependsOn.importIdentifier));
   }
   for (const auto &dependsOn :
-       moduleDependencyInfo->getOptionalModuleImports()) {
-    bool underlyingClangModuleLookup = moduleID.ModuleName == dependsOn.importIdentifier;
-    bool isTestable = moduleDependencyInfo->isTestableImport(dependsOn.importIdentifier);
-    ScanningThreadPool.async(scanForModuleDependency, getModuleImportIdentifier(dependsOn.importIdentifier),
-                             underlyingClangModuleLookup, isTestable);
+       moduleDependencyInfo.getOptionalModuleImports()) {
+    // Avoid querying the underlying Clang module here
+    if (moduleID.ModuleName == dependsOn.importIdentifier)
+      continue;
+    ScanningThreadPool.async(
+        scanForSwiftModuleDependency,
+        getModuleImportIdentifier(dependsOn.importIdentifier),
+        moduleDependencyInfo.isTestableImport(dependsOn.importIdentifier));
   }
   ScanningThreadPool.wait();
 
-  std::vector<ScannerImportStatementInfo> unresolvedImports;
-  // Aggregate both previously-cached and freshly-scanned module results
   auto recordResolvedModuleImport =
-      [&cache, &moduleLookupResult, &unresolvedImports, &directDependencies,
-       moduleID](const ScannerImportStatementInfo &moduleImport, bool optionalImport) {
-        bool underlyingClangModule = moduleID.ModuleName == moduleImport.importIdentifier;
+      [&cache, &moduleLookupResult, &importedSwiftDependencies,
+       moduleID](const ScannerImportStatementInfo &moduleImport) {
+        if (moduleID.ModuleName == moduleImport.importIdentifier)
+          return;
         auto lookupResult = moduleLookupResult[moduleImport.importIdentifier];
         // The imported module was found in the cache
         if (lookupResult == std::nullopt) {
-          const ModuleDependencyInfo *cachedInfo;
-          if (underlyingClangModule)
-            cachedInfo =
-                cache.findDependency(moduleImport.importIdentifier,
-                                     ModuleDependencyKind::Clang).value();
-          else
-            cachedInfo =
-              cache.findDependency(moduleImport.importIdentifier).value();
-          assert(cachedInfo && "Expected cached dependency info");
-          directDependencies.insert({moduleImport.importIdentifier,
-                                     cachedInfo->getKind()});
+          auto cachedInfo = cache.findSwiftDependency(moduleImport.importIdentifier);
+          if (cachedInfo.has_value())
+            importedSwiftDependencies.insert(
+              {moduleImport.importIdentifier, cachedInfo.value()->getKind()});
         } else {
           // Cache discovered module dependencies.
           if (!lookupResult.value().empty()) {
             cache.recordDependencies(lookupResult.value());
-            directDependencies.insert(
-                {moduleImport.importIdentifier,
-                 lookupResult.value()[0].first.Kind});
-          } else if (!optionalImport) {
-            // Otherwise, we failed to resolve this dependency. We will try
-            // again using the cache after all other imports have been resolved.
-            // If that fails too, a scanning failure will be diagnosed.
-            unresolvedImports.push_back(moduleImport);
+            importedSwiftDependencies.insert({moduleImport.importIdentifier,
+                                              lookupResult.value()[0].first.Kind});
           }
         }
       };
-  for (const auto &import : moduleDependencyInfo->getModuleImports())
-    recordResolvedModuleImport(import, /* optionalImport */ false);
-  for (const auto &import : moduleDependencyInfo->getOptionalModuleImports())
-    recordResolvedModuleImport(import, /* optionalImport */ true);
 
-  // It is possible that import resolution failed because we are attempting to
-  // resolve a module which can only be brought in via a modulemap of a
-  // different Clang module dependency which is not otherwise on the current
-  // search paths. For example, suppose we are scanning a `.swiftinterface` for
-  // module `Foo`, which contains:
-  // -----
-  // @_exported import Foo
-  // import Bar
-  // ...
-  // -----
-  // Where `Foo` is the underlying Framework clang module whose .modulemap
-  // defines an auxiliary module `Bar`. Because Foo is a framework, its
-  // modulemap is under
-  // `<some_framework_search_path>/Foo.framework/Modules/module.modulemap`.
-  // Which means that lookup of `Bar` alone from Swift will not be able to
-  // locate the module in it. However, the lookup of Foo will itself bring in
-  // the auxiliary module becuase the Clang scanner instance scanning for clang
-  // module Foo will be able to find it in the corresponding framework module's
-  // modulemap and register it as a dependency which means it will be registered
-  // with the scanner's cache in the step above. To handle such cases, we
-  // first add all successfully-resolved modules and (for Clang modules) their
-  // transitive dependencies to the cache, and then attempt to re-query imports
-  // for which resolution originally failed from the cache. If this fails, then
-  // the scanner genuinely failed to resolve this dependency.
-  for (const auto &moduleImport : unresolvedImports) {
-    auto optionalCachedModuleInfo =
-      cache.findDependency({moduleImport.importIdentifier,
-                            ModuleDependencyKind::Clang});
-    if (optionalCachedModuleInfo.has_value())
-      directDependencies.insert(
-          {moduleImport.importIdentifier,
-           optionalCachedModuleInfo.value()->getKind()});
-    else
-      diagnoseScannerFailure(moduleImport, Diagnostics, cache, moduleID);
-  }
+  for (const auto &importInfo : moduleDependencyInfo.getModuleImports())
+    recordResolvedModuleImport(importInfo);
+  for (const auto &importInfo : moduleDependencyInfo.getOptionalModuleImports())
+    recordResolvedModuleImport(importInfo);
+
+  // Resolve the dependency info with Swift dependency module information.
+  cache.setImportedSwiftDependencies(moduleID,
+                                     importedSwiftDependencies.getArrayRef());
 }
 
-void ModuleDependencyScanner::resolveHeaderDependencies(
+void ModuleDependencyScanner::resolveHeaderDependenciesForModule(
     const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
-    std::vector<std::string> &allClangModules,
-    llvm::StringSet<> &alreadyKnownModules,
-    ModuleDependencyIDSetVector &directDependencies) {
-  auto optionalModuleDependencyInfo = cache.findDependency(moduleID);
-  assert(optionalModuleDependencyInfo.has_value());
-  auto moduleDependencyInfo = optionalModuleDependencyInfo.value();
+    ModuleDependencyIDSetVector &headerClangModuleDependencies) {
+  PrettyStackTraceStringAction trace("Resolving header dependencies of Swift module",
+                                     moduleID.ModuleName);
+  std::vector<std::string> allClangModules;
+  llvm::StringSet<> alreadyKnownModules;
+  auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
 
   bool isTextualModuleWithABridgingHeader =
-      moduleDependencyInfo->isTextualSwiftModule() &&
-      moduleDependencyInfo->getBridgingHeader();
+      moduleDependencyInfo.isTextualSwiftModule() &&
+      moduleDependencyInfo.getBridgingHeader();
   bool isBinaryModuleWithHeaderInput =
-      moduleDependencyInfo->isSwiftBinaryModule() &&
-      !moduleDependencyInfo->getAsSwiftBinaryModule()->headerImport.empty();
+      moduleDependencyInfo.isSwiftBinaryModule() &&
+      !moduleDependencyInfo.getAsSwiftBinaryModule()->headerImport.empty();
 
   if (isTextualModuleWithABridgingHeader || isBinaryModuleWithHeaderInput) {
     withDependencyScanningWorker([&](ModuleDependencyScanningWorker
                                          *ScanningWorker) {
       auto clangImporter = static_cast<ClangImporter *>(
           ScanningWorker->clangScannerModuleLoader.get());
-      if (!clangImporter->addHeaderDependencies(
-              moduleID, ScanningWorker->clangScanningTool, cache)) {
-        // Grab the updated module dependencies.
-        const auto *updatedDependencyInfo =
-            cache.findDependency(moduleID).value();
-        // Add the Clang modules referenced from the header to the
-        // set of Clang modules we know about.
-        for (const auto &clangDep :
-             updatedDependencyInfo->getHeaderDependencies()) {
-          directDependencies.insert({clangDep, ModuleDependencyKind::Clang});
-          findAllImportedClangModules(clangDep, cache, allClangModules,
-                                      alreadyKnownModules);
-        }
+
+      std::vector<std::string> headerFileInputs;
+      std::optional<std::string> includeTreeID;
+      std::vector<std::string> bridgingHeaderCommandLine;
+      auto headerScan = clangImporter->getHeaderDependencies(moduleID, ScanningWorker->clangScanningTool, cache,
+                                                             headerClangModuleDependencies, headerFileInputs,
+                                                             bridgingHeaderCommandLine, includeTreeID);
+      if (!headerScan) {
+        // Record direct header Clang dependencies
+        cache.setHeaderClangDependencies(moduleID, headerClangModuleDependencies.getArrayRef());
+        // Record include Tree ID
+        if (includeTreeID.has_value())
+          moduleDependencyInfo.addBridgingHeaderIncludeTree(*includeTreeID);
+        // Record the bridging header command line
+        if (isTextualModuleWithABridgingHeader)
+          moduleDependencyInfo.updateBridgingHeaderCommandLine(bridgingHeaderCommandLine);
+        for (const auto &headerInput : headerFileInputs)
+          moduleDependencyInfo.addHeaderSourceFile(headerInput);
+        // Update the dependency in the cache
+        cache.updateDependency(moduleID, moduleDependencyInfo);
+      } else {
+        // Failure to scan header
       }
       return true;
     });
+    cache.setHeaderClangDependencies(moduleID, headerClangModuleDependencies.getArrayRef());
   }
 }
 
-void ModuleDependencyScanner::resolveSwiftOverlayDependencies(
+void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
     const ModuleDependencyID &moduleID,
-    const std::vector<std::string> &clangDependencies,
     ModuleDependenciesCache &cache,
-    ModuleDependencyIDSetVector &swiftOverlayDependencies,
-    ModuleDependencyIDSetVector &directDependencies) {
+    ModuleDependencyIDSetVector &swiftOverlayDependencies) {
+  PrettyStackTraceStringAction trace("Resolving Swift Overlay dependencies of module",
+                                     moduleID.ModuleName);
+  std::vector<std::string> allClangDependencies;
+  llvm::StringSet<> knownModules;
+
+  // Find all of the discovered Clang modules that this module depends on.
+  for (const auto &dep : cache.getClangDependencies(moduleID))
+    findAllImportedClangModules(dep.ModuleName, cache, allClangDependencies,
+                                knownModules);
+
   llvm::StringMap<std::optional<ModuleDependencyVector>>
       swiftOverlayLookupResult;
-  for (const auto &clangDep : clangDependencies)
+  for (const auto &clangDep : allClangDependencies)
     swiftOverlayLookupResult.insert(std::make_pair(clangDep, std::nullopt));
 
   // A scanning task to query a Swift module by-name. If the module already
@@ -804,43 +1099,35 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependencies(
   };
 
   // Enque asynchronous lookup tasks
-  for (const auto &clangDep : clangDependencies)
+  for (const auto &clangDep : allClangDependencies)
     ScanningThreadPool.async(scanForSwiftDependency, getModuleImportIdentifier(clangDep));
   ScanningThreadPool.wait();
 
   // Aggregate both previously-cached and freshly-scanned module results
   auto recordResult = [&cache, &swiftOverlayLookupResult,
                        &swiftOverlayDependencies,
-                       &directDependencies,
                        moduleID](const std::string &moduleName) {
     auto lookupResult = swiftOverlayLookupResult[moduleName];
     if (moduleName != moduleID.ModuleName) {
       if (lookupResult == std::nullopt) {
-        const ModuleDependencyInfo *cachedInfo = cache.findDependency(moduleName).value();
-        swiftOverlayDependencies.insert({moduleName, cachedInfo->getKind()});
-        // FIXME: Once all clients know to fetch these dependencies from
-        // `swiftOverlayDependencies`, the goal is to no longer have them in
-        // `directDependencies` so the following will need to go away.
-        directDependencies.insert({moduleName, cachedInfo->getKind()});
+        auto cachedInfo = cache.findSwiftDependency(moduleName);
+        if (cachedInfo.has_value())
+          swiftOverlayDependencies.insert(
+            {moduleName, cachedInfo.value()->getKind()});
       } else {
         // Cache discovered module dependencies.
         cache.recordDependencies(lookupResult.value());
-        if (!lookupResult.value().empty()) {
+        if (!lookupResult.value().empty())
           swiftOverlayDependencies.insert({moduleName, lookupResult.value()[0].first.Kind});
-          // FIXME: Once all clients know to fetch these dependencies from
-          // `swiftOverlayDependencies`, the goal is to no longer have them in
-          // `directDependencies` so the following will need to go away.
-          directDependencies.insert({moduleName, lookupResult.value()[0].first.Kind});
-        }
       }
     }
   };
-  for (const auto &clangDep : clangDependencies)
+  for (const auto &clangDep : allClangDependencies)
     recordResult(clangDep);
 
   // C++ Interop requires additional handling
   if (ScanCompilerInvocation.getLangOptions().EnableCXXInterop) {
-    for (const auto &clangDepName : clangDependencies) {
+    for (const auto &clangDepName : allClangDependencies) {
       // If this Clang module is a part of the C++ stdlib, and we haven't loaded
       // the overlay for it so far, it is a split libc++ module (e.g.
       // std_vector). Load the CxxStdlib overlay explicitly.
@@ -861,6 +1148,9 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependencies(
       }
     }
   }
+
+  // Resolve the dependency info with Swift overlay dependency module information.
+  cache.setSwiftOverlayDependencies(moduleID, swiftOverlayDependencies.getArrayRef());
 }
 
 void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
@@ -870,37 +1160,9 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
   // Modules explicitly imported. Only these can be secondary module.
   llvm::SetVector<Identifier> newOverlays;
   std::vector<std::pair<std::string, std::string>> overlayFiles;
-  for (auto dep : allDependencies) {
-    auto moduleName = dep.ModuleName;
-    // Do not look for overlays of main module under scan
-    if (moduleName == mainModuleName)
-      continue;
+  discoverCrossImportOverlayFiles(mainModuleName, allDependencies, cache,
+                                  ScanASTContext, newOverlays, overlayFiles);
 
-    auto dependencies = cache.findDependency(moduleName, dep.Kind).value();
-    // Collect a map from secondary module name to cross-import overlay names.
-    auto overlayMap = dependencies->collectCrossImportOverlayNames(
-        ScanASTContext, moduleName, overlayFiles);
-    if (overlayMap.empty())
-      continue;
-    for (const auto &dependencyId : allDependencies) {
-      auto moduleName = dependencyId.ModuleName;
-      // Do not look for overlays of main module under scan
-      if (moduleName == mainModuleName)
-        continue;
-      // check if any explicitly imported modules can serve as a
-      // secondary module, and add the overlay names to the
-      // dependencies list.
-      for (auto overlayName : overlayMap[moduleName]) {
-        if (overlayName.str() != mainModuleName &&
-            std::find_if(allDependencies.begin(), allDependencies.end(),
-                         [&](ModuleDependencyID Id) {
-                           return moduleName == overlayName.str();
-                         }) == allDependencies.end()) {
-          newOverlays.insert(overlayName);
-        }
-      }
-    }
-  }
   // No new cross-import overlays are found, return.
   if (newOverlays.empty())
     return;
@@ -908,6 +1170,10 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
   // Construct a dummy main to resolve the newly discovered cross import
   // overlays.
   StringRef dummyMainName = "DummyMainModuleForResolvingCrossImportOverlays";
+  auto dummyMainID = ModuleDependencyID{dummyMainName.str(),
+                                        ModuleDependencyKind::SwiftSource};
+  auto actualMainID = ModuleDependencyID{mainModuleName.str(),
+                                         ModuleDependencyKind::SwiftSource};
   auto dummyMainDependencies =
       ModuleDependencyInfo::forSwiftSourceModule({}, {}, {}, {});
   std::for_each(newOverlays.begin(), newOverlays.end(),
@@ -918,44 +1184,21 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
   if (cache.findDependency(dummyMainName, ModuleDependencyKind::SwiftSource)) {
-    cache.updateDependency(
-        ModuleDependencyID{dummyMainName.str(),
-                           ModuleDependencyKind::SwiftSource},
-        dummyMainDependencies);
+    cache.updateDependency(dummyMainID, dummyMainDependencies);
   } else {
     cache.recordDependency(dummyMainName, dummyMainDependencies);
   }
 
-  ModuleDependencyIDSetVector allModules;
-
-  // Seed the all module list from the dummy main module.
-  allModules.insert({dummyMainName.str(), dummyMainDependencies.getKind()});
-
-  // Explore the dependencies of every module.
-  for (unsigned currentModuleIdx = 0; currentModuleIdx < allModules.size();
-       ++currentModuleIdx) {
-    auto module = allModules[currentModuleIdx];
-    auto moduleDependnencyIDs = resolveDirectModuleDependencies(module, cache);
-    allModules.insert(moduleDependnencyIDs.begin(), moduleDependnencyIDs.end());
-  }
+  ModuleDependencyIDSetVector allModules =
+    resolveImportedModuleDependencies(dummyMainID, cache);
 
   // Update main module's dependencies to include these new overlays.
-  auto resolvedDummyDep =
-      **cache.findDependency(dummyMainName, ModuleDependencyKind::SwiftSource);
-  auto mainDep =
-      **cache.findDependency(mainModuleName, ModuleDependencyKind::SwiftSource);
-  auto newOverlayDeps = resolvedDummyDep.getDirectModuleDependencies();
-  auto existingMainDeps = mainDep.getDirectModuleDependencies();
-  ModuleDependencyIDSet existingMainDepsSet(existingMainDeps.begin(),
-                                            existingMainDeps.end());
-  // Ensure we do not add cross-import overlay dependencies in case they
-  // were already explicitly imported
-  std::for_each(newOverlayDeps.begin(), newOverlayDeps.end(),
-                [&](ModuleDependencyID crossImportOverlayModID) {
-                  if (!existingMainDepsSet.count(crossImportOverlayModID))
-                    mainDep.addModuleDependency(crossImportOverlayModID);
-                });
+  auto newOverlayDeps = cache.getAllDependencies(dummyMainID);
+  cache.setCrossImportOverlayDependencies(actualMainID, newOverlayDeps.getArrayRef());
 
+  // Update the command-line on the main module to
+  // disable implicit cross-import overlay search.
+  auto mainDep = cache.findKnownDependency(actualMainID);
   auto cmdCopy = mainDep.getCommandline();
   cmdCopy.push_back("-disable-cross-import-overlay-search");
   for (auto &entry : overlayFiles) {
@@ -966,9 +1209,7 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
     cmdCopy.push_back(overlayPath);
   }
   mainDep.updateCommandLine(cmdCopy);
-
-  cache.updateDependency(
-      {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);
+  cache.updateDependency(actualMainID, mainDep);
 
   // Report any discovered modules to the clients, which include all overlays
   // and their dependencies.

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -341,10 +341,10 @@ private:
     // If this binary module was built with a header, the header's module
     // dependencies must also specify a .modulemap to the compilation, in
     // order to resolve the header's own header include directives.
-    for (const auto &bridgingHeaderDepName :
+    for (const auto &bridgingHeaderDepID :
          binaryDepDetails.headerModuleDependencies) {
       auto optionalBridgingHeaderDepModuleInfo = cache.findKnownDependency(
-          {bridgingHeaderDepName, ModuleDependencyKind::Clang});
+          bridgingHeaderDepID);
       const auto bridgingHeaderDepModuleDetails =
           optionalBridgingHeaderDepModuleInfo.getAsClangModule();
       commandline.push_back("-Xcc");
@@ -431,7 +431,7 @@ private:
 
   void addMacroDependencies(ModuleDependencyID moduleID,
                             const ModuleDependencyInfoStorageBase &dep) {
-    auto &directDeps = resolvingDepInfo.getDirectModuleDependencies();
+    auto directDeps = cache.getAllDependencies(this->moduleID);
     if (llvm::find(directDeps, moduleID) == directDeps.end())
       return;
 
@@ -444,6 +444,7 @@ private:
     return arg == "-ivfsoverlay" || arg == "-vfsoverlay";
   };
   static bool isXCCArg(StringRef arg) { return arg == "-Xcc"; };
+
 
   void
   collectUsedVFSOverlay(const ClangModuleDependencyStorage &clangDepDetails) {
@@ -718,18 +719,18 @@ generateFullDependencyGraph(const CompilerInstance &instance,
       new swiftscan_dependency_info_t[dependencySet->count];
 
   for (size_t i = 0; i < allModules.size(); ++i) {
-    const auto &module = allModules[i];
-    auto &moduleDeps = cache.findKnownDependency(module);
+    const auto &moduleID = allModules[i];
+    auto &moduleDependencyInfo = cache.findKnownDependency(moduleID);
     // Collect all the required pieces to build a ModuleInfo
-    auto swiftPlaceholderDeps = moduleDeps.getAsPlaceholderDependencyModule();
-    auto swiftTextualDeps = moduleDeps.getAsSwiftInterfaceModule();
-    auto swiftSourceDeps = moduleDeps.getAsSwiftSourceModule();
-    auto swiftBinaryDeps = moduleDeps.getAsSwiftBinaryModule();
-    auto clangDeps = moduleDeps.getAsClangModule();
+    auto swiftPlaceholderDeps = moduleDependencyInfo.getAsPlaceholderDependencyModule();
+    auto swiftTextualDeps = moduleDependencyInfo.getAsSwiftInterfaceModule();
+    auto swiftSourceDeps = moduleDependencyInfo.getAsSwiftSourceModule();
+    auto swiftBinaryDeps = moduleDependencyInfo.getAsSwiftBinaryModule();
+    auto clangDeps = moduleDependencyInfo.getAsClangModule();
 
     // ModulePath
     const char *modulePathSuffix =
-        moduleDeps.isSwiftModule() ? ".swiftmodule" : ".pcm";
+        moduleDependencyInfo.isSwiftModule() ? ".swiftmodule" : ".pcm";
     std::string modulePath;
     if (swiftTextualDeps)
       modulePath = swiftTextualDeps->moduleOutputPath;
@@ -740,7 +741,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
     else if (clangDeps)
       modulePath = clangDeps->pcmOutputPath;
     else
-      modulePath = module.ModuleName + modulePathSuffix;
+      modulePath = moduleID.ModuleName + modulePathSuffix;
 
     // SourceFiles
     std::vector<std::string> sourceFiles;
@@ -750,8 +751,10 @@ generateFullDependencyGraph(const CompilerInstance &instance,
       sourceFiles = clangDeps->fileDependencies;
     }
 
-    auto &depInfo = cache.findKnownDependency(module);
-    auto directDependencies = depInfo.getDirectModuleDependencies();
+    auto directDependencies = cache.getAllDependencies(moduleID);
+    std::vector<std::string> clangHeaderDependencyNames;
+    for (const auto &headerDepID : moduleDependencyInfo.getHeaderClangDependencies())
+      clangHeaderDependencyNames.push_back(headerDepID.ModuleName);
 
     // Generate a swiftscan_clang_details_t object based on the dependency kind
     auto getModuleDetails = [&]() -> swiftscan_module_details_t {
@@ -779,8 +782,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
             bridgingHeaderPath,
             create_set(
                 swiftTextualDeps->textualModuleDetails.bridgingSourceFiles),
-            create_set(swiftTextualDeps->textualModuleDetails
-                           .bridgingModuleDependencies),
+            create_set(clangHeaderDependencyNames),
             create_set(bridgedOverlayDependencyNames),
             create_set(swiftTextualDeps->textualModuleDetails.buildCommandLine),
             /*bridgingHeaderBuildCommand*/ create_set({}),
@@ -813,8 +815,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
             moduleInterfacePath, create_empty_set(), bridgingHeaderPath,
             create_set(
                 swiftSourceDeps->textualModuleDetails.bridgingSourceFiles),
-            create_set(swiftSourceDeps->textualModuleDetails
-                           .bridgingModuleDependencies),
+            create_set(clangHeaderDependencyNames),
             create_set(bridgedOverlayDependencyNames),
             create_set(swiftSourceDeps->textualModuleDetails.buildCommandLine),
             create_set(swiftSourceDeps->bridgingHeaderBuildCommandLine),
@@ -852,7 +853,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
             create_clone(swiftBinaryDeps->sourceInfoPath.c_str()),
             create_set(bridgedOverlayDependencyNames),
             create_clone(swiftBinaryDeps->headerImport.c_str()),
-            create_set(swiftBinaryDeps->headerModuleDependencies),
+            create_set(clangHeaderDependencyNames),
             create_set(swiftBinaryDeps->headerSourceFiles),
             swiftBinaryDeps->isFramework,
             swiftBinaryDeps->isStatic,
@@ -877,7 +878,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
     swiftscan_dependency_info_s *moduleInfo = new swiftscan_dependency_info_s;
     dependencySet->modules[i] = moduleInfo;
 
-    std::string encodedModuleName = createEncodedModuleKindAndName(module);
+    std::string encodedModuleName = createEncodedModuleKindAndName(moduleID);
     auto ttt = create_clone(encodedModuleName.c_str());
     moduleInfo->module_name = ttt;
     moduleInfo->module_path = create_clone(modulePath.c_str());
@@ -885,12 +886,13 @@ generateFullDependencyGraph(const CompilerInstance &instance,
 
     // Create a direct dependencies set according to the output format
     std::vector<std::string> bridgedDependencyNames;
-    bridgeDependencyIDs(directDependencies, bridgedDependencyNames);
+    bridgeDependencyIDs(directDependencies.getArrayRef(),
+                        bridgedDependencyNames);
     moduleInfo->direct_dependencies = create_set(bridgedDependencyNames);
     moduleInfo->details = getModuleDetails();
 
     // Create a link libraries set for this module
-    auto &linkLibraries = depInfo.getLinkLibraries();
+    auto &linkLibraries = moduleDependencyInfo.getLinkLibraries();
     swiftscan_link_library_set_t *linkLibrarySet =
         new swiftscan_link_library_set_t;
     linkLibrarySet->count = linkLibraries.size();
@@ -1002,14 +1004,12 @@ static std::set<ModuleDependencyID> computeBridgingHeaderTransitiveDependencies(
         &transitiveClosures,
     const ModuleDependenciesCache &cache) {
   std::set<ModuleDependencyID> result;
-  auto *sourceDep = dep.getAsSwiftSourceModule();
-  if (!sourceDep)
+  if (!dep.isSwiftSourceModule())
     return result;
 
-  for (auto &dep : sourceDep->textualModuleDetails.bridgingModuleDependencies) {
-    ModuleDependencyID modID{dep, ModuleDependencyKind::Clang};
-    result.insert(modID);
-    auto succDeps = transitiveClosures.find(modID);
+  for (auto &depID : dep.getHeaderClangDependencies()) {
+    result.insert(depID);
+    auto succDeps = transitiveClosures.find(depID);
     assert(succDeps != transitiveClosures.end() && "unknown dependency");
     llvm::set_union(result, succDeps->second);
   }
@@ -1116,7 +1116,7 @@ static bool diagnoseCycle(const CompilerInstance &instance,
       const auto &nextID = *(it + 1);
       if (kindIsSwiftDependency(thisID) && kindIsSwiftDependency(nextID) &&
           llvm::any_of(
-              cache.getOnlyOverlayDependencies(thisID),
+              cache.getSwiftOverlayDependencies(thisID),
               [&](const ModuleDependencyID id) { return id == nextID; })) {
         llvm::SmallString<64> noteBuffer;
         auto clangDepPath = findClangDepPath(
@@ -1561,17 +1561,7 @@ swift::dependencies::performModuleScan(
     cache.recordDependency(mainModuleName, std::move(*mainModuleDepInfo));
 
   // Perform the full module scan starting at the main module.
-  auto allModules = scanner.getModuleDependencies(mainModuleID, cache);
-
-#ifndef NDEBUG
-  // Verify that all collected dependencies have had their
-  // imports resolved to module IDs.
-  for (const auto &moduleID : allModules)
-    assert(cache.findDependency(moduleID)
-               .value()
-               ->isResolved());
-#endif
-
+  auto allModules = scanner.performDependencyScan(mainModuleID, cache);
   if (diagnoseCycle(instance, cache, mainModuleID))
     return std::make_error_code(std::errc::not_supported);
 
@@ -1646,27 +1636,33 @@ swift::dependencies::performBatchModuleScan(
 
         StringRef moduleName = entry.moduleName;
         bool isClang = !entry.isSwift;
+        ModuleDependencyID moduleID{
+           moduleName.str(), isClang ? ModuleDependencyKind::Clang
+                                     : ModuleDependencyKind::SwiftInterface};
         std::optional<const ModuleDependencyInfo *> rootDeps;
+        std::vector<ModuleDependencyID> allDependencies;
         if (isClang) {
           // Loading the clang module using Clang importer.
           // This action will populate the cache with the main module's
           // dependencies.
-          rootDeps = scanner.getNamedClangModuleDependencyInfo(moduleName, cache);
+          ModuleDependencyIDSetVector allClangModules;
+          rootDeps = scanner.getNamedClangModuleDependencyInfo(moduleName, cache, allClangModules);
+          if (!rootDeps.has_value()) {
+            batchScanResult.push_back(
+                std::make_error_code(std::errc::invalid_argument));
+            return;
+          }
+          allDependencies = allClangModules.takeVector();
         } else {
           rootDeps = scanner.getNamedSwiftModuleDependencyInfo(moduleName, cache);
+          if (!rootDeps.has_value()) {
+            batchScanResult.push_back(
+                std::make_error_code(std::errc::invalid_argument));
+            return;
+          }
+          allDependencies = scanner.performDependencyScan(moduleID, cache);
         }
-        if (!rootDeps.has_value()) {
-          // We cannot find the clang module, abort.
-          batchScanResult.push_back(
-              std::make_error_code(std::errc::invalid_argument));
-          return;
-        }
-
-        ModuleDependencyIDSetVector allModules;
-        ModuleDependencyID moduleID{
-            moduleName.str(), isClang ? ModuleDependencyKind::Clang
-                                      : ModuleDependencyKind::SwiftInterface};
-        auto allDependencies = scanner.getModuleDependencies(moduleID, cache);
+        
         batchScanResult.push_back(
             generateFullDependencyGraph(instance, diagnosticCollector, cache,
                                         allDependencies));

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -150,9 +150,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.SerializeDependencyScannerCache |= Args.hasArg(OPT_serialize_dependency_scan_cache);
   Opts.ReuseDependencyScannerCache |= Args.hasArg(OPT_reuse_dependency_scan_cache);
   Opts.EmitDependencyScannerCacheRemarks |= Args.hasArg(OPT_dependency_scan_cache_remarks);
-  Opts.ParallelDependencyScan = Args.hasArg(OPT_parallel_scan,
-                                            OPT_no_parallel_scan,
-                                            true);
+  Opts.ParallelDependencyScan = Args.hasFlag(OPT_parallel_scan,
+                                             OPT_no_parallel_scan,
+                                             true);
   if (const Arg *A = Args.getLastArg(OPT_dependency_scan_cache_path)) {
     Opts.SerializedDependencyScannerCachePath = A->getValue();
   }

--- a/test/CAS/module_deps.swift
+++ b/test/CAS/module_deps.swift
@@ -98,16 +98,38 @@ import SubE
 // CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "swift": "F"
 
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+/// --------Clang module C
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
+
+// CHECK: "sourceFiles": [
+// CHECK-DAG: module.modulemap
+// CHECK-DAG: C.h
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-DAG:   "clang": "A"
-// CHECK-DAG:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK: "details":
-// CHECK: "moduleCacheKey":
+// CHECK-NEXT: "clang": "B"
+
+// CHECK: "moduleMapPath"
+// CHECK-SAME: module.modulemap
+
+// CHECK: "contextHash"
+// CHECK-SAME: "{{.*}}"
+
+/// --------Clang module B
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
+// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
+// CHECK: "-o"
+// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
+
+// Check make-style dependencies
+// CHECK-MAKE-DEPS: module_deps.swift
+// CHECK-MAKE-DEPS-SAME: A.swiftinterface
+// CHECK-MAKE-DEPS-SAME: G.swiftinterface
+// CHECK-MAKE-DEPS-SAME: B.h
+// CHECK-MAKE-DEPS-SAME: F.h
+// CHECK-MAKE-DEPS-SAME: Bridging.h
+// CHECK-MAKE-DEPS-SAME: BridgingOther.h
+// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module F
 // CHECK:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
@@ -120,6 +142,18 @@ import SubE
 // CHECK-DAG:     "swift": "SwiftOnoneSupport"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
+// CHECK: "details":
+// CHECK: "moduleCacheKey":
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK-NEXT: }
 // CHECK: "details":
 // CHECK: "moduleCacheKey":
 
@@ -162,39 +196,6 @@ import SubE
 
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
-
-/// --------Clang module C
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
-
-// CHECK: "sourceFiles": [
-// CHECK-DAG: module.modulemap
-// CHECK-DAG: C.h
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "B"
-
-// CHECK: "moduleMapPath"
-// CHECK-SAME: module.modulemap
-
-// CHECK: "contextHash"
-// CHECK-SAME: "{{.*}}"
-
-/// --------Clang module B
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
-// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
-// CHECK: "-o"
-// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
-
-// Check make-style dependencies
-// CHECK-MAKE-DEPS: module_deps.swift
-// CHECK-MAKE-DEPS-SAME: A.swiftinterface
-// CHECK-MAKE-DEPS-SAME: G.swiftinterface
-// CHECK-MAKE-DEPS-SAME: B.h
-// CHECK-MAKE-DEPS-SAME: F.h
-// CHECK-MAKE-DEPS-SAME: Bridging.h
-// CHECK-MAKE-DEPS-SAME: BridgingOther.h
-// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -97,16 +97,45 @@ import SubE
 // CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "swift": "F"
 
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+/// --------Clang module C
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
+
+// CHECK: "sourceFiles": [
+// CHECK-DAG: module.modulemap
+// CHECK-DAG: C.h
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-DAG:   "clang": "A"
-// CHECK-DAG:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK: "details":
-// CHECK: "moduleCacheKey":
+// CHECK-NEXT: "clang": "B"
+
+// CHECK: "moduleMapPath"
+// CHECK-SAME: module.modulemap
+
+// CHECK: "contextHash"
+// CHECK-SAME: "{{.*}}"
+
+// CHECK: "commandLine": [
+// CHECK:   "-fmodule-format=obj"
+// CHECK:   "-dwarf-ext-refs"
+
+/// --------Clang module B
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
+// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
+// CHECK: "commandLine": [
+// CHECK:      "-o"
+// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
+// CHECK:      "-fmodule-format=obj"
+// CHECK:      "-dwarf-ext-refs"
+
+// Check make-style dependencies
+// CHECK-MAKE-DEPS: module_deps_include_tree.swift
+// CHECK-MAKE-DEPS-SAME: A.swiftinterface
+// CHECK-MAKE-DEPS-SAME: G.swiftinterface
+// CHECK-MAKE-DEPS-SAME: B.h
+// CHECK-MAKE-DEPS-SAME: F.h
+// CHECK-MAKE-DEPS-SAME: Bridging.h
+// CHECK-MAKE-DEPS-SAME: BridgingOther.h
+// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module F
 // CHECK:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
@@ -119,6 +148,17 @@ import SubE
 // CHECK-DAG:     "swift": "SwiftOnoneSupport"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
+// CHECK: "details":
+// CHECK: "moduleCacheKey":
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-NEXT: }
 // CHECK: "details":
 // CHECK: "moduleCacheKey":
 
@@ -161,46 +201,6 @@ import SubE
 
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
-
-/// --------Clang module C
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
-
-// CHECK: "sourceFiles": [
-// CHECK-DAG: module.modulemap
-// CHECK-DAG: C.h
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "B"
-
-// CHECK: "moduleMapPath"
-// CHECK-SAME: module.modulemap
-
-// CHECK: "contextHash"
-// CHECK-SAME: "{{.*}}"
-
-// CHECK: "commandLine": [
-// CHECK:   "-fmodule-format=obj"
-// CHECK:   "-dwarf-ext-refs"
-
-/// --------Clang module B
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
-// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
-// CHECK: "commandLine": [
-// CHECK:      "-o"
-// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
-// CHECK:      "-fmodule-format=obj"
-// CHECK:      "-dwarf-ext-refs"
-
-// Check make-style dependencies
-// CHECK-MAKE-DEPS: module_deps_include_tree.swift
-// CHECK-MAKE-DEPS-SAME: A.swiftinterface
-// CHECK-MAKE-DEPS-SAME: G.swiftinterface
-// CHECK-MAKE-DEPS-SAME: B.h
-// CHECK-MAKE-DEPS-SAME: F.h
-// CHECK-MAKE-DEPS-SAME: Bridging.h
-// CHECK-MAKE-DEPS-SAME: BridgingOther.h
-// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -80,16 +80,39 @@ import SubE
 // CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "swift": "F"
 
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+/// --------Clang module C
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
+
+// CHECK: "sourceFiles": [
+// CHECK-DAG: module.modulemap
+// CHECK-DAG: C.h
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-DAG:   "clang": "A"
-// CHECK-DAG:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK: "details":
-// CHECK: "moduleCacheKey":
+// CHECK-NEXT: "clang": "B"
+
+// CHECK: "moduleMapPath"
+// CHECK-SAME: module.modulemap
+
+// CHECK: "contextHash"
+// CHECK-SAME: "{{.*}}"
+
+/// --------Clang module B
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
+// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
+// CHECK: "-o"
+// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
+
+// Check make-style dependencies
+// CHECK-MAKE-DEPS: plugin_cas.swift
+// CHECK-MAKE-DEPS-SAME: A.swiftinterface
+// CHECK-MAKE-DEPS-SAME: G.swiftinterface
+// CHECK-MAKE-DEPS-SAME: B.h
+// CHECK-MAKE-DEPS-SAME: F.h
+// CHECK-MAKE-DEPS-SAME: Bridging.h
+// CHECK-MAKE-DEPS-SAME: BridgingOther.h
+// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module F
 // CHECK:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
@@ -102,6 +125,17 @@ import SubE
 // CHECK-DAG:     "swift": "SwiftOnoneSupport"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
+// CHECK: "details":
+// CHECK: "moduleCacheKey":
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-NEXT: }
 // CHECK: "details":
 // CHECK: "moduleCacheKey":
 
@@ -142,39 +176,6 @@ import SubE
 
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
-
-/// --------Clang module C
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
-
-// CHECK: "sourceFiles": [
-// CHECK-DAG: module.modulemap
-// CHECK-DAG: C.h
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "B"
-
-// CHECK: "moduleMapPath"
-// CHECK-SAME: module.modulemap
-
-// CHECK: "contextHash"
-// CHECK-SAME: "{{.*}}"
-
-/// --------Clang module B
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
-// CHECK: "contextHash": "[[B_CONTEXT:.*]]",
-// CHECK: "-o"
-// CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
-
-// Check make-style dependencies
-// CHECK-MAKE-DEPS: plugin_cas.swift
-// CHECK-MAKE-DEPS-SAME: A.swiftinterface
-// CHECK-MAKE-DEPS-SAME: G.swiftinterface
-// CHECK-MAKE-DEPS-SAME: B.h
-// CHECK-MAKE-DEPS-SAME: F.h
-// CHECK-MAKE-DEPS-SAME: Bridging.h
-// CHECK-MAKE-DEPS-SAME: BridgingOther.h
-// CHECK-MAKE-DEPS-SAME: module.modulemap
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -37,7 +37,9 @@ import ImportsMacroSpecificClangModule
 //CHECK-NEXT:      ],
 //CHECK-NEXT:      "directDependencies": [
 //CHECK-NEXT:        {
-//CHECK-NEXT:          "clang": "OnlyWithMacro"
+//CHECK-DAG:          "clang": "OnlyWithMacro"
+//CHECK-DAG:          "swift": "SwiftOnoneSupport"
+//CHECK-NEXT:        }
 
 // CHECK:      "clang": "OnlyWithMacro"
 // CHECK-NEXT:    },

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -67,61 +67,6 @@ import SubE
 // CHECK-DAG: "swift": "F"
 // CHECK-DAG: "swift": "A"
 
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-DAG:   "clang": "A"
-// CHECK-DAG:   "swift": "Swift"
-
-/// --------Swift module F
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
-// CHECK-NEXT: "sourceFiles": [
-// CHECK-NEXT: ],
-// CHECK-NEXT: "directDependencies": [
-// CHECK-NEXT:   {
-// CHECK-DAG:     "clang": "F"
-// CHECK-DAG:     "swift": "Swift"
-// CHECK-DAG:     "swift": "SwiftOnoneSupport"
-// CHECK: ],
-
-/// --------Swift module G
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
-// CHECK: "directDependencies"
-// CHECK-NEXT: {
-// CHECK-DAG:   "clang": "G"
-// CHECK-DAG:   "swift": "Swift"
-// CHECK-DAG:   "swift": "SwiftOnoneSupport"
-// CHECK: ],
-// CHECK-NEXT: "linkLibraries": [
-// CHECK-NEXT: ],
-// CHECK-NEXT: "details": {
-
-// CHECK: "commandLine": [
-// CHECK: "-compile-module-from-interface"
-// CHECK: "-target"
-// CHECK: "-module-name"
-// CHECK: "G"
-// CHECK: "-swift-version"
-// CHECK: "5"
-// CHECK: ],
-// CHECK: "contextHash": "{{.*}}",
-// CHECK" "extraPcmArgs": [
-// CHECK"   "-target",
-// CHECK"   "-fapinotes-swift-version=5"
-// CHECK" ]
-
-/// --------Swift module E
-// CHECK: "swift": "E"
-// CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
-// CHECK: "directDependencies"
-// CHECK-NEXT: {
-// CHECK: "swift": "Swift"
-
-// CHECK: "moduleInterfacePath"
-// CHECK-SAME: E.swiftinterface
-
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}/C-{{.*}}.pcm",
 
@@ -158,6 +103,61 @@ import SubE
 // CHECK-NEXT: {
 // CHECK: "clang": "A"
 // CHECK-NEXT: }
+
+/// --------Swift module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
+// CHECK-NEXT: "sourceFiles": [
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-DAG:     "clang": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK: ],
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
+
+/// --------Swift module G
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
+// CHECK: "directDependencies"
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "G"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK: ],
+// CHECK-NEXT: "linkLibraries": [
+// CHECK-NEXT: ],
+// CHECK-NEXT: "details": {
+
+// CHECK: "commandLine": [
+// CHECK: "-compile-module-from-interface"
+// CHECK: "-target"
+// CHECK: "-module-name"
+// CHECK: "G"
+// CHECK: "-swift-version"
+// CHECK: "5"
+// CHECK: ],
+// CHECK: "contextHash": "{{.*}}",
+// CHECK" "extraPcmArgs": [
+// CHECK"   "-target",
+// CHECK"   "-fapinotes-swift-version=5"
+// CHECK" ]
+
+/// --------Swift module E
+// CHECK: "swift": "E"
+// CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
+// CHECK: "directDependencies"
+// CHECK-NEXT: {
+// CHECK: "swift": "Swift"
+
+// CHECK: "moduleInterfacePath"
+// CHECK-SAME: E.swiftinterface
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",

--- a/test/ScanDependencies/module_deps_link_libs.swift
+++ b/test/ScanDependencies/module_deps_link_libs.swift
@@ -12,15 +12,14 @@ import SubE
 
 // CHECK: "mainModuleName": "deps"
 
-// CHECK:       "linkLibraries": [
-// CHECK-DAG:           "linkName": "objc",
+// CHECK:           "linkName": "objc",
 // CHECK-NEXT:          "isFramework": false,
 // CHECK-NEXT:          "shouldForceLoad": false
 
-// CHECK-DAG:           "linkName": "swiftyLibE",
-// CHECK-NEXT:          "isFramework": false,
-// CHECK-NEXT:          "shouldForceLoad": true
-
-// CHECK-DAG:           "linkName": "nonSwiftyLibC",
+// CHECK:           "linkName": "nonSwiftyLibC",
 // CHECK-NEXT:          "isFramework": true,
 // CHECK-NEXT:          "shouldForceLoad": false
+
+// CHECK:           "linkName": "swiftyLibE",
+// CHECK-NEXT:          "isFramework": false,
+// CHECK-NEXT:          "shouldForceLoad": true


### PR DESCRIPTION
This change refactors the top-level dependency scanning flow to follow the following procedure:

`resolveImportedModuleDependencies()`:
1. From the source target under scan, query all imported module identifiers for a *Swift* module. Leave unresolved identifiers unresolved. Proceed transitively to build a *Swift* module dependency graph.
2. Take every unresolved import identifier in the graph from (1) and, assuming that it must be a Clang module, dispatch all of them to be queried in-parallel by the scanner's worker pool.
3. Resolve bridging header Clang module dependencies
4. Resolve all Swift overlay dependencies, relying on all Clang modules collected in (2) and (3)

Following `resolveImportedModuleDependencies()`, for the source target under scan, use all of the above discovered module dependencies to resolve all cross-import overlay dependencies.

Because operation (1) is typically quite fast (it does not take much work to discover Swift modules and their dependencies), this results in a much higher degree of parallelism available for operation (2). Note, that operations (4) and (5) themselves call into the top-level `resolveImportedModuleDependencies` for newly-discovered modules.