### PR TITLE
ASTGen: fix a compiler warning

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -356,7 +356,8 @@ extension ASTGenVisitor {
     var type = generate(type: node.baseType)
 
     // Handle specifiers.
-    if let specifier = node.specifier {
+    if case .simpleTypeSpecifier(let simpleSpecifier) = node.specifiers.first {
+      let specifier = simpleSpecifier.specifier
       if let kind = BridgedAttributedTypeSpecifier(from: specifier.keywordKind) {
         type =
           BridgedSpecifierTypeRepr.createParsed(


### PR DESCRIPTION
Fixes
```
.../swift/lib/ASTGen/Sources/ASTGen/Types.swift:359:29: warning: 'specifier' is deprecated: Access the specifiers list instead
    if let specifier = node.specifier {
                            ^
```
