### PR TITLE
Enable full SIL verification with `-compiler-assertions`

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2749,6 +2749,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                    Opts.EnableLifetimeDependenceDiagnostics);
 
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
+  Opts.VerifyAll |= CONDITIONAL_ASSERT_enabled();
   Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
@@ -2769,6 +2770,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DisableSILPartialApply |=
     Args.hasArg(OPT_disable_sil_partial_apply);
   Opts.VerifySILOwnership &= !Args.hasArg(OPT_disable_sil_ownership_verifier);
+  Opts.VerifySILOwnership |= CONDITIONAL_ASSERT_enabled();
   Opts.EnableDynamicReplacementCanCallPreviousImplementation = !Args.hasArg(
       OPT_disable_previous_implementation_calls_in_dynamic_replacements);
   Opts.ParseStdlib = FEOpts.ParseStdlib;
@@ -3652,6 +3654,8 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
+  ParseAssertionArgs(ParsedArgs);
+
   if (ParseFrontendArgs(FrontendOpts, ParsedArgs, Diags,
                         ConfigurationFileBuffers)) {
     return true;
@@ -3667,8 +3671,6 @@ bool CompilerInvocation::parseArgs(
   if (ParseCASArgs(CASOpts, ParsedArgs, Diags, FrontendOpts)) {
     return true;
   }
-
-  ParseAssertionArgs(ParsedArgs);
 
   if (ParseLangArgs(LangOpts, ParsedArgs, Diags, FrontendOpts)) {
     return true;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2749,7 +2749,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                    Opts.EnableLifetimeDependenceDiagnostics);
 
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
-  Opts.VerifyAll |= CONDITIONAL_ASSERT_enabled();
   Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
@@ -2770,7 +2769,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DisableSILPartialApply |=
     Args.hasArg(OPT_disable_sil_partial_apply);
   Opts.VerifySILOwnership &= !Args.hasArg(OPT_disable_sil_ownership_verifier);
-  Opts.VerifySILOwnership |= CONDITIONAL_ASSERT_enabled();
   Opts.EnableDynamicReplacementCanCallPreviousImplementation = !Args.hasArg(
       OPT_disable_previous_implementation_calls_in_dynamic_replacements);
   Opts.ParseStdlib = FEOpts.ParseStdlib;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7330,6 +7330,10 @@ static bool verificationEnabled(const SILModule &M) {
   if (M.getOptions().VerifyAll)
     return true;
 
+  // If we have asserts enabled, always verify...
+  if (CONDITIONAL_ASSERT_enabled())
+    return true;
+
 #ifndef NDEBUG
   // Otherwise if we do have asserts enabled, always verify...
   return true;


### PR DESCRIPTION
Incrementally expanding the scope of `-compiler-assertions`

Probably other existing verifiers should also be enabled with this switch.