### PR TITLE
AST: Make ExpandChildTypeRefinementContextsRequest a side effectful request

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4852,8 +4852,7 @@ public:
 /// Expand the children of the given type refinement context.
 class ExpandChildTypeRefinementContextsRequest
     : public SimpleRequest<ExpandChildTypeRefinementContextsRequest,
-                           std::vector<TypeRefinementContext *>(
-                               TypeRefinementContext *),
+                           evaluator::SideEffect(TypeRefinementContext *),
                            RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -4861,14 +4860,14 @@ public:
 private:
   friend SimpleRequest;
 
-  std::vector<TypeRefinementContext *>
-  evaluate(Evaluator &evaluator, TypeRefinementContext *parentTRC) const;
+  evaluator::SideEffect evaluate(Evaluator &evaluator,
+                                 TypeRefinementContext *parentTRC) const;
 
 public:
   // Separate caching.
   bool isCached() const { return true; }
-  std::optional<std::vector<TypeRefinementContext *>> getCachedResult() const;
-  void cacheResult(std::vector<TypeRefinementContext *> children) const;
+  std::optional<evaluator::SideEffect> getCachedResult() const;
+  void cacheResult(evaluator::SideEffect) const;
 };
 
 class SerializeAttrGenericSignatureRequest

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1384,8 +1384,7 @@ TypeChecker::getOrBuildTypeRefinementContext(SourceFile *SF) {
   return TRC;
 }
 
-std::vector<TypeRefinementContext *>
-ExpandChildTypeRefinementContextsRequest::evaluate(
+evaluator::SideEffect ExpandChildTypeRefinementContextsRequest::evaluate(
     Evaluator &evaluator, TypeRefinementContext *parentTRC) const {
   assert(parentTRC->getNeedsExpansion());
   if (auto decl = parentTRC->getDeclOrNull()) {
@@ -1394,7 +1393,7 @@ ExpandChildTypeRefinementContextsRequest::evaluate(
     builder.prepareDeclForLazyExpansion(decl);
     builder.build(decl);
   }
-  return parentTRC->Children;
+  return evaluator::SideEffect();
 }
 
 AvailabilityRange TypeChecker::overApproximateAvailabilityAtLocation(


### PR DESCRIPTION
While returning the actual child vector from `ExpandChildTypeRefinementContextsRequest` is a nice idea, it is both inefficient (the vector gets copied in and out) and kind of inaccurate, since the vector remains mutable after the initial expansion and may gain additional children as macros are lazily expanded.
