### PR TITLE
[ModuleCache] Prefer module cache passed on the command-line for checker

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -818,8 +818,11 @@ bool CompilerInstance::setUpModuleLoaders() {
   }
 
   // Configure ModuleInterfaceChecker for the ASTContext.
+  auto CacheFromInvocation = getInvocation().getClangModuleCachePath();
   auto const &Clang = clangImporter->getClangInstance();
-  std::string ModuleCachePath = getModuleCachePathFromClang(Clang);
+  std::string ModuleCachePath = CacheFromInvocation.empty()
+                                    ? getModuleCachePathFromClang(Clang)
+                                    : CacheFromInvocation.str();
   auto &FEOpts = Invocation.getFrontendOptions();
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   Context->addModuleInterfaceChecker(

--- a/test/ModuleInterface/ModuleCache/module-cache-options.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-options.swift
@@ -1,0 +1,39 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -parse-stdlib -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -parse-stdlib -I %t -module-cache-path %t/swiftcache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -parse-stdlib -I %t -module-cache-path %t/swiftcache -Xcc -fmodules-cache-path=%t/clangcache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %t/main.swift
+
+// RUN: NUM_SWIFT_MODULES=$(find %t/swiftcache -type f -name '*.swiftmodule' | wc -l)
+// RUN: NUM_CLANG_MODULES=$(find %t/clangcache -type f -name '*.pcm' | wc -l)
+/// Two swift modules, Leaf and Other
+// RUN: if [ ! $NUM_SWIFT_MODULES -eq 2 ]; then echo "Should only be 2 Swift Modules, found $NUM_SWIFT_MODULES"; exit 1; fi
+/// Two clang modules, shim and A
+// RUN: if [ ! $NUM_CLANG_MODULES -eq 2 ]; then echo "Should only be 2 Clang Modules, found $NUM_CLANG_MODULES"; exit 1; fi
+
+//--- leaf.swift
+public func LeafFunc() {}
+
+//--- other.swift
+import LeafModule
+public func OtherFunc() {}
+
+//--- module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- A.h
+void a(void);
+
+//--- main.swift
+import OtherModule
+import A
+
+public func TestFunc() {
+    OtherFunc()
+    a()
+}


### PR DESCRIPTION
When setting up the ModuleInterfaceChecker, prefer using the module cache path from command-line invocation `-module-cache-path` before falling back to clang options.

Usually those two yield the same result, except for LLDB under direct cc1 argument mode and explicit module build. Under such mode, the cc1 option for module cache path will be stripped since the output PCMs are explicit passed as output. When LLDB attempted to do an implicit module compilation for the swift interface, it will not be able to locate the module cache path from cc1 arguments. On the other hand, the module cache option has already be inherited by the sub-instance so it can just directly be located there.

rdar://137610484

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
