### PR TITLE
[PrintAsClang] Ensure that all macro-generated decls get printed.

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -188,7 +188,7 @@ public:
   }
 
   bool isEmptyExtensionDecl(const ExtensionDecl *ED) {
-    auto members = ED->getMembers();
+    auto members = ED->getAllMembers();
     auto hasMembers = std::any_of(members.begin(), members.end(),
                                   [this](const Decl *D) -> bool {
       if (auto VD = dyn_cast<ValueDecl>(D))
@@ -349,7 +349,7 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Non objc class.
       ClangClassTypePrinter(os).printClassTypeDecl(
-          CD, [&]() { printMembers(CD->getMembers()); }, owningPrinter);
+          CD, [&]() { printMembers(CD->getAllMembers()); }, owningPrinter);
       recordEmittedDeclInCurrentCxxLexicalScope(CD);
       return;
     }
@@ -389,7 +389,7 @@ private:
       os << " : " << getNameForObjC(superDecl);
     printProtocols(CD->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    printMembers(CD->getMembers());
+    printMembers(CD->getAllMembers());
     os << "@end\n";
   }
 
@@ -402,13 +402,13 @@ private:
     printer.printValueTypeDecl(
         SD, /*bodyPrinter=*/
         [&]() {
-          printMembers(SD->getMembers());
+          printMembers(SD->getAllMembers());
           for (const auto *ed :
                owningPrinter.interopContext.getExtensionsForNominalType(SD)) {
             if (!cxx_translation::isExposableToCxx(ed->getGenericSignature()))
               continue;
 
-            printMembers(ed->getMembers());
+            printMembers(ed->getAllMembers());
           }
         },
         owningPrinter);
@@ -428,7 +428,7 @@ private:
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    printMembers(ED->getMembers());
+    printMembers(ED->getAllMembers());
     os << "@end\n";
   }
 
@@ -449,7 +449,7 @@ private:
 
     printProtocols(PD->getInheritedProtocols());
     os << "\n";
-    printMembers(PD->getMembers());
+    printMembers(PD->getAllMembers());
     os << "@end\n";
   }
 
@@ -884,14 +884,14 @@ private:
           os << "  }\n"; // operator cases()'s closing bracket
           os << "\n";
 
-          printMembers(ED->getMembers());
+          printMembers(ED->getAllMembers());
 
           for (const auto *ext :
                owningPrinter.interopContext.getExtensionsForNominalType(ED)) {
             if (!cxx_translation::isExposableToCxx(ext->getGenericSignature()))
               continue;
 
-            printMembers(ext->getMembers());
+            printMembers(ext->getAllMembers());
           }
         },
         owningPrinter);

--- a/test/Macros/Inputs/objc_cxx_macro_definitions.swift
+++ b/test/Macros/Inputs/objc_cxx_macro_definitions.swift
@@ -1,0 +1,129 @@
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+struct ObjCMemberFuncMacro: MemberMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax], 
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let decl = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+    return ["@objc public func member_\(raw: decl.name.text)() {}"]
+  }
+}
+
+struct ObjCPeerFuncMacro: PeerMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let decl = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+    return ["@objc public func peer_\(raw: decl.name.text)() {}"]
+  }
+}
+
+struct ObjCFreestandingFuncMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["@objc public func member_freestanding() {}"]
+  }
+}
+
+struct ObjCFreestandingClassMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+      @objc public class MacroExpandedObjCClass: NSObject {
+        @objc public func member() {}
+      }
+      """]
+  }
+}
+
+struct CDeclFreestandingFuncMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [#"@_cdecl("c_freestanding") public func cFreestanding() {}"#]
+  }
+}
+
+struct ObjCExtensionMacro: ExtensionMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let decl: DeclSyntax = """
+      extension \(type): MyObjCProtocol {
+        public func objcRequirement() {}
+      }
+      """
+    return [decl.as(ExtensionDeclSyntax.self)!]
+  }
+}
+
+struct MemberFuncMacro: MemberMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax], 
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let decl = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+    return ["public func member_\(raw: decl.name.text)() {}"]
+  }
+}
+
+struct PeerFuncMacro: PeerMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let decl = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+    return ["public func peer_\(raw: decl.name.text)() {}"]
+  }
+}
+
+struct CxxFreestandingFuncMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["public func cxxFreestanding() {}"]
+  }
+}
+
+struct CxxFreestandingStructMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+      public struct MacroExpandedStruct {
+        private let x: Int = 0
+        public func member() {}
+      }
+      """]
+  }
+}

