### PR TITLE
bridging: reduce `#ifdef USED_IN_CPP_SOURCE` in bridging headers

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -22,24 +22,30 @@
 #include "swift/Basic/BasicBridging.h"
 
 #ifdef USED_IN_CPP_SOURCE
-#include "swift/AST/ArgumentList.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/DiagnosticConsumer.h"
-#include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/IfConfigClauseRangeInfo.h"
-#include "swift/AST/Stmt.h"
 #endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 namespace swift {
+class Argument;
 class ASTContext;
+struct ASTNode;
+class DeclAttributes;
+class DeclBaseName;
+class DeclNameLoc;
+class DeclNameRef;
 class DiagnosticArgument;
 class DiagnosticEngine;
+class Identifier;
+class IfConfigClauseRangeInfo;
+struct LabeledStmtInfo;
+class ProtocolConformanceRef;
 class Type;
 class CanType;
 class TypeBase;
+class StmtConditionElement;
 class SubstitutionMap;
 }
 
@@ -62,14 +68,9 @@ public:
   SWIFT_NAME("init(raw:)")
   BridgedIdentifier(const void *_Nullable raw) : Raw(raw) {}
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedIdentifier(swift::Identifier ident)
-      : Raw(ident.getAsOpaquePointer()) {}
+  BRIDGED_INLINE BridgedIdentifier(swift::Identifier ident);
 
-  swift::Identifier unbridged() const {
-    return swift::Identifier::getFromOpaquePointer(Raw);
-  }
-#endif
+  BRIDGED_INLINE swift::Identifier unbridged() const;
 };
 
 SWIFT_NAME("getter:BridgedIdentifier.raw(self:)")
@@ -89,17 +90,9 @@ class BridgedDeclBaseName {
   BridgedIdentifier Ident;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedDeclBaseName() : Ident() {}
+  BRIDGED_INLINE BridgedDeclBaseName(swift::DeclBaseName baseName);
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDeclBaseName(swift::DeclBaseName baseName) : Ident(baseName.Ident) {}
-
-  swift::DeclBaseName unbridged() const {
-    return swift::DeclBaseName(Ident.unbridged());
-  }
-#endif
+  BRIDGED_INLINE swift::DeclBaseName unbridged() const;
 };
 
 SWIFT_NAME("BridgedDeclBaseName.createConstructor()")
@@ -119,17 +112,9 @@ class BridgedDeclNameRef {
   void *_Nonnull opaque;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedDeclNameRef() : opaque() {}
+  BRIDGED_INLINE BridgedDeclNameRef(swift::DeclNameRef name);
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDeclNameRef(swift::DeclNameRef name) : opaque(name.getOpaqueValue()) {}
-
-  swift::DeclNameRef unbridged() const {
-    return swift::DeclNameRef::getFromOpaqueValue(opaque);
-  }
-#endif
+  BRIDGED_INLINE swift::DeclNameRef unbridged() const;
 };
 
 SWIFT_NAME("BridgedDeclNameRef.createParsed(_:baseName:argumentLabels:)")
