### PR TITLE
 Tests: Remove -disable-availability-checking in variadic generics tests

### DIFF
--- a/test/Constraints/issue-67906.swift
+++ b/test/Constraints/issue-67906.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 struct G<each T>: Sequence {
   typealias Element = Int

--- a/test/Constraints/nested_pack_expansion.swift
+++ b/test/Constraints/nested_pack_expansion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 func sameType<T>(_: T.Type, _: T.Type) {}
 

--- a/test/Constraints/one_element_tuple.swift
+++ b/test/Constraints/one_element_tuple.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 let t1: (_: Int) = (_: 3)
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 func tuplify<each T>(_ t: repeat each T) -> (repeat each T) {
   return (repeat each t)

--- a/test/Constraints/variadic_generic_init.swift
+++ b/test/Constraints/variadic_generic_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 // These test cases exercise variants of rdar://problem/112785081
 // and https://github.com/apple/swift/issues/68160.

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 // Parsing an UnresolvedSpecializeExpr containing a PackExpansionType
 struct G<each T> {}

--- a/test/DebugInfo/variadic-generics-count.swift
+++ b/test/DebugInfo/variadic-generics-count.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a -disable-availability-checking | %FileCheck %s
+// RUN:    -parse-as-library -module-name a -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 public func f1<each T>(ts: repeat each T) {
   // CHECK: define {{.*}} @"$s1a2f12tsyxxQp_tRvzlF"(ptr {{.*}}, i{{32|64}} [[COUNT1_1:.*]], ptr {{.*}})

--- a/test/DebugInfo/variadic-generics.swift
+++ b/test/DebugInfo/variadic-generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a -disable-availability-checking | %IRGenFileCheck %s
+// RUN:    -parse-as-library -module-name a -target %target-swift-5.9-abi-triple | %IRGenFileCheck %s
 
 public func foo<each T>(args: repeat each T) {
   // CHECK: define {{.*}} @"$s1a3foo4argsyxxQp_tRvzlF"

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-availability-checking 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -target %target-swift-5.9-abi-triple 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype A: P

--- a/test/Generics/rdar115538386.swift
+++ b/test/Generics/rdar115538386.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -disable-availability-checking
+// RUN: %target-swift-frontend -typecheck %s -target %target-swift-5.9-abi-triple
 
 protocol P<A> {
   associatedtype A

--- a/test/Generics/variadic_generic_requirements.swift
+++ b/test/Generics/variadic_generic_requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 struct Conformance<each T: Equatable> {}
 

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 // Disallowed cases
 struct MultiplePack<each T, each U> {} // expected-error {{generic type cannot declare more than one type pack}}

--- a/test/IRGen/bitwise_copyable.swift
+++ b/test/IRGen/bitwise_copyable.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend                           \
 // RUN:     -primary-file %s                             \
 // RUN:     -emit-ir                                     \
-// RUN:     -disable-availability-checking               \
+// RUN:     -target %target-swift-5.9-abi-triple         \
 // RUN:     -enable-builtin-module
 
 // REQUIRES: asserts

--- a/test/IRGen/builtin_pack_length.swift
+++ b/test/IRGen/builtin_pack_length.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name builtins -enable-builtin-module -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module -disable-availability-checking -O | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -module-name builtins -enable-builtin-module -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module -target %target-swift-5.9-abi-triple -O | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
 

--- a/test/IRGen/pack_archetype_canonicalization.swift
+++ b/test/IRGen/pack_archetype_canonicalization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple
 
 // This would crash.
 public struct G<T> {}

--- a/test/IRGen/pack_metadata_marker_inserter_onone.swift
+++ b/test/IRGen/pack_metadata_marker_inserter_onone.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Onone -disable-availability-checking -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true -Xllvm -sil-print-after=pack-metadata-marker-inserter 2>&1 | %FileCheck %s --check-prefixes CHECK-SIL
-// RUN: %target-swift-frontend -Onone -disable-availability-checking -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true | %IRGenFileCheck %s --check-prefixes CHECK-LLVM
+// RUN: %target-swift-frontend -Onone -target %target-swift-5.9-abi-triple -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true -Xllvm -sil-print-after=pack-metadata-marker-inserter 2>&1 | %FileCheck %s --check-prefixes CHECK-SIL
+// RUN: %target-swift-frontend -Onone -target %target-swift-5.9-abi-triple -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true | %IRGenFileCheck %s --check-prefixes CHECK-LLVM
 
 public struct G<each T> {
   var pack: (repeat each T)

--- a/test/IRGen/variadic_generic_conditional_conformances.swift
+++ b/test/IRGen/variadic_generic_conditional_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 protocol P {
   static func foobar()

--- a/test/IRGen/variadic_generic_fulfillment.swift
+++ b/test/IRGen/variadic_generic_fulfillment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s -DINT=i%target-ptrsize
 
 public struct G<T> {}
 

--- a/test/IRGen/variadic_generic_opaque.swift
+++ b/test/IRGen/variadic_generic_opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 public protocol P {}
 

--- a/test/IRGen/variadic_generic_types.swift
+++ b/test/IRGen/variadic_generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 // REQUIRES: PTRSIZE=64
 

--- a/test/Interpreter/import_parameter_pack_library.swift
+++ b/test/Interpreter/import_parameter_pack_library.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_library)) -Xfrontend -disable-availability-checking  -enable-library-evolution %S/Inputs/variadic_generic_library.swift -emit-module -emit-module-path %t/variadic_generic_library.swiftmodule -module-name variadic_generic_library
+// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_library)) -target %target-swift-5.9-abi-triple  -enable-library-evolution %S/Inputs/variadic_generic_library.swift -emit-module -emit-module-path %t/variadic_generic_library.swiftmodule -module-name variadic_generic_library
 // RUN: %target-codesign %t/%target-library-name(variadic_generic_library)
 
-// RUN: %target-build-swift %s -Xfrontend -disable-availability-checking -lvariadic_generic_library -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift %s -target %target-swift-5.9-abi-triple -lvariadic_generic_library -I %t -L %t -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
 // RUN: %target-run %t/main %t/%target-library-name(variadic_generic_library)

--- a/test/Interpreter/variadic_generic_conditional_conformances.swift
+++ b/test/Interpreter/variadic_generic_conditional_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/variadic_generic_conformances.swift
+++ b/test/Interpreter/variadic_generic_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 //
-// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_opaque_type_other)) %S/Inputs/variadic_generic_opaque_type_other.swift -emit-module -emit-module-path %t/variadic_generic_opaque_type_other.swiftmodule -module-name variadic_generic_opaque_type_other -Xfrontend -disable-availability-checking -enable-library-evolution
+// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_opaque_type_other)) %S/Inputs/variadic_generic_opaque_type_other.swift -emit-module -emit-module-path %t/variadic_generic_opaque_type_other.swiftmodule -module-name variadic_generic_opaque_type_other -target %target-swift-5.9-abi-triple -enable-library-evolution
 // RUN: %target-codesign %t/%target-library-name(variadic_generic_opaque_type_other)
 //
 // RUN: %target-build-swift %s -I %t -o %t/main.out -L %t %target-rpath(%t) -lvariadic_generic_opaque_type_other

--- a/test/Interpreter/variadic_generic_type_witnesses.swift
+++ b/test/Interpreter/variadic_generic_type_witnesses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-concrete-type-metadata-mangled-name-accessors -Xfrontend -disable-availability-checking)
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-concrete-type-metadata-mangled-name-accessors -target %target-swift-5.9-abi-triple)
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
 
 // REQUIRES: executable_test
 

--- a/test/Macros/macro_expand_variadic.swift
+++ b/test/Macros/macro_expand_variadic.swift
@@ -2,8 +2,8 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/variadic_macros.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/ModuleInterface/pack_expansion_type.swift
+++ b/test/ModuleInterface/pack_expansion_type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/PackExpansionType.swiftinterface) %s -module-name PackExpansionType -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/PackExpansionType.swiftinterface) %s -module-name PackExpansionType -target %target-swift-5.9-abi-triple
 // RUN: %FileCheck %s < %t/PackExpansionType.swiftinterface
 
 /// Requirements

