### PR TITLE
[embedded] Emit a weak_odr marker symbol indicating whether the module was built with ObjC interop, and with Embedded Swift

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2040,6 +2040,36 @@ bool IRGenModule::finalize() {
   }
   emitLazyPrivateDefinitions();
 
+  if (!getSILModule().getOptions().StopOptimizationAfterSerialization) {
+    uint32_t ABIValue = 0;
+    if (ObjCInterop) {
+      ABIValue |= 1; // bit 0
+    }
+    if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+      ABIValue |= 2; // bit 1
+    }
+      
+    auto *Value = llvm::ConstantInt::get(Int32Ty, ABIValue);
+    auto *ABIMarker = new llvm::GlobalVariable(
+        Module, Int32Ty, /*isConstant=*/true, llvm::GlobalValue::WeakODRLinkage,
+        Value, "swift_abi");
+    switch (TargetInfo.OutputObjectFormat) {
+    case llvm::Triple::MachO:
+      ABIMarker->setSection("__TEXT,__swift_abi");
+      break;
+    case llvm::Triple::ELF:
+    case llvm::Triple::Wasm:
+      ABIMarker->setSection(".swift_abi");
+      break;
+    case llvm::Triple::COFF:
+      ABIMarker->setSection(".sw5abi");
+      break;
+    default:
+      llvm_unreachable("unknown object format");
+    }
+    addUsedGlobal(ABIMarker);
+  }
+
   // Finalize Swift debug info before running Clang codegen, because it may
   // delete the llvm module.
   if (DebugInfo)

--- a/test/embedded/abi-marker.swift
+++ b/test/embedded/abi-marker.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -target aarch64-none-none-elf -wmo | %FileCheck %s --check-prefix CHECK-ELF
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -target arm64-apple-none-macho -wmo -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ | %FileCheck %s --check-prefix CHECK-MACHO
+
+// REQUIRES: swift_in_compiler
+
+public func main() {
+  print("hello")
+}
+
+// CHECK-ELF: @swift_abi = weak_odr constant i32 2, section ".swift_abi"
+// CHECK-ELF: @_swift1_autolink_entries =
+// CHECK-ELF: @llvm.used = appending global [2 x ptr] [ptr @swift_abi, ptr @_swift1_autolink_entries], section "llvm.metadata" 
+
+// CHECK-MACHO: @swift_abi = weak_odr constant i32 2, section "__TEXT,__swift_abi"
+// CHECK-MACHO: @llvm.used = appending global [1 x ptr] [ptr @swift_abi], section "llvm.metadata" 

--- a/test/embedded/internalize-no-stdlib.swift
+++ b/test/embedded/internalize-no-stdlib.swift
@@ -25,9 +25,9 @@ public func main() {
   start(p: Concrete())
 }
 
+// CHECK-ELF: @swift_abi = weak_odr constant i32 2, section ".swift_abi"
 // CHECK-ELF: @_swift1_autolink_entries =
-// CHECK-ELF: @llvm.used = appending global [1 x ptr] [ptr @_swift1_autolink_entries], section "llvm.metadata"
-// CHECK-ELF-NOT: @llvm.used
+// CHECK-ELF: @llvm.used = appending global [2 x ptr] [ptr @swift_abi, ptr @_swift1_autolink_entries], section "llvm.metadata" 
 
-// CHECK-MACHO-NOT: @llvm.compiler.used
-// CHECK-MACHO-NOT: @llvm.used
+// CHECK-MACHO: @swift_abi = weak_odr constant i32 2, section "__TEXT,__swift_abi"
+// CHECK-MACHO: @llvm.used = appending global [1 x ptr] [ptr @swift_abi], section "llvm.metadata" 


### PR DESCRIPTION
To support LLDB and debugging of Embedded Swift binaries, we need some sort of indicator in the binary itself that it's using the Embedded Swift ABI. Even though the ABI is not stable (see https://github.com/swiftlang/swift/blob/main/docs/EmbeddedSwift/ABI.md), LLDB needs to know that it's supposed to inspect e.g. class isa pointers in the way Embedded Swift uses those. Similarly, let's also encode whether the module is built with Obj-C interop enabled or not, which also affects the layout of class metadata.