### PR TITLE
[Concurrency] Polish up the new custom executor interface header.

### DIFF
--- a/stdlib/public/Concurrency/ConcurrencyHooks.cpp
+++ b/stdlib/public/Concurrency/ConcurrencyHooks.cpp
@@ -57,8 +57,7 @@ swift::swift_task_enqueueGlobal(Job *job) {
 
 SWIFT_CC(swift) static void
 swift_task_enqueueGlobalWithDelayOrig(JobDelay delay, Job *job) {
-  swift_task_enqueueGlobalWithDelayImpl(
-      static_cast<SwiftJobDelay>(delay), reinterpret_cast<SwiftJob *>(job));
+  swift_task_enqueueGlobalWithDelayImpl(delay, reinterpret_cast<SwiftJob *>(job));
 }
 
 void
@@ -79,8 +78,12 @@ swift_task_enqueueGlobalWithDeadlineOrig(
     long long tsec,
     long long tnsec,
     int clock, Job *job) {
-  swift_task_enqueueGlobalWithDeadlineImpl(sec, nsec, tsec, tnsec, clock,
-                                           reinterpret_cast<SwiftJob *>(job));
+  SwiftTime deadline = { sec, (uint64_t)nsec };
+  SwiftDuration tolerance = { tsec, (uint64_t)tnsec };
+  swift_task_enqueueGlobalWithDeadlineImpl(
+    deadline, tolerance, SwiftClockId(clock),
+    reinterpret_cast<SwiftJob *>(job)
+  );
 }
 
 void

--- a/stdlib/public/Concurrency/ExecutorImpl.h
+++ b/stdlib/public/Concurrency/ExecutorImpl.h
@@ -116,9 +116,21 @@ static inline SwiftJobPriority swift_job_getPriority(SwiftJob *job) {
 /// task is cleaned up.
 ///
 /// N.B. **Requires that the job kind is SwiftJobKindTask.**
+///
+/// Note also that the allocator used is a bump pointer allocator with
+/// stack discipline.  This means that you must deallocate in the
+/// opposite order to the order in which you allocate memory.
 void *swift_job_alloc(SwiftJob *job, size_t size);
 
 /// Release memory allocated using `swift_job_alloc()`.
+///
+/// Note that the allocator used here is a bump pointer allocator with
+/// stack discipline; you can only deallocate the last extant allocation.
+/// Attempting to dealloc anything other than the most recent extant
+/// allocation will result in a fatal error.
+///
+/// TL/DR: You must deallocate in the opposite order to the order
+///        in which you allocated memory.
 void swift_job_dealloc(SwiftJob *job, void *ptr);
 
 /// Swift's refcounted objects start with this header

--- a/stdlib/public/Concurrency/ExecutorImpl.h
+++ b/stdlib/public/Concurrency/ExecutorImpl.h
@@ -90,23 +90,16 @@ static inline int swift_priority_getBucketIndex(SwiftJobPriority priority) {
 }
 
 /// Used by the Concurrency runtime to represent a job.  The `schedulerPrivate`
-/// field may be freely used by the executor implementation.
+/// field may be freely used by the executor implementation.  Note that this
+/// is just the header of a larger struct that is used in the Concurrency
+/// runtime; you are not expected to allocate these in an executor, and you
+/// should only access the fields exposed here.
 typedef struct {
   SwiftHeapMetadata const *__ptrauth_objc_isa_pointer metadata;
   uintptr_t refCounts;
   void *schedulerPrivate[2];
   SwiftJobFlags flags;
 } __attribute__((aligned(2 * sizeof(void *)))) SwiftJob;
-
-/// Indexes in the schedulerPrivate array
-enum {
-  SwiftJobNextWaitingTaskIndex = 0,
-
-  // These are only relevant for the Dispatch executor
-  SwiftJobDispatchHasLongObjectHeader = sizeof(void *) == sizeof(int),
-  SwiftJobDispatchLinkageIndex = SwiftJobDispatchHasLongObjectHeader ? 1 : 0,
-  SwiftJobDispatchQueueIndex = SwiftJobDispatchHasLongObjectHeader? 0 : 1
-};
 
 /// Get the kind of a job, by directly accessing the flags field.
 static inline SwiftJobKind swift_job_getKind(SwiftJob *job) {
@@ -118,7 +111,11 @@ static inline SwiftJobPriority swift_job_getPriority(SwiftJob *job) {
   return (SwiftJobPriority)((job->flags >> 8) & 0xff);
 }
 
-/// Allocate memory associated with a job.
+/// Allocate memory associated with a job.  Memory is allocated using a
+/// per-task allocator and will be disposed of automatically when the
+/// task is cleaned up.
+///
+/// N.B. **Requires that the job kind is SwiftJobKindTask.**
 void *swift_job_alloc(SwiftJob *job, size_t size);
 
 /// Release memory allocated using `swift_job_alloc()`.
@@ -228,9 +225,6 @@ static inline void swift_job_run(SwiftJob *job, SwiftExecutorRef executor) {
   _swift_job_run_c(job, executor);
 }
 
-/// A delay in nanoseconds.
-typedef unsigned long long SwiftJobDelay;
-
 /// Names of clocks supported by the Swift time functions.
 typedef int SwiftClockId;
 enum {
@@ -240,57 +234,207 @@ enum {
 
 /// An accurate timestamp, with *up to* nanosecond precision.
 typedef struct {
-  long long seconds;
-  long long nanoseconds;
+  int64_t seconds;
+  uint64_t nanoseconds;
 } SwiftTime;
+
+/// Represents a duration.
+typedef struct {
+  int64_t seconds;
+  uint64_t nanoseconds;
+} SwiftDuration;
+
+/// A tolerance is a kind of duration
+typedef SwiftDuration SwiftTolerance;
+
+#define SWIFT_TOLERANCE_UNSPECIFIED ((SwiftTolerance){ 0, ~(uint64_t)0 })
+
+static inline bool swift_tolerance_isUnspecified(SwiftTolerance tolerance) {
+  return tolerance.nanoseconds == ~(uint64_t)0;
+}
 
 /// Get the current time from the specified clock
 extern SwiftTime swift_time_now(SwiftClockId clock);
 
 /// Get the resolution of the specified clock
-extern SwiftTime swift_time_getResolution(SwiftClockId clock);
+extern SwiftDuration swift_time_getResolution(SwiftClockId clock);
+
+/// Add a duration to a time
+static inline SwiftTime swift_time_add(SwiftTime time, SwiftDuration duration) {
+  SwiftTime result;
+
+  result.seconds = time.seconds + duration.seconds;
+  result.nanoseconds = time.nanoseconds + duration.nanoseconds;
+  if (result.nanoseconds >= 1000000000ull) {
+    uint64_t extraSeconds = result.nanoseconds / 1000000000ull;
+    result.nanoseconds %= 1000000000ull;
+    result.seconds += extraSeconds;
+  }
+
+  return result;
+}
+
+/// Subtract two times to get a duration
+static inline SwiftDuration swift_time_sub(SwiftTime lhs, SwiftTime rhs) {
+  SwiftDuration result;
+
+  result.seconds = lhs.seconds - rhs.seconds;
+  if (lhs.nanoseconds < rhs.nanoseconds) {
+    result.seconds -= 1;
+    result.nanoseconds = 1000000000ull + lhs.nanoseconds - rhs.nanoseconds;
+  } else {
+    result.nanoseconds = lhs.nanoseconds - rhs.nanoseconds;
+  }
+
+  return result;
+}
+
+/// Convert a time to a nanosecond count
+static inline int64_t swift_time_toNanoseconds(SwiftTime time) {
+  return time.seconds * 1000000000ll + time.nanoseconds;
+}
+
+/// Convert a duration to a nanosecond count
+static inline int64_t swift_duration_toNanoseconds(SwiftDuration duration) {
+  return duration.seconds * 1000000000ll + duration.nanoseconds;
+}
+
+/// Convert a tolerance to a nanosecond count
+static inline int64_t swift_tolerance_toNanoseconds(SwiftTolerance tolerance) {
+  return tolerance.seconds * 1000000000ll + tolerance.nanoseconds;
+}
 
 // -- Functions that executors must implement ----------------------------------
+
+// Your executor MUST provide definitions of ALL of these functions,
+// however some implementations may be trivial or just assert.
+//
+// Example minimal implementations for some of the functions are given
+// in the comments below.
 
 /// Enqueue a job on the global executor.
 SWIFT_CC(swift) void swift_task_enqueueGlobalImpl(SwiftJob *job);
 
-/// Enqueue a job on the global executor, with a specific delay before it
-/// should execute.
-SWIFT_CC(swift) void swift_task_enqueueGlobalWithDelayImpl(SwiftJobDelay delay,
-                                                           SwiftJob *job);
+/// Enqueue a job on the global executor after a specified delay in
+/// nanoseconds.  The job may be run on whichever clock is most convenient,
+/// though existing implementations effectively use the suspending clock.
+///
+/// - nanoseconds: The minimum time to wait before running the job.
+/// - job:         The job to schedule.
+///
+/// This gets used to implement `Task.sleep(nanoseconds:)` and the deprecated
+/// `Task.sleep(_ duration:)` method.  We don't build those on top of the newer
+/// `swift_task_enqueueGlobalWithDeadlineImpl()` function (or equivalently the
+/// `Task.sleep(until deadline:...)` or `Task.sleep(for duration:...)` methods
+/// because doing so would mean doing extra calculations in the runtime, and
+/// many back-ends are going to be able to sleep for a number of nanoseconds
+/// without fetching the current time first.
+///
+/// Some executors may choose to share the underlying implementation between
+/// this function and `swift_task_enqueueGlobalWithDeadlineImpl()`, for instance
+/// by doing
+///
+///     SWIFT_CC(swift) void
+///     swift_task_enqueueGlobalWithDelayImpl(
+///       uint64_t nanoseconds,
+///       SwiftJob *job
+///     ) {
+///       SwiftTime now = swift_time_now(SwiftSuspendingClock);
+///       SwiftDuration toWait = { 0, nanoseconds };
+///       SwiftTime deadline = swift_time_add(now, toWait);
+///       swift_task_enqueueGlobalWithDeadlineImpl(deadline,
+///                                                SWIFT_TOLERANCE_UNSPECIFIED,
+///                                                SwiftSuspendingClock,
+///                                                job);
+///     }
+SWIFT_CC(swift) void swift_task_enqueueGlobalWithDelayImpl(
+  uint64_t nanoseconds,
+  SwiftJob *job
+);
 
-/// Enqueue a job on the global executor, with a specific deadline before
-/// which it must execute.
-SWIFT_CC(swift) void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
-                                                              long long nsec,
-                                                              long long tsec,
-                                                              long long tnsec,
-                                                              int clock,
-                                                              SwiftJob *job);
+/// Enqueue a job on the global executor at a specified time.
+///
+/// - deadline:  The time at which the task should execute.
+/// - tolerance: The maximum extra delay acceptable before the task executes.
+/// - clock:     The clock associated with the deadline timestamp.
+/// - job:       The job to schedule.
+///
+/// This gets used to implement Task.sleep(until deadline:, tolerance:, clock:)
+/// and Task.sleep(for duration:, tolerance:, clock:), as well as the sleep
+/// functions on `ContinuousClock` and `SuspendingClock`.
+///
+/// Some executors may choose to share the underlying implementation between
+/// this function and `swift_task_enqueueGlobalWithDelayImpl()`, for instance
+/// by doing
+///
+///    SWIFT_CC(swift) void
+///    swift_task_enqueueGlobalWithDeadlineImpl(
+///      SwiftTime deadline,
+///      SwiftTolerance tolerance,
+///      SwiftClockId clock,
+///      SwiftJob *job
+///    ) {
+///      SwiftTime now = swift_time_now(clock);
+///      SwiftDuration toWait = swift_time_sub(deadline, now);
+///      uint64_t nanoseconds = swift_duration_toNanoseconds(toWait);
+///      swift_task_enqueueGlobalWithDelayImpl(nanoseconds, job);
+///    }
+SWIFT_CC(swift) void swift_task_enqueueGlobalWithDeadlineImpl(
+  SwiftTime deadline,
+  SwiftTolerance tolerance,
+  SwiftClockId clock,
+  SwiftJob *job
+);
 
-/// Enqueue a job on the main executor (which may or may not be the same as
-/// the global executor).
+/// Enqueue a job on the main executor.
+///
+/// The main executor is the executor responsible for jobs that are @MainActor.
+/// If your executor does not need support for @MainActor, you can implement
+/// this as:
+///
+///     SWIFT_CC(swift)
+///     void swift_task_enqueueMainExecutorImpl(SwiftJob *job) {
+///       swift_enqueueGlobalImpl(job);
+///     }
 SWIFT_CC(swift) void swift_task_enqueueMainExecutorImpl(SwiftJob *job);
 
 /// Assert that the specified executor is the current executor.
 SWIFT_CC(swift) void swift_task_checkIsolatedImpl(SwiftExecutorRef executor);
 
 /// Get a reference to the main executor.
+///
+/// The main executor is the executor responsible for jobs that are @MainActor.
+/// If your executor does not need support for @MainActor, you can implement
+/// this as:
+///
+///     SWIFT_CC(swift)
+///     SwiftExecutorRef swift_task_getMainExecutorImpl(void) {
+///       return swift_executor_generic();
+///     }
 SWIFT_CC(swift) SwiftExecutorRef swift_task_getMainExecutorImpl(void);
 
 /// Check if the specified executor is the main executor.
+///
+/// The main executor is the executor responsible for jobs that are @MainActor.
+/// If your executor does not need support for @MainActor, you can implement
+/// this as:
+///
+///     SWIFT_CC(swift)
+///     bool swift_task_isMainExecutorImpl(SwiftExecutorRef executor) {
+///       return swift_executor_isGeneric(executor)
+///     }
 SWIFT_CC(swift) bool swift_task_isMainExecutorImpl(SwiftExecutorRef executor);
 
-/// Drain the main executor's queue, processing jobs enqueued on it; this
-/// should never return.
+/// Drain the global executor's queue, processing jobs enqueued on it; this
+/// should never return.  This is called by the async main entry point.
 SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_CC(swift) void
   swift_task_asyncMainDrainQueueImpl(void);
 
 /// Hand control of the current thread to the global executor until the
-/// condition function returns `true`.  Support for this function is optional,
-/// but you should assert or provide a dummy implementation if your executor
-/// does not support it.
+/// condition function returns `true`.  This function is not directly used
+/// by the runtime or the compiler, but may be useful in embedded applications;
+/// you can provide a dummy implementation or just raise a fatal error if you
+/// do not plan on using swift_task_donateThreadToGlobalExecutorUntil().
 SWIFT_CC(swift) void
   swift_task_donateThreadToGlobalExecutorUntilImpl(bool (*condition)(void *),
                                                    void *conditionContext);

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -95,14 +95,16 @@ extern "C" void _swift_job_run_c(SwiftJob *job, SwiftExecutorRef executor)
 extern "C" SwiftTime swift_time_now(SwiftClockId clock)
 {
   SwiftTime result;
-  swift_get_time(&result.seconds, &result.nanoseconds, (swift_clock_id)clock);
+  swift_get_time(&result.seconds,
+                 (int64_t *)&result.nanoseconds,
+                 (swift_clock_id)clock);
   return result;
 }
 
-extern "C" SwiftTime swift_time_getResolution(SwiftClockId clock)
+extern "C" SwiftDuration swift_time_getResolution(SwiftClockId clock)
 {
-  SwiftTime result;
-  swift_get_clock_res(&result.seconds, &result.nanoseconds,
+  SwiftDuration result;
+  swift_get_clock_res(&result.seconds, (int64_t *)&result.nanoseconds,
                       (swift_clock_id)clock);
   return result;
 }

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -94,19 +94,19 @@ extern "C" void _swift_job_run_c(SwiftJob *job, SwiftExecutorRef executor)
 
 extern "C" SwiftTime swift_time_now(SwiftClockId clock)
 {
-  SwiftTime result;
-  swift_get_time(&result.seconds,
-                 (int64_t *)&result.nanoseconds,
+  long long llsecs, llnsecs;
+  swift_get_time(&llsecs,
+                 &llnsecs,
                  (swift_clock_id)clock);
-  return result;
+  return { (int64_t)llsecs, (uint64_t)llnsecs };
 }
 
 extern "C" SwiftDuration swift_time_getResolution(SwiftClockId clock)
 {
-  SwiftDuration result;
-  swift_get_clock_res(&result.seconds, (int64_t *)&result.nanoseconds,
+  long long llsecs, llnsecs;
+  swift_get_clock_res(&llsecs, &llnsecs,
                       (swift_clock_id)clock);
-  return result;
+  return { (int64_t)llsecs, (uint64_t)llnsecs };
 }
 
 bool swift::swift_executor_isComplexEquality(SerialExecutorRef ref) {

--- a/stdlib/public/Concurrency/NonDispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/NonDispatchGlobalExecutor.cpp
@@ -45,7 +45,7 @@ void swift_task_enqueueGlobalImpl(SwiftJob *job) {
 }
 
 SWIFT_CC(swift)
-void swift_task_enqueueGlobalWithDelayImpl(SwiftJobDelay delay,
+void swift_task_enqueueGlobalWithDelayImpl(uint64_t delay,
                                            SwiftJob *job) {
   assert(job && "no job provided");
 
@@ -54,11 +54,10 @@ void swift_task_enqueueGlobalWithDelayImpl(SwiftJobDelay delay,
 }
 
 SWIFT_CC(swift)
-void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
-                                              long long nsec,
-                                              long long tsec,
-                                              long long tnsec,
-                                              int clock, SwiftJob *job) {
+void swift_task_enqueueGlobalWithDeadlineImpl(SwiftTime deadline,
+                                              SwiftTolerance tolerance,
+                                              SwiftClockId clock,
+                                              SwiftJob *job) {
   assert(job && "no job provided");
 
   swift_reportError(0, "operation unsupported without libdispatch: "


### PR DESCRIPTION
Added many more comments to the header; also tweaked a couple of things relating to the time-based enqueuing functions.

rdar://137885540
