### PR TITLE
[6.0] Add missed case to AssignAddressToDef.

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3798,6 +3798,15 @@ protected:
     assignment.mapValueToAddress(origValue, newAddr);
     assignment.markForDeletion(bc);
   }
+
+  void visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *bc) {
+    auto builder = assignment.getBuilder(bc->getIterator());
+    auto opdAddr = assignment.getAddressForValue(bc->getOperand());
+    auto newAddr = builder.createUncheckedAddrCast(
+        bc->getLoc(), opdAddr, bc->getType().getAddressType());
+    assignment.mapValueToAddress(origValue, newAddr);
+    assignment.markForDeletion(bc);
+  }
 };
 } // namespace
 


### PR DESCRIPTION
  - **Explanation**:
 Cherrypicks the fix for the assertion failure from https://github.com/swiftlang/swift/pull/72617 into 6.0 release toolchains.
  - **Scope**:
Looks like this mainly affects autodiff code.
  - **Issues**:
https://github.com/swiftlang/swift/issues/71744
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/72617
  - **Risk**:
Low, the original fix has landed and stuck on main for months.
  - **Testing**:
No additional testing needed.
  - **Reviewers**:
@asl 
@aschwaighofer 