### PR TITLE
[api-digester] Avoid modeling ParenType

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1065,15 +1065,13 @@ static StringRef getPrintedName(SDKContext &Ctx, Type Ty,
   if (IsImplicitlyUnwrappedOptional)
     PO.PrintOptionalAsImplicitlyUnwrapped = true;
 
-  Ty.print(OS, PO);
+  Ty->getWithoutParens().print(OS, PO);
   return Ctx.buffer(OS.str());
 }
 
 static StringRef getTypeName(SDKContext &Ctx, Type Ty,
                              bool IsImplicitlyUnwrappedOptional) {
-  if (Ty->getKind() == TypeKind::Paren) {
-    return Ctx.buffer("Paren");
-  }
+  Ty = Ty->getWithoutParens();
   if (Ty->isVoid()) {
     return Ctx.buffer("Void");
   }
@@ -1661,12 +1659,6 @@ SwiftDeclCollector::constructTypeNode(Type T, TypeInitInfo Info) {
   }
 
   SDKNode* Root = SDKNodeInitInfo(Ctx, T, Info).createSDKNode(SDKNodeKind::TypeNominal);
-
-  // Keep paren type as a stand-alone level.
-  if (auto *PT = dyn_cast<ParenType>(T.getPointer())) {
-    Root->addChild(constructTypeNode(PT->getSinglyDesugaredType()));
-    return Root;
-  }
 
   // Handle the case where Type has sub-types.
   if (auto BGT = T->getAs<BoundGenericType>()) {

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -684,21 +684,14 @@
                   },
                   {
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(cake.Number.Type)",
+                    "name": "Metatype",
+                    "printedName": "cake.Number.Type",
                     "children": [
                       {
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "cake.Number.Type",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Number",
-                            "printedName": "cake.Number",
-                            "usr": "s:4cake6NumberO"
-                          }
-                        ]
+                        "name": "Number",
+                        "printedName": "cake.Number",
+                        "usr": "s:4cake6NumberO"
                       }
                     ]
                   }

--- a/test/api-digester/Outputs/clang-module-dump.txt
+++ b/test/api-digester/Outputs/clang-module-dump.txt
@@ -623,16 +623,8 @@
       "children": [
         {
           "kind": "TypeNominal",
-          "name": "Paren",
-          "printedName": "(__ObjC.__va_list_tag)",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "__va_list_tag",
-              "printedName": "__ObjC.__va_list_tag",
-              "usr": "c:@S@__va_list_tag"
-            }
-          ],
+          "name": "__va_list_tag",
+          "printedName": "__ObjC.__va_list_tag",
           "usr": "c:@S@__va_list_tag"
         }
       ],

--- a/test/api-digester/Outputs/macro-gen.def
+++ b/test/api-digester/Outputs/macro-gen.def
@@ -16,7 +16,7 @@ SDK_CHANGE(Function, WrapOptional, "2:0", "s:12macrogenleft2S1V4foo91x1yySaySDyS
 SDK_CHANGE(Function, UnwrapOptional, "1:0:1", "s:12macrogenleft2S1V4foo91x1yySaySDySiSSSgGG_SaySiGtF", "", "", "", "macrogenleft")
 SDK_CHANGE(Function, WrapOptional, "1:1:1:1:1:0", "s:12macrogenleft2S1V5foo101xySSSi_SDySiSDySSSaySiGGGtXE_tF", "", "", "", "macrogenleft")
 SDK_CHANGE(Function, TypeRewritten, "1:1:1:1", "s:12macrogenleft2S1V5foo111xySSSi_SDySiSDySSSaySiGGGtXE_tF", "", "[String : [Int]]", "Int", "macrogenleft")
-SDK_CHANGE(Function, TypeRewritten, "1:1:1:1:1:0:0:0:0", "s:12macrogenleft2S1V5foo121xySSSi_SDySiSDySSSaySiGGGtXE_tF", "", "Int", "String", "macrogenleft")
+SDK_CHANGE(Function, TypeRewritten, "1:1:1:1:1:0", "s:12macrogenleft2S1V5foo121xySSSi_SDySiSDySSSaySiGGGtXE_tF", "", "Int", "String", "macrogenleft")
 SDK_CHANGE(Constructor, TypeRewritten, "1", "s:12macrogenleft2S1VyACSicfc", "", "Int", "Double", "macrogenleft")
 #undef SDK_CHANGE
 

--- a/test/api-digester/Outputs/macro-gen.json
+++ b/test/api-digester/Outputs/macro-gen.json
@@ -157,7 +157,7 @@
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
     "NodeAnnotation": "TypeRewritten",
-    "ChildIndex": "1:1:1:1:1:0:0:0:0",
+    "ChildIndex": "1:1:1:1:1:0",
     "LeftUsr": "s:12macrogenleft2S1V5foo121xySSSi_SDySiSDySSSaySiGGGtXE_tF",
     "LeftComment": "Int",
     "RightUsr": "",


### PR DESCRIPTION
Split out the ParenType removal from the api-digester from #59141