### PR TITLE
[cxx-interop] Diagnose misuses of escapability and lifetimebound

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -289,5 +289,8 @@ NOTE(forward_declared_protocol_clashes_with_imported_objc_Swift_protocol, none,
      "its name conflicts with a %1 in module %2",
      (const clang::NamedDecl*, StringRef, StringRef))
 
+WARNING(return_escapable_with_lifetimebound, none, "the returned type '%0' is annotated as escapable; it cannot have lifetime dependencies", (StringRef))
+WARNING(return_nonescapable_without_lifetimebound, none, "the returned type '%0' is annotated as non-escapable; its lifetime dependencies must be annotated", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -19,11 +19,35 @@ private:
     const int *member;
 };
 
+struct SWIFT_ESCAPABLE Owner {
+    int data;
+};
+
+Owner f(int* x [[clang::lifetimebound]]) { 
+    return Owner{0};
+}
+
+Owner f2(int* x [[clang::lifetimebound]], int* y [[clang::lifetimebound]]) { 
+    return Owner{0};
+}
+
+View g(int* x) {
+    return View(x);
+}
+
 //--- test.swift
 
 import Test
 
 // CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
 public func noAnnotations() -> View {
-    View()
+    // CHECK: nonescapable.h:15:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
+    f(nil)
+    // CHECK: nonescapable.h:19:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
+    // No duplicate warning for f2:
+    // CHECK-NOT: nonescapable.h:19
+    f2(nil, nil)
+    // CHECK: nonescapable.h:23:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
+    g(nil)
+    return View()
 }


### PR DESCRIPTION
When a type is explicitly annotated as escapable or non-escapable it has requirements about the lifetime annotations. This patch introduces diagnostics to detect that.
