### PR TITLE
[AutoDiff] Fix assert on missing struct decl on cross-file derivative search

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5459,7 +5459,8 @@ static AbstractFunctionDecl *findAutoDiffOriginalFunctionDecl(
   if (!baseType && lookupContext->isTypeContext())
     baseType = lookupContext->getSelfTypeInContext();
   if (baseType) {
-    results = TypeChecker::lookupMember(lookupContext, baseType, funcName);
+    if (!baseType.getPointer()->hasError())
+      results = TypeChecker::lookupMember(lookupContext, baseType, funcName);
   } else {
     results = TypeChecker::lookupUnqualified(
         lookupContext, funcName, funcNameLoc.getBaseNameLoc(), lookupOptions);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5459,7 +5459,7 @@ static AbstractFunctionDecl *findAutoDiffOriginalFunctionDecl(
   if (!baseType && lookupContext->isTypeContext())
     baseType = lookupContext->getSelfTypeInContext();
   if (baseType) {
-    if (!baseType.getPointer()->hasError())
+    if (!baseType->hasError())
       results = TypeChecker::lookupMember(lookupContext, baseType, funcName);
   } else {
     results = TypeChecker::lookupUnqualified(

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/Inputs/derivatives-error.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/Inputs/derivatives-error.swift
@@ -19,7 +19,7 @@ func minVJP<T: Comparable & Differentiable>(
 
 extension Struct {
     @inlinable
-    @derivative(of: max)
+    @derivative(of: max) // expected-error {{cannot find 'max' in scope}}
     static func maxVJP<T: Comparable & Differentiable>(
         _ x: T,
         _ y: T

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/Inputs/struct.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/Inputs/struct.swift
@@ -1,0 +1,14 @@
+import _Differentiation
+
+struct Struct {
+    @inlinable
+    static func max<T: Comparable>(
+        _ x: T,
+        _ y: T
+    ) -> T {
+        if x > y
+            return y
+        else
+            return x
+    }
+}

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/error.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/error.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/derivatives-error.swift -module-name main -o /dev/null
+
+import _Differentiation
+
+@differentiable(reverse)
+func clamp(_ value: Double, _ lowerBound: Double, _ upperBound: Double) -> Double {
+    return Struct.max(min(value, upperBound), lowerBound) // expected-error {{cannot find 'Struct' in scope}}
+}

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/main.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossFile/main.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/derivatives.swift -module-name main -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s \
+// RUN:   %S/Inputs/derivatives.swift %S/Inputs/struct.swift -module-name main -o /dev/null
 
 import _Differentiation
 
 @differentiable(reverse)
 func clamp(_ value: Double, _ lowerBound: Double, _ upperBound: Double) -> Double {
     // No error expected
-    return max(min(value, upperBound), lowerBound)
+    return Struct.max(min(value, upperBound), lowerBound)
 }


### PR DESCRIPTION
Consider:

1. File struct.swift defining `struct Struct` with `static func max` member
2. File derivatives.swift defining `extension Struct` with custom derivative of the `max` function
3. File error.swift defining a differentiable function which uses `Struct.max`.

Previously, when passing error.swift as primary file and derivatives.swift as a secondary file to swift-frontend (and forgetting to pass struct.swift as a secondary file as well), an assertion failure was triggered in the following call stack:

```
assert(type->mayHaveMembers()); // while type is ErrorType
TypeChecker::lookupMember
findAutoDiffOriginalFunctionDecl
typeCheckDerivativeAttr
DerivativeAttrOriginalDeclRequest::evaluate
```

This patch fixes the issue by adding a check against `ErrorType` in `findAutoDiffOriginalFunctionDecl` before calling `lookupMember`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
