### PR TITLE
Add -print-zero-stats to fix ensure_no_astgen.swift in release mode

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -175,6 +175,9 @@ private:
   /// record any additional stats until we've finished.
   bool IsFlushingTracesAndProfiles;
 
+  /// Whether we are printing all stats even if they are zero.
+  bool IsPrintingZeroStats;
+
   void publishAlwaysOnStatsToLLVM();
   void printAlwaysOnStatsAndTimers(raw_ostream &OS);
 
@@ -186,7 +189,8 @@ private:
                        bool FineGrainedTimers,
                        bool TraceEvents,
                        bool ProfileEvents,
-                       bool ProfileEntities);
+                       bool ProfileEntities,
+                       bool PrintZeroStats);
 public:
   UnifiedStatsReporter(StringRef ProgramName,
                        StringRef ModuleName,
@@ -200,7 +204,8 @@ public:
                        bool FineGrainedTimers,
                        bool TraceEvents,
                        bool ProfileEvents,
-                       bool ProfileEntities);
+                       bool ProfileEntities,
+                       bool PrintZeroStats);
   ~UnifiedStatsReporter();
 
   bool fineGrainedTimers() const { return FineGrainedTimers; }

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -232,6 +232,9 @@ public:
   /// runtime overhead.
   bool FineGrainedTimers = false;
 
+  /// Whether we are printing all stats even if they are zero.
+  bool PrintZeroStats = false;
+
   /// Trace changes to stats to files in StatsOutputDir.
   bool TraceStats = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -361,6 +361,9 @@ def driver_time_compilation : Flag<["-"], "driver-time-compilation">,
 def stats_output_dir: Separate<["-"], "stats-output-dir">,
   Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Directory to write unified compilation-statistics files to">;
+def print_zero_stats: Flag<["-"], "print-zero-stats">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Prints all stats even if they are zero">;
 def fine_grained_timers: Flag<["-"], "fine-grained-timers">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Enable per-request timers">;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -522,6 +522,7 @@ createStatsReporter(const llvm::opt::InputArgList *ArgList,
                                                  false,
                                                  false,
                                                  false,
+                                                 false,
                                                  false);
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -406,7 +406,8 @@ void ArgsToFrontendOptionsConverter::computePrintStatsOptions() {
   using namespace options;
   Opts.PrintStats |= Args.hasArg(OPT_print_stats);
   Opts.PrintClangStats |= Args.hasArg(OPT_print_clang_stats);
-#if defined(NDEBUG) && !defined(LLVM_ENABLE_STATS)
+  Opts.PrintZeroStats |= Args.hasArg(OPT_print_zero_stats);
+#if defined(NDEBUG) && !LLVM_ENABLE_STATS
   if (Opts.PrintStats || Opts.PrintClangStats)
     Diags.diagnose(SourceLoc(), diag::stats_disabled);
 #endif

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -384,7 +384,8 @@ void CompilerInstance::setupStatsReporter() {
       Invoke.getFrontendOptions().FineGrainedTimers,
       Invoke.getFrontendOptions().TraceStats,
       Invoke.getFrontendOptions().ProfileEvents,
-      Invoke.getFrontendOptions().ProfileEntities);
+      Invoke.getFrontendOptions().ProfileEntities,
+      Invoke.getFrontendOptions().PrintZeroStats);
   // Hand the stats reporter down to the ASTContext so the rest of the compiler
   // can use it.
   getASTContext().setStatsReporter(Reporter.get());

--- a/test/Macros/lazy_parsing.swift
+++ b/test/Macros/lazy_parsing.swift
@@ -10,8 +10,8 @@
 
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-no-lookup -fine-grained-timers -primary-file %t/b.swift %t/a.swift
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-lookup -fine-grained-timers -primary-file %t/c.swift %t/a.swift
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-no-lookup -fine-grained-timers -print-zero-stats -primary-file %t/b.swift %t/a.swift
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-lookup -fine-grained-timers -print-zero-stats -primary-file %t/c.swift %t/a.swift
 
 // We use '<=' here instead of '==' to take account of the fact that in debug
 // builds we'll be doing round-trip checking, which will parse the syntax tree

--- a/test/ScanDependencies/ensure_no_astgen.swift
+++ b/test/ScanDependencies/ensure_no_astgen.swift
@@ -9,7 +9,7 @@
 // This test ensures we don't attempt to do syntax tree parsing for dependency
 // scanning.
 
-// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/a.swift %t/b.swift -I %t/deps -stats-output-dir %t/stats
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/a.swift %t/b.swift -I %t/deps -stats-output-dir %t/stats -print-zero-stats
 // RUN: %{python} %utils/process-stats-dir.py --evaluate 'ExportedSourceFileRequest == 0' %t/stats
 
 //--- Foo.swiftinterface


### PR DESCRIPTION
as stats collection depends on asserts enabled or forced stats collection.

Fix diagnostic when compiler is built without statistics support.

