### PR TITLE
[cxx-interop] Add test for iterator conformances with nested typedefs

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -259,6 +259,29 @@ struct HasCustomRACIteratorTag {
   }
 };
 
+struct HasCustomInheritedRACIteratorTag {
+  struct CustomTag0 : public std::random_access_iterator_tag {};
+  using CustomTag1 = CustomTag0;
+  struct CustomTag2 : public CustomTag1 {};
+  using CustomTag3 = CustomTag2;
+  using CustomTag4 = CustomTag3;
+
+  int value;
+  using iterator_category = CustomTag4;
+  const int &operator*() const { return value; }
+  HasCustomInheritedRACIteratorTag &operator++() {
+    value++;
+    return *this;
+  }
+  void operator+=(int x) { value += x; }
+  int operator-(const HasCustomInheritedRACIteratorTag &x) const {
+    return value - x.value;
+  }
+  bool operator==(const HasCustomInheritedRACIteratorTag &other) const {
+    return value == other.value;
+  }
+};
+
 struct HasCustomIteratorTagInline {
   struct iterator_category : public std::input_iterator_tag {};
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -66,6 +66,23 @@
 // CHECK:   static func == (lhs: HasCustomRACIteratorTag, other: HasCustomRACIteratorTag) -> Bool
 // CHECK: }
 
+// CHECK: struct HasCustomInheritedRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   func successor() -> HasCustomInheritedRACIteratorTag
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK:   struct CustomTag0 {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   typealias CustomTag1 = HasCustomInheritedRACIteratorTag.CustomTag0
+// CHECK:   struct CustomTag2 {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   typealias CustomTag3 = HasCustomInheritedRACIteratorTag.CustomTag2
+// CHECK:   typealias CustomTag4 = HasCustomInheritedRACIteratorTag.CustomTag3
+// CHECK:   typealias iterator_category = HasCustomInheritedRACIteratorTag.CustomTag4
+// CHECK: }
+
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomIteratorTagInline
 // CHECK:   var pointee: Int32 { get }


### PR DESCRIPTION
Follow-up to 34f6cd3f.

This addresses @Xazax-hun's comment: https://github.com/swiftlang/swift/pull/77049#discussion_r1803511159

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
