### PR TITLE
[build-script] Enable new parser validation by default

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1691,7 +1691,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableDynamicActorIsolation |=
       Args.hasArg(OPT_disable_dynamic_actor_isolation);
 
-#if SWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION
+#if !defined(NDEBUG) && SWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION
   /// Enable round trip parsing via the new swift parser unless it is disabled
   /// explicitly. The new Swift parser can have mismatches with C++ parser -
   /// rdar://118013482 Use this flag to disable round trip through the new

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1996,7 +1996,6 @@ skstresstester
 sourcekit-lsp
 install-swiftformat
 skip-test-swift=false
-enable-experimental-parser-validation=true
 
 [preset: buildbot_swiftsyntax_linux]
 mixin-preset=mixin_swiftpm_package_linux_platform
@@ -2008,7 +2007,6 @@ swiftsyntax-enable-test-fuzzing
 sourcekit-lsp
 swiftformat
 install-swiftformat
-enable-experimental-parser-validation=true
 
 #===------------------------------------------------------------------------===#
 # Test Swift Format
@@ -2997,14 +2995,12 @@ mixin-preset=source_compat_suite_macos_base
 debug
 assertions
 cross-compile-hosts=macosx-arm64
-enable-experimental-parser-validation=true
 
 [preset: source_compat_suite_macos_RA]
 mixin-preset=source_compat_suite_macos_base
 release
 assertions
 cross-compile-hosts=macosx-arm64
-enable-experimental-parser-validation=true
 
 [preset: source_compat_suite_macos_R]
 mixin-preset=source_compat_suite_macos_base
@@ -3022,13 +3018,11 @@ cross-compile-hosts=macosx-arm64
 mixin-preset=source_compat_suite_linux_base
 debug
 assertions
-enable-experimental-parser-validation=true
 
 [preset: source_compat_suite_linux_RA]
 mixin-preset=source_compat_suite_linux_base
 release
 assertions
-enable-experimental-parser-validation=true
 
 [preset: source_compat_suite_linux_R]
 mixin-preset=source_compat_suite_linux_base

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1494,7 +1494,7 @@ def create_argument_parser():
            help='Enable Volatile module.')
 
     option('--enable-experimental-parser-validation', toggle_true,
-           default=False,
+           default=True,
            help='Enable experimental Swift Parser validation by default.')
 
     # -------------------------------------------------------------------------

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -184,7 +184,7 @@ EXPECTED_DEFAULTS = {
     'enable_experimental_nonescapable_types': False,
     'enable_experimental_string_processing': True,
     'enable_experimental_observation': True,
-    'enable_experimental_parser_validation': False,
+    'enable_experimental_parser_validation': True,
     'swift_enable_backtracing': True,
     'enable_synchronization': True,
     'enable_volatile': True,


### PR DESCRIPTION
Widen the parser validation coverage.
This encourages the developers to implement the new grammar in SwiftParser in addition to the old C++ parser.

In case  there's an unavoidable reason not to implement in SwiftParser, disable the validation for each test case by passing a frontend option '-disable-experimental-parser-round-trip'. But please file an issue and add FIXME like:

```
// FIXME: Remove '-disable-experimental-parser-round-trip' (rdar://xxx).
```