### PR TITLE
Sema: Give constraints a more dignified retirement

### DIFF
--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -69,7 +69,6 @@ CLOSURE_CHANGE(RecordedPreconcurrencyClosure)
 CONSTRAINT_CHANGE(DisabledConstraint)
 CONSTRAINT_CHANGE(FavoredConstraint)
 CONSTRAINT_CHANGE(GeneratedConstraint)
-CONSTRAINT_CHANGE(RetiredConstraint)
 
 GRAPH_NODE_CHANGE(AddedConstraint)
 GRAPH_NODE_CHANGE(RemovedConstraint)
@@ -97,8 +96,9 @@ CHANGE(RecordedCaseLabelItemInfo)
 CHANGE(RecordedPotentialThrowSite)
 CHANGE(RecordedIsolatedParam)
 CHANGE(RecordedKeyPath)
+CHANGE(RetiredConstraint)
 
-LAST_CHANGE(RecordedKeyPath)
+LAST_CHANGE(RetiredConstraint)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -20,6 +20,8 @@
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
+#include "swift/Sema/Constraint.h"
+#include "llvm/ADT/ilist.h"
 #include <vector>
 
 namespace llvm {
@@ -103,7 +105,6 @@ public:
         Type DstType;
       } Restriction;
 
-
       struct {
         GenericTypeParamType *GP;
         Type ReqTy;
@@ -118,6 +119,14 @@ public:
         const KeyPathExpr *Expr;
         Type OldType;
       } KeyPath;
+
+      struct {
+        /// It's former position in the inactive constraints list.
+        llvm::ilist<Constraint>::iterator Where;
+
+        /// The constraint.
+        Constraint *Constraint;
+      } Retiree;
 
       ConstraintFix *TheFix;
       ConstraintLocator *TheLocator;
@@ -212,6 +221,10 @@ public:
 
     /// Create a change that recorded a key path expression.
     static Change RecordedKeyPath(KeyPathExpr *expr);
+
+    /// Create a change that removed a constraint from the inactive constraint list.
+    static Change RetiredConstraint(llvm::ilist<Constraint>::iterator where,
+                                    Constraint *constraint);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -430,9 +430,11 @@ StepResult ComponentStep::take(bool prevFailed) {
       return suspend(
           std::make_unique<DisjunctionStep>(CS, disjunction, Solutions));
     }
-    case StepKind::Conjunction:
+    case StepKind::Conjunction: {
+      CS.retireConstraint(conjunction);
       return suspend(
           std::make_unique<ConjunctionStep>(CS, conjunction, Solutions));
+    }
     }
     llvm_unreachable("Unhandled case in switch!");
   }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -425,9 +425,11 @@ StepResult ComponentStep::take(bool prevFailed) {
     case StepKind::Binding:
       return suspend(
           std::make_unique<TypeVariableStep>(*bestBindings, Solutions));
-    case StepKind::Disjunction:
+    case StepKind::Disjunction: {
+      CS.retireConstraint(disjunction);
       return suspend(
           std::make_unique<DisjunctionStep>(CS, disjunction, Solutions));
+    }
     case StepKind::Conjunction:
       return suspend(
           std::make_unique<ConjunctionStep>(CS, conjunction, Solutions));

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -684,7 +684,6 @@ protected:
 class DisjunctionStep final : public BindingStep<DisjunctionChoiceProducer> {
   Constraint *Disjunction;
   SmallVector<Constraint *, 4> DisabledChoices;
-  ConstraintList::iterator AfterDisjunction;
 
   std::optional<Score> BestNonGenericScore;
   std::optional<std::pair<Constraint *, Score>> LastSolvedChoice;
@@ -692,8 +691,7 @@ class DisjunctionStep final : public BindingStep<DisjunctionChoiceProducer> {
 public:
   DisjunctionStep(ConstraintSystem &cs, Constraint *disjunction,
                   SmallVectorImpl<Solution> &solutions)
-      : BindingStep(cs, {cs, disjunction}, solutions), Disjunction(disjunction),
-        AfterDisjunction(erase(disjunction)) {
+      : BindingStep(cs, {cs, disjunction}, solutions), Disjunction(disjunction) {
     assert(Disjunction->getKind() == ConstraintKind::Disjunction);
     pruneOverloadSet(Disjunction);
     ++cs.solverState->NumDisjunctions;
@@ -702,8 +700,6 @@ public:
   ~DisjunctionStep() override {
     // Rewind back any changes left after attempting last choice.
     ActiveChoice.reset();
-    // Return disjunction constraint back to the system.
-    restore(AfterDisjunction, Disjunction);
     // Re-enable previously disabled overload choices.
     for (auto *choice : DisabledChoices)
       choice->setEnabled();

--- a/test/Constraints/issue-77008.swift
+++ b/test/Constraints/issue-77008.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+// Just don't crash.
+
+Binding<Bool>Binding<Bool>

--- a/validation-test/Sema/type_checker_perf/fast/borderline_flat_map_operator_mix.swift
+++ b/validation-test/Sema/type_checker_perf/fast/borderline_flat_map_operator_mix.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=10
 
+// REQUIRES: no_asan
+
 struct S {
     var t: Double
 

--- a/validation-test/Sema/type_checker_perf/slow/coerce_literal_linear_combo.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/coerce_literal_linear_combo.swift.gyb
@@ -1,5 +1,7 @@
 // RUN: %scale-test --invert-result --begin 2 --end 5 --step 1 --select NumLeafScopes %s
 
+// REQUIRES: no_asan
+
 func g<T: Equatable>(_: T, _: T) {}
 
 let base: UInt64 = 0

--- a/validation-test/Sema/type_checker_perf/slow/simd_scalar_multiple.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/simd_scalar_multiple.swift.gyb
@@ -1,5 +1,7 @@
 // RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s
 
+// REQUIRES: no_asan
+
 func f(c: Float, a: SIMD2<Float>) -> SIMD2<Float> {
   return (c * a)
 %for i in range(1, N):


### PR DESCRIPTION
When we retire a constraint, there is no guarantee that it is at the end of the list, so it is not correct to always reinsert it at the end of the list when the constraint comes out of retirement. Instead, remember the position where we removed it from, so that we can always reinsert it in the correct position. This allows us to replace some bespoke logic in CSStep.h with a call to `retireConstraint()`.

Fixes https://github.com/swiftlang/swift/issues/77008
Also fixes rdar://problem/138246764 