### PR TITLE
[Frontend/AST] Add `-interface-compiler-version` option to frontend/modules

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -345,6 +345,11 @@ public:
     return {};
   }
 
+  /// Returns the version of the Swift compiler used to create this module.
+  virtual llvm::VersionTuple getSwiftCompilerVersion() const {
+    return {};
+  }
+
   SWIFT_DEBUG_DUMPER(dumpDisplayDecls());
   SWIFT_DEBUG_DUMPER(dumpTopLevelDecls());
 

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -345,8 +345,9 @@ public:
     return {};
   }
 
-  /// Returns the version of the Swift compiler used to create this module.
-  virtual llvm::VersionTuple getSwiftCompilerVersion() const {
+  /// Returns the version of the Swift compiler used to create generate
+  /// .swiftinterface file if this file is produced from one.
+  virtual llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
     return {};
   }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -254,6 +254,9 @@ class ModuleDecl
 
   mutable Identifier PublicModuleName;
 
+  /// Indicates that version of the Swift compiler this module was built with.
+  mutable llvm::VersionTuple SwiftCompilerVersion;
+
 public:
   /// Produces the components of a given module's full name in reverse order.
   ///
@@ -518,11 +521,20 @@ public:
     PublicModuleName = name;
   }
 
+  /// The version of the Swift compiler this module was built with.
+  llvm::VersionTuple getSwiftCompilerVersion() const {
+    return SwiftCompilerVersion;
+  }
+
+  void setSwiftCompilerVersion(llvm::VersionTuple version) {
+    SwiftCompilerVersion = version;
+  }
+
   /// Retrieve the actual module name of an alias used for this module (if any).
   ///
-  /// For example, if '-module-alias Foo=Bar' is passed in when building the main module,
-  /// and this module is (a) not the main module and (b) is named Foo, then it returns
-  /// the real (physically on-disk) module name Bar.
+  /// For example, if '-module-alias Foo=Bar' is passed in when building the
+  /// main module, and this module is (a) not the main module and (b) is named
+  /// Foo, then it returns the real (physically on-disk) module name Bar.
   ///
   /// If no module aliasing is set, it will return getName(), i.e. Foo.
   Identifier getRealName() const;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -254,8 +254,9 @@ class ModuleDecl
 
   mutable Identifier PublicModuleName;
 
-  /// Indicates that version of the Swift compiler this module was built with.
-  mutable llvm::VersionTuple SwiftCompilerVersion;
+  /// Indicates a version of the Swift compiler used to generate 
+  /// .swiftinterface file that this module was produced from (if any).
+  mutable llvm::VersionTuple InterfaceCompilerVersion;
 
 public:
   /// Produces the components of a given module's full name in reverse order.
@@ -521,13 +522,13 @@ public:
     PublicModuleName = name;
   }
 
-  /// The version of the Swift compiler this module was built with.
-  llvm::VersionTuple getSwiftCompilerVersion() const {
-    return SwiftCompilerVersion;
+  /// See \c InterfaceCompilerVersion
+  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+    return InterfaceCompilerVersion;
   }
 
-  void setSwiftCompilerVersion(llvm::VersionTuple version) {
-    SwiftCompilerVersion = version;
+  void setSwiftInterfaceCompilerVersion(llvm::VersionTuple version) {
+    InterfaceCompilerVersion = version;
   }
 
   /// Retrieve the actual module name of an alias used for this module (if any).

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -187,6 +187,10 @@ StringRef getCurrentCompilerChannel();
 /// users.
 unsigned getUpcomingCxxInteropCompatVersion();
 
+/// Retrieves the version of the running compiler. It could be a tag or
+/// a "development" version that only has major/minor.
+std::string getCompilerVersion();
+
 } // end namespace version
 } // end namespace swift
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -110,6 +110,10 @@ public:
   /// User-defined module version number.
   llvm::VersionTuple UserModuleVersion;
 
+  /// The Swift compiler version number that would be used to synthesize
+  /// swiftinterface files and subsequently swiftmodules.
+  llvm::VersionTuple SwiftCompilerVersion;
+
   /// A set of modules allowed to import this module.
   std::set<std::string> AllowableClients;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -111,8 +111,8 @@ public:
   llvm::VersionTuple UserModuleVersion;
 
   /// The Swift compiler version number that would be used to synthesize
