### PR TITLE
Tests: Remove -disable-availability-checking in more tests that use concurrency

### DIFF
--- a/test/ASTGen/exprs.swift
+++ b/test/ASTGen/exprs.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only > %t/cpp-parser.ast.raw
+// RUN: %target-swift-frontend %s -dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
+// RUN: %target-swift-frontend %s -dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only > %t/cpp-parser.ast.raw
 
 // Filter out any addresses in the dump, since they can differ.
 // RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
@@ -9,7 +9,7 @@
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_swift_parser

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx12.0 -module-name main -emit-ir -o %t/new.ir
 // RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
-// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -disable-availability-checking
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir
 
 // Check that we add extra type metadata accessors for new kinds of functions
@@ -9,7 +9,7 @@
 // variables since old runtimes cannot synthesize type metadata based on the
 // new mangling.
 
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/test_mangling -target %target-swift-5.1-abi-triple
 // RUN: %target-run %t/test_mangling
 
 // REQUIRES: OS=macosx

--- a/test/Concurrency/Backdeploy/weak_linking.swift
+++ b/test/Concurrency/Backdeploy/weak_linking.swift
@@ -6,10 +6,10 @@
 // RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx12.0 -module-name main -emit-ir -o %t/backdeploy_56.ir
 // RUN: %FileCheck %s --check-prefix=BACKDEPLOY56 < %t/backdeploy_56.ir
 
-// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/backdeployed_concurrency.ir -disable-availability-checking
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/backdeployed_concurrency.ir -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s --check-prefixes=BACKDEPLOY_CONCURRENCY,BACKDEPLOY56 < %t/backdeployed_concurrency.ir
 
-// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -O -module-name main -emit-ir -o %t/optimized.ir -disable-availability-checking
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -O -module-name main -emit-ir -o %t/optimized.ir -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s --check-prefix=OPTIMIZED < %t/optimized.ir
 
 

--- a/test/Concurrency/Runtime/reasync.swift
+++ b/test/Concurrency/Runtime/reasync.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/reasync.swiftmodule %S/Inputs/reasync.swift -enable-experimental-concurrency -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module-path %t/reasync.swiftmodule %S/Inputs/reasync.swift -enable-experimental-concurrency -target %target-swift-5.1-abi-triple
 // RUN: %target-build-swift %s -I %t -o %t/main -module-name main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -target %target-swift-5.1-abi-triple
 
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify  -parse-as-library -enable-upcoming-feature GlobalConcurrency
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -parse-as-library -enable-upcoming-feature GlobalConcurrency

--- a/test/Concurrency/predates_concurrency_import_emitmodule.swift
+++ b/test/Concurrency/predates_concurrency_import_emitmodule.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -target %target-swift-5.1-abi-triple
 
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=targeted

--- a/test/DebugInfo/DynamicSelfLocation.swift
+++ b/test/DebugInfo/DynamicSelfLocation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-irgen -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-irgen -g -o - | %FileCheck %s
 // REQUIRES: concurrency
 
 func some_func(_: () -> Void) async {}

--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name M  -disable-availability-checking \
+// RUN:    -module-name M  -target %target-swift-5.1-abi-triple \
 // RUN:    -parse-as-library | %FileCheck %s
 
 // REQUIRES: concurrency

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - -parse-as-library \
-// RUN:    -module-name M  -disable-availability-checking | %FileCheck %s
+// RUN:    -module-name M  -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)

--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name a  -disable-availability-checking \
+// RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64

--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name M  -disable-availability-checking \
+// RUN:    -module-name M  -target %target-swift-5.1-abi-triple \
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: concurrency

--- a/test/DebugInfo/async-let.swift
+++ b/test/DebugInfo/async-let.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name M  -disable-availability-checking \
+// RUN:    -module-name M  -target %target-swift-5.1-abi-triple \
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: concurrency

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name a  -disable-availability-checking \
+// RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name a  -disable-availability-checking \
+// RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64

--- a/test/DebugInfo/async-task-alloc.swift
+++ b/test/DebugInfo/async-task-alloc.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
-// RUN:    -module-name a  -disable-availability-checking \
+// RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 

--- a/test/DebugInfo/debug_fragment_merge.swift
+++ b/test/DebugInfo/debug_fragment_merge.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-sil -O -g | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-irgen -O -g | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -primary-file %s -emit-sil -O -g | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -primary-file %s -emit-irgen -O -g | %FileCheck %s
 
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -emit-sil -o - %s | %FileCheck -check-prefix=SIL %s
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -emit-ir -o - %s | %FileCheck %s
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -c %s -o %t/out.o
+// RUN: %target-swift-frontend -parse-as-library -target %target-swift-5.1-abi-triple -g -emit-sil -o - %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-frontend -parse-as-library -target %target-swift-5.1-abi-triple -g -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -target %target-swift-5.1-abi-triple -g -c %s -o %t/out.o
 
 // This test checks that:
 //

--- a/test/DebugInfo/sending_params_and_results.swift
+++ b/test/DebugInfo/sending_params_and_results.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -g -o - -module-name test -strict-concurrency=complete -swift-version 5 -enable-upcoming-feature SendingArgsAndResults -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -g -o - -module-name test -strict-concurrency=complete -swift-version 5 -enable-upcoming-feature SendingArgsAndResults -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 // Test that we can properly reconstruct sending from various tests when
 // emitting debug info. Only place examples in here that have already failed.

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_expansion_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_expansion_errors.swift
@@ -7,8 +7,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: not %target-swift-frontend -typecheck -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: not %target-swift-frontend -typecheck -target %target-swift-5.1-abi-triple -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s 2>&1 | %FileCheck %s
 
 import Distributed
 

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability_swift59.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability_swift59.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -parse-as-library -target %target-swift-5.9-abi-triple -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/CustomSerialExecutorAvailability.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN:  %target-run %t/a.out

