### PR TITLE
[Index] Convert to hashing to `HashBuilder` with BLAKE3

### DIFF
--- a/test/Index/Store/cross-import-overlay.swift
+++ b/test/Index/Store/cross-import-overlay.swift
@@ -25,7 +25,7 @@ from__ABAdditionsCAdditions()
 //
 // RUN: %FileCheck %s --input-file %t/units --check-prefix=MAIN
 // MAIN:      module-name: cross_import_overlay
-// MAIN:      out-file: {{.*}}/file1.o
+// MAIN:      out-file: {{.*}}{{/|\\}}file1.o
 // MAIN-NEXT: target: {{.*}}
 // MAIN-NEXT: is-debug: 1
 // MAIN-NEXT: DEPEND START

--- a/test/Index/Store/unit-multiple-sourcefiles-remapped.swift
+++ b/test/Index/Store/unit-multiple-sourcefiles-remapped.swift
@@ -2,39 +2,50 @@
 
 // RUN: %empty-directory(%t)
 // RUN: touch %t/s1.swift %t/s2.swift
-// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file %t/s1.swift %t/s2.swift -o %t/s1.o -c -module-name main -emit-module -emit-module-path %t/s1.swiftmodule
-// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift -primary-file %t/s2.swift -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/s2.swiftmodule
-// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swiftmodule %t/s2.swiftmodule -emit-module -o %t/main.swiftmodule -module-name main
-// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+// RUN: echo "-----separate-----" > %t/units.out
+// RUN: %target-swift-frontend -index-store-path %t/idx1 -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file %t/s1.swift %t/s2.swift -o %t/s1.o -c -module-name main -emit-module -emit-module-path %t/s1.swiftmodule
+// RUN: %target-swift-frontend -index-store-path %t/idx1 -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift -primary-file %t/s2.swift -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/s2.swiftmodule
+// RUN: %target-swift-frontend -index-store-path %t/idx1 -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swiftmodule %t/s2.swiftmodule -emit-module -o %t/main.swiftmodule -module-name main
+// RUN: c-index-test core -print-unit %t/idx1 >> %t/units.out
 
 //===--- Building source files together (e.g. WMO)
 
-// RUN: %empty-directory(%t)
-// RUN: touch %t/s1.swift %t/s2.swift
-// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift %t/s2.swift -o %t/s1.o -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/main.swiftmodule
-// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+// RUN: echo "-----together-----" >> %t/units.out
+// RUN: %target-swift-frontend -index-store-path %t/idx2 -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift %t/s2.swift -o %t/s1.o -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/main.swiftmodule
+// RUN: c-index-test core -print-unit %t/idx2 >> %t/units.out
 
 //===--- Building separately but with relative paths for the source file inputs
 
-// RUN: %empty-directory(%t)
 // RUN: cd %t
-// RUN: touch %t/s1.swift %t/s2.swift
-// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file s1.swift s2.swift -o s1.o -c -module-name main -emit-module -emit-module-path s1.swiftmodule
-// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR s1.swift -primary-file s2.swift -o s2.o -c -module-name main -emit-module -emit-module-path s2.swiftmodule
-// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR s1.swiftmodule s2.swiftmodule -emit-module -o main.swiftmodule -module-name main
-// RUN: c-index-test core -print-unit idx | %FileCheck %s
-// CHECK-NOT: main.swiftmodule-{{[A-Z0-9]*}}
+// RUN: echo "-----together-relative-----" >> %t/units.out
+// RUN: %target-swift-frontend -index-store-path idx3 -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file s1.swift s2.swift -o s1.o -c -module-name main -emit-module -emit-module-path s1.swiftmodule
+// RUN: %target-swift-frontend -index-store-path idx3 -file-prefix-map %t=REMAPPED_OUT_DIR s1.swift -primary-file s2.swift -o s2.o -c -module-name main -emit-module -emit-module-path s2.swiftmodule
+// RUN: %target-swift-frontend -index-store-path idx3 -file-prefix-map %t=REMAPPED_OUT_DIR s1.swiftmodule s2.swiftmodule -emit-module -o main.swiftmodule -module-name main
+// RUN: c-index-test core -print-unit idx3 >> %t/units.out
 
-// CHECK: s1.o-{{2LQAU7D8TZHZ8|2RHC8ZJFDYDW4}}
+// RUN: %FileCheck %s --dump-input-filter all < %t/units.out
+
+// CHECK: -----separate-----
+// CHECK: s1.o-[[S1_HASH:.*$]]
 // CHECK: --------
 // CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s1.o
-// CHECK: DEPEND START
-// CHECK: Unit | system | {{.*}}Swift.swiftmodule
-// CHECK: DEPEND END
-
-// CHECK: s2.o-{{2OIL2LG8UULK6|15MCL6ZLKZKNL}}
+// CHECK: s2.o-[[S2_HASH:.*$]]
 // CHECK: --------
 // CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s2.o
