### PR TITLE
[IRGen] Don't try to emit single payload CVW for incompatible multi p…

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2408,7 +2408,8 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
     if (isMultiPayloadEnum() &&
         buildMultiPayloadRefCountString(IGM, B, genericSig)) {
       return true;
-    } else if (buildSinglePayloadRefCountString(IGM, B, genericSig)) {
+    } else if (!isMultiPayloadEnum() &&
+               buildSinglePayloadRefCountString(IGM, B, genericSig)) {
       return true;
     }
 


### PR DESCRIPTION
…ayload enums

rdar://137954177

There was a missing condition in the branch that caused the compiler to try to emit a single payload enum compact value witness for multi payload enums, when the multi payload enum contained an incompatible case.