### PR TITLE
AST/Sema: Introduce `AvailabilityContext`

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -17,8 +17,10 @@
 #ifndef SWIFT_AST_AVAILABILITY_H
 #define SWIFT_AST_AVAILABILITY_H
 
+#include "swift/AST/PlatformKind.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
 
@@ -173,6 +175,8 @@ public:
   static VersionRange allGTE(const llvm::VersionTuple &EndPoint) {
     return VersionRange(EndPoint);
   }
+
+  void Profile(llvm::FoldingSetNodeID &ID) const;
 
 private:
   VersionRange(const llvm::VersionTuple &LowerEndpoint) {
@@ -329,6 +333,80 @@ public:
     assert(Range.hasLowerEndpoint());
     return Range.getLowerEndpoint().getAsString();
   }
+};
+
+/// An `AvailabilityContext` summarizes the availability constraints for a
+/// specific scope, such as within a declaration or at a particular source
+/// location in a function body. This context is sufficient to determine whether
+/// a declaration is available or not in that scope.
+class AvailabilityContext : public llvm::FoldingSetNode {
+  /// Summarizes platform specific availability constraints.
+  struct PlatformInfo {
+    /// The introduction version.
+    AvailabilityRange Range;
+
+    /// Sets `Range` to `other` if `other` is more restrictive. Returns true if
+    /// any property changed as a result of adding this constraint.
+    bool constrainRange(const AvailabilityRange &other) {
+      if (!other.isContainedIn(Range))
+        return false;
+
+      Range = other;
+      return true;
+    }
+
+    /// Sets `Range` to the platform introduction range of `decl` if that range
+    /// is more restrictive. Returns true if
+    /// any property changed as a result of adding this constraint.
+    bool constrainRange(const Decl *decl);
+
+    void Profile(llvm::FoldingSetNodeID &ID) const {
+      Range.getRawVersionRange().Profile(ID);
+    }
+  };
+  PlatformInfo PlatformAvailability;
+
+  AvailabilityContext(const PlatformInfo &platformInfo)
+      : PlatformAvailability(platformInfo){};
+
+  static const AvailabilityContext *get(const PlatformInfo &platformInfo,
+                                        ASTContext &ctx);
+
+public:
+  /// Retrieves the default `AvailabilityContext`, which is maximally available.
+  /// The platform availability range will be set to the deployment target (or
+  /// minimum inlining target when applicable).
+  static const AvailabilityContext *getDefault(ASTContext &ctx);
+
+  /// Retrieves a uniqued `AvailabilityContext` with the given platform
+  /// availability parameters.
+  static const AvailabilityContext *
+  get(const AvailabilityRange &platformAvailability, ASTContext &ctx) {
+    PlatformInfo platformInfo{
+        .Range = platformAvailability,
+    };
+    return get(platformInfo, ctx);
+  }
+
+  /// Returns the range of platform versions which may execute code in the
+  /// availability context, starting at its introduction version.
+  AvailabilityRange getPlatformRange() const {
+    return PlatformAvailability.Range;
+  }
+
+  /// Returns the unique context that is the result of constraining the current
+  /// context's platform availability range with `platformRange`.
+  const AvailabilityContext *
+  constrainWithPlatformRange(const AvailabilityRange &platformRange,
+                             ASTContext &ctx) const;
+
+  /// Returns the unique context that is the result of constraining the current
+  /// context both with the availability attributes of `decl` and with
+  /// `platformRange`.
+  const AvailabilityContext *constrainWithDeclAndPlatformRange(
+      Decl *decl, const AvailabilityRange &platformRange) const;
+
+  void Profile(llvm::FoldingSetNodeID &ID) const;
 };
 
 class AvailabilityInference {

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -382,9 +382,7 @@ public:
   /// availability parameters.
   static const AvailabilityContext *
   get(const AvailabilityRange &platformAvailability, ASTContext &ctx) {
-    PlatformInfo platformInfo{
-        .Range = platformAvailability,
-    };
+    PlatformInfo platformInfo{platformAvailability};
     return get(platformInfo, ctx);
   }
 

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -171,7 +171,7 @@ private:
 
   /// A canonical availability info for this context, computed top-down from the
   /// root context.
-  AvailabilityRange AvailabilityInfo;
+  const AvailabilityContext *AvailabilityInfo;
 
   std::vector<TypeRefinementContext *> Children;
 
@@ -184,33 +184,33 @@ private:
 
   TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
                         TypeRefinementContext *Parent, SourceRange SrcRange,
-                        const AvailabilityRange &Info);
+                        const AvailabilityContext *Info);
 
 public:
   /// Create the root refinement context for the given SourceFile.
   static TypeRefinementContext *
