### PR TITLE
[Concurrency] Avoid relying on stderr, fprintf(), write() in Embedded Concurrency runtime

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -645,12 +645,14 @@ void swift::swift_task_reportUnexpectedExecutor(
         &details);
   }
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
 #define STDERR_FILENO 2
   _write(STDERR_FILENO, message, strlen(message));
-#else
+#elif !SWIFT_CONCURRENCY_EMBEDDED
   fputs(message, stderr);
   fflush(stderr);
+#else
+  puts(message);
 #endif
 #if SWIFT_STDLIB_HAS_ASL
 #pragma clang diagnostic push

--- a/stdlib/public/Concurrency/Error.cpp
+++ b/stdlib/public/Concurrency/Error.cpp
@@ -21,7 +21,11 @@ SWIFT_NORETURN
 SWIFT_VFORMAT(2)
 void swift::swift_Concurrency_fatalErrorv(uint32_t flags, const char *format,
                                           va_list val) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   vfprintf(stderr, format, val);
+#else
+  vprintf(format, val);
+#endif
   abort();
 }
 

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -47,7 +47,7 @@ static TaskAllocator &allocator(AsyncTask *task) {
   static GlobalAllocator global;
   return global.allocator;
 #else
-  fprintf(stderr, "global allocator fallback not available\n");
+  puts("global allocator fallback not available\n");
   abort();
 #endif
 }

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -610,11 +610,13 @@ struct TaskGroupStatus {
     }
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
     #define STDERR_FILENO 2
    _write(STDERR_FILENO, message, strlen(message));
-#elif defined(STDERR_FILENO)
+#elif defined(STDERR_FILENO) && !SWIFT_CONCURRENCY_EMBEDDED
     write(STDERR_FILENO, message, strlen(message));
+#else
+    puts(message);
 #endif
 #if defined(SWIFT_STDLIB_HAS_ASL)
 #pragma clang diagnostic push

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -11,10 +11,8 @@
 // RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
 
 // DEP: ___assert_rtn
-// DEP: ___error
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
-// DEP: ___stderrp
 // DEP: _abort
 // DEP: _clock_gettime
 // DEP: _exit
@@ -27,11 +25,10 @@
 // DEP: _nanosleep
 // DEP: _posix_memalign
 // DEP: _putchar
+// DEP: _puts
 // DEP: _strlen
-// DEP: _vfprintf
 // DEP: _vprintf
 // DEP: _vsnprintf
-// DEP: _write
 
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -9,24 +9,13 @@
 // Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
 // RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
 
-// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKc
-// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKcm
-// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6insertEmPKc
-// DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED1Ev
 // DEP: __ZNSt3__16chrono12steady_clock3nowEv
-// DEP: __ZNSt3__19to_stringEj
-// DEP: __ZNSt3__19to_stringEy
-// DEP: __ZdlPv
-// DEP: __ZdlPvm
-// DEP: __Znwm
 // DEP: ___assert_rtn
 // DEP: ___error
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
-// DEP: ___stderrp
 // DEP: _abort
 // DEP: _exit
-// DEP: _fprintf
 // DEP: _free
 // DEP: _malloc
 // DEP: _memmove
@@ -35,10 +24,10 @@
 // DEP: _nanosleep
 // DEP: _posix_memalign
 // DEP: _putchar
+// DEP: _puts
 // DEP: _strlen
-// DEP: _vfprintf
+// DEP: _vprintf
 // DEP: _vsnprintf
-// DEP: _write
 
 // RUN: %target-run %t/a.out | %FileCheck %s
 


### PR DESCRIPTION
This removes a few more unwanted dependencies from the Embedded Concurrency runtime: stderr, errno, fprintf and write.