--- a/test/Macros/macro_generated_header_cxx.swift
+++ b/test/Macros/macro_generated_header_cxx.swift
@@ -1,0 +1,43 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/objc_cxx_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk) -typecheck -swift-version 5 -parse-as-library -clang-header-expose-decls=all-public -emit-clang-header-path %t/MacroUser.h -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser
+// RUN: %FileCheck --check-prefix CHECK %s < %t/MacroUser.h
+
+@attached(member, names: prefixed(member_))
+public macro MemberFunc() = #externalMacro(module: "MacroDefinition", type: "MemberFuncMacro")
+
+@attached(peer, names: prefixed(peer_))
+public macro PeerFunc() = #externalMacro(module: "MacroDefinition", type: "PeerFuncMacro")
+
+@freestanding(declaration, names: named(cxxFreestanding))
+public macro CxxFreestandingFunc() = #externalMacro(module: "MacroDefinition", type: "CxxFreestandingFuncMacro")
+
+@freestanding(declaration, names: named(MacroExpandedStruct))
+public macro CxxFreestandingStruct() = #externalMacro(module: "MacroDefinition", type: "CxxFreestandingStructMacro")
+
+// ---
+
+// CHECK:     class SWIFT_SYMBOL("s:9MacroUser0A14ExpandedStructV") MacroExpandedStruct final {
+// CHECK-DAG: SWIFT_INLINE_THUNK void member() const SWIFT_SYMBOL("s:9MacroUser0A14ExpandedStructV6memberyyF");
+#CxxFreestandingStruct
+
+// CHECK: class SWIFT_SYMBOL("s:9MacroUser10SomeStructV") SomeStruct final {
+@MemberFunc
+public struct SomeStruct {
+  private var someProperty: Int = 0
+
+  @PeerFunc
+  public func someMethod() {}
+
+  #CxxFreestandingFunc
+
+  // CHECK-DAG: SWIFT_INLINE_THUNK void peer_someMethod() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV15peer_someMethodyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void someMethod() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV10someMethodyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void cxxFreestanding() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV15cxxFreestandingyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void member_SomeStruct() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV07member_cD0yyF");
+}

--- a/test/Macros/macro_generated_header_objc.swift
+++ b/test/Macros/macro_generated_header_objc.swift
@@ -1,0 +1,64 @@
+// REQUIRES: swift_swift_parser, objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/objc_cxx_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk) -typecheck -swift-version 5 -parse-as-library -enable-objc-interop -emit-objc-header-path %t/MacroUser.h -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser
+// RUN: %FileCheck --check-prefix CHECK %s < %t/MacroUser.h
+
+@attached(member, names: prefixed(member_))
+public macro ObjCMemberFunc() = #externalMacro(module: "MacroDefinition", type: "ObjCMemberFuncMacro")
+
+@attached(peer, names: prefixed(peer_))
+public macro ObjCPeerFunc() = #externalMacro(module: "MacroDefinition", type: "ObjCPeerFuncMacro")
+
+@freestanding(declaration, names: named(member_freestanding))
+public macro ObjCFreestandingFunc() = #externalMacro(module: "MacroDefinition", type: "ObjCFreestandingFuncMacro")
+
+@freestanding(declaration, names: named(MacroExpandedObjCClass))
+public macro ObjCFreestandingClass() = #externalMacro(module: "MacroDefinition", type: "ObjCFreestandingClassMacro")
+
+@attached(extension, conformances: MyObjCProtocol, names: named(objcRequirement))
+public macro ObjCExtension() = #externalMacro(module: "MacroDefinition", type: "ObjCExtensionMacro")
+
+@objc public protocol MyObjCProtocol {
+  func objcRequirement()
+}
+
+// ---
+
+import Foundation
+
+// CHECK:      SWIFT_CLASS("_TtC9MacroUser1A")
+// CHECK-NEXT: @interface A : NSObject
+@ObjCMemberFunc
+public class A: NSObject {
+  @ObjCPeerFunc
+  @objc public func a() {}
+  // CHECK-DAG: - (void)a;
+  // CHECK-DAG: - (void)member_A;
+  // CHECK-DAG: - (void)peer_a;
+
+  #ObjCFreestandingFunc
+  // CHECK-DAG: - (void)member_freestanding;
+}
+// CHECK-DAG: @end
+
+
+// CHECK:      SWIFT_CLASS("_TtC9MacroUser1B")
+// CHECK-NEXT: @interface B : NSObject
+
+// CHECK:      @interface B (SWIFT_EXTENSION(MacroUser)) <MyObjCProtocol>
+// CHECK-NEXT: - (void)objcRequirement;
+// CHECK-NEXT: @end
+@ObjCExtension
+public class B: NSObject {}
+
+
+// CHECK:      SWIFT_CLASS("_TtC9MacroUser22MacroExpandedObjCClass")
+// CHECK-NEXT: @interface MacroExpandedObjCClass : NSObject
+// CHECK-DAG:  - (void)member;
+// CHECK-DAG:  @end
+#ObjCFreestandingClass


### PR DESCRIPTION
Some macro-generated declarations are not being printed in the Obj-C/C++ generated header. Members introduced by attached `member` macros on a type appear to be fine, but those introduced by a attached `peer` or freestanding `declaration` macros don't show up.

This change updates the header writer to call `getAllMembers` throughout instead of `getMembers`, which makes sure that everything gets collected. Likewise, we update the top-level logic from `getTopLevelDecls` to `getTopLevelDeclsWithAuxiliaryDecls` to pick up freestanding decls introduced at file scope.

Fixes https://github.com/swiftlang/swift/issues/68170.
