### PR TITLE
[build] Do not implicitly bump macCatalyst deployment target

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -55,7 +55,7 @@ function(_add_target_variant_c_compile_link_flags)
   if("${CFLAGS_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
     # Check if there's a specific OS deployment version needed for this invocation
     if("${CFLAGS_SDK}" STREQUAL "OSX")
-      if(DEFINED maccatalyst_build_flavor)
+      if(DEFINED maccatalyst_build_flavor AND DEFINED CFLAGS_DEPLOYMENT_VERSION_MACCATALYST)
         set(DEPLOYMENT_VERSION ${CFLAGS_DEPLOYMENT_VERSION_MACCATALYST})
       else()
         set(DEPLOYMENT_VERSION ${CFLAGS_DEPLOYMENT_VERSION_OSX})

--- a/test/Concurrency/Backdeploy/linking_maccatalyst.swift
+++ b/test/Concurrency/Backdeploy/linking_maccatalyst.swift
@@ -1,7 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx12 %s -o %t/linking_direct
-// RUN: %target-build-swift -target %target-cpu-apple-macosx11 %s -o %t/linking_rpath
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/linking_rpath_old
+// RUN: %target-build-swift -target %target-cpu-apple-macosx12 %s -o %t/linking_direct 2>&1 | %FileCheck -allow-empty -check-prefix CHECK-BUILD-ERRORS %s
+// RUN: %target-build-swift -target %target-cpu-apple-macosx11 %s -o %t/linking_rpath 2>&1 | %FileCheck -allow-empty -check-prefix CHECK-BUILD-ERRORS %s
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/linking_rpath_old 2>&1 | %FileCheck -allow-empty -check-prefix CHECK-BUILD-ERRORS %s
+
+// Make sure the linker didn't emit any version mismatch warnings.
+// CHECK-BUILD-ERRORS-NOT: was built for newer 'macOS' version
 
 // RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s


### PR DESCRIPTION
This fixes linker warnings that look like this:
```
ld: warning: object file (libswiftCompatibility56.a) was built for newer 'macOS' version (XYZ) than being linked (ABC)
```

These were caused by the compatibility binary being incorrectly built with a newer `-target` than desired: the CMake logic was overriding the requested minimum macOS deployment version (10.9) with a much newer macOS SDK version.

rdar://137565964

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
