### PR TITLE
[swift-inspect] Force forkCorpse if VMUProcInfo advises it.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -125,7 +125,17 @@ internal final class DarwinRemoteProcess: RemoteProcess {
       return nil
     }
 
-    if forkCorpse {
+    // Consult with VMUProcInfo to determine if we should force forkCorpse.
+    let forceForkCorpse: Bool
+    if let procInfoClass = getVMUProcInfoClass() {
+      let procInfo = procInfoClass.init(task: task)
+      forceForkCorpse = procInfo.shouldAnalyzeWithCorpse
+    } else {
+      // Default to not forcing forkCorpse.
+      forceForkCorpse = false
+    }
+
+    if forkCorpse || forceForkCorpse {
       var corpse = task_t()
       let maxRetry = 6
       for retry in 0..<maxRetry {


### PR DESCRIPTION
Various processes, such as launchd, are unsafe to inspect directly. Inspecting them pauses them and the system does not like it when they're paused. Forking a corpse avoids this, as the original process continues running while we inspect the forked corpse.

VMUProcInfo provides a shouldAnalyzeWithCorpse call which tells us whether we're inspecting one of those processes. When we are, then we force the forkCorpse option even when it's not specified.

Add shims to Symbolication+Extensions.swift to allow calls to VMUProcInfo and use it to force forkCorpse when appropriate.

rdar://124720793