### PR TITLE
Tests: Remove -disable-availability-checking in tests that use opaque types

### DIFF
--- a/test/AssociatedTypeInference/rdar122596633-2.swift
+++ b/test/AssociatedTypeInference/rdar122596633-2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 public protocol P<A> {
     associatedtype A

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s -package-name myPkg
-// RUN: %target-swift-frontend-typecheck -enable-testing -verify -disable-availability-checking %s -package-name myPkg
+// RUN: %target-swift-frontend-typecheck -verify -target %target-swift-5.1-abi-triple %s -package-name myPkg
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify -target %target-swift-5.1-abi-triple %s -package-name myPkg
 
 // Swift.AdditiveArithmetic:3:17: note: cannot yet register derivative default implementation for protocol requirements
 

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s
-// RUN: %target-swift-frontend-typecheck -enable-testing -verify -disable-availability-checking %s
+// RUN: %target-swift-frontend-typecheck -verify -target %target-swift-5.1-abi-triple %s
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify -target %target-swift-5.1-abi-triple %s
 
 import _Differentiation
 

--- a/test/AutoDiff/compiler_crashers_fixed/issue-55099-differentiation-opaque-result-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-55099-differentiation-opaque-result-type.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
+// RUN: not %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-sil -verify %s
 
 // https://github.com/apple/swift/issues/55099
 // Differentiation transform crashes for original function with opaque

--- a/test/Constraints/ambiguity_diagnostics.swift
+++ b/test/Constraints/ambiguity_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -swift-version 5 -target %target-swift-5.1-abi-triple
 
 protocol View {
 }

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 struct IntList : ExpressibleByArrayLiteral {
   typealias Element = Int

--- a/test/Constraints/result_builder_conjunction_selection.swift
+++ b/test/Constraints/result_builder_conjunction_selection.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -debug-constraints -disable-availability-checking 2>%t.err
+// RUN: %target-typecheck-verify-swift -debug-constraints -target %target-swift-5.1-abi-triple 2>%t.err
 // RUN: %FileCheck %s < %t.err
 
 protocol P<Output> {

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 enum Either<T,U> {
   case first(T)

--- a/test/Constraints/result_builder_opaque_result.swift
+++ b/test/Constraints/result_builder_opaque_result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify %s
 
 protocol Taggable {}
 extension String: Taggable {}

--- a/test/Constraints/result_builder_opaque_result_structural.swift
+++ b/test/Constraints/result_builder_opaque_result_structural.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 
 @resultBuilder
 struct TupleBuilder {

--- a/test/Constraints/static_member_on_protocol_with_opaque_result.swift
+++ b/test/Constraints/static_member_on_protocol_with_opaque_result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -typecheck -verify %s
 
 // rdar://75978086 - static member lookup doesn't work with opaque types
 

--- a/test/DebugInfo/opaque_result_type.swift
+++ b/test/DebugInfo/opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -g %s -disable-availability-checking
+// RUN: %target-swift-frontend -emit-ir -g %s -target %target-swift-5.1-abi-triple
 
 public protocol P {
   associatedtype Horse

--- a/test/Generics/issue-58301.swift
+++ b/test/Generics/issue-58301.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -disable-availability-checking -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -target %target-swift-5.1-abi-triple -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/58301
 

--- a/test/Generics/opaque_archetype_concrete_requirement.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -debug-generic-signatures -enable-requirement-machine-opaque-archetypes 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking -enable-requirement-machine-opaque-archetypes
+// RUN: %target-swift-frontend -typecheck -verify %s -target %target-swift-5.1-abi-triple -debug-generic-signatures -enable-requirement-machine-opaque-archetypes 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -target %target-swift-5.1-abi-triple -enable-requirement-machine-opaque-archetypes
 
 protocol P1 {
   associatedtype T : P2

--- a/test/Generics/opaque_archetype_concrete_requirement_invalid.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -enable-requirement-machine-opaque-archetypes
+// RUN: %target-swift-frontend -typecheck -verify %s -target %target-swift-5.1-abi-triple -enable-requirement-machine-opaque-archetypes
 
 protocol P1 {}
 

--- a/test/Generics/opaque_archetype_concrete_requirement_recursive.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_recursive.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -debug-generic-signatures 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+// RUN: %target-swift-frontend -typecheck -verify %s -target %target-swift-5.1-abi-triple -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -target %target-swift-5.1-abi-triple
 
 // FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
 // See opaque_archetype_concrete_requirement_rejected.swift for a demonstration

--- a/test/Generics/opaque_archetype_concrete_requirement_recursive_rejected.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_recursive_rejected.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-requirement-machine-opaque-archetypes
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-requirement-machine-opaque-archetypes
 
 // FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
 // See opaque_archetype_concrete_requirement_recursive.swift for a demonstration

--- a/test/Generics/rdar124697829.swift
+++ b/test/Generics/rdar124697829.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.1-abi-triple
 
 // This is a generics test, but only IRGen exercised the substitution of
 // an abstract conformance with a type parameter -- in the type checker and

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t/ImportPath)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
 
 // BEGIN Lib.swift
 

--- a/test/IDE/print_usrs_opaque_types.swift
+++ b/test/IDE/print_usrs_opaque_types.swift
@@ -2,7 +2,7 @@
 // opaque result types, even in the presence of errors or unusual generic
 // signatures.
 
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-ide-test -print-usrs -source-filename %s | %FileCheck -strict-whitespace %s
 
 // CHECK: [[@LINE+1]]:{{[0-9]+}} s:14swift_ide_test0C21UnifyingGenericParams1xQrx_tq_Rszr0_lF

--- a/test/IRGen/dynamic_replaceable_opaque_return.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
 
 // The arm64e test is in ptrauth-dynamic_replaceable.sil.
 // UNSUPPORTED: CPU=arm64e

--- a/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -enable-implicit-dynamic -enable-private-imports %S/Inputs/opaque_return_type_parameter.swift -module-name Repo -emit-module -emit-module-path %t/Repo.swiftmodule
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -c -o %t/tmp.o
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-implicit-dynamic -enable-private-imports %S/Inputs/opaque_return_type_parameter.swift -module-name Repo -emit-module -emit-module-path %t/Repo.swiftmodule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -module-name A -swift-version 5 -primary-file %s -c -o %t/tmp.o
 @_private(sourceFile: "opaque_return_type_parameter.swift") import Repo
 
 // Make sure we are not emitting a replacement for the opaque result type used as parameter (Assoc).

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -target %target-swift-5.1-abi-triple | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-frontend -emit-irgen %s -I %t -I %S/Inputs/has_symbol -module-name test | %FileCheck %s
 
 // UNSUPPORTED: OS=windows-msvc

--- a/test/IRGen/implicit_some_a.swift
+++ b/test/IRGen/implicit_some_a.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-availability-checking -primary-file %s %S/Inputs/implicit_some_b.swift -enable-experimental-feature ImplicitSome
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.1-abi-triple -primary-file %s %S/Inputs/implicit_some_b.swift -enable-experimental-feature ImplicitSome
 
 // Because of -enable-experimental-feature ImplicitSome
 // REQUIRES: asserts

--- a/test/IRGen/lazy_opaque_result_type.swift
+++ b/test/IRGen/lazy_opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -enable-implicit-dynamic -target %target-swift-5.1-abi-triple -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll
 
 protocol P { }

--- a/test/IRGen/loadable_by_address_subst_function_type_return.swift
+++ b/test/IRGen/loadable_by_address_subst_function_type_return.swift
@@ -1,5 +1,5 @@
 // rdar://87792152
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -verify %s
 
 public struct S1 {
   var a: Int?

--- a/test/IRGen/mangle-opaque-return-type.swift
+++ b/test/IRGen/mangle-opaque-return-type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module -enable-library-evolution -emit-module-path=%t/A.swiftmodule -module-name=A %S/Inputs/mangle-opaque-return-types-A.swift
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir  %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-module -enable-library-evolution -emit-module-path=%t/A.swiftmodule -module-name=A %S/Inputs/mangle-opaque-return-types-A.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -emit-ir  %s
 import A
 
 public struct C<T, Content: Proto> {

--- a/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
+++ b/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -disable-availability-checking -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -target %target-swift-5.1-abi-triple -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
-// RUN: %target-swift-frontend -enable-experimental-named-opaque-types -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
+// RUN: %target-swift-frontend -enable-experimental-named-opaque-types -enable-implicit-dynamic -target %target-swift-5.1-abi-triple -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
 // rdar://76863553
 // UNSUPPORTED: OS=watchos && CPU=x86_64

--- a/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
+++ b/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir %s | %FileCheck %s
 
 protocol Butt { }
 

--- a/test/IRGen/opaque_result_type_debug.swift
+++ b/test/IRGen/opaque_result_type_debug.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-library-evolution -disable-availability-checking -emit-module -emit-module-path %t/opaque_result_type_debug_other.swiftmodule -module-name opaque_result_type_debug_other -enable-anonymous-context-mangled-names %s -DLIBRARY
-// RUN: %target-swift-frontend -disable-availability-checking -g -emit-ir -enable-anonymous-context-mangled-names %s -DCLIENT -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -enable-library-evolution -target %target-swift-5.1-abi-triple -emit-module -emit-module-path %t/opaque_result_type_debug_other.swiftmodule -module-name opaque_result_type_debug_other -enable-anonymous-context-mangled-names %s -DLIBRARY
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -g -emit-ir -enable-anonymous-context-mangled-names %s -DCLIENT -I %t | %FileCheck %s
 
 #if LIBRARY
 

--- a/test/IRGen/opaque_result_type_global.swift
+++ b/test/IRGen/opaque_result_type_global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -verify %s
 
 // rdar://problem/49818962
 func foo() -> some Collection {

--- a/test/IRGen/opaque_result_type_internal.swift
+++ b/test/IRGen/opaque_result_type_internal.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -O -disable-availability-checking -emit-module -emit-module-path=%t/R.swiftmodule -module-name=R %S/Inputs/opaque_result_type_internal_inlinable.swift
-// RUN: %target-swift-frontend -O -I %t -disable-availability-checking -c -primary-file %s
+// RUN: %target-swift-frontend -O -target %target-swift-5.1-abi-triple -emit-module -emit-module-path=%t/R.swiftmodule -module-name=R %S/Inputs/opaque_result_type_internal_inlinable.swift
+// RUN: %target-swift-frontend -O -I %t -target %target-swift-5.1-abi-triple -c -primary-file %s
 
 import R
 

--- a/test/IRGen/opaque_result_type_metadata_peephole.swift
+++ b/test/IRGen/opaque_result_type_metadata_peephole.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -static -enable-library-evolution -emit-module-path %t/opaque_result_type_metadata_external.swiftmodule %S/Inputs/opaque_result_type_metadata_external.swift
-// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=DEFAULT
-// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=CHECK --check-prefix=IMPLICIT-DYNAMIC
+// RUN: %target-swift-frontend -swift-version 5 -target %target-swift-5.1-abi-triple -static -enable-library-evolution -emit-module-path %t/opaque_result_type_metadata_external.swiftmodule %S/Inputs/opaque_result_type_metadata_external.swift
+// RUN: %target-swift-frontend -swift-version 5 -target %target-swift-5.1-abi-triple -emit-ir -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=DEFAULT
+// RUN: %target-swift-frontend -swift-version 5 -target %target-swift-5.1-abi-triple -emit-ir -I %t %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=CHECK --check-prefix=IMPLICIT-DYNAMIC
 
 
 import opaque_result_type_metadata_external

--- a/test/IRGen/opaque_result_type_private.swift
+++ b/test/IRGen/opaque_result_type_private.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -c -primary-file %s %S/Inputs/opaque_result_type_private_2.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -c -primary-file %s %S/Inputs/opaque_result_type_private_2.swift
 
 // This test used to crash during IRGen.
 

--- a/test/IRGen/opaque_result_type_private_typemetadata.swift
+++ b/test/IRGen/opaque_result_type_private_typemetadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -primary-file %s %S/Inputs/opaque_result_type_private_typemetadata2.swift | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -primary-file %s %S/Inputs/opaque_result_type_private_typemetadata2.swift | %FileCheck %s
 
 // Container's fields are not ABI accessible so copying Container must use its
 // metadata instead of exploding its fields.

--- a/test/IRGen/opaque_result_type_private_underlying.swift
+++ b/test/IRGen/opaque_result_type_private_underlying.swift
@@ -1,13 +1,13 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_2.swift | %FileCheck %s --check-prefix=SINGLEMODULE
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_2.swift | %FileCheck %s --check-prefix=SINGLEMODULE
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -primary-file %s  -DUSEMODULE | %FileCheck %s --check-prefix=NONRESILIENT
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -emit-ir -primary-file %s  -DUSEMODULE | %FileCheck %s --check-prefix=NONRESILIENT
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -primary-file %s  -DUSEMODULE | %FileCheck %s --check-prefix=RESILIENT
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -emit-ir -primary-file %s  -DUSEMODULE | %FileCheck %s --check-prefix=RESILIENT
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_3.swift -DUSEMODULE -DUSESECONDFILE | %FileCheck %s --check-prefix=RESILIENT
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-library-evolution -emit-module -emit-module-path=%t/Repo1.swiftmodule -module-name=Repo1 %S/Inputs/opaque_result_type_private_underlying_2.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -I %t -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_3.swift -DUSEMODULE -DUSESECONDFILE | %FileCheck %s --check-prefix=RESILIENT
 
 #if USEMODULE
 import Repo1

--- a/test/IRGen/opaque_result_type_substitution.swift
+++ b/test/IRGen/opaque_result_type_substitution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-type-layout -enable-library-evolution -disable-availability-checking -emit-ir -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-type-layout -enable-library-evolution -target %target-swift-5.1-abi-triple -emit-ir -primary-file %s | %FileCheck %s
 
 public protocol E {}
 

--- a/test/IRGen/opaque_result_type_substitution_2.swift
+++ b/test/IRGen/opaque_result_type_substitution_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-type-layout -enable-library-evolution -disable-availability-checking -emit-ir -primary-file %s
+// RUN: %target-swift-frontend -disable-type-layout -enable-library-evolution -target %target-swift-5.1-abi-triple -emit-ir -primary-file %s
 
 protocol P { }
 

--- a/test/IRGen/weak_import_opaque_result_type.swift
+++ b/test/IRGen/weak_import_opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weak_import_opaque_result_type_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_opaque_result_type_helper.swift -enable-library-evolution -disable-availability-checking
-// RUN: %target-swift-frontend -disable-type-layout -disable-availability-checking -primary-file %s -I %t -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weak_import_opaque_result_type_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_opaque_result_type_helper.swift -enable-library-evolution -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -disable-type-layout -target %target-swift-5.1-abi-triple -primary-file %s -I %t -emit-ir | %FileCheck %s
 
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/Interpreter/moveonly_generics_opaque.swift
+++ b/test/Interpreter/moveonly_generics_opaque.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -O) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -O) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/opaque_result_type_runtime_call.swift
+++ b/test/Interpreter/opaque_result_type_runtime_call.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(opaque_result_type_runtime_call_other)) -enable-library-evolution %S/Inputs/opaque_result_type_runtime_call_other.swift -emit-module -emit-module-path %t/opaque_result_type_runtime_call_other.swiftmodule -module-name opaque_result_type_runtime_call_other -Xfrontend -disable-availability-checking
+// RUN: %target-build-swift-dylib(%t/%target-library-name(opaque_result_type_runtime_call_other)) -enable-library-evolution %S/Inputs/opaque_result_type_runtime_call_other.swift -emit-module -emit-module-path %t/opaque_result_type_runtime_call_other.swiftmodule -module-name opaque_result_type_runtime_call_other -target %target-swift-5.1-abi-triple
 // RUN: %target-codesign %t/%target-library-name(opaque_result_type_runtime_call_other)
-// RUN: %target-build-swift %s -lopaque_result_type_runtime_call_other -I %t -L %t -o %t/main %target-rpath(%t) -Xfrontend -disable-availability-checking
+// RUN: %target-build-swift %s -lopaque_result_type_runtime_call_other -I %t -L %t -o %t/main %target-rpath(%t) -target %target-swift-5.1-abi-triple
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(opaque_result_type_runtime_call_other) | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/ModuleInterface/originally-defined-attr-opaque-result.swift
+++ b/test/ModuleInterface/originally-defined-attr-opaque-result.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-emit-module-interface(%t/CoreVegetable.swiftinterface) %S/Inputs/CoreVegetable.swift -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/CoreVegetable.swiftinterface) %S/Inputs/CoreVegetable.swift -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-typecheck-module-from-interface(%t/CoreVegetable.swiftinterface)
-// RUN: %target-swift-emit-module-interface(%t/CoreChef.swiftinterface) %s -module-name CoreChef -I %t -disable-availability-checking -DLIB
-// RUN: %target-swift-typecheck-module-from-interface(%t/CoreChef.swiftinterface) -module-name CoreChef -I %t -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/CoreChef.swiftinterface) %s -module-name CoreChef -I %t -target %target-swift-5.1-abi-triple -DLIB
+// RUN: %target-swift-typecheck-module-from-interface(%t/CoreChef.swiftinterface) -module-name CoreChef -I %t -target %target-swift-5.1-abi-triple
 
 // Also build the module itself with -g to exercise debug info round tripping.
-// RUN: %target-swift-frontend -emit-ir -g %s -I %t -disable-availability-checking
+// RUN: %target-swift-frontend -emit-ir -g %s -I %t -target %target-swift-5.1-abi-triple
 
 // RUN: %FileCheck %s < %t/CoreChef.swiftinterface
 

--- a/test/ModuleInterface/parameterized-protocol-opaque-result-types.swift
+++ b/test/ModuleInterface/parameterized-protocol-opaque-result-types.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/ParameterizedProtocols.swiftinterface) %s -module-name ParameterizedProtocols -disable-availability-checking
-// RUN: %target-swift-typecheck-module-from-interface(%t/ParameterizedProtocols.swiftinterface) -module-name ParameterizedProtocols -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/ParameterizedProtocols.swiftinterface) %s -module-name ParameterizedProtocols -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t/ParameterizedProtocols.swiftinterface) -module-name ParameterizedProtocols -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s < %t/ParameterizedProtocols.swiftinterface
 
 public protocol P<T> {

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend                                  \
 // RUN:     %s                                                  \
 // RUN:     -emit-silgen                                        \
-// RUN:     -disable-availability-checking                      \
+// RUN:     -target %target-swift-5.1-abi-triple                      \
 // RUN:     -enable-experimental-feature Sensitive              \
 // RUN:     -enable-builtin-module
 

--- a/test/SILGen/function_type_lowering.swift
+++ b/test/SILGen/function_type_lowering.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -disable-availability-checking -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -target %target-swift-5.1-abi-triple -module-name main %s | %FileCheck %s
 
 
 // Similarly-abstract generic signatures should share an unsubstituted type

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithStaticMembers -disable-availability-checking -disable-experimental-parser-round-trip -parse-stdlib -module-name keypaths %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithStaticMembers -target %target-swift-5.1-abi-triple -disable-experimental-parser-round-trip -parse-stdlib -module-name keypaths %s | %FileCheck %s
 // FIXME: Remove '-disable-experimental-parser-round-trip'.
 
 // REQUIRES: asserts

--- a/test/SILGen/mangle_structural_opaque_type_name.swift
+++ b/test/SILGen/mangle_structural_opaque_type_name.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -verify %s
 
 protocol View { }
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -I %t -disable-availability-checking -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -target %target-swift-5.1-abi-triple -emit-silgen %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/SILGen/opaque_result_type_captured.swift
+++ b/test/SILGen/opaque_result_type_captured.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -verify %s
 // rdar://83378116
 
 public protocol P {}

--- a/test/SILGen/opaque_result_type_captured_wmo.swift
+++ b/test/SILGen/opaque_result_type_captured_wmo.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking -verify -wmo %s %S/Inputs/opaque_result_type_captured_wmo_2.swift
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -verify -wmo %s %S/Inputs/opaque_result_type_captured_wmo_2.swift
 func foo(s: String?) {
   let x = PImpl()
     .burritoed()

--- a/test/SILGen/opaque_result_type_class_property.swift
+++ b/test/SILGen/opaque_result_type_class_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -enable-library-evolution -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-library-evolution -target %target-swift-5.1-abi-triple | %FileCheck %s
 
 public protocol V {}
 public struct E : V {}

--- a/test/SILGen/opaque_result_type_fragile.swift
+++ b/test/SILGen/opaque_result_type_fragile.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module %S/Inputs/opaque_result_type_fragile_other.swift -emit-module-path %t/opaque_result_type_fragile_other.swiftmodule
-// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -I%t %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-module %S/Inputs/opaque_result_type_fragile_other.swift -emit-module-path %t/opaque_result_type_fragile_other.swiftmodule
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-silgen -I%t %s | %FileCheck %s
 
 import opaque_result_type_fragile_other
 

--- a/test/SILGen/opaque_result_type_inlinable.swift
+++ b/test/SILGen/opaque_result_type_inlinable.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -primary-file %s -primary-file %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -primary-file %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-silgen -primary-file %s -primary-file %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-silgen -primary-file %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-silgen %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s28opaque_result_type_inlinable6callerQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6callerQryF", 0) __> {
 // CHECK: bb0(%0 : $*@_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6calleeQryF", 0) __):


### PR DESCRIPTION
Use the `%target-swift-5.1-abi-triple` substitution to compile the tests for deployment to the minimum OS versions required for use of opaque types, instead of disabling availability checking.