### PR TITLE
Concurrency: Make `IsolatedDeinit` a suppressible feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -411,8 +411,8 @@ EXPERIMENTAL_FEATURE(WarnUnsafe, true)
 /// Import unsafe C and C++ constructs as @unsafe.
 EXPERIMENTAL_FEATURE(SafeInterop, true)
 
-// isolated deinit
-EXPERIMENTAL_FEATURE(IsolatedDeinit, true)
+// Isolated deinit
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedDeinit, true)
 
 // Enable values in generic signatures, e.g. <let N: Int>
 EXPERIMENTAL_FEATURE(ValueGenerics, true)

--- a/test/ModuleInterface/isolated-deinit-compatibility.swift
+++ b/test/ModuleInterface/isolated-deinit-compatibility.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -disable-availability-checking -emit-silgen -verify %s
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -enable-experimental-feature IsolatedDeinit -disable-availability-checking -module-name IsolatedDeinitCompatibility
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-experimental-feature IsolatedDeinit -disable-availability-checking -module-name IsolatedDeinitCompatibility
-// RUN: %FileCheck %s --dump-input=always < %t.swiftinterface
+// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -target %target-swift-abi-5.5-triple -emit-silgen -verify %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -enable-experimental-feature IsolatedDeinit -target %target-swift-abi-5.5-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-experimental-feature IsolatedDeinit -target %target-swift-abi-5.5-triple -module-name IsolatedDeinitCompatibility
+// RUN: %FileCheck %s < %t.swiftinterface
 
 // MARK: Sync deinit in class
 


### PR DESCRIPTION
Also, avoid using `-disable-availability-checking` in its ModuleInterface test.