### PR TITLE
[Windows] Run swift-format tests

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,swift,dispatch,foundation,xctest,
+set TestArg=-Test lld,swift,dispatch,foundation,xctest,swift-format,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 


### PR DESCRIPTION
This reverts commit 2c78894f5cd50676483cb22b82973fb6699ae402, re-enabling swift-format tests on Windows.
