### PR TITLE
Don’t run swift-format tests on Windows

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,swift,dispatch,foundation,xctest,swift-format,
+set TestArg=-Test lld,swift,dispatch,foundation,xctest,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 


### PR DESCRIPTION
I saw the following failure on PR testing. Disabling swift-format tests while I investigate

```
error: supplementary output file map 'T:\\tmp\\TemporaryDirectory.mtdzGg\\supplementaryOutputs-1' is missing an entry for 'C:\\Users\\swift-ci\\jenkins\\workspace\\sourcekit-lsp-PR-windows\\swift-format\\Tests\\SwiftFormatTests\\API\\ConfigurationTests.swift' (this likely indicates a compiler issue; please submit a bug report (https://swift.org/contributing/#reporting-bugs))
```
