### PR TITLE
[ASTGen/Parse] Implement ASTGen changes for integer generics from Swift Syntax and restrict parsing integer types in certain contexts

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1938,6 +1938,12 @@ BridgedVarargTypeRepr_createParsed(BridgedASTContext cContext,
                                    BridgedTypeRepr base,
                                    BridgedSourceLoc cEllipsisLoc);
 
+SWIFT_NAME(
+    "BridgedIntegerTypeRepr.createParsed(_:string:loc:minusLoc:)")
+BridgedIntegerTypeRepr BridgedIntegerTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedStringRef cString, BridgedSourceLoc cLoc,
+    BridgedSourceLoc cMinusLoc);
+
 SWIFT_NAME("BridgedTypeRepr.dump(self:)")
 void BridgedTypeRepr_dump(BridgedTypeRepr type);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1411,6 +1411,11 @@ public:
   ParserResult<TypeRepr> parseTypeSimple(
       Diag<> MessageID, ParseTypeReason reason);
 
+  ParserResult<TypeRepr> parseTypeOrValue();
+  ParserResult<TypeRepr> parseTypeOrValue(Diag<> MessageID,
+                          ParseTypeReason reason = ParseTypeReason::Unspecified,
+                          bool fromASTGen = false);
+
   /// Parse layout constraint.
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 

--- a/lib/AST/Bridging/TypeReprBridging.cpp
+++ b/lib/AST/Bridging/TypeReprBridging.cpp
@@ -298,3 +298,13 @@ BridgedExistentialTypeRepr_createParsed(BridgedASTContext cContext,
   return new (context)
       ExistentialTypeRepr(cAnyLoc.unbridged(), baseTy.unbridged());
 }
