### PR TITLE
Sema: Diagnose accessor exportability even if storage is unavailable

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4037,6 +4037,14 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   if (isa<GenericTypeParamDecl>(D))
     return false;
 
+  if (R.isValid()) {
+    if (TypeChecker::diagnoseInlinableDeclRefAccess(R.Start, D, Where))
+      return true;
+
+    if (TypeChecker::diagnoseDeclRefExportability(R.Start, D, Where))
+      return true;
+  }
+
   // Keep track if this is an accessor.
   auto accessor = dyn_cast<AccessorDecl>(D);
 
@@ -4045,14 +4053,6 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
     // with any of the rest of this.
     if (AvailableAttr::isUnavailable(accessor->getStorage()))
       return false;
-  }
-
-  if (R.isValid()) {
-    if (TypeChecker::diagnoseInlinableDeclRefAccess(R.Start, D, Where))
-      return true;
-
-    if (TypeChecker::diagnoseDeclRefExportability(R.Start, D, Where))
-      return true;
   }
 
   if (diagnoseExplicitUnavailability(D, R, Where, call, Flags))

--- a/test/attr/attr_inlinable_accessor_with_unavailable_storage.swift
+++ b/test/attr/attr_inlinable_accessor_with_unavailable_storage.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// REQUIRES: OS=macosx
+
+public struct HasVarWithInternalAccessor {
+  @available(macOS, unavailable)
+  public internal(set) var internalSetterVar: Int {
+    get { return 1 }
+    set { } // expected-note {{setter for property 'internalSetterVar' is not '@usableFromInline' or public}}
+  }
+
+  @available(macOS, unavailable)
+  @inlinable mutating public func inlinable() {
+    internalSetterVar = 2 // expected-error {{setter for property 'internalSetterVar' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+}


### PR DESCRIPTION
It is invalid to reference an internal setter from a fragile function regardless of whether the storage is unavailable. The swiftinterface generated for this code would not typecheck since the setter is not known to exist outside the module.
