### PR TITLE
[CoroutineAccessors] Permit read requirement.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -255,6 +255,8 @@ ERROR(static_var_decl_global_scope,none,
       (StaticSpellingKind))
 ERROR(expected_getset_in_protocol,none,
       "expected get or set in a protocol property", ())
+ERROR(expected_getreadset_in_protocol,none,
+      "expected get, read, or set in a protocol property", ())
 ERROR(unexpected_getset_implementation_in_protocol,none,
       "protocol property %0 cannot have a default implementation specified "
       "here; use extension instead", (StringRef))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8144,7 +8144,10 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
 
       // parsingLimitedSyntax mode cannot have a body.
       if (parsingLimitedSyntax) {
-        diagnose(Tok, diag::expected_getset_in_protocol);
+        auto diag = Context.LangOpts.hasFeature(Feature::CoroutineAccessors)
+                        ? diag::expected_getreadset_in_protocol
+                        : diag::expected_getset_in_protocol;
+        diagnose(Tok, diag);
         Status |= makeParserError();
         break;
       }
@@ -8178,7 +8181,10 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
     // avoid having to deal with them everywhere.
     if (parsingLimitedSyntax && !isAllowedWhenParsingLimitedSyntax(
                                     Kind, SF.Kind == SourceFileKind::SIL)) {
-      diagnose(Loc, diag::expected_getset_in_protocol);
+      auto diag = Context.LangOpts.hasFeature(Feature::CoroutineAccessors)
+                      ? diag::expected_getreadset_in_protocol
+                      : diag::expected_getset_in_protocol;
+      diagnose(Loc, diag);
       continue;
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7806,6 +7806,7 @@ static bool isAllowedWhenParsingLimitedSyntax(AccessorKind kind, bool forSIL) {
   case AccessorKind::Get:
   case AccessorKind::DistributedGet:
   case AccessorKind::Set:
+  case AccessorKind::Read2:
     return true;
 
   case AccessorKind::Address:
@@ -7813,7 +7814,6 @@ static bool isAllowedWhenParsingLimitedSyntax(AccessorKind kind, bool forSIL) {
   case AccessorKind::WillSet:
   case AccessorKind::DidSet:
   case AccessorKind::Read:
-  case AccessorKind::Read2:
   case AccessorKind::Modify:
   case AccessorKind::Modify2:
     return false;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -859,6 +859,9 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     return OpaqueReadOwnership::Borrowed;
   };
 
+  if (storage->getAccessor(AccessorKind::Read2))
+    return OpaqueReadOwnership::Borrowed;
+
   if (storage->getAttrs().hasAttribute<BorrowedAttr>())
     return usesBorrowed(DiagKind::BorrowedAttr);
 
@@ -3846,8 +3849,12 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       readImpl = ReadImplKind::Get;
       writeImpl = WriteImplKind::Set;
       readWriteImpl = ReadWriteImplKind::MaterializeToTemporary;
-    } else if (storage->getParsedAccessor(AccessorKind::Get)) {
+    }
+    if (storage->getParsedAccessor(AccessorKind::Get)) {
       readImpl = ReadImplKind::Get;
+    }
+    if (storage->getParsedAccessor(AccessorKind::Read2)) {
+      readImpl = ReadImplKind::Read2;
     }
 
     StorageImplInfo info(readImpl, writeImpl, readWriteImpl);

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -37,10 +37,11 @@ public var irm: Int {
   modify {
     yield &_i
   }
-// CHECK-OLD-LABEL: define{{.*}} {{i64|i32}} @"$s19coroutine_accessors1SV3irmSivg"(
-// CHECK-OLD-SAME:      ptr %0,
-// CHECK-OLD-SAME:      [[INT]] %1
-// CHECK-OLD-SAME:  ) #0
+// CHECK-OLD-LABEL: define{{.*}} { ptr, {{i64|i32}} } @"$s19coroutine_accessors1SV3irmSivr"(
+// CHECK-OLD-SAME:      ptr noalias dereferenceable({{32|16}}) %0,
+// CHECK-OLD-SAME:      ptr %1,
+// CHECK-OLD-SAME:      [[INT]] %2
+// CHECK-OLD-SAME:  )
 // CHECK-OLD-SAME:  {
 // CHECK-OLD:       }
 // CHECK-OLD-LABEL: define{{.*}} void @"$s19coroutine_accessors1SV3irmSivs"(

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -326,3 +326,18 @@ var ir_rm_m: Int {
     fatalError()
   }
 }
+
+// =============================================================================
+// Protocol Requirements
+// =============================================================================
+
+protocol P {
+  var goodP: Int { read set } //expected-disabled-error{{property in protocol must have explicit { get } or { get set } specifier}}
+                              //expected-disabled-error@-1{{expected get or set in a protocol property}}
+  var badP: Int { read modify } //expected-enabled-error{{expected get or set in a protocol property}}
+                                //expected-disabled-error@-1{{property in protocol must have explicit { get } or { get set } specifier}}
+                                //expected-disabled-error@-2{{expected get or set in a protocol property}}
+  subscript(goodS goodS: Int) -> Int { read set } //expected-disabled-error{{expected get or set in a protocol property}}
+  subscript(badS badS: Int) -> Int { read modify } //expected-enabled-error{{expected get or set in a protocol property}}
+                                                   //expected-disabled-error@-1{{expected get or set in a protocol property}}
+}

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -334,10 +334,10 @@ var ir_rm_m: Int {
 protocol P {
   var goodP: Int { read set } //expected-disabled-error{{property in protocol must have explicit { get } or { get set } specifier}}
                               //expected-disabled-error@-1{{expected get or set in a protocol property}}
-  var badP: Int { read modify } //expected-enabled-error{{expected get or set in a protocol property}}
+  var badP: Int { read modify } //expected-enabled-error{{expected get, read, or set in a protocol property}}
                                 //expected-disabled-error@-1{{property in protocol must have explicit { get } or { get set } specifier}}
                                 //expected-disabled-error@-2{{expected get or set in a protocol property}}
   subscript(goodS goodS: Int) -> Int { read set } //expected-disabled-error{{expected get or set in a protocol property}}
-  subscript(badS badS: Int) -> Int { read modify } //expected-enabled-error{{expected get or set in a protocol property}}
+  subscript(badS badS: Int) -> Int { read modify } //expected-enabled-error{{expected get, read, or set in a protocol property}}
                                                    //expected-disabled-error@-1{{expected get or set in a protocol property}}
 }

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -95,12 +95,14 @@ public var irm: Int {
 // CHECK-SAME:   [[TOKEN:%[^,]+]],
 // CHECK-SAME:   [[ALLOCATION:%[^)]+]])
 // CHECK-SAME:  = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
-// CHECK:       yield [[VALUE_ADDRESS:%[^,]+]] : $*Int, resume bb1, unwind bb2
-// CHECK:     bb1:
+// CHECK:       yield [[VALUE_ADDRESS]] 
+// CHECK-SAME:      resume [[RESUME_BB:bb[0-9]+]]
+// CHECK-SAME:      unwind [[UNWIND_BB:bb[0-9]+]]
+// CHECK:     [[RESUME_BB]]:
 // CHECK:       end_apply [[TOKEN]]
 // CHECK:       end_access [[SELF_ACCESS]]
 // CHECK:       dealloc_stack [[ALLOCATION]]
-// CHECK:     bb2:
+// CHECK:     [[UNWIND_BB]]:
 // CHECK:       end_apply [[TOKEN]]
 // CHECK:       dealloc_stack [[ALLOCATION]]
 // CHECK:       end_access [[SELF_ACCESS]]

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -38,24 +38,26 @@ public var irm: Int {
   modify {
     yield &_i
   }
-// CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivg :
-// CHECK-SAME:      $@convention(method)
+// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors1SV3irmSivr :
+// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      @convention(method)
 // CHECK-SAME:      (@guaranteed S)
 // CHECK-SAME:      ->
-// CHECK-SAME:      Int
+// CHECK-SAME:      @yields Int
 // CHECK-SAME:  {
 // CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^,]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[READ_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
-// CHECK:         ([[VALUE:%[^,]+]],
-// CHECK-SAME:     [[TOKEN:%[^,]+]],
-// CHECK-SAME:     [[ALLOCATION:%[^)]+]])
-// CHECK-SAME:    = begin_apply [[READ_ACCESSOR]]([[SELF]])
+// CHECK:           [[SELF:%[^,]+]] :
+// CHECK:       ):
+// CHECK:         [[READER2:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivy
+// CHECK:         ([[VALUE_ADDRESS:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READER2]]([[SELF]])
 // CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         return [[VALUE:%[^,]+]]
-// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivg'
+// CHECK:         yield [[VALUE_ADDRESS]] : $Int, resume bb1, unwind bb2
+// CHECK:       bb1:
+// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
+// CHECK:       bb2:
+// CHECK:         dealloc_stack [[ALLOCATION]] : $*Builtin.SILToken
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors1SV3irmSivr'
 
 // CHECK-LABEL: sil {{.*}}[ossa] @$s19coroutine_accessors1SV3irmSivs :
 // CHECK-SAME:      $@convention(method)
@@ -125,7 +127,7 @@ public var irm: Int {
 // CHECK:      store [[NEW_VALUE:%[^,]+]] to [trivial] [[NEW_VALUE_ADDR]]
 // CHECK:      [[SELF_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[SELF]]
 // CHECK:      [[MODIFY_ACCESSOR:%[^,]+]] = function_ref @$s19coroutine_accessors1SV3irmSivx
-// CHECK:      ([[VALUE_ADDR:%[^,]+]], 
+// CHECK:      ([[VALUE_ADDR:%[^,]+]],
 // CHECK-SAME:  [[TOKEN:%[^,]+]],
 // CHECK-SAME:  [[ALLOCATION:%[^)]+]])
 // CHECK-SAME: = begin_apply [[MODIFY_ACCESSOR]]([[SELF_ACCESS]])
@@ -165,4 +167,66 @@ func update<T : Equatable>(at location: inout T, to newValue: T) throws -> T {
   }
   location = newValue
   return oldValue
+}
+
+protocol ReadableTitle {
+  var title: String { read }
+}
+class OverridableGetter : ReadableTitle {
+  var title: String = ""
+}
+//   The read witness thunk does a direct call to the concrete read accessor.
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvrTW
+// CHECK:       function_ref @$s19coroutine_accessors17OverridableGetterC5titleSSvr
+// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvrTW'
+//   The concrete read accessor is generated on-demand and does a class dispatch to the getter.
+// CHECK-LABEL: sil shared [ossa] @$s19coroutine_accessors17OverridableGetterC5titleSSvr
+// CHECK:       class_method %0 : $OverridableGetter, #OverridableGetter.title!getter
+// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterC5titleSSvr'
+
+class ImplementedReader : ReadableTitle {
+  var _title: String = ""
+  var title: String {
+    read {
+      yield _title
+    }
+  }
+}
+
+protocol GettableTitle {
+  var title: String { get }
+}
+
+// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s19coroutine_accessors17OverridableReaderC5titleSSvg
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s19coroutine_accessors17OverridableReaderC5titleSSvg : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!read
+// CHECK:         ([[TITLE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         [[RETVAL:%[^,]+]] = copy_value [[TITLE]]
+// CHECK:         end_apply [[TOKEN]] as $()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderC5titleSSvg'
+
+// CHECK-LABEL: sil_witness_table{{.*}} OverridableReader: GettableTitle {{.*}} {
+// CHECK-NEXT:    method #GettableTitle.title!getter
+// CHECK-SAME:        @$s19coroutine_accessors17OverridableReaderCAA13GettableTitleA2aDP5titleSSvgTW
+// CHECK-NEXT:  }
+class OverridableReader : GettableTitle {
+  var _title: String = ""
+  var title: String {
+    read {
+      yield _title
+    }
+  }
 }

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1,0 +1,1030 @@
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %s                                              \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+
+// RUN: %target-swift-emit-silgen                                              \
+// RUN:     %s                                                                 \
+// RUN:     -enable-experimental-feature CoroutineAccessors                    \
+// RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
+
+// A read requirement may be satisfied by
+// - a stored property
+// - a _read accessor
+// - a read accessor
+// - a get accessor
+// - an unsafeAddress accessor
+
+struct U : ~Copyable {}
+
+// Protocols are split up to improve the ordering of the functions in the output
+// (implementation, then conformance thunk).
+protocol P1 : ~Copyable {
+  @_borrowed
+  var ubgs: U { get set }
+}
+protocol P2 : ~Copyable {
+  var urs: U { read set }
+}
+protocol P3 : ~Copyable {
+  var ur: U { read }
+}
+
+struct ImplAStored : ~Copyable & P1 {
+  var ubgs: U
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplAStored.ubgs
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr
+// CHECK:         ([[VALUE_ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE_ADDR]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW'
+}
+
+struct ImplBStored : ~Copyable & P2 {
+  var dummy: ()
+  var urs: U
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         debug_value [[COPY]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplBStored.urs
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBStoredV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW'
+}
+
+struct ImplCStored : ~Copyable & P3 {
+  var dummy: ()
+  var ur: U
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplCStored.ur
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCStoredV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW'
+}
+
+struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
+  typealias Property = U
+  var _i: U
+  var ubgs: U {
+    _read {
+      yield _i
+    }
+    _modify {
+      yield &_i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK:             #ImplAUnderscoredCoroutineAccessors._i
+// CHECK:         yield [[VALUE]] : $U
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+}
+
+struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
+  typealias Property = U
+  var _i: U
+  var urs: U {
+    _read {
+      yield _i
+    }
+    _modify {
+      yield &_i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplBUnderscoredCoroutineAccessors._i
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]] : $U
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
+}
+
+struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
+  typealias Property = U
+  var _i: U
+  var ur: U {
+    _read {
+      yield _i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK:       ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
+}
+
+struct ImplACoroutineAccessors : ~Copyable & P1 {
+  var _i: U
+  var ubgs: U {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK:           [[SELF:%[^:]+]]
+// CHECK:       ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK:             #ImplACoroutineAccessors._i
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+}
+
+struct ImplBCoroutineAccessors : ~Copyable & P2 {
+  var _i: U
+  var urs: U {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]] : $ImplBCoroutineAccessors
+// CHECK:             #ImplBCoroutineAccessors._i
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]] : $ImplBCoroutineAccessors
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]] : $ImplBCoroutineAccessors
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
+}
+
+struct ImplCCoroutineAccessors : ~Copyable & P3 {
+  var _i: U
+  var ur: U {
+    read {
+      yield _i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplCCoroutineAccessors._i
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF:%[^,]+]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE:%[^,]+]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
+}
+
+struct ImplAGetSet : P1 {
+  var _i: U {
+    get { return U() }
+    set {}
+  }
+  var ubgs: U {
+    get {
+      return _i
+    }
+    set {
+      _i = newValue
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[_I_GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV2_iAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
+// CHECK:         return [[VALUE]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW'
+}
+
+struct ImplBGetSet : P2 {
+  var _i: U {
+    get { return U() }
+    set {}
+  }
+  var urs: U {
+    get {
+      return _i
+    }
+    set {
+      _i = newValue
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetV3ursAA1UVvg : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[_I_GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV2_iAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
+// CHECK:         return [[VALUE]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvg'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetV3ursAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW'
+}
+
+struct ImplCGetSet : P3 {
+  var _i: U {
+    get { return U() }
+    set {}
+  }
+  var ur: U {
+    get {
+      return _i
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvg : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[_I_GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2_iAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
+// CHECK:         return [[VALUE]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvg'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW'
+}
+
+struct ImplAUnsafeAddressors : P1 {
+  var iAddr: UnsafePointer<U>
+  var iMutableAddr: UnsafeMutablePointer<U> {
+    .init(mutating: iAddr)
+  }
+  var ubgs: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = struct_extract [[SELF]] : $ImplAUnsafeAddressors
+// CHECK:             #ImplAUnsafeAddressors.iAddr
+// CHECK:         return [[UNSAFE_POINTER]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]] : $UnsafePointer<U>, #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+}
+
+struct ImplBUnsafeAddressors : P2 {
+  var iAddr: UnsafePointer<U>
+  var iMutableAddr: UnsafeMutablePointer<U> {
+    .init(mutating: iAddr)
+  }
+  var urs: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = struct_extract [[SELF]]
+// CHECK:             #ImplBUnsafeAddressors.iAddr
+// CHECK:         return [[UNSAFE_POINTER]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
+// CHECK:             #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW'
+}
+
+struct ImplCUnsafeAddressors : P3 {
+  var iAddr: UnsafePointer<U>
+  var iMutableAddr: UnsafeMutablePointer<U> {
+    .init(mutating: iAddr)
+  }
+  var ur: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = struct_extract [[SELF]]
+// CHECK:             #ImplCUnsafeAddressors.iAddr 
+// CHECK:         return [[UNSAFE_POINTER]]
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
+// CHECK:             #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW'
+}
+// CHECK-LABEL: sil_witness_table{{.*}} ImplAStored: P1 module read_requirements {
+// CHECK:         method #P1.ubgs!read
+// CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK:         method #P1.ubgs!setter
+// CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK:         method #P1.ubgs!modify
+// CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
+// CHECK:         method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK:         method #P2.urs!setter
+// CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK:         method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCStored: P3 module read_requirements {
+// CHECK:         method #P3.ur!read
+// CHECK-SAME:        : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplAUnderscoredCoroutineAccessors: P1 module read_requirements {
+// CHECK:         method #P1.ubgs!read
+// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK:         method #P1.ubgs!setter
+// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK:         method #P1.ubgs!modify
+// CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
+// CHECK:         method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK:         method #P2.urs!setter
+// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK:         method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCUnderscoredCoroutineAccessors: P3 module read_requirements {
+// CHECK:         method #P3.ur!read
+// CHECK-SAME:        : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplACoroutineAccessors: P1 module read_requirements {
+// CHECK:         method #P1.ubgs!read
+// CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK:         method #P1.ubgs!setter
+// CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK:         method #P1.ubgs!modify
+// CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
+// CHECK:         method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK:         method #P2.urs!setter
+// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK:         method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCCoroutineAccessors: P3 module read_requirements {
+// CHECK:         method #P3.ur!read
+// CHECK-SAME:        : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplAGetSet: P1 module read_requirements {
+// CHECK:         method #P1.ubgs!read
+// CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK:         method #P1.ubgs!setter
+// CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK:         method #P1.ubgs!modify
+// CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
+// CHECK:         method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK:         method #P2.urs!setter
+// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK:         method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCGetSet: P3 module read_requirements {
+// CHECK:         method #P3.ur!read
+// CHECK-SAME:        : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplAUnsafeAddressors: P1 module read_requirements {
+// CHECK:         method #P1.ubgs!read
+// CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK:         method #P1.ubgs!setter
+// CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvsTW
+// CHECK:         method #P1.ubgs!modify
+// CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
+// CHECK:         method #P2.urs!read
+// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK:         method #P2.urs!setter
+// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
+// CHECK:         method #P2.urs!modify
+// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK:       }
+
+// CHECK-LABEL: sil_witness_table{{.*}} ImplCUnsafeAddressors: P3 module read_requirements {
+// CHECK:         method #P3.ur!read
+// CHECK-SAME:        : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK:       }

--- a/test/Sema/coroutine_accessors.swift
+++ b/test/Sema/coroutine_accessors.swift
@@ -3,8 +3,6 @@
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN:     -debug-diagnostic-names
 
-// REQUIRES: asserts
-
 struct S {
 var i: Int
 

--- a/test/Sema/read_requirements.swift
+++ b/test/Sema/read_requirements.swift
@@ -1,0 +1,149 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:     -verify-additional-prefix enabled- \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -debug-diagnostic-names
+
+// A read requirement may be satisfied by
+// - a stored property
+// - a _read accessor
+// - a read accessor
+// - a get accessor
+// - an unsafeAddress accessor
+
+struct U : ~Copyable {}
+
+protocol P : ~Copyable {
+  @_borrowed
+  var ubgs: U { get set }
+
+  var urs: U { read set }
+
+  var ur: U { read }
+}
+
+struct ImplStored : ~Copyable & P {
+  var ubgs: U
+  var urs: U
+  var ur: U
+}
+
+struct ImplUnderscoredCoroutineAccessors : ~Copyable & P {
+  typealias Property = U
+  var _i: U
+  var ubgs: U {
+    _read {
+      yield _i
+    }
+    _modify {
+      yield &_i
+    }
+  }
+
+  var urs: U {
+    _read {
+      yield _i
+    }
+    _modify {
+      yield &_i
+    }
+  }
+
+  var ur: U {
+    _read {
+      yield _i
+    }
+  }
+}
+
+struct ImplCoroutineAccessors : ~Copyable & P {
+  var _i: U
+  var ubgs: U {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+
+  var urs: U {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+
+  var ur: U {
+    read {
+      yield _i
+    }
+  }
+}
+
+struct ImplGetSet : P {
+  var _i: U {
+    get { return U() }
+    set {}
+  }
+  var ubgs: U {
+    get {
+      return _i
+    }
+    set {
+      _i = newValue
+    }
+  }
+
+  var urs: U {
+    get {
+      return _i
+    }
+    set {
+      _i = newValue
+    }
+  }
+
+  var ur: U {
+    get {
+      return _i
+    }
+    set {
+      _i = newValue
+    }
+  }
+}
+
+struct ImplUnsafeAddressors : P {
+  var iAddr: UnsafePointer<U>
+  var iMutableAddr: UnsafeMutablePointer<U> {
+    .init(mutating: iAddr)
+  }
+  var ubgs: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+
+  var urs: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+
+  var ur: U {
+    unsafeAddress {
+      return iAddr
+    }
+    unsafeMutableAddress {
+      return iMutableAddr
+    }
+  }
+}


### PR DESCRIPTION
Along with `get` and `set`, permit `read` to be required.  When a type defines `read`, the read impl is that `read`.
