### PR TITLE
Parse: Save and restore InFreestandingMacroArgument when delayed parsing

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -798,6 +798,10 @@ class IterableDeclContext {
   /// while skipping the body of this context.
   unsigned HasNestedClassDeclarations : 1;
 
+  /// Whether we were inside a freestanding macro argument when we were parsed.
+  /// We must restore this when delayed parsing the body.
+  unsigned InFreestandingMacroArgument : 1;
+
   template<class A, class B, class C>
   friend struct ::llvm::CastInfo;
 
@@ -814,6 +818,7 @@ public:
     AddedParsedMembers = 0;
     HasOperatorDeclarations = 0;
     HasNestedClassDeclarations = 0;
+    InFreestandingMacroArgument = 0;
   }
 
   /// Determine the kind of iterable context we have.
@@ -839,6 +844,15 @@ public:
   void setMaybeHasNestedClassDeclarations() {
     assert(hasUnparsedMembers());
     HasNestedClassDeclarations = 1;
+  }
+
+  bool inFreestandingMacroArgument() const {
+    return InFreestandingMacroArgument;
+  }
+
+  void setInFreestandingMacroArgument() {
+    assert(hasUnparsedMembers());
+    InFreestandingMacroArgument = 1;
   }
 
   /// Retrieve the current set of members in this context.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7031,8 +7031,8 @@ bool Parser::parseMemberDeclList(SourceLoc &LBLoc, SourceLoc &RBLoc,
   llvm::SaveAndRestore<std::optional<StableHasher>> T(CurrentTokenHash,
                                                       std::nullopt);
 
-  bool HasOperatorDeclarations;
-  bool HasNestedClassDeclarations;
+  bool HasOperatorDeclarations = false;
+  bool HasNestedClassDeclarations = false;
 
   if (canDelayMemberDeclParsing(HasOperatorDeclarations,
                                 HasNestedClassDeclarations)) {
@@ -7040,6 +7040,8 @@ bool Parser::parseMemberDeclList(SourceLoc &LBLoc, SourceLoc &RBLoc,
       IDC->setMaybeHasOperatorDeclarations();
     if (HasNestedClassDeclarations)
       IDC->setMaybeHasNestedClassDeclarations();
+    if (InFreestandingMacroArgument)
+      IDC->setInFreestandingMacroArgument();
 
     if (delayParsingDeclList(LBLoc, RBLoc, IDC))
       return true;

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -75,6 +75,8 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
   // Lexer diagnostics have been emitted during skipping, so we disable lexer's
   // diagnostic engine here.
   Parser parser(bufferID, *sf, /*No Lexer Diags*/nullptr, nullptr, nullptr);
+  parser.InFreestandingMacroArgument = idc->inFreestandingMacroArgument();
+
   auto declsAndHash = parser.parseDeclListDelayed(idc);
   FingerprintAndMembers fingerprintAndMembers = {declsAndHash.second,
                                                  declsAndHash.first};

--- a/test/Macros/delayed_parsing.swift
+++ b/test/Macros/delayed_parsing.swift
@@ -1,0 +1,20 @@
+// REQUIRES: swift_swift_parser
+//
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -parse-as-library -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Type check testing
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/delayed_parsing.swiftmodule -experimental-skip-non-inlinable-function-bodies-without-types -swift-version 5 -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) %s
+
+@freestanding(declaration)
+macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+#freestandingWithClosure(0) { (x: Int) in
+  struct LocalStruct {
+    func opaqueReturn() -> some Any {
+      return 3
+    }
+  }
+
+  return x
+}


### PR DESCRIPTION
Closures appearing in freestanding macro arguments don't have discriminators assigned, since we don't actually emit them.

Similarly we skip recording opaque return types that appear in macro arguments, since they don't get emitted.

However this logic didn't take delayed parsing into account, which must save and restore the InFreestandingMacroArgument bit correctly.

As a result, if the freestanding macro argument contained a closure which contained a local function with a declaration that has an opaque return type, we would crash in serialization from attempting to mangle an opaque return type nested inside of a closure without a discriminator.

Fixes rdar://135445004