+
+BridgedIntegerTypeRepr
+BridgedIntegerTypeRepr_createParsed(BridgedASTContext cContext,
+                                    BridgedStringRef cString,
+                                    BridgedSourceLoc cLoc,
+                                    BridgedSourceLoc cMinusLoc) {
+  ASTContext &context = cContext.unbridged();
+  return new (context) IntegerTypeRepr(cString.unbridged(), cLoc.unbridged(),
+                                       cMinusLoc.unbridged());
+}

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -760,7 +760,7 @@ extension ASTGenVisitor {
     let generics = node.genericArgumentClause
     let lAngleLoc = self.generateSourceLoc(generics.leftAngle)
     let genericArguments = generics.arguments.lazy.map {
-      self.generate(type: $0.argument)
+      self.generate(genericArgument: $0.argument)
     }
     let rAngleLoc = self.generateSourceLoc(generics.rightAngle)
     return .createParsed(

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -659,7 +659,7 @@ extension ASTGenVisitor {
     if let generics = node.genericArgumentClause {
       leftAngleLoc = self.generateSourceLoc(generics.leftAngle)
       genericArgs = generics.arguments.map {
-        self.generate(type: $0.argument)
+        self.generate(genericArgument: $0.argument)
       }
       rightAngleLoc = self.generateSourceLoc(generics.rightAngle)
     } else {

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -75,6 +75,7 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.NonescapableTypes, to: .nonescapableTypes)
     mapFeature(.TrailingComma, to: .trailingComma)
     mapFeature(.CoroutineAccessors, to: .coroutineAccessors)
+    mapFeature(.ValueGenerics, to: .valueGenerics)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -120,7 +120,7 @@ extension ASTGenVisitor {
     }
 
     let genericArguments = generics.arguments.lazy.map {
-      self.generate(type: $0.argument)
+      self.generate(genericArgument: $0.argument)
     }
 
     return BridgedUnqualifiedIdentTypeRepr.createParsed(
@@ -140,7 +140,7 @@ extension ASTGenVisitor {
     let angleRange: BridgedSourceRange
     if let generics = node.genericArgumentClause {
       genericArguments = generics.arguments.lazy.map {
-        self.generate(type: $0.argument)
+        self.generate(genericArgument: $0.argument)
       }.bridgedArray(in: self)
 
       angleRange = self.generateSourceRange(start: generics.leftAngle, end: generics.rightAngle)

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(ExperimentalLanguageFeatures)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
@@ -141,10 +142,21 @@ extension DistributedResolvableMacro {
         specificActorSystemRequirement = conformanceReq.rightType.trimmed
         isGenericStub = true
 
-      case .sameTypeRequirement(let sameTypeReq)
-           where sameTypeReq.leftType.isActorSystem:
-        specificActorSystemRequirement = sameTypeReq.rightType.trimmed
-        isGenericStub = false
+      case .sameTypeRequirement(let sameTypeReq):
+        switch sameTypeReq.leftType {
+        case .type(let type) where type.isActorSystem:
+          switch sameTypeReq.rightType.trimmed {
+          case .type(let rightType):
+            specificActorSystemRequirement = rightType
+            isGenericStub = false
+
+          case .expr:
+            fatalError("Expression type not supported for distributed actor")
+          }
+
+        default:
+          continue
+        }
 
       default:
         continue

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -151,7 +151,11 @@ extension DistributedResolvableMacro {
             isGenericStub = false
 
           case .expr:
-            fatalError("Expression type not supported for distributed actor")
+            throw DiagnosticsError(
+              syntax: sameTypeReq.rightType,
+              message: "Expression type not supported for distributed actor",
+              id: .invalidGenericArgument
+            )
           }
 
         default:
@@ -277,6 +281,7 @@ struct DistributedResolvableMacroDiagnostic: DiagnosticMessage {
   enum ID: String {
     case invalidApplication = "invalid type"
     case missingInitializer = "missing initializer"
+    case invalidGenericArgument = "invalid generic argument"
   }
 
   var message: String

--- a/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
@@ -72,7 +72,7 @@ public struct OptionSetMacro {
     of attribute: AttributeSyntax,
     attachedTo decl: Decl,
     in context: Context
-  ) -> (StructDeclSyntax, EnumDeclSyntax, TypeSyntax)? {
+  ) -> (StructDeclSyntax, EnumDeclSyntax, GenericArgumentSyntax.Argument)? {
     // Determine the name of the options enum.
     let optionsEnumName: String
     if case let .argumentList(arguments) = attribute.arguments,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3963,7 +3963,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
      
-      auto countType = parseType(diag::expected_type);
+      auto countType = parseTypeOrValue(diag::expected_type);
       if (countType.isNull()) {
         return makeParserSuccess();
       }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -317,7 +317,9 @@ ParserStatus Parser::parseGenericWhereClause(
 
     // Parse the leading type. It doesn't necessarily have to be just a type
     // identifier if we're dealing with a same-type constraint.
-    ParserResult<TypeRepr> FirstType = parseType();
+    //
+    // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
+    ParserResult<TypeRepr> FirstType = parseTypeOrValue();
 
     if (FirstType.hasCodeCompletion()) {
       Status.setHasCodeCompletionAndIsError();
@@ -377,7 +379,9 @@ ParserStatus Parser::parseGenericWhereClause(
       SourceLoc EqualLoc = consumeToken();
 
       // Parse the second type.
-      ParserResult<TypeRepr> SecondType = parseType();
+      //
+      // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
+      ParserResult<TypeRepr> SecondType = parseTypeOrValue();
       Status |= SecondType;
       if (SecondType.isNull())
         SecondType = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1067,6 +1067,42 @@ bool SILParser::parseASTType(CanType &result,
   return false;
 }
 
+bool SILParser::parseASTTypeOrValue(CanType &result,
+                                    GenericSignature genericSig,
+                                    GenericParamList *genericParams,
+                                    bool forceContextualType) {
+  auto parsedType = P.parseTypeOrValue();
+  if (parsedType.isNull()) return true;
+
+  // If we weren't given a specific generic context to resolve the type
+  // within, use the contextual generic parameters and always produce
+  // a contextual type.  Otherwise, produce a contextual type only if
+  // we were asked for one.
+  bool wantContextualType = forceContextualType;
+  if (!genericSig) {
+    genericSig = ContextGenericSig;
+    wantContextualType = true;
+  }
+  if (genericParams == nullptr)
+    genericParams = ContextGenericParams;
+
+  bindSILGenericParams(parsedType.get());
+
+  auto resolvedType = performTypeResolution(
+      parsedType.get(), /*isSILType=*/false, genericSig, genericParams);
+  if (wantContextualType && genericSig) {
+    resolvedType = genericSig.getGenericEnvironment()
+        ->mapTypeIntoContext(resolvedType);
+  }
+
+  if (resolvedType->hasError())
+    return true;
+
+  result = resolvedType->getCanonicalType();
+
+  return false;
+}
+
 void SILParser::bindSILGenericParams(TypeRepr *TyR) {
   // Resolve the generic environments for parsed generic function and box types.
   class HandleSILGenericParamsWalker : public ASTWalker {
@@ -3122,7 +3158,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     CanType paramType;
     if (parseSILType(Ty) ||
         parseVerbatim("for") ||
-        parseASTType(paramType))
+        parseASTTypeOrValue(paramType))
       return true;
 
     ResultVal = B.createTypeValue(InstLoc, Ty, paramType);

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -235,6 +235,11 @@ public:
     return false;
   }
 
+  bool parseASTTypeOrValue(CanType &result,
+                           GenericSignature genericSig = GenericSignature(),
+                           GenericParamList *genericParams = nullptr,
+                           bool forceContextualType = false);
+
   std::optional<StringRef>
   parseOptionalAttribute(ArrayRef<StringRef> expected) {
     // We parse here @ <identifier>.

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -291,3 +291,12 @@ struct ValueStruct<let N: Int> {}
 func genericTest1<T>(_: T) {}
 func genericTest2<each T>(_: repeat each T) {}
 func genericTest4<let T: Int>(_: ValueStruct<T>) {}
+
+func concreteValueTest1(_: ValueStruct<123>) {}
+func concreteValueTest2(_: ValueStruct<-123>) {}
+
+extension ValueStruct where N == 123 {}
+extension ValueStruct where 123 == N {}
+extension ValueStruct where N == -123 {}
+extension ValueStruct where -123 == N {}
+

--- a/test/Interpreter/value_generics.swift
+++ b/test/Interpreter/value_generics.swift
@@ -1,5 +1,4 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking -Xfrontend -disable-experimental-parser-round-trip) | %FileCheck %s
-// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
+// RUN: %target-run-simple-swift(-enable-experimental-feature ValueGenerics -Xfrontend  -disable-availability-checking) | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name ValueGeneric -enable-experimental-feature ValueGenerics -disable-availability-checking -disable-experimental-parser-round-trip
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking -disable-experimental-parser-round-trip
-// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name ValueGeneric -enable-experimental-feature ValueGenerics -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // REQUIRES: swift_feature_ValueGenerics

--- a/test/Parse/integer_types.swift
+++ b/test/Parse/integer_types.swift
@@ -1,8 +1,12 @@
 // RUN: %target-typecheck-verify-swift
 
-let a: 123 // expected-error {{integer unexpectedly used in a type position}}
+let a: 123 // expected-error {{consecutive statements on a line must be separated by ';'}}
+           // expected-error@-1 {{expected type}}
+           // expected-warning@-2 {{integer literal is unused}}
 
-let b: -123 // expected-error {{integer unexpectedly used in a type position}}
+let b: -123 // expected-error {{consecutive statements on a line must be separated by ';'}}
+           // expected-error@-1 {{expected type}}
+           // expected-warning@-2 {{integer literal is unused}}
 
 let c: -Int // expected-error {{expected type}}
             // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
@@ -30,3 +34,19 @@ let f = Generic<-Int>.self // expected-error {{generic parameter 'T' could not b
                            // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
                            // expected-error@-2 {{'>' is not a postfix unary operator}}
                            // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}
+
+let g: 123.Type // expected-error {{consecutive statements on a line must be separated by ';'}}
+                // expected-error@-1 {{expected type}}
+                // expected-error@-2 {{value of type 'Int' has no member 'Type'}}
+
+let h: 123.Protocol // expected-error {{consecutive statements on a line must be separated by ';'}}
+                    // expected-error@-1 {{expected type}}
+                    // expected-error@-2 {{value of type 'Int' has no member 'Protocol'}}
+
+let i: 123? // expected-error {{consecutive statements on a line must be separated by ';'}}
+            // expected-error@-1 {{expected type}}
+            // expected-error@-2 {{cannot use optional chaining on non-optional value of type 'Int'}}
+
+let j: 123! // expected-error {{consecutive statements on a line must be separated by ';'}}
+            // expected-error@-1 {{expected type}}
+            // expected-error@-2 {{cannot force unwrap value of non-optional type 'Int'}}

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ValueGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking -disable-experimental-parser-round-trip
-// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ValueGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking
 
 // REQUIRES: swift_feature_NonescapableTypes
 // REQUIRES: swift_feature_ValueGenerics

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -53,18 +53,21 @@ struct Generic<T: ~Copyable & ~Escapable> {}
 struct GenericWithIntParam<T: ~Copyable & ~Escapable, let N: Int> {}
 
 extension Generic where T == 123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
-extension Generic where T == 123.Type {} // expected-error {{integer unexpectedly used in a type position}}
+extension Generic where T == 123.Type {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+                                         // expected-error@-1 {{expected '{' in extension}}
+extension Generic where T == 123? {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
+                                     // expected-error@-1 {{expected '{' in extension}}
 
 func f(_: Generic<123>) {} // expected-error {{integer unexpectedly used in a type position}}
 func g<let N: Int>(_: Generic<N>) {} // expected-error {{cannot use value type 'N' for generic argument 'T'}}
-func h(_: (Int, 123)) {} // expected-error {{integer unexpectedly used in a type position}}
-func i(_: () -> 123) {} // expected-error {{integer unexpectedly used in a type position}}
+func h(_: (Int, 123)) {} // expected-error {{expected type}}
+func i(_: () -> 123) {} // expected-error {{expected type}}
 func j(_: (A<123>) -> ()) {} // OK
-func k(_: some 123) {} // expected-error {{integer unexpectedly used in a type position}}
+func k(_: some 123) {} // expected-error {{expected parameter type following ':'}}
 func l(_: GenericWithIntParam<123, Int>) {} // expected-error {{cannot pass type 'Int' as a value for generic value 'N'}}
 func m(_: GenericWithIntParam<Int, 123>) {} // OK
 
-typealias One = 1 // expected-error {{integer unexpectedly used in a type position}}
+typealias One = 1 // expected-error {{expected type in type alias declaration}}
 
 struct B<let N: UInt8> {} // expected-error {{'UInt8' is not a supported value type for 'N'}}
 

--- a/test/Serialization/value_generics.swift
+++ b/test/Serialization/value_generics.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature ValueGenerics -enable-experimental-feature RawLayout -disable-availability-checking -disable-experimental-parser-round-trip -parse-as-library -o %t
-// FIXME: Remove -disable-experimental-parser-round-trip after https://github.com/swiftlang/swift-syntax/pull/2859 is merged
+// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature ValueGenerics -enable-experimental-feature RawLayout -disable-availability-checking -parse-as-library -o %t
 // RUN: %target-sil-opt -enable-sil-verify-all %t/value_generics.swiftmodule -o - | %FileCheck %s
 
 // REQUIRES: swift_feature_RawLayout

--- a/test/attr/attr_implements_bad_parse.swift
+++ b/test/attr/attr_implements_bad_parse.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -parse -verify %s
 
 struct S0 {
-  @_implements(1, Foo) // OK. We can parse integers as types now, so this is fine. We will diagnose its incorrect usage during type checking.
+  @_implements(1, Foo) // expected-error {{expected type}}
   func f() { }
 }
 

--- a/test/expr/postfix/init/unqualified.swift
+++ b/test/expr/postfix/init/unqualified.swift
@@ -62,7 +62,7 @@ class Theodosia: Aaron {
 
     // FIXME: We could optimistically parse this as an expression instead
     // expected-error@+2 {{initializers may only be declared within a type}}
-    // expected-error@+1 {{integer unexpectedly used in a type position}}
+    // expected-error@+1 {{expected parameter type following ':'}}
     init(z: 0)
   }
 
@@ -98,7 +98,7 @@ struct AaronStruct {
 
     // FIXME: We could optimistically parse this as an expression instead
     // expected-error@+2 {{initializers may only be declared within a type}}
-    // expected-error@+1 {{integer unexpectedly used in a type position}}
+    // expected-error@+1 {{expected parameter type following ':'}}
     init(y: 1)
   }
 


### PR DESCRIPTION
In support of the Swift syntax parser being able to parse integer changes, we need to handle those in ASTGen.

Syntax PR: https://github.com/swiftlang/swift-syntax/pull/2859