-  /// swiftinterface files and subsequently swiftmodules.
-  llvm::VersionTuple SwiftCompilerVersion;
+  /// swiftinterface files and subsequently their swiftmodules.
+  llvm::VersionTuple SwiftInterfaceCompilerVersion;
 
   /// A set of modules allowed to import this module.
   std::set<std::string> AllowableClients;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -304,8 +304,8 @@ def package_description_version: Separate<["-"], "package-description-version">,
   MetaVarName<"<vers>">;
 
 def swift_compiler_version : Separate<["-"], "swift-compiler-version">,
-  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOptionIgnorable]>,
-  HelpText<"The version of the Swift compiler used to emit swift interface and module">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"The version of the Swift compiler used to build swift interface and module">,
   MetaVarName<"<compvers>">;
 
 def tools_directory : Separate<["-"], "tools-directory">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -303,6 +303,11 @@ def package_description_version: Separate<["-"], "package-description-version">,
   HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,
   MetaVarName<"<vers>">;
 
+def swift_compiler_version : Separate<["-"], "swift-compiler-version">,
+  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOptionIgnorable]>,
+  HelpText<"The version of the Swift compiler used to emit swift interface and module">,
+  MetaVarName<"<compvers>">;
+
 def tools_directory : Separate<["-"], "tools-directory">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
          ArgumentIsPath]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -303,10 +303,10 @@ def package_description_version: Separate<["-"], "package-description-version">,
   HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,
   MetaVarName<"<vers>">;
 
-def swift_compiler_version : Separate<["-"], "swift-compiler-version">,
+def swiftinterface_compiler_version : Separate<["-"], "interface-compiler-version">,
   Flags<[FrontendOption, HelpHidden]>,
-  HelpText<"The version of the Swift compiler used to build swift interface and module">,
-  MetaVarName<"<compvers>">;
+  HelpText<"The version of the Swift compiler used to generate a .swiftinterface file">,
+  MetaVarName<"<intcvers>">;
 
 def tools_directory : Separate<["-"], "tools-directory">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -539,6 +539,8 @@ public:
 
   virtual StringRef getPublicModuleName() const override;
 
+  virtual llvm::VersionTuple getSwiftCompilerVersion() const override;
+
   ValueDecl *getMainDecl() const override;
 
   bool hasEntryPoint() const override;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -539,7 +539,7 @@ public:
 
   virtual StringRef getPublicModuleName() const override;
 
-  virtual llvm::VersionTuple getSwiftCompilerVersion() const override;
+  virtual llvm::VersionTuple getSwiftInterfaceCompilerVersion() const override;
 
   ValueDecl *getMainDecl() const override;
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -131,6 +131,7 @@ class ExtendedValidationInfo {
   StringRef ExportAsName;
   StringRef PublicModuleName;
   CXXStdlibKind CXXStdlib;
+  llvm::VersionTuple SwiftCompilerVersion;
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -250,6 +251,16 @@ public:
 
   CXXStdlibKind getCXXStdlibKind() const { return CXXStdlib; }
   void setCXXStdlibKind(CXXStdlibKind kind) { CXXStdlib = kind; }
+
+  llvm::VersionTuple getSwiftCompilerVersion() const {
+    return SwiftCompilerVersion;
+  }
+  void setSwiftCompilerVersion(StringRef version) {
+    llvm::VersionTuple compilerVersion;
+    if (compilerVersion.tryParse(version))
+      return;
+    SwiftCompilerVersion = compilerVersion;
+  }
 };
 
 struct SearchPath {

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -131,7 +131,7 @@ class ExtendedValidationInfo {
   StringRef ExportAsName;
   StringRef PublicModuleName;
   CXXStdlibKind CXXStdlib;
-  llvm::VersionTuple SwiftCompilerVersion;
+  llvm::VersionTuple SwiftInterfaceCompilerVersion;
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -252,14 +252,14 @@ public:
   CXXStdlibKind getCXXStdlibKind() const { return CXXStdlib; }
   void setCXXStdlibKind(CXXStdlibKind kind) { CXXStdlib = kind; }
 
-  llvm::VersionTuple getSwiftCompilerVersion() const {
-    return SwiftCompilerVersion;
+  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+    return SwiftInterfaceCompilerVersion;
   }
-  void setSwiftCompilerVersion(StringRef version) {
+  void setSwiftInterfaceCompilerVersion(StringRef version) {
     llvm::VersionTuple compilerVersion;
     if (compilerVersion.tryParse(version))
       return;
-    SwiftCompilerVersion = compilerVersion;
+    SwiftInterfaceCompilerVersion = compilerVersion;
   }
 };
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -339,5 +339,18 @@ unsigned getUpcomingCxxInteropCompatVersion() {
   return SWIFT_VERSION_MAJOR + 1;
 }
 
+std::string getCompilerVersion() {
+  std::string buf;
+  llvm::raw_string_ostream OS(buf);
+
+#if defined(SWIFT_COMPILER_VERSION)
+  OS << SWIFT_COMPILER_VERSION;
+#else
+  OS << SWIFT_VERSION_STRING;
+#endif
+
+  return OS.str();
+}
+
 } // end namespace version
 } // end namespace swift

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -299,6 +299,15 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_public_module_name))
     Opts.PublicModuleName = A->getValue();
 
