### PR TITLE
[CSBindings] Limit `BindingSet::isViable` binding skipping to stdlib …

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1215,8 +1215,12 @@ bool BindingSet::isViable(PotentialBinding &binding, bool isTransitive) {
     // as a binding because `$T0` could be inferred to
     // `(key: String, value: Int)` and binding `$T1` to `Array<(String, Int)>`
     // eagerly would be incorrect.
-    if (existing->Kind != binding.Kind)
-      continue;
+    if (existing->Kind != binding.Kind) {
+      // Array, Set and Dictionary allow conversions, everything else
+      // requires their generic arguments to match exactly.
+      if (existingType->isKnownStdlibCollectionType())
+        continue;
+    }
 
     // If new type has a type variable it shouldn't
     // be considered  viable.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -1072,3 +1072,18 @@ do {
     // expected-error@-1 {{referencing instance method 'compute()' on 'Dictionary' requires the types 'any P' and 'Any' be equivalent}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/77003
+do {
+  func f<T, U>(_: T.Type, _ fn: (T) -> U?, _: (U) -> ()) {}
+
+  struct Task<E> {
+    init(_: () -> ()) where E == Never {}
+    init(_: () throws -> ()) where E == Error {}
+  }
+
+  func test(x: Int?.Type) {
+      // Note that it's important that Task stays unused, using `_ = ` changes constraint generation behavior.
+      f(x, { $0 }, { _ in Task {} }) // expected-warning {{result of 'Task<E>' initializer is unused}}
+  }
+}

--- a/validation-test/Sema/SwiftUI/rdar98862079.swift
+++ b/validation-test/Sema/SwiftUI/rdar98862079.swift
@@ -22,7 +22,7 @@ struct MyView : View {
 
   var body: some View {
     test(value: true ? $newBounds.maxBinding : $newBounds.minBinding, in: bounds)
-    // expected-error@-1 {{cannot convert value of type 'Binding<Binding<Double>?>' to expected argument type 'Binding<Double>'}}
-    // expected-note@-2 {{arguments to generic parameter 'Value' ('Binding<Double>?' and 'Double') are expected to be equal}}
+    // expected-error@-1 2 {{result values in '? :' expression have mismatching types 'Binding<Binding<Double>?>' and 'Binding<Double>'}}
+    // expected-note@-2 2 {{arguments to generic parameter 'Value' ('Binding<Double>?' and 'Double') are expected to be equal}}
   }
 }


### PR DESCRIPTION
…collection types

This is follow-up to https://github.com/swiftlang/swift/pull/76487

It's reasonable to coalesce bindings of different kind if they don't allow implicit conversions like stdlib collection types do.

Resolves: https://github.com/swiftlang/swift/issues/77003

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
