### PR TITLE
[6.0][IRGen] Don't try to emit single payload CVW for incompatible multi p…

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2406,7 +2406,8 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
     if (isMultiPayloadEnum() &&
         buildMultiPayloadRefCountString(IGM, B, genericSig)) {
       return true;
-    } else if (buildSinglePayloadRefCountString(IGM, B, genericSig)) {
+    } else if (!isMultiPayloadEnum() &&
+               buildSinglePayloadRefCountString(IGM, B, genericSig)) {
       return true;
     }
 


### PR DESCRIPTION
…ayload enums

  - **Explanation**: There was a missing condition in the branch that caused the compiler to try to emit a single payload enum compact value witness for multi payload enums, when the multi payload enum contained an incompatible case.

  - **Scope**: Compact value witnesses

  - **Issues**: rdar://137954177

  - **Original PRs**: https://github.com/swiftlang/swift/pull/77056

  - **Risk**: Low. Only affects compact value witnesses and the fix is small and tested.

  - **Testing**: Added unit test covering this issue.

  - **Reviewers**: @mikeash 