### PR TITLE
[swift_snapshot_tool] Turn off dry run from run command.

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -56,7 +56,7 @@ struct RunToolchains: AsyncParsableCommand {
     }
 
     // Load our tags from swift's github repo
-    let tags = try! await getTagsFromSwiftRepo(branch: branch, dryRun: true)
+    let tags = try! await getTagsFromSwiftRepo(branch: branch)
 
     guard var tagIndex = tags.firstIndex(where: { $0.tag.name == self.tag }) else {
       log("Failed to find tag: \(self.tag)")


### PR DESCRIPTION
I think this snuck in b/c I was playing with run_toolchain... unfortunately it made it not actually work. Noticed it while I was triaging today.