--- a/test/Distributed/Runtime/distributed_actor_isolated_existential.swift
+++ b/test/Distributed/Runtime/distributed_actor_isolated_existential.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Distributed/Runtime/distributed_actor_isolation_passing.swift
+++ b/test/Distributed/Runtime/distributed_actor_isolation_passing.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -parse-as-library -swift-version 6 -target %target-swift-5.9-abi-triple -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/CustomSerialExecutorAvailability.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Distributed/distributed_actor_accessor_section_macho.swift
+++ b/test/Distributed/distributed_actor_accessor_section_macho.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -disable-availability-checking -I %t 2>&1 %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-5.1-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency

--- a/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
+++ b/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2> %t/output.txt || echo 'failed expectedly'
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.1-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-5.1-abi-triple -j2 -parse-as-library -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2> %t/output.txt || echo 'failed expectedly'
 // RUN: %FileCheck %s < %t/output.txt
 
 // REQUIRES: concurrency

--- a/test/Distributed/distributed_actor_missing_distributed_import.swift
+++ b/test/Distributed/distributed_actor_missing_distributed_import.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Distributed/distributed_missing_import.swift
+++ b/test/Distributed/distributed_missing_import.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Distributed/distributed_missing_import_fixit.swift
+++ b/test/Distributed/distributed_missing_import_fixit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Generics/inverse_classes2.swift
+++ b/test/Generics/inverse_classes2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 class KlassModern: ~Copyable {} // expected-error {{classes cannot be '~Copyable'}}
 

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -62,7 +62,7 @@ func testSyncMember(obj: MyActor) async -> Int {
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %empty-directory(%t/Modules)
-// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/Modules %t/MyModule.swift -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/Modules %t/MyModule.swift -target %target-swift-5.1-abi-triple
 
 // RUN: %empty-directory(%t/output)
 // RUN: %empty-directory(%t/ccp)

--- a/test/IRGen/actor_class.swift
+++ b/test/IRGen/actor_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -swift-version 5  -disable-availability-checking | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5  -target %target-swift-5.1-abi-triple | %IRGenFileCheck %s
 // REQUIRES: concurrency
 
 

--- a/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-ir %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/IRGen/async-inheritance.swift
+++ b/test/IRGen/async-inheritance.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(L)) -Xfrontend -disable-availability-checking -module-name L -emit-module -emit-module-path %t/L.swiftmodule %s -DL
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%t -L%t -lL -parse-as-library %s -module-name E -o %t/E %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(L)) -target %target-swift-5.1-abi-triple -module-name L -emit-module -emit-module-path %t/L.swiftmodule %s -DL
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -I%t -L%t -lL -parse-as-library %s -module-name E -o %t/E %target-rpath(%t)
 // RUN: %target-codesign %t/E
 // RUN: %target-codesign %t/%target-library-name(L)
 // RUN: %target-run %t/E %t/%target-library-name(L) | %FileCheck %s

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -disable-availability-checking | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -disable-availability-checking -enable-library-evolution
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -target %target-swift-5.1-abi-triple | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -target %target-swift-5.1-abi-triple -enable-library-evolution
 
 // REQUIRES: concurrency
 // UNSUPPORTED: CPU=wasm32

--- a/test/IRGen/async/class_resilience.swift
+++ b/test/IRGen/async/class_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module  -disable-availability-checking -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class %S/Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir  -disable-availability-checking -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
+// RUN: %target-swift-frontend -emit-module  -target %target-swift-5.1-abi-triple -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class %S/Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir  -target %target-swift-5.1-abi-triple -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
 import resilient_class

--- a/test/IRGen/async/debug.swift
+++ b/test/IRGen/async/debug.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -disable-availability-checking -g | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -target %target-swift-5.1-abi-triple -g | %FileCheck %s
 // REQUIRES: concurrency
 
 // Don't assert on dynamically sized variables.

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -I %t -emit-ir  -disable-availability-checking -enable-library-evolution %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir  -target %target-swift-5.1-abi-triple -enable-library-evolution %s | %IRGenFileCheck %s
 // REQUIRES: concurrency
 
 // CHECK: @"$s13default_actor1ACMn" = hidden constant

--- a/test/IRGen/async/protocol_req_descriptor.swift
+++ b/test/IRGen/async/protocol_req_descriptor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir  -disable-availability-checking %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
+// RUN: %target-swift-frontend -emit-ir  -target %target-swift-5.1-abi-triple %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
 // UNSUPPORTED: CPU=arm64e

--- a/test/IRGen/async/protocol_resilience.swift
+++ b/test/IRGen/async/protocol_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module  -disable-availability-checking -g -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/Inputs/resilient_protocol.swift
-// RUN: %target-swift-frontend -I %t -emit-ir  -disable-availability-checking -g -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
+// RUN: %target-swift-frontend -emit-module  -target %target-swift-5.1-abi-triple -g -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -I %t -emit-ir  -target %target-swift-5.1-abi-triple -g -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
 import resilient_protocol

--- a/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
+++ b/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -emit-ir -module-name main | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -emit-ir -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-call-generic-to-void.swift
+++ b/test/IRGen/async/run-call-generic-to-void.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -emit-ir | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -emit-ir | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(NonresilientClass)) %S/Inputs/class_open-1instance-void_to_void.swift  -Xfrontend -disable-availability-checking -g -module-name NonresilientClass -emit-module -emit-module-path %t/NonresilientClass.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(NonresilientClass)) %S/Inputs/class_open-1instance-void_to_void.swift  -target %target-swift-5.1-abi-triple -g -module-name NonresilientClass -emit-module -emit-module-path %t/NonresilientClass.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(NonresilientClass)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %S/Inputs/class_open-1instance-void_to_void.swift -emit-ir -I %t -L %t -lNonresilientClass -parse-as-library -module-name main | %FileCheck %S/Inputs/class_open-1instance-void_to_void.swift --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main -I %t -L %t -lNonresilientClass %target-rpath(%t) 
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %S/Inputs/class_open-1instance-void_to_void.swift -emit-ir -I %t -L %t -lNonresilientClass -parse-as-library -module-name main | %FileCheck %S/Inputs/class_open-1instance-void_to_void.swift --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main -I %t -L %t -lNonresilientClass %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(NonresilientClass) | %FileCheck %s
 

