### PR TITLE
[swift_snapshot_tool] Fatal error if the older assumed good fails or if the newer assumed bad succeeds.

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -119,7 +119,8 @@ struct BisectToolchains: AsyncParsableCommand {
         success = !success
       }
       if !success {
-        log("[INFO] Oldest snapshot fails?! We assume that the oldest snapshot is known good!")
+        log("[INFO] Oldest assumed good snapshot fails! Did you forget to pass --invert?")
+        fatalError()
       } else {
         log("[INFO] Oldest snapshot passes test. Snapshot: \(tags[startIndex])")
       }
@@ -135,7 +136,8 @@ struct BisectToolchains: AsyncParsableCommand {
         success = !success
       }
       if !success {
-        log("[INFO] Newest snapshot succeceds?! We assume that the newest snapshot is known bad!")
+        log("[INFO] Newest assumed bad snapshot succeeds! Did you forget to pass --invert?")
+        fatalError()
       } else {
         log("[INFO] Newest snapshot passes test. Snapshot: \(tags[endIndex])")
       }


### PR DESCRIPTION
Often times this happens since one forget to add --invert to invert the failure code in situations where the newer change succeeds and the older change fails... so I added that admonition to the error message.

----

Just making some improvements as I run into them as I am triaging other issues.