### PR TITLE
[ASTGen] Correct swiftMacroEvaluation source path in Package.swift

### DIFF
--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -78,7 +78,7 @@ let package = Package(
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax"),
       ],
-      path: "Sources/Macros",
+      path: "Sources/MacroEvaluation",
       swiftSettings: swiftSetttings
     ),
     .target(


### PR DESCRIPTION
#76937 missed this change