### PR TITLE
[Runtime] Fix SwiftError handling in CVW runtime

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -249,8 +249,6 @@ static void handleEnd(const Metadata *metadata,
 static void errorDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
                          uintptr_t &addrOffset, uint8_t *addr) {
   uintptr_t object = *(uintptr_t *)(addr + addrOffset);
-  if (object & _swift_abi_ObjCReservedBitsMask)
-    return;
   object &= ~_swift_abi_SwiftSpareBitsMask;
   addrOffset += sizeof(SwiftError*);
   swift_errorRelease((SwiftError *)object);
@@ -911,8 +909,6 @@ static void errorRetain(const Metadata *metadata, LayoutStringReader1 &reader,
                         uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
-  if (object & _swift_abi_ObjCReservedBitsMask)
-    return;
   memcpy(dest + addrOffset, &object, sizeof(SwiftError*));
   object &= ~_swift_abi_SwiftSpareBitsMask;
   addrOffset = _addrOffset + sizeof(SwiftError *);
@@ -1306,15 +1302,10 @@ static void errorAssignWithCopy(const Metadata *metadata,
   memcpy(dest + _addrOffset, &srcObject, sizeof(SwiftError *));
   addrOffset = _addrOffset + sizeof(SwiftError *);
 
-  if (!(destObject & _swift_abi_ObjCReservedBitsMask)) {
-    destObject &= ~_swift_abi_SwiftSpareBitsMask;
-    swift_errorRelease((SwiftError *)destObject);
-  }
-
-  if (!(srcObject & _swift_abi_ObjCReservedBitsMask)) {
-    srcObject &= ~_swift_abi_SwiftSpareBitsMask;
-    swift_errorRetain((SwiftError *)srcObject);
-  }
+  destObject &= ~_swift_abi_SwiftSpareBitsMask;
+  srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+  swift_errorRelease((SwiftError *)destObject);
+  swift_errorRetain((SwiftError *)srcObject);
 }
 
 static void nativeStrongAssignWithCopy(const Metadata *metadata,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -617,6 +617,7 @@ public enum MultiPayloadError {
     case empty
     case error1(Int, Error)
     case error2(Int, Error)
+    case error3(Int, Error)
 }
 
 public enum TwoPayloadInner {
@@ -659,6 +660,11 @@ public enum OneExtraTagValue {
     case x3(E4, Int8, Int16, Int32)
     case y(SimpleClass)
     case z
+}
+
+public enum ErrorWrapper {
+    case x(Error)
+    case y(Error)
 }
 
 @inline(never)

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1175,6 +1175,19 @@ func testMultiPayloadError() {
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
 
+    // initWithCopy
+    do {
+        let x = MultiPayloadError.error3(0, MyError(x: SimpleClass(x: 23)))
+        testInit(ptr, to: x)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
     ptr.deallocate()
 }
 
@@ -1194,6 +1207,7 @@ func testMultiPayloadErrorKeepsTagIntact() {
     switch ptr.pointee {
         case .error1: print("Get error1!")
         case .error2: print("Got error2!")
+        case .error3: print("Got error3!")
         case .empty: print("Got empty!")
     }
 


### PR DESCRIPTION
rdar://138085348

Even though errors are ObjC boxes, they can't be tagged pointers and in fact may use that bit to store enum tags, so treating them like regular ObjC references here can cause ref count issues.