### PR TITLE
[cxx-interop] Consider extern "C" structs as resilient

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -15,19 +15,20 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckAccess.h"
-#include "TypeChecker.h"
-#include "TypeCheckAvailability.h"
 #include "TypeAccessScopeChecker.h"
+#include "TypeCheckAvailability.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Import.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 
 using namespace swift;
@@ -1883,6 +1884,11 @@ bool isFragileClangNode(const ClangNode &node) {
     return isFragileClangType(pd->getType());
   if (auto *typedefDecl = dyn_cast<clang::TypedefNameDecl>(decl))
     return isFragileClangType(typedefDecl->getUnderlyingType());
+  if (auto *rd = dyn_cast<clang::RecordDecl>(decl)) {
+    if (!isa<clang::CXXRecordDecl>(rd))
+      return false;
+    return !rd->getDeclContext()->isExternCContext();
+  }
   return true;
 }
 

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -typecheck -enable-library-evolution -enable-experimental-cxx-interop -verify
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/header.h
+
+class CxxStruct {
+public:
+    int x; int y;
+
+    void method() const;
+};
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+struct CStruct {
+    int x; int y;
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+//--- test.swift
+
+import CxxModule
+
+public func useCStruct(_ x: CStruct) {
+}
+
+// expected-error@+1 {{cannot use struct 'CxxStruct' here; C++ types from imported module 'CxxModule' do not support library evolution}}
+public func usesCxxStruct(_ x: CxxStruct) {
+}


### PR DESCRIPTION
Changing the members of these structs are still API and ABI breaking changes but they are not as fragile as C++ classes where adding/removing virtual functions or doing other changes can also result in breaking the ABI.

rdar://119319825
