### PR TITLE
Sema: Finish hollowing out SolverScope

### DIFF
--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -78,8 +78,10 @@ CHANGE(RecordedCaseLabelItemInfo)
 CHANGE(RecordedPotentialThrowSite)
 CHANGE(RecordedIsolatedParam)
 CHANGE(RecordedKeyPath)
+CHANGE(IncreasedScore)
+CHANGE(DecreasedScore)
 
-LAST_CHANGE(RecordedKeyPath)
+LAST_CHANGE(DecreasedScore)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -61,6 +61,7 @@ CLOSURE_CHANGE(RecordedPreconcurrencyClosure)
 CONSTRAINT_CHANGE(DisabledConstraint)
 CONSTRAINT_CHANGE(FavoredConstraint)
 CONSTRAINT_CHANGE(GeneratedConstraint)
+CONSTRAINT_CHANGE(RetiredConstraint)
 
 CHANGE(AddedTypeVariable)
 CHANGE(AddedConstraint)

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -30,6 +30,10 @@
 #define CLOSURE_CHANGE(Name) CHANGE(Name)
 #endif
 
+#ifndef CONSTRAINT_CHANGE
+#define CONSTRAINT_CHANGE(Name) CHANGE(Name)
+#endif
+
 #ifndef LAST_CHANGE
 #define LAST_CHANGE(Name)
 #endif
@@ -54,6 +58,10 @@ EXPR_CHANGE(RecordedExprPattern)
 CLOSURE_CHANGE(RecordedClosureType)
 CLOSURE_CHANGE(RecordedPreconcurrencyClosure)
 
+CONSTRAINT_CHANGE(DisabledConstraint)
+CONSTRAINT_CHANGE(FavoredConstraint)
+CONSTRAINT_CHANGE(GeneratedConstraint)
+
 CHANGE(AddedTypeVariable)
 CHANGE(AddedConstraint)
 CHANGE(RemovedConstraint)
@@ -69,8 +77,6 @@ CHANGE(RecordedOpenedPackExpansionType)
 CHANGE(RecordedPackEnvironment)
 CHANGE(RecordedNodeType)
 CHANGE(RecordedKeyPathComponentType)
-CHANGE(DisabledConstraint)
-CHANGE(FavoredConstraint)
 CHANGE(RecordedResultBuilderTransform)
 CHANGE(RecordedContextualInfo)
 CHANGE(RecordedTarget)
@@ -86,5 +92,6 @@ LAST_CHANGE(DecreasedScore)
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE
 #undef CLOSURE_CHANGE
+#undef CONSTRAINT_CHANGE
 #undef LAST_CHANGE
 #undef CHANGE

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -34,6 +34,14 @@
 #define CONSTRAINT_CHANGE(Name) CHANGE(Name)
 #endif
 
+#ifndef GRAPH_NODE_CHANGE
+#define GRAPH_NODE_CHANGE(Name) CHANGE(Name)
+#endif
+
+#ifndef SCORE_CHANGE
+#define SCORE_CHANGE(Name) CHANGE(Name)
+#endif
+
 #ifndef LAST_CHANGE
 #define LAST_CHANGE(Name)
 #endif
@@ -63,13 +71,17 @@ CONSTRAINT_CHANGE(FavoredConstraint)
 CONSTRAINT_CHANGE(GeneratedConstraint)
 CONSTRAINT_CHANGE(RetiredConstraint)
 
+GRAPH_NODE_CHANGE(AddedConstraint)
+GRAPH_NODE_CHANGE(RemovedConstraint)
+GRAPH_NODE_CHANGE(InferredBindings)
+GRAPH_NODE_CHANGE(RetractedBindings)
+
+SCORE_CHANGE(IncreasedScore)
+SCORE_CHANGE(DecreasedScore)
+
 CHANGE(AddedTypeVariable)
-CHANGE(AddedConstraint)
-CHANGE(RemovedConstraint)
 CHANGE(ExtendedEquivalenceClass)
 CHANGE(RelatedTypeVariables)
-CHANGE(InferredBindings)
-CHANGE(RetractedBindings)
 CHANGE(UpdatedTypeVariable)
 CHANGE(AddedConversionRestriction)
 CHANGE(AddedFix)
