### PR TITLE
DCE unconditional_checked_cast

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -55,6 +55,10 @@ static bool seemsUseful(SILInstruction *I) {
       isa<EndBorrowInst>(I))
     return false;
 
+  if (isa<UnconditionalCheckedCastInst>(I)) {
+    return false;
+  }
+
   // A load [copy] is okay to be DCE'ed if there are no useful dependencies
   if (auto *load = dyn_cast<LoadInst>(I)) {
     if (load->getOwnershipQualifier() == LoadOwnershipQualifier::Copy)

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -270,3 +270,18 @@ bb0(%0 : $*Container):
   %999 = tuple ()
   return %999 : $()
 }
+
+class B {}
+
+// CHECK-LABEL: sil @dead_unconditional_checked_cast
+// CHECK-NOT: unconditional_checked_cast
+// CHECK-LABEL: end sil function 'dead_unconditional_checked_cast'
+sil @dead_unconditional_checked_cast : $@convention(thin) (B, B) -> () {
+bb0(%0 : $B, %1: $B):
+  strong_retain %0: $B
+  apply undef() : $@convention(thin) () -> ()
+  %3 = unconditional_checked_cast %0 : $B to Builtin.NativeObject
+  strong_release %0: $B
+  %5 = tuple()
+  return %5 : $()
+}


### PR DESCRIPTION
We were not eliminating a dead unconditional_checked_cast because it is marked as 'mayRead'. Make it legal to eliminate it.