### PR TITLE
[CSBindings] Adjust `hasConversions` to handle `Void` has having not …

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1269,7 +1269,8 @@ static bool hasConversions(Type type) {
   }
 
   return !(type->is<StructType>() || type->is<EnumType>() ||
-           type->is<BuiltinType>() || type->is<ArchetypeType>());
+           type->is<BuiltinType>() || type->is<ArchetypeType>() ||
+           type->isVoid());
 }
 
 bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {


### PR DESCRIPTION
…conversions

Tuples in general do have conversions but an empty tuple or `Void` doesn't, which means that if a type variable has a subtype binding to `Void` it should be safe to prioritize.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