@@ -149,15 +134,9 @@ class BridgedDeclNameLoc {
 public:
   BridgedDeclNameLoc() : LocationInfo(nullptr), NumArgumentLabels(0) {}
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDeclNameLoc(swift::DeclNameLoc loc)
-      : LocationInfo(loc.LocationInfo),
-        NumArgumentLabels(loc.NumArgumentLabels) {}
+  BRIDGED_INLINE BridgedDeclNameLoc(swift::DeclNameLoc loc);
 
-  swift::DeclNameLoc unbridged() const {
-    return swift::DeclNameLoc(LocationInfo, NumArgumentLabels);
-  }
-#endif
+  BRIDGED_INLINE swift::DeclNameLoc unbridged() const;
 };
 
 SWIFT_NAME("BridgedDeclNameLoc.createParsed(_:baseNameLoc:lParenLoc:"
@@ -179,17 +158,11 @@ class BridgedASTContext {
   swift::ASTContext * _Nonnull Ctx;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedASTContext() : Ctx() {}
-
-#ifdef USED_IN_CPP_SOURCE
   SWIFT_UNAVAILABLE("Use init(raw:) instead")
-  BridgedASTContext(swift::ASTContext &ctx) : Ctx(&ctx) {}
+  BRIDGED_INLINE BridgedASTContext(swift::ASTContext &ctx);
 
   SWIFT_UNAVAILABLE("Use '.raw' instead")
-  swift::ASTContext &unbridged() const { return *Ctx; }
-#endif
+  BRIDGED_INLINE swift::ASTContext &unbridged() const;
 };
 
 SWIFT_NAME("getter:BridgedASTContext.raw(self:)")
@@ -343,18 +316,7 @@ struct BridgedASTNode {
   SWIFT_NAME("kind")
   ASTNodeKind Kind;
 
-#ifdef USED_IN_CPP_SOURCE
-  swift::ASTNode unbridged() const {
-    switch (Kind) {
-    case ASTNodeKindExpr:
-      return swift::ASTNode(static_cast<swift::Expr *>(Raw));
-    case ASTNodeKindStmt:
-      return swift::ASTNode(static_cast<swift::Stmt *>(Raw));
-    case ASTNodeKindDecl:
-      return swift::ASTNode(static_cast<swift::Decl *>(Raw));
-    }
-  }
-#endif
+  BRIDGED_INLINE swift::ASTNode unbridged() const;
 };
 
 // Forward declare the underlying AST node type for each wrapper.
@@ -453,39 +415,16 @@ class BridgedDiagnosticArgument {
   int64_t storage[3];
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedDiagnosticArgument() {}
-
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg) {
-    *reinterpret_cast<swift::DiagnosticArgument *>(&storage) = arg;
-  }
-  const swift::DiagnosticArgument &unbridged() const {
-    return *reinterpret_cast<const swift::DiagnosticArgument *>(&storage);
-  }
-#endif
+  BRIDGED_INLINE BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg);
+  BRIDGED_INLINE const swift::DiagnosticArgument &unbridged() const;
 
   BridgedDiagnosticArgument(SwiftInt i);
   BridgedDiagnosticArgument(BridgedStringRef s);
 };
 
 class BridgedDiagnosticFixIt {
-  int64_t storage[7];
-
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedDiagnosticFixIt() {}
-
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDiagnosticFixIt(const swift::DiagnosticInfo::FixIt &fixit){
-    *reinterpret_cast<swift::DiagnosticInfo::FixIt *>(&storage) = fixit;
-  }
-  const swift::DiagnosticInfo::FixIt &unbridged() const {
-    return *reinterpret_cast<const swift::DiagnosticInfo::FixIt *>(&storage);
-  }
-#endif
+  int64_t storage[7];
 
   BridgedDiagnosticFixIt(BridgedSourceLoc start, uint32_t length, BridgedStringRef text);
 };
@@ -585,16 +524,9 @@ struct BridgedDeclAttributes {
 
   BridgedDeclAttributes() : chain(nullptr){};
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedDeclAttributes(swift::DeclAttributes attrs)
-      : chain(attrs.getRawAttributeChain()) {}
+  BRIDGED_INLINE BridgedDeclAttributes(swift::DeclAttributes attrs);
 
-  swift::DeclAttributes unbridged() const {
-    swift::DeclAttributes attrs;
-    attrs.setRawAttributeChain(chain.unbridged());
-    return attrs;
-  }
-#endif
+  BRIDGED_INLINE swift::DeclAttributes unbridged() const;
 };
 
 SWIFT_NAME("BridgedDeclAttributes.add(self:_:)")
@@ -1209,12 +1141,7 @@ struct BridgedCallArgument {
   BridgedIdentifier label;
   BridgedExpr argExpr;
 
-#ifdef USED_IN_CPP_SOURCE
-  swift::Argument unbridged() const {
-    return swift::Argument(labelLoc.unbridged(), label.unbridged(),
-                           argExpr.unbridged());
-  }
-#endif
+  BRIDGED_INLINE swift::Argument unbridged() const;
 };
 
 SWIFT_NAME("BridgedArgumentList.createImplicitUnlabeled(_:exprs:)")
@@ -1528,29 +1455,16 @@ struct BridgedLabeledStmtInfo {
   SWIFT_NAME("loc")
   BridgedSourceLoc Loc;
 
-#ifdef USED_IN_CPP_SOURCE
-  swift::LabeledStmtInfo unbridged() const {
-    return {Name.unbridged(), Loc.unbridged()};
-  }
-#endif
+  BRIDGED_INLINE swift::LabeledStmtInfo unbridged() const;
 };
 
 class BridgedStmtConditionElement {
   void *_Nonnull Raw;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedStmtConditionElement() {}
+  BRIDGED_INLINE BridgedStmtConditionElement(swift::StmtConditionElement elem);
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedStmtConditionElement(swift::StmtConditionElement elem)
-      : Raw(elem.getOpaqueValue()) {}
-
-  swift::StmtConditionElement unbridged() const {
-    return swift::StmtConditionElement::fromOpaqueValue(Raw);
-  }
-#endif
+  BRIDGED_INLINE swift::StmtConditionElement unbridged() const;
 };
 
 SWIFT_NAME("BridgedStmtConditionElement.createBoolean(expr:)")
