### PR TITLE
Don't serialize relative resource dir paths in swiftmodules

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -105,6 +105,12 @@ bool ExplicitModuleInterfaceBuilder::collectDepsForSerialization(
   path::native(SDKPath);
   SmallString<128> ResourcePath(Opts.RuntimeResourcePath);
   path::native(ResourcePath);
+  // When compiling with a relative resource dir, the clang
+  // importer will track inputs with absolute paths. To avoid
+  // serializing resource dir inputs we need to check for
+  // relative _and_ absolute prefixes.
+  SmallString<128> AbsResourcePath(ResourcePath);
+  llvm::sys::fs::make_absolute(AbsResourcePath);
 
   auto DTDeps = Instance.getDependencyTracker()->getDependencies();
   SmallVector<std::string, 16> InitialDepNames(DTDeps.begin(), DTDeps.end());
@@ -146,7 +152,7 @@ bool ExplicitModuleInterfaceBuilder::collectDepsForSerialization(
     }
 
     // Don't serialize compiler-relative deps so the cache is relocatable.
-    if (DepName.starts_with(ResourcePath))
+    if (DepName.starts_with(ResourcePath) || DepName.starts_with(AbsResourcePath))
       continue;
 
     auto Status = fs.status(DepName);

--- a/test/ModuleInterface/Inputs/resource_dir/apinotes/ClangModule.apinotes
+++ b/test/ModuleInterface/Inputs/resource_dir/apinotes/ClangModule.apinotes
@@ -1,0 +1,4 @@
+Name: ClangModule
+Globals:
+  - Name: CMThing
+    SwiftName: SwiftThing

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/include/ClangModuleHeader.h
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/include/ClangModuleHeader.h
@@ -1,0 +1,1 @@
+struct CMThing {};

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/include/module.modulemap
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/include/module.modulemap
@@ -1,0 +1,3 @@
+module ClangModule [system] {
+	header "ClangModuleHeader.h"
+}

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/arm64-apple-macos.swiftinterface
@@ -2,6 +2,7 @@
 // swift-module-flags: -target arm64-apple-macosx15.0 -module-name OtherModule -O
 
 import Swift
+import ClangModule
 
 public struct OtherStruct {
     var x : Int

--- a/test/ModuleInterface/relative-resource-path.swift
+++ b/test/ModuleInterface/relative-resource-path.swift
@@ -1,0 +1,13 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t.relative_resource_path)
+// RUN: %empty-directory(%t.mcp)
+// RUN: cp -R %S/Inputs/resource_dir %t.relative_resource_path/
+// RUN: cd %t.relative_resource_path
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -module-cache-path %t.mcp) -target arm64-apple-macosx15.0 \
+// RUN:   -resource-dir resource_dir -compile-module-from-interface -o OtherModule.swiftmodule \
+// RUN:   %S/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/arm64-apple-macos.swiftinterface
+// RUN: llvm-bcanalyzer -dump OtherModule.swiftmodule | %FileCheck %s
+
+// CHECK-NOT: <DEPENDENCY_DIRECTORY abbrevid=11/> blob data = '/


### PR DESCRIPTION
When compiling swiftmodule files with relative resource directory paths, we
need to compare inputs against relative _and_ absolute resource directory
prefixes to avoid serializing clang importer dependencies, such as apinotes.