-  createForSourceFile(SourceFile *SF, const AvailabilityRange &Info);
+  createForSourceFile(SourceFile *SF, const AvailabilityContext *Info);
 
   /// Create a refinement context for the given declaration.
   static TypeRefinementContext *createForDecl(ASTContext &Ctx, Decl *D,
                                               TypeRefinementContext *Parent,
-                                              const AvailabilityRange &Info,
+                                              const AvailabilityContext *Info,
                                               SourceRange SrcRange);
 
   /// Create a refinement context for the given declaration.
   static TypeRefinementContext *
   createForDeclImplicit(ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
-                        const AvailabilityRange &Info, SourceRange SrcRange);
+                        const AvailabilityContext *Info, SourceRange SrcRange);
 
   /// Create a refinement context for the Then branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtThen(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,
-                      const AvailabilityRange &Info);
+                      const AvailabilityContext *Info);
 
   /// Create a refinement context for the Else branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtElse(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,
-                      const AvailabilityRange &Info);
+                      const AvailabilityContext *Info);
 
   /// Create a refinement context for the true-branch control flow to
   /// further StmtConditionElements following a #available() query in
@@ -219,24 +219,24 @@ public:
   createForConditionFollowingQuery(ASTContext &Ctx, PoundAvailableInfo *PAI,
                                    const StmtConditionElement &LastElement,
                                    TypeRefinementContext *Parent,
-                                   const AvailabilityRange &Info);
+                                   const AvailabilityContext *Info);
 
   /// Create a refinement context for the fallthrough of a GuardStmt.
   static TypeRefinementContext *createForGuardStmtFallthrough(
       ASTContext &Ctx, GuardStmt *RS, BraceStmt *ContainingBraceStmt,
-      TypeRefinementContext *Parent, const AvailabilityRange &Info);
+      TypeRefinementContext *Parent, const AvailabilityContext *Info);
 
   /// Create a refinement context for the else branch of a GuardStmt.
   static TypeRefinementContext *
   createForGuardStmtElse(ASTContext &Ctx, GuardStmt *RS,
                          TypeRefinementContext *Parent,
-                         const AvailabilityRange &Info);
+                         const AvailabilityContext *Info);
 
   /// Create a refinement context for the body of a WhileStmt.
   static TypeRefinementContext *
   createForWhileStmtBody(ASTContext &Ctx, WhileStmt *WS,
                          TypeRefinementContext *Parent,
-                         const AvailabilityRange &Info);
+                         const AvailabilityContext *Info);
 
   Decl *getDeclOrNull() const {
     auto IntroReason = getReason();
@@ -276,10 +276,15 @@ public:
   /// Returns the source range on which this context refines types.
   SourceRange getSourceRange() const { return SrcRange; }
 
-  /// Returns the information on what can be assumed present at run time when
-  /// running code contained in this context.
-  const AvailabilityRange &getAvailabilityInfo() const {
+  /// Returns the availability context of code contained in this context.
+  const AvailabilityContext *getAvailabilityContext() const {
     return AvailabilityInfo;
+  }
+
+  /// Returns the platform version range that can be assumed present at run
+  /// time when running code contained in this context.
+  const AvailabilityRange getPlatformAvailabilityRange() const {
+    return AvailabilityInfo->getPlatformRange();
   }
 
   /// Adds a child refinement context.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -29,6 +29,26 @@
 
 using namespace swift;
 
+void VersionRange::Profile(llvm::FoldingSetNodeID &id) const {
+  id.AddBoolean(hasLowerEndpoint());
+  if (!hasLowerEndpoint()) {
+    id.AddBoolean(isAll());
+    return;
+  }
+
+  auto profileVersionComponent = [&id](std::optional<unsigned> component) {
+    id.AddBoolean(component.has_value());
+    if (component)
+      id.AddInteger(*component);
+  };
+
+  auto lowerEndpoint = getLowerEndpoint();
+  id.AddInteger(lowerEndpoint.getMajor());
+  profileVersionComponent(lowerEndpoint.getMinor());
+  profileVersionComponent(lowerEndpoint.getSubminor());
+  profileVersionComponent(lowerEndpoint.getBuild());
+}
+
 AvailabilityRange
 AvailabilityRange::forDeploymentTarget(const ASTContext &Ctx) {
   return AvailabilityRange(
@@ -42,6 +62,47 @@ AvailabilityRange AvailabilityRange::forInliningTarget(const ASTContext &Ctx) {
 
 AvailabilityRange AvailabilityRange::forRuntimeTarget(const ASTContext &Ctx) {
   return AvailabilityRange(VersionRange::allGTE(Ctx.LangOpts.RuntimeVersion));
+}
+
+bool AvailabilityContext::PlatformInfo::constrainRange(const Decl *decl) {
+  if (auto range = AvailabilityInference::annotatedAvailableRange(decl))
+    return constrainRange(*range);
+
+  return false;
+}
+
+const AvailabilityContext *AvailabilityContext::getDefault(ASTContext &ctx) {
+  PlatformInfo platformInfo{.Range = AvailabilityRange::forInliningTarget(ctx)};
+  return AvailabilityContext::get(platformInfo, ctx);
+}
+
+/// Returns the unique context that is the result of constraining the current
+/// context's platform availability range with `platformRange`.
+const AvailabilityContext *AvailabilityContext::constrainWithPlatformRange(
+    const AvailabilityRange &platformRange, ASTContext &ctx) const {
+  PlatformInfo platformAvailability{PlatformAvailability};
+  if (platformAvailability.constrainRange(platformRange))
+    return get(platformAvailability, ctx);
+
+  return this;
+}
+
+const AvailabilityContext *
+AvailabilityContext::constrainWithDeclAndPlatformRange(
+    Decl *decl, const AvailabilityRange &platformRange) const {
+  PlatformInfo platformAvailability{PlatformAvailability};
+  bool isConstrained = false;
+  isConstrained |= platformAvailability.constrainRange(decl);
+  isConstrained |= platformAvailability.constrainRange(platformRange);
+
+  if (!isConstrained)
+    return this;
+
+  return get(platformAvailability, decl->getASTContext());
+}
+
+void AvailabilityContext::Profile(llvm::FoldingSetNodeID &id) const {
+  PlatformAvailability.Profile(id);
 }
 
 namespace {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -72,7 +72,7 @@ bool AvailabilityContext::PlatformInfo::constrainRange(const Decl *decl) {
 }
 
 const AvailabilityContext *AvailabilityContext::getDefault(ASTContext &ctx) {
-  PlatformInfo platformInfo{.Range = AvailabilityRange::forInliningTarget(ctx)};
+  PlatformInfo platformInfo{AvailabilityRange::forInliningTarget(ctx)};
   return AvailabilityContext::get(platformInfo, ctx);
 }
 


### PR DESCRIPTION
`AvailabilityContext` is designed to be a compact representation of the active availability constraints in a specific scope. For now, it only models platform introduction availability but it will soon be updated to cover additional availability constraints, like platform unavailability.

`TypeRefinementContext` now represents availability constraints using `AvailabilityContext` instead of just an `AvailabilityRange` representing only platform introduction versions. In anticipation of the memory requirements for `AvailabilityContext` growing, a cache of uniqued instances of `AvailabilityContext` are stored in a
`llvm::FoldingSet` on `ASTContext`.

There should be no functional changes since this just changes the representation of the existing information stored by `TypeRefinementContext`. However, in the future `AvailabilityContext` will be expanded to represent additional availability constraints.
