### PR TITLE
Sema: Fix source ranges for string literals in TypeRefinementContext

### DIFF
--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -299,6 +299,18 @@ var someComputedGlobalVar: Int {
   set { }
 }
 
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=interpolated
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=string
+
+func testStringInterpolation() {
+  let interpolated = """
+    \([""].map {
+      let string = $0
+      return string
+    })
+    """
+}
+
 // CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl
 
 @available(OSX 51, *)


### PR DESCRIPTION
Since string literals are only a single token from the perspective of the parser, the source range for a pattern binding decl that is initialized with a string literal expression only extends to the beginning of the string literal. To ensure the `TypeRefinementContext` for a pattern binding decl includes the entire contents of the init expression we must calculate the character source range of the decl instead.

Resolves rdar://110952225 and https://github.com/swiftlang/swift/issues/77050.