### PR TITLE
Sema: Introduce UnmetAvailabilityRequirement

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -350,15 +350,20 @@ public:
 
   static AvailabilityRange inferForType(Type t);
 
-  /// Returns the context where a declaration is available
-  /// We assume a declaration without an annotation is always available.
+  /// Returns the range of platform versions in which the decl is available.
   static AvailabilityRange availableRange(const Decl *D);
+
+  /// Returns the range of platform versions in which the decl is available and
+  /// the attribute which determined this range (which may be `nullptr` if the
+  /// declaration is always available.
+  static std::pair<AvailabilityRange, const AvailableAttr *>
+  availableRangeAndAttr(const Decl *D);
 
   /// Returns true is the declaration is `@_spi_available`.
   static bool isAvailableAsSPI(const Decl *D);
 
-  /// Returns the availability context for a declaration with the given
-  /// @available attribute.
+  /// Returns the range of platform versions in which a declaration with the
+  /// given `@available` attribute is available.
   ///
   /// NOTE: The attribute must be active on the current platform.
   static AvailabilityRange availableRange(const AvailableAttr *attr,

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -580,12 +580,18 @@ static const AvailableAttr *attrForAvailableRange(const Decl *D) {
   return nullptr;
 }
 
-AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
-  if (auto attr = attrForAvailableRange(D))
-    return availableRange(attr, D->getASTContext());
+std::pair<AvailabilityRange, const AvailableAttr *>
+AvailabilityInference::availableRangeAndAttr(const Decl *D) {
+  if (auto attr = attrForAvailableRange(D)) {
+    return {availableRange(attr, D->getASTContext()), attr};
+  }
 
   // Treat unannotated declarations as always available.
-  return AvailabilityRange::alwaysAvailable();
+  return {AvailabilityRange::alwaysAvailable(), nullptr};
+}
+
+AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
+  return availableRangeAndAttr(D).first;
 }
 
 bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -345,8 +345,9 @@ static bool computeContainedByDeploymentTarget(TypeRefinementContext *TRC,
 /// Returns true if the reference or any of its parents is an
 /// unconditional unavailable declaration for the same platform.
 static bool isInsideCompatibleUnavailableDeclaration(
-    const Decl *D, const ExportContext &where, const AvailableAttr *attr) {
-  auto referencedPlatform = where.getUnavailablePlatformKind();
+    const Decl *D, AvailabilityContext availabilityContext,
+    const AvailableAttr *attr) {
+  auto referencedPlatform = availabilityContext.getUnavailablePlatformKind();
   if (!referencedPlatform)
     return false;
 
@@ -374,7 +375,7 @@ ExportContext::shouldDiagnoseDeclAsUnavailable(const Decl *D) const {
   if (!attr)
     return nullptr;
 
-  if (isInsideCompatibleUnavailableDeclaration(D, *this, attr))
+  if (isInsideCompatibleUnavailableDeclaration(D, Availability, attr))
     return nullptr;
 
   return attr;
@@ -1496,7 +1497,8 @@ TypeChecker::checkDeclarationAvailability(const Decl *D,
   // Skip computing potential unavailability if the declaration is explicitly
   // unavailable and the context is also unavailable.
   if (const AvailableAttr *Attr = AvailableAttr::isUnavailable(D))
-    if (isInsideCompatibleUnavailableDeclaration(D, Where, Attr))
+    if (isInsideCompatibleUnavailableDeclaration(D, Where.getAvailability(),
+                                                 Attr))
       return std::nullopt;
 
   if (isDeclarationUnavailable(D, Where.getDeclContext(), [&Where] {

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -156,6 +156,8 @@ public:
 
   DeclContext *getDeclContext() const { return DC; }
 
+  AvailabilityContext getAvailability() const { return Availability; }
+
   AvailabilityRange getAvailabilityRange() const {
     return Availability.getPlatformRange();
   }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -200,6 +200,74 @@ public:
   const AvailableAttr *shouldDiagnoseDeclAsUnavailable(const Decl *decl) const;
 };
 
+/// Represents the reason a declaration is considered unavailable in a certain
+/// context.
+class UnmetAvailabilityRequirement {
+public:
+  enum class Kind {
+    /// The declaration is referenced in a context in which it is
+    /// generally unavailable. For example, a reference to a declaration that is
+    /// unavailable on macOS from a context that may execute on macOS has this
+    /// unmet requirement.
+    AlwaysUnavailable,
+
+    /// The declaration is referenced in a context in which it is considered
+    /// obsolete. For example, a reference to a declaration that is obsolete in
+    /// macOS 13 from a context that may execute on macOS 13 or later has this
+    /// unmet requirement.
+    Obsoleted,
+
+    /// The declaration is only available in a different version. For example,
+    /// the declaration might only be introduced in the Swift 6 language mode
+    /// while the module is being compiled in the Swift 5 language mode.
+    RequiresVersion,
+
+    /// The declaration is referenced in a context that does not have an
+    /// adequate minimum version constraint. For example, a reference to a
+    /// declaration that is introduced in macOS 13 from a context that may
+    /// execute on earlier versions of macOS has this unmet requirement. This
+    /// kind of unmet requirement can be addressed by tightening the minimum
+    /// version of the context with `if #available(...)` or by adding or
+    /// adjusting an `@available` attribute.
+    IntroducedInNewerVersion,
+  };
+
+private:
+  Kind kind;
+  const AvailableAttr *attr;
+
+  UnmetAvailabilityRequirement(Kind kind, const AvailableAttr *attr)
+      : kind(kind), attr(attr){};
+
+public:
+  static UnmetAvailabilityRequirement
+  forAlwaysUnavailable(const AvailableAttr *attr) {
+    return UnmetAvailabilityRequirement(Kind::AlwaysUnavailable, attr);
+  }
+
+  static UnmetAvailabilityRequirement forObsoleted(const AvailableAttr *attr) {
+    return UnmetAvailabilityRequirement(Kind::Obsoleted, attr);
+  }
+
+  static UnmetAvailabilityRequirement
+  forRequiresVersion(const AvailableAttr *attr) {
+    return UnmetAvailabilityRequirement(Kind::RequiresVersion, attr);
+  }
+
+  static UnmetAvailabilityRequirement
+  forIntroducedInNewerVersion(const AvailableAttr *attr) {
+    return UnmetAvailabilityRequirement(Kind::IntroducedInNewerVersion, attr);
+  }
+
+  Kind getKind() const { return kind; }
+  const AvailableAttr *getAttr() const { return attr; }
+
+  /// Returns the required range for `IntroducedInNewerVersion` requirements, or
+  /// `std::nullopt` otherwise.
+  std::optional<AvailabilityRange>
+  getRequiredNewerAvailabilityRange(ASTContext &ctx) const;
+};
+
 /// Check if a declaration is exported as part of a module's external interface.
 /// This includes public and @usableFromInline decls.
 bool isExported(const ValueDecl *VD);
@@ -249,6 +317,14 @@ bool diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
                                     const ExportContext &Where,
                                     const Expr *call,
                                     DeclAvailabilityFlags Flags = std::nullopt);
+
+/// Checks whether a declaration should be considered unavailable when referred
+/// to in the given declaration context and availability context and, if so,
+/// returns a result that describes the unmet availability requirements.
+/// Returns `std::nullopt` if the declaration is available.
+std::optional<UnmetAvailabilityRequirement>
+checkDeclarationAvailability(const Decl *decl, const DeclContext *declContext,
+                             AvailabilityContext availabilityContext);
 
 /// Diagnose uses of the runtime support of the given type, such as
 /// type metadata and dynamic casting.


### PR DESCRIPTION
This class is used to represent the reason a declaration is unavailable in a specific context.