### PR TITLE
embedded: print an error for class existentials where not all protocols of a composition are class bound

### DIFF
--- a/test/embedded/existential-composition.swift
+++ b/test/embedded/existential-composition.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+protocol ClassBound: AnyObject {
+  func foo()
+}
+
+protocol OtherProtocol {
+  func bar()
+}
+
+class MyClass: ClassBound, OtherProtocol {
+  func foo() { print("MyClass.foo()") }
+  func bar() { print("MyClass.bar()") }
+}
+
+// Currently we don't support this
+func test(existential: any ClassBound & OtherProtocol) {
+}
+
+@main
+struct Main {
+  static func main() {
+    test(existential: MyClass()) // expected-error {{cannot use a value of protocol type 'any ClassBound & OtherProtocol' in embedded Swift}}
+                                 // expected-note@-4 {{called from here}}
+  }
+}


### PR DESCRIPTION
We don't support this, yet.
Without the error IRGen would crash.
rdar://137517212
