### PR TITLE
Update swift::canUseObject for unconditional_checked_cast

### DIFF
--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -175,7 +175,6 @@ bool swift::canUseObject(SILInstruction *Inst) {
   case SILInstructionKind::UncheckedAddrCastInst:
   case SILInstructionKind::RefToRawPointerInst:
   case SILInstructionKind::RawPointerToRefInst:
-  case SILInstructionKind::UnconditionalCheckedCastInst:
   case SILInstructionKind::UncheckedBitwiseCastInst:
   case SILInstructionKind::EndInitLetRefInst:
   case SILInstructionKind::BeginDeallocRefInst:

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -1123,3 +1123,18 @@ bb1:
   return %5 : $()
 }
 
+// CHECK: sil @dont_hoist_release_accross_cast
+// CHECK: retain
+// CHECK: apply
+// CHECK: unconditional_checked_cast
+// CHECK: release
+sil @dont_hoist_release_accross_cast : $@convention(thin) (B, B) -> () {
+bb0(%0 : $B, %1: $B):
+  strong_retain %0: $B
+  apply undef() : $@convention(thin) () -> ()
+  %3 = unconditional_checked_cast %0 : $B to Builtin.NativeObject
+  strong_release %0: $B
+  %5 = tuple()
+  return %5 : $()
+}
+


### PR DESCRIPTION
unconditional_checked_cast can read the pointer, update swift::canUseObject to return false for this.

Previously, if unconditional_checked_cast was dead, we could get a miscompile because of release hoisting.

Fixes rdar://137990246

