### PR TITLE
[SymbolGraphGen] Include explicitly unnamed parameter names in function signature

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -413,7 +413,8 @@ void Symbol::serializeFunctionSignature(llvm::json::OStream &OS) const {
       OS.attributeArray("parameters", [&]() {
         for (const auto *Param : *ParamList) {
           auto ExternalName = Param->getArgumentName().str();
-          auto InternalName = Param->getParameterName().str();
+          // `getNameStr()` returns "_" if the parameter is unnamed.
+          auto InternalName = Param->getNameStr();
 
           OS.object([&]() {
             if (ExternalName.empty()) {

--- a/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
+++ b/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
@@ -4,6 +4,7 @@
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=FUNC
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=INIT
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=SUBSCRIPT
+// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=FUNC2
 
 public struct MyStruct {
   public init(_ noext: Int, ext int: Int) {}
@@ -101,5 +102,37 @@ public struct MyStruct {
 // FUNC: "kind": "typeIdentifier"
 // FUNC-NEXT: "spelling": "String"
 // FUNC-NEXT: "preciseIdentifier": "s:SS"
+    
+  public func bar(_: Int, ext _: Int) -> Void {}
+      
+// FUNC2-LABEL: "precise": "s:17FunctionSignature8MyStructV3bar_3extySi_SitF",
+// FUNC2: "name": "_"
+// FUNC2-NOT: "internalName": "_"
+// FUNC2-NEXT: declarationFragments
+
+// FUNC2: "kind": "identifier"
+// FUNC2-NEXT: "spelling": "_"
+// FUNC2: "kind": "text"
+// FUNC2-NEXT: "spelling": ": "
+// FUNC2: "kind": "typeIdentifier"
+// FUNC2-NEXT: "spelling": "Int"
+// FUNC2-NEXT: "preciseIdentifier": "s:Si"
+
+// FUNC2: "name": "ext"
+// FUNC2-NEXT: "internalName": "_"
+// FUNC2-NEXT: declarationFragments
+
+// FUNC2: "kind": "identifier"
+// FUNC2-NEXT: "spelling": "_"
+// FUNC2: "kind": "text"
+// FUNC2-NEXT: "spelling": ": "
+// FUNC2: "kind": "typeIdentifier"
+// FUNC2-NEXT: "spelling": "Int"
+// FUNC2-NEXT: "preciseIdentifier": "s:Si"
+
+// FUNC2: returns
+// FUNC2: "kind": "typeIdentifier"
+// FUNC2-NEXT: "spelling": "Void"
+// FUNC2-NEXT: "preciseIdentifier": "s:s4Voida"
     
 }


### PR DESCRIPTION
This updated the "functionSignature" data to include explicitly unnamed parameter names.

For example, consider this Swift function:
```swift
func doSomething(_: Int, external _: Int) {}
```

Today, SymbolGraphGen emits the following signature information:

```json
"functionSignature": {
  "parameters": [
    {
      "name": "",
      "declarationFragments": [ ... ]
    },
    {
      "name": "external",
      "declarationFragments": [ ... ]
    }
  ]
}
```

The empty string for the first parameter causes issues for DocC when it tries to associate parameter documentation with the parameter. I could imagine other tools that process documentation would face the similar issues with this information.

With the changes in this PR, SymbolGraphGen would instead emit this the following signature information:

```json
"functionSignature": {
  "parameters": [
    {
      "name": "_",
      "declarationFragments": [ ... ]
    },
    {
      "name": "external",
      "internalName": "_",
      "declarationFragments": [ ... ]
    }
  ]
}
```

I think this is a clear benefit for the first parameter in the example above (`_: Int`) because it allows developers to write documentation for it like below and allows tools that process the function signature information to associate that documentation with that parameter.

```
/// - Parameter _: Some documentation for the unnamed (and unused) parameter.
```

That said, I'm a bit torn about what's there best way to emit the parameter names for the second parameter.

It might make more sense for the developer to reference that parameter by its argument label (external name) rather than its parameter name (internal name).
Parameter names are generally preferred over arguments labels in Swift documentation because they are unique and because Swift's API design guidelines sometime lead to argument labels that serve as a prepositional phrase, for example:
- "with" (`starts(with possiblePrefix:)`)
- "at" (`remove(at index:)`)
- "for" (`sleep(for duration:)`)
- "by" (`sorted(by areInIncreasingOrder:)`

However, it's allowed to use "_" for multiple parameters (as shown above) which removes the uniqueness benefit and "_" isn't any more descriptive than "with", "at", "for", or "using" would be.

Resolves rdar://138630917