### PR TITLE
[6.0][Runtime] Properly compute offset for unmanaged properties in generic…

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2863,11 +2863,12 @@ void swift::swift_initStructMetadataWithLayoutString(
 
         auto tagAndOffset = ((uint64_t)tag << 56) | offset;
         writer.writeBytes(tagAndOffset);
+        previousFieldOffset = fieldType->size - sizeof(uintptr_t);
+      } else {
+        previousFieldOffset += fieldType->size;
       }
 
       fullOffset += fieldType->size;
-      previousFieldOffset = fieldType->size - sizeof(uintptr_t);
-
       continue;
     }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2853,11 +2853,10 @@ void swift::swift_initStructMetadataWithLayoutString(
     if (fieldTag) {
       const TypeLayout *fieldType = (const TypeLayout*)fieldTypes[i];
       auto alignmentMask = fieldType->flags.getAlignmentMask();
+      
       fullOffset = roundUpToAlignMask(fullOffset, alignmentMask);
-
+      size_t offset = fullOffset - unalignedOffset + previousFieldOffset;
       if (fieldTag <= 0x4) {
-        size_t offset = fullOffset - unalignedOffset + previousFieldOffset;
-
         auto tag = fieldTag <= 0x2 ? RefCountingKind::UnknownUnowned :
                                      RefCountingKind::UnknownWeak;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2865,7 +2865,7 @@ void swift::swift_initStructMetadataWithLayoutString(
         writer.writeBytes(tagAndOffset);
         previousFieldOffset = fieldType->size - sizeof(uintptr_t);
       } else {
-        previousFieldOffset += fieldType->size;
+        previousFieldOffset = offset + fieldType->size;
       }
 
       fullOffset += fieldType->size;

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -19,6 +19,17 @@ public struct GenericResilient<C, T> {
     }
 }
 
+public struct GenericResilientWithUnmanagedAndWeak<T> {
+    public let x: T
+    public unowned(unsafe) var y: AnyObject?
+    public let z: Int = 500
+    public weak var w: AnyObject?
+
+    public init(x: T) {
+        self.x = x
+    }
+}
+
 public enum ResilientSinglePayloadEnumGeneric<T> {
     case empty0
     case empty1

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -20,9 +20,10 @@ public struct GenericResilient<C, T> {
 }
 
 public struct GenericResilientWithUnmanagedAndWeak<T> {
-    public let x: T
+    public let b: Bool = false
     public unowned(unsafe) var y: AnyObject?
-    public let z: Int = 500
+    public let z: Bool = false
+    public let x: T
     public weak var w: AnyObject?
 
     public init(x: T) {

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1209,6 +1209,34 @@ func testWeakRefOptionalNative() {
 
 testWeakRefOptionalNative()
 
+func testGenericResilientWithUnmanagedAndWeak() {
+    let ptr = allocateInternalGenericPtr(of: GenericResilientWithUnmanagedAndWeak<TestClass>.self)
+
+    do {
+        let x = GenericResilientWithUnmanagedAndWeak<TestClass>(x: TestClass())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = GenericResilientWithUnmanagedAndWeak<TestClass>(x: TestClass())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: TestClass deinitialized!
+    testGenericDestroy(ptr, of: GenericResilientWithUnmanagedAndWeak<TestClass>.self)
+
+    ptr.deallocate()
+}
+
+testGenericResilientWithUnmanagedAndWeak()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
… CVW instantiation

  - **Explanation**: An unmanaged property does not map to an operation in CVW, instead it will be copied like primitive values. When instantiating the layout string, we correctly do not emit an operation, but we compute the offset to the next field as if we did. This is causing the offset to be incorrect and subsequent operations to be executed on the wrong address, causing crashes or other misbehavior.

  - **Scope**: Compact value witnesses

  - **Issues**: rdar://137066879

  - **Original PRs**: https://github.com/swiftlang/swift/pull/76799 https://github.com/swiftlang/swift/pull/77078

  - **Risk**: Low. Only affects compact value witnesses and the fix is small and tested.

  - **Testing**: Added unit test covering this issue.

  - **Reviewers**: @mikeash 
