### PR TITLE
Run Foundation tests in parallel

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/foundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/foundationtests.py
@@ -74,7 +74,8 @@ class FoundationTests(product.Product):
             '--toolchain', self.install_toolchain_path(host_target),
             '--configuration', self.configuration(),
             '--scratch-path', self.build_dir,
-            '--package-path', package_path
+            '--package-path', package_path,
+            '--parallel',
         ]
         if self.args.verbose_build:
             cmd.append('--verbose')

--- a/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
@@ -69,7 +69,8 @@ class SwiftFoundationTests(product.Product):
             '--toolchain', self.install_toolchain_path(host_target),
             '--configuration', self.configuration(),
             '--scratch-path', self.build_dir,
-            '--package-path', package_path
+            '--package-path', package_path,
+            '--parallel',
         ]
         if self.args.verbose_build:
             cmd.append('--verbose')


### PR DESCRIPTION
Should be significantly faster than running them serially.