### PR TITLE
[CoroutineAccessors] SIL represents callee alloc.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -856,6 +856,7 @@ mangled in to disambiguate.
   FUNC-REPRESENTATION ::= 'W'                // protocol witness
 
   COROUTINE-KIND ::= 'A'                     // yield-once coroutine
+  COROUTINE-KIND ::= 'I'                     // yield-once-2 coroutine
   COROUTINE-KIND ::= 'G'                     // yield-many coroutine
 
   #if SWIFT_RUNTIME_VERSION >= 5.5

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -789,13 +789,16 @@ coroutine, where a normal function return would need to transfer ownership of
 its return value, since a normal function's context ceases to exist and be able
 to maintain ownership of the value after it returns.
 
-To support these concepts, SIL supports two kinds of coroutine:
-``@yield_many`` and ``@yield_once``. Either of these attributes may be
+To support these concepts, SIL supports two flavors: single-yield and
+multi-yield.  These two flavors correspond to three kinds.  A multi-yield
+coroutine is of kind ``@yield_many``. A single-yield coroutine is of kind
+either ``@yield_once`` or ``@yield_once_2``. Any of these attributes may be
 written before a function type to indicate that it is a coroutine type.
-``@yield_many`` and ``@yield_once`` coroutines are allowed to also be
-``@async``. (Note that ``@async`` functions are not themselves modeled
-explicitly as coroutines in SIL, although the implementation may use a coroutine
-lowering strategy.)
+
+Both single-yield and multi-yield coroutines are allowed to also be ``@async``.
+(Note that ``@async`` functions are not themselves modeled explicitly as
+coroutines in SIL, although the implementation may use a coroutine lowering
+strategy.)
 
 A coroutine type may declare any number of *yielded values*, which is to
 say, values which are provided to the caller at a yield point.  Yielded
@@ -816,9 +819,10 @@ calling a yield-many coroutine of any kind.
 Coroutines may contain the special ``yield`` and ``unwind``
 instructions.
 
