### PR TITLE
[DebugInfo] Stop emitting spare bits mask in debug info

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1384,21 +1384,9 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       }
     }
 
-    APInt SpareBitsMask;
-    auto &EnumStrategy =
-        getEnumImplStrategy(IGM, DbgTy.getType()->getCanonicalType());
-
-    auto VariantOffsetInBits = 0;
-    if (auto SpareBitsMaskInfo = EnumStrategy.calculateSpareBitsMask()) {
-      SpareBitsMask = SpareBitsMaskInfo->bits;
-      // The offset of the variant mask in the overall enum.
-      VariantOffsetInBits = SpareBitsMaskInfo->byteOffset * 8;
-    }
-
     auto VPTy = DBuilder.createVariantPart(
         Scope, {}, File, Line, SizeInBits, AlignInBits, Flags, nullptr,
-        DBuilder.getOrCreateArray(Elements), /*UniqueIdentifier=*/"",
-        VariantOffsetInBits, SpareBitsMask);
+        DBuilder.getOrCreateArray(Elements), /*UniqueIdentifier=*/"");
 
     auto DITy = DBuilder.createStructType(
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags, nullptr,

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -28,22 +28,6 @@ enum Either {
 // CHECK: ![[EMPTY:.*]] = !{}
 let E : Either = .Neither;
 
-class C {}
-enum EitherWithSpareBits {
-  case Left(C), Right(Int32)
-// DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "EitherWithSpareBits", 
-// DWARF-SAME:             size: 64,
-// DWARF-SAME:             runtimeLang: DW_LANG_Swift, identifier: "$s4enum19EitherWithSpareBitsOD")
-
-// DWARF: !DICompositeType(tag: DW_TAG_variant_part,
-// DWARF-SAME:             size: 64, offset: 56, spare_bits_mask: {{240|255}}
-
-// DWARF: !DIDerivedType(tag: DW_TAG_member, name: "Left"
-
-// DWARF: !DIDerivedType(tag: DW_TAG_member, name: "Right"
-}
-let Right: EitherWithSpareBits = .Right(32)
-
 // CHECK: !DICompositeType({{.*}}name: "Color",
 // CHECK-SAME:             size: 8,
 // CHECK-SAME:             identifier: "$s4enum5ColorOD"


### PR DESCRIPTION
We're now able to calculate the spare bits mask from other information. Stop emitting it in debug info.
