### PR TITLE
[build.ps1] Support llvm-lit tests with `REQUIRES: native` condition on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1432,6 +1432,15 @@ function Build-Compilers() {
       $SwiftFlags += @("-Xcc", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
     }
 
+    if (-not $IsCrossCompiling) {
+      # We hardcode LLVM_DEFAULT_TARGET_TRIPLE to x86_64-unknown-windows-msvc,
+      # but the host triple might be inferred as x86_64-pc-windows-msvc, which
+      # causes llvm-lit to skip `REQUIRES: native` tests.
+      $TestingDefines += @{
+        LLVM_HOST_TRIPLE = $Arch.LLVMTarget
+      }
+    }
+
     Build-CMakeProject `
       -Src $SourceCache\llvm-project\llvm `
       -Bin $CompilersBinaryCache `


### PR DESCRIPTION
lit adds the `native` item in available_features, if [the target-triple and host-triple strings are equivalent](https://github.com/llvm/llvm-project/blob/2c4f938f1c01794d9b944c24e9067eac6763e95c/llvm/utils/lit/lit/llvm/config.py#L102). While we hardcode LLVM_DEFAULT_TARGET_TRIPLE to `x86_64-unknown-windows-msvc` in the [CMake cache file](https://github.com/swiftlang/swift/blob/f6a0f5527db09da6b50c3ea4040207bf9244ba65/cmake/caches/Windows-x86_64.cmake#L24), LLVM_HOST_TRIPLE is inferred automatically, which results in `x86_64-pc-windows-msvc`.

These triples are compatible, but not string-equivalent and so lit skips all related tests. Let's fix by setting LLVM_HOST_TRIPLE explicitly. We cannot do it in the cache file, because we have to consider cross-compilation.