@@ -2099,14 +2013,8 @@ public:
 struct BridgedConformance {
   void * _Nullable opaqueValue;
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedConformance(swift::ProtocolConformanceRef conformance)
-      : opaqueValue(conformance.getOpaqueValue()) {}
-
-  swift::ProtocolConformanceRef unbridged() const {
-    return swift::ProtocolConformanceRef::getFromOpaqueValue(opaqueValue);
-  }
-#endif
+  BRIDGED_INLINE BridgedConformance(swift::ProtocolConformanceRef conformance);
+  BRIDGED_INLINE swift::ProtocolConformanceRef unbridged() const;
 
   BridgedOwnedString getDebugDescription() const;
   BRIDGED_INLINE bool isConcrete() const;
@@ -2121,15 +2029,6 @@ struct BridgedConformance {
 
 struct BridgedConformanceArray {
   BridgedArrayRef pcArray;
-
-#ifdef USED_IN_CPP_SOURCE
-  BridgedConformanceArray(llvm::ArrayRef<swift::ProtocolConformanceRef> conformances)
-      : pcArray(conformances) {}
-
-  llvm::ArrayRef<swift::ProtocolConformanceRef> unbridged() const {
-    return pcArray.unbridged<swift::ProtocolConformanceRef>();
-  }
-#endif
 
   SwiftInt getCount() const { return SwiftInt(pcArray.Length); }
 
@@ -2168,29 +2067,7 @@ struct BridgedIfConfigClauseRangeInfo {
   BridgedSourceLoc endLoc;
   BridgedIfConfigClauseKind kind;
 
-#ifdef USED_IN_CPP_SOURCE
-  swift::IfConfigClauseRangeInfo unbridged() const {
-    swift::IfConfigClauseRangeInfo::ClauseKind clauseKind;
-    switch (kind) {
-    case IfConfigActive:
-      clauseKind = swift::IfConfigClauseRangeInfo::ActiveClause;
-      break;
-
-    case IfConfigInactive:
-      clauseKind = swift::IfConfigClauseRangeInfo::InactiveClause;
-      break;
-
-    case IfConfigEnd:
-      clauseKind = swift::IfConfigClauseRangeInfo::EndDirective;
-      break;
-    }
-
-    return swift::IfConfigClauseRangeInfo(directiveLoc.unbridged(),
-                                          bodyLoc.unbridged(),
-                                          endLoc.unbridged(),
-                                          clauseKind);
-  }
-#endif
+  BRIDGED_INLINE swift::IfConfigClauseRangeInfo unbridged() const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -14,15 +14,67 @@
 #define SWIFT_AST_ASTBRIDGINGIMPL_H
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ArgumentList.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/IfConfigClauseRangeInfo.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedIdentifier
+//===----------------------------------------------------------------------===//
+
+BridgedIdentifier::BridgedIdentifier(swift::Identifier ident)
+    : Raw(ident.getAsOpaquePointer()) {}
+
+swift::Identifier BridgedIdentifier::unbridged() const {
+  return swift::Identifier::getFromOpaquePointer(Raw);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedDeclBaseName
+//===----------------------------------------------------------------------===//
+
+BridgedDeclBaseName::BridgedDeclBaseName(swift::DeclBaseName baseName)
+  : Ident(baseName.Ident) {}
+
+swift::DeclBaseName BridgedDeclBaseName::unbridged() const {
+  return swift::DeclBaseName(Ident.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedDeclNameRef
+//===----------------------------------------------------------------------===//
+
+BridgedDeclNameRef::BridgedDeclNameRef(swift::DeclNameRef name)
+  : opaque(name.getOpaqueValue()) {}
+
+swift::DeclNameRef BridgedDeclNameRef::unbridged() const {
+  return swift::DeclNameRef::getFromOpaqueValue(opaque);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedDeclNameLoc
+//===----------------------------------------------------------------------===//
+
+BridgedDeclNameLoc::BridgedDeclNameLoc(swift::DeclNameLoc loc)
+    : LocationInfo(loc.LocationInfo),
+      NumArgumentLabels(loc.NumArgumentLabels) {}
+
+swift::DeclNameLoc BridgedDeclNameLoc::unbridged() const {
+  return swift::DeclNameLoc(LocationInfo, NumArgumentLabels);
+}
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedASTContext
 //===----------------------------------------------------------------------===//
+
+BridgedASTContext::BridgedASTContext(swift::ASTContext &ctx) : Ctx(&ctx) {}
+
+swift::ASTContext &BridgedASTContext::unbridged() const { return *Ctx; }
 
 void * _Nonnull BridgedASTContext_raw(BridgedASTContext bridged) {
   return &bridged.unbridged();
@@ -89,6 +141,46 @@ BridgedASTType BridgedDeclObj::Class_getSuperclass() const {
 }
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedASTNode
+//===----------------------------------------------------------------------===//
+
+swift::ASTNode BridgedASTNode::unbridged() const {
+  switch (Kind) {
+  case ASTNodeKindExpr:
+    return swift::ASTNode(static_cast<swift::Expr *>(Raw));
+  case ASTNodeKindStmt:
+    return swift::ASTNode(static_cast<swift::Stmt *>(Raw));
+  case ASTNodeKindDecl:
+    return swift::ASTNode(static_cast<swift::Decl *>(Raw));
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Diagnostic Engine
+//===----------------------------------------------------------------------===//
+
+BridgedDiagnosticArgument::BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg) {
+  *reinterpret_cast<swift::DiagnosticArgument *>(&storage) = arg;
+}
+
+const swift::DiagnosticArgument &BridgedDiagnosticArgument::unbridged() const {
+  return *reinterpret_cast<const swift::DiagnosticArgument *>(&storage);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedDeclAttributes
+//===----------------------------------------------------------------------===//
+
+BridgedDeclAttributes::BridgedDeclAttributes(swift::DeclAttributes attrs)
+    : chain(attrs.getRawAttributeChain()) {}
+
+swift::DeclAttributes BridgedDeclAttributes::unbridged() const {
+  swift::DeclAttributes attrs;
+  attrs.setRawAttributeChain(chain.unbridged());
+  return attrs;
+}
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedSubscriptDecl
 //===----------------------------------------------------------------------===//
 
@@ -104,6 +196,23 @@ BridgedSubscriptDecl_asAbstractStorageDecl(BridgedSubscriptDecl decl) {
 BridgedAbstractStorageDecl
 BridgedVarDecl_asAbstractStorageDecl(BridgedVarDecl decl) {
   return decl.unbridged();
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedCallArgument
+//===----------------------------------------------------------------------===//
+
+swift::Argument BridgedCallArgument::unbridged() const {
+  return swift::Argument(labelLoc.unbridged(), label.unbridged(),
+                         argExpr.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedLabeledStmtInfo
+//===----------------------------------------------------------------------===//
+
+swift::LabeledStmtInfo BridgedLabeledStmtInfo::unbridged() const {
+  return {Name.unbridged(), Loc.unbridged()};
 }
 
 //===----------------------------------------------------------------------===//
@@ -167,6 +276,13 @@ BridgedASTType BridgedCanType::getType() const {
 
 static_assert(sizeof(BridgedConformance) == sizeof(swift::ProtocolConformanceRef));
 
+BridgedConformance::BridgedConformance(swift::ProtocolConformanceRef conformance)
+    : opaqueValue(conformance.getOpaqueValue()) {}
+
+swift::ProtocolConformanceRef BridgedConformance::unbridged() const {
+  return swift::ProtocolConformanceRef::getFromOpaqueValue(opaqueValue);
+}
+
 bool BridgedConformance::isConcrete() const {
   return unbridged().isConcrete();
 }
@@ -203,7 +319,7 @@ BridgedSubstitutionMap BridgedConformance::getSpecializedSubstitutions() const {
 }
 
 BridgedConformance BridgedConformanceArray::getAt(SwiftInt index) const {
-  return unbridged()[index];
+  return pcArray.unbridged<swift::ProtocolConformanceRef>()[index];
 }
 
 //===----------------------------------------------------------------------===//
@@ -218,8 +334,8 @@ swift::SubstitutionMap BridgedSubstitutionMap::unbridged() const {
   return *reinterpret_cast<const swift::SubstitutionMap *>(&storage);
 }
 
-BridgedSubstitutionMap::BridgedSubstitutionMap() : BridgedSubstitutionMap(swift::SubstitutionMap()) {
-}
+BridgedSubstitutionMap::BridgedSubstitutionMap()
+  : BridgedSubstitutionMap(swift::SubstitutionMap()) {}
 
 bool BridgedSubstitutionMap::isEmpty() const {
   return unbridged().empty();
@@ -236,6 +352,44 @@ SwiftInt BridgedSubstitutionMap::getNumConformances() const {
 BridgedConformance BridgedSubstitutionMap::getConformance(SwiftInt index) const {
   return unbridged().getConformances()[index];
 }
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedIfConfigClauseRangeInfo
+//===----------------------------------------------------------------------===//
+
+swift::IfConfigClauseRangeInfo BridgedIfConfigClauseRangeInfo::unbridged() const {
+  swift::IfConfigClauseRangeInfo::ClauseKind clauseKind;
+  switch (kind) {
+  case IfConfigActive:
+    clauseKind = swift::IfConfigClauseRangeInfo::ActiveClause;
+    break;
+
+  case IfConfigInactive:
+    clauseKind = swift::IfConfigClauseRangeInfo::InactiveClause;
+    break;
+
+  case IfConfigEnd:
+    clauseKind = swift::IfConfigClauseRangeInfo::EndDirective;
+    break;
+  }
+
+  return swift::IfConfigClauseRangeInfo(directiveLoc.unbridged(),
+                                        bodyLoc.unbridged(),
+                                        endLoc.unbridged(),
+                                        clauseKind);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedStmtConditionElement
+//===----------------------------------------------------------------------===//
+
+BridgedStmtConditionElement::BridgedStmtConditionElement(swift::StmtConditionElement elem)
+    : Raw(elem.getOpaqueValue()) {}
+
+swift::StmtConditionElement BridgedStmtConditionElement::unbridged() const {
+  return swift::StmtConditionElement::fromOpaqueValue(Raw);
+}
+
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -32,6 +32,11 @@
 // and C++, we need to be careful to match the return convention
 // matches between the non-USED_IN_CPP_SOURCE (Swift) side and the
 // USE_IN_CPP_SOURCE (C++) side.
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !! Do not put any constructors inside an `#ifdef USED_IN_CPP_SOURCE` block !!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 #include "swift/Basic/BridgedSwiftObject.h"
 #include "swift/Basic/Compiler.h"
 
@@ -72,7 +77,14 @@
 
 namespace llvm {
 class raw_ostream;
+class StringRef;
 } // end namespace llvm
+
+namespace swift {
+class SourceLoc;
+class SourceRange;
+class CharSourceRange;
+}
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -205,12 +217,8 @@ class BridgedStringRef {
   size_t Length;
 
 public:
-#ifdef USED_IN_CPP_SOURCE
-  BridgedStringRef(llvm::StringRef sref)
-      : Data(sref.data()), Length(sref.size()) {}
-
-  llvm::StringRef unbridged() const { return llvm::StringRef(Data, Length); }
-#endif
+  BRIDGED_INLINE BridgedStringRef(llvm::StringRef sref);
+  BRIDGED_INLINE llvm::StringRef unbridged() const;
 
   BridgedStringRef() : Data(nullptr), Length(0) {}
 
@@ -236,15 +244,9 @@ class BridgedOwnedString {
   size_t Length;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedOwnedString() {}
+  BridgedOwnedString(llvm::StringRef stringToCopy);
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedOwnedString(const std::string &stringToCopy);
-
-  llvm::StringRef unbridgedRef() const { return llvm::StringRef(Data, Length); }
-#endif
+  BRIDGED_INLINE llvm::StringRef unbridgedRef() const;
 
   void destroy() const;
 } SWIFT_SELF_CONTAINED;
@@ -305,14 +307,9 @@ public:
   SWIFT_NAME("init(raw:)")
   BridgedSourceLoc(const void *_Nullable raw) : Raw(raw) {}
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedSourceLoc(swift::SourceLoc loc) : Raw(loc.getOpaquePointerValue()) {}
+  BRIDGED_INLINE BridgedSourceLoc(swift::SourceLoc loc);
 
-  swift::SourceLoc unbridged() const {
-    return swift::SourceLoc(
-        llvm::SMLoc::getFromPointer(static_cast<const char *>(Raw)));
-  }
-#endif
+  BRIDGED_INLINE swift::SourceLoc unbridged() const;
 
   SWIFT_IMPORT_UNSAFE
   const void *_Nullable getOpaquePointerValue() const { return Raw; }
@@ -343,14 +340,9 @@ public:
   BridgedSourceRange(BridgedSourceLoc start, BridgedSourceLoc end)
       : Start(start), End(end) {}
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedSourceRange(swift::SourceRange range)
-      : Start(range.Start), End(range.End) {}
+  BRIDGED_INLINE BridgedSourceRange(swift::SourceRange range);
 
-  swift::SourceRange unbridged() const {
-    return swift::SourceRange(Start.unbridged(), End.unbridged());
-  }
-#endif
+  BRIDGED_INLINE swift::SourceRange unbridged() const;
 };
 
 //===----------------------------------------------------------------------===//
@@ -369,14 +361,9 @@ public:
   BridgedCharSourceRange(BridgedSourceLoc start, unsigned byteLength)
       : Start(start), ByteLength(byteLength) {}
 
-#ifdef USED_IN_CPP_SOURCE
-  BridgedCharSourceRange(swift::CharSourceRange range)
-      : Start(range.getStart()), ByteLength(range.getByteLength()) {}
+  BRIDGED_INLINE BridgedCharSourceRange(swift::CharSourceRange range);
 
-  swift::CharSourceRange unbridged() const {
-    return swift::CharSourceRange(Start.unbridged(), ByteLength);
-  }
-#endif
+  BRIDGED_INLINE swift::CharSourceRange unbridged() const;
 };
 
 SWIFT_NAME("getter:BridgedCharSourceRange.start(self:)")

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -43,6 +43,13 @@ SwiftInt BridgedData_count(BridgedData data) {
 // MARK: BridgedStringRef
 //===----------------------------------------------------------------------===//
 
+BridgedStringRef::BridgedStringRef(llvm::StringRef sref)
+    : Data(sref.data()), Length(sref.size()) {}
+
+llvm::StringRef BridgedStringRef::unbridged() const {
+  return llvm::StringRef(Data, Length);
+}
+
 const uint8_t *_Nullable BridgedStringRef_data(BridgedStringRef str) {
   return (const uint8_t *)str.unbridged().data();
 }
@@ -58,6 +65,8 @@ bool BridgedStringRef_empty(BridgedStringRef str) {
 //===----------------------------------------------------------------------===//
 // MARK: BridgedOwnedString
 //===----------------------------------------------------------------------===//
+
+llvm::StringRef BridgedOwnedString::unbridgedRef() const { return llvm::StringRef(Data, Length); }
 
 const uint8_t *_Nullable BridgedOwnedString_data(BridgedOwnedString str) {
   auto *data = str.unbridgedRef().data();
@@ -76,12 +85,42 @@ bool BridgedOwnedString_empty(BridgedOwnedString str) {
 // MARK: BridgedSourceLoc
 //===----------------------------------------------------------------------===//
 
+BridgedSourceLoc::BridgedSourceLoc(swift::SourceLoc loc)
+  : Raw(loc.getOpaquePointerValue()) {}
+
+swift::SourceLoc BridgedSourceLoc::unbridged() const {
+  return swift::SourceLoc(
+      llvm::SMLoc::getFromPointer(static_cast<const char *>(Raw)));
+}
+
 bool BridgedSourceLoc_isValid(BridgedSourceLoc loc) {
   return loc.getOpaquePointerValue() != nullptr;
 }
 
 BridgedSourceLoc BridgedSourceLoc::advancedBy(size_t n) const {
   return BridgedSourceLoc(unbridged().getAdvancedLoc(n));
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedSourceRange
+//===----------------------------------------------------------------------===//
+
+BridgedSourceRange::BridgedSourceRange(swift::SourceRange range)
+    : Start(range.Start), End(range.End) {}
+
+swift::SourceRange BridgedSourceRange::unbridged() const {
+  return swift::SourceRange(Start.unbridged(), End.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedCharSourceRange
+//===----------------------------------------------------------------------===//
+
+BridgedCharSourceRange::BridgedCharSourceRange(swift::CharSourceRange range)
+    : Start(range.getStart()), ByteLength(range.getByteLength()) {}
+
+swift::CharSourceRange BridgedCharSourceRange::unbridged() const {
+  return swift::CharSourceRange(Start.unbridged(), ByteLength);
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/Parse/ParseBridging.h
+++ b/include/swift/Parse/ParseBridging.h
@@ -16,13 +16,9 @@
 #include "swift/AST/ASTBridging.h"
 #include "swift/Basic/BasicBridging.h"
 
-#ifdef USED_IN_CPP_SOURC
-#include "swift/Parse/Parser.h"
-#else
 namespace swift {
 class Parser;
 }
-#endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -30,15 +26,9 @@ class BridgedLegacyParser {
   swift::Parser *_Nonnull const handle;
 
 public:
-  // Ensure that this struct value type will be indirectly returned on
-  // Windows ARM64
-  BridgedLegacyParser() : handle(nullptr) {}
-
-#ifdef USED_IN_CPP_SOURCE
   BridgedLegacyParser(swift::Parser &P) : handle(&P) {}
 
   swift::Parser &unbridged() const { return *handle; }
-#endif
 };
 
 SWIFT_NAME("BridgedLegacyParser.parseExpr(self:_:_:_:)")

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -23,11 +23,7 @@
 #include "swift/AST/ASTBridging.h"
 #include "swift/SIL/SILBridging.h"
 
-#ifdef USED_IN_CPP_SOURCE
-
-#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
-
-#else // USED_IN_CPP_SOURCE
+#ifndef USED_IN_CPP_SOURCE
 
 // Pure bridging mode does not permit including any C++/llvm/swift headers.
 // See also the comments for `BRIDGING_MODE` in the top-level CMakeLists.txt file.
@@ -45,6 +41,7 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 namespace swift {
 class AliasAnalysis;
 class BasicCalleeAnalysis;
+class CalleeList;
 class DeadEndBlocks;
 class DominanceInfo;
 class PostDominanceInfo;
@@ -94,18 +91,8 @@ struct BridgedCalleeAnalysis {
   struct CalleeList {
     uint64_t storage[3];
 
-    // Ensure that this struct value type will be indirectly returned on
-    // Windows ARM64
-    CalleeList() {}
-
-#ifdef USED_IN_CPP_SOURCE
-    CalleeList(swift::CalleeList list) {
-      *reinterpret_cast<swift::CalleeList *>(&storage) = list;
-    }
-    swift::CalleeList unbridged() const {
-      return *reinterpret_cast<const swift::CalleeList *>(&storage);
-    }
-#endif
+    BRIDGED_INLINE CalleeList(swift::CalleeList list);
+    BRIDGED_INLINE swift::CalleeList unbridged() const;
 
     BRIDGED_INLINE bool isIncomplete() const;
     BRIDGED_INLINE SwiftInt getCount() const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -45,6 +45,14 @@ bool BridgedAliasAnalysis::unused(BridgedValue address1, BridgedValue address2) 
 static_assert(sizeof(BridgedCalleeAnalysis::CalleeList) >= sizeof(swift::CalleeList),
               "BridgedCalleeAnalysis::CalleeList has wrong size");
 
+BridgedCalleeAnalysis::CalleeList::CalleeList(swift::CalleeList list) {
+  *reinterpret_cast<swift::CalleeList *>(&storage) = list;
+}
+
+swift::CalleeList BridgedCalleeAnalysis::CalleeList::unbridged() const {
+  return *reinterpret_cast<const swift::CalleeList *>(&storage);
+}
+
 bool BridgedCalleeAnalysis::CalleeList::isIncomplete() const {
   return unbridged().isIncomplete();
 }
@@ -509,7 +517,7 @@ void BridgedPassContext::SSAUpdater_initialize(
     BridgedFunction function, BridgedType type,
     BridgedValue::Ownership ownership) const {
   invocation->initializeSSAUpdater(function.getFunction(), type.unbridged(),
-                                   BridgedValue::castToOwnership(ownership));
+                                   BridgedValue::unbridge(ownership));
 }
 
 void BridgedPassContext::addFunctionToPassManagerWorklist(

--- a/lib/AST/Bridging/MiscBridging.cpp
+++ b/lib/AST/Bridging/MiscBridging.cpp
@@ -94,7 +94,7 @@ BridgedOwnedString BridgedDeclObj::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
   unbridged()->print(os);
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -105,7 +105,7 @@ BridgedOwnedString BridgedConformance::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
   unbridged().print(os);
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -119,6 +119,6 @@ BridgedOwnedString BridgedSubstitutionMap::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
   unbridged().dump(os);
-  return str;
+  return BridgedOwnedString(str);
 }
 

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -60,7 +60,7 @@ void BridgedStringRef::write(BridgedOStream os) const {
 // MARK: BridgedOwnedString
 //===----------------------------------------------------------------------===//
 
-BridgedOwnedString::BridgedOwnedString(const std::string &stringToCopy)
+BridgedOwnedString::BridgedOwnedString(llvm::StringRef stringToCopy)
     : Data(nullptr), Length(stringToCopy.size()) {
   if (Length != 0) {
     Data = new char[Length];

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -207,7 +207,7 @@ BridgedOwnedString BridgedFunction::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   getFunction()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 BridgedSubstitutionMap BridgedFunction::getMethodSubstitutions(BridgedSubstitutionMap contextSubs) const {
@@ -231,7 +231,7 @@ BridgedOwnedString BridgedBasicBlock::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   unbridged()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -243,7 +243,7 @@ BridgedOwnedString BridgedValue::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   getSILValue()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 BridgedValue::Kind BridgedValue::getKind() const {
@@ -310,7 +310,7 @@ static_assert((int)BridgedLinkage::HiddenExternal == (int)swift::SILLinkage::Hid
 void BridgedOperand::changeOwnership(BridgedValue::Ownership from, BridgedValue::Ownership to) const {
   swift::ForwardingOperand forwardingOp(op);
   assert(forwardingOp);
-  forwardingOp.replaceOwnershipKind(BridgedValue::castToOwnership(from), BridgedValue::castToOwnership(to));
+  forwardingOp.replaceOwnershipKind(BridgedValue::unbridge(from), BridgedValue::unbridge(to));
 }
 
 //===----------------------------------------------------------------------===//
@@ -322,7 +322,7 @@ BridgedOwnedString BridgedGlobalVar::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   getGlobal()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 bool BridgedGlobalVar::canBeInitializedStatically() const {
@@ -350,7 +350,7 @@ BridgedOwnedString BridgedDeclRef::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
   unbridged().print(os);
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -369,7 +369,7 @@ BridgedOwnedString BridgedVTable::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   vTable->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 BridgedOwnedString BridgedVTableEntry::getDebugDescription() const {
@@ -377,7 +377,7 @@ BridgedOwnedString BridgedVTableEntry::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   unbridged().print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -398,7 +398,7 @@ BridgedOwnedString BridgedWitnessTableEntry::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   unbridged().print(os, /*verbose=*/ false, PrintOptions::printSIL());
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 BridgedOwnedString BridgedWitnessTable::getDebugDescription() const {
@@ -406,7 +406,7 @@ BridgedOwnedString BridgedWitnessTable::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   table->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 BridgedOwnedString BridgedDefaultWitnessTable::getDebugDescription() const {
@@ -414,7 +414,7 @@ BridgedOwnedString BridgedDefaultWitnessTable::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   table->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -439,7 +439,7 @@ BridgedOwnedString BridgedLocation::getDebugDescription() const {
     }
   }
 #endif
-  return str;
+  return BridgedOwnedString(str);
 }
 
 //===----------------------------------------------------------------------===//
@@ -457,7 +457,7 @@ BridgedOwnedString BridgedInstruction::getDebugDescription() const {
   llvm::raw_string_ostream os(str);
   unbridged()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 bool BridgedInstruction::mayAccessPointer() const {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1652,7 +1652,7 @@ BridgedOwnedString BridgedPassContext::getModuleDescription() const {
   llvm::raw_string_ostream os(str);
   invocation->getPassManager()->getModule()->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return BridgedOwnedString(str);
 }
 
 bool BridgedPassContext::tryOptimizeApplyOfPartialApply(BridgedInstruction closure) const {
@@ -1815,7 +1815,7 @@ BridgedOwnedString BridgedPassContext::mangleOutlinedVariable(BridgedFunction fu
     GlobalVariableMangler mangler;
     std::string name = mangler.mangleOutlinedVariable(f, idx);
     if (!mod.lookUpGlobalVariable(name))
-      return name;
+      return BridgedOwnedString(name);
     idx++;
   }
 }
@@ -1829,7 +1829,7 @@ BridgedOwnedString BridgedPassContext::mangleAsyncRemoved(BridgedFunction functi
   Mangle::FunctionSignatureSpecializationMangler Mangler(
       P, F->getSerializedKind(), F);
   Mangler.setRemovedEffect(EffectKind::Async);
-  return Mangler.mangle();
+  return BridgedOwnedString(Mangler.mangle());
 }
 
 BridgedOwnedString BridgedPassContext::mangleWithDeadArgs(const SwiftInt * _Nullable deadArgs,
@@ -1842,7 +1842,7 @@ BridgedOwnedString BridgedPassContext::mangleWithDeadArgs(const SwiftInt * _Null
   for (SwiftInt idx = 0; idx < numDeadArgs; idx++) {
     Mangler.setArgumentDead((unsigned)idx);
   }
-  return Mangler.mangle();
+  return BridgedOwnedString(Mangler.mangle());
 }
 
 BridgedOwnedString BridgedPassContext::mangleWithClosureArgs(
@@ -1876,7 +1876,7 @@ BridgedOwnedString BridgedPassContext::mangleWithClosureArgs(
     }
   }
 
-  return mangler.mangle();
+  return BridgedOwnedString(mangler.mangle());
 }
 
 BridgedGlobalVar BridgedPassContext::createGlobalVariable(BridgedStringRef name, BridgedType type, bool isPrivate) const {


### PR DESCRIPTION
Especially avoid any constructors in `#ifdef USED_IN_CPP_SOURCE` blocks, because this breaks Windows ARM64.
