### PR TITLE
[cxx-interop] Support ObjC protocols in C++ interop

### DIFF
--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -67,7 +67,7 @@ StringRef
 getNameForCxx(const ValueDecl *VD,
               CustomNamesOnly_t customNamesOnly = objc_translation::Normal);
 
-enum RepresentationKind { Representable, Unsupported };
+enum RepresentationKind { Representable, ObjCxxOnly, Unsupported };
 
 enum RepresentationError {
   UnrepresentableObjC,

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -229,7 +229,7 @@ void ClangSyntaxPrinter::printObjCBlock(
     llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const {
   os << "#if defined(__OBJC__)\n";
   bodyPrinter(os);
-  os << "\n#endif\n";
+  os << "\n#endif // defined(__OBJC__)\n";
 }
 
 void ClangSyntaxPrinter::printSwiftImplQualifier() const {

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -80,7 +80,7 @@ private:
 public:
   DeclAndTypePrinter(ModuleDecl &mod, raw_ostream &out, raw_ostream &prologueOS,
                      raw_ostream &outOfLineDefinitionsOS,
-                     DelayedMemberSet &delayed,
+                     const DelayedMemberSet &delayed,
                      CxxDeclEmissionScope &topLevelEmissionScope,
                      PrimitiveTypeMapping &typeMapping,
                      SwiftToClangInteropContext &interopContext,
@@ -103,6 +103,13 @@ public:
     return *cxxDeclEmissionScope;
   }
 
+  DeclAndTypePrinter withOutputStream(raw_ostream &s) {
+    return DeclAndTypePrinter(
+        M, s, prologueOS, outOfLineDefinitionsOS, objcDelayedMembers,
+        *cxxDeclEmissionScope, typeMapping, interopContext, minRequiredAccess,
+        requiresExposedAttribute, exposedModules, outputLang);
+  }
+
   void setCxxDeclEmissionScope(CxxDeclEmissionScope &scope) {
     cxxDeclEmissionScope = &scope;
   }
@@ -116,7 +123,8 @@ public:
   bool isVisible(const ValueDecl *vd) const;
 
   void print(const Decl *D);
-  void print(Type ty);
+  void print(Type ty, std::optional<OptionalTypeKind> overrideOptionalTypeKind =
+                          std::nullopt);
 
   /// Prints the name of the type including generic arguments.
   void printTypeName(raw_ostream &os, Type ty, const ModuleDecl *moduleContext);

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -42,7 +42,7 @@ class SwiftToClangInteropContext;
 class DeclAndTypePrinter;
 
 struct ClangRepresentation {
-  enum Kind { representable, unsupported };
+  enum Kind { representable, objcxxonly, unsupported };
 
   ClangRepresentation(Kind kind) : kind(kind) {}
 
@@ -50,8 +50,14 @@ struct ClangRepresentation {
   /// language mode.
   bool isUnsupported() const { return kind == unsupported; }
 
+  /// Returns true if the given Swift node is only supported in
+  /// Objective C++ mode.
+  bool isObjCxxOnly() const { return kind == objcxxonly; }
+
   const ClangRepresentation &merge(ClangRepresentation other) {
-    if (kind != unsupported)
+    if (other.kind == unsupported)
+      kind = unsupported;
+    else if (kind == representable)
       kind = other.kind;
     return *this;
   }

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
@@ -24,6 +24,16 @@
 -(int)getValue;
 @end
 
+@protocol ObjCProtocol
+@required
+- (int)method;
+@end
+
+@interface ObjCKlassConforming : NSObject<ObjCProtocol>
+- (ObjCKlassConforming * _Nonnull) init:(int)x;
+- (int)method;
+@end
+
 //--- module.modulemap
 module ObjCTest {
     header "header.h"
@@ -64,6 +74,18 @@ public func passThroughObjClass(_ x: ObjCKlass?) -> ObjCKlass? {
     return x
 }
 
+public func takeObjCProtocol(_ x: ObjCProtocol) {
+    print("ObjCKlassConforming:", x.method());
+}
+
+public func retObjCProtocol() -> ObjCProtocol {
+    return ObjCKlassConforming(2)
+}
+
+public func retObjCProtocolNullable() -> ObjCProtocol? {
+    return ObjCKlassConforming(2)
+}
+
 //--- use-swift-objc-types.mm
 
 #include "header.h"
@@ -98,6 +120,30 @@ struct DeinitPrinter {
 
 @end
 
+struct DeinitPrinter2 {
+    ~DeinitPrinter2() {
+        puts("destroy ObjCKlassConforming");
+        --globalCounter;
+    }
+};
+
+@implementation ObjCKlassConforming {
+    int _x;
+    DeinitPrinter2 _printer;
+}
+- (ObjCKlassConforming * _Nonnull) init:(int)x {
+    ObjCKlassConforming *result = [super init];
+    result->_x = x;
+    puts("create ObjCKlassConforming");
+    ++globalCounter;
+    return result;
+}
+
+-(int)method {
+    return self->_x;
+}
+@end
+
 int main() {
   using namespace UseObjCTy;
   @autoreleasepool {
@@ -130,5 +176,17 @@ int main() {
 // CHECK-NEXT: OBJClass: 1
 // CHECK-NEXT: destroy ObjCKlass
 // DESTROY: destroy ObjCKlass
+  puts("Part3");
+  @autoreleasepool {
+    id <ObjCProtocol> val = retObjCProtocol();
+    assert(globalCounter == 1);
+    assert([val method] == 2);
+    takeObjCProtocol(val);
+  }
+// CHECK: Part3
+// CHECK-NEXT: create ObjCKlassConforming
+// CHECK-NEXT: ObjCKlassConforming: 2
+// CHECK-NEXT: destroy ObjCKlassConforming
+// DESTROY: destroy ObjCKlassConforming
   return 0;
 }

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -5,10 +5,6 @@
 
 // RUN: %FileCheck %s < %t/UseObjCTy.h
 
-// RUN: %target-swift-frontend -typecheck %t/use-objc-types.swift -typecheck -module-name UseObjCTy -emit-clang-header-path %t/UseObjCTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr
-
-// RUN: %FileCheck %s < %t/UseObjCTyExposeOnly.h
-
 // FIXME: remove once https://github.com/apple/swift/pull/60971 lands.
 // RUN: echo "#include \"header.h\"" > %t/full-header.h
 // RUN: cat %t/UseObjCTy.h >> %t/full-header.h
@@ -18,9 +14,20 @@
 // REQUIRES: objc_interop
 
 //--- header.h
+#import <Foundation/Foundation.h>
 
 @interface ObjCKlass
 -(ObjCKlass * _Nonnull) init;
+@end
+
+@protocol ObjCProtocol
+@required
+- (void)method;
+@end
+
+@interface ObjCKlassConforming : NSObject<ObjCProtocol>
+- (ObjCKlassConforming * _Nonnull) init;
+- (void)method;
 @end
 
 //--- module.modulemap
@@ -31,33 +38,65 @@ module ObjCTest {
 //--- use-objc-types.swift
 import ObjCTest
 
-@_expose(Cxx)
 public func retObjClass() -> ObjCKlass {
     return ObjCKlass()
 }
 
-@_expose(Cxx)
 public func takeObjCClass(_ x: ObjCKlass) {
 }
 
-@_expose(Cxx)
 public func takeObjCClassInout(_ x: inout ObjCKlass) {
 }
 
-@_expose(Cxx)
 public func takeObjCClassNullable(_ x: ObjCKlass?) {
 }
 
-@_expose(Cxx)
 public func retObjClassNullable() -> ObjCKlass? {
     return nil
 }
 
+public func takeObjCProtocol(_ x: ObjCProtocol) {
+}
+
+public func retObjCProtocol() -> ObjCProtocol {
+    return ObjCKlassConforming()
+}
+
+public func takeObjCProtocolNullable(_ x: ObjCProtocol?) {
+}
+
+public func retObjCProtocolNullable() -> ObjCProtocol? {
+    return nil
+}
+
+// CHECK: SWIFT_EXTERN id <ObjCProtocol> _Nonnull $s9UseObjCTy03retB9CProtocolSo0bE0_pyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retObjCProtocol()
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_EXTERN id <ObjCProtocol> _Nullable $s9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retObjCProtocolNullable()
+// CHECK-NEXT: #endif
 // CHECK: ObjCKlass *_Nonnull $s9UseObjCTy03retB5ClassSo0B6CKlassCyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: ObjCKlass *_Nullable $s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: void $s9UseObjCTy04takeB6CClassyySo0B6CKlassCF(ObjCKlass *_Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: void $s9UseObjCTy04takeB11CClassInoutyySo0B6CKlassCzF(ObjCKlass *_Nonnull __strong * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: void $s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(ObjCKlass *_Nullable x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_EXTERN void $s9UseObjCTy04takeB9CProtocolyySo0bE0_pF(id <ObjCProtocol> _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // takeObjCProtocol(_:)
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_EXTERN void $s9UseObjCTy04takeB17CProtocolNullableyySo0bE0_pSgF(id <ObjCProtocol> _Nullable x) SWIFT_NOEXCEPT SWIFT_CALL; // takeObjCProtocolNullable(_:)
+// CHECK-NEXT: #endif
+
+// CHECK: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nonnull retObjCProtocol() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB9CProtocolSo0bE0_pyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return (__bridge_transfer id <ObjCProtocol>)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB9CProtocolSo0bE0_pyF();
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nullable retObjCProtocolNullable() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: return (__bridge_transfer id <ObjCProtocol>)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF();
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
 
 // CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
@@ -73,3 +112,16 @@ public func retObjClassNullable() -> ObjCKlass? {
 
 // CHECK: SWIFT_INLINE_THUNK void takeObjCClassNullable(ObjCKlass *_Nullable x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: _impl::$s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(x);
+
+
+// CHECK: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_INLINE_THUNK void takeObjCProtocol(id <ObjCProtocol> _Nonnull x) noexcept SWIFT_SYMBOL("s:9UseObjCTy04takeB9CProtocolyySo0bE0_pF") {
+// CHECK-NEXT:   UseObjCTy::_impl::$s9UseObjCTy04takeB9CProtocolyySo0bE0_pF(x);
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK: #if defined(__OBJC__)
+// CHECK-NEXT: SWIFT_INLINE_THUNK void takeObjCProtocolNullable(id <ObjCProtocol> _Nullable x) noexcept SWIFT_SYMBOL("s:9UseObjCTy04takeB17CProtocolNullableyySo0bE0_pSgF") {
+// CHECK-NEXT:   UseObjCTy::_impl::$s9UseObjCTy04takeB17CProtocolNullableyySo0bE0_pSgF(x);
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -86,8 +86,7 @@
 // CHECK:  SWIFT_INLINE_THUNK void append(const String& other)
 // CHECK:  SWIFT_INLINE_THUNK UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const UTF8View& newValue) SWIFT_SYMBOL({{.*}});
-// CHECK:  #if defined(__OBJC__)
-// CHECK-NEXT:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
+// CHECK:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
 // CHECK-NEXT:   }
 // CHECK-NEXT:  static SWIFT_INLINE_THUNK String init(NSString * _Nonnull nsString) noexcept {
@@ -97,7 +96,7 @@
 // CHECK-NEXT:  return result;
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  #endif
+// CHECK-NEXT:  #endif // defined(__OBJC__)
 // CHECK-NEXT: #define SWIFT_CXX_INTEROP_STRING_MIXIN
 
 // CHECK-NEXT: #pragma clang diagnostic push


### PR DESCRIPTION
This patch introduces handling of ObjC protocols similar to how ObjC classes work. Since this only works in ObjC++, all declarations containing ObjC protocols will be protected by the __OBJC__ macro.

This patch results in some `_bridgeObjC` methods being exposed, we might end up hiding those in the future, but there is no harm having them in the interop header for the interim period.

rdar://136757913