--- a/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(PrintShims)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientProtocol)) %S/Inputs/protocol-1instance-void_to_void.swift  -Xfrontend -disable-availability-checking -g -module-name ResilientProtocol -emit-module -emit-module-path %t/ResilientProtocol.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientProtocol)) %S/Inputs/protocol-1instance-void_to_void.swift  -target %target-swift-5.1-abi-triple -g -module-name ResilientProtocol -emit-module -emit-module-path %t/ResilientProtocol.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(ResilientProtocol)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -emit-ir -I %t -L %t -lPrintShim -lResilientProtocol -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main -I %t -L %t -lPrintShims -lResilientProtocol %target-rpath(%t) 
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -emit-ir -I %t -L %t -lPrintShim -lResilientProtocol -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main -I %t -L %t -lPrintShims -lResilientProtocol %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(PrintShims) %t/%target-library-name(ResilientProtocol) | %FileCheck %s
 

--- a/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
+++ b/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-call-void-to-int64.swift
+++ b/test/IRGen/async/run-call-void-to-int64.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -emit-ir | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -emit-ir | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-structinstance_generic-void-to-void-constrained.swift
+++ b/test/IRGen/async/run-structinstance_generic-void-to-void-constrained.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple -g %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/run-switch-executor.swift
+++ b/test/IRGen/async/run-switch-executor.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -g -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -g -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/throwing.swift
+++ b/test/IRGen/async/throwing.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-as-library  -Xfrontend -disable-availability-checking -g %s -module-name main -o %t/main
+// RUN: %target-build-swift -parse-as-library  -target %target-swift-5.1-abi-triple -g %s -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/async/unreachable.swift
+++ b/test/IRGen/async/unreachable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -g -emit-irgen  -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -g -emit-irgen  -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 
 // CHECK: call i1 (ptr, i1, ...) @llvm.coro.end.async

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-availability-checking -disable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -target %target-swift-5.1-abi-triple -disable-objc-interop | %FileCheck %s
 
 // REQUIRES: concurrency
 // LLVM does not support swifttailcc for WebAssembly target for now

--- a/test/IRGen/async_frame_entry_return_metadata.swift
+++ b/test/IRGen/async_frame_entry_return_metadata.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -disable-availability-checking -enable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=ENABLED
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -disable-availability-checking -O -enable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=ENABLED
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -disable-availability-checking -disable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=DISABLED
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -disable-availability-checking | %FileCheck %s --check-prefix=DISABLED
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -target %target-swift-5.1-abi-triple -enable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=ENABLED
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -target %target-swift-5.1-abi-triple -O -enable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=ENABLED
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -target %target-swift-5.1-abi-triple -disable-async-frame-push-pop-metadata | %FileCheck %s --check-prefix=DISABLED
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -module-name async -target %target-swift-5.1-abi-triple | %FileCheck %s --check-prefix=DISABLED
 
 // REQUIRES: OS=macosx || OS=iphoneos
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/disable-llvm-optzns.swift
+++ b/test/IRGen/disable-llvm-optzns.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -disable-availability-checking -c -o /dev/null -O -disable-llvm-optzns
+// RUN: %target-swift-frontend -primary-file %s -target %target-swift-5.1-abi-triple -c -o /dev/null -O -disable-llvm-optzns
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/has_symbol_async.swift
+++ b/test/IRGen/has_symbol_async.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution -disable-availability-checking -DCONCURRENCY
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution -target %target-swift-5.1-abi-triple -DCONCURRENCY
 // RUN: %target-swift-frontend -emit-irgen %s -I %t -module-name test | %FileCheck %s
 
 // REQUIRES: concurrency

--- a/test/IRGen/objc_async_metadata.swift
+++ b/test/IRGen/objc_async_metadata.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -disable-availability-checking %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -target %target-swift-5.1-abi-triple %s -emit-ir | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -2,7 +2,7 @@
 
 // We compile with -O (optimizations) and -disable-access-control (which
 // allows use to "call" methods that are removed by dead code elimination).
-// RUN: %target-build-swift -parse-as-library %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -Xfrontend -disable-availability-checking -o %t/report_dead_method_call
+// RUN: %target-build-swift -parse-as-library %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -target %target-swift-5.1-abi-triple -o %t/report_dead_method_call
 
 // The private, unused methods are optimized away. The test calls these
 // methods anyway (since it has overridden the access control), so we

--- a/test/IRGen/serialised-pwt-afp.swift
+++ b/test/IRGen/serialised-pwt-afp.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module -emit-module-path %t/P.swiftmodule -parse-as-library -module-name P -DP %s
-// RUN: %target-swift-frontend -disable-availability-checking -I%t -parse-as-library -module-name Q -c %s -o /dev/null -validate-tbd-against-ir=missing
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-module -emit-module-path %t/P.swiftmodule -parse-as-library -module-name P -DP %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I%t -parse-as-library -module-name Q -c %s -o /dev/null -validate-tbd-against-ir=missing
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
 
 // Verify that we can link successfully.
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -O %t/A.swift %t/B.swift -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -O %t/A.swift %t/B.swift -o %t/a.out
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -1,13 +1,13 @@
-// RUN: %target-swift-frontend -disable-availability-checking -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
-// RUN: %target-swift-frontend -disable-availability-checking -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=auto -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=auto -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=never -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=NEVER %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=never -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=NEVER %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=ALWAYS %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=never -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=NEVER-ARM64 %s
-// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=ALWAYS-ARM64 %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=auto -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=auto -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=never -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=NEVER %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=never -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=NEVER %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=always -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=always -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=never -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=NEVER-ARM64 %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-async-frame-pointer=always -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=ALWAYS-ARM64 %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: CODEGENERATOR=X86 && CODEGENERATOR=AArch64

