### PR TITLE
[test] Disable device and back deployment for Interpreter/value_generics.swift

### DIFF
--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -1,5 +1,8 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking -Xfrontend -disable-experimental-parser-round-trip) | %FileCheck %s
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // REQUIRES: executable_test
 
 struct A<let N: Int, let M: Int> {}


### PR DESCRIPTION
This test requires new runtime features which aren't in any OS runtime yet.