### PR TITLE
[DiagnoseUnreachable] Ignore dead_end destroys.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -775,6 +775,14 @@ static bool simplifyBlocksWithCallsToNoReturn(SILBasicBlock &BB,
     if (isa<EndBorrowInst>(currInst))
       return false;
 
+    // destroy_value [dead_end] instructions are inserted at the availability
+    // boundary by lifetime completion.  Such instructions correctly mark the
+    // lifetime boundary of the destroyed value and never arise from dead user
+    // code.
+    auto *dvi = dyn_cast<DestroyValueInst>(currInst);
+    if (dvi && dvi->isDeadEnd())
+      return false;
+
     // If no-return instruction is not something we can point in code or
     // it's an explicit cast, skip it.
     if (!noReturnCall->getLoc().is<RegularLocation>() ||

--- a/validation-test/SILOptimizer/rdar137960229.swift
+++ b/validation-test/SILOptimizer/rdar137960229.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -c %s -verify
+
+func testFatalError(_ message: @autoclosure () -> String = String()) -> Never {
+  Swift.fatalError()
+}
+
+func test() {
+  testFatalError()
+}


### PR DESCRIPTION
Such destroys mark the lifetime end of their operands along their availability boundary.  They are currently inserted in this test case by the ClosureLifetimeFixup pass, but in the fullness of time they will be present for every value which is not explicitly destroyed (that's what complete OSSA lifetimes is mostly about).

Currently, such destroys are diagnosed by DiagnoseUnreachable.  Fix the diagnostic pass not to diagnose these valid instructions.

rdar://137960229
