### PR TITLE
Cache absence of lifetime dependencies during deserialization

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3749,10 +3749,9 @@ public:
       lifetimeDependencies.push_back(*info);
     }
 
-    if (!lifetimeDependencies.empty()) {
-      ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{ctor},
-                                ctx.AllocateCopy(lifetimeDependencies));
-    }
+    ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{ctor},
+                              lifetimeDependencies.empty()? std::nullopt :
+                                  ctx.AllocateCopy(lifetimeDependencies));
 
     if (auto errorConvention = MF.maybeReadForeignErrorConvention())
       ctor->setForeignErrorConvention(*errorConvention);
@@ -4338,10 +4337,9 @@ public:
       lifetimeDependencies.push_back(*info);
     }
 
-    if (!lifetimeDependencies.empty()) {
-      ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{fn},
-                                ctx.AllocateCopy(lifetimeDependencies));
-    }
+    ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{fn},
+                              lifetimeDependencies.empty() ? std::nullopt
+                                  : ctx.AllocateCopy(lifetimeDependencies));
 
     if (auto errorConvention = MF.maybeReadForeignErrorConvention())
       fn->setForeignErrorConvention(*errorConvention);


### PR DESCRIPTION
Fixes rdar://136769990

Absence of lifetime dependencies weren't cached which resulted in running `LifetimeDependence::infer` on deserialized decls. 

`USRGenerationRequest::evaluate` can call to `InterfaceTypeRequest::evaluate` which in turn calls `LifetimeDependence::infer` which ends up calling `USRGenerationRequest::evaluate` due to a call to `getLoc()` leading to circular reference errors in a previous revision of the compiler.

This isn't an existing issue on main because the call to `getLoc()` in `LifetimeDependence::infer` only happens when result is `~Escapable`. Fixing this anyhow, to avoid  `LifetimeDependence::infer` on deserialized decls. 