### PR TITLE
ABI comments: include stored property names

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3157,12 +3157,10 @@ std::optional<std::string> PrintAST::mangledNameToPrint(const Decl *D) {
     return mangler.mangleConstructorEntity(init, /*isAllocating=*/true);
   }
 
-  // For global and static variables, mangle the entity directly.
+  // For variables, mangle the entity directly.
   if (auto var = dyn_cast<VarDecl>(D)) {
-    if (!var->isInstanceMember()) {
-      ASTMangler mangler;
-      return mangler.mangleEntity(var);
-    }
+    ASTMangler mangler;
+    return mangler.mangleEntity(var);
   }
 
   // For subscripts, mangle the entity directly.

--- a/test/ModuleInterface/abi-comments.swift
+++ b/test/ModuleInterface/abi-comments.swift
@@ -8,10 +8,35 @@
 // CHECK-NEXT: public func intToString(_ value: Swift.Int) -> Swift.String
 public func intToString(_ value: Int) -> String { "\(value)" }
 
+// CHECK: // MANGLED NAME: $s11ABIComments13globalCounterSivp
+// CHECK-NEXT: @_hasInitialValue public var globalCounter: Swift.Int
+public var globalCounter: Int = 23
+
 // CHECK: // MANGLED NAME: $s11ABIComments8MyStructVMa
 // CHECK-NEXT: public struct MyStruct {
 public struct MyStruct {
   // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV6methodSiyF
   // CHECK-NEXT: public func method() -> Swift.Int
   public func method() -> Int { 5 }
+
+  // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV7counterSivp
+  // CHECK-NEXT: @_hasInitialValue public var counter: Swift.Int
+  public var counter: Int = 23
+
+  // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV11constantNumSivp
+  // CHECK-NEXT: @_hasInitialValue public let constantNum: Swift.Int
+  public let constantNum: Int = 23
+
+  // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV9staticLetSivpZ
+  // CHECK-NEXT: @_hasInitialValue public static let staticLet: Swift.Int
+  public static let staticLet: Int = 23
+
+  // CHECK: // MANGLED NAME: $s11ABIComments8MyStructV8computedSivp
+  // CHECK-NEXT: public var computed: Swift.Int {
+  // CHECK-NEXT: // MANGLED NAME: $s11ABIComments8MyStructV8computedSivg
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
+  public var computed: Int {
+    13
+  }
 }


### PR DESCRIPTION
Include property mangled names in the -abi-comments-in-module-interface %s mode.
