### PR TITLE
Mitigate the code size increase from eager-lazy array bridging by marking some methods release none

### DIFF
--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -51,12 +51,16 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
 
   @usableFromInline
   internal var endIndex: Int {
-    return core.count
+    @_effects(releasenone) get {
+      core.count
+    }
   }
 
   @usableFromInline
   internal subscript(i: Int) -> AnyObject {
-    return core.objectAt(i)
+    @_effects(releasenone) get {
+      core.objectAt(i)
+    }
   }
 
   @usableFromInline


### PR DESCRIPTION
Fixes rdar://137709108