### PR TITLE
[swiftinterface] Handle target variants the same as targets

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -571,7 +571,8 @@ public:
 bool extractCompilerFlagsFromInterface(
     StringRef interfacePath, StringRef buffer, llvm::StringSaver &ArgSaver,
     SmallVectorImpl<const char *> &SubArgs,
-    std::optional<llvm::Triple> PreferredTarget = std::nullopt);
+    std::optional<llvm::Triple> PreferredTarget = std::nullopt,
+    std::optional<llvm::Triple> PreferredTargetVariant = std::nullopt);
 
 /// Extract the user module version number from an interface file.
 llvm::VersionTuple extractUserModuleVersionFromInterface(StringRef moduleInterfacePath);


### PR DESCRIPTION
Based on preliminary work from @rmaz.

The compilation arguments for a swiftinterface file are preprocessed to modify the `-target` argument to match the preferred target (which comes from the command line) in cases in which the sub-architecture differs, but it is compatible (for example using `arm64e` when `arm64` is being compiled), but this was not done for the target variant, which ended up with mismatches on the sub-architecture used by the target and target variant, which fails an assert in assert toolchains.

Maybe solves rdar://135322077