### PR TITLE
[Backtracing] Bail out earlier for privileged binaries on macOS.

### DIFF
--- a/stdlib/public/Backtracing/modules/OS/Darwin.h
+++ b/stdlib/public/Backtracing/modules/OS/Darwin.h
@@ -135,6 +135,8 @@ extern void _dyld_process_info_for_each_segment(dyld_process_info info, uint64_t
 // .. Code Signing SPI .........................................................
 
 #define CS_OPS_STATUS 0
+#define CS_GET_TASK_ALLOW  0x00000004
+#define CS_RUNTIME         0x00010000
 #define CS_PLATFORM_BINARY 0x04000000
 #define CS_PLATFORM_PATH   0x08000000
 extern int csops(int, unsigned int, void *, size_t);

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -456,7 +456,15 @@ Generate a backtrace for the parent process.
     }
   }
 
+  static func unblockSignals() {
+    var mask = sigset_t()
+
+    sigfillset(&mask)
+    sigprocmask(SIG_UNBLOCK, &mask, nil)
+  }
+
   static func main() {
+    unblockSignals()
     parseArguments()
 
     guard let crashInfoAddr = args.crashInfo else {


### PR DESCRIPTION
Also remove the code that deals with file descriptors; we will now only start the backtracer for processes that have the get-task-allow entitlement, which means that they've been specifically signed for debugging, and *that* means that it is no longer critical to ensure that unexpectedly inherited fds are closed.

rdar://137551812
