### PR TITLE
[NFC] PredictableMemOpts: refactor to allow extension

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -43,9 +43,40 @@ STATISTIC(NumLoadTakePromoted, "Number of load takes promoted");
 STATISTIC(NumDestroyAddrPromoted, "Number of destroy_addrs promoted");
 STATISTIC(NumAllocRemoved, "Number of allocations completely removed");
 
+namespace {
+
+/// The following utilities handle two fundamentally different optimizations:
+/// - load-copy removal preserves allocation
+/// - dead allocation removal replaces the allocation
+///
+/// Ownership handling is completely different in these cases. The utilities are
+/// not well-factored to reflect this, so we have a mode flag.
+enum class OptimizationMode {
+  PreserveAlloc,
+  ReplaceAlloc
+};
+
+} // end namespace
+
 //===----------------------------------------------------------------------===//
 //                            Subelement Analysis
 //===----------------------------------------------------------------------===//
+
+namespace {
+
+// The type of a particular memory access and its corresponding subelement index
+// range relative to the allocation being optimized.
+struct LoadInfo {
+  SILType loadType;
+  unsigned firstElt;
+  unsigned numElts;
+
+  IntRange<unsigned> range() const {
+    return IntRange<unsigned>(firstElt, firstElt + numElts);
+  }
+};
+
+} // namespace
 
 // We can only analyze components of structs whose storage is fully accessible
 // from Swift.
@@ -414,6 +445,235 @@ static SILValue nonDestructivelyExtractSubElement(const AvailableValue &Val,
 }
 
 //===----------------------------------------------------------------------===//
