### PR TITLE
[MoveAddrChecker] Look through mark_dependence to determine whether an address is initialized to begin with.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -993,6 +993,11 @@ addressBeginsInitialized(MarkUnresolvedNonCopyableValueInst *address) {
   // derivable from the CheckKind of the mark instruction.
 
   SILValue operand = address->getOperand();
+
+  if (auto *mdi = dyn_cast<MarkDependenceInst>(operand)) {
+    operand = mdi->getValue();
+  }
+
   {
     // Then check if our markedValue is from an argument that is in,
     // in_guaranteed, inout, or inout_aliasable, consider the marked address to

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature NonescapableTypes %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature NonescapableTypes %s
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on
@@ -45,4 +45,19 @@ struct S
         utf8.withUnsafeBufferPointer { _ in }
         fatalError()
     }
+}
+
+struct TestCoroAccessorOfCoroAccessor<T : ~Escapable> : ~Copyable & ~Escapable {
+  var t: T
+
+  var inner: TestCoroAccessorOfCoroAccessor<T> {
+    _read {
+      fatalError()
+    }
+  }
+  var outer: TestCoroAccessorOfCoroAccessor<T> {
+    _read {
+      yield inner
+    }
+  }
 }


### PR DESCRIPTION
Extract the hack to determine whether an address starts out initialized into a separate function and then extend it to look through `mark_dependence` instructions.

Fixes a bug with nested accessors.
