### PR TITLE
[Frontend] Fix a small `unique_ptr` array access.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1988,7 +1988,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   // hundreds or thousands of lines. Skip dumping this output in that case.
   if (!Invocation.getFrontendOptions().InputsAndOutputs.isWholeModule()) {
     for_each(configurationFileBuffers.begin(), configurationFileBuffers.end(),
-             &configurationFileStackTraces[0],
+             configurationFileStackTraces.get(),
              [](const std::unique_ptr<llvm::MemoryBuffer> &buffer,
                 std::optional<PrettyStackTraceFileContents> &trace) {
                trace.emplace(*buffer);


### PR DESCRIPTION
When the size of the array accessed here is zero, retrieving the address of the zero-th element here is undefined. When the frontend is linked against a libc++ that has the `unique_ptr` hardening in [this commit](https://github.com/llvm/llvm-project/commit/18df9d23ea390eaa50b41f3083a42f700a2b0e39) enabled, it traps here.

Instead, simply call `.get()` to retrieve the address of the array, which works even when it is a zero-byte allocation.