--- a/test/Parse/type_parameter_packs.swift
+++ b/test/Parse/type_parameter_packs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 protocol P {}
 

--- a/test/SILGen/nested_pack_expansion.swift
+++ b/test/SILGen/nested_pack_expansion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 typealias A<each T, U, V> = (repeat (each T, U, V))
 

--- a/test/SILGen/pack_expansion_type.swift
+++ b/test/SILGen/pack_expansion_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 // CHECK-LABEL: sil [ossa] @$s19pack_expansion_type16variadicFunction1t1ux_q_txQp_txxQp_q_xQptRvzRv_q_Rhzr0_lF : $@convention(thin) <each T, each U where (repeat (each T, each U)) : Any> (@pack_guaranteed Pack{repeat each T}, @pack_guaranteed Pack{repeat each U}) -> @pack_out Pack{repeat (each T, each U)} {
 // CHECK: bb0(%0 : $*Pack{repeat (each T, each U)}, %1 : $*Pack{repeat each T}, %2 : $*Pack{repeat each U}):

--- a/test/SILGen/parameterized_existentials.swift
+++ b/test/SILGen/parameterized_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name parameterized -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name parameterized -target %target-swift-5.7-abi-triple %s | %FileCheck %s
 
 protocol P<T, U, V> {
   associatedtype T

--- a/test/SILGen/parameterized_existentials_variadic.swift
+++ b/test/SILGen/parameterized_existentials_variadic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name parameterized -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name parameterized -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 protocol P<A> {
   associatedtype A

--- a/test/SILGen/variadic-generic-class-methods.swift
+++ b/test/SILGen/variadic-generic-class-methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 public class A<each T> {
   public func f(_ action: (repeat each T) -> ()) {}

--- a/test/SILGen/variadic-generic-closures.swift
+++ b/test/SILGen/variadic-generic-closures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 public struct G<T> {}
 

--- a/test/SILGen/variadic-generic-lowering.swift
+++ b/test/SILGen/variadic-generic-lowering.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple
 
 // Make sure we can lower all of these types without crashing.
 

--- a/test/SILGen/variadic-generic-reabstract-tuple-arg.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-arg.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 func takeEscapingFunction<each Input, Output>(function: @escaping ((repeat each Input)) -> Output) {}
 func returnFunction<each Input, Output>(args: (repeat each Input).Type, result: Output.Type) -> (_: (repeat each Input)) -> Output {}

--- a/test/SILGen/variadic-generic-reabstract-tuple-result.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 
 

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 func takeAny(_ arg: Any) {}
 

--- a/test/SILGen/variadic-generic-vanishing-tuples.swift
+++ b/test/SILGen/variadic-generic-vanishing-tuples.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 // rdar://107459964
 // rdar://107478603

--- a/test/SILGen/variadic_generic_allocating_init.swift
+++ b/test/SILGen/variadic_generic_allocating_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s
 
 class C<each T> {
   var values: (repeat each T)

--- a/test/SILGen/variadic_generic_keypath_descriptors.swift
+++ b/test/SILGen/variadic_generic_keypath_descriptors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-library-evolution -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-library-evolution -target %target-swift-5.9-abi-triple %s | %FileCheck %s
 
 // rdar://problem/112474421
 

--- a/test/SILGen/variadic_generic_opaque_multifile.swift
+++ b/test/SILGen/variadic_generic_opaque_multifile.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/variadic_generic_opaque_multifile_other.swift -disable-availability-checking
-// RUN: %target-swift-frontend -emit-silgen %s %S/Inputs/variadic_generic_opaque_multifile_other.swift -disable-availability-checking
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/variadic_generic_opaque_multifile_other.swift -target %target-swift-5.9-abi-triple
+// RUN: %target-swift-frontend -emit-silgen %s %S/Inputs/variadic_generic_opaque_multifile_other.swift -target %target-swift-5.9-abi-triple
 
 public func caller() {
   callee(1, 2, 3).f()

--- a/test/SILGen/variadic_generic_types.swift
+++ b/test/SILGen/variadic_generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -disable-availability-checking
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple
 
 struct Variadic<each T> where repeat each T: Equatable {}
 

--- a/test/Serialization/nested_pack_expansion.swift
+++ b/test/Serialization/nested_pack_expansion.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/Inputs/nested_pack_expansion_other.swift -emit-module -emit-module-path %t/nested_pack_expansion_other.swiftmodule -disable-availability-checking
-// RUN: %target-typecheck-verify-swift -I %t -disable-availability-checking
+// RUN: %target-swift-frontend %S/Inputs/nested_pack_expansion_other.swift -emit-module -emit-module-path %t/nested_pack_expansion_other.swiftmodule -target %target-swift-5.9-abi-triple
+// RUN: %target-typecheck-verify-swift -I %t -target %target-swift-5.9-abi-triple
 
 import nested_pack_expansion_other
 

--- a/test/Serialization/pack_expansion_type.swift
+++ b/test/Serialization/pack_expansion_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/Inputs/pack_expansion_type_other.swift -emit-module -emit-module-path %t/pack_expansion_type_other.swiftmodule -disable-availability-checking
-// RUN: %target-typecheck-verify-swift -I %t -disable-availability-checking
+// RUN: %target-swift-frontend %S/Inputs/pack_expansion_type_other.swift -emit-module -emit-module-path %t/pack_expansion_type_other.swiftmodule -target %target-swift-5.9-abi-triple
+// RUN: %target-typecheck-verify-swift -I %t -target %target-swift-5.9-abi-triple
 
 import pack_expansion_type_other
 

--- a/test/TypeDecoder/variadic_nominal_types.swift
+++ b/test/TypeDecoder/variadic_nominal_types.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-executable %s -g -o %t/variadic_nominal_types -emit-module -Xfrontend -disable-availability-checking
+// RUN: %target-build-swift -emit-executable %s -g -o %t/variadic_nominal_types -emit-module -target %target-swift-5.9-abi-triple
 
 // RUN: sed -ne '/\/\/ *DEMANGLE-TYPE: /s/\/\/ *DEMANGLE-TYPE: *//p' < %s > %t/input
 // RUN: %lldb-moduleimport-test-with-sdk %t/variadic_nominal_types -type-from-mangled=%t/input | %FileCheck %s --check-prefix=CHECK-TYPE

--- a/test/decl/protocol/conforms/variadic_generic_type.swift
+++ b/test/decl/protocol/conforms/variadic_generic_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 // Generic parameter packs cannot witness associated type requirements
 protocol HasAssoc {

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 //===----------------------------------------------------------------------===//
 // Use of protocols with Self or associated type requirements

--- a/test/stdlib/MirrorWithPacks.swift
+++ b/test/stdlib/MirrorWithPacks.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift %t/main.swift -o %t/Mirror -Xfrontend -disable-availability-checking
+// RUN: %target-build-swift %t/main.swift -o %t/Mirror -target %target-swift-5.9-abi-triple
 // RUN: %target-codesign %t/Mirror
 // RUN: %target-run %t/Mirror
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
 func f1<each T>() -> repeat each T {}
 // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}


### PR DESCRIPTION
Use the `%target-swift-5.9-abi-triple` substitution to compile the tests for deployment to the minimum OS versions required for the APIs used in the tests, instead of disabling availability checking.