### PR TITLE
[Test] Add 'REQUIRES: embedded_stdlib' to an embedded test

### DIFF
--- a/test/Interop/SwiftToCxx/core/embedded-swift.swift
+++ b/test/Interop/SwiftToCxx/core/embedded-swift.swift
@@ -3,6 +3,7 @@
 // RUN: %FileCheck %s < %t/core.h
 
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 
 public func id(_ x: Int) -> Int {
     return x


### PR DESCRIPTION
Fix
```
<unknown>:0: error: unable to load standard library for target 'arm64-apple-macos15.0'
```
for `--build-embedded-stdlib false`