### PR TITLE
Sema: Adopt AvailabilityContext in ExportContext

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -71,6 +71,12 @@ public:
   /// Returns true if this context is deprecated on the current platform.
   bool isDeprecated() const;
 
+  /// Constrain with another `AvailabilityContext`.
+  void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);
+
+  /// Constrain with the availability attributes of `decl`.
+  void constrainWithDecl(const Decl *decl);
+
   /// Constrain the platform availability range with `platformRange`.
   void constrainWithPlatformRange(const AvailabilityRange &platformRange,
                                   ASTContext &ctx);

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -75,10 +75,10 @@ public:
   void constrainWithPlatformRange(const AvailabilityRange &platformRange,
                                   ASTContext &ctx);
 
-  /// Constrain the platform availability range with both the availability
-  /// attributes of `decl` and with `platformRange`.
+  /// Constrain with the availability attributes of `decl`, intersecting the
+  /// platform range of `decl` with `platformRange`.
   void
-  constrainWithDeclAndPlatformRange(Decl *decl,
+  constrainWithDeclAndPlatformRange(const Decl *decl,
                                     const AvailabilityRange &platformRange);
 
   /// Returns true if `other` is as available or is more available.

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -40,10 +40,13 @@ struct AvailabilityContext::PlatformInfo {
   /// platform.
   unsigned IsDeprecated : 1;
 
-  /// Sets `Range` to `other` if `other` is more restrictive. Returns true if
-  /// any property changed as a result of adding this constraint.
+  /// Sets each field to the value of the corresponding field in `other` if the
+  /// other is more restrictive. Returns true if any field changed as a result
+  /// of adding this constraint.
+  bool constrainWith(const PlatformInfo &other);
+
   /// Updates each field to reflect the availability of `decl`, if that
-  /// availability is more restrictive. Return true if any field was updated.
+  /// availability is more restrictive. Returns true if any field was updated.
   bool constrainWith(const Decl *decl);
 
   bool constrainRange(const AvailabilityRange &other) {

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -42,6 +42,10 @@ struct AvailabilityContext::PlatformInfo {
 
   /// Sets `Range` to `other` if `other` is more restrictive. Returns true if
   /// any property changed as a result of adding this constraint.
+  /// Updates each field to reflect the availability of `decl`, if that
+  /// availability is more restrictive. Return true if any field was updated.
+  bool constrainWith(const Decl *decl);
+
   bool constrainRange(const AvailabilityRange &other) {
     if (!other.isContainedIn(Range))
       return false;
@@ -50,19 +54,9 @@ struct AvailabilityContext::PlatformInfo {
     return true;
   }
 
-  /// Sets `Range` to the platform introduction range of `decl` if that range
-  /// is more restrictive. Returns true if
-  /// any property changed as a result of adding this constraint.
-  bool constrainRange(const Decl *decl);
+  bool constrainUnavailability(std::optional<PlatformKind> unavailablePlatform);
 
-  /// Updates `UnavailablePlatform` and `IsUnavailable` to reflect the status
-  /// of `decl` if its platform unavailability is more restrictive. Returns
-  /// true if any property changed as a result of adding this constraint.
-  bool constrainUnavailability(const Decl *decl);
-
-  /// If `decl` is deprecated, sets `IsDeprecated` to true. Returns true if
-  /// any property changed as a result of adding this constraint.
-  bool constrainDeprecated(const Decl *decl);
+  bool constrainDeprecated(bool deprecated);
 
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const PlatformInfo &other) const;

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -39,15 +39,21 @@ bool AvailabilityContext::PlatformInfo::constrainUnavailability(
   if (!unavailablePlatform)
     return false;
 
-  // Check whether the decl's unavailability reason is the same.
-  if (IsUnavailable && UnavailablePlatform == *unavailablePlatform)
-    return false;
+  if (IsUnavailable) {
+    // Universal unavailability cannot be refined.
+    if (UnavailablePlatform == PlatformKind::none)
+      return false;
 
-  // Check whether the decl's unavailability reason is more specific.
-  if (*unavailablePlatform != PlatformKind::none &&
-      inheritsAvailabilityFromPlatform(*unavailablePlatform,
-                                       UnavailablePlatform))
-    return false;
+    // There's nothing to do if the platforms already match.
+    if (UnavailablePlatform == *unavailablePlatform)
+      return false;
+
+    // The new platform must be more restrictive.
+    if (*unavailablePlatform != PlatformKind::none &&
+        inheritsAvailabilityFromPlatform(*unavailablePlatform,
+                                         UnavailablePlatform))
+      return false;
+  }
 
   IsUnavailable = true;
   UnavailablePlatform = *unavailablePlatform;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -348,8 +348,7 @@ static const AvailableAttr *getActiveAvailableAttribute(const Decl *D,
 
 /// Returns true if there is any availability attribute on the declaration
 /// that is active on the target platform.
-static bool hasActiveAvailableAttribute(Decl *D,
-                                           ASTContext &AC) {
+static bool hasActiveAvailableAttribute(const Decl *D, ASTContext &AC) {
   return getActiveAvailableAttribute(D, AC);
 }
 
@@ -718,8 +717,12 @@ private:
     return nullptr;
   }
 
-  const AvailabilityContext getEffectiveAvailabilityForDeclSignature(Decl *D) {
+  const AvailabilityContext
+  getEffectiveAvailabilityForDeclSignature(const Decl *D) {
     auto EffectiveIntroduction = AvailabilityRange::alwaysAvailable();
+
+    // Availability attributes are found abstract syntax decls.
+    D = abstractSyntaxDeclForAvailableAttribute(D);
 
     // As a special case, extension decls are treated as effectively as
     // available as the nominal type they extend, up to the deployment target.
@@ -754,7 +757,7 @@ private:
   /// are not constrained since they appear in the interface of the module and
   /// may be consumed by clients with lower deployment targets, but there are
   /// some exceptions.
-  bool shouldConstrainSignatureToDeploymentTarget(Decl *D) {
+  bool shouldConstrainSignatureToDeploymentTarget(const Decl *D) {
     if (isCurrentTRCContainedByDeploymentTarget())
       return false;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -695,7 +695,7 @@ private:
       return nullptr;
 
     // Declarations with explicit availability attributes always get a TRC.
-    if (AvailabilityInference::attrForAnnotatedAvailableRange(D)) {
+    if (hasActiveAvailableAttribute(D, Context)) {
       return TypeRefinementContext::createForDecl(
           Context, D, getCurrentTRC(),
           getEffectiveAvailabilityForDeclSignature(D),

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -998,6 +998,13 @@ bool isAvailabilitySafeForConformance(
     const ValueDecl *witness, const DeclContext *dc,
     AvailabilityRange &requiredAvailability);
 
+/// Returns the most refined `AvailabilityContext` for the given location.
+/// If `MostRefined` is not `nullptr`, it will be set to the most refined TRC
+/// that contains the given location.
+AvailabilityContext
+availabilityAtLocation(SourceLoc loc, const DeclContext *DC,
+                       const TypeRefinementContext **MostRefined = nullptr);
+
 /// Returns an over-approximation of the range of operating system versions
 /// that could the passed-in location could be executing upon for
 /// the target platform. If MostRefined != nullptr, set to the most-refined

--- a/test/Sema/availability_deprecated_script_mode.swift
+++ b/test/Sema/availability_deprecated_script_mode.swift
@@ -20,11 +20,8 @@ var testDeprecatedReferencingDeprecated2: () {
   x - y // no-warning
 }
 
-// FIXME: This doesn't work because the file is parsed in script mode.
 @available(*, deprecated)
 var testDeprecatedReferencingDeprecated3: () = DummyType() - DummyType()
-// expected-warning@-1 {{'-' is deprecated}}
-// expected-note@-2 {{use '&-' instead}}
 
 struct HasDeprecatedMembers {
   @available(*, deprecated)

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -311,7 +311,7 @@ func testStringInterpolation() {
     """
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 unavailable=macOS decl=unavailableOnMacOS()
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOS()
 // CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=x
 
 @available(macOS, unavailable)
@@ -322,7 +322,7 @@ func unavailableOnMacOS() {
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=unavailableOnMacOS
-// CHECK-NEXT: {{^}}        (decl_implicit version=51 unavailable=macOS decl=unavailableOnMacOS
+// CHECK-NEXT: {{^}}        (decl version=51 unavailable=macOS decl=unavailableOnMacOS
 @available(OSX 51, *)
 extension SomeEnum {
   @available(macOS, unavailable)
@@ -330,10 +330,10 @@ extension SomeEnum {
 }
 
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
 // CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=* decl=neverAvailable()
+// CHECK-NEXT: {{^}}      (decl version=50 unavailable=* decl=neverAvailable()
 
 @available(macOS, unavailable)
 extension SomeEnum {
@@ -347,7 +347,8 @@ extension SomeEnum {
   func neverAvailable() {}
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 unavailable=* decl=NeverAvailable
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=* decl=NeverAvailable
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=* decl=unavailableOnMacOS()
 
 @available(*, unavailable)
 struct NeverAvailable {
@@ -355,7 +356,7 @@ struct NeverAvailable {
   func unavailableOnMacOS() {}
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 deprecated decl=deprecatedOnMacOS()
+// CHECK-NEXT: {{^}}  (decl version=50 deprecated decl=deprecatedOnMacOS()
 // CHECK-NEXT: {{^}}    (decl_implicit version=50 deprecated decl=x
 
 @available(macOS, deprecated)

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -319,23 +319,38 @@ func unavailableOnMacOS() {
   let x = 1
 }
 
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=* decl=neverAvailable()
+
+@available(macOS, unavailable)
+extension SomeEnum {
+  @available(OSX 52, *)
+  var availableMacOS_52: Int { 1 }
+
+  @available(macOSApplicationExtension, unavailable)
+  func unavailableInAppExtensions() {}
+
+  @available(*, unavailable)
+  func neverAvailable() {}
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 unavailable=* decl=NeverAvailable
+
+@available(*, unavailable)
+struct NeverAvailable {
+  @available(macOS, unavailable)
+  func unavailableOnMacOS() {}
+}
+
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 deprecated decl=deprecatedOnMacOS()
 // CHECK-NEXT: {{^}}    (decl_implicit version=50 deprecated decl=x
 
 @available(macOS, deprecated)
 func deprecatedOnMacOS() {
   let x = 1
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=propertyInUnavailableExtension
-// CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=propertyInUnavailableExtension
-
-@available(macOS, unavailable)
-extension SomeEnum {
-  @available(OSX 52, *)
-  var propertyInUnavailableExtension: Int { 1 }
 }
 
 // CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -320,6 +320,16 @@ func unavailableOnMacOS() {
 }
 
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=unavailableOnMacOS
+// CHECK-NEXT: {{^}}        (decl_implicit version=51 unavailable=macOS decl=unavailableOnMacOS
+@available(OSX 51, *)
+extension SomeEnum {
+  @available(macOS, unavailable)
+  var unavailableOnMacOS: Int { 1 }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
 // CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=availableMacOS_52

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -133,7 +133,7 @@ extension Outer {
 
   @available(*, unavailable)
   func osx_universally_unavailable_call_osx() {
-    osx() // OK
+    osx() // expected-error {{'osx()' is unavailable in macOS}}
   }
   
   // rdar://92551870


### PR DESCRIPTION
When forming an ExportContext, query for an `AvailabilityContext` using the `TypeRefinementContext` tree instead of computing availability by performing a `DeclContext` traversal. This revealed a few bugs in how `AvailabilityContext` were built and also fixed a couple of longstanding bugs.