### PR TITLE
Add -Rpass-analysis= option and switch assembly vision to analysis remarks

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -665,6 +665,7 @@ ERROR(non_borrowed_indirect_addressof,none,
 
 REMARK(opt_remark_passed, none, "%0", (StringRef))
 REMARK(opt_remark_missed, none, "%0", (StringRef))
+REMARK(opt_remark_analysis, none, "%0", (StringRef))
 NOTE(opt_remark_note, none, "%0", (StringRef))
 
 // Float-point to integer conversions

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -487,6 +487,7 @@ namespace swift {
     /// These are shared_ptrs so that this class remains copyable.
     std::shared_ptr<llvm::Regex> OptimizationRemarkPassedPattern;
     std::shared_ptr<llvm::Regex> OptimizationRemarkMissedPattern;
+    std::shared_ptr<llvm::Regex> OptimizationRemarkAnalysisPattern;
 
     /// How should we emit diagnostics about access notes?
     AccessNoteDiagnosticBehavior AccessNoteBehavior =

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -926,6 +926,11 @@ def Rpass_missed_EQ : Joined<["-"], "Rpass-missed=">,
   HelpText<"Report missed transformations by optimization passes whose "
            "name matches the given POSIX regular expression">;
 
+def Rpass_analysis_EQ : Joined<["-"], "Rpass-analysis=">,
+  Flags<[FrontendOption]>,
+  HelpText<"Report transformation analysis from optimization passes whose "
+           "name matches the given POSIX regular expression">;
+
 def save_optimization_record : Flag<["-"], "save-optimization-record">,
   Flags<[FrontendOption]>, HelpText<"Generate a YAML optimization record file">;
 def save_optimization_record_EQ : Joined<["-"], "save-optimization-record=">,

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -273,6 +273,20 @@ struct RemarkMissed : public Remark<RemarkMissed> {
                SourceLocPresentationKind locPresentationKind)
       : Remark(id, i, inferenceBehavior, locPresentationKind) {}
 };
+/// Remark to report analysis.
+struct RemarkAnalysis : public Remark<RemarkAnalysis> {
+  RemarkAnalysis(StringRef id, SILInstruction &i)
+      : Remark(id, i, SourceLocInferenceBehavior::None,
+               SourceLocPresentationKind::StartRange) {}
+  RemarkAnalysis(StringRef id, SILInstruction &i,
+               SourceLocInferenceBehavior inferenceBehavior)
+      : Remark(id, i, inferenceBehavior,
+               SourceLocPresentationKind::StartRange) {}
+  RemarkAnalysis(StringRef id, SILInstruction &i,
+               SourceLocInferenceBehavior inferenceBehavior,
+               SourceLocPresentationKind locPresentationKind)
+      : Remark(id, i, inferenceBehavior, locPresentationKind) {}
+};
 
 /// Used to emit the remarks.  Passes reporting remarks should create an
 /// instance of this.
@@ -281,12 +295,15 @@ class Emitter {
   std::string passName;
   bool passedEnabled;
   bool missedEnabled;
+  bool analysisEnabled;
 
   // Making these non-generic allows out-of-line definition.
   void emit(const RemarkPassed &remark);
   void emit(const RemarkMissed &remark);
+  void emit(const RemarkAnalysis &remark);
   static void emitDebug(const RemarkPassed &remark);
   static void emitDebug(const RemarkMissed &remark);
+  static void emitDebug(const RemarkAnalysis &remark);
 
   template <typename RemarkT> bool isEnabled();
 
@@ -345,6 +362,9 @@ template <> inline bool Emitter::isEnabled<RemarkMissed>() {
 }
 template <> inline bool Emitter::isEnabled<RemarkPassed>() {
   return passedEnabled;
+}
+template <> inline bool Emitter::isEnabled<RemarkAnalysis>() {
+  return analysisEnabled;
 }
 } // namespace OptRemark
 } // namespace swift