+//                              Ownership Fixup
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// For OptimizedMode == PreserveAlloc. Track inserted copies and casts for
+/// ownership fixup.
+struct AvailableValueFixup {
+  /// Keep track of all instructions that we have added. Once we are done
+  /// promoting a value, we need to make sure that if we need to balance any
+  /// copies (to avoid leaks), we do so. This is not used if we are performing a
+  /// take.
+  SmallVector<SILInstruction *, 16> insertedInsts;
+
+  AvailableValueFixup() = default;
+  AvailableValueFixup(const AvailableValueFixup &) = delete;
+  AvailableValueFixup &operator=(const AvailableValueFixup &) = delete;
+
+  ~AvailableValueFixup() {
+    assert(insertedInsts.empty() && "need to fix ownership");
+  }
+};
+
+} // end namespace
+
+namespace {
+
+/// For available value data flow with OptimizedMode::PreserveAlloc: track only
+/// inserted copies and casts for ownership fixup after dataflow completes. Phis
+/// are not allowed.
+struct AvailableValueDataflowFixup: AvailableValueFixup {
+  /// Given a single available value, get an owned copy if it is possible to
+  /// create one without introducing a phi. Return the copy. Otherwise, return
+  /// an invalid SILValue.
+  SILValue getSingleOwnedValue(const AvailableValue &availableVal);
+
+  /// Fix ownership of inserted instructions and delete dead instructions.
+  void fixupOwnership(InstructionDeleter &deleter,
+                      DeadEndBlocks &deBlocks);
+};
+
+} // end namespace
+
+// In OptimizationMode::PreserveAlloc, get a copy of this single available
+// value. This requires a copy at the allocation's insertion point (store).
+//
+// Assumption: this copy will be consumed at a cast-like instruction
+// (mark_dependence), which caused dataflow to invalidate the currently
+// available value. Therefore, since phis are not allowed, the consumption
+// cannot be in an inner loop relative to the copy. Unlike getMergedOwnedValue,
+// there is no need for a second copy.
+//
+// Note: the caller must add the consuming cast to this->insertedInsts.
+SILValue AvailableValueDataflowFixup::getSingleOwnedValue(
+  const AvailableValue &availableVal) {
+
+  SILValue value = availableVal.getValue();
+  // If there is no need for copies, then we don't care about multiple insertion
+  // points.
+  if (value->getType().isTrivial(*value->getFunction())) {
+    return value;
+  }
+  ArrayRef<StoreInst *> insertPts = availableVal.getInsertionPoints();
+  if (insertPts.size() > 1)
+    return SILValue();
+  
+  return SILBuilderWithScope(insertPts[0], &insertedInsts)
+    .emitCopyValueOperation(insertPts[0]->getLoc(), value);
+}
+
+// In OptimizationMode::PreserveAlloc, delete any inserted instructions that are
+// still dead and fix ownership of any live inserted copies or casts
+// (mark_dependence).
+void AvailableValueDataflowFixup::fixupOwnership(InstructionDeleter &deleter,
+                                                 DeadEndBlocks &deBlocks) {
+  for (auto *inst : insertedInsts) {
+    if (inst->isDeleted())
+      continue;
+    
+    deleter.deleteIfDead(inst);
+  }
+  auto *function = const_cast<SILFunction *>(deBlocks.getFunction());
+  OSSALifetimeCompletion completion(function, /*DomInfo*/ nullptr, deBlocks);
+  for (auto *inst : insertedInsts) {
+    if (inst->isDeleted())
+      continue;
+
+    // If any inserted instruction was not removed, complete its lifetime.
+    for (auto result : inst->getResults()) {
+      completion.completeOSSALifetime(
+        result, OSSALifetimeCompletion::Boundary::Liveness);
+    }
+  }
+  insertedInsts.clear();
+}
+
+// In OptimizationMode::PreserveAlloc: insert copies and phis for aggregate
+// values.
+struct AvailableValueAggregationFixup: AvailableValueFixup {
+  DeadEndBlocks &deadEndBlocks;
+  
+  /// The list of phi nodes inserted by the SSA updater.
+  SmallVector<SILPhiArgument *, 16> insertedPhiNodes;
+
+  /// A set of copy_values whose lifetime we balanced while inserting phi
+  /// nodes. This means that these copy_value must be skipped in
+  /// addMissingDestroysForCopiedValues.
+  SmallPtrSet<CopyValueInst *, 16> copyValueProcessedWithPhiNodes;
+
+  AvailableValueAggregationFixup(DeadEndBlocks &deadEndBlocks)
+    : deadEndBlocks(deadEndBlocks) {}
+
+  /// For a single 'availableVal', insert copies at each insertion point. Merge
+  /// all copies, creating phis if needed. Return the final copy. Otherwise,
+  /// return an invalid SILValue.
+  SILValue mergeCopies(const AvailableValue &availableVal,
+                       SILType loadTy,
+                       SILInstruction *availableAtInst,
+                       bool isFullyAvailable);
+
+  /// Call this after mergeSingleValueCopies() or mergeAggregateCopies().
+  void fixupOwnership(SILInstruction *load, SILValue newVal) {
+    addHandOffCopyDestroysForPhis(load, newVal);
+
+    // TODO: use OwnershipLifetimeCompletion instead.
+    addMissingDestroysForCopiedValues(load, newVal);
+    
+    insertedInsts.clear();
+    insertedPhiNodes.clear();
+    copyValueProcessedWithPhiNodes.clear();
+  }
+
+private:
+  /// As a result of us using the SSA updater, insert hand off copy/destroys at
+  /// each phi and make sure that intermediate phis do not leak by inserting
+  /// destroys along paths that go through the intermediate phi that do not also
+  /// go through the.
+  void addHandOffCopyDestroysForPhis(SILInstruction *load, SILValue newVal);
+
+  /// If as a result of us copying values, we may have unconsumed destroys, find
+  /// the appropriate location and place the values there. Only used when
+  /// ownership is enabled.
+  void addMissingDestroysForCopiedValues(SILInstruction *load, SILValue newVal);
+};
+
+// For OptimizationMode::PreserveAlloc, insert copies at the available value's
+// insertion points to provide an owned value. Merge the copies into phis.
+// Create another copy before 'availableAtInst' in case it consumes the owned
+// value within an inner loop. Add the copies to insertedInsts and phis to
+// insertedPhiNodes.
+SILValue AvailableValueAggregationFixup::mergeCopies(
+  const AvailableValue &availableVal, SILType loadTy,
+  SILInstruction *availableAtInst,
+  bool isFullyAvailable) {
+
+  auto emitValue = [&](SILInstruction *insertPt) {
+    if (isFullyAvailable) {
+      SILValue fullVal = availableVal.getValue();
+      if (fullVal->use_empty()
+          && fullVal->getOwnershipKind() == OwnershipKind::Owned) {
+        // This value was inserted during data flow to propagate ownership. It
+        // does not need to be copied.
+        return fullVal;
+      }
+      return SILBuilderWithScope(insertPt, &insertedInsts)
+        .emitCopyValueOperation(insertPt->getLoc(), fullVal);
+    }
+    SILBuilderWithScope builder(insertPt, &insertedInsts);
+    SILValue eltVal = nonDestructivelyExtractSubElement(availableVal, builder,
+                                                        insertPt->getLoc());
+    assert(eltVal->getType() == loadTy && "Subelement types mismatch");
+    assert(eltVal->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
+    return eltVal;
+  };
+
+  ArrayRef<StoreInst *> insertPts = availableVal.getInsertionPoints();
+  if (insertPts.size() == 1) {
+    SILValue eltVal = emitValue(insertPts[0]);
+    if (isFullyAvailable)
+      return eltVal;
+    
+    return SILBuilderWithScope(availableAtInst, &insertedInsts)
+      .emitCopyValueOperation(availableAtInst->getLoc(), eltVal);
+  }
+  // If we have multiple insertion points, put copies at each point and use the
+  // SSA updater to get a value. The reason why this is safe is that we can only
+  // have multiple insertion points if we are storing exactly the same value
+  // implying that we can just copy firstVal at each insertion point.
+  SILSSAUpdater updater(&insertedPhiNodes);
+  SILFunction *function = availableAtInst->getFunction();
+  assert(function->hasOwnership() && "requires OSSA");
+  updater.initialize(function, loadTy, OwnershipKind::Owned);
+
+  std::optional<SILValue> singularValue;
+  for (auto *insertPt : insertPts) {
+    SILValue eltVal = emitValue(insertPt);
+
+    if (!singularValue.has_value()) {
+      singularValue = eltVal;
+    } else if (*singularValue != eltVal) {
+      singularValue = SILValue();
+    }
+    // And then put the value into the SSA updater.
+    updater.addAvailableValue(insertPt->getParent(), eltVal);
+  }
+
+  // If we only are tracking a singular value, we do not need to construct
+  // SSA. Just return that value.
+  if (auto val = singularValue.value_or(SILValue())) {
+    // Non-trivial values will always be copied above at each insertion
+    // point, and will, therefore, have multiple incoming values.
+    assert(val->getType().isTrivial(*function) &&
+           "Should never reach this code path if we are in ossa and have a "
+           "non-trivial value");
+    return val;
+  }
+
+  // Finally, grab the value from the SSA updater.
+  SILValue result =
+    updater.getValueInMiddleOfBlock(availableAtInst->getParent());
+  assert(result->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
+  assert(result->getType() == loadTy && "Subelement types mismatch");
+  // Insert another copy at the point of availability in case it is inside a
+  // loop.
+  return SILBuilderWithScope(availableAtInst, &insertedInsts)
+    .emitCopyValueOperation(availableAtInst->getLoc(), result);
+}
+
+//===----------------------------------------------------------------------===//
 //                        Available Value Aggregation
 //===----------------------------------------------------------------------===//
 
@@ -444,22 +704,9 @@ class AvailableValueAggregator {
   SILLocation Loc;
   ArrayRef<AvailableValue> AvailableValueList;
   SmallVectorImpl<PMOMemoryUse> &Uses;
-  DeadEndBlocks &deadEndBlocks;
   AvailableValueExpectedOwnership expectedOwnership;
 
-  /// Keep track of all instructions that we have added. Once we are done
-  /// promoting a value, we need to make sure that if we need to balance any
-  /// copies (to avoid leaks), we do so. This is not used if we are performing a
-  /// take.
-  SmallVector<SILInstruction *, 16> insertedInsts;
-
-  /// The list of phi nodes inserted by the SSA updater.
-  SmallVector<SILPhiArgument *, 16> insertedPhiNodes;
-
-  /// A set of copy_values whose lifetime we balanced while inserting phi
-  /// nodes. This means that these copy_value must be skipped in
-  /// addMissingDestroysForCopiedValues.
-  SmallPtrSet<CopyValueInst *, 16> copyValueProcessedWithPhiNodes;
+  AvailableValueAggregationFixup ownershipFixup;
 
 public:
   AvailableValueAggregator(SILInstruction *Inst,
@@ -469,7 +716,8 @@ public:
                            AvailableValueExpectedOwnership expectedOwnership)
       : M(Inst->getModule()), B(Inst), Loc(Inst->getLoc()),
         AvailableValueList(AvailableValueList), Uses(Uses),
-        deadEndBlocks(deadEndBlocks), expectedOwnership(expectedOwnership) {}
+        expectedOwnership(expectedOwnership), ownershipFixup(deadEndBlocks)
+  {}
 
   // This is intended to be passed by reference only once constructed.
   AvailableValueAggregator(const AvailableValueAggregator &) = delete;
@@ -503,9 +751,7 @@ public:
   /// the same number of times).
   void fixupOwnership(SILInstruction *load, SILValue newVal) {
     assert(isa<LoadBorrowInst>(load) || isa<LoadInst>(load));
-
-    addHandOffCopyDestroysForPhis(load, newVal);
-    addMissingDestroysForCopiedValues(load, newVal);
+    ownershipFixup.fixupOwnership(load, newVal);
   }
 
 private:
@@ -514,20 +760,6 @@ private:
                                  SILValue address, unsigned firstElt);
   SILValue aggregateStructSubElts(StructDecl *sd, SILType loadTy,
                                   SILValue address, unsigned firstElt);
-  SILValue handlePrimitiveValue(SILType loadTy, SILValue address,
-                                unsigned firstElt);
-
-
-  /// If as a result of us copying values, we may have unconsumed destroys, find
-  /// the appropriate location and place the values there. Only used when
-  /// ownership is enabled.
-  void addMissingDestroysForCopiedValues(SILInstruction *load, SILValue newVal);
-
-  /// As a result of us using the SSA updater, insert hand off copy/destroys at
-  /// each phi and make sure that intermediate phis do not leak by inserting
-  /// destroys along paths that go through the intermediate phi that do not also
-  /// go through the
-  void addHandOffCopyDestroysForPhis(SILInstruction *load, SILValue newVal);
 };
 
 } // end anonymous namespace
