### PR TITLE
[Diagnostics] Improve warning suggestion for `var` in for loop

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7032,6 +7032,10 @@ WARNING(variable_never_mutated, none,
         "variable %0 was never mutated; "
         "consider %select{removing 'var' to make it|changing to 'let'}1 constant",
         (Identifier, bool))
+WARNING(variable_tuple_elt_never_mutated, none,
+        "variable %0 was never mutated; "
+        "consider changing the pattern to 'case (..., let %1, ...)'",
+        (Identifier, StringRef))
 WARNING(variable_never_read, none,
         "variable %0 was written to, but never read",
         (Identifier))

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -563,3 +563,11 @@ func testUselessCastWithInvalidParam(foo: Any?) -> Int {
   if let bar = foo as? Foo { return 42 } // expected-warning {{value 'bar' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{20-23=is}}
   else { return 54 }
 }
+
+// https://github.com/swiftlang/swift/issues/72811
+func testEnumeratedForLoop(a: [Int]) {
+  for var (b, c) in a.enumerated() {  // expected-warning {{variable 'b' was never mutated; consider changing the pattern to 'case (..., let b, ...)'}}
+    c = b
+    let _ = c
+  }
+}


### PR DESCRIPTION
When iterator consists of tuple of variable and iteration only mutates the tuple partially, improve the warning message from "changing to 'let" to "changing to 'case let'"

Resolves https://github.com/swiftlang/swift/issues/72811
