### PR TITLE
[cxx-interop] Mark some zero-sized value types as unavailable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2086,6 +2086,8 @@ ERROR(unexposed_other_decl_in_cxx,none,
       "%kind0 is not yet exposed to C++", (ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,
       "Swift %kind0 cannot be represented in C++", (ValueDecl *))
+ERROR(expose_zero_size_to_cxx,none,
+      "%0 is a zero sized value type, it cannot be exposed to C++ yet", (ValueDecl *))
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -14,8 +14,10 @@
 #define SWIFT_NAME_TRANSLATION_H
 
 #include "swift/AST/AttrKind.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Identifier.h"
+#include <optional>
 
 namespace swift {
 
@@ -84,6 +86,7 @@ enum RepresentationError {
   UnrepresentableMoveOnly,
   UnrepresentableNested,
   UnrepresentableMacro,
+  UnrepresentableZeroSizedValueType,
 };
 
 /// Constructs a diagnostic that describes the given C++ representation error.
@@ -99,11 +102,15 @@ struct DeclRepresentation {
 };
 
 /// Returns the C++ representation info for the given declaration.
-DeclRepresentation getDeclRepresentation(const ValueDecl *VD);
+DeclRepresentation getDeclRepresentation(
+    const ValueDecl *VD,
+    std::optional<std::function<bool(const NominalTypeDecl *)>> isZeroSized);
 
 /// Returns true if the given value decl is exposable to C++.
-inline bool isExposableToCxx(const ValueDecl *VD) {
-  return !getDeclRepresentation(VD).isUnsupported();
+inline bool isExposableToCxx(
+    const ValueDecl *VD,
+    std::optional<std::function<bool(const NominalTypeDecl *)>> isZeroSized) {
+  return !getDeclRepresentation(VD, isZeroSized).isUnsupported();
 }
 
 /// Returns true if the given value decl D is visible to C++ of its

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -118,6 +118,8 @@ public:
   /// the options the printer was constructed with.
   bool shouldInclude(const ValueDecl *VD);
 
+  bool isZeroSized(const NominalTypeDecl *decl);
+
   /// Returns true if \p vd is visible given the current access level and thus
   /// can be included in the generated header.
   bool isVisible(const ValueDecl *vd) const;

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -952,7 +952,10 @@ public:
 
       // Emit an unavailable stub for a Swift type.
       if (auto *nmtd = dyn_cast<NominalTypeDecl>(vd)) {
-        auto representation = cxx_translation::getDeclRepresentation(vd);
+        auto representation = cxx_translation::getDeclRepresentation(
+            vd, [this](const NominalTypeDecl *decl) {
+              return printer.isZeroSized(decl);
+            });
         if (nmtd->isGeneric()) {
           auto genericSignature =
               nmtd->getGenericSignature().getCanonicalSignature();

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -208,6 +208,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
     // e.g. it has resilient fields.
     if (typeSizeAlign && typeSizeAlign->size == 0) {
       // FIXME: How to represent 0 sized structs?
+      declAndTypePrinter.getCxxDeclEmissionScope()
+          .additionalUnrepresentableDeclarations.push_back(typeDecl);
       return;
     }
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -50,6 +50,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
+#include <optional>
 
 using namespace swift;
 
@@ -2321,7 +2322,7 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
     }
 
     // Verify that the declaration is exposable.
-    auto repr = cxx_translation::getDeclRepresentation(VD);
+    auto repr = cxx_translation::getDeclRepresentation(VD, std::nullopt);
     if (repr.isUnsupported())
       diagnose(attr->getLocation(),
                cxx_translation::diagnoseRepresenationError(*repr.error, VD));

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -8,4 +8,45 @@
 
 public struct ZeroSizedStruct {}
 
+public struct ZeroSizedStruct2 {
+    var property: ZeroSizedStruct
+    var void: Void
+    var bar: ()
+    public init() {
+        property = .init()
+    }
+}
+
+public enum ZeroSizedEnum {
+}
+
+public enum ZeroSizedEnum2 {
+    case foo
+}
+
+public enum ZeroSizedEnum3 {
+    case foo(ZeroSizedStruct, ZeroSizedEnum, ZeroSizedStruct2)
+}
+
+public func f() -> ZeroSizedStruct {
+    ZeroSizedStruct()
+}
+
+public func g(x: ZeroSizedStruct) {
+}
+
+// CHECK: class ZeroSizedEnum { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum' is a zero sized value type, it cannot be exposed to C++ yet");
+
+// CHECK: class ZeroSizedEnum2 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum2' is a zero sized value type, it cannot be exposed to C++ yet");
+
+// CHECK: class ZeroSizedEnum3 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedEnum3' is a zero sized value type, it cannot be exposed to C++ yet");
+
+// CHECK: class ZeroSizedStruct { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedStruct' is a zero sized value type, it cannot be exposed to C++ yet");
+
+// CHECK: class ZeroSizedStruct2 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedStruct2' is a zero sized value type, it cannot be exposed to C++ yet");
+
+// CHECK: // Unavailable in C++: Swift global function 'f()'.
+
+// CHECK: // Unavailable in C++: Swift global function 'g(x:)'.
+
 // CHECK: } // namespace Structs


### PR DESCRIPTION
Currently, we do not support exporting zero-sized value types from Swift to C++. It needs some work on our end as these types are not part of the lowered signature. In the meantime, this PR makes sure that common (but not all) zero sized types are properly marked as unavailable. This is important as the proper diagnostic will give users a hint how to work around this problem. Moreover, it is really easy to hit this when someone is experimenting with interop, so it is important to not have a cryptic failure mode.

rdar://138122545
