### PR TITLE
Macros: Implement `expansion(of:providingMembersOf:conformingTo:in:)` on MemberMacros

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -141,7 +141,6 @@ extension ASTGenVisitor {
       return self.generate(nilLiteralExpr: node).asExpr
     case .optionalChainingExpr(let node):
       return self.generate(optionalChainingExpr: node).asExpr
-      break
     case .packElementExpr(let node):
       return self.generate(packElementExpr: node).asExpr
     case .packExpansionExpr(let node):

--- a/lib/Macros/Sources/ObservationMacros/Availability.swift
+++ b/lib/Macros/Sources/ObservationMacros/Availability.swift
@@ -86,7 +86,7 @@ extension AttributeListSyntax.Element {
       if let availability = ifConfig.availability {
         return .ifConfigDecl(availability)
       }
-    default:
+    @unknown default:
       break
     }
     return nil

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -196,6 +196,7 @@ extension ObservableMacro: MemberMacro {
   >(
     of node: AttributeSyntax,
     providingMembersOf declaration: Declaration,
+    conformingTo protocols: [TypeSyntax],
     in context: Context
   ) throws -> [DeclSyntax] {
     guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {

--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -24,6 +24,7 @@ extension DebugDescriptionMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   )
   throws -> [DeclSyntax]

--- a/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
@@ -152,6 +152,7 @@ extension OptionSetMacro: MemberMacro {
   >(
     of attribute: AttributeSyntax,
     providingMembersOf decl: Decl,
+    conformingTo protocols: [TypeSyntax],
     in context: Context
   ) throws -> [DeclSyntax] {
     // Decode the expansion arguments.


### PR DESCRIPTION
Resolves a warning about using a deprecated default implementation.

Also, fixes a few other warnings.