+  if (auto A = Args.getLastArg(OPT_swift_compiler_version)) {
+    if (Opts.SwiftCompilerVersion.tryParse(A->getValue())) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+    }
+  } else {
+    Opts.SwiftCompilerVersion.tryParse(version::getCompilerVersion());
+  }
+
   // This must be called after computing module name, module abi name,
   // and module link name. If computing module aliases is unsuccessful,
   // return early.

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -299,18 +299,11 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_public_module_name))
     Opts.PublicModuleName = A->getValue();
 
-  if (auto A = Args.getLastArg(OPT_swift_compiler_version)) {
-    if (Opts.SwiftCompilerVersion.tryParse(A->getValue())) {
+  if (auto A = Args.getLastArg(OPT_swiftinterface_compiler_version)) {
+    if (Opts.SwiftInterfaceCompilerVersion.tryParse(A->getValue())) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
     }
-  // If swiftinterface doesn't have a flag, let's not set the version
-  // to the current compiler version here. This helps us to identify
-  // swiftmodules built from swiftinterface generated before introduction
-  // of `-swift-compiler-version` flag.
-  } else if (Opts.InputMode !=
-             FrontendOptions::ParseInputMode::SwiftModuleInterface) {
-    Opts.SwiftCompilerVersion.tryParse(version::getCompilerVersion());
   }
 
   // This must be called after computing module name, module abi name,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -304,7 +304,12 @@ bool ArgsToFrontendOptionsConverter::convert(
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
     }
-  } else {
+  // If swiftinterface doesn't have a flag, let's not set the version
+  // to the current compiler version here. This helps us to identify
+  // swiftmodules built from swiftinterface generated before introduction
+  // of `-swift-compiler-version` flag.
+  } else if (Opts.InputMode !=
+             FrontendOptions::ParseInputMode::SwiftModuleInterface) {
     Opts.SwiftCompilerVersion.tryParse(version::getCompilerVersion());
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1489,8 +1489,10 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getSILOptions().EnableSerializePackage)
       MainModule->setSerializePackageEnabled();
 
-    MainModule->setSwiftCompilerVersion(
-        Invocation.getFrontendOptions().SwiftCompilerVersion);
+    if (auto compilerVersion =
+            Invocation.getFrontendOptions().SwiftCompilerVersion) {
+      MainModule->setSwiftCompilerVersion(compilerVersion);
+    }
 
     // Register the main module with the AST context.
     Context->addLoadedModule(MainModule);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1490,8 +1490,8 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setSerializePackageEnabled();
 
     if (auto compilerVersion =
-            Invocation.getFrontendOptions().SwiftCompilerVersion) {
-      MainModule->setSwiftCompilerVersion(compilerVersion);
+            Invocation.getFrontendOptions().SwiftInterfaceCompilerVersion) {
+      MainModule->setSwiftInterfaceCompilerVersion(compilerVersion);
     }
 
     // Register the main module with the AST context.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1489,6 +1489,9 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getSILOptions().EnableSerializePackage)
       MainModule->setSerializePackageEnabled();
 
+    MainModule->setSwiftCompilerVersion(
+        Invocation.getFrontendOptions().SwiftCompilerVersion);
+
     // Register the main module with the AST context.
     Context->addLoadedModule(MainModule);
     Context->MainModule = MainModule;

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -124,6 +124,9 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
         !Opts.PackageFlags.IgnorableFlags.empty())
       ignorableFlags.push_back(Opts.PackageFlags.IgnorableFlags);
 