--- a/include/swift/SIL/SILRemarkStreamer.h
+++ b/include/swift/SIL/SILRemarkStreamer.h
@@ -86,6 +86,8 @@ template <typename RemarkT> static llvm::remarks::Type toRemarkType() {
     return llvm::remarks::Type::Passed;
   if (std::is_same<RemarkT, OptRemark::RemarkMissed>::value)
     return llvm::remarks::Type::Missed;
+  if (std::is_same<RemarkT, OptRemark::RemarkAnalysis>::value)
+    return llvm::remarks::Type::Analysis;
   llvm_unreachable("Unknown remark type");
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -295,6 +295,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_warn_swift3_objc_inference);
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_missed_EQ);
+  inputArgs.AddLastArg(arguments, options::OPT_Rpass_analysis_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_warnings);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_remarks);
   inputArgs.AddLastArg(arguments, options::OPT_experimental_package_bypass_resilience);

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -508,6 +508,13 @@ struct SILOptOptions {
       cl::Hidden);
 
   cl::opt<std::string>
+    PassRemarksAnalysis = cl::opt<std::string>(
+      "sil-remarks-analysis", cl::value_desc("pattern"),
+      cl::desc("Enable analysis remarks from passes whose name match "
+               "the given regular expression"),
+      cl::Hidden);
+
+  cl::opt<std::string>
       RemarksFilename = cl::opt<std::string>("save-optimization-record-path",
                       cl::desc("YAML output filename for pass remarks"),
                       cl::value_desc("filename"));
@@ -780,6 +787,8 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       createOptRemarkRegex(options.PassRemarksPassed);
   Invocation.getLangOptions().OptimizationRemarkMissedPattern =
       createOptRemarkRegex(options.PassRemarksMissed);
+  Invocation.getLangOptions().OptimizationRemarkAnalysisPattern =
+      createOptRemarkRegex(options.PassRemarksAnalysis);
 
   if (options.EnableExperimentalStaticAssert)
     Invocation.getLangOptions().enableFeature(Feature::StaticAssert);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1268,6 +1268,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Arg *A = Args.getLastArg(OPT_Rpass_missed_EQ))
     Opts.OptimizationRemarkMissedPattern =
         generateOptimizationRemarkRegex(Diags, Args, A);
