### PR TITLE
[build.ps1] In Build-Compilers() let TestingDefines override defaults

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1374,7 +1374,7 @@ function Build-Compilers() {
       -UsePinnedCompilers Swift `
       -BuildTargets $Targets `
       -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Arch.LLVMName).cmake `
-      -Defines ($TestingDefines + @{
+      -Defines (@{
         CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
         CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
         CMAKE_Swift_FLAGS = $SwiftFlags;
@@ -1406,7 +1406,7 @@ function Build-Compilers() {
         SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
         SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK);
         "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
-      })
+      } + $TestingDefines)
   }
 }
 


### PR DESCRIPTION
In CMake trailing parameters win. That way we can pass `LLDB_INCLUDE_TESTS=On` for `-Test lldb` and `LLDB_INCLUDE_TESTS=Off` otherwise (and don't bother with LLDB's test suite requirements). 