### PR TITLE
[unittest] Disambiguate references to errno

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -20,6 +20,7 @@ import SwiftPrivateLibcExtras
 import Foundation
 #endif
 import Darwin
+import var Darwin.errno
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -1106,7 +1107,7 @@ class _ParentProcess {
       var ret: CInt
       repeat {
         ret = _stdlib_select(&readfds, &writefds, &errorfds, nil)
-      } while ret == -1  &&  errno == EINTR
+      } while ret == -1 && errno == EINTR
       if ret <= 0 {
         fatalError("select() returned an error")
       }

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -31,6 +31,7 @@ let RequestPointerSize = "p"
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import MachO
 import Darwin
+import var Darwin.errno
 
 #if arch(x86_64) || arch(arm64)
 typealias MachHeader = mach_header_64


### PR DESCRIPTION
In Xcode 16 SDKs there seem to be two `errno` visible for some files, one in the `Darwin` module, and one in the `_errno` module (which seems new for this Xcode version).

Disambiguate the references by prepending `Darwin`, which should be the one that was being used before Xcode 16 SDKs.