-// CHECK: DEPEND START
-// CHECK: Unit | system | {{.*}}Swift.swiftmodule
-// CHECK: DEPEND END
+
+// CHECK: -----together-----
+// CHECK: s1.o-[[S1_HASH]]
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s1.o
+// CHECK: s2.o-[[S2_HASH]]
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s2.o
+
+// CHECK: -----together-relative-----
+// CHECK: s1.o-[[S1_HASH]]
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s1.o
+// CHECK: s2.o-[[S2_HASH]]
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s2.o

--- a/test/Index/Store/unit-one-sourcefile-remapped.swift
+++ b/test/Index/Store/unit-one-sourcefile-remapped.swift
@@ -1,9 +1,16 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/BuildRoot && cd %t/BuildRoot
-// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %S=REMAPPED_SRC_ROOT -file-prefix-map %t=REMAPPED_OUT_DIR %s -o %t/file1.o -typecheck
-// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s --dump-input-filter all
 
-// CHECK: file1.o-1AYKXZF3HH50A
+// Check paths are mapped
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %S=REMAPPED_SRC_ROOT -file-prefix-map %t=REMAPPED_OUT_DIR %s -o %t/file1.o -typecheck
+// RUN: c-index-test core -print-unit %t/idx > %t/units.out
+
+// Check round-trip remapping to make sure they're converted back to the local paths
+// RUN: c-index-test core -print-unit %t/idx -index-store-prefix-map REMAPPED_SRC_ROOT=%S -index-store-prefix-map REMAPPED_OUT_DIR=%t >> %t/units.out
+
+// RUN: %FileCheck %s --dump-input-filter all < %t/units.out
+
+// CHECK: file1.o-[[UNIT_HASH:.*$]]
 // CHECK: --------
 // CHECK: main-path: REMAPPED_SRC_ROOT{{/|\\}}unit-one-sourcefile-remapped.swift
 // CHECK: work-dir: REMAPPED_OUT_DIR{{/|\\}}BuildRoot
@@ -12,11 +19,9 @@
 // CHECK: Unit | system | Swift | {{BUILD_DIR|.*lib\\swift\\windows}}{{.*}}Swift.swiftmodule
 // CHECK: DEPEND END
 
+// CHECK: file1.o-[[UNIT_HASH]]
+// CHECK: --------
+// CHECK: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}Index{{/|\\}}Store{{/|\\}}unit-one-sourcefile-remapped.swift
+// CHECK-NOT: work-dir: REMAPPED_OUT_DIR
 
-// Check round-trip remapping to make sure they're converted back to the local paths.
-// RUN: c-index-test core -print-unit %t/idx -index-store-prefix-map REMAPPED_SRC_ROOT=%S -index-store-prefix-map  REMAPPED_OUT_DIR=%t | %FileCheck %s -check-prefix=ROUNDTRIP --dump-input-filter all
-
-// ROUNDTRIP: file1.o-1AYKXZF3HH50A
-// ROUNDTRIP: --------
-// ROUNDTRIP: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}Index{{/|\\}}Store{{/|\\}}unit-one-sourcefile-remapped.swift
-// ROUNDTRIP-NOT: work-dir: REMAPPED_OUT_DIR
+// CHECK-NOT: file1.o-[[UNIT_HASH]]

--- a/test/Index/Store/unit-pcm-dependency-remapped.swift
+++ b/test/Index/Store/unit-pcm-dependency-remapped.swift
@@ -59,7 +59,7 @@ func test() {
 // FILE1: Record | user | {{.*}}ClangModuleB.h | ClangModuleB.h-
 // FILE1: DEPEND END
 
-// FILE1: s1.o-{{2LQAU7D8TZHZ8|2RHC8ZJFDYDW4}}
+// FILE1: s1.o-
 // FILE1: --------
 // FILE1: has-main: 1
 // FILE1-ABSOLUTE: main-path: REMAPPED_SRC_DIR{{.*}}unit-pcm-dependency-remapped.swift
@@ -81,7 +81,7 @@ func test() {
 
 // FILE2-NOT: main.swiftmodule-
 
-// FILE2: s2.o-{{2OIL2LG8UULK6|15MCL6ZLKZKNL}}
+// FILE2: s2.o-
 // FILE2: --------
 // FILE2: has-main: 1
 // FILE2: main-path: REMAPPED_OUT_DIR{{.*}}s2.swift

--- a/test/Index/Store/unit-swiftmodule-dependency.swift
+++ b/test/Index/Store/unit-swiftmodule-dependency.swift
@@ -27,7 +27,7 @@ func test() {
 // CHECK: [[MODB:SwiftModuleB.swiftmodule-[A-Z0-9]*]]
 // CHECK: --------
 // CHECK: has-main: 1
-// CHECK: out-file: {{.*}}/SwiftModuleB.swiftmodule
+// CHECK: out-file: {{.*}}{{/|\\}}SwiftModuleB.swiftmodule
 // CHECK: DEPEND START
 // CHECK: Unit | system | Swift | {{.*}}{{/|\\}}Swift.swiftmodule
 // CHECK: Unit | user | SwiftModuleA | {{.*}}{{/|\\}}SwiftModuleA.swiftmodule


### PR DESCRIPTION
`Hashing.h` is non-deterministic between runs. Update the index hashing to use BLAKE3 for the record hash. xxhash is faster in benchmarks that I've found, but there's no easy `HashBuilder` option for it today.