### PR TITLE
[Driver] Always parse response files as GNU command line arguments

### DIFF
--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -31,11 +31,8 @@ void swift::driver::ExpandResponseFilesWithRetry(llvm::StringSaver &Saver,
                                 llvm::SmallVectorImpl<const char *> &Args) {
   const unsigned MAX_COUNT = 30;
   for (unsigned I = 0; I != MAX_COUNT; ++I) {
-    if (llvm::cl::ExpandResponseFiles(Saver,
-        llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()
-          ? llvm::cl::TokenizeWindowsCommandLine
-          : llvm::cl::TokenizeGNUCommandLine,
-        Args)) {
+    if (llvm::cl::ExpandResponseFiles(Saver, llvm::cl::TokenizeGNUCommandLine,
+                                      Args)) {
       return;
     }
   }


### PR DESCRIPTION
clang parses response files in GNU mode, even on Windows except
- If you explicitly pass `--rsp-quoting=windows` in the command line invocation or
- If no `--rsp-quoting` is specified and clang is running `cl` mode, which is the case if clang is invoked as `cl` or `clang-cl`, which is the compatibility mode to Window’s `cl` compiler as far as I can tell.

The Swift driver always outputs response files in GNU mode (https://github.com/swiftlang/swift-driver/pull/1000).

Since Swift does not need to support a compatibility mode with another compiler, there is no need for it to parse response files in Windows mode. We should unconditionally parse the response files in GNU mode.