@@ -610,7 +842,8 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
         aggregateTupleSubElts(tupleType, LoadTy, Address, FirstElt);
     if (isTopLevel && result->getOwnershipKind() == OwnershipKind::Guaranteed) {
       SILValue borrowedResult = result;
-      SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
+      SILBuilderWithScope builder(&*B.getInsertionPoint(),
+                                  &ownershipFixup.insertedInsts);
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
       SmallVector<BorrowedValue, 4> introducers;
       bool foundIntroducers =
@@ -631,7 +864,8 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
         aggregateStructSubElts(structDecl, LoadTy, Address, FirstElt);
     if (isTopLevel && result->getOwnershipKind() == OwnershipKind::Guaranteed) {
       SILValue borrowedResult = result;
-      SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
+      SILBuilderWithScope builder(&*B.getInsertionPoint(),
+                                  &ownershipFixup.insertedInsts);
       result = builder.emitCopyValueOperation(Loc, borrowedResult);
       SmallVector<BorrowedValue, 4> introducers;
       bool foundIntroducers =
@@ -650,7 +884,23 @@ SILValue AvailableValueAggregator::aggregateValues(SILType LoadTy,
   // NOTE: We should never call this when taking since when taking we know that
   // our underlying value is always fully available.
   assert(!isTake());
-  return handlePrimitiveValue(LoadTy, Address, FirstElt);
+  // If the value is not available, load the value and update our use list.
+  auto &val = AvailableValueList[FirstElt];
+  if (!val) {
+    LoadInst *load = ([&]() {
+      if (B.hasOwnership()) {
+        SILBuilderWithScope builder(&*B.getInsertionPoint(),
+                                    &ownershipFixup.insertedInsts);
+        return builder.createTrivialLoadOr(Loc, Address,
+                                           LoadOwnershipQualifier::Copy);
+      }
+      return B.createLoad(Loc, Address, LoadOwnershipQualifier::Unqualified);
+    }());
+    Uses.emplace_back(load, PMOUseKind::Load);
+    return load;
+  }
+  return ownershipFixup.mergeCopies(val, LoadTy, &*B.getInsertionPoint(),
+                                    /*isFullyAvailable*/false);
 }
 
 // See if we have this value is fully available. In such a case, return it as an
@@ -667,82 +917,16 @@ AvailableValueAggregator::aggregateFullyAvailableValue(SILType loadTy,
   auto &firstVal = AvailableValueList[firstElt];
 
   // Ok, we know that all of our available values are all parts of the same
-  // value. Without ownership, we can just return the underlying first value.
-  if (!B.hasOwnership())
+  // value.
+  assert(B.hasOwnership() && "requires OSSA");
+  if (isTake())
     return firstVal.getValue();
 
   // Otherwise, we need to put in a copy. This is b/c we only propagate along +1
   // values and we are eliminating a load [copy].
-  ArrayRef<StoreInst *> insertPts = firstVal.getInsertionPoints();
-  if (insertPts.size() == 1) {
-    // Use the scope and location of the store at the insertion point.
-    SILBuilderWithScope builder(insertPts[0], &insertedInsts);
-    SILLocation loc = insertPts[0]->getLoc();
-    // If we have a take, just return the value.
-    if (isTake())
-      return firstVal.getValue();
-    // Otherwise, return a copy of the value.
-    return builder.emitCopyValueOperation(loc, firstVal.getValue());
-  }
-
-  // If we have multiple insertion points, put copies at each point and use the
-  // SSA updater to get a value. The reason why this is safe is that we can only
-  // have multiple insertion points if we are storing exactly the same value
-  // implying that we can just copy firstVal at each insertion point.
-  SILSSAUpdater updater(&insertedPhiNodes);
-  updater.initialize(&B.getFunction(), loadTy,
-                     B.hasOwnership() ? OwnershipKind::Owned
-                                      : OwnershipKind::None);
-
-  std::optional<SILValue> singularValue;
-  for (auto *insertPt : insertPts) {
-    // Use the scope and location of the store at the insertion point.
-    SILBuilderWithScope builder(insertPt, &insertedInsts);
-    SILLocation loc = insertPt->getLoc();
-    SILValue eltVal = firstVal.getValue();
-
-    // If we are not taking, copy the element value.
-    if (!isTake()) {
-      eltVal = builder.emitCopyValueOperation(loc, eltVal);
-    }
-
-    if (!singularValue.has_value()) {
-      singularValue = eltVal;
-    } else if (*singularValue != eltVal) {
-      singularValue = SILValue();
-    }
-
-    // And then put the value into the SSA updater.
-    updater.addAvailableValue(insertPt->getParent(), eltVal);
-  }
-
-  // If we only are tracking a singular value, we do not need to construct
-  // SSA. Just return that value.
-  if (auto val = singularValue.value_or(SILValue())) {
-    // This assert documents that we are expecting that if we are in ossa, have
-    // a non-trivial value, and are not taking, we should never go down this
-    // code path. If we did, we would need to insert a copy here. The reason why
-    // we know we will never go down this code path is since we have been
-    // inserting copy_values implying that our potential singular value would be
-    // of the copy_values which are guaranteed to all be different.
-    assert((!B.hasOwnership() || isTake() ||
-            val->getType().isTrivial(*B.getInsertionBB()->getParent())) &&
-           "Should never reach this code path if we are in ossa and have a "
-           "non-trivial value");
-    return val;
-  }
-
-  // Finally, grab the value from the SSA updater.
-  SILValue result = updater.getValueInMiddleOfBlock(B.getInsertionBB());
-  assert(result->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
-  if (isTake() || !B.hasOwnership()) {
-    return result;
-  }
-
-  // Be careful with this value and insert a copy in our load block to prevent
-  // any weird control equivalence issues.
-  SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
-  return builder.emitCopyValueOperation(Loc, result);
+  return
+    ownershipFixup.mergeCopies(firstVal, loadTy, &*B.getInsertionPoint(),
+                               /*isFullyAvailable*/true);
 }
 
 SILValue AvailableValueAggregator::aggregateTupleSubElts(TupleType *TT,
@@ -814,108 +998,6 @@ SILValue AvailableValueAggregator::aggregateStructSubElts(StructDecl *sd,
   }
 
   return B.createStruct(Loc, loadTy, resultElts);
-}
-
-// We have looked through all of the aggregate values and finally found a value
-// that is not available without transforming, i.e. a "primitive value". If the
-// value is available, use it (extracting if we need to), otherwise emit a load
-// of the value with the appropriate qualifier.
-SILValue AvailableValueAggregator::handlePrimitiveValue(SILType loadTy,
-                                                        SILValue address,
-                                                        unsigned firstElt) {
-  assert(!isTake() && "Should only take fully available values?!");
-
-  // If the value is not available, load the value and update our use list.
-  auto &val = AvailableValueList[firstElt];
-  if (!val) {
-    LoadInst *load = ([&]() {
-      if (B.hasOwnership()) {
-        SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
-        return builder.createTrivialLoadOr(Loc, address,
-                                           LoadOwnershipQualifier::Copy);
-      }
-      return B.createLoad(Loc, address, LoadOwnershipQualifier::Unqualified);
-    }());
-    Uses.emplace_back(load, PMOUseKind::Load);
-    return load;
-  }
-
-  // If we have 1 insertion point, just extract the value and return.
-  //
-  // This saves us from having to spend compile time in the SSA updater in this
-  // case.
-  ArrayRef<StoreInst *> insertPts = val.getInsertionPoints();
-  if (insertPts.size() == 1) {
-    // Use the scope and location of the store at the insertion point.
-    SILBuilderWithScope builder(insertPts[0], &insertedInsts);
-    SILLocation loc = insertPts[0]->getLoc();
-    SILValue eltVal = nonDestructivelyExtractSubElement(val, builder, loc);
-    assert(!builder.hasOwnership() ||
-           eltVal->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
-    assert(eltVal->getType() == loadTy && "Subelement types mismatch");
-
-    if (!builder.hasOwnership()) {
-      return eltVal;
-    }
-
-    SILBuilderWithScope builder2(&*B.getInsertionPoint(), &insertedInsts);
-    return builder2.emitCopyValueOperation(Loc, eltVal);
-  }
-
-  // If we have an available value, then we want to extract the subelement from
-  // the borrowed aggregate before each insertion point. Note that since we have
-  // inserted copies at each of these insertion points, we know that we will
-  // never have the same value along all paths unless we have a trivial value
-  // meaning the SSA updater given a non-trivial value must /always/ be used.
-  SILSSAUpdater updater(&insertedPhiNodes);
-  updater.initialize(&B.getFunction(), loadTy,
-                     B.hasOwnership() ? OwnershipKind::Owned
-                                      : OwnershipKind::None);
-
-  std::optional<SILValue> singularValue;
-  for (auto *i : insertPts) {
-    // Use the scope and location of the store at the insertion point.
-    SILBuilderWithScope builder(i, &insertedInsts);
-    SILLocation loc = i->getLoc();
-    SILValue eltVal = nonDestructivelyExtractSubElement(val, builder, loc);
-    assert(!builder.hasOwnership() ||
-           eltVal->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
-
-    if (!singularValue.has_value()) {
-      singularValue = eltVal;
-    } else if (*singularValue != eltVal) {
-      singularValue = SILValue();
-    }
-
-    updater.addAvailableValue(i->getParent(), eltVal);
-  }
-
-  SILBasicBlock *insertBlock = B.getInsertionBB();
-
-  // If we are not in ossa and have a singular value or if we are in ossa and
-  // have a trivial singular value, just return that value.
-  //
-  // This can never happen for non-trivial values in ossa since we never should
-  // visit this code path if we have a take implying that non-trivial values
-  // /will/ have a copy and thus are guaranteed (since each copy yields a
-  // different value) to not be singular values.
-  if (auto val = singularValue.value_or(SILValue())) {
-    assert((!B.hasOwnership() ||
-            val->getType().isTrivial(*insertBlock->getParent())) &&
-           "Should have inserted copies for each insertion point, so shouldn't "
-           "have a singular value if non-trivial?!");
-    return val;
-  }
-
-  // Finally, grab the value from the SSA updater.
-  SILValue eltVal = updater.getValueInMiddleOfBlock(insertBlock);
-  assert(!B.hasOwnership() ||
-         eltVal->getOwnershipKind().isCompatibleWith(OwnershipKind::Owned));
-  assert(eltVal->getType() == loadTy && "Subelement types mismatch");
-  if (!B.hasOwnership())
-    return eltVal;
-  SILBuilderWithScope builder(&*B.getInsertionPoint(), &insertedInsts);
-  return builder.emitCopyValueOperation(Loc, eltVal);
 }
 
 static SILInstruction *
@@ -1054,9 +1136,12 @@ void PhiNodeCopyCleanupInserter::emit(DeadEndBlocks &deadEndBlocks) && {
   }
 }
 
-void AvailableValueAggregator::addHandOffCopyDestroysForPhis(
+void AvailableValueAggregationFixup::addHandOffCopyDestroysForPhis(
     SILInstruction *load, SILValue newVal) {
   assert(isa<LoadBorrowInst>(load) || isa<LoadInst>(load));
+
+  if (insertedPhiNodes.empty())
+    return;
 
   SmallVector<SILBasicBlock *, 8> leakingBlocks;
   SmallVector<std::pair<SILBasicBlock *, SILValue>, 8> incomingValues;
@@ -1238,9 +1323,10 @@ void AvailableValueAggregator::addHandOffCopyDestroysForPhis(
   insertedPhiNodes.clear();
 }
 
-void AvailableValueAggregator::addMissingDestroysForCopiedValues(
+// TODO: use standard lifetime completion
+void AvailableValueAggregationFixup::addMissingDestroysForCopiedValues(
     SILInstruction *load, SILValue newVal) {
-  assert(B.hasOwnership() &&
+  assert(load->getFunction()->hasOwnership() &&
          "We assume this is only called if we have ownership");
 
   SmallVector<SILBasicBlock *, 8> leakingBlocks;
@@ -1368,6 +1454,8 @@ class AvailableValueDataflowContext {
   /// InOutUses, and Escapes), to their entry in Uses.
   llvm::SmallDenseMap<SILInstruction *, unsigned, 16> NonLoadUses;
 
+  AvailableValueDataflowFixup ownershipFixup;
+
   /// Does this value escape anywhere in the function. We use this very
   /// conservatively.
   bool HasAnyEscape = false;
@@ -1375,26 +1463,18 @@ class AvailableValueDataflowContext {
 public:
   AvailableValueDataflowContext(AllocationInst *TheMemory,
                                 unsigned NumMemorySubElements,
+                                OptimizationMode mode,
                                 SmallVectorImpl<PMOMemoryUse> &Uses,
-                                InstructionDeleter &deleter);
+                                InstructionDeleter &deleter,
+                                DeadEndBlocks &deBlocks);
 
   // Find an available for for subelements of 'SrcAddr'.
   // Return the SILType of the object in 'SrcAddr' and index of the first sub
   // element in that object.
   // If not all subelements are availab, return nullopt.
-  std::optional<std::pair<SILType, unsigned>>
+  std::optional<LoadInfo>
   computeAvailableValues(SILValue SrcAddr, SILInstruction *Inst,
                          SmallVectorImpl<AvailableValue> &AvailableValues);
-
-  /// Try to compute available values for "TheMemory" at the instruction \p
-  /// StartingFrom. We only compute the values for set bits in \p
-  /// RequiredElts. We return the vailable values in \p Result. If any available
-  /// values were found, return true. Otherwise, return false.
-  bool computeAvailableValues(SILInstruction *StartingFrom,
-                              unsigned FirstEltOffset,
-                              unsigned NumLoadSubElements,
-                              SmallBitVector &RequiredElts,
-                              SmallVectorImpl<AvailableValue> &Result);
 
   /// Return true if the box has escaped at the specified instruction.  We are
   /// not
@@ -1404,13 +1484,31 @@ public:
   /// Explode a copy_addr, updating the Uses at the same time.
   void explodeCopyAddr(CopyAddrInst *CAI);
 
+  void fixupOwnership(InstructionDeleter &deleter,
+                      DeadEndBlocks &deBlocks) {
+    ownershipFixup.fixupOwnership(deleter, deBlocks);
+  }
+
 private:
   SILModule &getModule() const { return TheMemory->getModule(); }
 
-  void updateAvailableValues(SILInstruction *Inst,
-                             SmallBitVector &RequiredElts,
-                             SmallVectorImpl<AvailableValue> &Result,
-                             SmallBitVector &ConflictingValues);
+  void updateAvailableValues(
+    SILInstruction *Inst,
+    SmallBitVector &RequiredElts,
+    SmallVectorImpl<AvailableValue> &Result,
+    llvm::SmallDenseMap<SILBasicBlock *, SmallBitVector, 32> &VisitedBlocks,
+    SmallBitVector &ConflictingValues);
+
+  /// Try to compute available values for "TheMemory" at the instruction \p
+  /// StartingFrom. We only compute the values for set bits in \p
+  /// RequiredElts. We return the vailable values in \p Result. If any available
+  /// values were found, return true. Otherwise, return false.
+  bool computeAvailableValues(SILInstruction *StartingFrom,
+                              LoadInfo loadInfo,
+                              SmallBitVector &RequiredElts,
+                              SmallVectorImpl<AvailableValue> &Result);
+
+
   void computeAvailableValuesFrom(
       SILBasicBlock::iterator StartingFrom, SILBasicBlock *BB,
       SmallBitVector &RequiredElts,
@@ -1424,7 +1522,8 @@ private:
 
 AvailableValueDataflowContext::AvailableValueDataflowContext(
     AllocationInst *InputTheMemory, unsigned NumMemorySubElements,
-    SmallVectorImpl<PMOMemoryUse> &InputUses, InstructionDeleter &deleter)
+    OptimizationMode mode, SmallVectorImpl<PMOMemoryUse> &InputUses,
+    InstructionDeleter &deleter, DeadEndBlocks &deBlocks)
     : TheMemory(InputTheMemory), NumMemorySubElements(NumMemorySubElements),
       Uses(InputUses), deleter(deleter),
       HasLocalDefinition(InputTheMemory->getFunction()),
@@ -1482,7 +1581,7 @@ AvailableValueDataflowContext::AvailableValueDataflowContext(
 }
 
 
-std::optional<std::pair<SILType, unsigned>>
+std::optional<LoadInfo>
 AvailableValueDataflowContext::computeAvailableValues(
     SILValue SrcAddr, SILInstruction *Inst,
     SmallVectorImpl<AvailableValue> &AvailableValues) {
@@ -1506,20 +1605,24 @@ AvailableValueDataflowContext::computeAvailableValues(
   unsigned NumLoadSubElements = getNumSubElements(
     LoadTy, getModule(), TypeExpansionContext(*TheMemory->getFunction()));
 
-  // Set up the bitvector of elements being demanded by the load.
-  SmallBitVector RequiredElts(NumMemorySubElements);
-  RequiredElts.set(FirstElt, FirstElt + NumLoadSubElements);
+  LoadInfo loadInfo = {LoadTy, FirstElt, NumLoadSubElements};
 
   AvailableValues.resize(NumMemorySubElements);
 
-  // Find out if we have any available values.  If no bits are demanded, we
-  // trivially succeed. This can happen when there is a load of an empty struct.
-  if (NumLoadSubElements != 0
-      && !computeAvailableValues(
-        Inst, FirstElt, NumLoadSubElements, RequiredElts, AvailableValues))
-    return std::nullopt;
+  // If no bits are demanded, we trivially succeed. This can happen when there
+  // is a load of an empty struct.
+  if (NumLoadSubElements == 0)
+    return loadInfo;
 
-  return std::make_pair(LoadTy, FirstElt);
+  // Set up the bitvector of elements being demanded by the load.
+  SmallBitVector RequiredElts(NumMemorySubElements);
+  RequiredElts.set(*loadInfo.range().begin(), *loadInfo.range().end());
+
+  // Find out if we have any available values.
+  if (!computeAvailableValues(Inst, loadInfo, RequiredElts, AvailableValues)) {
+    return std::nullopt;
+  }
+  return loadInfo;
 }
 
 // This function takes in the current (potentially uninitialized) available
@@ -1589,6 +1692,7 @@ static inline void updateAvailableValuesHelper(
 void AvailableValueDataflowContext::updateAvailableValues(
     SILInstruction *Inst, SmallBitVector &RequiredElts,
     SmallVectorImpl<AvailableValue> &Result,
+    llvm::SmallDenseMap<SILBasicBlock *, SmallBitVector, 32> &VisitedBlocks,
     SmallBitVector &ConflictingValues) {
 
   // If we are visiting a load [take], it invalidates the underlying available
@@ -1709,9 +1813,8 @@ void AvailableValueDataflowContext::updateAvailableValues(
 }
 
 bool AvailableValueDataflowContext::computeAvailableValues(
-    SILInstruction *StartingFrom, unsigned FirstEltOffset,
-    unsigned NumLoadSubElements, SmallBitVector &RequiredElts,
-    SmallVectorImpl<AvailableValue> &Result) {
+    SILInstruction *StartingFrom, LoadInfo loadInfo,
+    SmallBitVector &RequiredElts, SmallVectorImpl<AvailableValue> &Result) {
   llvm::SmallDenseMap<SILBasicBlock*, SmallBitVector, 32> VisitedBlocks;
   SmallBitVector ConflictingValues(Result.size());
 
@@ -1722,8 +1825,7 @@ bool AvailableValueDataflowContext::computeAvailableValues(
   // promote this load and there is nothing to do.
   SmallBitVector AvailableValueIsPresent(NumMemorySubElements);
 
-  for (unsigned i :
-       range(FirstEltOffset, FirstEltOffset + NumLoadSubElements)) {
+  for (unsigned i : loadInfo.range()) {
     AvailableValueIsPresent[i] = Result[i].getValue();
   }
 
@@ -1780,7 +1882,8 @@ void AvailableValueDataflowContext::computeAvailableValuesFrom(
       // Given an interesting instruction, incorporate it into the set of
       // results, and filter down the list of demanded subelements that we still
       // need.
-      updateAvailableValues(TheInst, RequiredElts, Result, ConflictingValues);
+      updateAvailableValues(TheInst, RequiredElts, Result, VisitedBlocks,
+                            ConflictingValues);
       
       // If this satisfied all of the demanded values, we're done.
       if (RequiredElts.none())
@@ -1994,9 +2097,9 @@ class OptimizeAllocLoads {
 
   SmallVectorImpl<PMOMemoryUse> &Uses;
 
-  DeadEndBlocks &deadEndBlocks;
-
   InstructionDeleter &deleter;
+
+  DeadEndBlocks &deadEndBlocks;
 
   /// A structure that we use to compute our available values.
   AvailableValueDataflowContext DataflowContext;
@@ -2010,12 +2113,15 @@ public:
         MemoryType(getMemoryType(memory)),
         NumMemorySubElements(getNumSubElements(
             MemoryType, Module, TypeExpansionContext(*memory->getFunction()))),
-        Uses(uses), deadEndBlocks(deadEndBlocks), deleter(deleter),
-        DataflowContext(TheMemory, NumMemorySubElements, uses, deleter) {}
+        Uses(uses), deleter(deleter), deadEndBlocks(deadEndBlocks),
+        DataflowContext(TheMemory, NumMemorySubElements,
+                        OptimizationMode::PreserveAlloc, uses,
+                        deleter, deadEndBlocks) {}
 
   bool optimize();
 
 private:
+  bool optimizeLoadUse(SILInstruction *inst);
   bool promoteLoadCopy(LoadInst *li);
   bool promoteLoadBorrow(LoadBorrowInst *lbi);
   bool promoteCopyAddr(CopyAddrInst *cai);
@@ -2065,12 +2171,9 @@ bool OptimizeAllocLoads::promoteLoadCopy(LoadInst *li) {
     return false;
 
   SmallVector<AvailableValue, 8> availableValues;
-  auto result = DataflowContext.computeAvailableValues(srcAddr, li, availableValues);
-  if (!result.has_value())
+  auto loadInfo = DataflowContext.computeAvailableValues(srcAddr, li, availableValues);
+  if (!loadInfo.has_value())
     return false;
-
-  SILType loadTy = result->first;
-  unsigned firstElt = result->second;
 
   // Aggregate together all of the subelements into something that has the same
   // type as the load did, and emit smaller loads for any subelements that were
@@ -2078,7 +2181,8 @@ bool OptimizeAllocLoads::promoteLoadCopy(LoadInst *li) {
   // points.
   AvailableValueAggregator agg(li, availableValues, Uses, deadEndBlocks,
                                AvailableValueExpectedOwnership::Copy);
-  SILValue newVal = agg.aggregateValues(loadTy, li->getOperand(), firstElt);
+  SILValue newVal = agg.aggregateValues(loadInfo->loadType, li->getOperand(),
+                                        loadInfo->firstElt);
 
   LLVM_DEBUG(llvm::dbgs() << "  *** Promoting load: " << *li);
   LLVM_DEBUG(llvm::dbgs() << "      To value: " << *newVal);
@@ -2088,6 +2192,7 @@ bool OptimizeAllocLoads::promoteLoadCopy(LoadInst *li) {
   // so we can just RAUW and return.
   if (!li->getFunction()->hasOwnership()) {
     li->replaceAllUsesWith(newVal);
+
     SILValue addr = li->getOperand();
     deleter.forceDelete(li);
     if (auto *addrI = addr->getDefiningInstruction())
@@ -2105,10 +2210,11 @@ bool OptimizeAllocLoads::promoteLoadCopy(LoadInst *li) {
   agg.fixupOwnership(li, newVal);
 
   // Now that we have fixed up all of our missing destroys, insert the copy
-  // value for our actual load and RAUW.
+  // value for our actual load, in case the load was in an inner loop, and RAUW.
   newVal = SILBuilderWithScope(li).emitCopyValueOperation(li->getLoc(), newVal);
 
   li->replaceAllUsesWith(newVal);
+
   SILValue addr = li->getOperand();
   deleter.forceDelete(li);
   if (auto *addrI = addr->getDefiningInstruction())
@@ -2165,9 +2271,9 @@ bool OptimizeAllocLoads::promoteLoadBorrow(LoadBorrowInst *lbi) {
     return false;
 
   SmallVector<AvailableValue, 8> availableValues;
-  auto result = DataflowContext.computeAvailableValues(srcAddr, lbi,
-                                                       availableValues);
-  if (!result.has_value())
+  auto loadInfo = DataflowContext.computeAvailableValues(srcAddr, lbi,
+                                                         availableValues);
+  if (!loadInfo.has_value())
     return false;
 
   // Bail if the load_borrow has reborrows. In this case it's not so easy to
@@ -2178,16 +2284,14 @@ bool OptimizeAllocLoads::promoteLoadBorrow(LoadBorrowInst *lbi) {
 
   ++NumLoadPromoted;
 
-  SILType loadTy = result->first;
-  unsigned firstElt = result->second;
-
   // Aggregate together all of the subelements into something that has the same
   // type as the load did, and emit smaller loads for any subelements that were
   // not available. We are "propagating" a +1 available value from the store
   // points.
   AvailableValueAggregator agg(lbi, availableValues, Uses, deadEndBlocks,
                                AvailableValueExpectedOwnership::Borrow);
-  SILValue newVal = agg.aggregateValues(loadTy, lbi->getOperand(), firstElt);
+  SILValue newVal = agg.aggregateValues(loadInfo->loadType, lbi->getOperand(),
+                                        loadInfo->firstElt);
 
   LLVM_DEBUG(llvm::dbgs() << "  *** Promoting load: " << *lbi);
   LLVM_DEBUG(llvm::dbgs() << "      To value: " << *newVal);
@@ -2220,6 +2324,7 @@ bool OptimizeAllocLoads::promoteLoadBorrow(LoadBorrowInst *lbi) {
   }
 
   lbi->replaceAllUsesWith(newVal);
+
   SILValue addr = lbi->getOperand();
   deleter.forceDelete(lbi);
   if (auto *addrI = addr->getDefiningInstruction())
@@ -2237,33 +2342,30 @@ bool OptimizeAllocLoads::optimize() {
     auto &use = Uses[i];
     // Ignore entries for instructions that got expanded along the way.
     if (use.Inst && use.Kind == PMOUseKind::Load) {
-      if (auto *cai = dyn_cast<CopyAddrInst>(use.Inst)) {
-        if (promoteCopyAddr(cai)) {
-          Uses[i].Inst = nullptr; // remove entry if load got deleted.
-          changed = true;
-        }
-        continue;
-      }
-
-      if (auto *lbi = dyn_cast<LoadBorrowInst>(use.Inst)) {
-        if (promoteLoadBorrow(lbi)) {
-          Uses[i].Inst = nullptr; // remove entry if load got deleted.
-          changed = true;
-        }
-        continue;
-      }
-
-      if (auto *li = dyn_cast<LoadInst>(use.Inst)) {
-        if (promoteLoadCopy(li)) {
-          Uses[i].Inst = nullptr; // remove entry if load got deleted.
-          changed = true;
-        }
-        continue;
+      if (optimizeLoadUse(use.Inst)) {
+        changed = true;
+        Uses[i].Inst = nullptr; // remove entry if load got deleted.
       }
     }
   }
-
   return changed;
+}
+
+bool OptimizeAllocLoads::optimizeLoadUse(SILInstruction *inst) {
+  // After replacing load uses with promoted values, fixup ownership for copies
+  // or casts inserted during dataflow.
+  SWIFT_DEFER { DataflowContext.fixupOwnership(deleter, deadEndBlocks); };
+
+  if (auto *cai = dyn_cast<CopyAddrInst>(inst))
+    return promoteCopyAddr(cai);
+
+  if (auto *lbi = dyn_cast<LoadBorrowInst>(inst))
+    return promoteLoadBorrow(lbi);
+
+  if (auto *li = dyn_cast<LoadInst>(inst))
+    return promoteLoadCopy(li);
+
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2403,7 +2505,9 @@ public:
             MemoryType, Module, TypeExpansionContext(*memory->getFunction()))),
         Uses(uses), Releases(releases), deadEndBlocks(deadEndBlocks),
         deleter(deleter), domInfo(domInfo),
-        DataflowContext(TheMemory, NumMemorySubElements, uses, deleter) {}
+        DataflowContext(TheMemory, NumMemorySubElements,
+                        OptimizationMode::ReplaceAlloc, uses, deleter,
+                        deadEndBlocks) {}
 
   /// If the allocation is an autogenerated allocation that is only stored to
   /// (after load promotion) then remove it completely.
@@ -2465,6 +2569,8 @@ bool OptimizeDeadAlloc::tryToRemoveDeadAllocation() {
                             << *badUser);
     return false;
   }
+
+  SWIFT_DEFER { DataflowContext.fixupOwnership(deleter, deadEndBlocks); };
 
   if (isTrivial()) {
     removeDeadAllocation();
@@ -2574,38 +2680,13 @@ bool OptimizeDeadAlloc::canPromoteTake(
 
   // We cannot promote destroys of address-only types, because we can't expose
   // the load.
-  SILType loadTy = address->getType().getObjectType();
-  if (loadTy.isAddressOnly(*inst->getFunction()))
+  if (address->getType().isAddressOnly(*inst->getFunction()))
     return false;
 
-  // If the box has escaped at this instruction, we can't safely promote the
-  // load.
-  if (DataflowContext.hasEscapedAt(inst))
-    return false;
-
-  // Compute the access path down to the field so we can determine precise
-  // def/use behavior.
-  unsigned firstElt = computeSubelement(address, TheMemory);
-  assert(firstElt != ~0U && "destroy within enum projection is not valid");
-  auto expansionContext = TypeExpansionContext(*inst->getFunction());
-  unsigned numLoadSubElements =
-      getNumSubElements(loadTy, Module, expansionContext);
-
-  // Find out if we have any available values.  If no bits are demanded, we
-  // trivially succeed. This can happen when there is a load of an empty struct.
-  if (numLoadSubElements == 0)
-    return true;
-
-  // Set up the bitvector of elements being demanded by the load.
-  SmallBitVector requiredElts(NumMemorySubElements);
-  requiredElts.set(firstElt, firstElt + numLoadSubElements);
-
-  // Compute our available values. If we do not have any available values,
-  // return false. We have nothing further to do.
   SmallVector<AvailableValue, 8> availableValues;
-  availableValues.resize(NumMemorySubElements);
-  if (!DataflowContext.computeAvailableValues(
-          inst, firstElt, numLoadSubElements, requiredElts, availableValues))
+  auto loadInfo = DataflowContext.computeAvailableValues(address, inst,
+                                                         availableValues);
+  if (!loadInfo.has_value())
     return false;
 
   // Now check that we can perform a take upon our available values. This
@@ -2614,7 +2695,7 @@ bool OptimizeDeadAlloc::canPromoteTake(
   // do not support that yet.
   AvailableValueAggregator agg(inst, availableValues, Uses, deadEndBlocks,
                                AvailableValueExpectedOwnership::Take);
-  if (!agg.canTake(loadTy, firstElt))
+  if (!agg.canTake(loadInfo->loadType, loadInfo->firstElt))
     return false;
 
   // As a final check, make sure that we have an available value for each value,

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -34,14 +34,17 @@ sil [ossa] [transparent] @partial_apply_on_stack_nesting_violator : $@convention
 
 // Verify that when inlining partial_apply_on_stack_nesting_violator, the stack
 // nesting of the on_stack closures is fixed.
-// CHECK-LABEL: sil [no_locks] [perf_constraint] @test_inline_stack_violating_ossa_func : {{.*}} {
+//
+// NON_OSSA: stack nesting is not fixed until after OSSA lowering. These tests only run mandatory optimization.
+//
+// CHECK-LABEL: sil [no_locks] [perf_constraint] [ossa] @test_inline_stack_violating_ossa_func : {{.*}} {
 // CHECK:         [[PAABLE:%[^,]+]] = function_ref @paable
 // CHECK:         [[FIRST:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[PAABLE]]
 // CHECK:         [[SECOND:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[PAABLE]]
-// CHECK:         dealloc_stack [[SECOND]]
-// CHECK:         dealloc_stack [[FIRST]]
+// NON_OSSA:          dealloc_stack [[SECOND]]
+// NON_OSSA:          dealloc_stack [[FIRST]]
 // CHECK-LABEL: } // end sil function 'test_inline_stack_violating_ossa_func'
-sil [no_locks] @test_inline_stack_violating_ossa_func : $@convention(thin) () -> () {
+sil [no_locks] [ossa] @test_inline_stack_violating_ossa_func : $@convention(thin) () -> () {
     %callee = function_ref @partial_apply_on_stack_nesting_violator : $@convention(thin) <T> () -> ()
     apply %callee<Builtin.Int64>() : $@convention(thin) <T> () -> ()
     %retval = tuple ()
@@ -69,10 +72,10 @@ bb0:
   return %retval : $Builtin.Int64
 }
 
-// CHECK-LABEL: sil [no_allocation] [perf_constraint] @deserialize_and_inline_after_devirtualize
+// CHECK-LABEL: sil [no_allocation] [perf_constraint] [ossa] @deserialize_and_inline_after_devirtualize
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function 'deserialize_and_inline_after_devirtualize'
-sil [no_allocation] @deserialize_and_inline_after_devirtualize : $@convention(thin) (@in Int) -> () {
+sil [no_allocation] [ossa] @deserialize_and_inline_after_devirtualize : $@convention(thin) (@in Int) -> () {
 bb0(%0 : $*Int):
   %1 = metatype $@thick Int.Type
   %2 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
@@ -95,25 +98,11 @@ bb0(%0 : $Builtin.Int32):
   return %2 : $Builtin.Int32
 }
 
-// CHECK-LABEL: sil [no_allocation] [perf_constraint] @dont_do_dead_alloc_elimination_on_non_ossa
-// CHECK:         alloc_stack
-// CHECK-NOT:     load
-// CHECK:         return %0
-// CHECK:       } // end sil function 'dont_do_dead_alloc_elimination_on_non_ossa'
-sil [no_allocation] @dont_do_dead_alloc_elimination_on_non_ossa : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
-bb0(%0 : $Builtin.Int32):
-  %1 = alloc_stack $Builtin.Int32
-  store %0 to %1 : $*Builtin.Int32
-  %2 = load %1 : $*Builtin.Int32
-  dealloc_stack %1 : $*Builtin.Int32
-  return %2 : $Builtin.Int32
-}
-
-// CHECK-LABEL: sil [no_allocation] [perf_constraint] @dead_metatype :
+// CHECK-LABEL: sil [no_allocation] [perf_constraint] [ossa] @dead_metatype :
 // CHECK-NOT:     metatype
 // CHECK-NOT:     debug_value
 // CHECK:       } // end sil function 'dead_metatype'
-sil [no_allocation] @dead_metatype : $@convention(thin) () -> () {
+sil [no_allocation] [ossa] @dead_metatype : $@convention(thin) () -> () {
 bb0:
   %0 = metatype $@thick Int.Type
   debug_value %0 : $@thick Int.Type
@@ -132,37 +121,37 @@ sil_witness_table public_external [serialized] Int: Comparable module Swift {
   method #Comparable."<": <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : @$sSiSLsSL1loiySbx_xtFZTW
 }
 
-sil @get_int_value : $@convention(thin) () -> Int32 {
+sil [ossa] @get_int_value : $@convention(thin) () -> Int32 {
 bb0:
   %0 = integer_literal $Builtin.Int32, 10
   %1 = struct $Int32 (%0 : $Builtin.Int32)
   return %1 : $Int32
 }
 
-// CHECK-LABEL: sil [global_init_once_fn] [no_locks] [perf_constraint] @globalinit_inline_into_init :
+// CHECK-LABEL: sil [global_init_once_fn] [no_locks] [perf_constraint] [ossa] @globalinit_inline_into_init :
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function 'globalinit_inline_into_init'
-sil [global_init_once_fn] [no_locks] @globalinit_inline_into_init : $@convention(c) () -> () {
+sil [global_init_once_fn] [no_locks] [ossa] @globalinit_inline_into_init : $@convention(c) () -> () {
 bb0:
   alloc_global @g1
   %1 = global_addr @g1 : $*Int32
   %2 = function_ref @get_int_value : $@convention(thin) () -> Int32
   %3 = apply %2() : $@convention(thin) () -> Int32
-  store %3 to %1 : $*Int32
+  store %3 to [trivial] %1 : $*Int32
   %6 = tuple ()
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [global_init_once_fn] [no_locks] [perf_constraint] @globalinit_dont_inline_non_inlinable_into_inlinable :
+// CHECK-LABEL: sil [serialized] [global_init_once_fn] [no_locks] [perf_constraint] [ossa] @globalinit_dont_inline_non_inlinable_into_inlinable :
 // CHECK:         apply
 // CHECK:       } // end sil function 'globalinit_dont_inline_non_inlinable_into_inlinable'
-sil [serialized] [global_init_once_fn] [no_locks] @globalinit_dont_inline_non_inlinable_into_inlinable : $@convention(c) () -> () {
+sil [serialized] [global_init_once_fn] [no_locks] [ossa] @globalinit_dont_inline_non_inlinable_into_inlinable : $@convention(c) () -> () {
 bb0:
   alloc_global @g2
   %1 = global_addr @g2 : $*Int32
   %2 = function_ref @get_int_value : $@convention(thin) () -> Int32
   %3 = apply %2() : $@convention(thin) () -> Int32
-  store %3 to %1 : $*Int32
+  store %3 to [trivial] %1 : $*Int32
   %6 = tuple ()
   return %6 : $()
 }
@@ -170,9 +159,9 @@ bb0:
 // Check that we don't crash on global init-once declarations.
 
 // CHECK-LABEL: sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
-sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
+sil [global_init_once_fn] [no_locks] [ossa] @external_global_init_once : $@convention(c) () -> ()
 
-sil @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32) {
+sil [ossa] @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32) {
 bb0:
   %0 = integer_literal $Builtin.Int32, 10
   %1 = struct $Int32 (%0 : $Builtin.Int32)
@@ -184,10 +173,10 @@ bb2:
   unwind
 }
 
-// CHECK-LABEL: sil [no_locks] [perf_constraint] @inline_begin_apply :
+// CHECK-LABEL: sil [no_locks] [perf_constraint] [ossa] @inline_begin_apply :
 // CHECK-NOT:     begin_apply
 // CHECK:       } // end sil function 'inline_begin_apply'
-sil [no_locks] @inline_begin_apply : $@convention(thin) () -> Int32 {
+sil [no_locks] [ossa] @inline_begin_apply : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32)
   (%1, %2) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields Int32)
@@ -195,10 +184,10 @@ bb0:
   return %1 : $Int32
 }
 
-// CHECK-LABEL: sil [no_locks] [perf_constraint] @dont_inline_begin_apply :
+// CHECK-LABEL: sil [no_locks] [perf_constraint] [ossa] @dont_inline_begin_apply :
 // CHECK:         begin_apply
 // CHECK:       } // end sil function 'dont_inline_begin_apply'
-sil [no_locks] @dont_inline_begin_apply : $@convention(thin) () -> Int32 {
+sil [no_locks] [ossa] @dont_inline_begin_apply : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32)
   (%1, %2) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields Int32)


### PR DESCRIPTION
Needed to add handling for mark_dependence instructions.

Extracting NFC changes to ensure that behavior of this mandatory pass does not accidentally change. It is closely coupled with several diagnostic passes.

Fully encapsulate ownership fixup so we can extend it.

PredictableMemOpt: remove non-OSSA support

    PredictableMemOpt only runs with OSSA. The recent refactoring did not
    preserve non-OSSA conditions because it adds complexity. This commit
    just makes it official.

    In the near future, this pass will be replaced by an OSSA-only pass
    anyway, so this brings us one small step closer to that.