### PR TITLE
IDETool: Register SourceFile for replaced function body

### DIFF
--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -354,6 +354,7 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
           nullptr
         }
     );
+    SM.recordSourceFile(newBufferID, AFD->getParentSourceFile());
 
     AFD->setBodyToBeReparsed(newBodyRange);
     oldSF->clearScope();

--- a/test/SourceKit/CodeComplete/issue-76944.swift
+++ b/test/SourceKit/CodeComplete/issue-76944.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+//--- input.swift
+
+//--- input2.swift
+func body() {
+
+extension InvalidProto {}
+
+//--- input3.swift
+func body() {
+
+extension InvalidProto {}
+
+struct MyStruct {
+
+//--- dummy.swift
+
+// RUN: %sourcekitd-test \
+// RUN: -req=open %t/input.swift -req-opts=syntactic_only=1 -print-raw-response == \
+// RUN: -req=typecontextinfo -pos=4:1 %t/input.swift -text-input %t/input2.swift -- %t/input.swift == \
+// RUN: -req=complete -pos=6:1 %t/input.swift -text-input %t/input3.swift -repeat-request 2 -- %t/input.swift


### PR DESCRIPTION
This prevents a nullptr dereference in `ASTScope::unqualifiedLookup()` after querying for the `SourceFile` containing a given source location.

Fixes rdar://137652856 and https://github.com/swiftlang/swift/issues/76944.
