### PR TITLE
Enable experimental parser round-trip in test cases that no longer need it

### DIFF
--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking -Xfrontend -disable-experimental-parser-round-trip) | %FileCheck %s
+// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/ModuleInterface/specialize-attr.swift
+++ b/test/ModuleInterface/specialize-attr.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test
-// R/UN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test -disable-experimental-parser-round-trip
+// R/UN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --implicit-check-not "\$SpecializeAttributeWithAvailability" < %t.swiftinterface
 
 // CHECK: @_specialize(exported: false, kind: full, where T == Swift.Double)

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name ValueGeneric -enable-experimental-feature ValueGenerics -disable-availability-checking -disable-experimental-parser-round-trip
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking -disable-experimental-parser-round-trip
+// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // REQUIRES: swift_feature_ValueGenerics

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -disable-experimental-parser-round-trip | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_NonescapableTypes

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -disable-experimental-parser-round-trip -parse-stdlib -module-name keypaths %s | %FileCheck %s
-// FIXME: Remove '-disable-experimental-parser-round-trip'.
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -parse-stdlib -module-name keypaths %s | %FileCheck %s
 
 // REQUIRES: swift_feature_KeyPathWithStaticMembers
 

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
-// FIXME: Remove '-disable-experimental-parser-round-trip'.
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: swift_feature_NonescapableTypes
 

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature ValueGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking -disable-experimental-parser-round-trip
+// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
 
 // REQUIRES: swift_feature_NonescapableTypes
 // REQUIRES: swift_feature_ValueGenerics

--- a/test/Serialization/value_generics.swift
+++ b/test/Serialization/value_generics.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature ValueGenerics -enable-experimental-feature RawLayout -disable-availability-checking -disable-experimental-parser-round-trip -parse-as-library -o %t
+// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
 // RUN: %target-sil-opt -enable-sil-verify-all %t/value_generics.swiftmodule -o - | %FileCheck %s
 
 // REQUIRES: swift_feature_RawLayout


### PR DESCRIPTION
Also, track all remaining uses of `-disable-experimental-parser-round-trip` by issues.
