### PR TITLE
[Tests][Reflection] Fully disable typeref_decoding_asan on Linux aarch64.

### DIFF
--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=linux-gnu && CPU=aarch64
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e


### PR DESCRIPTION
We XFAILed it but it's still passing sometimes.