### PR TITLE
MandatoryPerformanceOptimization: don't let not-inlinable functions to be inlined

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -650,27 +650,6 @@ extension Function {
 }
 
 extension FullApplySite {
-  var canInline: Bool {
-    // Some checks which are implemented in C++
-    if !FullApplySite_canInline(bridged) {
-      return false
-    }
-    // Cannot inline a non-inlinable function it an inlinable function.
-    if let calleeFunction = referencedFunction,
-       !calleeFunction.canBeInlinedIntoCaller(parentFunction.serializedKind) {
-      return false
-    }
-
-    // Cannot inline a non-ossa function into an ossa function
-    if parentFunction.hasOwnership,
-      let calleeFunction = referencedFunction,
-      !calleeFunction.hasOwnership {
-      return false
-    }
-
-    return true
-  }
-
   var inliningCanInvalidateStackNesting: Bool {
     guard let calleeFunction = referencedFunction else {
       return false
@@ -689,6 +668,10 @@ extension FullApplySite {
     }
     return false
   }
+}
+
+extension BeginApplyInst {
+  var canInline: Bool { BeginApply_canInline(bridged) }
 }
 
 extension GlobalVariable {

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -401,7 +401,7 @@ struct BridgedPassContext {
   bool completeLifetime(BridgedValue value) const;
 };
 
-bool FullApplySite_canInline(BridgedInstruction apply);
+bool BeginApply_canInline(BridgedInstruction beginApply);
 
 enum class BridgedDynamicCastResult {
   willSucceed,

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -58,6 +58,8 @@ public:
       : FuncBuilder(FuncBuilder), deleter(deleter), IKind(IKind),
         ApplySubs(ApplySubs) {}
 
+  static bool canInlineBeginApply(BeginApplyInst *BA);
+
   /// Returns true if we are able to inline \arg AI.
   ///
   /// *NOTE* This must be checked before attempting to inline \arg AI. If one

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -2062,9 +2062,8 @@ bool BridgedPassContext::completeLifetime(BridgedValue value) const {
   return result == LifetimeCompletion::WasCompleted;
 }
 
-bool FullApplySite_canInline(BridgedInstruction apply) {
-  return swift::SILInliner::canInlineApplySite(
-      swift::FullApplySite(apply.unbridged()));
+bool BeginApply_canInline(BridgedInstruction beginApply) {
+  return swift::SILInliner::canInlineBeginApply(beginApply.getAs<BeginApplyInst>());
 }
 
 BridgedDynamicCastResult classifyDynamicCastBridged(BridgedType sourceTy, BridgedType destTy,

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -29,7 +29,7 @@
 
 using namespace swift;
 
-static bool canInlineBeginApply(BeginApplyInst *BA) {
+bool SILInliner::canInlineBeginApply(BeginApplyInst *BA) {
   // Don't inline if we have multiple resumption sites (i.e. end_apply or
   // abort_apply instructions).  The current implementation clones a single
   // copy of the end_apply and abort_apply paths, so it can't handle values

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -7,6 +7,14 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
+var dict1: [Int: Int] = [1:10]
+var dict2: [Int: Int] = [1:20]
+
+func do_swap(n: Int) {
+  swap(&dict2[n], &dict1[n])
+}
+
+
 @main
 struct Main {
   static func main() {
@@ -14,11 +22,18 @@ struct Main {
     dict[11] = "hello"
     dict[33] = "!"
     dict[22] = "world"
+
+    // CHECK: hello world !
     for key in dict.keys.sorted() {
       print(dict[key]!, terminator: " ")
     }
     print("")
+
+    do_swap(n: 1)
+    // CHECK: 20
+    print(dict1[1]!)
+    // CHECK: 10
+    print(dict2[1]!)
   }
 }
 
-// CHECK: hello world !


### PR DESCRIPTION
Fixes a compiler crash.
rdar://137544788
