### PR TITLE
[region-isolation] Add a special error for when a closure captures a non-Sendable box.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1036,6 +1036,9 @@ NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value,
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_task_isolated, none,
      "closure captures %0 which is accessible to code in the current task",
      (DeclName))
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_boxed_value_task_isolated, none,
+     "closure captures reference to mutable %1 %0 which is accessible to code in the current task",
+     (DeclName, DescriptiveDeclKind))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region, none,
      "closure captures %1 which is accessible to %0 code",
      (StringRef, DeclName))

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1456,6 +1456,19 @@ public:
 
     auto capturedLoc = RegularLocation(capturedValue.getLoc());
     if (getIsolationRegionInfo().getIsolationInfo().isTaskIsolated()) {
+      // If we have a closure capture box, emit a special diagnostic.
+      if (auto *fArg = dyn_cast<SILFunctionArgument>(
+              getIsolationRegionInfo().getIsolationInfo().getIsolatedValue())) {
+        if (fArg->isClosureCapture() && fArg->getType().is<SILBoxType>()) {
+          auto diag = diag::
+              regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_boxed_value_task_isolated;
+          auto *decl = capturedValue.getDecl();
+          diagnoseNote(capturedLoc, diag, decl->getName(),
+                       decl->getDescriptiveKind());
+          return;
+        }
+      }
+
       auto diag = diag::
           regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_task_isolated;
       diagnoseNote(capturedLoc, diag, capturedValue.getDecl()->getName());

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1866,3 +1866,25 @@ extension MyActor {
   }
 }
 
+func nonSendableAllocBoxConsumingParameter(x: consuming SendableKlass) async throws {
+  try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      useValue(x) // expected-tns-note {{closure captures reference to mutable parameter 'x' which is accessible to code in the current task}}
+    }
+
+    try await group.waitForAll()
+  }
+}
+
+func nonSendableAllocBoxConsumingVar() async throws {
+  var x = SendableKlass()
+  x = SendableKlass()
+
+  try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      useValue(x) // expected-tns-note {{closure captures reference to mutable var 'x' which is accessible to code in the current task}}
+    }
+
+    try await group.waitForAll()
+  }
+}


### PR DESCRIPTION
The reason that I am modifying this error is that in situations like the
following one can have a Sendable type that triggers this error since the box
containing the value is non-Sendable.

```
func methodConsuming(x: consuming SendableKlass) async throws {
  try await withThrowingTaskGroup(of: Void.self) { group in
    group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
      useValue(x) // expected-tns-note {{closure captures reference to mutable parameter 'x' which is accessible to code in the current task}}
    }

    try await group.waitForAll()
  }
}
```

rdar://133813644

