### PR TITLE
[embedded] Fix a memory leak caused by incorrect refcounting logic around doNotFreeBit

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -458,7 +458,8 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
   if (IGM.canMakeStaticObjectReadOnly(OI->getType())) {
     if (!IGM.swiftImmortalRefCount) {
       if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
-        // = HeapObject.immortalRefCount
+        // = HeapObject.immortalRefCount | HeapObject.doNotFreeBit
+        // 0xffff_ffff on 32-bit, 0xffff_ffff_ffff_ffff on 64-bit
         IGM.swiftImmortalRefCount = llvm::ConstantInt::get(IGM.IntPtrTy, -1);
       } else {
         IGM.swiftImmortalRefCount = llvm::ConstantExpr::getPtrToInt(

--- a/test/embedded/Inputs/debug-malloc.c
+++ b/test/embedded/Inputs/debug-malloc.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define HEAP_SIZE (8 * 1024)
+
+__attribute__((aligned(16)))
+char heap[HEAP_SIZE] = {};
+
+size_t next_heap_index = 0;
+
+void *calloc(size_t count, size_t size) {
+  printf("malloc(%ld)", count);
+
+  if (next_heap_index + count * size > HEAP_SIZE) {
+    puts("HEAP EXHAUSTED\n");
+    __builtin_trap();
+  }
+  void *p = &heap[next_heap_index];
+  next_heap_index += count * size;
+  printf("-> %p\n", p);
+  return p;
+}
+
+void *malloc(size_t count) {
+  return calloc(count, 1);
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+  *memptr = calloc(size + alignment, 1);
+  if (((uintptr_t)*memptr) % alignment == 0) return 0;
+  *(uintptr_t *)memptr += alignment - ((uintptr_t)*memptr % alignment);
+  return 0;
+}
+
+void free(void *ptr) {
+  // don't actually free
+  printf("free(%p)\n", ptr);
+}

--- a/test/embedded/refcounting-leak.swift
+++ b/test/embedded/refcounting-leak.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang -x c -std=c11 -c %S/Inputs/debug-malloc.c -o %t/debug-malloc.o
+// RUN: %target-clang %t/a.o %t/debug-malloc.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+var x: UInt = 1
+func randomNumber() -> UInt {
+    x = ((x >> 16) ^ x) &* 0x45d9f3b
+    x = ((x >> 16) ^ x) &* 0x45d9f3b
+    x = (x >> 16) ^ x
+    return x
+}
+
+@main
+struct Main {
+    static func main() {
+        for _ in 0 ..< 3 {
+            _ = randomNumber().description
+        }
+        print("OK!")
+        // CHECK: malloc
+        // CHECK: free
+        // CHECK: malloc
+        // CHECK: free
+        // CHECK: malloc
+        // CHECK: free
+        // CHECK: OK!
+    }
+}


### PR DESCRIPTION
Looks like we had a major memory leak caused by the changes from https://github.com/swiftlang/swift/pull/76231. We can't set the refcount to `HeapObject.immortalRefCount` (0xffff_ffff) because that (accidentally) also includes `HeapObject.doNotFreeBit` (0x8000_000). Let's separate the two -- immortalRefCount is now only 0x7fff_ffff and the highest bit is used as a doNotFreeBit regardless of whether the refcount is immortal or not.

Fixes https://github.com/swiftlang/swift/issues/76998
