### PR TITLE
Fix multi-payload enums with Class Existential payloads on 32-bit targets

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -438,13 +438,15 @@ BitMask RecordTypeInfo::getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const
     break;
   }
   case RecordKind::ClassExistential:
-    // Class existential is a data pointer that does expose spare bits
+    // Class existential is a bunch of pointers that expose spare bits
     // ... so we can fall through ...
   case RecordKind::ExistentialMetatype: {
-    // Initial metadata pointer has spare bits
+    // A bunch of pointers that expose spare bits
     auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
-    mask.andMask(mpePointerSpareBits, 0);
-    mask.keepOnlyLeastSignificantBytes(TC.targetPointerSize());
+    auto mpePointerSpareBitMask = BitMask(TC.targetPointerSize(), mpePointerSpareBits);
+    for (int offset = 0; offset < (int)getSize(); offset += TC.targetPointerSize()) {
+      mask.andMask(mpePointerSpareBitMask, offset);
+    }
     return mask;
   }
   case RecordKind::ErrorExistential:

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -447,7 +447,7 @@ BitMask RecordTypeInfo::getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const
       mask.andMask(zeroPointerSizedMask, 0);
     }
     // Otherwise, it's the same as an Existential Metatype
-    DISPATCH_FALLTHROUGH;
+    SWIFT_FALLTHROUGH;
   }
   case RecordKind::ExistentialMetatype: {
     // All the pointers in an Existential Metatype expose spare bits...

--- a/validation-test/Reflection/reflect_Enum_values10.swift
+++ b/validation-test/Reflection/reflect_Enum_values10.swift
@@ -147,6 +147,30 @@ reflect(enumValue: Q2.e(C()))
 // CHECKALL-NEXT: (enum reflect_Enum_values10.Q2)
 // CHECKALL-NEXT: Value: .e(_)
 
+reflect(enumValue: Optional<Q2>.some(.a(C())))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (bound_generic_enum Swift.Optional
+// CHECKALL-NEXT:   (enum reflect_Enum_values10.Q2))
+// CHECKALL-NEXT: Value: .some(.a(_))
+
+reflect(enumValue: Optional<Q2>.some(.e(C())))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (bound_generic_enum Swift.Optional
+// CHECKALL-NEXT:   (enum reflect_Enum_values10.Q2))
+// CHECKALL-NEXT: Value: .some(.e(_))
+
+reflect(enumValue: Optional<Q2>.none)
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (bound_generic_enum Swift.Optional
+// CHECKALL-NEXT:   (enum reflect_Enum_values10.Q2))
+// CHECKALL-NEXT: Value: .none
+
 doneReflecting()
 
 // CHECKALL: Done.

--- a/validation-test/Reflection/reflect_Enum_values10.swift
+++ b/validation-test/Reflection/reflect_Enum_values10.swift
@@ -10,9 +10,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 
-// This is broken on ARM64_32, disable it temporarily until we can fix it. rdar://137351613
-// UNSUPPORTED: CPU=arm64_32
-
 import SwiftReflectionTest
 
 protocol P : AnyObject {
@@ -24,7 +21,8 @@ class C : P {
   init() { a = 0; b = 0; }
 }
 
-// MemoryLayout<B>.size == 8
+// On 64-bit: MemoryLayout<B>.size == 8
+// On 32-bit: MemoryLayout<B>.size == 4
 enum B {
 case a(C)
 case b(C)
@@ -44,8 +42,8 @@ reflect(enumValue: B.b(C()))
 // CHECKALL-NEXT: (enum reflect_Enum_values10.B)
 // CHECKALL-NEXT: Value: .b(_)
 
-// MemoryLayout<Q>.size == 16
-// MemoryLayout<P>.size == 16
+// On 64-bit: MemoryLayout<Q>.size == MemoryLayout<P>.size == 16
+// On 32-bit: MemoryLayout<Q>.size == MemoryLayout<P>.size == 8
 enum Q {
 case a(P)
 case b(P)
@@ -64,6 +62,90 @@ reflect(enumValue: Q.b(C()))
 // CHECKALL-NEXT: Type reference:
 // CHECKALL-NEXT: (enum reflect_Enum_values10.Q)
 // CHECKALL-NEXT: Value: .b(_)
+
+enum B1 {
+case a(C)
+case b
+}
+
+reflect(enumValue: B1.a(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.B1)
+// CHECKALL-NEXT: Value: .a(_)
+
+reflect(enumValue: B1.b)
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.B1)
+// CHECKALL-NEXT: Value: .b
+
+enum Q1 {
+case a(P)
+case b
+}
+
+reflect(enumValue: Q1.a(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.Q1)
+// CHECKALL-NEXT: Value: .a(_)
+
+reflect(enumValue: Q1.b)
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.Q1)
+// CHECKALL-NEXT: Value: .b
+
+enum B2 {
+case a(C)
+case b(C)
+case c(C)
+case d(C)
+case e(C)
+}
+
+reflect(enumValue: B2.a(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.B2)
+// CHECKALL-NEXT: Value: .a(_)
+
+reflect(enumValue: B2.e(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.B2)
+// CHECKALL-NEXT: Value: .e(_)
+
+// On 64-bit: MemoryLayout<Q>.size == MemoryLayout<P>.size == 16
+// On 32-bit: MemoryLayout<Q>.size == MemoryLayout<P>.size == 8
+enum Q2 {
+case a(P)
+case b(P)
+case c(P)
+case d(P)
+case e(P)
+}
+
+reflect(enumValue: Q2.a(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.Q2)
+// CHECKALL-NEXT: Value: .a(_)
+
+reflect(enumValue: Q2.e(C()))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values10.Q2)
+// CHECKALL-NEXT: Value: .e(_)
 
 doneReflecting()
 


### PR DESCRIPTION
Class existentials expose spare bits from all of the pointers, not just the first one. Due to a bad bug here, we were properly exposing spare bits from the first pointer, but then claiming that all bits of subsequent pointers were spare. This accidentally resulted in the correct operation on 64-bit targets (it picked the highest-order spare bit, which happened to be spare in both the broken mask and the correct mask).  But on 32-bit targets, this exposed the high-order bits of pointers, which is incorrect.

Expand the test a bit while we're here as well.

Resolves rdar://132715829