### PR TITLE
Disable use-std-function.swift on ubuntu-24.04

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -10,7 +10,7 @@
 // libstdc++11 declares a templated constructor of std::function with an rvalue-reference parameter,
 // which aren't yet supported in Swift. Therefore initializing a std::function from Swift closures
 // will not work on the platforms that are shipped with this version of libstdc++ (rdar://125816354).
-// XFAIL: LinuxDistribution=ubuntu-24.10
+// XFAIL: LinuxDistribution=ubuntu-24.04
 // XFAIL: LinuxDistribution=ubuntu-22.04
 // XFAIL: LinuxDistribution=rhel-9.3
 // XFAIL: LinuxDistribution=rhel-9.4


### PR DESCRIPTION
This fixes 9850a28ace397927aec09c8c00fd6d2eee7e0575, which was checking for the wrong Ubuntu version.

rdar://138183421