### PR TITLE
When printing logging, dump out the whole function.

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1495,14 +1495,15 @@ public:
 
     REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
-        << PER_FUNCTION_SEP_STR
-        << "Beginning processing: " << function->getName() << '\n'
-        << "Demangled: "
-        << Demangle::demangleSymbolAsString(
-               function->getName(),
-               Demangle::DemangleOptions::SimplifiedUIDemangleOptions())
-        << '\n'
-        << PER_FUNCTION_SEP_STR);
+            << PER_FUNCTION_SEP_STR
+            << "Beginning processing: " << function->getName() << '\n'
+            << "Demangled: "
+            << Demangle::demangleSymbolAsString(
+                   function->getName(),
+                   Demangle::DemangleOptions::SimplifiedUIDemangleOptions())
+            << '\n'
+            << PER_FUNCTION_SEP_STR << "Dump:\n";
+        function->print(llvm::dbgs()));
 
     gatherFlowInsensitiveInformationBeforeDataflow();
 


### PR DESCRIPTION
Just to make it a little quicker to debug/get this information when debugging the pass. I have been wanting this and just hadn't gotten around to adding it. It just centralizes the last piece of information that one wants to reach for when debugging.