### PR TITLE
Add mailto format for code-owners@forums.swift.org .

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ To switch to this template when drafting a pull request in a [swiftlang](https:/
 ### Commit Access
 
 Commit access is granted to contributors with a track record of submitting high-quality changes.
-If you would like commit access, please send an email to [the code owners list](code-owners@forums.swift.org) with the GitHub user name that you want to use and a list of 5 non-trivial pull requests that were accepted without modifications.
+If you would like commit access, please send an email to [the code owners list](mailto:code-owners@forums.swift.org) with the GitHub user name that you want to use and a list of 5 non-trivial pull requests that were accepted without modifications.
 
 Once you’ve been granted commit access, you will be able to commit to all of the GitHub repositories that host Swift.org projects.
 To verify that your commit access works, please make a test commit (for example, change a comment or add a blank line). The following policies apply to users with commit access:


### PR DESCRIPTION
Currently, tapped to `the code owners list` at `CONTRIBUTING.md` it will navigate to `https://github.com/swiftlang/swift/blob/main/code-owners@forums.swift.org` (Not Found) because it does not use `mailto` format. Adding `mailto` format to open mail application.