### PR TITLE
[6.0] IRGen: Fix emission of calls to opaque return type metadata access function with packs

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -451,12 +451,16 @@ withOpaqueTypeGenericArgs(IRGenFunction &IGF,
     SmallVector<llvm::Value *, 4> args;
     SmallVector<llvm::Type *, 4> types;
 
+    // We need to pass onHeapPacks=true because the runtime demangler
+    // expects to differentiate on-heap packs from non-pack types by
+    // checking the least significant bit of the metadata pointer.
     enumerateGenericSignatureRequirements(
         opaqueDecl->getGenericSignature().getCanonicalSignature(),
         [&](GenericRequirement reqt) {
           auto arg = emitGenericRequirementFromSubstitutions(
               IGF, reqt, MetadataState::Abstract,
-              archetype->getSubstitutions());
+              archetype->getSubstitutions(),
+              /*onHeapPacks=*/true);
           args.push_back(arg);
           types.push_back(args.back()->getType());
         });

--- a/test/Interpreter/Inputs/variadic_generic_opaque_type_other.swift
+++ b/test/Interpreter/Inputs/variadic_generic_opaque_type_other.swift
@@ -1,0 +1,22 @@
+public protocol P {}
+
+extension Int: P {}
+extension String: P {}
+extension Bool: P {}
+extension Double: P {}
+
+public protocol Q {}
+
+public func f1<each T: P>(_ t: repeat each T) -> some Any {
+  return (repeat each t)
+}
+
+public struct G2<T>: Q {}
+public func f2<each T: P>(_ t: repeat each T) -> some Q {
+  return G2<(repeat each T)>()
+}
+
+public struct G3<each T>: Q {}
+public func f3<each T: P>(_ t: repeat each T) -> some Q {
+  return G3<repeat each T>()
+}

--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_opaque_type_other)) %S/Inputs/variadic_generic_opaque_type_other.swift -emit-module -emit-module-path %t/variadic_generic_opaque_type_other.swiftmodule -module-name variadic_generic_opaque_type_other -Xfrontend -disable-availability-checking -enable-library-evolution
+// RUN: %target-codesign %t/%target-library-name(variadic_generic_opaque_type_other)
+//
+// RUN: %target-build-swift %s -I %t -o %t/main.out -L %t %target-rpath(%t) -lvariadic_generic_opaque_type_other
+// RUN: %target-codesign %t/main.out
+//
+// RUN: %target-run %t/main.out %t/%target-library-name(variadic_generic_opaque_type_other)
+
+// REQUIRES: executable_test
+
+import variadic_generic_opaque_type_other
+import StdlibUnittest
+
+var opaque = TestSuite("VariadicGenericOpaqueTypes")
+
+func getType<T>(_: T) -> Any.Type {
+  return T.self
+}
+
+opaque.test("Opaque1") {
+  expectEqual((Int, String).self, getType(f1(1, "hi")))
+  expectEqual(G2<(Bool, String)>.self, getType(f2(false, "hi")))
+  expectEqual(G3<Bool, Double>.self, getType(f3(false, 3.0)))
+}
+
+func g1<each T: P>(_ t: repeat each T) -> Any.Type {
+  return getType(f1(repeat each t))
+}
+func g2<each T: P>(_ t: repeat each T) -> Any.Type {
+  return getType(f2(repeat each t))
+}
+func g3<each T: P>(_ t: repeat each T) -> Any.Type {
+  return getType(f3(repeat each t))
+}
+
+opaque.test("Opaque2") {
+  expectEqual((Int, String).self, g1(1, "hi"))
+  expectEqual(G2<(Bool, String)>.self, g2(false, "hi"))
+  expectEqual(G3<Bool, Double>.self, g3(false, 3.0))
+}
+
+runAllTests()


### PR DESCRIPTION
* **Main PR:** https://github.com/swiftlang/swift/pull/77034

* **Description:** If a function that is generic over packs has an opaque return type, and the underlying type of the opaque return type involves those packs, and you called the opaque type's metadata accessor from outside the module, we would crash at runtime.

  The issue is that the runtime entry point expects on-heap packs. We correctly heap-allocate packs in other places that the runtime demangler is called, but we didn't in this case. The fix is in IRGen, not the runtime. (In the future, we might want to change the runtime to correctly decode which generic arguments are packs by looking at the descriptors. We do this in most places, but not in the demangler, which relies on a trick to differentiate type metadata from packs that only works with on-heap packs. In any case, this would require a deployment target check, which this fix avoids.)

* **Origination:** It looks like this never worked. (When the opaque return type is referenced within its defining module, we don't call the accessor at all, so we're fine. We also don't call the accessor when the opaque return type is referenced with fully-concrete substitutions. So the broken case is when you directly instantiate an opaque return type in another module, in a way where it's substitutions depend on another generic context.)

* **Tested:** Added execution test to cover this behavior.

* **Reviewed by:** @rjmccall 

* **Radar:** Fixes rdar://117815191.
