### PR TITLE
AST/Sema: Remove unnecessary ASTContext parameters from availability APIs

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -342,17 +342,16 @@ public:
   /// to ToDecl.
   static void
   applyInferredAvailableAttrs(Decl *ToDecl,
-                              ArrayRef<const Decl *> InferredFromDecls,
-                              ASTContext &Context);
+                              ArrayRef<const Decl *> InferredFromDecls);
 
   static AvailabilityRange inferForType(Type t);
 
   /// Returns the context where a declaration is available
   /// We assume a declaration without an annotation is always available.
-  static AvailabilityRange availableRange(const Decl *D, ASTContext &C);
+  static AvailabilityRange availableRange(const Decl *D);
 
   /// Returns true is the declaration is `@_spi_available`.
-  static bool isAvailableAsSPI(const Decl *D, ASTContext &C);
+  static bool isAvailableAsSPI(const Decl *D);
 
   /// Returns the availability context for a declaration with the given
   /// @available attribute.
@@ -363,14 +362,13 @@ public:
 
   /// Returns the attribute that should be used to determine the availability
   /// range of the given declaration, or nullptr if there is none.
-  static const AvailableAttr *attrForAnnotatedAvailableRange(const Decl *D,
-                                                             ASTContext &Ctx);
+  static const AvailableAttr *attrForAnnotatedAvailableRange(const Decl *D);
 
   /// Returns the context for which the declaration
   /// is annotated as available, or None if the declaration
   /// has no availability annotation.
   static std::optional<AvailabilityRange>