@@ -85,14 +97,14 @@ CHANGE(RecordedCaseLabelItemInfo)
 CHANGE(RecordedPotentialThrowSite)
 CHANGE(RecordedIsolatedParam)
 CHANGE(RecordedKeyPath)
-CHANGE(IncreasedScore)
-CHANGE(DecreasedScore)
 
-LAST_CHANGE(DecreasedScore)
+LAST_CHANGE(RecordedKeyPath)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE
 #undef CLOSURE_CHANGE
 #undef CONSTRAINT_CHANGE
+#undef GRAPH_NODE_CHANGE
+#undef SCORE_CHANGE
 #undef LAST_CHANGE
 #undef CHANGE

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -229,6 +229,12 @@ public:
     /// Create a change that recorded a key path expression.
     static Change RecordedKeyPath(KeyPathExpr *expr);
 
+    /// Create a change that increased the score.
+    static Change IncreasedScore(ScoreKind kind, unsigned value);
+
+    /// Create a change that decreased the score.
+    static Change DecreasedScore(ScoreKind kind, unsigned value);
+
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.
     ///

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -143,16 +143,13 @@ public:
 #define EXPR_CHANGE(Name) static Change Name(Expr *expr);
 #define CLOSURE_CHANGE(Name) static Change Name(ClosureExpr *closure);
 #define CONSTRAINT_CHANGE(Name) static Change Name(Constraint *constraint);
+#define SCORE_CHANGE(Name) static Change Name(ScoreKind kind, unsigned value);
+#define GRAPH_NODE_CHANGE(Name) static Change Name(TypeVariableType *typeVar, \
+                                                   Constraint *constraint);
 #include "swift/Sema/CSTrail.def"
 
     /// Create a change that added a type variable.
     static Change AddedTypeVariable(TypeVariableType *typeVar);
