### PR TITLE
prevent modules from leaking internal and @_implementationOnly imported fields in public structs

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6620,12 +6620,11 @@ public:
   /// @frozen and resides in a resilient module.
   bool isInitExposedToClients() const;
 
-  /// Determines if this var is exposed as part of the layout of a
-  /// @frozen struct.
-  ///
-  /// From the standpoint of access control and exportability checking, this
-  /// var will behave as if it was public, even if it is internal or private.
-  bool isLayoutExposedToClients() const;
+  /// Determines if this var is exposed as part of the layout of its
+  /// containing type. If true is passed for the inFrozenContext
+  /// parameter, a stored var will behave as if it was public, even if
+  /// declared internal or private.
+  bool isLayoutExposedToClients(bool inFrozenContext) const;
 
   /// Is this a special debugger variable?
   bool isDebuggerVar() const { return Bits.VarDecl.IsDebuggerVar; }

--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -102,7 +102,8 @@ public:
   }
 
   bool visitVarDecl(const VarDecl *var) {
-    if (var->isLayoutExposedToClients())
+    auto &context = var->getASTContext();
+    if (var->isLayoutExposedToClients(context.TypeCheckerOpts.DiagnoseEscapingImplementationOnlyProperties))
       return true;
 
     // Consider all lazy var storage as exportable.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2391,6 +2391,13 @@ ERROR(pattern_type_access,none,
       "because its type uses "
       "%select{a private|a fileprivate|an internal|a package|%error|%error}5 type",
       (bool, bool, bool, AccessLevel, bool, AccessLevel))
