### PR TITLE
embedded: make sure to de-serialize vtable/wtable methods before trying to specialize them

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -86,6 +86,7 @@ private struct VTableSpecializer {
       let methodSubs = classContextSubs.getMethodSubstitutions(for: entry.implementation)
 
       guard !methodSubs.conformances.contains(where: {!$0.isValid}),
+            context.loadFunction(function: entry.implementation, loadCalleesRecursively: true),
             let specializedMethod = context.specialize(function: entry.implementation, for: methodSubs) else
       {
         context.diagnosticEngine.diagnose(entry.methodDecl.location.sourceLoc, .non_final_generic_class_function)
@@ -125,6 +126,7 @@ func specializeWitnessTable(forConformance conformance: Conformance,
       let methodSubs = conformance.specializedSubstitutions.getMethodSubstitutions(for: origMethod)
 
       guard !methodSubs.conformances.contains(where: {!$0.isValid}),
+            context.loadFunction(function: origMethod, loadCalleesRecursively: true),
             let specializedMethod = context.specialize(function: origMethod, for: methodSubs) else
       {
         context.diagnosticEngine.diagnose(errorLocation.sourceLoc, .cannot_specialize_witness_method, requirement)

--- a/test/embedded/generic-class-multi-module.swift
+++ b/test/embedded/generic-class-multi-module.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// BEGIN MyModule.swift
+
+
+// Check that the compiler can build this and doesn't crash.
+
+public class SubClass<T> {
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+var dummy: [SubClass<Int>] = []


### PR DESCRIPTION
Fixes a compiler crash.
rdar://138341211
