### PR TITLE
[Tests] NFC: Update lifetime tests to avoid overloading on borrowing/…

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -32,7 +32,9 @@ struct View : ~Escapable {
     self.ptr = k.ptr
     self.c = k.c
   }
-  init(_ k: consuming View) {
+  // This overload requires a separate label because overloading
+  // on borrowing/consuming attributes is not allowed
+  init(consumingView k: consuming View) {
     self.ptr = k.ptr
     self.c = k.c
   }
@@ -65,7 +67,7 @@ func consume(_ o : consuming MutableView) {}
 
 @lifetime(x)
 func getConsumingView(_ x: consuming View) -> View {
-  return View(x)
+  return View(consumingView: x)
 }
 
 @lifetime(borrow x)


### PR DESCRIPTION
…consuming attributes

Overloading like that should not be allowed but that would have to be addressed separately, 
meanwhile let's add a label to `consuming` init to make sure that the test no longer relies on the type-checker hacks.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
