### PR TITLE
[SourceKit] Check if the realpath of a module is inside the SDK to decide if it's system

### DIFF
--- a/validation-test/IDE/complete_sdk_is_symlink.swift
+++ b/validation-test/IDE/complete_sdk_is_symlink.swift
@@ -1,0 +1,10 @@
+// UNSUPPORTED: OS=windows-msvc
+
+// RUN: %empty-directory(%t)
+// RUN: ln -s %sdk %t/sdk
+// RUN: ln -s %test-resource-dir %t/test_resource_dir
+
+// RUN: %batch-code-completion -sdk %t/sdk -resource-dir %t/test_resource_dir
+
+#^COMPLETE^#
+// COMPLETE: Decl[FreeFunction]/OtherModule[Swift]/IsSystem: print


### PR DESCRIPTION
On Windows, we run into the following situation when running SourceKit-LSP tests:
- The SDK is located at `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk` with `S:` being a substitution drive
- We find `Swift.swiftmodule` at `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\lib\swift\windows\Swift.swiftmodule`
- Now, to check if `Swift.swiftmodule` is a system module, we take the realpath of the SDK, which resolves the substitution drive an results in something like `C:\Users\alex\src\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`
- Since we don’t take the realpath of `Swift.swiftmodule`, we will assume that it’s not in the SDK, because the SDK’s path is on `C:` while `Swift.swiftmodule` lives on `S:`

To fix this, we also need to check if a module’s real path is inside the SDK.

Fixes swiftlang/sourcekit-lsp#1770
rdar://138210224
