### PR TITLE
[IRGen] Support generic but concrete metatypes with hasSymbol

### DIFF
--- a/test/IRGen/Inputs/has_symbol/has_symbol_helper.swift
+++ b/test/IRGen/Inputs/has_symbol/has_symbol_helper.swift
@@ -64,3 +64,5 @@ public actor A {
   public func asyncMethod() async {}
 }
 #endif
+
+public struct Generic<T> {}

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -165,8 +165,15 @@ public func testExistentialParameter(_ p: any P) {
 public func testMetatypes() {
   // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1SVTwS"()
   if #_hasSymbol(S.self) {}
+
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper7GenericVTwS"()
+  if #_hasSymbol(Generic<Void>.self) {}
 }
 
 // --- S.self ---
 // CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper1SVTwS"()
 // CHECK:   ret i1 and (i1 and (i1 icmp ne (ptr @"$s17has_symbol_helper1SVMn", ptr null), i1 icmp ne (ptr @"$s17has_symbol_helper1SVN", ptr null)), i1 icmp ne (ptr @"$s17has_symbol_helper1SVMa", ptr null))
+
+// --- Generic<Void>.self ---
+// CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper7GenericVTwS"()
+// CHECK:   ret i1 and (i1 icmp ne (ptr @"$s17has_symbol_helper7GenericVMn", ptr null), i1 icmp ne (ptr @"$s17has_symbol_helper7GenericVMa", ptr null))


### PR DESCRIPTION
The current code was calling into a getAddr routine that did not want any form of generic type, even if it were concrete. Check if we have a generic type and call into the right getAddr.

Should resolve: rdar://138067133