### PR TITLE
[Test] Disable experimental parser round-trip in '@lifetime' test cases

### DIFF
--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -1,9 +1,12 @@
 // RUN: %empty-directory(%t)
 
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
+
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/lifetime_dependence.swiftmodule \
 // RUN:     -emit-module-interface-path %t/lifetime_dependence.swiftinterface \
+// RUN:     -disable-experimental-parser-round-trip \
 // RUN:     %S/Inputs/lifetime_dependence.swift
 // REQUIRES: asserts
 
@@ -15,9 +18,11 @@
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN:    -enable-experimental-feature NonescapableTypes \
+// RUN:    -disable-experimental-parser-round-trip \
 // RUN:    %t/lifetime_dependence.swiftinterface -o %t/lifetime_dependence.swiftmodule
 
 // RUN: %target-swift-frontend -typecheck -I %t %s \
+// RUN:    -disable-experimental-parser-round-trip \
 // RUN:    -enable-experimental-feature NonescapableTypes
 
 import lifetime_dependence

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -1,7 +1,11 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  \
 // RUN: -enable-builtin-module \
-// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN: -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 import Builtin
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  -disable-availability-checking \
-// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN: -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 // REQUIRES: asserts
 
 struct BufferView : ~Escapable {

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes | %FileCheck %s
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-silgen \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/initializer.swift
+++ b/test/SILOptimizer/lifetime_dependence/initializer.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/inout.swift
+++ b/test/SILOptimizer/lifetime_dependence/inout.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -2,7 +2,9 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   2>&1 | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
@@ -4,7 +4,9 @@
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -parse-stdlib -module-name Swift
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
@@ -3,7 +3,9 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -2,7 +2,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
@@ -2,7 +2,9 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   2>&1 | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_todo.swift
@@ -2,7 +2,9 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -3,7 +3,9 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 // REQUIRES: asserts
 
 struct BufferView : ~Escapable, ~Copyable {

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -1,12 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_explicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-lifetime-dependence-diagnostics
+// RUN: -disable-lifetime-dependence-diagnostics \
+// RUN: -disable-experimental-parser-round-trip
 
 // RUN: llvm-bcanalyzer %t/def_explicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN: -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 import def_explicit_lifetime_dependence
 func testBasic() {

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -1,12 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_implicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-lifetime-dependence-diagnostics
+// RUN: -disable-lifetime-dependence-diagnostics \
+// RUN: -disable-experimental-parser-round-trip
 
 // RUN: llvm-bcanalyzer %t/def_implicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN: -disable-experimental-parser-round-trip \
+// RUN: | %FileCheck %s
+
+// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://137636751).
 
 import def_implicit_lifetime_dependence
 


### PR DESCRIPTION
Until SwiftParser supports the syntax

rdar://137636751
