### PR TITLE
Disable profiling_marker_thunks.swift on arm64e

### DIFF
--- a/test/IRGen/profiling_marker_thunks.swift
+++ b/test/IRGen/profiling_marker_thunks.swift
@@ -9,6 +9,8 @@
 // UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
+// UNSUPPORTED: CPU=arm64e
+
 // NOTHUNK-NOT: __swift_prof_thunk
 
 import P


### PR DESCRIPTION
The test fails because the output is different due to pointer signing

rdar://138114215