### PR TITLE
[ASTGen/Tests] Add `-disable-availability-checking` to regex test cases

### DIFF
--- a/test/ASTGen/regex.swift
+++ b/test/ASTGen/regex.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex > %t/cpp-parser.ast.raw
+// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex -disable-availability-checking -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
+// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex -disable-availability-checking > %t/cpp-parser.ast.raw
 
 // Filter out any addresses in the dump, since they can differ.
 // RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
@@ -8,7 +8,7 @@
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen -enable-bare-slash-regex -disable-availability-checking
 
 // REQUIRES: swift_swift_parser
 


### PR DESCRIPTION
Regex is not always available for the default OS versions. For example

```
  error: 'Regex' is only available in watchOS 9.0 or newer
```

But the current watchOS deployment target for testing is `-target x86_64-apple-watchos6.0-simulator`