-A ``@yield_many`` coroutine may yield as many times as it desires.
-A ``@yield_once`` coroutine may yield exactly once before returning,
-although it may also ``throw`` before reaching that point.
+A multi-yield (``@yield_many``) coroutine may yield as many times as it desires.
+A single-yield (``@yield_once`` or ``@yield_once_2``) coroutine may yield
+exactly once before returning, although it may also ``throw`` before reaching
+that point.
 
 Variadic Generics
 `````````````````
@@ -8376,9 +8380,10 @@ the current function was invoked with a ``try_apply`` instruction, control
 resumes at the normal destination, and the value of the basic block argument
 will be the operand of this ``return`` instruction.
 
-If the current function is a ``yield_once`` coroutine, there must not be
-a path from the entry block to a ``return`` which does not pass through
-a ``yield`` instruction. This rule does not apply in the ``raw`` SIL stage.
+If the current function is a single-yield coroutine (``yield_once`` or
+``yield_once_2``), there must not be a path from the entry block to a
+``return`` which does not pass through a ``yield`` instruction. This rule does
+not apply in the ``raw`` SIL stage.
 
 ``return`` does not retain or release its operand or any other values.
 
@@ -8446,9 +8451,10 @@ The ``resume`` and ``unwind`` destination blocks must be uniquely
 referenced by the ``yield`` instruction.  This prevents them from becoming
 critical edges.
 
-In a ``yield_once`` coroutine, there must not be a control flow path leading
-from the ``resume`` edge to another ``yield`` instruction in this function.
-This rule does not apply in the ``raw`` SIL stage.
+In a single-yield coroutine (``yield_once`` or ``yield_once_2``), there must
+not be a control flow path leading from the ``resume`` edge to another
+``yield`` instruction in this function. This rule does not apply in the ``raw``
+SIL stage.
 
 There must not be a control flow path leading from the ``unwind`` edge to
 a ``return`` instruction, to a ``throw`` instruction, or to any block

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6132,11 +6132,18 @@ begin_apply
   // %float : $Float
   // %token is a token
 
+  (%anyAddr, %float, %token, %allocation) = begin_apply %0() : $@yield_once_2 () -> (@yields @inout %Any, @yields Float)
+  // %anyAddr : $*Any
+  // %float : $Float
+  // %token is a token
+  // %allocation is a pointer to a token
+
 Transfers control to coroutine ``%0``, passing it the given arguments.
 The rules for the application generally follow the rules for ``apply``,
 except:
 
-- the callee value must have a ``yield_once`` coroutine type,
+- the callee value must have be of single-yield coroutine type (``yield_once``
+  or ``yield_once_2``)
 
 - control returns to this function not when the coroutine performs a
   ``return``, but when it performs a ``yield``, and
@@ -6144,11 +6151,17 @@ except:
 - the instruction results are derived from the yields of the coroutine
   instead of its normal results.
 
-The final result of a ``begin_apply`` is a "token", a special value which
-can only be used as the operand of an ``end_apply`` or ``abort_apply``
-instruction.  Before this second instruction is executed, the coroutine
-is said to be "suspended", and the token represents a reference to its
-suspended activation record.
+The final (in the case of ``@yield_once``) or penultimate (in the case of
+``@yield_once_2``) result of a ``begin_apply`` is a "token", a special value
+which can only be used as the operand of an ``end_apply`` or ``abort_apply``
+instruction.  Before this second instruction is executed, the coroutine is said
+to be "suspended", and the token represents a reference to its suspended
+activation record.
+
+If the coroutine's kind ``yield_once_2``, its final result is an address of a
+"token", representing the allocation done by the callee coroutine.  It can only
+be used as the operand of a ``dealloc_stack`` which must appear after the
+coroutine is resumed.
 
 The other results of the instruction correspond to the yields in the
 coroutine type.  In general, the rules of a yield are similar to the rules

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -485,6 +485,9 @@ public:
 
   unsigned EmitAsyncFramePushPopMetadata : 1;
 
+  // Whether to use the yield_once ABI when emitting yield_once_2 coroutines.
+  unsigned EmitYieldOnce2AsYieldOnce : 1;
+
   // Whether to force emission of a frame for all async functions
   // (LLVM's 'frame-pointer=all').
   unsigned AsyncFramePointerAll : 1;
@@ -577,10 +580,10 @@ public:
         EmitGenericRODatas(true), NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
-        UseFragileResilientProtocolWitnesses(false),
-        EnableHotColdSplit(false), EmitAsyncFramePushPopMetadata(false),
-        AsyncFramePointerAll(false),
-        CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
+        UseFragileResilientProtocolWitnesses(false), EnableHotColdSplit(false),
+        EmitAsyncFramePushPopMetadata(false), EmitYieldOnce2AsYieldOnce(true),
+        AsyncFramePointerAll(false), CmdArgs(),
+        SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),
         CASObjMode(llvm::CASBackendMode::Native) {

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -165,6 +165,9 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
   /// Resumption functions from yield-once coroutines.
   PointerAuthSchema YieldOnceResumeFunctions;
 
+  /// Resumption functions from yield-once-2 coroutines.
+  PointerAuthSchema YieldOnce2ResumeFunctions;
+
   /// Resumption functions from yield-many coroutines.
   PointerAuthSchema YieldManyResumeFunctions;
 

--- a/include/swift/AST/TypeAttr.def
+++ b/include/swift/AST/TypeAttr.def
@@ -101,6 +101,7 @@ SIMPLE_SIL_TYPE_ATTR(pseudogeneric, Pseudogeneric)
 SIMPLE_SIL_TYPE_ATTR(unimplementable, Unimplementable)
 SIMPLE_SIL_TYPE_ATTR(yields, Yields)
 SIMPLE_SIL_TYPE_ATTR(yield_once, YieldOnce)
+SIMPLE_SIL_TYPE_ATTR(yield_once_2, YieldOnce2)
 SIMPLE_SIL_TYPE_ATTR(yield_many, YieldMany)
 SIMPLE_SIL_TYPE_ATTR(captures_generics, CapturesGenerics)
 // Used at the SIL level to mark a type as moveOnly.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4825,7 +4825,8 @@ enum class SILCoroutineKind : uint8_t {
 
   /// This function is a yield-once coroutine (used by read and modify
   /// accessors).  It has the following differences from YieldOnce:
-  /// - it does not observe errors thrown by its caller
+  /// - it does not observe errors thrown by its caller (unless the feature
+  /// CoroutineAccessorsUnwindOnCallerError is enabled)
   /// - it uses the callee-allocated ABI
   YieldOnce2,
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4823,11 +4823,17 @@ enum class SILCoroutineKind : uint8_t {
   /// It must not have normal results and may have arbitrary yield results.
   YieldOnce,
 
+  /// This function is a yield-once coroutine (used by read and modify
+  /// accessors).  It has the following differences from YieldOnce:
+  /// - it does not observe errors thrown by its caller
+  /// - it uses the callee-allocated ABI
+  YieldOnce2,
+
   /// This function is a yield-many coroutine (used by e.g. generators).
   /// It must not have normal results and may have arbitrary yield results.
   YieldMany,
 };
-  
+
 class SILFunctionConventions;
 
 
@@ -5038,6 +5044,17 @@ public:
   }
   SILCoroutineKind getCoroutineKind() const {
     return SILCoroutineKind(Bits.SILFunctionType.CoroutineKind);
+  }
+  /// Whether this coroutine's ABI is callee-allocated.
+  bool isCalleeAllocatedCoroutine() const {
+    switch (getCoroutineKind()) {
+    case SILCoroutineKind::None:
+    case SILCoroutineKind::YieldOnce:
+    case SILCoroutineKind::YieldMany:
+      return false;
+    case SILCoroutineKind::YieldOnce2:
+      return true;
+    }
   }
 
   bool isSendable() const { return getExtInfo().isSendable(); }

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -430,6 +430,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 /// modify/read single-yield coroutines always execute code post-yield code
 EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
 
+/// modify/read coroutines use the callee-allocated ABI
+EXPERIMENTAL_FEATURE(CoroutineAccessorsAllocateInCallee, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -427,6 +427,9 @@ EXPERIMENTAL_FEATURE(UnspecifiedMeansMainActorIsolated, false)
 /// modify/read single-yield coroutines
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 
+/// modify/read single-yield coroutines always execute code post-yield code
+EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -51,6 +51,7 @@ enum class ImplMetatypeRepresentation {
 enum class ImplCoroutineKind {
   None,
   YieldOnce,
+  YieldOnce2,
   YieldMany,
 };
 
@@ -1097,6 +1098,8 @@ protected:
             return MAKE_NODE_TYPE_ERROR0(child, "expected text");
           if (child->getText() == "yield_once") {
             coroutineKind = ImplCoroutineKind::YieldOnce;
+          } else if (child->getText() == "yield_once_2") {
+            coroutineKind = ImplCoroutineKind::YieldOnce2;
           } else if (child->getText() == "yield_many") {
             coroutineKind = ImplCoroutineKind::YieldMany;
           } else

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3251,6 +3251,10 @@ class BeginApplyInst final
 public:
   using MultipleValueInstructionTrailingObjects::totalSizeToAlloc;
 
+  bool isCalleeAllocated() const {
+    return getSubstCalleeType()->isCalleeAllocatedCoroutine();
+  }
+
   MultipleValueInstructionResult *getTokenResult() const {
     return const_cast<MultipleValueInstructionResult *>(
              &getAllResultsBuffer().back());

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -847,6 +847,9 @@ public:
   /// instruction.
   bool isAllocatingStack() const;
 
+  /// The stack allocation produced by the instruction, if any.
+  SILValue getStackAllocation() const;
+
   /// Returns true if this is the deallocation of a stack allocating instruction.
   /// The first operand must be the allocating instruction.
   bool isDeallocatingStack() const;
@@ -3257,11 +3260,19 @@ public:
 
   MultipleValueInstructionResult *getTokenResult() const {
     return const_cast<MultipleValueInstructionResult *>(
+        &getAllResultsBuffer().drop_back(isCalleeAllocated() ? 1 : 0).back());
+  }
+
+  MultipleValueInstructionResult *getCalleeAllocationResult() const {
+    if (!isCalleeAllocated()) {
+      return nullptr;
+    }
+    return const_cast<MultipleValueInstructionResult *>(
              &getAllResultsBuffer().back());
   }
 
   SILInstructionResultArray getYieldedValues() const {
-    return getAllResultsBuffer().drop_back();
+    return getAllResultsBuffer().drop_back(isCalleeAllocated() ? 2 : 1);
   }
 
   void getCoroutineEndPoints(

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -582,6 +582,8 @@ getCoroutineKind(ImplCoroutineKind kind) {
     return SILCoroutineKind::None;
   case ImplCoroutineKind::YieldOnce:
     return SILCoroutineKind::YieldOnce;
+  case ImplCoroutineKind::YieldOnce2:
+    return SILCoroutineKind::YieldOnce2;
   case ImplCoroutineKind::YieldMany:
     return SILCoroutineKind::YieldMany;
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2149,6 +2149,9 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
   case SILCoroutineKind::YieldOnce:
     OpArgs.push_back('A');
     break;
+  case SILCoroutineKind::YieldOnce2:
+    OpArgs.push_back('I');
+    break;
   case SILCoroutineKind::YieldMany:
     OpArgs.push_back('G');
     break;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6748,6 +6748,9 @@ public:
     case SILCoroutineKind::YieldOnce:
       Printer << "@yield_once ";
       return;
+    case SILCoroutineKind::YieldOnce2:
+      Printer << "@yield_once_2 ";
+      return;
     case SILCoroutineKind::YieldMany:
       Printer << "@yield_many ";
       return;

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -297,6 +297,7 @@ UNINTERESTING_FEATURE(WarnUnsafe)
 UNINTERESTING_FEATURE(SafeInterop)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
+UNINTERESTING_FEATURE(CoroutineAccessorsAllocateInCallee)
 
 bool swift::usesFeatureIsolatedDeinit(const Decl *decl) {
   if (auto cd = dyn_cast<ClassDecl>(decl)) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -296,6 +296,7 @@ static bool usesFeatureAllowUnsafeAttribute(Decl *decl) {
 UNINTERESTING_FEATURE(WarnUnsafe)
 UNINTERESTING_FEATURE(SafeInterop)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
+UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 
 bool swift::usesFeatureIsolatedDeinit(const Decl *decl) {
   if (auto cd = dyn_cast<ClassDecl>(decl)) {

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -69,6 +69,7 @@ extension ASTGenVisitor {
         .yields,
         .yieldMany,
         .yieldOnce,
+        .yieldOnce2,
         .thin,
         .thick,
         .unimplementable:

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2345,6 +2345,8 @@ NodePointer Demangler::demangleImplFunctionType() {
   const char *CoroAttr = nullptr;
   if (nextIf('A'))
     CoroAttr = "yield_once";
+  else if (nextIf('I'))
+    CoroAttr = "yield_once_2";
   else if (nextIf('G'))
     CoroAttr = "yield_many";
   if (CoroAttr)

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1684,6 +1684,8 @@ ManglingError Remangler::mangleImplCoroutineKind(Node *node,
   StringRef text = node->getText();
   if (text == "yield_once") {
     Buffer << "A";
+  } else if (text == "yield_once_2") {
+    Buffer << "I";
   } else if (text == "yield_many") {
     Buffer << "G";
   } else {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2089,6 +2089,7 @@ ManglingError Remangler::mangleImplFunctionType(Node *node, unsigned depth) {
       case Node::Kind::ImplCoroutineKind: {
         char CoroAttr = llvm::StringSwitch<char>(Child->getText())
                         .Case("yield_once", 'A')
+                        .Case("yield_once_2", 'I')
                         .Case("yield_many", 'G')
                         .Default(0);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2981,6 +2981,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                            DiagnosticEngine &Diags,
                            const FrontendOptions &FrontendOpts,
                            const SILOptions &SILOpts,
+                           const LangOptions &LangOpts,
                            StringRef SDKPath,
                            StringRef ResourceDir,
                            const llvm::Triple &Triple) {
@@ -3694,7 +3695,7 @@ bool CompilerInvocation::parseArgs(
   }
 
   if (ParseIRGenArgs(IRGenOpts, ParsedArgs, Diags, FrontendOpts, SILOpts,
-                     getSDKPath(), SearchPathOpts.RuntimeResourcePath,
+                     LangOpts, getSDKPath(), SearchPathOpts.RuntimeResourcePath,
                      LangOpts.Target)) {
     return true;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3473,6 +3473,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Args.hasFlag(OPT_enable_fragile_resilient_protocol_witnesses,
                  OPT_disable_fragile_resilient_protocol_witnesses,
                  Opts.UseFragileResilientProtocolWitnesses);
+  Opts.EmitYieldOnce2AsYieldOnce =
+      !LangOpts.hasFeature(Feature::CoroutineAccessorsAllocateInCallee);
   Opts.EnableHotColdSplit =
       Args.hasFlag(OPT_enable_split_cold_code,
                    OPT_disable_split_cold_code,

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4635,6 +4635,16 @@ void irgen::emitDeallocYieldManyCoroutineBuffer(IRGenFunction &IGF,
   IGF.Builder.CreateLifetimeEnd(buffer, bufferSize);
 }
 
+void irgen::emitDeallocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
+                                                llvm::Value *allocation) {
+  if (IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+    assert(!allocation);
+    return;
+  }
+  assert(allocation);
+  llvm::report_fatal_error("unimplemented");
+}
+
 Address irgen::emitAllocAsyncContext(IRGenFunction &IGF,
                                      llvm::Value *sizeValue) {
   auto alignment = IGF.IGM.getAsyncContextAlignment();

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -203,6 +203,8 @@ namespace irgen {
 
   Address emitAllocYieldOnceCoroutineBuffer(IRGenFunction &IGF);
   void emitDeallocYieldOnceCoroutineBuffer(IRGenFunction &IGF, Address buffer);
+  void emitDeallocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
+                                           llvm::Value *allocation);
   void
   emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
                               CanSILFunctionType coroutineType,

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -207,6 +207,10 @@ namespace irgen {
   emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
                               CanSILFunctionType coroutineType,
                               NativeCCEntryPointArgumentEmission &emission);
+  void
+  emitYieldOnce2CoroutineEntry(IRGenFunction &IGF,
+                               CanSILFunctionType coroutineType,
+                               NativeCCEntryPointArgumentEmission &emission);
 
   Address emitAllocYieldManyCoroutineBuffer(IRGenFunction &IGF);
   void emitDeallocYieldManyCoroutineBuffer(IRGenFunction &IGF, Address buffer);

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -598,6 +598,8 @@ static uint64_t getYieldTypesHash(IRGenModule &IGM, CanSILFunctionType type) {
     switch (type->getCoroutineKind()) {
     case SILCoroutineKind::YieldMany: return "yield_many:";
     case SILCoroutineKind::YieldOnce: return "yield_once:";
+    case SILCoroutineKind::YieldOnce2:
+      return "yield_once_2:";
     case SILCoroutineKind::None: llvm_unreachable("not a coroutine");
     }
     llvm_unreachable("bad coroutine kind");

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -797,6 +797,8 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Type);
   opts.YieldOnceResumeFunctions =
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Type);
+  opts.YieldOnce2ResumeFunctions =
+      PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Type);
 
   opts.ResilientClassStubInitCallbacks =
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Constant,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -366,6 +366,7 @@ public:
   llvm::DenseMap<SILValue, LoweredValue> LoweredValues;
   llvm::DenseMap<SILValue, StackAddress> LoweredPartialApplyAllocations;
   llvm::DenseMap<SILType, LoweredValue> LoweredUndefs;
+  llvm::DenseMap<SILValue, llvm::Value *> LoweredSingleYieldFrames;
 
   /// All alloc_ref instructions which allocate the object on the stack.
   llvm::SmallPtrSet<SILInstruction *, 8> StackAllocs;
@@ -6262,6 +6263,13 @@ void IRGenSILFunction::visitDeallocStackInst(swift::DeallocStackInst *i) {
     assert(closure->isOnStack());
     auto stackAddr = LoweredPartialApplyAllocations[i->getOperand()];
     emitDeallocateDynamicAlloca(stackAddr);
+    return;
+  }
+  if (isaResultOf<BeginApplyInst>(i->getOperand())) {
+    auto *mvi = getAsResultOf<BeginApplyInst>(i->getOperand());
+    auto *bai = cast<BeginApplyInst>(mvi->getParent());
+    emitDeallocYieldOnce2CoroutineFrame(
+        *this, LoweredSingleYieldFrames[bai->getCalleeAllocationResult()]);
     return;
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2130,11 +2130,15 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   switch (funcTy->getCoroutineKind()) {
   case SILCoroutineKind::None:
     break;
+  case SILCoroutineKind::YieldOnce2:
+    if (IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+      LLVM_FALLTHROUGH;
+    } else {
+      emitYieldOnce2CoroutineEntry(IGF, funcTy, *emission);
+      break;
+    }
   case SILCoroutineKind::YieldOnce:
     emitYieldOnceCoroutineEntry(IGF, funcTy, *emission);
-    break;
-  case SILCoroutineKind::YieldOnce2:
-    emitYieldOnce2CoroutineEntry(IGF, funcTy, *emission);
     break;
   case SILCoroutineKind::YieldMany:
     emitYieldManyCoroutineEntry(IGF, funcTy, *emission);
@@ -3786,12 +3790,16 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   case SILCoroutineKind::None:
     break;
 
+  case SILCoroutineKind::YieldOnce2:
+    if (IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+      LLVM_FALLTHROUGH;
+    } else {
+      // @yield_once_2 coroutines allocate in the callee
+      break;
+    }
+
   case SILCoroutineKind::YieldOnce:
     coroutineBuffer = emitAllocYieldOnceCoroutineBuffer(*this);
-    break;
-
-  case SILCoroutineKind::YieldOnce2:
-    // @yield_once_2 coroutines allocate in the callee
     break;
 
   case SILCoroutineKind::YieldMany:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2133,6 +2133,9 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   case SILCoroutineKind::YieldOnce:
     emitYieldOnceCoroutineEntry(IGF, funcTy, *emission);
     break;
+  case SILCoroutineKind::YieldOnce2:
+    emitYieldOnce2CoroutineEntry(IGF, funcTy, *emission);
+    break;
   case SILCoroutineKind::YieldMany:
     emitYieldManyCoroutineEntry(IGF, funcTy, *emission);
     break;
@@ -3785,6 +3788,10 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
 
   case SILCoroutineKind::YieldOnce:
     coroutineBuffer = emitAllocYieldOnceCoroutineBuffer(*this);
+    break;
+
+  case SILCoroutineKind::YieldOnce2:
+    // @yield_once_2 coroutines allocate in the callee
     break;
 
   case SILCoroutineKind::YieldMany:

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2307,8 +2307,11 @@ static CanSILFunctionType getSILFunctionType(
   
   if (auto accessor = getAsCoroutineAccessor(constant)) {
     auto origAccessor = cast<AccessorDecl>(origConstant->getDecl());
-    coroutineKind = SILCoroutineKind::YieldOnce;
-    
+    coroutineKind =
+        requiresFeatureCoroutineAccessors(accessor->getAccessorKind())
+            ? SILCoroutineKind::YieldOnce2
+            : SILCoroutineKind::YieldOnce;
+
     // Coroutine accessors are always native, so fetch the native
     // abstraction pattern.
     auto origStorage = origAccessor->getStorage();

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1283,6 +1283,10 @@ bool SILInstruction::isAllocatingStack() const {
       && !PA->getFunction()->hasOwnership();
   }
 
+  if (auto *BAI = dyn_cast<BeginApplyInst>(this)) {
+    return BAI->isCalleeAllocated();
+  }
+
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
     if (BI->getBuiltinKind() == BuiltinValueKind::StackAlloc ||
         BI->getBuiltinKind() == BuiltinValueKind::UnprotectedStackAlloc) {
@@ -1291,6 +1295,17 @@ bool SILInstruction::isAllocatingStack() const {
   }
 
   return false;
+}
+
+SILValue SILInstruction::getStackAllocation() const {
+  if (!isAllocatingStack()) {
+    return {};
+  }
+
+  if (auto *bai = dyn_cast<BeginApplyInst>(this)) {
+    return bai->getCalleeAllocationResult();
+  }
+  return cast<SingleValueInstruction>(this);
 }
 
 bool SILInstruction::isDeallocatingStack() const {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6883,7 +6883,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
       return true;
     }
   } else if (Opcode == SILInstructionKind::BeginApplyInst) {
-    if (FTI->getCoroutineKind() != SILCoroutineKind::YieldOnce) {
+    if (FTI->getCoroutineKind() != SILCoroutineKind::YieldOnce &&
+        FTI->getCoroutineKind() != SILCoroutineKind::YieldOnce2) {
       P.diagnose(TypeLoc, diag::expected_sil_type_kind,
                  "to be a yield_once coroutine");
       return true;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1688,8 +1688,11 @@ public:
   }
 
   static bool isLegalSILTokenProducer(SILValue value) {
-    if (auto *baResult = isaResultOf<BeginApplyInst>(value))
-      return baResult->isBeginApplyToken();
+    if (auto *baResult = isaResultOf<BeginApplyInst>(value)) {
+      auto *bai = cast<BeginApplyInst>(baResult->getParent());
+      return value == bai->getTokenResult() ||
+             value == bai->getCalleeAllocationResult();
+    }
 
     if (isa<OpenPackElementInst>(value))
       return true;
@@ -3772,12 +3775,23 @@ public:
   }
 
   void checkDeallocStackInst(DeallocStackInst *DI) {
+    auto isTokenFromCalleeAllocatedBeginApply = [](SILValue value) -> bool {
+      auto *inst = value->getDefiningInstruction();
+      if (!inst)
+        return false;
+      auto *bai = dyn_cast<BeginApplyInst>(inst);
+      if (!bai)
+        return false;
+      return value == bai->getCalleeAllocationResult();
+    };
     require(isa<SILUndef>(DI->getOperand()) ||
                 isa<AllocStackInst>(DI->getOperand()) ||
                 isa<AllocVectorInst>(DI->getOperand()) ||
                 (isa<PartialApplyInst>(DI->getOperand()) &&
-                 cast<PartialApplyInst>(DI->getOperand())->isOnStack()),
-            "Operand of dealloc_stack must be an alloc_stack, alloc_vector or partial_apply "
+                 cast<PartialApplyInst>(DI->getOperand())->isOnStack()) ||
+                (isTokenFromCalleeAllocatedBeginApply(DI->getOperand())),
+            "Operand of dealloc_stack must be an alloc_stack, alloc_vector or "
+            "partial_apply "
             "[stack]");
   }
   void checkDeallocPackInst(DeallocPackInst *DI) {
@@ -6768,7 +6782,7 @@ public:
     };
 
     struct BBState {
-      std::vector<SingleValueInstruction*> Stack;
+      std::vector<SILValue> Stack;
 
       /// Contents: BeginAccessInst*, BeginApplyInst*.
       std::set<SILInstruction*> ActiveOps;
@@ -6818,9 +6832,15 @@ public:
         }
           
         if (i.isAllocatingStack()) {
-          state.Stack.push_back(cast<SingleValueInstruction>(&i));
-
-        } else if (i.isDeallocatingStack()) {
+          if (auto *BAI = dyn_cast<BeginApplyInst>(&i)) {
+            state.Stack.push_back(BAI->getCalleeAllocationResult());
+          } else {
+            state.Stack.push_back(cast<SingleValueInstruction>(&i));
+          }
+          // Not "else if": begin_apply both allocates stack and begins an
+          // operation.
+        }
+        if (i.isDeallocatingStack()) {
           SILValue op = i.getOperand(0);
           while (auto *mvi = dyn_cast<MoveValueInst>(op)) {
             op = mvi->getOperand();

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2110,8 +2110,12 @@ public:
               "begin_apply instruction cannot call function with error result");
     }
 
-    require(calleeConv.funcTy->getCoroutineKind() == SILCoroutineKind::YieldOnce,
-            "must call yield_once coroutine with begin_apply");
+    auto coroKind = calleeConv.funcTy->getCoroutineKind();
+
+    require(coroKind == SILCoroutineKind::YieldOnce ||
+                coroKind == SILCoroutineKind::YieldOnce2,
+            "first operand of begin_apply must be a yield_once or yield_once_2 "
+            "coroutine");
     require(!calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync(),
             "cannot call an async function from a non async function");
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5056,6 +5056,10 @@ SILGenFunction::emitBeginApply(SILLocation loc, ManagedValue fn,
                /*indirect results*/ {}, /*indirect errors*/ {},
                rawResults, ExecutorBreadcrumb());
 
+  if (substFnType->isCalleeAllocatedCoroutine()) {
+    auto allocation = rawResults.pop_back_val();
+    enterDeallocStackCleanup(allocation);
+  }
   auto token = rawResults.pop_back_val();
   auto yieldValues = llvm::ArrayRef(rawResults);
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4992,7 +4992,10 @@ public:
     auto *beginApply =
         cast<BeginApplyInst>(ApplyToken->getDefiningInstruction());
     auto isCalleeAllocated = beginApply->isCalleeAllocated();
-    auto unwindOnCallerError = !isCalleeAllocated;
+    auto unwindOnCallerError =
+        !isCalleeAllocated ||
+        SGF.SGM.getASTContext().LangOpts.hasFeature(
+            Feature::CoroutineAccessorsUnwindOnCallerError);
     if (forUnwind && unwindOnCallerError) {
       SGF.B.createAbortApply(l, ApplyToken);
     } else {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4989,7 +4989,11 @@ public:
       SGF.B.createEndBorrow(l, *i);
       SGF.B.createDestroyValue(l, (*i)->getOperand());
     }
-    if (forUnwind) {
+    auto *beginApply =
+        cast<BeginApplyInst>(ApplyToken->getDefiningInstruction());
+    auto isCalleeAllocated = beginApply->isCalleeAllocated();
+    auto unwindOnCallerError = !isCalleeAllocated;
+    if (forUnwind && unwindOnCallerError) {
       SGF.B.createAbortApply(l, ApplyToken);
     } else {
       SGF.B.createEndApply(l, ApplyToken,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -6821,7 +6821,8 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
     break;
   }
 
-  case SILCoroutineKind::YieldOnce: {
+  case SILCoroutineKind::YieldOnce:
+  case SILCoroutineKind::YieldOnce2: {
     SmallVector<SILValue, 4> derivedYields;
     auto tokenAndCleanup =
         emitBeginApplyWithRethrow(loc, derivedRef,
@@ -7209,7 +7210,8 @@ void SILGenFunction::emitProtocolWitness(
     break;
   }
 
-  case SILCoroutineKind::YieldOnce: {
+  case SILCoroutineKind::YieldOnce:
+  case SILCoroutineKind::YieldOnce2: {
     SmallVector<SILValue, 4> witnessYields;
     auto tokenAndCleanup =
       emitBeginApplyWithRethrow(loc, witnessFnRef, witnessSILTy, witnessSubs,

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -265,6 +265,13 @@ public:
     for (auto *EndBorrow : EndBorrows)
       EndBorrow->eraseFromParent();
 
+    if (auto allocation = BeginApply->getCalleeAllocationResult()) {
+      for (auto *user : allocation->getUsers()) {
+        auto *dsi = cast<DeallocStackInst>(user);
+        dsi->eraseFromParent();
+      }
+    }
+
     assert(!BeginApply->hasUsesOfAnyResult());
   }
 };

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6647,6 +6647,7 @@ getActualSILCoroutineKind(uint8_t rep) {
     return swift::SILCoroutineKind::KIND;
   CASE(None)
   CASE(YieldOnce)
+  CASE(YieldOnce2)
   CASE(YieldMany)
 #undef CASE
   default:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 895; // @yield_once_2
+const uint16_t SWIFTMODULE_VERSION_MINOR = 896; // @yield_once_2 produces address
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 894; // ThunkInst
+const uint16_t SWIFTMODULE_VERSION_MINOR = 895; // @yield_once_2
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -311,7 +311,8 @@ using SILFunctionTypeRepresentationField = BCFixed<5>;
 enum class SILCoroutineKind : uint8_t {
   None = 0,
   YieldOnce = 1,
-  YieldMany = 2,
+  YieldOnce2 = 2,
+  YieldMany = 3,
 };
 using SILCoroutineKindField = BCFixed<2>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5238,6 +5238,7 @@ static uint8_t getRawStableSILCoroutineKind(
   switch (kind) {
   SIMPLE_CASE(SILCoroutineKind, None)
   SIMPLE_CASE(SILCoroutineKind, YieldOnce)
+  SIMPLE_CASE(SILCoroutineKind, YieldOnce2)
   SIMPLE_CASE(SILCoroutineKind, YieldMany)
   }
   llvm_unreachable("bad kind");

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -476,3 +476,4 @@ $s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ --
 $sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
 $s2hi1SV1iSivx ---> hi.S.i.modify2 : Swift.Int
 $s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
+$s2hi1SVIetMIy_TC  ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-irgen                             \
+// RUN:     %s                                               \
+// RUN:     -enable-experimental-feature CoroutineAccessors  \
+// RUN: | %IRGenFileCheck %s --check-prefix=CHECK-OLD
+
+// For now, a crash is expected when attempting to use the callee-allocated ABI: 
+// it's not implemented.
+// RUN: not --crash                                             \
+// RUN:     %target-swift-emit-irgen                            \
+// RUN:         %s                                              \
+// RUN:         -enable-experimental-feature CoroutineAccessors \
+// RUN:         -enable-experimental-feature CoroutineAccessorsAllocateInCallee
+
+// REQUIRES: asserts
+
+public struct S {
+public var o: any AnyObject
+public var _i: Int = 0
+
+public var irm: Int {
+// CHECK-OLD-LABEL: define{{.*}} { ptr, i64 } @"$s19coroutine_accessors1SV3irmSivy"(
+// CHECK-OLD-SAME:      ptr noalias dereferenceable(32) %0,
+// CHECK-OLD-SAME:      ptr %1,
+// CHECK-OLD-SAME:      i64 %2
+// CHECK-OLD-SAME:  )
+// CHECK-OLD-SAME:  {
+// CHECK-OLD:       }
+  read {
+    yield _i
+  }
+// CHECK-OLD-LABEL: define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
+// CHECK-OLD-SAME:      ptr noalias dereferenceable(32) %0, 
+// CHECK-OLD-SAME:      ptr nocapture swiftself dereferenceable(16) %1
+// CHECK-OLD-SAME:  )
+// CHECK-OLD-SAME:  {
+// CHECK-OLD:       }
+  modify {
+    yield &_i
+  }
+// CHECK-OLD-LABEL: define{{.*}} i64 @"$s19coroutine_accessors1SV3irmSivg"(
+// CHECK-OLD-SAME:      ptr %0,
+// CHECK-OLD-SAME:      i64 %1
+// CHECK-OLD-SAME:  ) #0
+// CHECK-OLD-SAME:  {
+// CHECK-OLD:       }
+// CHECK-OLD-LABEL: define{{.*}} void @"$s19coroutine_accessors1SV3irmSivs"(
+// CHECK-OLD-SAME:      i64 %0, 
+// CHECK-OLD-SAME:      ptr nocapture swiftself dereferenceable(16) %1
+// CHECK-OLD-SAME:  )
+// CHECK-OLD-SAME:  {
+// CHECK-OLD:       }
+} // public var irm
+}

--- a/test/SIL/Parser/coroutines.sil
+++ b/test/SIL/Parser/coroutines.sil
@@ -2,6 +2,7 @@
 
 sil_stage raw
 
+import Builtin
 import Swift
 
 sil @use_int : $@convention(thin) (Int) -> ()
@@ -72,9 +73,10 @@ bb0(%0 : $Int, %1 : $Float):
 sil [ossa] @begin_apply_2 : $(Int, Float) -> () {
 bb0(%0 : $Int, %1 : $Float):
   %coro = function_ref @yield_2 : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
-  (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
+  (%int, %float, %token, %allocation) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
 
   end_apply %token as $()
+  dealloc_stack %allocation : $*Builtin.SILToken
   %r = tuple ()
   return %r : $()
 }

--- a/test/SIL/Parser/coroutines.sil
+++ b/test/SIL/Parser/coroutines.sil
@@ -6,8 +6,15 @@ import Swift
 
 sil @use_int : $@convention(thin) (Int) -> ()
 sil @use_float : $@convention(thin) (Float) -> ()
+sil @yield_2 : $@yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
 
 sil @once_signature : $@yield_once () -> (@yields Int, @yields Float) {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+sil @once_2_signature : $@yield_once_2 () -> (@yields Int, @yields Float) {
 bb0:
   %0 = tuple ()
   return %0 : $()
@@ -56,6 +63,16 @@ sil [ossa] @begin_apply : $(Int, Float) -> () {
 bb0(%0 : $Int, %1 : $Float):
   %coro = function_ref @yield : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
   (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
+
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @begin_apply_2 : $(Int, Float) -> () {
+bb0(%0 : $Int, %1 : $Float):
+  %coro = function_ref @yield_2 : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
+  (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
 
   end_apply %token as $()
   %r = tuple ()

--- a/test/SIL/Serialization/coroutines.sil
+++ b/test/SIL/Serialization/coroutines.sil
@@ -1,0 +1,121 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name coroutines -emit-sorted-sil | %FileCheck %s
+
+sil_stage raw
+
+import Swift
+
+// CHECK-LABEL: sil [ossa] @begin_apply : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[INT:%[^,]+]] :
+// CHECK-SAME:      [[FLOAT:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[YIELD:%[^,]+]] = function_ref @yield : $@yield_once @convention(thin)
+// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[TOKEN:%[^,]+]]) = begin_apply [[YIELD]]([[INT]], [[FLOAT]])
+// CHECK:         {{%[^,]+}} = end_apply [[TOKEN]]
+// CHECK-LABEL: } // end sil function 'begin_apply'
+sil [ossa] @begin_apply : $(Int, Float) -> () {
+bb0(%0 : $Int, %1 : $Float):
+  %coro = function_ref @yield : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
+  (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
+
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @many_signature :
+// CHECK-SAME:      $@yield_many
+// CHECK-SAME:      @convention(thin)
+// CHECK-SAME:      ()
+// CHECK-SAME:      ->
+// CHECK-SAME:      (@yields Int, @yields Float)
+sil @many_signature : $@yield_many () -> (@yields Int, @yields Float) {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil @once_signature :
+// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      @convention(thin)
+// CHECK-SAME:      ()
+// CHECK-SAME:      ->
+// CHECK-SAME:      (@yields Int, @yields Float)
+sil @once_signature : $@yield_once () -> (@yields Int, @yields Float) {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @yield : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[INT:%[^,]+]] :
+// CHECK-SAME:      [[FLOAT:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         yield ([[INT]] : $Int, [[FLOAT]] : $Float),
+// CHECK-SAME:        resume [[RESUME_BB:bb[0-9]+]],
+// CHECK-SAME:        unwind [[UNWIND_BB:bb[0-9]+]]
+// CHECK:         [[UNWIND_BB]]:
+// CHECK:           unwind
+// CHECK:         [[RESUME_BB]]:
+// CHECK:           return
+// CHECK-LABEL: } // end sil function 'yield'
+sil [ossa] @yield : $@yield_once (Int, Float) -> (@yields Int, @yields Float) {
+bb0(%0 : $Int, %1 : $Float):
+  yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
+
+bb1:
+  %r = tuple ()
+  return %r : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil [ossa] @yield_many : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[INT:%[^,]+]] :
+// CHECK-SAME:      [[FLOAT:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         yield (%0 : $Int, %1 : $Float),
+// CHECK:             resume [[RESUME_BLOCK_1:bb[0-9]+]],
+// CHECK:             unwind [[UNWIND_BLOCK_1:bb[0-9]+]]
+// CHECK:       [[UNWIND_BLOCK_1]]:
+// CHECK:         br [[UNWIND_BLOCK:bb[0-9]+]]
+// CHECK:       [[RESUME_BLOCK_1]]:
+// CHECK:         yield (%0 : $Int, %1 : $Float),
+// CHECK:             resume [[RESUME_BLOCK_2:bb[0-9]+]],
+// CHECK:             unwind [[UNWIND_BLOCK_2:bb[0-9]+]]
+// CHECK:       [[UNWIND_BLOCK_2]]:
+// CHECK:         br [[UNWIND_BLOCK:bb[0-9]+]]
+// CHECK:       [[UNWIND_BLOCK]]:
+// CHECK:         unwind
+// CHECK:       [[RESUME_BLOCK_2]]:
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'yield_many'
+sil [ossa] @yield_many : $@yield_many (Int, Float) -> (@yields Int, @yields Float) {
+bb0(%0 : $Int, %1 : $Float):
+  yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb3
+
+bb1:
+  yield (%0 : $Int, %1 : $Float), resume bb2, unwind bb4
+
+bb2:
+  %r = tuple ()
+  return %r : $()
+
+bb3:
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  unwind
+}
+

--- a/test/SIL/Serialization/coroutines.sil
+++ b/test/SIL/Serialization/coroutines.sil
@@ -27,6 +27,25 @@ bb0(%0 : $Int, %1 : $Float):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @begin_apply_2 : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[INT:%[^,]+]] :
+// CHECK-SAME:      [[FLOAT:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[YIELD:%[^,]+]] = function_ref @yield_2 : $@yield_once_2 @convention(thin)
+// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[TOKEN:%[^,]+]]) = begin_apply [[YIELD]]([[INT]], [[FLOAT]])
+// CHECK:         {{%[^,]+}} = end_apply [[TOKEN]]
+// CHECK-LABEL: } // end sil function 'begin_apply_2'
+sil [ossa] @begin_apply_2 : $(Int, Float) -> () {
+bb0(%0 : $Int, %1 : $Float):
+  %coro = function_ref @yield_2 : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
+  (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
+
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil @many_signature :
 // CHECK-SAME:      $@yield_many
 // CHECK-SAME:      @convention(thin)
@@ -34,6 +53,18 @@ bb0(%0 : $Int, %1 : $Float):
 // CHECK-SAME:      ->
 // CHECK-SAME:      (@yields Int, @yields Float)
 sil @many_signature : $@yield_many () -> (@yields Int, @yields Float) {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK-LABEL: sil @once_2_signature :
+// CHECK-SAME:      $@yield_once_2
+// CHECK-SAME:      @convention(thin)
+// CHECK-SAME:      ()
+// CHECK-SAME:      ->
+// CHECK-SAME:      (@yields Int, @yields Float)
+sil @once_2_signature : $@yield_once_2 () -> (@yields Int, @yields Float) {
 bb0:
   %0 = tuple ()
   return %0 : $()
@@ -66,6 +97,31 @@ bb0:
 // CHECK:           return
 // CHECK-LABEL: } // end sil function 'yield'
 sil [ossa] @yield : $@yield_once (Int, Float) -> (@yields Int, @yields Float) {
+bb0(%0 : $Int, %1 : $Float):
+  yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
+
+bb1:
+  %r = tuple ()
+  return %r : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil [ossa] @yield_2 : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[INT:%[^,]+]] :
+// CHECK-SAME:      [[FLOAT:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         yield ([[INT]] : $Int, [[FLOAT]] : $Float),
+// CHECK-SAME:        resume [[RESUME_BB:bb[0-9]+]],
+// CHECK-SAME:        unwind [[UNWIND_BB:bb[0-9]+]]
+// CHECK:         [[UNWIND_BB]]:
+// CHECK:           unwind
+// CHECK:         [[RESUME_BB]]:
+// CHECK:           return
+// CHECK-LABEL: } // end sil function 'yield_2'
+sil [ossa] @yield_2 : $@yield_once_2 (Int, Float) -> (@yields Int, @yields Float) {
 bb0(%0 : $Int, %1 : $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
 

--- a/test/SIL/Serialization/coroutines.sil
+++ b/test/SIL/Serialization/coroutines.sil
@@ -6,6 +6,7 @@
 
 sil_stage raw
 
+import Builtin
 import Swift
 
 // CHECK-LABEL: sil [ossa] @begin_apply : {{.*}} {
@@ -33,15 +34,17 @@ bb0(%0 : $Int, %1 : $Float):
 // CHECK-SAME:      [[FLOAT:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[YIELD:%[^,]+]] = function_ref @yield_2 : $@yield_once_2 @convention(thin)
-// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[TOKEN:%[^,]+]]) = begin_apply [[YIELD]]([[INT]], [[FLOAT]])
+// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[YIELD]]([[INT]], [[FLOAT]])
 // CHECK:         {{%[^,]+}} = end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK-LABEL: } // end sil function 'begin_apply_2'
 sil [ossa] @begin_apply_2 : $(Int, Float) -> () {
 bb0(%0 : $Int, %1 : $Float):
   %coro = function_ref @yield_2 : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
-  (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
+  (%int, %float, %token, %allocation) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once_2 (Int, Float) -> (@yields Int, @yields Float)
 
   end_apply %token as $()
+  dealloc_stack %allocation : $*Builtin.SILToken
   %r = tuple ()
   return %r : $()
 }

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -48,8 +48,12 @@ public var irm: Int {
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[READ_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READ_ACCESSOR]]([[SELF]])
+// CHECK:         ([[VALUE:%[^,]+]],
+// CHECK-SAME:     [[TOKEN:%[^,]+]],
+// CHECK-SAME:     [[ALLOCATION:%[^)]+]])
+// CHECK-SAME:    = begin_apply [[READ_ACCESSOR]]([[SELF]])
 // CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return [[VALUE:%[^,]+]]
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivg'
 
@@ -65,10 +69,14 @@ public var irm: Int {
 // CHECK-SAME:  ):
 // CHECK:         [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
 // CHECK:         [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:         ([[VALUE_ADDRESS:%[^,]+]],
+// CHECK-SAME:     [[TOKEN:%[^,]+]],
+// CHECK-SAME:     [[ALLOCATION:%[^)]+]])
+// CHECK-SAME:    = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
 // CHECK:         assign [[NEW_VALUE:%[^,]+]] to [[VALUE_ADDRESS]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_access [[SELF_ACCESS]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV3irmSivs'
 
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivM :
@@ -83,13 +91,18 @@ public var irm: Int {
 // CHECK-SAME:  ):
 // CHECK:       [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
 // CHECK:       [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:       ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:       ([[VALUE_ADDRESS:%[^,]+]],
+// CHECK-SAME:   [[TOKEN:%[^,]+]],
+// CHECK-SAME:   [[ALLOCATION:%[^)]+]])
+// CHECK-SAME:  = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
 // CHECK:       yield [[VALUE_ADDRESS:%[^,]+]] : $*Int, resume bb1, unwind bb2
 // CHECK:     bb1:
 // CHECK:       end_apply [[TOKEN]]
 // CHECK:       end_access [[SELF_ACCESS]]
+// CHECK:       dealloc_stack [[ALLOCATION]]
 // CHECK:     bb2:
 // CHECK:       end_apply [[TOKEN]]
+// CHECK:       dealloc_stack [[ALLOCATION]]
 // CHECK:       end_access [[SELF_ACCESS]]
 // CHECK:       unwind
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivM'
@@ -110,12 +123,16 @@ public var irm: Int {
 // CHECK:      store [[NEW_VALUE:%[^,]+]] to [trivial] [[NEW_VALUE_ADDR]]
 // CHECK:      [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
 // CHECK:      [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:      ([[VALUE_ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:      ([[VALUE_ADDR:%[^,]+]], 
+// CHECK-SAME:  [[TOKEN:%[^,]+]],
+// CHECK-SAME:  [[ALLOCATION:%[^)]+]])
+// CHECK-SAME: = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
 // CHECK:      [[UPDATE:%[^,]+]] = function_ref @$s19coroutine_accessors6update2at2toxxz_xtKSQRzlF
 // CHECK:      try_apply [[UPDATE:%[^,]+]]<Int>([[OLD_VALUE_ADDR]], [[VALUE_ADDR]], [[NEW_VALUE_ADDR]])
 // CHECK:    bb1
 // CHECK:      end_apply [[TOKEN]] as $()
 // CHECK:      end_access [[SELF_ACCESS]]
+// CHECK:      dealloc_stack [[ALLOCATION]]
 // CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
 // CHECK:      [[OLD_VALUE:%[^,]+]] = load [trivial] [[OLD_VALUE_ADDR]]
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
@@ -123,6 +140,7 @@ public var irm: Int {
 // CHECK:    bb2([[ERROR:%[^,]+]] : @owned $any Error):
 // CHECK-NOUNWIND: end_apply [[TOKEN]]
 // CHECK-UNWIND: abort_apply [[TOKEN]]
+// CHECK:      dealloc_stack [[ALLOCATION]]
 // CHECK:      end_access [[SELF_ACCESS]]
 // CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -1,7 +1,13 @@
 // RUN: %target-swift-emit-silgen                           \
 // RUN:     %s                                              \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+
+// RUN: %target-swift-emit-silgen                                              \
+// RUN:     %s                                                                 \
+// RUN:     -enable-experimental-feature CoroutineAccessors                    \
+// RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
 
 // REQUIRES: asserts
 
@@ -115,7 +121,8 @@ public var irm: Int {
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
 // CHECK:      return [[OLD_VALUE]]
 // CHECK:    bb2([[ERROR:%[^,]+]] : @owned $any Error):
-// CHECK:      end_apply [[TOKEN]]
+// CHECK-NOUNWIND: end_apply [[TOKEN]]
+// CHECK-UNWIND: abort_apply [[TOKEN]]
 // CHECK:      end_access [[SELF_ACCESS]]
 // CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -64,6 +64,29 @@ public var irm: Int {
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_access [[SELF_ACCESS]]
 // CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV3irmSivs'
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivM :
+// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      @convention(method)
+// CHECK-SAME:      (@inout S)
+// CHECK-SAME:      ->
+// CHECK-SAME:      @yields @inout Int
+// CHECK-SAME:  {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:       [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK:       [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
+// CHECK:       ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:       yield [[VALUE_ADDRESS:%[^,]+]] : $*Int, resume bb1, unwind bb2
+// CHECK:     bb1:
+// CHECK:       end_apply [[TOKEN]]
+// CHECK:       end_access [[SELF_ACCESS]]
+// CHECK:     bb2:
+// CHECK:       end_apply [[TOKEN]]
+// CHECK:       end_access [[SELF_ACCESS]]
+// CHECK:       unwind
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivM'
 } // public var irm
 
 } // public struct S

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen \
-// RUN:     %s \
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %s                                              \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s
 
@@ -10,7 +10,7 @@ public var o: any AnyObject
 public var _i: Int = 0
 
 public var irm: Int {
-// CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivy : 
+// CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivy :
 // CHECK-SAME:      $@yield_once
 // CHECK-SAME:      @convention(method)
 // CHECK-SAME:      (@guaranteed S)
@@ -21,7 +21,7 @@ public var irm: Int {
   read {
     yield _i
   }
-// CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivx : 
+// CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivx :
 // CHECK-SAME:      $@yield_once
 // CHECK-SAME:      @convention(method)
 // CHECK-SAME:      (@inout S)
@@ -46,6 +46,7 @@ public var irm: Int {
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         return [[VALUE:%[^,]+]]
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivg'
+
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivs :
 // CHECK-SAME:      $@convention(method)
 // CHECK-SAME:      (Int, @inout S)
@@ -55,14 +56,14 @@ public var irm: Int {
 // CHECK:       bb0(
 // CHECK-SAME:      [[NEW_VALUE:%[^,]+]] :
 // CHECK-SAME:      [[SELF:%[^,]+]] :
-// CHECK-SAME: ):
-// CHECK:        [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
-// CHECK:        [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:        ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
-// CHECK:        assign [[NEW_VALUE:%[^,]+]] to [[VALUE_ADDRESS]]
-// CHECK:        end_apply [[TOKEN]]
-// CHECK:        end_access [[SELF_ACCESS]]
-// CHECK-LABEL:  } // end sil function '$s19coroutine_accessors1SV3irmSivs'
+// CHECK-SAME:  ):
+// CHECK:         [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK:         [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
+// CHECK:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:         assign [[NEW_VALUE:%[^,]+]] to [[VALUE_ADDRESS]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_access [[SELF_ACCESS]]
+// CHECK-LABEL:} // end sil function '$s19coroutine_accessors1SV3irmSivs'
 } // public var irm
 
 } // public struct S

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -89,4 +89,53 @@ public var irm: Int {
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivM'
 } // public var irm
 
+// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV6update3irmS2i_tKF :
+// CHECK-SAME:      $@convention(method)
+// CHECK-SAME:      (Int, @inout S)
+// CHECK-SAME:      ->
+// CHECK-SAME:      (Int, @error any Error)
+// CHECK-SAME: {
+// CHECK:      bb0(
+// CHECK-SAME:      [[NEW_VALUE:%[^,]+]] :
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME: ):
+// CHECK:      [[OLD_VALUE_ADDR:%[^,]+]] = alloc_stack $Int
+// CHECK:      [[NEW_VALUE_ADDR:%[^,]+]] = alloc_stack $Int
+// CHECK:      store [[NEW_VALUE:%[^,]+]] to [trivial] [[NEW_VALUE_ADDR]]
+// CHECK:      [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
+// CHECK:      [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
+// CHECK:      ([[VALUE_ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
+// CHECK:      [[UPDATE:%[^,]+]] = function_ref @$s19coroutine_accessors6update2at2toxxz_xtKSQRzlF
+// CHECK:      try_apply [[UPDATE:%[^,]+]]<Int>([[OLD_VALUE_ADDR]], [[VALUE_ADDR]], [[NEW_VALUE_ADDR]])
+// CHECK:    bb1
+// CHECK:      end_apply [[TOKEN]] as $()
+// CHECK:      end_access [[SELF_ACCESS]]
+// CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
+// CHECK:      [[OLD_VALUE:%[^,]+]] = load [trivial] [[OLD_VALUE_ADDR]]
+// CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
+// CHECK:      return [[OLD_VALUE]]
+// CHECK:    bb2([[ERROR:%[^,]+]] : @owned $any Error):
+// CHECK:      abort_apply [[TOKEN]]
+// CHECK:      end_access [[SELF_ACCESS]]
+// CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
+// CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
+// CHECK:      throw [[ERROR]]
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV6update3irmS2i_tKF'
+mutating func update(irm newValue: Int) throws -> Int {
+  try coroutine_accessors.update(at: &irm, to: newValue)
+}
+
 } // public struct S
+
+enum E : Error {
+  case e
+}
+
+func update<T : Equatable>(at location: inout T, to newValue: T) throws -> T {
+  let oldValue = location
+  if oldValue == newValue {
+    throw E.e
+  }
+  location = newValue
+  return oldValue
+}

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -115,7 +115,7 @@ public var irm: Int {
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
 // CHECK:      return [[OLD_VALUE]]
 // CHECK:    bb2([[ERROR:%[^,]+]] : @owned $any Error):
-// CHECK:      abort_apply [[TOKEN]]
+// CHECK:      end_apply [[TOKEN]]
 // CHECK:      end_access [[SELF_ACCESS]]
 // CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -805,3 +805,29 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+sil [transparent] [ossa] @simplest_yield_once_2 : $@yield_once_2 @convention(thin) () -> @yields @in_guaranteed () {
+  %addr = alloc_stack $()
+  yield %addr : $*(), resume resume_block, unwind unwind_block
+
+unwind_block:
+  dealloc_stack %addr : $*()
+  unwind
+
+resume_block:
+  dealloc_stack %addr : $*()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simplest_begin_apply_yield_once_2 : {{.*}} {
+// CHECK-NOT:     begin_apply
+// CHECK-LABEL: } // end sil function 'simplest_begin_apply_yield_once_2'
+sil [ossa] @simplest_begin_apply_yield_once_2 : $@convention(thin) () -> () {
+  %callee = function_ref @simplest_yield_once_2 : $@yield_once_2 @convention(thin) () -> @yields @in_guaranteed ()
+  (%addr, %token, %allocation) = begin_apply %callee() : $@yield_once_2 @convention(thin) () -> @yields @in_guaranteed ()
+  end_apply %token as $()
+  dealloc_stack %allocation : $*Builtin.SILToken
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/utils/stack_nesting.sil
+++ b/test/SILOptimizer/utils/stack_nesting.sil
@@ -1,0 +1,31 @@
+// RUN: %target-sil-opt               \
+// RUN:     -test-runner              \
+// RUN:     -sil-disable-input-verify \
+// RUN:     %s                        \
+// RUN:     -o /dev/null              \
+// RUN: 2>&1 | %FileCheck %s
+
+import Builtin
+
+sil @coro : $@convention(thin) @yield_once_2 <T> () -> (@yields @in_guaranteed T)
+
+// CHECK-LABEL: begin running test {{.*}} on begin_apply_fixup: stack_nesting_fixup
+// CHECK-LABEL: sil @begin_apply_fixup : $@convention(thin) <T> () -> () {
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack
+// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[ALLOCATION:%[^,]+]]) = begin_apply
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         dealloc_stack [[STACK]]
+// CHECK-LABEL: } // end sil function 'begin_apply_fixup'
+// CHECK-LABEL: end running test {{.*}} on begin_apply_fixup: stack_nesting_fixup
+sil @begin_apply_fixup : $@convention(thin) <T> () -> () {
+entry:
+  specify_test "stack_nesting_fixup"
+  %stk = alloc_stack $T
+  %coro = function_ref @coro : $@convention(thin) @yield_once_2 <T> () -> (@yields @in_guaranteed T)
+  (%t, %token, %allocation) = begin_apply %coro<T>() : $@convention(thin) @yield_once_2 <T> () -> (@yields @in_guaranteed T) 
+  end_apply %token as $()
+  dealloc_stack %stk : $*T
+  dealloc_stack %allocation : $*Builtin.SILToken
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When its operand has coroutine kind `yield_once_2`, a `begin_apply` instruction produces an additional value representing the storage allocated by the callee.  This storage must be deallocated by a `dealloc_stack` on every path out of the function.  Like any other stack allocation, it must obey stack discipline.
