### PR TITLE
Teach check-incremental about -emit-empty-object-file (which disables incremental LLVM codegen, so don't check timestamps if present)

### DIFF
--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -61,6 +61,8 @@ def main():
             write_obj_file = True
         elif arg == '-disable-incremental-llvm-codegen':
             compare_time = False
+        elif arg == '-emit-empty-object-file':
+            compare_time = False
         elif arg == '-o':
             next_arg_is_output = True
 


### PR DESCRIPTION
To resolve this ongoing CI build failure: https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/6524/

...where we are failing a build incrementality check. Given that the embedded _Concurrency.o is an empty object file, it seems like the simplest solution is to just silence the incremental check via `-Xfrontend -disable-incremental-llvm-codegen`.