### PR TITLE
Sema: Fix access of wrong union member

### DIFF
--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -688,8 +688,8 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
   case ChangeKind::RetiredConstraint:
     out << "(RetiredConstraint ";
-    TheConstraint.Constraint->print(out, &cs.getASTContext().SourceMgr,
-                                    indent + 2);
+    Retiree.Constraint->print(out, &cs.getASTContext().SourceMgr,
+                              indent + 2);
     out << ")\n";
     break;
   }


### PR DESCRIPTION
This might be responsible for the failure in https://github.com/swiftlang/swift/pull/77152#issuecomment-2433472255, since the failing tests are exactly those that pass `-debug-constraints` to the frontend.