### PR TITLE
Concurrency: Fix warnings in the runtime

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1396,7 +1396,9 @@ namespace continuationChecking {
 
 enum class State : uint8_t { Uninitialized, On, Off };
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 static std::atomic<State> CurrentState;
+#endif
 
 static LazyMutex ActiveContinuationsLock;
 static Lazy<std::unordered_set<AsyncTask *>> ActiveContinuations;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -967,13 +967,13 @@ static void swift_taskGroup_initializeImpl(TaskGroup *group, const Metadata *T) 
 SWIFT_CC(swift)
 static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
                                                     TaskGroup *group, const Metadata *T) {
-  ResultTypeInfo resultType;
 #if !SWIFT_CONCURRENCY_EMBEDDED
+  ResultTypeInfo resultType;
   resultType.metadata = T;
+  _swift_taskGroup_initialize(resultType, rawGroupFlags, group);
 #else
   swift_unreachable("swift_taskGroup_initializeWithFlags in embedded");
 #endif
-  _swift_taskGroup_initialize(resultType, rawGroupFlags, group);
 }
 
 // Initializes into the preallocated _group an actual instance.


### PR DESCRIPTION
Addresses an unused variable warning and an unreachable code warning.
