### PR TITLE
[SymbolGraphGen] don't emit both requirementOf and optionalRequirementOf for the same relationship

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -465,7 +465,8 @@ void
 SymbolGraph::recordRequirementRelationships(Symbol S) {
   const auto VD = S.getSymbolDecl();
   if (const auto *Protocol = dyn_cast<ProtocolDecl>(VD->getDeclContext())) {
-    if (VD->isProtocolRequirement()) {
+    if (VD->isProtocolRequirement() &&
+        !VD->getAttrs().hasAttribute<OptionalAttr>()) {
       recordEdge(Symbol(this, VD, nullptr),
                  Symbol(this, Protocol, nullptr),
                  RelationshipKind::RequirementOf());

--- a/test/SymbolGraph/Relationships/OptionalRequirementOf.swift
+++ b/test/SymbolGraph/Relationships/OptionalRequirementOf.swift
@@ -9,11 +9,11 @@
 // RUN: %FileCheck %s --input-file %t/OptionalRequirementOf.symbols.json
 
 // ObjCProto.objcReq -> ObjCProto
-// CHECK-DAG: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto(im)swiftReq",{{[[:space:]]*}}"target": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto"
+// CHECK-NOT: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto(im)swiftReq",{{[[:space:]]*}}"target": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto"
 // CHECK-DAG: "kind": "optionalRequirementOf",{{[[:space:]]*}}"source": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto(im)swiftReq",{{[[:space:]]*}}"target": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto"
 
 // SwiftProto.swiftReq -> SwiftProto
-// CHECK-DAG: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:objc(pl)ObjCProto(im)objcReq",{{[[:space:]]*}}"target": "c:objc(pl)ObjCProto"
+// CHECK-NOT: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:objc(pl)ObjCProto(im)objcReq",{{[[:space:]]*}}"target": "c:objc(pl)ObjCProto"
 // CHECK-DAG: "kind": "optionalRequirementOf",{{[[:space:]]*}}"source": "c:objc(pl)ObjCProto(im)objcReq",{{[[:space:]]*}}"target": "c:objc(pl)ObjCProto"
 
 //--- reqs.swift


### PR DESCRIPTION
Resolves rdar://83519993

This PR changes the relationship emitting logic in SymbolGraphGen so that optional protocol requirements don't generate both a `requirementOf` and `optionalRequirementOf` relationship. This confuses tools like Swift-DocC, which render these relationships as both optional and required, even though the former should override it. To prevent this confusion, we can formalize the notion that `optionalRequirementOf` relationships imply a `requirementOf` relationship, and only emit the former when it's necessary.