### PR TITLE
Ensure that new bridged types are indirectly returned on Windows ARM64

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2099,6 +2099,10 @@ public:
 struct BridgedConformance {
   void * _Nullable opaqueValue;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedConformance() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedConformance(swift::ProtocolConformanceRef conformance)
       : opaqueValue(conformance.getOpaqueValue()) {}
@@ -2121,6 +2125,10 @@ struct BridgedConformance {
 
 struct BridgedConformanceArray {
   BridgedArrayRef pcArray;
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedConformanceArray() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedConformanceArray(llvm::ArrayRef<swift::ProtocolConformanceRef> conformances)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1015,6 +1015,10 @@ struct BridgedSuccessorArray {
 struct BridgedDeclRef {
   uint64_t storage[4];
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedDeclRef() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedDeclRef(swift::SILDeclRef declRef) {
     *reinterpret_cast<swift::SILDeclRef *>(&storage) = declRef;
@@ -1038,6 +1042,10 @@ struct BridgedVTableEntry {
     Inherited,
     Override
   };
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedVTableEntry() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedVTableEntry(const swift::SILVTableEntry &entry) {
@@ -1089,6 +1097,10 @@ struct BridgedWitnessTableEntry {
     associatedConformance,
     baseProtocol
   };
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedWitnessTableEntry() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedWitnessTableEntry(const swift::SILWitnessTable::Entry &entry) {


### PR DESCRIPTION
This is necessary to have the SwiftCompilerSources-enabled Windows ARM64 compiler work.