### PR TITLE
Added temporary workaround for stack allocation optimization breaking isolated deinit tests in optimized mode

### DIFF
--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -266,6 +266,14 @@ func adopt(voucher: voucher_t?) {
   os_release(voucher_adopt(os_retain(voucher)))
 }
 
+// Dummy global variable to suppress stack propagation
+// TODO: Remove it after disabling allocation on stack for classes with isolated deinit
+var x: AnyObject? = nil
+func preventAllocationOnStack(_ object: AnyObject) {
+  x = object
+  x = nil
+}
+
 let tests = TestSuite("Voucher Propagation")
 
 if #available(SwiftStdlib 5.1, *) {
@@ -436,15 +444,15 @@ if #available(SwiftStdlib 5.1, *) {
       Task {
         await AnotherActor.shared.performTesting {
           adopt(voucher: v1)
-          _ = ClassWithIsolatedDeinit(expectedVoucher: v1, group: group)
+          preventAllocationOnStack(ClassWithIsolatedDeinit(expectedVoucher: v1, group: group))
         }
         await AnotherActor.shared.performTesting {
           adopt(voucher: v2)
-          _ = ActorWithSelfIsolatedDeinit(expectedVoucher: v2, group: group)
+          preventAllocationOnStack(ActorWithSelfIsolatedDeinit(expectedVoucher: v2, group: group))
         }
         await AnotherActor.shared.performTesting {
           adopt(voucher: v3)
-          _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v3, group: group)
+          preventAllocationOnStack(ActorWithDeinitIsolatedOnAnother(expectedVoucher: v3, group: group))
         }
       }
       group.wait()
@@ -459,11 +467,11 @@ if #available(SwiftStdlib 5.1, *) {
       Task {
         do {
           adopt(voucher: v1)
-          _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v1, group: group)
+          preventAllocationOnStack(ActorWithDeinitIsolatedOnAnother(expectedVoucher: v1, group: group))
         }
         do {
           adopt(voucher: v2)
-          _ = ClassWithIsolatedDeinit(expectedVoucher: v2, group: group)
+          preventAllocationOnStack(ClassWithIsolatedDeinit(expectedVoucher: v2, group: group))
         }
       }
       group.wait()


### PR DESCRIPTION
This is a temporary workaround to fix CI pipelines. Proper fix will be submitted later.