+    ignorableFlags.push_back("-swift-compiler-version");
+    ignorableFlags.push_back(version::getCompilerVersion());
+
     if (!ignorableFlags.empty()) {
       out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": ";
       llvm::interleave(

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -124,7 +124,7 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
         !Opts.PackageFlags.IgnorableFlags.empty())
       ignorableFlags.push_back(Opts.PackageFlags.IgnorableFlags);
 
-    ignorableFlags.push_back("-swift-compiler-version");
+    ignorableFlags.push_back("-interface-compiler-version");
     ignorableFlags.push_back(version::getCompilerVersion());
 
     if (!ignorableFlags.empty()) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1409,3 +1409,7 @@ StringRef SerializedASTFile::getExportedModuleName() const {
 StringRef SerializedASTFile::getPublicModuleName() const {
   return File.getPublicModuleName();
 }
+
+llvm::VersionTuple SerializedASTFile::getSwiftCompilerVersion() const {
+  return File.getSwiftCompilerVersion();
+}

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1410,6 +1410,6 @@ StringRef SerializedASTFile::getPublicModuleName() const {
   return File.getPublicModuleName();
 }
 
-llvm::VersionTuple SerializedASTFile::getSwiftCompilerVersion() const {
-  return File.getSwiftCompilerVersion();
+llvm::VersionTuple SerializedASTFile::getSwiftInterfaceCompilerVersion() const {
+  return File.getSwiftInterfaceCompilerVersion();
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -603,6 +603,10 @@ public:
     return Core->UserModuleVersion;
   }
 
+  llvm::VersionTuple getSwiftCompilerVersion() const {
+    return Core->SwiftCompilerVersion;
+  }
+
   ArrayRef<StringRef> getAllowableClientNames() const {
     return Core->AllowableClientNames;
   }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -603,8 +603,8 @@ public:
     return Core->UserModuleVersion;
   }
 
-  llvm::VersionTuple getSwiftCompilerVersion() const {
-    return Core->SwiftCompilerVersion;
+  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+    return Core->SwiftInterfaceCompilerVersion;
   }
 
   ArrayRef<StringRef> getAllowableClientNames() const {

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -214,6 +214,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::PUBLIC_MODULE_NAME:
       extendedInfo.setPublicModuleName(blobData);
       break;
+    case options_block::SWIFT_COMPILER_VERSION:
+      extendedInfo.setSwiftCompilerVersion(blobData);
+      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1496,6 +1499,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       ModulePackageName = extInfo.getModulePackageName();
       ModuleExportAsName = extInfo.getExportAsName();
       PublicModuleName = extInfo.getPublicModuleName();
+      SwiftCompilerVersion = extInfo.getSwiftCompilerVersion();
 
       hasValidControlBlock = true;
       break;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -214,8 +214,8 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::PUBLIC_MODULE_NAME:
       extendedInfo.setPublicModuleName(blobData);
       break;
-    case options_block::SWIFT_COMPILER_VERSION:
-      extendedInfo.setSwiftCompilerVersion(blobData);
+    case options_block::SWIFT_INTERFACE_COMPILER_VERSION:
+      extendedInfo.setSwiftInterfaceCompilerVersion(blobData);
       break;
     default:
       // Unknown options record, possibly for use by a future version of the
@@ -1499,7 +1499,8 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       ModulePackageName = extInfo.getModulePackageName();
       ModuleExportAsName = extInfo.getExportAsName();
       PublicModuleName = extInfo.getPublicModuleName();
-      SwiftCompilerVersion = extInfo.getSwiftCompilerVersion();
+      SwiftInterfaceCompilerVersion =
+          extInfo.getSwiftInterfaceCompilerVersion();
 
       hasValidControlBlock = true;
       break;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -103,6 +103,12 @@ class ModuleFileSharedCore {
   /// Name to use in public facing diagnostics and documentation.
   StringRef PublicModuleName;
 
+  /// The version of the Swift compiler used to produce swiftinterface
+  /// this module is based on or build the module itself. This is
+  /// the most precise version possible - a compiler tag or version
+  /// if this is a development compiler.
+  llvm::VersionTuple SwiftCompilerVersion;
+
   /// \c true if this module has incremental dependency information.
   bool HasIncrementalInfo = false;
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -104,10 +104,9 @@ class ModuleFileSharedCore {
   StringRef PublicModuleName;
 
   /// The version of the Swift compiler used to produce swiftinterface
-  /// this module is based on or build the module itself. This is
-  /// the most precise version possible - a compiler tag or version
-  /// if this is a development compiler.
-  llvm::VersionTuple SwiftCompilerVersion;
+  /// this module is based on. This is the most precise version possible
+  /// - a compiler tag or version if this is a development compiler.
+  llvm::VersionTuple SwiftInterfaceCompilerVersion;
 
   /// \c true if this module has incremental dependency information.
   bool HasIncrementalInfo = false;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 897; // Builtin.FixedArray
+const uint16_t SWIFTMODULE_VERSION_MINOR = 898; // swift-compiler-version
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -966,6 +966,7 @@ namespace options_block {
     SERIALIZE_PACKAGE_ENABLED,
     CXX_STDLIB_KIND,
     PUBLIC_MODULE_NAME,
+    SWIFT_COMPILER_VERSION,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1065,6 +1066,11 @@ namespace options_block {
   using PublicModuleNameLayout = BCRecordLayout<
     PUBLIC_MODULE_NAME,
     BCBlob
+  >;
+
+    using SwiftCompilerVersionLayout = BCRecordLayout<
+    SWIFT_COMPILER_VERSION,
+    BCBlob // version tuple
   >;
 }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 898; // swift-compiler-version
+const uint16_t SWIFTMODULE_VERSION_MINOR = 898; // interface-compiler-version
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -966,7 +966,7 @@ namespace options_block {
     SERIALIZE_PACKAGE_ENABLED,
     CXX_STDLIB_KIND,
     PUBLIC_MODULE_NAME,
-    SWIFT_COMPILER_VERSION,
+    SWIFT_INTERFACE_COMPILER_VERSION,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1068,8 +1068,8 @@ namespace options_block {
     BCBlob
   >;
 
-    using SwiftCompilerVersionLayout = BCRecordLayout<
-    SWIFT_COMPILER_VERSION,
+    using SwiftInterfaceCompilerVersionLayout = BCRecordLayout<
+    SWIFT_INTERFACE_COMPILER_VERSION,
     BCBlob // version tuple
   >;
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -864,7 +864,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, SERIALIZE_PACKAGE_ENABLED);
   BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, PUBLIC_MODULE_NAME);
-  BLOCK_RECORD(options_block, SWIFT_COMPILER_VERSION);
+  BLOCK_RECORD(options_block, SWIFT_INTERFACE_COMPILER_VERSION);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1140,10 +1140,11 @@ void Serializer::writeHeader() {
         PublicModuleName.emit(ScratchRecord, publicModuleName.str());
       }
 
-      llvm::VersionTuple compilerVersion = M->getSwiftCompilerVersion();
+      llvm::VersionTuple compilerVersion =
+          M->getSwiftInterfaceCompilerVersion();
       if (compilerVersion) {
-        options_block::SwiftCompilerVersionLayout SwiftCompilerVersion(Out);
-        SwiftCompilerVersion.emit(ScratchRecord, compilerVersion.getAsString());
+        options_block::SwiftInterfaceCompilerVersionLayout Version(Out);
+        Version.emit(ScratchRecord, compilerVersion.getAsString());
       }
 
       if (M->isConcurrencyChecked()) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -864,6 +864,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, SERIALIZE_PACKAGE_ENABLED);
   BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, PUBLIC_MODULE_NAME);
+  BLOCK_RECORD(options_block, SWIFT_COMPILER_VERSION);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1138,6 +1139,10 @@ void Serializer::writeHeader() {
         options_block::PublicModuleNameLayout PublicModuleName(Out);
         PublicModuleName.emit(ScratchRecord, publicModuleName.str());
       }
+
+      llvm::VersionTuple compilerVersion = M->getSwiftCompilerVersion();
+      options_block::SwiftCompilerVersionLayout SwiftCompilerVersion(Out);
+      SwiftCompilerVersion.emit(ScratchRecord, compilerVersion.getAsString());
 
       if (M->isConcurrencyChecked()) {
         options_block::IsConcurrencyCheckedLayout IsConcurrencyChecked(Out);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1141,8 +1141,10 @@ void Serializer::writeHeader() {
       }
 
       llvm::VersionTuple compilerVersion = M->getSwiftCompilerVersion();
-      options_block::SwiftCompilerVersionLayout SwiftCompilerVersion(Out);
-      SwiftCompilerVersion.emit(ScratchRecord, compilerVersion.getAsString());
+      if (compilerVersion) {
+        options_block::SwiftCompilerVersionLayout SwiftCompilerVersion(Out);
+        SwiftCompilerVersion.emit(ScratchRecord, compilerVersion.getAsString());
+      }
 
       if (M->isConcurrencyChecked()) {
         options_block::IsConcurrencyCheckedLayout IsConcurrencyChecked(Out);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1035,6 +1035,7 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
     }
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());
+    M.setSwiftCompilerVersion(loadedModuleFile->getSwiftCompilerVersion());
     for (auto name: loadedModuleFile->getAllowableClientNames()) {
       M.addAllowableClientName(Ctx.getIdentifier(name));
     }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1035,7 +1035,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
     }
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());
-    M.setSwiftCompilerVersion(loadedModuleFile->getSwiftCompilerVersion());
+    M.setSwiftInterfaceCompilerVersion(
+        loadedModuleFile->getSwiftInterfaceCompilerVersion());
     for (auto name: loadedModuleFile->getAllowableClientNames()) {
       M.addAllowableClientName(Ctx.getIdentifier(name));
     }

--- a/test/CAS/embedded-Xcc.swift
+++ b/test/CAS/embedded-Xcc.swift
@@ -20,10 +20,10 @@
 
 // RUN: llvm-bcanalyzer --dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <XCC abbrevid=6/> blob data = '-cc1'
-// CHECK: <XCC abbrevid=6/> blob data = '-D'
-// CHECK: <XCC abbrevid=6/> blob data = 'TEST=1'
-// CHECK-NOT: <XCC abbrevid=6/> blob data = '--target=
+// CHECK: <XCC abbrevid=7/> blob data = '-cc1'
+// CHECK: <XCC abbrevid=7/> blob data = '-D'
+// CHECK: <XCC abbrevid=7/> blob data = 'TEST=1'
+// CHECK-NOT: <XCC abbrevid=7/> blob data = '--target=
 
 //--- main.swift
 public func test() {}

--- a/test/CAS/embedded-Xcc.swift
+++ b/test/CAS/embedded-Xcc.swift
@@ -20,10 +20,10 @@
 
 // RUN: llvm-bcanalyzer --dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <XCC abbrevid=7/> blob data = '-cc1'
-// CHECK: <XCC abbrevid=7/> blob data = '-D'
-// CHECK: <XCC abbrevid=7/> blob data = 'TEST=1'
-// CHECK-NOT: <XCC abbrevid=7/> blob data = '--target=
+// CHECK: <XCC abbrevid=6/> blob data = '-cc1'
+// CHECK: <XCC abbrevid=6/> blob data = '-D'
+// CHECK: <XCC abbrevid=6/> blob data = 'TEST=1'
+// CHECK-NOT: <XCC abbrevid=6/> blob data = '--target=
 
 //--- main.swift
 public func test() {}

--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -61,8 +61,8 @@
 // RUN: not %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err.txt 2>&1
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR <%t/err.txt
-// CHECK-ERROR: LeafModule.swiftinterface:7:8: error: no such module 'NotAModule'
-// CHECK-ERROR: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
+// CHECK-ERROR: LeafModule.swiftinterface:8:8: error: no such module 'NotAModule'
+// CHECK-ERROR: OtherModule.swiftinterface:5:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 // CHECK-ERROR: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 //
 //
@@ -85,8 +85,8 @@
 // RUN: not %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err-inline.txt 2>&1
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR-INLINE <%t/err-inline.txt
-// CHECK-ERROR-INLINE: LeafModule.swiftinterface:6:33: error: cannot find 'unresolved' in scope
-// CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
+// CHECK-ERROR-INLINE: LeafModule.swiftinterface:7:33: error: cannot find 'unresolved' in scope
+// CHECK-ERROR-INLINE: OtherModule.swiftinterface:5:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 // CHECK-ERROR-INLINE: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 //
 //

--- a/test/ModuleInterface/swift-compiler-version-option.swift
+++ b/test/ModuleInterface/swift-compiler-version-option.swift
@@ -4,20 +4,20 @@
 // RUN: %target-swift-frontend %s \
 // RUN:   -emit-module-path %t/Lib.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
-// RUN:   -enable-library-evolution -swift-version 6 \
-// RUN:   -swift-compiler-version 6.0.0.1
+// RUN:   -enable-library-evolution \
+// RUN:   -swift-version 6
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Lib.swiftinterface)
 
 /// Check option in swiftinterface
 // RUN: cat %t/Lib.swiftinterface | %FileCheck --check-prefix=CHECK-OPTION %s
-// CHECK-OPTION: swift-module-flags:
-// CHECK-SAME-OPTION: -swift-compiler-version 6.0.0.1
+// CHECK-OPTION: swift-module-flags-ignorable:
+// CHECK-SAME-OPTION: -swift-compiler-version {{.*}}
 
 /// Check option in swiftmodule
 // RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck --check-prefix=CHECK-MODULE-OPTION %s
 // CHECK-MODULE-OPTION: <OPTIONS_BLOCK
-// CHECK-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '6.0.0.1'
+// CHECK-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
 // CHECK-MODULE-OPTION: </OPTIONS_BLOCK>
 
 public struct S {

--- a/test/ModuleInterface/swift-compiler-version-option.swift
+++ b/test/ModuleInterface/swift-compiler-version-option.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+/// Build the libraries.
+// RUN: %target-swift-frontend %s \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -swift-compiler-version 6.0.0.1
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Lib.swiftinterface)
+
+/// Check option in swiftinterface
+// RUN: cat %t/Lib.swiftinterface | %FileCheck --check-prefix=CHECK-OPTION %s
+// CHECK-OPTION: swift-module-flags:
+// CHECK-SAME-OPTION: -swift-compiler-version 6.0.0.1
+
+/// Check option in swiftmodule
+// RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck --check-prefix=CHECK-MODULE-OPTION %s
+// CHECK-MODULE-OPTION: <OPTIONS_BLOCK
+// CHECK-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '6.0.0.1'
+// CHECK-MODULE-OPTION: </OPTIONS_BLOCK>
+
+public struct S {
+    public var test: Int = 42
+}

--- a/test/ModuleInterface/swift-compiler-version-option.swift
+++ b/test/ModuleInterface/swift-compiler-version-option.swift
@@ -2,6 +2,7 @@
 
 /// Build the libraries.
 // RUN: %target-swift-frontend %s \
+// RUN:   -module-name Lib \
 // RUN:   -emit-module-path %t/Lib.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
 // RUN:   -enable-library-evolution \
@@ -19,6 +20,16 @@
 // CHECK-MODULE-OPTION: <OPTIONS_BLOCK
 // CHECK-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
 // CHECK-MODULE-OPTION: </OPTIONS_BLOCK>
+
+// Drop and rebuilt swiftmodule to make sure that the version is inferred from the interface file.
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Lib.swiftinterface -o %t/Lib.swiftmodule -module-name Lib
+
+/// Check option in swiftmodule
+// RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck --check-prefix=CHECK-REBUILT-MODULE-OPTION %s
+// CHECK-REBUILT-MODULE-OPTION: <OPTIONS_BLOCK
+// CHECK-REBUILT-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
+// CHECK-REBUILT-MODULE-OPTION: </OPTIONS_BLOCK>
 
 public struct S {
     public var test: Int = 42

--- a/test/ModuleInterface/swiftinterface-compiler-version-option.swift
+++ b/test/ModuleInterface/swiftinterface-compiler-version-option.swift
@@ -18,7 +18,7 @@
 /// Check option in swiftmodule
 // RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck --check-prefix=CHECK-MODULE-OPTION %s
 // CHECK-MODULE-OPTION: <OPTIONS_BLOCK
-// CHECK-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
+// CHECK-NOT-MODULE-OPTION: <SWIFT_INTERFACE_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
 // CHECK-MODULE-OPTION: </OPTIONS_BLOCK>
 
 // Drop and rebuilt swiftmodule to make sure that the version is inferred from the interface file.
@@ -28,7 +28,7 @@
 /// Check option in swiftmodule
 // RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck --check-prefix=CHECK-REBUILT-MODULE-OPTION %s
 // CHECK-REBUILT-MODULE-OPTION: <OPTIONS_BLOCK
-// CHECK-REBUILT-MODULE-OPTION: <SWIFT_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
+// CHECK-REBUILT-MODULE-OPTION: <SWIFT_INTERFACE_COMPILER_VERSION abbrevid={{.*}}/> blob data = '{{.*}}'
 // CHECK-REBUILT-MODULE-OPTION: </OPTIONS_BLOCK>
 
 public struct S {


### PR DESCRIPTION
This option is going to be used to indicate what compiler was used
to build swift interface/module which is required for SE-0438.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
