### PR TITLE
Implement _tryAppendFromUTF8

### DIFF
--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -108,6 +108,17 @@ extension String {
     return String._uncheckedFromUTF8(input, isASCII: extraInfo.isASCII)
   }
 
+  @available(SwiftStdlib 6.1, *)
+  public // SPI(Foundation)
+  mutating func _tryAppendFromUTF8(_ input: UnsafeBufferPointer<UInt8>) -> Bool {
+    guard case .success(let extraInfo) = validateUTF8(input) else {
+      return false
+    }
+
+    self._guts.append(input, isASCII: extraInfo.isASCII)
+    return true
+  }
+
   @usableFromInline
   internal static func _fromUTF8Repairing(
     _ input: UnsafeBufferPointer<UInt8>


### PR DESCRIPTION
`String` has had a private UTF-8 validating creation function for a while that is used by Foundation: `_tryFromUTF8`. However, Foundation's `JSONDecoder` has an immediate need for the ability to validated and *append* UTF-8 bytes to an existing String, allowing it to avoid redundant allocation, memcpy, retain/release traffic, and deallocation of a temporary string created by `_tryFromUTF8`.

Eventually, I expect this should be surfaced as a general use API that takes a `UTF8Span` or similar. Howver, as that is still in the works, this function will provide a stopgap to faciliate `JSONDecoder` development.