### PR TITLE
[cxx-interop] Allow creating a String from `std::string_view`

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -291,3 +291,61 @@ extension String {
     withExtendedLifetime(cxxU32String) {}
   }
 }
+
+// MARK: Initializing Swift String from a C++ string_view
+
+extension String {
+  /// Creates a String having the same content as the given C++ string view.
+  ///
+  /// If `cxxStringView` contains ill-formed UTF-8 code unit sequences, this
+  /// initializer replaces them with the Unicode replacement character
+  /// (`"\u{FFFD}"`).
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ string
+  ///   view.
+  public init(_ cxxStringView: std.string_view) {
+    let buffer = UnsafeBufferPointer<CChar>(
+      start: cxxStringView.__dataUnsafe(),
+      count: cxxStringView.size())
+    self = buffer.withMemoryRebound(to: UInt8.self) {
+      String(decoding: $0, as: UTF8.self)
+    }
+    withExtendedLifetime(cxxStringView) {}
+  }
+
+  /// Creates a String having the same content as the given C++ UTF-16 string
+  /// view.
+  ///
+  /// If `cxxU16StringView` contains ill-formed UTF-16 code unit sequences, this
+  /// initializer replaces them with the Unicode replacement character
+  /// (`"\u{FFFD}"`).
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
+  ///   string view.
+  public init(_ cxxU16StringView: std.u16string_view) {
+    let buffer = UnsafeBufferPointer<UInt16>(
+      start: cxxU16StringView.__dataUnsafe(),
+      count: cxxU16StringView.size())
+    self = String(decoding: buffer, as: UTF16.self)
+    withExtendedLifetime(cxxU16StringView) {}
+  }
+
+  /// Creates a String having the same content as the given C++ UTF-32 string
+  /// view.
+  ///
+  /// If `cxxU32StringView` contains ill-formed UTF-32 code unit sequences, this
+  /// initializer replaces them with the Unicode replacement character
+  /// (`"\u{FFFD}"`).
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-32
+  ///   string view.
+  public init(_ cxxU32StringView: std.u32string_view) {
+    let buffer = UnsafeBufferPointer<Unicode.Scalar>(
+      start: cxxU32StringView.__dataUnsafe(),
+      count: cxxU32StringView.size())
+    self = buffer.withMemoryRebound(to: UInt32.self) {
+      String(decoding: $0, as: UTF32.self)
+    }
+    withExtendedLifetime(cxxU32StringView) {}
+  }
+}

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -40,6 +40,12 @@ module StdString {
   export *
 }
 
+module StdStringView {
+  header "std-string-view.h"
+  requires cplusplus
+  export *
+}
+
 module StdPair {
   header "std-pair.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-string-view.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-string-view.h
@@ -1,0 +1,15 @@
+#include <string_view>
+
+static std::string_view staticStringView{"abc210"};
+static std::string_view staticEmptyStringView{""};
+static std::string_view staticNonASCIIStringView{"тест"};
+
+// UTF-16
+static std::u16string_view staticU16StringView{u"abc210"};
+static std::u16string_view staticU16EmptyStringView{u""};
+static std::u16string_view staticU16NonASCIIStringView{u"тест"};
+
+// UTF-32
+static std::u32string_view staticU32StringView{U"abc210"};
+static std::u32string_view staticU32EmptyStringView{U""};
+static std::u32string_view staticU32NonASCIIStringView{U"тест"};

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import CxxStdlib
+import StdStringView
+
+var StdStringTestSuite = TestSuite("StdStringView")
+
+StdStringTestSuite.test("String.init(_: std.string_view)") {
+    expectEqual("abc210", String(staticStringView))
+    expectEqual("", String(staticEmptyStringView))
+    expectEqual("тест", String(staticNonASCIIStringView))
+}
+
+StdStringTestSuite.test("String.init(_: std.u16string_view)") {
+    expectEqual("abc210", String(staticU16StringView))
+    expectEqual("", String(staticU16EmptyStringView))
+    expectEqual("тест", String(staticU16NonASCIIStringView))
+}
+
+StdStringTestSuite.test("String.init(_: std.u32string_view)") {
+    expectEqual("abc210", String(staticU32StringView))
+    expectEqual("", String(staticU32EmptyStringView))
+    expectEqual("тест", String(staticU32NonASCIIStringView))
+}
+
+runAllTests()


### PR DESCRIPTION
This adds overlay support for initializing a Swift String from C++ `std::string_view`, `std::u16string_view`, `std::u32string_view`.

rdar://138417835

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
