### PR TITLE
[Compile Time Constant Extraction] Add information about where a particular conformance has been defined

### DIFF
--- a/test/ConstExtraction/ExtractAnnotations.swift
+++ b/test/ConstExtraction/ExtractAnnotations.swift
@@ -37,6 +37,12 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractAnnotations.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractAnnotations.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractAnnotations"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
@@ -138,6 +144,12 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:    "line": 28,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractAnnotations.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractAnnotations.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractAnnotations"
+// CHECK-NEXT:      }
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [],

--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -46,6 +46,12 @@ public struct Bat {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractCalls.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractCalls.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractCalls"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {

--- a/test/ConstExtraction/ExtractEnums.swift
+++ b/test/ConstExtraction/ExtractEnums.swift
@@ -40,6 +40,20 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      "Swift.Hashable",
 // CHECK-NEXT:      "ExtractEnums.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.Equatable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.Hashable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractEnums.MyProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
@@ -82,6 +96,24 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      "Swift.RawRepresentable",
 // CHECK-NEXT:      "ExtractEnums.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.Equatable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.Hashable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.RawRepresentable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractEnums.MyProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
 // CHECK-NEXT:    "associatedTypeAliases": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "typeAliasName": "RawValue",
@@ -123,7 +155,13 @@ public struct Enums: MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractEnums.MyProto"
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [],    
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractEnums.MyProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [],
 // CHECK-NEXT:    "cases": [
 // CHECK-NEXT:      {
@@ -158,7 +196,13 @@ public struct Enums: MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractEnums.MyProto"
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [],    
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractEnums.MyProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractEnums"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum1",

--- a/test/ConstExtraction/ExtractExternalConformances.swift
+++ b/test/ConstExtraction/ExtractExternalConformances.swift
@@ -1,0 +1,46 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// Build external Swift library/module to also check conformances to external protocols
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %S/../Reflection/Inputs/swiftmodules/testModB.swift -parse-as-library -emit-module -emit-library -module-name testModB -o %t/includes/testModB.o
+
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -typecheck -emit-const-values-path %t/ExtractExternalConformances.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -I %t/includes
+// RUN: cat %t/ExtractExternalConformances.swiftconstvalues 2>&1 | %FileCheck %s
+import testModB
+
+public protocol MyProto { }
+
+extension TestExternalConformanceStruct: MyProto {}
+
+extension TestExternalConformanceStruct: TestExternalConformanceProtocol {}
+
+// CHECK: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "testModB.TestExternalConformanceStruct",
+// CHECK-NEXT:     "mangledTypeName": "8testModB29TestExternalConformanceStructV",
+// CHECK-NEXT:     "kind": "struct",
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "testModB.testModBProtocol",
+// CHECK-NEXT:       "ExtractExternalConformances.MyProto",
+// CHECK-NEXT:       "testModB.TestExternalConformanceProtocol"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "testModB.testModBProtocol",
+// CHECK-NEXT:         "conformanceDefiningModule": "testModB"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractExternalConformances.MyProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractExternalConformances"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "testModB.TestExternalConformanceProtocol",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractExternalConformances"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:     "properties": []
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -45,6 +45,12 @@ extension String: Foo {}
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractGroups.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractGroups.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractGroups"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
@@ -128,7 +134,13 @@ extension String: Foo {}
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractGroups.MyProto"
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [],    
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractGroups.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractGroups"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict1",
@@ -267,6 +279,12 @@ extension String: Foo {}
 // CHECK-NEXT:    "line": 27,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractGroups.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractGroups.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractGroups"
+// CHECK-NEXT:      }
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [

--- a/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
+++ b/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
@@ -36,6 +36,12 @@ public struct External: MyProto {
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractInterpolatedStringLiterals.MyProto"
 // CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractInterpolatedStringLiterals.MyProto"
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractInterpolatedStringLiterals"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
 // CHECK-NEXT:     "associatedTypeAliases": [],
 // CHECK-NEXT:     "properties": [
 // CHECK-NEXT:       {
@@ -59,6 +65,12 @@ public struct External: MyProto {
 // CHECK-NEXT:     "line": 25,
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractInterpolatedStringLiterals.MyProto"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractInterpolatedStringLiterals.MyProto"
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractInterpolatedStringLiterals"
+// CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "associatedTypeAliases": [],
 // CHECK-NEXT:     "properties": [

--- a/test/ConstExtraction/ExtractKeyPaths.swift
+++ b/test/ConstExtraction/ExtractKeyPaths.swift
@@ -36,7 +36,13 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractKeyPaths.MyProto"
 // CHECK-NEXT:     ],
-// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractKeyPaths.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractKeyPaths"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "label": "nestedVariable",

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -104,6 +104,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractLiterals.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractLiterals"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
@@ -138,6 +144,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "line": 14,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractLiterals.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractLiterals"
+// CHECK-NEXT:      }
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
@@ -185,6 +197,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractLiterals.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractLiterals"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
@@ -229,6 +247,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "line": 26,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractLiterals.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractLiterals"
+// CHECK-NEXT:      }
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
@@ -275,6 +299,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "line": 37,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractLiterals.MyProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractLiterals"
+// CHECK-NEXT:      }
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [

--- a/test/ConstExtraction/ExtractOpaqueGenericTypealias.swift
+++ b/test/ConstExtraction/ExtractOpaqueGenericTypealias.swift
@@ -36,6 +36,20 @@ struct Foo<L : Hashable> : myProto {
 // CHECK-NEXT:       "Swift.Sendable",
 // CHECK-NEXT:       "Swift.BitwiseCopyable"
 // CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractOpaqueGenericTypealias.myProto",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractOpaqueGenericTypealias"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.Sendable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractOpaqueGenericTypealias"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "Swift.BitwiseCopyable",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractOpaqueGenericTypealias"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
 // CHECK-NEXT:     "associatedTypeAliases": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "typeAliasName": "T",

--- a/test/ConstExtraction/ExtractOpaqueTypealias.swift
+++ b/test/ConstExtraction/ExtractOpaqueTypealias.swift
@@ -44,6 +44,12 @@ private func baz() -> some protoA<testModBStruct> & protoB<Float> & testModBProt
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractOpaqueTypealias.myProto"
 // CHECK-NEXT:    ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractOpaqueTypealias.myProto"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractOpaqueTypealias"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:    "associatedTypeAliases": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "typeAliasName": "PerformReturn",

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -127,6 +127,12 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractResultBuilders"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:     "associatedTypeAliases": [],
 // CHECK-NEXT:     "properties": [
 // CHECK-NEXT:       {
@@ -238,6 +244,12 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
+// CHECK-NEXT:    "allConformances": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "protocolName": "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:        "conformanceDefiningModule": "ExtractResultBuilders"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK-NEXT:     "associatedTypeAliases": [],
 // CHECK-NEXT:     "properties": [
 // CHECK-NEXT:       {

--- a/test/Reflection/Inputs/swiftmodules/testModB.swift
+++ b/test/Reflection/Inputs/swiftmodules/testModB.swift
@@ -2,3 +2,6 @@ import Foundation
 
 public struct testModBStruct {}
 public protocol testModBProtocol {}
+
+public protocol TestExternalConformanceProtocol {}
+public struct TestExternalConformanceStruct: testModBProtocol {}


### PR DESCRIPTION
This is meant to add some additional information to the conformances of a particular struct/class.

This adds an `allConformances` field that has a list of protocols along with the location where a particular conformance has been defined.

Example:
```
// This is in TestFramework

public protocol A {}

public struct TestA: A {}

```

Then, in a different module
```
// Say this is TestFile.swift
import TestFramework

public protocol B {}

public extension TestA: B {}
```

Here, we expect to see the following in the `swiftconstvalues`.

```
"allConformances": [
      {
        "protocol": "TestFramework.A",
        "definingModule": "TestFramework"
      },
      {
        "protocol": "TestFile.B",
        "definingModule": "TestFile"
      }
    ],
```

Resolves rdar://132996271