-  annotatedAvailableRange(const Decl *D, ASTContext &C);
+  annotatedAvailableRange(const Decl *D);
 
   static AvailabilityRange
   annotatedAvailableRangeForAttr(const SpecializeAttr *attr, ASTContext &ctx);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1254,8 +1254,7 @@ AvailabilityRange Decl::getAvailabilityForLinkage() const {
   if (auto backDeployVersion = getBackDeployedBeforeOSVersion(ctx))
     return AvailabilityRange{VersionRange::allGTE(*backDeployVersion)};
 
-  auto containingContext =
-      AvailabilityInference::annotatedAvailableRange(this, getASTContext());
+  auto containingContext = AvailabilityInference::annotatedAvailableRange(this);
   if (containingContext.has_value()) {
     // If this entity comes from the concurrency module, adjust its
     // availability for linkage purposes up to Swift 5.5, so that we use

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1540,7 +1540,7 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
   auto &ctx = getASTContext();
 
   AvailabilityRange conformanceAvailability{
-      AvailabilityInference::availableRange(ext, ctx)};
+      AvailabilityInference::availableRange(ext)};
 
   auto deploymentTarget = AvailabilityRange::forDeploymentTarget(ctx);
 

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -364,10 +364,8 @@ TypeRefinementContext::getExplicitAvailabilityRange() const {
 
   case Reason::Decl: {
     auto decl = Node.getAsDecl();
-    auto &ctx = decl->getASTContext();
-    if (auto attr =
-            AvailabilityInference::attrForAnnotatedAvailableRange(decl, ctx))
-      return AvailabilityInference::availableRange(attr, ctx);
+    if (auto attr = AvailabilityInference::attrForAnnotatedAvailableRange(decl))
+      return AvailabilityInference::availableRange(attr, decl->getASTContext());
 
     return std::nullopt;
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -575,7 +575,7 @@ static void inferProtocolMemberAvailability(ClangImporter::Implementation &impl,
 
   const Decl *innermostDecl = dc->getInnermostDeclarationDeclContext();
   AvailabilityRange containingDeclRange =
-      AvailabilityInference::availableRange(innermostDecl, C);
+      AvailabilityInference::availableRange(innermostDecl);
 
   requiredRange.intersectWith(containingDeclRange);
 
@@ -6811,7 +6811,7 @@ bool SwiftDeclConverter::existingConstructorIsWorse(
   // other?
   llvm::VersionTuple introduced = findLatestIntroduction(objcMethod);
   AvailabilityRange existingAvailability =
-      AvailabilityInference::availableRange(existingCtor, Impl.SwiftContext);
+      AvailabilityInference::availableRange(existingCtor);
   assert(!existingAvailability.isKnownUnreachable());
 
   if (existingAvailability.isAlwaysAvailable()) {
@@ -9119,7 +9119,7 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
       if (proto->getAttrs().hasAttribute<AvailableAttr>()) {
         if (!result->getAttrs().hasAttribute<AvailableAttr>()) {
           AvailabilityRange protoRange =
-              AvailabilityInference::availableRange(proto, SwiftContext);
+              AvailabilityInference::availableRange(proto);
           applyAvailableAttribute(result, protoRange, SwiftContext);
         }
       } else {

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -710,7 +710,7 @@ static bool isCheckExpectedExecutorIntrinsicAvailable(SILGenModule &SGM) {
   if (!C.LangOpts.DisableAvailabilityChecking) {
     auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(C);
     auto declAvailability =
-        AvailabilityInference::availableRange(checkExecutor, C);
+        AvailabilityInference::availableRange(checkExecutor);
     return deploymentAvailability.isContainedIn(declAvailability);
   }
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -336,15 +336,15 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
     // Only constrain the availability of the typealias by the availability of
     // the associated type if the associated type is less available than its
     // protocol. This is required for source compatibility.
-    auto protoAvailability = AvailabilityInference::availableRange(proto, ctx);
+    auto protoAvailability = AvailabilityInference::availableRange(proto);
     auto assocTypeAvailability =
-        AvailabilityInference::availableRange(assocType, ctx);
+        AvailabilityInference::availableRange(assocType);
     if (protoAvailability.isSupersetOf(assocTypeAvailability)) {
       availabilitySources.push_back(assocType);
     }
 
-    AvailabilityInference::applyInferredAvailableAttrs(
-        aliasDecl, availabilitySources, ctx);
+    AvailabilityInference::applyInferredAvailableAttrs(aliasDecl,
+                                                       availabilitySources);
 
     if (nominal == dc) {
       nominal->addMember(aliasDecl);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -626,8 +626,7 @@ configureInheritedDesignatedInitAttributes(ClassDecl *classDecl,
     if (auto *parentDecl = classDecl->getInnermostDeclWithAvailability()) {
       asAvailableAs.push_back(parentDecl);
     }
-    AvailabilityInference::applyInferredAvailableAttrs(
-        ctor, asAvailableAs, ctx);
+    AvailabilityInference::applyInferredAvailableAttrs(ctor, asAvailableAs);
   }
 
   // Wire up the overrides.

--- a/lib/Sema/DerivedConformanceActor.cpp
+++ b/lib/Sema/DerivedConformanceActor.cpp
@@ -160,8 +160,7 @@ static ValueDecl *deriveActor_unownedExecutor(DerivedConformance &derived) {
   if (auto enclosingDecl = property->getInnermostDeclWithAvailability())
     asAvailableAs.push_back(enclosingDecl);
 
-  AvailabilityInference::applyInferredAvailableAttrs(
-      property, asAvailableAs, ctx);
+  AvailabilityInference::applyInferredAvailableAttrs(property, asAvailableAs);
 
   auto getter = derived.addGetterToReadOnlyDerivedProperty(property);
   getter->setBodySynthesizer(deriveBodyActor_unownedExecutor);

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -809,8 +809,7 @@ static ValueDecl *deriveDistributedActor_unownedExecutor(DerivedConformance &der
   if (auto enclosingDecl = property->getInnermostDeclWithAvailability())
     asAvailableAs.push_back(enclosingDecl);
 
-  AvailabilityInference::applyInferredAvailableAttrs(
-      property, asAvailableAs, ctx);
+  AvailabilityInference::applyInferredAvailableAttrs(property, asAvailableAs);
 
   auto getter = derived.addGetterToReadOnlyDerivedProperty(property);
   getter->setBodySynthesizer(deriveBodyDistributedActor_unownedExecutor);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -690,7 +690,7 @@ private:
 
     // Declarations with an explicit availability attribute always get a TRC.
     AvailabilityRange DeclaredAvailability =
-        swift::AvailabilityInference::availableRange(D, Context);
+        swift::AvailabilityInference::availableRange(D);
     if (!DeclaredAvailability.isAlwaysAvailable()) {
       return TypeRefinementContext::createForDecl(
           Context, D, getCurrentTRC(),
@@ -1431,7 +1431,7 @@ AvailabilityRange TypeChecker::overApproximateAvailabilityAtLocation(
     loc = D->getLoc();
 
     std::optional<AvailabilityRange> Info =
-        AvailabilityInference::annotatedAvailableRange(D, Context);
+        AvailabilityInference::annotatedAvailableRange(D);
 
     if (Info.has_value()) {
       OverApproximateContext.constrainWith(Info.value());
@@ -1472,7 +1472,7 @@ bool TypeChecker::isDeclarationUnavailable(
   }
 
   AvailabilityRange safeRangeUnderApprox{
-      AvailabilityInference::availableRange(D, Context)};
+      AvailabilityInference::availableRange(D)};
 
   if (safeRangeUnderApprox.isAlwaysAvailable())
     return false;
@@ -1499,8 +1499,7 @@ TypeChecker::checkDeclarationAvailability(const Decl *D,
   if (isDeclarationUnavailable(D, Where.getDeclContext(), [&Where] {
         return Where.getAvailabilityRange();
       })) {
-    auto &Context = Where.getDeclContext()->getASTContext();
-    return AvailabilityInference::availableRange(D, Context);
+    return AvailabilityInference::availableRange(D);
   }
 
   return std::nullopt;
@@ -4639,7 +4638,7 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
     return false;
 
   // Warn on decls without an introduction version.
-  auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl, ctx);
+  auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl);
   return safeRangeUnderApprox.isAlwaysAvailable();
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1491,7 +1491,7 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
   } else {
     // Check if the availability of nominal is high enough to be using the ExecutorJob version
     AvailabilityRange requirementInfo =
-        AvailabilityInference::availableRange(moveOnlyEnqueueRequirement, C);
+        AvailabilityInference::availableRange(moveOnlyEnqueueRequirement);
     AvailabilityRange declInfo =
         TypeChecker::overApproximateAvailabilityAtLocation(
             nominal->getLoc(), dyn_cast<DeclContext>(nominal));

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1696,8 +1696,8 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   // range with both the conforming type's available range and the protocol
   // declaration's available range.
   AvailabilityRange witnessInfo =
-      AvailabilityInference::availableRange(witness, Context);
-  requirementInfo = AvailabilityInference::availableRange(requirement, Context);
+      AvailabilityInference::availableRange(witness);
+  requirementInfo = AvailabilityInference::availableRange(requirement);
 
   AvailabilityRange infoForConformingDecl =
       overApproximateAvailabilityAtLocation(dc->getAsDecl()->getLoc(), dc);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -535,7 +535,7 @@ static bool checkObjCClassStubAvailability(ASTContext &ctx, const Decl *decl) {
   if (deploymentTarget.isContainedIn(stubAvailability))
     return true;
 
-  auto declAvailability = AvailabilityInference::availableRange(decl, ctx);
+  auto declAvailability = AvailabilityInference::availableRange(decl);
   return declAvailability.isContainedIn(stubAvailability);
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1800,14 +1800,12 @@ OverrideRequiresKeyword swift::overrideRequiresKeyword(ValueDecl *overridden) {
 /// makes it a safe override, given the availability of the base declaration.
 static bool isAvailabilitySafeForOverride(ValueDecl *override,
                                           ValueDecl *base) {
-  ASTContext &ctx = override->getASTContext();
-
   // API availability ranges are contravariant: make sure the version range
   // of an overridden declaration is fully contained in the range of the
   // overriding declaration.
   AvailabilityRange overrideInfo =
-      AvailabilityInference::availableRange(override, ctx);
-  AvailabilityRange baseInfo = AvailabilityInference::availableRange(base, ctx);
+      AvailabilityInference::availableRange(override);
+  AvailabilityRange baseInfo = AvailabilityInference::availableRange(base);
 
   if (baseInfo.isContainedIn(overrideInfo))
     return true;
@@ -1815,7 +1813,7 @@ static bool isAvailabilitySafeForOverride(ValueDecl *override,
   // Allow overrides that are not as available as the base decl as long as the
   // override is as available as its context.
   auto overrideTypeAvailability = AvailabilityInference::availableRange(
-      override->getDeclContext()->getSelfNominalTypeDecl(), ctx);
+      override->getDeclContext()->getSelfNominalTypeDecl());
 
   return overrideTypeAvailability.isContainedIn(overrideInfo);
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3085,8 +3085,8 @@ public:
     auto module = AT->getDeclContext()->getParentModule();
     if (!defaultType &&
         module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
-        AvailabilityInference::availableRange(proto, Ctx)
-          .isSupersetOf(AvailabilityInference::availableRange(AT, Ctx))) {
+        AvailabilityInference::availableRange(proto).isSupersetOf(
+            AvailabilityInference::availableRange(AT))) {
       AT->diagnose(
           diag::resilient_associated_type_less_available_requires_default, AT);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6041,7 +6041,7 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl) {
   // a new-enough OS.
   if (auto sourceFile = classDecl->getParentSourceFile()) {
     AvailabilityRange safeRangeUnderApprox{
-        AvailabilityInference::availableRange(classDecl, ctx)};
+        AvailabilityInference::availableRange(classDecl)};
     AvailabilityRange runningOSOverApprox =
         AvailabilityRange::forDeploymentTarget(ctx);
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2510,8 +2510,7 @@ static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
   }
   
   if (!asAvailableAs.empty()) {
-    AvailabilityInference::applyInferredAvailableAttrs(
-        setter, asAvailableAs, ctx);
+    AvailabilityInference::applyInferredAvailableAttrs(setter, asAvailableAs);
   }
   
   finishImplicitAccessor(setter, ctx);
@@ -2575,8 +2574,7 @@ createCoroutineAccessorPrototype(AbstractStorageDecl *storage,
     addPropertyWrapperAccessorAvailability(var, kind, asAvailableAs);
   }
 
-  AvailabilityInference::applyInferredAvailableAttrs(accessor,
-                                                     asAvailableAs, ctx);
+  AvailabilityInference::applyInferredAvailableAttrs(accessor, asAvailableAs);
 
   // A modify coroutine should have the same SPI visibility as the setter.
   if (isYieldingDefaultMutatingAccessor(kind)) {


### PR DESCRIPTION
Many of the methods on `AvailabilityInference` take both a `Decl` and an `ASTContext`, which is redundant.
