### PR TITLE
[build.ps1] In Build-CMakeProject() always log all config parameters

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1117,6 +1117,13 @@ function Build-CMakeProject {
     } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
+
+    if ($ToBatch) {
+      Write-Output ""
+      Write-Output "echo cmake.exe $cmakeGenerateArgs"
+    } else {
+      Write-Host "cmake.exe $cmakeGenerateArgs"
+    }
     Invoke-Program cmake.exe @cmakeGenerateArgs
 
     # Build all requested targets


### PR DESCRIPTION
Full CMake config line is logged in backtraces when configuration fails, but otherwise it's not visible in the log. This seems useful to better understand CI failures.