+  if (Arg *A = Args.getLastArg(OPT_Rpass_analysis_EQ))
+    Opts.OptimizationRemarkAnalysisPattern =
+        generateOptimizationRemarkRegex(Diags, Args, A);
 
   if (Arg *A = Args.getLastArg(OPT_Raccess_note)) {
     auto value =

--- a/lib/SIL/Utils/OptimizationRemark.cpp
+++ b/lib/SIL/Utils/OptimizationRemark.cpp
@@ -159,6 +159,12 @@ Emitter::Emitter(StringRef passName, SILFunction &fn)
           isMethodWithForceEmitSemanticAttrNominalType(fn) ||
           (fn.getASTContext().LangOpts.OptimizationRemarkMissedPattern &&
            fn.getASTContext().LangOpts.OptimizationRemarkMissedPattern->match(
+               passName))),
+      analysisEnabled(
+          hasForceEmitSemanticAttr(fn, passName) ||
+          isMethodWithForceEmitSemanticAttrNominalType(fn) ||
+          (fn.getASTContext().LangOpts.OptimizationRemarkAnalysisPattern &&
+           fn.getASTContext().LangOpts.OptimizationRemarkAnalysisPattern->match(
                passName))) {}
 
 static SourceLoc getLocForPresentation(SILLocation loc,
@@ -343,10 +349,15 @@ void Emitter::emit(const RemarkMissed &remark) {
   emitRemark(fn, remark, diag::opt_remark_missed, isEnabled<RemarkMissed>());
 }
 
+void Emitter::emit(const RemarkAnalysis &remark) {
+  emitRemark(fn, remark, diag::opt_remark_analysis, isEnabled<RemarkAnalysis>());
+}
 void Emitter::emitDebug(const RemarkPassed &remark) {
   llvm::dbgs() << remark.getDebugMsg();
 }
-
 void Emitter::emitDebug(const RemarkMissed &remark) {
+  llvm::dbgs() << remark.getDebugMsg();
+}
+void Emitter::emitDebug(const RemarkAnalysis &remark) {
   llvm::dbgs() << remark.getDebugMsg();
 }

--- a/lib/SILOptimizer/Transforms/AssemblyVisionRemarkGenerator.cpp
+++ b/lib/SILOptimizer/Transforms/AssemblyVisionRemarkGenerator.cpp
@@ -549,7 +549,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::
     (void)foundArgs;
 
     // Use the actual source loc of the
-    auto remark = RemarkMissed("memory", *uccai)
+    auto remark = RemarkAnalysis("memory", *uccai)
                   << "unconditional runtime cast of value with type '"
                   << NV("ValueType", uccai->getSrc()->getType()) << "' to '"
                   << NV("CastType", uccai->getDest()->getType()) << "'";
@@ -571,7 +571,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::
     (void)foundArgs;
 
     // Use the actual source loc of the
-    auto remark = RemarkMissed("memory", *ccabi)
+    auto remark = RemarkAnalysis("memory", *ccabi)
                   << "conditional runtime cast of value with type '"
                   << NV("ValueType", ccabi->getSrc()->getType()) << "' to '"
                   << NV("CastType", ccabi->getDest()->getType()) << "'";
@@ -594,7 +594,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitBeginAccessInst(
 
     // Use the actual source loc of the
     auto remark =
-        RemarkMissed("memory", *bai, SourceLocInferenceBehavior::ForwardScan)
+        RemarkAnalysis("memory", *bai, SourceLocInferenceBehavior::ForwardScan)
         << "begin exclusive access to value of type '"
         << NV("ValueType", bai->getOperand()->getType()) << "'";
     for (auto arg : inferredArgs) {
@@ -618,7 +618,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitEndAccessInst(
     // Use the actual source loc of the begin_access if it works. Otherwise,
     // scan backwards.
     auto remark =
-        RemarkMissed("memory", *eai,
+        RemarkAnalysis("memory", *eai,
                      SourceLocInferenceBehavior::BackwardThenForwardAlwaysInfer,
                      SourceLocPresentationKind::EndRange)
         << "end exclusive access to value of type '"
@@ -641,7 +641,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitStrongRetainInst(
 
     // Retains begin a lifetime scope so we infer scan forward.
     auto remark =
-        RemarkMissed("memory", *sri,
+        RemarkAnalysis("memory", *sri,
                      SourceLocInferenceBehavior::ForwardScanAlwaysInfer)
         << "retain of type '" << NV("ValueType", sri->getOperand()->getType())
         << "'";
@@ -663,7 +663,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitStrongReleaseInst(
     (void)foundArgs;
 
     auto remark =
-        RemarkMissed("memory", *sri,
+        RemarkAnalysis("memory", *sri,
                      SourceLocInferenceBehavior::BackwardThenForwardAlwaysInfer,
                      SourceLocPresentationKind::EndRange)
         << "release of type '" << NV("ValueType", sri->getOperand()->getType())
@@ -685,7 +685,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitRetainValueInst(
     (void)foundArgs;
     // Retains begin a lifetime scope, so we infer scan forwards.
     auto remark =
-        RemarkMissed("memory", *rvi,
+        RemarkAnalysis("memory", *rvi,
                      SourceLocInferenceBehavior::ForwardScanAlwaysInfer)
         << "retain of type '" << NV("ValueType", rvi->getOperand()->getType())
         << "'";
@@ -707,7 +707,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitReleaseValueInst(
 
     // Releases end a lifetime scope so we infer scan backward.
     auto remark =
-        RemarkMissed("memory", *rvi,
+        RemarkAnalysis("memory", *rvi,
                      SourceLocInferenceBehavior::BackwardThenForwardAlwaysInfer)
         << "release of type '" << NV("ValueType", rvi->getOperand()->getType())
         << "'";
@@ -728,7 +728,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitAllocRefInstBase(
           valueToDeclInferrer.infer(ArgumentKeyKind::Note, ari, inferredArgs);
       (void)foundArgs;
       auto resultRemark =
-          RemarkPassed("memory", *ari, SourceLocInferenceBehavior::ForwardScan)
+          RemarkAnalysis("memory", *ari, SourceLocInferenceBehavior::ForwardScan)
           << "stack allocated ref of type '" << NV("ValueType", ari->getType())
           << "'";
       for (auto &arg : inferredArgs)
@@ -745,7 +745,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitAllocRefInstBase(
     (void)foundArgs;
 
     auto resultRemark =
-        RemarkMissed("memory", *ari, SourceLocInferenceBehavior::ForwardScan)
+        RemarkAnalysis("memory", *ari, SourceLocInferenceBehavior::ForwardScan)
         << "heap allocated ref of type '" << NV("ValueType", ari->getType())
         << "'";
     for (auto &arg : inferredArgs)
@@ -775,7 +775,7 @@ void AssemblyVisionRemarkGeneratorInstructionVisitor::visitAllocBoxInst(
     (void)foundArgs;
 
     auto resultRemark =
-        RemarkMissed("memory", *abi, SourceLocInferenceBehavior::ForwardScan)
+        RemarkAnalysis("memory", *abi, SourceLocInferenceBehavior::ForwardScan)
         << "heap allocated box of type '" << NV("ValueType", abi->getType())
         << "'";
     for (auto &arg : inferredArgs)
@@ -801,6 +801,7 @@ class AssemblyVisionRemarkGenerator : public SILFunctionTransform {
     // If we are supposed to emit remarks, always emit.
     if (bool(langOpts.OptimizationRemarkMissedPattern) ||
         bool(langOpts.OptimizationRemarkPassedPattern) ||
+        bool(langOpts.OptimizationRemarkAnalysisPattern) ||
         fn->getModule().getSILRemarkStreamer())
       return true;
 

--- a/test/SILOptimizer/assemblyvision_remark/basic.sil
+++ b/test/SILOptimizer/assemblyvision_remark/basic.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-opt-remark-ignore-always-infer -assemblyvisionremarkgen-declless-debugvalue-use-sildebugvar-info -assembly-vision-remark-generator -sil-remarks-missed=sil-assembly-vision-remark-gen -verify %s -o /dev/null
+// RUN: %target-sil-opt -sil-opt-remark-ignore-always-infer -assemblyvisionremarkgen-declless-debugvalue-use-sildebugvar-info -assembly-vision-remark-generator -sil-remarks-analysis=sil-assembly-vision-remark-gen -verify %s -o /dev/null
 
 sil_stage canonical
 

--- a/test/SILOptimizer/assemblyvision_remark/basic.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -O -Rpass-analysis=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify
 // REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -O -Rpass-analysis=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
@@ -12,7 +12,7 @@
 
 public class Klass {}
 
-// CHECK: --- !Missed
+// CHECK: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift',
@@ -25,7 +25,7 @@ public class Klass {}
 // CHECK-NEXT: ...
 public var global = Klass() // expected-remark {{heap allocated ref of type 'Klass'}}
 
-// CHECK: --- !Missed
+// CHECK: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
@@ -40,7 +40,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT:                        Line: [[# @LINE - 14 ]], Column: 12 }
 // CHECK-NEXT: ...
 //
-// CHECK: --- !Missed
+// CHECK: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
@@ -55,7 +55,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT:                        Line: [[# @LINE - 29 ]], Column: 12 }
 // CHECK-NEXT: ...
 //
-// CHECK: --- !Missed
+// CHECK: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift',
@@ -80,7 +80,7 @@ public func getGlobal() -> Klass {
                   // expected-note @-54:12 {{of 'global'}}
 }
 
-// CHECK: --- !Missed
+// CHECK: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
@@ -91,7 +91,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT:   - ValueType:
 // CHECK-NEXT:   - String:          ''''
 // CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
+// CHECK-NEXT: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
@@ -105,7 +105,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                        Line: [[# @LINE + 29 ]], Column: 9 }
 // CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
+// CHECK-NEXT: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
@@ -116,7 +116,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT:   - ValueType:
 // CHECK-NEXT:   - String:          ''''
 // CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
+// CHECK-NEXT: --- !Analysis
 // CHECK-NEXT: Pass:            sil-assembly-vision-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xfrontend -enable-copy-propagation=requested-passes-only -Xfrontend -enable-lexical-lifetimes=false -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -O -Rpass-analysis=sil-assembly-vision-remark-gen -Xfrontend -enable-copy-propagation=requested-passes-only -Xfrontend -enable-lexical-lifetimes=false -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_stdlib_no_asserts

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -O -Rpass-analysis=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib

--- a/test/SILOptimizer/assemblyvision_remark/force_emit_implicit_autogen.swift
+++ b/test/SILOptimizer/assemblyvision_remark/force_emit_implicit_autogen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify -Xllvm -assemblyvisionremarkgen-visit-implicit-autogen-funcs=1
+// RUN: %target-swiftc_driver -O -Rpass-analysis=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify -Xllvm -assemblyvisionremarkgen-visit-implicit-autogen-funcs=1
 
 // From the constructor.
 class Klass {} // expected-remark {{heap allocated ref of type 'Klass'}}


### PR DESCRIPTION
Now that the LLVM remarks has an analysis type, assembly vision should be switched as it is not missed optimizations.