### PR TITLE
[6.0] Ensure we are using mapped SIL type for switch_enum case and not the original lowered one

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4044,8 +4044,8 @@ protected:
 
       SILBuilder caseBuilder = assignment.getBuilder(caseBB->begin());
       auto *caseAddr =
-          caseBuilder.createUncheckedTakeEnumDataAddr(loc, opdAddr, caseDecl);
-
+        caseBuilder.createUncheckedTakeEnumDataAddr(loc, opdAddr, caseDecl,
+                                                    caseArg->getType().getAddressType());
       if (assignment.isLargeLoadableType(caseArg->getType())) {
         assignment.mapValueToAddress(caseArg, caseAddr);
         assignment.markBlockArgumentForDeletion(caseBB);

--- a/test/IRGen/loadable_by_address_issue73018.sil
+++ b/test/IRGen/loadable_by_address_issue73018.sil
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -Xllvm -verify-continue-on-failure -c -o %t/t.o 2>&1 | %FileCheck %s
+
+// This used to trigger an assertion due to LoadableByAddress not doing proper mapping of
+// switch_enum arguments during rewriting
+
+import Builtin
+import Swift
+
+typealias X = Int
+typealias LargeX = (() -> X, () -> X, () -> X, () -> X, () -> X, () -> X, () -> X, () -> X, () -> X)
+
+enum enum1 {
+case bb0(LargeX)
+}
+
+enum enum2 {
+case bb0(LargeX)
+}
+
+enum large_enum {
+case bb1((enum1, X))
+case bb2((enum2, X))
+}
+
+sil @test1 : $@convention(thin) (@guaranteed large_enum) -> () {
+// CHECK-LABEL: sil @test1
+bb0(%arg : $large_enum):
+  %loc = alloc_stack $(@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                       @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                       @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                       @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,                       
+                       @callee_guaranteed () -> @owned X)
+  switch_enum %arg : $large_enum, case #large_enum.bb1!enumelt: bb1, case #large_enum.bb2!enumelt: bb2
+
+bb1(%e1 : $(enum1, X)):
+  // CHECK: %[[ADDR1:.*]] = unchecked_take_enum_data_addr %{{.*}} : $*enum1, #enum1.bb0!enumelt
+  // CHECK: copy_addr [take] %[[ADDR1]] to [init] %1 : $*(@callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int)
+  %e11 = tuple_extract %e1 : $(enum1, X), 0
+  switch_enum %e11 : $enum1, case #enum1.bb0!enumelt: bb11
+
+bb11(%p1 : $((@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,              
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X))):
+  br bb3(%p1 : $((@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,                  
+                  @callee_guaranteed () -> @owned X)))                      
+
+bb2(%e2 : $(enum2, X)):
+  // CHECK: %[[ADDR2:.*]] = unchecked_take_enum_data_addr %{{.*}} : $*enum2, #enum2.bb0!enumelt
+  // CHECK: copy_addr [take] %[[ADDR2]] to [init] %1 : $*(@callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int, @callee_guaranteed () -> @owned Int)
+  %e22 = tuple_extract %e2 : $(enum2, X), 0
+  switch_enum %e22 : $enum2, case #enum2.bb0!enumelt: bb22
+
+bb22(%p2 : $((@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+              @callee_guaranteed () -> @owned X))):
+  br bb3(%p2 : $((@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,  
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                  @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,            
+                  @callee_guaranteed () -> @owned X)))                      
+
+bb3(%p3 : $((@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+             @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+             @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+             @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,              
+             @callee_guaranteed () -> @owned X))):
+  store %p3 to %loc : $*(@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                         @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                         @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                         @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,              
+                         @callee_guaranteed () -> @owned X)
+            
+  dealloc_stack %loc : $*(@callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                          @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                          @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,
+                          @callee_guaranteed () -> @owned X, @callee_guaranteed () -> @owned X,              
+                          @callee_guaranteed () -> @owned X)
+  %t = tuple ()
+  return %t : $()
+}


### PR DESCRIPTION
  - **Explanation**:
 Cherrypicks the fix for the assertion failure from https://github.com/swiftlang/swift/issues/73018 into 6.0 release toolchains.
  - **Scope**:
Looks like this mainly affects autodiff code.
  - **Issues**:
https://github.com/swiftlang/swift/issues/73018
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/73385
  - **Risk**:
Low, the original fix has landed and stuck on main for months.
  - **Testing**:
A test case is included. No additional testing needed.
  - **Reviewers**:
@asl 
@aschwaighofer 
@slavapestov 