### PR TITLE
[Tests] Fix Interpreter/layout_string_witnesses_objc.swift

### DIFF
--- a/test/Interpreter/layout_string_witnesses_objc.swift
+++ b/test/Interpreter/layout_string_witnesses_objc.swift
@@ -64,7 +64,7 @@ struct MultiPayloadObjCExistentialWrapper {
 }
 
 func testMultiPayloadObjCExistentialWrapper() {
-    let ptr = allocateInternalGenericPtr(of: NestedWrapper<MultiPayloadObjCExistentialWrapper>.self)
+    let ptr = allocateInternalGenericPtr(of: MultiPayloadObjCExistentialWrapper.self)
 
     do {
         let x = MultiPayloadObjCExistentialWrapper(x: .y(ObjCPrintOnDealloc()))
@@ -84,7 +84,7 @@ func testMultiPayloadObjCExistentialWrapper() {
     print("Before deinit")
 
     // CHECK-NEXT: ObjCPrintOnDealloc deinitialized!
-    testGenericDestroy(ptr, of: NestedWrapper<MultiPayloadObjCExistentialWrapper>.self)
+    testGenericDestroy(ptr, of: MultiPayloadObjCExistentialWrapper.self)
 
     ptr.deallocate()
 }


### PR DESCRIPTION
rdar://138141889

The allocation and destruction was accidentally using a wrapper, but the initialization did not, so this test could crash if the uninitialized memory contained a valid address.