-
-    /// Create a change that added a constraint.
-    static Change AddedConstraint(TypeVariableType *typeVar, Constraint *constraint);
-
-    /// Create a change that removed a constraint.
-    static Change RemovedConstraint(TypeVariableType *typeVar, Constraint *constraint);
 
     /// Create a change that extended an equivalence class.
     static Change ExtendedEquivalenceClass(TypeVariableType *typeVar,
@@ -162,14 +159,6 @@ public:
     /// a type variable pair.
     static Change RelatedTypeVariables(TypeVariableType *typeVar,
                                        TypeVariableType *otherTypeVar);
-
-    /// Create a change that inferred bindings from a constraint.
-    static Change InferredBindings(TypeVariableType *typeVar,
-                                   Constraint *constraint);
-
-    /// Create a change that retracted bindings from a constraint.
-    static Change RetractedBindings(TypeVariableType *typeVar,
-                                    Constraint *constraint);
 
     /// Create a change that updated a type variable.
     static Change UpdatedTypeVariable(
@@ -223,12 +212,6 @@ public:
 
     /// Create a change that recorded a key path expression.
     static Change RecordedKeyPath(KeyPathExpr *expr);
-
-    /// Create a change that increased the score.
-    static Change IncreasedScore(ScoreKind kind, unsigned value);
-
-    /// Create a change that decreased the score.
-    static Change DecreasedScore(ScoreKind kind, unsigned value);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -142,6 +142,7 @@ public:
 #define LOCATOR_CHANGE(Name, _) static Change Name(ConstraintLocator *locator);
 #define EXPR_CHANGE(Name) static Change Name(Expr *expr);
 #define CLOSURE_CHANGE(Name) static Change Name(ClosureExpr *closure);
+#define CONSTRAINT_CHANGE(Name) static Change Name(Constraint *constraint);
 #include "swift/Sema/CSTrail.def"
 
     /// Create a change that added a type variable.
@@ -201,12 +202,6 @@ public:
     static Change RecordedKeyPathComponentType(const KeyPathExpr *expr,
                                                unsigned component,
                                                Type oldType);
-
-    /// Create a change that disabled a constraint.
-    static Change DisabledConstraint(Constraint *constraint);
-
-    /// Create a change that favored a constraint.
-    static Change FavoredConstraint(Constraint *constraint);
 
     /// Create a change that recorded a result builder transform.
     static Change RecordedResultBuilderTransform(AnyFunctionRef fn);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2857,9 +2857,6 @@ public:
     /// FIXME: Remove this.
     unsigned numFixes;
 
-    /// The previous score.
-    Score PreviousScore;
-
     /// The scope number of this scope. Set when the scope is registered.
     unsigned scopeNumber = 0;
 
@@ -5534,9 +5531,12 @@ private:
 
 public:
   /// Increase the score of the given kind for the current (partial) solution
-  /// along the.
+  /// along the current solver path.
   void increaseScore(ScoreKind kind, ConstraintLocatorBuilder Locator,
                      unsigned value = 1);
+
+  /// Primitive form of the above. Records a change in the trail.
+  void increaseScore(ScoreKind kind, unsigned value);
 
   /// Determine whether this solution is guaranteed to be worse than the best
   /// solution found so far.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2533,8 +2533,8 @@ private:
     /// The number of the solution attempts we're looking at.
     unsigned SolutionAttempt;
 
-    /// Refers to the innermost partial solution scope.
-    SolverScope *PartialSolutionScope = nullptr;
+    /// The number of fixes in the innermost partial solution scope.
+    unsigned numPartialSolutionFixes = 0;
 
     // Statistics
     #define CS_STATISTIC(Name, Description) unsigned Name = 0;
@@ -2783,11 +2783,6 @@ public:
 
     /// The length of \c Trail.
     unsigned numTrailChanges;
-
-    /// The length of \c Fixes.
-    ///
-    /// FIXME: Remove this.
-    unsigned numFixes;
 
     /// The scope number of this scope. Set when the scope is registered.
     unsigned scopeNumber = 0;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2905,7 +2905,8 @@ private:
   /// This operation is used to take a solution computed based on some
   /// subset of the constraints and then apply it back to the
   /// constraint system for further exploration.
-  void applySolution(const Solution &solution);
+  void replaySolution(const Solution &solution,
+                      bool shouldIncreaseScore=true);
 
   // FIXME: Perhaps these belong on ConstraintSystem itself.
   friend std::optional<BraceStmt *>

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2540,26 +2540,11 @@ private:
     #define CS_STATISTIC(Name, Description) unsigned Name = 0;
     #include "ConstraintSolverStats.def"
 
-    /// Check whether there are any retired constraints present.
-    bool hasRetiredConstraints() const {
-      return !retiredConstraints.empty();
-    }
-
     /// Mark given constraint as retired along current solver path.
     ///
     /// \param constraint The constraint to retire temporarily.
     void retireConstraint(Constraint *constraint) {
-      retiredConstraints.push_front(constraint);
-    }
-
-    /// Iterate over all of the retired constraints registered with
-    /// current solver state.
-    ///
-    /// \param processor The processor function to be applied to each of
-    /// the constraints retrieved.
-    void forEachRetired(llvm::function_ref<void(Constraint &)> processor) {
-      for (auto &constraint : retiredConstraints)
-        processor(constraint);
+      Trail.recordChange(SolverTrail::Change::RetiredConstraint(constraint));
     }
 
     /// Add new "generated" constraint along the current solver path.
@@ -2569,49 +2554,26 @@ private:
       Trail.recordChange(SolverTrail::Change::GeneratedConstraint(constraint));
     }
 
-    /// Register given scope to be tracked by the current solver state,
-    /// this helps to make sure that all of the retired/generated constraints
-    /// are dealt with correctly when the life time of the scope ends.
+    /// Update statistics when a scope begins.
     ///
     /// \param scope The scope to associate with current solver state.
-    void registerScope(SolverScope *scope) {
+    void beginScope(SolverScope *scope) {
       ++depth;
       maxDepth = std::max(maxDepth, depth);
       scope->scopeNumber = NumStatesExplored++;
 
       CS.incrementScopeCounter();
-      auto scopeInfo =
-        std::make_tuple(scope, retiredConstraints.begin());
-      scopes.push_back(scopeInfo);
     }
 
-    /// Restore all of the retired/generated constraints to the state
-    /// before given scope. This is required because retired constraints have
-    /// to be re-introduced to the system in order of arrival (LIFO) and list
-    /// of the generated constraints has to be truncated back to the
-    /// original size.
+    /// Update statistics when a scope ends.
     ///
     /// \param scope The solver scope to rollback.
-    void rollback(SolverScope *scope) {
+    void endScope(SolverScope *scope) {
       --depth;
 
       unsigned countScopesExplored = NumStatesExplored - scope->scopeNumber;
       if (countScopesExplored == 1)
         CS.incrementLeafScopes();
-
-      SolverScope *savedScope;
-      // The position of last retired constraint before given scope.
-      ConstraintList::iterator lastRetiredPos;
-
-      std::tie(savedScope, lastRetiredPos) =
-        scopes.pop_back_val();
-
-      assert(savedScope == scope && "Scope rollback not in LIFO order!");
-
-      // Restore all of the retired constraints.
-      CS.InactiveConstraints.splice(CS.InactiveConstraints.end(),
-                                    retiredConstraints,
-                                    retiredConstraints.begin(), lastRetiredPos);
     }
 
     /// Check whether constraint system is allowed to form solutions
@@ -2638,25 +2600,12 @@ private:
     }
 
   private:
-    /// The list of constraints that have been retired along the
-    /// current path, this list is used in LIFO fashion when
-    /// constraints are added back to the circulation.
-    ConstraintList retiredConstraints;
+    /// Depth of the solution stack.
+    unsigned depth = 0;
 
     /// The set of constraints which were active at the time of this state
     /// creating, it's used to re-activate them on destruction.
     SmallVector<Constraint *, 4> activeConstraints;
-
-    /// The collection which holds association between solver scope
-    /// and position of the last retired constraint and number of
-    /// constraints generated before registration of given scope,
-    /// this helps to rollback all of the constraints retired/generated
-    /// each of the registered scopes correct (LIFO) order.
-    llvm::SmallVector<
-      std::tuple<SolverScope *, ConstraintList::iterator>, 4> scopes;
-
-    /// Depth of the solution stack.
-    unsigned depth = 0;
   };
 
   class CacheExprTypes : public ASTWalker {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1045,6 +1045,7 @@ struct Score {
   friend Score operator-(const Score &x, const Score &y) {
     Score result;
     for (unsigned i = 0; i != NumScoreKinds; ++i) {
+      ASSERT(x.Data[i] >= y.Data[i]);
       result.Data[i] = x.Data[i] - y.Data[i];
     }
     return result;
@@ -1052,6 +1053,7 @@ struct Score {
 
   friend Score &operator-=(Score &x, const Score &y) {
     for (unsigned i = 0; i != NumScoreKinds; ++i) {
+      ASSERT(x.Data[i] >= y.Data[i]);
       x.Data[i] -= y.Data[i];
     }
     return x;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1082,7 +1082,7 @@ TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func, Type builderType) {
   }
 
   // FIXME: Shouldn't need to do this.
-  cs.applySolution(solutions.front());
+  cs.replaySolution(solutions.front());
 
   // Apply the solution to the function body.
   if (auto result = cs.applySolution(solutions.front(), target)) {

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -110,6 +110,14 @@ static bool shouldIgnoreScoreIncreaseForCodeCompletion(
   return false;
 }
 
+void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
+  unsigned index = static_cast<unsigned>(kind);
+  CurrentScore.Data[index] += value;
+
+  if (solverState && value > 0)
+    recordChange(SolverTrail::Change::IncreasedScore(kind, value));
+}
+
 void ConstraintSystem::increaseScore(ScoreKind kind,
                                      ConstraintLocatorBuilder Locator,
                                      unsigned value) {
@@ -135,8 +143,7 @@ void ConstraintSystem::increaseScore(ScoreKind kind,
     llvm::errs() << ")\n";
   }
 
-  unsigned index = static_cast<unsigned>(kind);
-  CurrentScore.Data[index] += value;
+  increaseScore(kind, value);
 }
 
 bool ConstraintSystem::worseThanBestSolution() const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15032,9 +15032,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     SmallVector<Type, 4> unwraps2;
     type2->lookThroughAllOptionalTypes(unwraps2);
 
-    auto impact = unwraps1.size() != unwraps2.size()
-                      ? unwraps1.size() - unwraps2.size()
-                      : 1;
+    unsigned impact = 1;
+    if (unwraps1.size() > unwraps2.size())
+      impact = unwraps1.size() - unwraps2.size();
+    else if (unwraps2.size() > unwraps1.size())
+      impact = unwraps2.size() - unwraps1.size();
+
     return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -272,9 +272,10 @@ Solution ConstraintSystem::finalize() {
   return solution;
 }
 
-void ConstraintSystem::applySolution(const Solution &solution) {
-  // Update the score.
-  CurrentScore += solution.getFixedScore();
+void ConstraintSystem::replaySolution(const Solution &solution,
+                                      bool shouldIncreaseScore) {
+  if (shouldIncreaseScore)
+    CurrentScore += solution.getFixedScore();
 
   // Assign fixed types to the type variables solved by this solution.
   for (auto binding : solution.typeBindings) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -658,9 +658,6 @@ ConstraintSystem::SolverState::~SolverState() {
   // to constraint system.
   assert(!hasRetiredConstraints());
 
-  // Make sure that all of the generated constraints have been handled.
-  assert(generatedConstraints.empty());
-
   // Re-activate constraints which were initially marked as "active"
   // to restore original state of the constraint system.
   for (auto *constraint : activeConstraints) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -654,10 +654,6 @@ ConstraintSystem::SolverState::~SolverState() {
   if (CS.inInvalidState())
     return;
 
-  // Make sure that all of the retired constraints have been returned
-  // to constraint system.
-  assert(!hasRetiredConstraints());
-
   // Re-activate constraints which were initially marked as "active"
   // to restore original state of the constraint system.
   for (auto *constraint : activeConstraints) {
@@ -715,7 +711,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numTypeVariables = cs.TypeVariables.size();
   numFixes = cs.Fixes.size();
 
-  cs.solverState->registerScope(this);
+  cs.solverState->beginScope(this);
   assert(!cs.failedConstraint && "Unexpected failed constraint!");
 }
 
@@ -739,10 +735,7 @@ ConstraintSystem::SolverScope::~SolverScope() {
   // Roll back changes to the constraint system.
   cs.solverState->Trail.undo(numTrailChanges);
 
-  // Rollback all of the changes done to constraints by the current scope,
-  // e.g. add retired constraints back to the circulation and remove generated
-  // constraints introduced by the current scope.
-  cs.solverState->rollback(this);
+  cs.solverState->endScope(this);
 
   // Clear out other "failed" state.
   cs.failedConstraint = nullptr;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -128,11 +128,8 @@ Solution ConstraintSystem::finalize() {
 
   // For each of the fixes, record it as an operation on the affected
   // expression.
-  unsigned firstFixIndex = 0;
-  if (solverState && solverState->PartialSolutionScope) {
-    firstFixIndex = solverState->PartialSolutionScope->numFixes;
-  }
-
+  unsigned firstFixIndex =
+      (solverState ? solverState->numPartialSolutionFixes : 0);
   for (const auto &fix :
        llvm::make_range(Fixes.begin() + firstFixIndex, Fixes.end()))
     solution.Fixes.push_back(fix);
@@ -709,7 +706,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numTrailChanges = cs.solverState->Trail.size();
 
   numTypeVariables = cs.TypeVariables.size();
-  numFixes = cs.Fixes.size();
 
   cs.solverState->beginScope(this);
   assert(!cs.failedConstraint && "Unexpected failed constraint!");

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -42,8 +42,8 @@ ComponentStep::Scope::Scope(ComponentStep &component)
   workList.splice(workList.end(), *component.Constraints);
 
   SolverScope = new ConstraintSystem::SolverScope(CS);
-  PrevPartialScope = CS.solverState->PartialSolutionScope;
-  CS.solverState->PartialSolutionScope = SolverScope;
+  prevPartialSolutionFixes = CS.solverState->numPartialSolutionFixes;
+  CS.solverState->numPartialSolutionFixes = CS.Fixes.size();
 }
 
 StepResult SplitterStep::take(bool prevFailed) {

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -41,7 +41,7 @@ ComponentStep::Scope::Scope(ComponentStep &component)
   auto &workList = CS.InactiveConstraints;
   workList.splice(workList.end(), *component.Constraints);
 
-  SolverScope = new ConstraintSystem::SolverScope(CS);
+  SolverScope.emplace(CS);
   prevPartialSolutionFixes = CS.solverState->numPartialSolutionFixes;
   CS.solverState->numPartialSolutionFixes = CS.Fixes.size();
 }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -885,6 +885,12 @@ bool ConjunctionStep::attempt(const ConjunctionElement &element) {
 
   // Make sure that element is solved in isolation
   // by dropping all scoring information.
+  for (unsigned i = 0; i < NumScoreKinds; ++i) {
+    if (unsigned value = CS.CurrentScore.Data[i]) {
+      CS.recordChange(
+        SolverTrail::Change::DecreasedScore(ScoreKind(i), value));
+    }
+  }
   CS.CurrentScore = Score();
 
   // Reset the scope counter to avoid "too complex" failures

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -865,7 +865,7 @@ class ConjunctionStep : public BindingStep<ConjunctionElementProducer> {
       IsolationScope = std::make_unique<Scope>(CS);
 
       // Apply solution inferred for the conjunction.
-      applySolution(solution);
+      replaySolution(solution);
 
       // Add constraints to the graph after solution
       // has been applied to make sure that all type
@@ -901,7 +901,7 @@ class ConjunctionStep : public BindingStep<ConjunctionElementProducer> {
         CG.addConstraint(&constraint);
     }
 
-    void applySolution(const Solution &solution);
+    void replaySolution(const Solution &solution);
   };
 
   /// Best solution solver reached so far.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -342,7 +342,7 @@ class ComponentStep final : public SolverStep {
     ConstraintSystem::SolverScope *SolverScope;
 
     SetVector<TypeVariableType *> TypeVars;
-    ConstraintSystem::SolverScope *PrevPartialScope = nullptr;
+    unsigned prevPartialSolutionFixes = 0;
 
     // The component this scope is associated with.
     ComponentStep &Component;
@@ -352,7 +352,7 @@ class ComponentStep final : public SolverStep {
 
     ~Scope() {
       delete SolverScope; // rewind back all of the changes.
-      CS.solverState->PartialSolutionScope = PrevPartialScope;
+      CS.solverState->numPartialSolutionFixes = prevPartialSolutionFixes;
 
       // return all of the saved type variables back to the system.
       CS.TypeVariables = std::move(TypeVars);

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -520,6 +520,10 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
     cs.InactiveConstraints.erase(iter);
     break;
   }
+
+  case ChangeKind::RetiredConstraint:
+    cs.InactiveConstraints.push_back(TheConstraint.Constraint);
+    break;
   }
 }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1508,15 +1508,6 @@ void ConstraintSystem::print(raw_ostream &out) const {
     }
   }
 
-  if (solverState && solverState->hasRetiredConstraints()) {
-    out.indent(indent) << "Retired Constraints:\n";
-    solverState->forEachRetired([&](Constraint &constraint) {
-      out.indent(indent + 2);
-      constraint.print(out, &getASTContext().SourceMgr);
-      out << "\n";
-    });
-  }
-
   if (!ResolvedOverloads.empty()) {
     out.indent(indent) << "Resolved overloads:\n";
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -461,7 +461,7 @@ TypeChecker::typeCheckTarget(SyntacticElementTarget &target,
   // Apply this solution to the constraint system.
   // FIXME: This shouldn't be necessary.
   auto &solution = (*viable)[0];
-  cs.applySolution(solution);
+  cs.replaySolution(solution);
 
   // Apply the solution to the expression.
   auto resultTarget = cs.applySolution(solution, target);
@@ -753,7 +753,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
 
   auto &solution = (*viable)[0];
 
-  cs.applySolution(solution);
+  cs.replaySolution(solution);
 
   if (auto result = cs.applySolution(solution, defaultExprTarget)) {
     // Perform syntactic diagnostics on the type-checked target.


### PR DESCRIPTION
The scope now just records three things: the current number of type variables, the position in the trail, and the number of scopes seen so far.