### PR TITLE
test: Fix profiling_marker_thunks.swift for 32bit & comdat available targets

### DIFF
--- a/test/IRGen/profiling_marker_thunks.swift
+++ b/test/IRGen/profiling_marker_thunks.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/P.swiftmodule -module-name=P %S/../Inputs/resilient_protocol.swift
 // RUN: %target-swift-frontend -module-name A -I %t -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s
 // RUN: %target-swift-frontend -module-name A -I %t -enable-library-evolution -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name A -I %t -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s --check-prefix=ATTRIBUTE
+// RUN: %target-swift-frontend -module-name A -I %t -enable-profiling-marker-thunks -emit-ir %s | %FileCheck %s --check-prefix=ATTRIBUTE -DINT=i%target-ptrsize
 // RUN: %target-swift-frontend -module-name A -I %t -disable-profiling-marker-thunks -emit-ir %s | %FileCheck %s --check-prefix=NOTHUNK
 // RUN: %target-swift-frontend -module-name A -I %t -emit-ir %s | %FileCheck %s --check-prefix=NOTHUNK
 
@@ -95,8 +95,8 @@ public func test() {
 // CHECK: call swiftcc void @"$s1A7genericyyxlF"(ptr noalias %0, ptr %1)
 // CHECK: ret
 
-// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"({{.*}}) #[[ATTR]] {
-// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"({{.*}}) #[[ATTR]] {
+// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"({{.*}}) #[[ATTR]]{{( comdat)?}} {
+// CHECK: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"({{.*}}) #[[ATTR]]{{( comdat)?}} {
 
 // CHECK: attributes #[[ATTR]] = { noinline "frame-pointer"="all"
 
@@ -106,9 +106,9 @@ public func test() {
 // ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_func__1__$s1A16SomeGenericThingVySiSdGN___fun__$s1A7genericyyxlF"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP8retAssoc1TQzyFTW"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_witness__$s1A9ConformerVyxGAA9SomeProtoA2aEP5plainyyKFTW"({{.*}}) #[[ATTR]]
-// ATTRIBUTE: define {{.*}} i64 @"__swift_prof_thunk__generic_witness__$s1A18ResilientConformerVyxG1P0A12BaseProtocolAaeFP11requirementSiyFTW"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} [[INT]] @"__swift_prof_thunk__generic_witness__$s1A18ResilientConformerVyxG1P0A12BaseProtocolAaeFP11requirementSiyFTW"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvg"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: define {{.*}} void @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC1xxvs"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: define {{.*}} ptr @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassCyACyxGxcfC"({{.*}}) #[[ATTR]]
-// ATTRIBUTE: define {{.*}} i64 @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC10someMethodSiyF"({{.*}}) #[[ATTR]]
+// ATTRIBUTE: define {{.*}} [[INT]] @"__swift_prof_thunk__generic_vtable__$s1A12GenericClassC10someMethodSiyF"({{.*}}) #[[ATTR]]
 // ATTRIBUTE: #[[ATTR]] = { noinline "frame-pointer"="all"


### PR DESCRIPTION
The test case is failing on Wasm CI, so adjust it for such platforms https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1698/console