--- a/test/IRGen/temporary_allocation/async.swift
+++ b/test/IRGen/temporary_allocation/async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 
 @_silgen_name("blackHole")

--- a/test/IRGen/typed_throws_thunks.swift
+++ b/test/IRGen/typed_throws_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-irgen -disable-availability-checking -runtime-compatibility-version none -target %module-target-future -enable-library-evolution | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -primary-file %s -emit-irgen -target %target-swift-5.1-abi-triple -runtime-compatibility-version none -target %module-target-future -enable-library-evolution | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: PTRSIZE=64
 // UNSUPPORTED: CPU=arm64e

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -disable-availability-checking -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -target %target-swift-5.1-abi-triple -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver  -Xfrontend -disable-availability-checking %s -o %t/out
+// RUN: %target-swiftc_driver  -target %target-swift-5.1-abi-triple %s -o %t/out
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 

--- a/test/Interpreter/actor_subclass_metatypes.swift
+++ b/test/Interpreter/actor_subclass_metatypes.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver  -Xfrontend -disable-availability-checking %s -o %t/out
+// RUN: %target-swiftc_driver  -target %target-swift-5.1-abi-triple %s -o %t/out
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 

--- a/test/Interpreter/async.swift
+++ b/test/Interpreter/async.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/async_dynamic.swift
+++ b/test/Interpreter/async_dynamic.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/async_dynamic_replacement.swift
+++ b/test/Interpreter/async_dynamic_replacement.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/async_fib.swift
+++ b/test/Interpreter/async_fib.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/async_resilience.swift
+++ b/test/Interpreter/async_resilience.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -Xfrontend -disable-availability-checking -module-name resilient_async
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -target %target-swift-5.1-abi-triple -module-name resilient_async
 // RUN: %target-codesign %t/%target-library-name(resilient_async)
 
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library %s -lresilient_async -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -parse-as-library %s -lresilient_async -I %t -L %t -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
 // Introduce a defaulted protocol method.
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution -Xfrontend -disable-availability-checking %S/Inputs/resilient_async2.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution -target %target-swift-5.1-abi-triple %S/Inputs/resilient_async2.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
 // RUN: %target-codesign %t/%target-library-name(resilient_async)
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_async)

--- a/test/Interpreter/async_witness_matching.swift
+++ b/test/Interpreter/async_witness_matching.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -o %t/main
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang %S/Inputs/rdar80847020.m -I %S/Inputs -c -o %t/rdar80847020.o
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Misc/effectful_properties_keypath.swift
+++ b/test/Misc/effectful_properties_keypath.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // REQUIRES: objc_interop
 

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name EffProps -disable-availability-checking
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name EffProps -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name EffProps -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name EffProps -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s < %t.swiftinterface
 
 public struct MyStruct {}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-emit-module-interface(%t/FeatureTest.swiftinterface) %s -module-name FeatureTest -disable-availability-checking
-// RUN: %target-swift-typecheck-module-from-interface(%t/FeatureTest.swiftinterface) -module-name FeatureTest -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/FeatureTest.swiftinterface) %s -module-name FeatureTest -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t/FeatureTest.swiftinterface) -module-name FeatureTest -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s \
 // RUN:   --implicit-check-not "\$AsyncAwait" \
 // RUN:   --implicit-check-not "\$Actors" \

--- a/test/ModuleInterface/preconcurrency_conformances.swift
+++ b/test/ModuleInterface/preconcurrency_conformances.swift
@@ -13,16 +13,16 @@
 // RUN:   -emit-module-path %t/Client.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
 // RUN:   -enable-upcoming-feature DynamicActorIsolation \
-// RUN:   -disable-availability-checking \
+// RUN:   -target %target-swift-5.1-abi-triple \
 // RUN:   -verify
 
 // RUN: %FileCheck %s < %t/Client.swiftinterface
 
 // RUN: %target-swift-emit-module-interface(%t/Client.swiftinterface) -I %t %t/src/Client.swift -module-name Client \
