### PR TITLE
[DebugInfo] Emit types with @_originallyDefinedIn under original module

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -23,6 +23,7 @@
 #include "IRBuilder.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -2381,6 +2382,24 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
           Scope = getOrCreateModule(*SubModuleDesc, nullptr);
       }
     }
+
+    if (TypeDecl) {
+      // If the type has the @_originallyDefinedIn attribute, IRGenDebugInfo
+      // emits it as a child of the original module. We do this so LLDB has
+      // enough information to both find the type in reflection metadata (the
+      // parent module name) and find it in the swiftmodule (the module name in
+      // the type mangled name).
+      if (auto Attribute =
+              TypeDecl->getAttrs().getAttribute<OriginallyDefinedInAttr>()) {
+        auto Identifier = IGM.getSILModule().getASTContext().getIdentifier(
+            Attribute->OriginalModuleName);
+
+        void *Key = (void *)Identifier.get();
+        Scope =
+            getOrCreateModule(Key, TheCU, Attribute->OriginalModuleName, {});
+      }
+    }
+
     if (!Scope)
       Scope = getOrCreateContext(Context);
 

--- a/test/DebugInfo/originally_defined_in.swift
+++ b/test/DebugInfo/originally_defined_in.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct A {
+    let i = 10
+}
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "A", scope: ![[S1:[0-9]+]]
+// CHECK-NEXT: [[S1]] = !DIModule({{.*}}name: "Other"
+
+func f() {
+    let a = A()
+}
+
+f()


### PR DESCRIPTION
LLDB does not have enough information to find types with the @_originallyDefinedIn attribute in reflection metadata and in swiftmodules.

When emitting debug info for such a type, emit it under the module where the type was originally defined, but in the mangled name emit the current ABI module name.

This way LLDB has enough information to locate the type in both places.

rdar://137146961