### PR TITLE
[Runtime] Use aligned offset to compute new field offset for unmanage…

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2846,10 +2846,8 @@ void swift::swift_initStructMetadataWithLayoutString(
       const TypeLayout *fieldType = (const TypeLayout*)fieldTypes[i];
       auto alignmentMask = fieldType->flags.getAlignmentMask();
       fullOffset = roundUpToAlignMask(fullOffset, alignmentMask);
-
+      size_t offset = fullOffset - unalignedOffset + previousFieldOffset;
       if (fieldTag <= 0x4) {
-        size_t offset = fullOffset - unalignedOffset + previousFieldOffset;
-
         auto tag = fieldTag <= 0x2 ? RefCountingKind::UnknownUnowned :
                                      RefCountingKind::UnknownWeak;
 
@@ -2857,7 +2855,7 @@ void swift::swift_initStructMetadataWithLayoutString(
         writer.writeBytes(tagAndOffset);
         previousFieldOffset = fieldType->size - sizeof(uintptr_t);
       } else {
-        previousFieldOffset += fieldType->size;
+        previousFieldOffset = offset + fieldType->size;
       }
 
       fullOffset += fieldType->size;

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -20,9 +20,10 @@ public struct GenericResilient<C, T> {
 }
 
 public struct GenericResilientWithUnmanagedAndWeak<T> {
-    public let x: T
+    public let b: Bool = false
     public unowned(unsafe) var y: AnyObject?
-    public let z: Int = 500
+    public let z: Bool = false
+    public let x: T
     public weak var w: AnyObject?
 
     public init(x: T) {


### PR DESCRIPTION
…d properties in CVW

The original fix only added the field size to the unaligned offset, which is not correct.