-// RUN:   -disable-availability-checking -enable-upcoming-feature DynamicActorIsolation -verify
+// RUN:   -target %target-swift-5.1-abi-triple -enable-upcoming-feature DynamicActorIsolation -verify
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t -module-name Client \
-// RUN:   -disable-availability-checking -enable-upcoming-feature DynamicActorIsolation -verify
+// RUN:   -target %target-swift-5.1-abi-triple -enable-upcoming-feature DynamicActorIsolation -verify
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/Parse/actor.swift
+++ b/test/Parse/actor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Parse/async-syntax.swift
+++ b/test/Parse/async-syntax.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Parse/effectful_properties.swift
+++ b/test/Parse/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 struct MyProps {
   var prop1 : Int {

--- a/test/Parse/foreach_async.swift
+++ b/test/Parse/foreach_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
 import _Concurrency
 

--- a/test/PrintAsObjC/async.swift
+++ b/test/PrintAsObjC/async.swift
@@ -3,15 +3,15 @@
 // RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module -disable-availability-checking
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift -disable-availability-checking
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift -disable-availability-checking
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift -disable-availability-checking
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module -target %target-swift-5.1-abi-triple
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift -target %target-swift-5.1-abi-triple
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift -target %target-swift-5.1-abi-triple
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift -target %target-swift-5.1-abi-triple
 // FIXME: END -enable-source-import hackaround
 
 // REQUIRES: concurrency
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/async.h -import-objc-header %S/../Inputs/empty.h   -typecheck -disable-availability-checking
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/async.h -import-objc-header %S/../Inputs/empty.h   -typecheck -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s < %t/async.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/async.h
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple -parse-stdlib %s -module-name main -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s \
-// RUN: -emit-sil  -disable-availability-checking \
+// RUN: -emit-sil  -target %target-swift-5.1-abi-triple \
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -disable-experimental-parser-round-trip \
 // RUN: | %FileCheck %s

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking -parse-stdlib -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple -parse-stdlib -sil-verify-all | %FileCheck %s
 // REQUIRES: concurrency
 
 import Swift

--- a/test/SILGen/async_conversion.swift
+++ b/test/SILGen/async_conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking | %FileCheck --implicit-check-not hop_to_executor %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck --implicit-check-not hop_to_executor %s
 // REQUIRES: concurrency
 
 func f(_: Int, _: String) -> String? { nil }

--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name initializers -swift-version 5  -disable-availability-checking | %FileCheck %s --enable-var-scope --implicit-check-not=hop_to_executor
+// RUN: %target-swift-frontend -emit-silgen %s -module-name initializers -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck %s --enable-var-scope --implicit-check-not=hop_to_executor
 // REQUIRES: concurrency
 
 // CHECK:       protocol Person {

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking -parse-stdlib -sil-verify-all | %FileCheck %s --dump-input always
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple -parse-stdlib -sil-verify-all | %FileCheck %s --dump-input always
 // REQUIRES: concurrency
 
 import Swift

--- a/test/SILGen/async_let_reabstraction.swift
+++ b/test/SILGen/async_let_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+// RUN: %target-swift-frontend -emit-silgen %s -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
 
 public func callee() async -> (() -> ()) {

--- a/test/SILGen/async_vtable_thunk.swift
+++ b/test/SILGen/async_vtable_thunk.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s  -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s  -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 
 class BaseClass<T> {

--- a/test/SILGen/check_executor.swift
+++ b/test/SILGen/check_executor.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking -enable-actor-data-race-checks | %FileCheck --enable-var-scope %s --check-prefix=CHECK-RAW
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking -enable-actor-data-race-checks > %t.sil
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple -enable-actor-data-race-checks | %FileCheck --enable-var-scope %s --check-prefix=CHECK-RAW
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple -enable-actor-data-race-checks > %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -lower-hop-to-actor  | %FileCheck --enable-var-scope %s --check-prefix=CHECK-CANONICAL
 // REQUIRES: concurrency
 

--- a/test/SILGen/concurrent_prologue.swift
+++ b/test/SILGen/concurrent_prologue.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name a -swift-version 5  -disable-availability-checking -Xllvm -sil-print-debuginfo -emit-verbose-sil -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name a -swift-version 5  -target %target-swift-5.1-abi-triple -Xllvm -sil-print-debuginfo -emit-verbose-sil -parse-as-library | %FileCheck %s
 // REQUIRES: concurrency
 
 // Test that the async dispatch code in the prologue has auto-generated debug

--- a/test/SILGen/effectful_properties.swift
+++ b/test/SILGen/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -disable-availability-checking %s -module-name accessors -swift-version 5 | %FileCheck --enable-var-scope %s
+// RUN: %target-swift-frontend -emit-silgen -target %target-swift-5.1-abi-triple %s -module-name accessors -swift-version 5 | %FileCheck --enable-var-scope %s
 
 class C {
   // CHECK-DAG: sil hidden [ossa] @$s9accessors1CC16prop_asyncThrowsSivg : $@convention(method) @async (@guaranteed C) -> (Int, @error any Error) {

--- a/test/SILGen/global-actor.swift
+++ b/test/SILGen/global-actor.swift
@@ -9,13 +9,13 @@ import MeowActor
 @available(SwiftStdlib 5.1, *)
 @HissActor func doHiss() {}
 
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-RESILIENT %s
 // CHECK-RESILIENT: metatype $@thick MeowActor.Type
 // CHECK-RESILIENT: metatype $@thick HissActor.Type
 
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
 // CHECK-FRAGILE: metatype $@thin MeowActor.Type
 // CHECK-FRAGILE: metatype $@thin HissActor.Type
 

--- a/test/SILGen/global_actor_functions.swift
+++ b/test/SILGen/global_actor_functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking | %FileCheck --enable-var-scope %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck --enable-var-scope %s
 // REQUIRES: concurrency
 
 actor MyActor { }

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking | %FileCheck --enable-var-scope %s --implicit-check-not 'hop_to_executor {{%[0-9]+}}'
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck --enable-var-scope %s --implicit-check-not 'hop_to_executor {{%[0-9]+}}'
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test16unspecifiedAsyncyyYaF : $@convention(thin) @async () -> ()

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -disable-availability-checking | %FileCheck --enable-var-scope %s --implicit-check-not 'hop_to_executor {{%[0-9]+}}'
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck --enable-var-scope %s --implicit-check-not 'hop_to_executor {{%[0-9]+}}'
 // REQUIRES: concurrency
 
 @propertyWrapper

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature IsolatedDeinit -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature IsolatedDeinit -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
 @inlinable public func fragileFunction() {

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: asserts
 

--- a/test/SILGen/isolated_any_invalid.swift
+++ b/test/SILGen/isolated_any_invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -disable-availability-checking -verify
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -target %target-swift-5.1-abi-triple -verify
 // REQUIRES: concurrency
 
 func takeSyncIsolatedAny(fn: @escaping @isolated(any) () -> ()) {}

--- a/test/SILGen/isolated_self_capture.swift
+++ b/test/SILGen/isolated_self_capture.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -disable-availability-checking -sil-verify-all -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -target %target-swift-5.1-abi-triple -sil-verify-all -swift-version 5 | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/SILGen/local_function_isolation.swift
+++ b/test/SILGen/local_function_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -target %target-swift-5.1-abi-triple | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/SILGen/objc_actor.swift
+++ b/test/SILGen/objc_actor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -swift-version 5  -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 5  -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_async_checked.swift
+++ b/test/SILGen/objc_async_checked.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -swift-version 6 -I %S/Inputs/custom-modules -disable-availability-checking %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -swift-version 6 -I %S/Inputs/custom-modules -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/SILGen/objc_async_defined_in_swift_any.swift
+++ b/test/SILGen/objc_async_defined_in_swift_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -disable-availability-checking -verify %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -target %target-swift-5.1-abi-triple -verify %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify | %FileCheck --implicit-check-not=hop_to_executor --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --implicit-check-not=hop_to_executor --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_async_tuple_return_88949633.swift
+++ b/test/SILGen/objc_async_tuple_return_88949633.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/objc_async_tuple_88949633.h -disable-availability-checking %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/objc_async_tuple_88949633.h -target %target-swift-5.1-abi-triple %s -verify
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_effectful_properties.swift
+++ b/test/SILGen/objc_effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -disable-availability-checking -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_effectful_properties_checked.swift
+++ b/test/SILGen/objc_effectful_properties_checked.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -swift-version 6 -disable-availability-checking -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -swift-version 6 -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -target %target-swift-5.1-abi-triple | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -swift-version 5 -disable-availability-checking -Xllvm -sil-full-demangle -parse-as-library -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 5 -target %target-swift-5.1-abi-triple -Xllvm -sil-full-demangle -parse-as-library -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/SILGen/opened_existential_in_init_delegation.swift
+++ b/test/SILGen/opened_existential_in_init_delegation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.1-abi-triple
 
 protocol P {}
 class C {

--- a/test/SILGen/preconcurrency_conformances.swift
+++ b/test/SILGen/preconcurrency_conformances.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t/src)
 // RUN: split-file %s %t/src
 
-// RUN: %target-swift-emit-silgen -disable-availability-checking -module-name preconcurrency_conformances -enable-upcoming-feature DynamicActorIsolation %t/src/checks.swift -verify | %FileCheck %t/src/checks.swift
-// RUN: %target-swift-emit-silgen -swift-version 6 -disable-availability-checking -module-name preconcurrency_conformances -disable-dynamic-actor-isolation %t/src/checks_disabled.swift -verify | %FileCheck %t/src/checks_disabled.swift
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -module-name preconcurrency_conformances -enable-upcoming-feature DynamicActorIsolation %t/src/checks.swift -verify | %FileCheck %t/src/checks.swift
+// RUN: %target-swift-emit-silgen -swift-version 6 -target %target-swift-5.1-abi-triple -module-name preconcurrency_conformances -disable-dynamic-actor-isolation %t/src/checks_disabled.swift -verify | %FileCheck %t/src/checks_disabled.swift
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/SILGen/reasync.swift
+++ b/test/SILGen/reasync.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -enable-experimental-concurrency -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -enable-experimental-concurrency -target %target-swift-5.1-abi-triple | %FileCheck %s
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil hidden [ossa] @$s7reasync0A8FunctionyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {

--- a/test/SILGen/sending.swift
+++ b/test/SILGen/sending.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name sending -disable-availability-checking -strict-concurrency=complete %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name sending -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s | %FileCheck %s
 
 class NonSendable {}
 

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -disable-availability-checking -enable-experimental-async-top-level %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -target %target-swift-5.1-abi-triple -enable-experimental-async-top-level %s | %FileCheck %s
 
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int

--- a/test/SILOptimizer/async-demotion/basic.swift
+++ b/test/SILOptimizer/async-demotion/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-async-demotion -disable-availability-checking -module-name main -O -emit-sil -primary-file %s | %FileCheck %s --implicit-check-not hop_to_executor
+// RUN: %target-swift-frontend -enable-experimental-async-demotion -target %target-swift-5.1-abi-triple -module-name main -O -emit-sil -primary-file %s | %FileCheck %s --implicit-check-not hop_to_executor
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: concurrency

--- a/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -sil-verify-all  -disable-availability-checking -emit-sil -enable-copy-propagation=false -I %t -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all  -target %target-swift-5.1-abi-triple -emit-sil -enable-copy-propagation=false -I %t -o - | %FileCheck %s
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil @$s34closure_lifetime_fixup_concurrency12testAsyncLetyS2SYaF : $@convention(thin) @async (@guaranteed String) -> @owned String {

--- a/test/SILOptimizer/consuming_parameter.swift
+++ b/test/SILOptimizer/consuming_parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -c -disable-availability-checking -Xllvm --sil-print-final-ossa-module -O -module-name=main -o /dev/null %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c -target %target-swift-5.1-abi-triple -Xllvm --sil-print-final-ossa-module -O -module-name=main -o /dev/null %s 2>&1 | %FileCheck %s
  
 // REQUIRES: concurrency
 

--- a/test/SILOptimizer/definite_init_actor.swift
+++ b/test/SILOptimizer/definite_init_actor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name test -disable-availability-checking -swift-version 5 -sil-verify-all -emit-sil %s | %FileCheck --enable-var-scope --implicit-check-not='hop_to_executor' %s
+// RUN: %target-swift-frontend -module-name test -target %target-swift-5.1-abi-triple -swift-version 5 -sil-verify-all -emit-sil %s | %FileCheck --enable-var-scope --implicit-check-not='hop_to_executor' %s
 
 // REQUIRES: concurrency
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/discard_checking.swift
+++ b/test/SILOptimizer/discard_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s -disable-availability-checking
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/mandatory_inlining_reasync.swift
+++ b/test/SILOptimizer/mandatory_inlining_reasync.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-concurrency -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-concurrency -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 // REQUIRES: concurrency
 
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -verify -sil-verify-all -disable-availability-checking
+// RUN: %target-swift-frontend -emit-sil %s -verify -sil-verify-all -target %target-swift-5.1-abi-triple
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -1,17 +1,17 @@
 // RUN: %target-swift-frontend %s \
-// RUN:   -disable-availability-checking \
+// RUN:   -target %target-swift-5.1-abi-triple \
 // RUN:   -enable-throws-prediction \
 // RUN:   -sil-verify-all -module-name=test -emit-sil \
 // RUN:       | %FileCheck --check-prefix CHECK-SIL %s
 
 // RUN: %target-swift-frontend %s \
-// RUN:   -disable-availability-checking \
+// RUN:   -target %target-swift-5.1-abi-triple \
 // RUN:   -enable-throws-prediction \
 // RUN:   -sil-verify-all -module-name=test -emit-irgen \
 // RUN:       | %FileCheck --check-prefix CHECK-IR %s
 
 // RUN: %target-swift-frontend %s \
-// RUN:   -disable-availability-checking \
+// RUN:   -target %target-swift-5.1-abi-triple \
 // RUN:   -disable-throws-prediction \
 // RUN:   -sil-verify-all -module-name=test -emit-sil \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s

--- a/test/Sema/immutability_overload_async.swift
+++ b/test/Sema/immutability_overload_async.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Sema/moveonly_decl_attr.swift
+++ b/test/Sema/moveonly_decl_attr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // expected-error@+1 {{'@_moveOnly' attribute is deprecated and will be removed; use '~Copyable' instead}}
 @_moveOnly class C { // expected-error {{'@_moveOnly' attribute is only valid on structs or enums}}{{1-12=}}

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature MoveOnlyClasses
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature MoveOnlyClasses
 
 // REQUIRES: concurrency
 

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Serialization/actor-attr-query-cycle.swift
+++ b/test/Serialization/actor-attr-query-cycle.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -o %t/a.swiftmodule -emit-module-source-info-path %t/a.swiftsourceinfo -primary-file %s %S/Inputs/actor_bar.swift -module-name Foo -disable-availability-checking
-// RUN: %target-swift-frontend -emit-module -o %t/b.swiftmodule -emit-module-source-info-path %t/b.swiftsourceinfo -primary-file %S/Inputs/actor_bar.swift %s -module-name Foo -disable-availability-checking
-// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Foo.swiftmodule  -emit-module-source-info-path %t/Foo.swiftsourceinfo %t/a.swiftmodule %t/b.swiftmodule -module-name Foo -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -o %t/a.swiftmodule -emit-module-source-info-path %t/a.swiftsourceinfo -primary-file %s %S/Inputs/actor_bar.swift -module-name Foo -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -emit-module -o %t/b.swiftmodule -emit-module-source-info-path %t/b.swiftsourceinfo -primary-file %S/Inputs/actor_bar.swift %s -module-name Foo -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Foo.swiftmodule  -emit-module-source-info-path %t/Foo.swiftsourceinfo %t/a.swiftmodule %t/b.swiftmodule -module-name Foo -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Serialization/async.swift
+++ b/test/Serialization/async.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_async~partial.swiftmodule -primary-file %S/Inputs/def_async.swift -module-name def_async  -disable-availability-checking
-// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_async~partial.swiftmodule -module-name def_async -o %t/def_async.swiftmodule  -disable-availability-checking
-// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_async~partial.swiftmodule -primary-file %S/Inputs/def_async.swift -module-name def_async  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_async~partial.swiftmodule -module-name def_async -o %t/def_async.swiftmodule  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Serialization/async_initializers.swift
+++ b/test/Serialization/async_initializers.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-module-path %t/a.swiftmodule -module-name a %s
 // RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
 

--- a/test/Serialization/attr-nonisolated.swift
+++ b/test/Serialization/attr-nonisolated.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %target-swift-frontend  -target %target-swift-5.1-abi-triple -emit-module-path %t/a.swiftmodule -module-name a %s
 // RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
 

--- a/test/Serialization/concurrency_sil.swift
+++ b/test/Serialization/concurrency_sil.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xllvm -sil-disable-pass=simplification -emit-module  -Xfrontend -disable-availability-checking -Xfrontend -disable-diagnostic-passes -whole-module-optimization -Xfrontend -enable-objc-interop -o %t/def_concurrency.swiftmodule %S/Inputs/def_concurrency.sil
+// RUN: %target-build-swift -Xllvm -sil-disable-pass=simplification -emit-module  -target %target-swift-5.1-abi-triple -Xfrontend -disable-diagnostic-passes -whole-module-optimization -Xfrontend -enable-objc-interop -o %t/def_concurrency.swiftmodule %S/Inputs/def_concurrency.sil
 // RUN: llvm-bcanalyzer %t/def_concurrency.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-sil -I %t %s -o %t/concurrency_sil.sil
 // RUN: %target-sil-opt -parse-serialized-sil -I %t %t/concurrency_sil.sil -performance-linker | %FileCheck %S/Inputs/def_concurrency.sil

--- a/test/Serialization/effectful_properties.swift
+++ b/test/Serialization/effectful_properties.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/a.swiftmodule -module-name a %s -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module-path %t/a.swiftmodule -module-name a %s -target %target-swift-5.1-abi-triple
 // RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
 

--- a/test/Serialization/isolated-params.swift
+++ b/test/Serialization/isolated-params.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_isolated~partial.swiftmodule -primary-file %S/Inputs/def_isolated.swift -module-name def_isolated  -disable-availability-checking
-// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_isolated~partial.swiftmodule -module-name def_isolated -o %t/def_isolated.swiftmodule  -disable-availability-checking
-// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_isolated~partial.swiftmodule -primary-file %S/Inputs/def_isolated.swift -module-name def_isolated  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_isolated~partial.swiftmodule -module-name def_isolated -o %t/def_isolated.swiftmodule  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/Serialization/objc_async.swift
+++ b/test/Serialization/objc_async.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_objc_async~partial.swiftmodule -primary-file %S/Inputs/def_objc_async.swift -module-name def_objc_async  -disable-availability-checking
-// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_objc_async~partial.swiftmodule -module-name def_objc_async -o %t/def_objc_async.swiftmodule  -disable-availability-checking
-// RUN: %target-swift-frontend -typecheck -I%t -verify %s  -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_objc_async~partial.swiftmodule -primary-file %S/Inputs/def_objc_async.swift -module-name def_objc_async  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_objc_async~partial.swiftmodule -module-name def_objc_async -o %t/def_objc_async.swiftmodule  -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
@@ -4,7 +4,7 @@
 // RUN: %empty-directory(%t/Modules)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -o %t/Modules/MyModule.swiftmodule -module-name MyModule %t/MyModule.swift  -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -o %t/Modules/MyModule.swiftmodule -module-name MyModule %t/MyModule.swift  -target %target-swift-5.1-abi-triple
 
 // RUN: %sourcekitd-test -req=cursor -pos=1:15 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple  | %FileCheck -check-prefix=ACTOR %s
 // RUN: %sourcekitd-test -req=cursor -pos=2:15 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple  | %FileCheck -check-prefix=FUNC %s

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Isolated.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Isolated.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -module-name Isolated -emit-module -emit-module-path %t/Isolated.swiftmodule -disable-availability-checking
+// RUN: %target-swift-frontend %s -module-name Isolated -emit-module -emit-module-path %t/Isolated.swiftmodule -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-symbolgraph-extract -module-name Isolated -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/Isolated.symbols.json
 

--- a/test/TBD/async-function-pointer.swift
+++ b/test/TBD/async-function-pointer.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: concurrency
-// RUN: %target-swift-frontend -emit-ir %s  -disable-availability-checking -validate-tbd-against-ir=all -module-name test | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s  -target %target-swift-5.1-abi-triple -validate-tbd-against-ir=all -module-name test | %FileCheck %s
 
 // CHECK: @barTu = global %swift.async_func_pointer
 @_silgen_name("bar")

--- a/test/TBD/rdar80485869.swift
+++ b/test/TBD/rdar80485869.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module-path %t/module -emit-tbd -enable-testing -disable-availability-checking -tbd-install_name test 
+// RUN: %target-swift-frontend %s -emit-module-path %t/module -emit-tbd -enable-testing -target %target-swift-5.1-abi-triple -tbd-install_name test 
 
 public actor Tom {
     init() async {

--- a/test/TBD/rdar82045176.swift
+++ b/test/TBD/rdar82045176.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %s -emit-module -module-name thing -emit-tbd -enable-testing -Xfrontend -disable-availability-checking -Xfrontend -validate-tbd-against-ir=all -Xfrontend -tbd-install_name -Xfrontend thing
+// RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %s -emit-module -module-name thing -emit-tbd -enable-testing -target %target-swift-5.1-abi-triple -Xfrontend -validate-tbd-against-ir=all -Xfrontend -tbd-install_name -Xfrontend thing
 
 class Test {
   init() async { }

--- a/test/attr/attr_borrowed.swift
+++ b/test/attr/attr_borrowed.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 

--- a/test/decl/async/objc.swift
+++ b/test/decl/async/objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 5  -disable-availability-checking
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 5  -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 5  | %FileCheck %s
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/decl/class/actor/initializers.swift
+++ b/test/decl/class/actor/initializers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-sil -verify %s
+// RUN: %target-swift-frontend -swift-version 5 -target %target-swift-5.1-abi-triple -emit-sil -verify %s
 
 // check the initializer kinds for protocols and their extensions
 

--- a/test/decl/class/effectful_properties.swift
+++ b/test/decl/class/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 enum E : Error {
   case NotAvailable

--- a/test/decl/class/effectful_properties_objc.swift
+++ b/test/decl/class/effectful_properties_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // REQUIRES: objc_interop
 

--- a/test/decl/func/async.swift
+++ b/test/decl/func/async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/decl/protocol/async_requirements.swift
+++ b/test/decl/protocol/async_requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // Ensure that a protocol with async requirements can be conformed to by
 // non-async requirements, and that overloading works.

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify -verify-ignore-unknown
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 /////
 // This test is focused on checking protocol conformance and constraint checking

--- a/test/decl/protocol/effectful_properties_objc.swift
+++ b/test/decl/protocol/effectful_properties_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // REQUIRES: objc_interop
 

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -target %target-swift-5.1-abi-triple
 
 // REQUIRES: concurrency
 

--- a/test/decl/var/default_init.swift
+++ b/test/decl/var/default_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -parse-as-library %s -verify -swift-version 5 -disable-availability-checking
+// RUN: %target-swift-frontend -typecheck -parse-as-library %s -verify -swift-version 5 -target %target-swift-5.1-abi-triple
 
 // Default initialization of variables.
 

--- a/test/decl/var/effectful_properties_global.swift
+++ b/test/decl/var/effectful_properties_global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 var intAsyncProp : Int {
   get async { 0 }

--- a/test/decl/var/effectful_property_wrapper.swift
+++ b/test/decl/var/effectful_property_wrapper.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // Currently, we don't support having property wrappers that are effectful.
 // Eventually we'd like to add this.

--- a/test/decl/var/lazy_properties_effects.swift
+++ b/test/decl/var/lazy_properties_effects.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 // We could make this work by having `lazy` synthesize an effectful
 // getter, but for now let's reject it instead of crashing.


### PR DESCRIPTION
Use the `%target-swift-5.1-abi-triple` substitution to compile the tests for deployment to the minimum OS versions required for use of _Concurrency APIs, instead of disabling availability checking.