+ERROR(pattern_type_access_leak,none,
+      "%select{%select{variable|constant}0|property}1 "
+      "%select{must be declared %select{public|private or fileprivate}4"
+      "|cannot be declared "
+      "%select{in this context|fileprivate|internal|package|public|open}3}2 "
+      "because its type is non-public and its enclosing type's layout is exposed to clients",
+      (bool, bool, bool, AccessLevel, bool, AccessLevel))
 WARNING(pattern_type_access_warn,none,
         "%select{%select{variable|constant}0|property}1 "
         "%select{should be declared %select{private|fileprivate|internal|package|%error|%error}5"
@@ -2429,6 +2436,11 @@ ERROR(pattern_type_not_usable_from_inline_frozen,none,
       "type referenced from a stored property in a '@frozen' struct must "
       "be '@usableFromInline' or public",
       (/*ignored*/bool, /*ignored*/bool))
+ERROR(pattern_type_not_usable_from_inline_implicit_frozen,none,
+      "type referenced from a stored property in a public struct must "
+      "be '@usableFromInline' or public when building "
+      "with '-diagnose-escaping-implementation-only-properties'",
+      (/*ignored*/bool, /*ignored*/bool))
 ERROR(pattern_type_not_usable_from_inline_inferred,none,
       "type referenced from a '@usableFromInline' "
       "%select{%select{variable|constant}0|property}1 "
@@ -2445,7 +2457,11 @@ ERROR(pattern_type_not_usable_from_inline_inferred_frozen,none,
       "type referenced from a stored property with inferred type %2 in a "
       "'@frozen' struct must be '@usableFromInline' or public",
       (/*ignored*/bool, /*ignored*/bool, Type))
-
+ERROR(pattern_type_not_usable_from_inline_inferred_implicit_frozen,none,
+      "type referenced from a stored property with inferred type %2 in a "
+      "public struct must be '@usableFromInline' or public when building "
+      "with '-non-resilient-hide-internal-dependencies'",
+      (/*ignored*/bool, /*ignored*/bool, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",
@@ -7192,6 +7208,18 @@ ERROR(inlinable_decl_ref_from_hidden_module,
       "%2 was not imported publicly}3",
       (const ValueDecl *, unsigned, Identifier, unsigned))
 
+ERROR(inlinable_decl_ref_from_hidden_module_leak,
+      none, "%kind0 cannot be used here "
+      "because %select{%2 was imported implementation-only|"
+      "it is an SPI imported from %2|"
+      "it is SPI|"
+      "%2 was imported for SPI only|"
+      "%2 was not imported by this file|"
+      "C++ APIs from imported module %2 do not support library evolution|"
+      "%2 was not imported publicly}3 "
+      "and its layout is exposed to clients",
+      (const ValueDecl *, unsigned, Identifier, unsigned))
+
 ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       none, "%0 aliases '%1.%2' and cannot be used in " FRAGILE_FUNC_KIND "3 "
       "because %select{%4 has been imported as implementation-only|"
@@ -7509,9 +7537,25 @@ ERROR(property_wrapper_type_access,none,
       "because its property wrapper type uses "
       "%select{a private|a fileprivate|an internal|a package|%error|%error}5 type",
       (bool, bool, bool, AccessLevel, bool, AccessLevel))
+ERROR(property_wrapper_type_access_leak,none,
+      "%select{%select{variable|constant}0|property}1 "
+      "%select{must be declared %select{"
+      "public|private or fileprivate}4"
+      "|cannot be declared "
+      "%select{in this context|fileprivate|internal|package|public|open}3}2 "
+      "because its property wrapper type uses "
+      "%select{a private|a fileprivate|an internal|a package|%error|%error}5 type "
+      "and its enclosing type's layout is exposed to clients",
+      (bool, bool, bool, AccessLevel, bool, AccessLevel))
 ERROR(property_wrapper_type_not_usable_from_inline,none,
       "property wrapper type referenced from a '@usableFromInline' "
       "%select{%select{variable|constant}0|property}1 "
+      "must be '@usableFromInline' or public",
+      (bool, bool))
+ERROR(property_wrapper_type_not_usable_from_inline_leak,none,
+      "property wrapper type referenced from a "
+      "%select{%select{variable|constant}0|property}1 "
+      "visible to clients "
       "must be '@usableFromInline' or public",
       (bool, bool))
 WARNING(property_wrapper_wrapperValue,Deprecation,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -709,6 +709,7 @@ public:
   ResilienceStrategy getResilienceStrategy() const {
     return ResilienceStrategy(Bits.ModuleDecl.RawResilienceStrategy);
   }
+  
   void setResilienceStrategy(ResilienceStrategy strategy) {
     Bits.ModuleDecl.RawResilienceStrategy = unsigned(strategy);
   }

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -986,6 +986,10 @@ namespace swift {
 
     /// Disable the component splitter phase of the expression type checker.
     bool SolverDisableSplitter = false;
+
+    /// Diagnose when a type imported via _implementationOnly import or as an SPI
+    /// is used to define a property on a public struct or class.
+    bool DiagnoseEscapingImplementationOnlyProperties = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1466,6 +1466,10 @@ def experimental_spi_only_imports :
   Flag<["-"], "experimental-spi-only-imports">,
   HelpText<"Enable use of @_spiOnly imports">;
 
+def diagnose_escaping_implementation_only_properties :
+  Flag<["-"], "diagnose-escaping-implementation-only-properties">,
+  HelpText<"Diagnose use of implementationOnly imported types in public structs or classes">;
+
 def enable_ossa_complete_lifetimes :
   Flag<["-"], "enable-ossa-complete-lifetimes">,
   HelpText<"Require linear OSSA lifetimes after SILGen">;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -1137,8 +1137,9 @@ bool swift::isExported(const ValueDecl *VD) {
     return true;
 
   // Is this a stored property in a @frozen struct or class?
+  ASTContext &Context = VD->getASTContext();
   if (auto *property = dyn_cast<VarDecl>(VD))
-    if (property->isLayoutExposedToClients())
+    if (property->isLayoutExposedToClients(Context.TypeCheckerOpts.DiagnoseEscapingImplementationOnlyProperties))
       return true;
 
   return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2640,23 +2640,25 @@ bool VarDecl::isInitExposedToClients() const {
   if (getAttrs().hasAttribute<LazyAttr>())
     return false;
 
-  return hasInitialValue() && isLayoutExposedToClients();
+  auto &context = getASTContext();
+  return hasInitialValue() && isLayoutExposedToClients(context.TypeCheckerOpts.DiagnoseEscapingImplementationOnlyProperties);
 }
 
-bool VarDecl::isLayoutExposedToClients() const {
+bool VarDecl::isLayoutExposedToClients(bool inFrozenContext) const {
   auto parent = dyn_cast<NominalTypeDecl>(getDeclContext());
   if (!parent) return false;
   if (isStatic()) return false;
-
 
   auto nominalAccess =
     parent->getFormalAccessScope(/*useDC=*/nullptr,
                                  /*treatUsableFromInlineAsPublic=*/true);
   if (!nominalAccess.isPublic()) return false;
 
-  if (!parent->getAttrs().hasAttribute<FrozenAttr>() &&
-      !parent->getAttrs().hasAttribute<FixedLayoutAttr>())
-    return false;
+  auto parentIsClass = dyn_cast<ClassDecl>(parent);
+  if (parentIsClass || !inFrozenContext)
+    if (!parent->getAttrs().hasAttribute<FrozenAttr>() &&
+        !parent->getAttrs().hasAttribute<FixedLayoutAttr>())
+      return false;
 
   if (!hasStorage() &&
       !getAttrs().hasAttribute<LazyAttr>() &&

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1955,6 +1955,9 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.PrintFullConvention |=
       Args.hasArg(OPT_experimental_print_full_convention);
 
+  Opts.DiagnoseEscapingImplementationOnlyProperties |=
+      Args.hasArg(OPT_diagnose_escaping_implementation_only_properties); 
+
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
 
   for (const Arg *A : Args.filtered(OPT_debug_constraints_on_line)) {

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -6,7 +6,8 @@ target_link_libraries(swiftSIL PRIVATE
   swiftAST
   swiftClangImporter
   swiftSema
-  swiftSerialization)
+  swiftSerialization
+  swiftSILOptimizer)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -308,7 +308,10 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
            originKind == DisallowedOriginKind::MissingImport &&
            "Only implicitly imported decls should be reported as a warning.");
 
-    ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_from_hidden_module, D,
+    auto diagID = diag::inlinable_decl_ref_from_hidden_module;
+    if (ctx.TypeCheckerOpts.DiagnoseEscapingImplementationOnlyProperties)
+      diagID = diag::inlinable_decl_ref_from_hidden_module_leak;
+    ctx.Diags.diagnose(loc, diagID, D,
                        fragileKind.getSelector(), definingModule->getName(),
                        static_cast<unsigned>(originKind))
         .warnUntilSwiftVersionIf(downgradeToWarning == DowngradeToWarning::Yes,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1361,10 +1361,13 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
                             VD);
     }
 
+    auto &Context = VD->getASTContext();
+
     // Forbid stored properties marked SPI in frozen types.
     if (auto property = dyn_cast<VarDecl>(VD)) {
       if (auto NTD = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
-        if (property->isLayoutExposedToClients() && !NTD->isSPI()) {
+        if (property->isLayoutExposedToClients(Context.TypeCheckerOpts.DiagnoseEscapingImplementationOnlyProperties) 
+            && !NTD->isSPI()) {
           diagnoseAndRemoveAttr(attr,
                                 diag::spi_attribute_on_frozen_stored_properties,
                                 VD);

--- a/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
+++ b/test/Sema/Inputs/implementation-only-import-in-decls-helper.swift
@@ -10,7 +10,11 @@ extension NormalClass: @retroactive NormalProto {
   public typealias Assoc = Int
 }
 
-public struct BadStruct {}
+public struct BadStruct {
+  public init() {}
+
+  public static let namedInstance = BadClass()
+}
 public protocol BadProto {}
 open class BadClass {}
 

--- a/test/Sema/implementation-only-import-diagnose-escaping-properties.swift
+++ b/test/Sema/implementation-only-import-diagnose-escaping-properties.swift
@@ -1,0 +1,132 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift
+// RUN: %target-swift-frontend -emit-module -module-name BADLibrary -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -I %t -module-name ThisTest -diagnose-escaping-implementation-only-properties
+
+@_implementationOnly import BADLibrary
+// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'ThisTest' may lead to instability during execution}}
+
+public protocol TestOpaqueReturnProto {}
+extension BadStruct: TestOpaqueReturnProto {} // okay bc internal
+
+public func testOpaqueReturn() -> some TestOpaqueReturnProto {
+  return BadStruct() // ok, type will be determined at runtime
+}
+
+public func testBoxedReturn() -> any TestOpaqueReturnProto {
+  return BadStruct() // ok, type will be determined at runtime
+}
+
+internal struct InternalStructShouldNotLeak { // expected-note 8 {{type declared here}}
+  private var privatelyOkayInInternalStruct: BadStruct?
+}
+
+public struct PublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyNamed = BadStruct.namedInstance // expected-error {{cannot use class 'BadClass' here; 'BADLibrary' has been imported as implementation-only}}
+  // expected-error@-1 {{struct 'BadStruct' cannot be used here because 'BADLibrary' was imported implementation-only and its layout is exposed to clients}}
+  // expected-error@-2 {{static property 'namedInstance' cannot be used here because 'BADLibrary' was imported implementation-only and its layout is exposed to clients}}
+  internal var internalSibling: InternalStructShouldNotLeak? // expected-error {{property cannot be declared internal because its type is non-public and its enclosing type's layout is exposed to clients}}
+  // expected-error@-1 {{type referenced from a stored property in a public struct must be '@usableFromInline' or public when building with '-diagnose-escaping-implementation-only-properties'}}
+  public var cantInternalMember: InternalStructShouldNotLeak? // expected-error {{property cannot be declared public because its type is non-public and its enclosing type's layout is exposed to clients}}
+  // expected-error@-1 {{type referenced from a stored property in a public struct must be '@usableFromInline' or public when building with '-diagnose-escaping-implementation-only-properties'}}
+  var cantImplicitMember: InternalStructShouldNotLeak? // expected-error {{property must be declared public because its type is non-public and its enclosing type's layout is exposed to clients}}
+  // expected-error@-1 {{type referenced from a stored property in a public struct must be '@usableFromInline' or public when building with '-diagnose-escaping-implementation-only-properties'}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar = [BadStruct]() // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  // expected-error@-1 {{struct 'BadStruct' cannot be used here because 'BADLibrary' was imported implementation-only and its layout is exposed to clients}}
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  public var opaqueReturnType: some TestOpaqueReturnProto { BadStruct() } // okay, opaque return types metadata are accessed at runtime
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@usableFromInline internal struct UFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar = [BadStruct]() // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  // expected-error@-1 {{struct 'BadStruct' cannot be used here because 'BADLibrary' was imported implementation-only and its layout is exposed to clients}}
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+public class PublicClassStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // okay
+  private var privatelyBad: BadStruct? // okay
+  private let letIsLikeVar = [BadStruct]() // okay
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+// MARK: Frozen types
+
+@frozen
+public struct FrozenPublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internalLeak: InternalStructShouldNotLeak? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-error@-1 {{property cannot be declared internal because its type is non-public and its enclosing type's layout is exposed to clients}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@frozen
+@usableFromInline internal struct FrozenUFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@_fixed_layout
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+public struct FixedLayoutPublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@_fixed_layout
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+@usableFromInline internal struct FixedLayoutUFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@_fixed_layout
+public class FrozenPublicClassStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}


### PR DESCRIPTION
Here I am adding diagnostics to move towards lifting the restriction from [SE-0409] that dependencies imported non-publicly must still be provided to clients when building without resiliency.

With flag `-diagnose-escaping-implementation-only-properties`, any public struct is treated as implicitly frozen for the purposes of diagnosing these leaks of memory layout information. Without resilience, we must limit properties that affect memory layout to those that are already visible to clients, either imported publicly (and without @_implementationOnly) or declared as public or @_usableFromInline.

```swift
internal struct Bar {}
public struct Foo {
  internal var bar: Bar? // illegal as Bar is not visible to clients
}
```