### PR TITLE
[Diagnostics] Extend fix-it logic for misssing arguments without parenthesis

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5338,6 +5338,8 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
     // fn(argX, argY):
     //   fn(argX, argY[, argMissing])
     if (args->empty()) {
+      if (!args->getRParenLoc().isValid())
+        return false;  
       insertLoc = args->getRParenLoc();
     } else if (position != 0) {
       auto argPos = std::min(args->size(), position) - 1;
@@ -5376,9 +5378,6 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
           Lexer::getLocForEndOfToken(ctx.SourceMgr, fnExpr->getEndLoc());
     }
   }
-
-  if (insertLoc.isInvalid())
-    return false;
 
   // If we are trying to insert a trailing closure but the parameter
   // corresponding to the missing argument doesn't support a trailing closure,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5338,9 +5338,16 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
     // fn(argX, argY):
     //   fn(argX, argY[, argMissing])
     if (args->empty()) {
-      if (!args->getRParenLoc().isValid())
-        return false;  
-      insertLoc = args->getRParenLoc();
+      if (args->getRParenLoc().isInvalid()) { 
+        // Extend fix-it if no parenthesis and no args
+        insertBuf.insert(insertBuf.begin(), '(');
+        insertBuf.insert(insertBuf.end(), ')');
+        insertLoc =
+          Lexer::getLocForEndOfToken(ctx.SourceMgr, fnExpr->getEndLoc());
+        if (insertLoc.isInvalid()) 
+          return false;
+      } else 
+        insertLoc = args->getRParenLoc();
     } else if (position != 0) {
       auto argPos = std::min(args->size(), position) - 1;
       insertLoc = Lexer::getLocForEndOfToken(

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -17,9 +17,7 @@
 // expected-note@-1{{'m3(message:)' declared here}}
 
 @attached(peer) macro m4(_ param1: Int, label2 param2: String) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
-// expected-note@-1{{'m4(_:label2:)' declared here}}
-// expected-note@-2{{'m4(_:label2:)' declared here}}
-// expected-note@-3{{'m4(_:label2:)' declared here}}
+// expected-note@-1 3 {{'m4(_:label2:)' declared here}}
 
 @attached(peer) macro m5(label1: Int, label2: String) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
 // expected-note@-1{{'m5(label1:label2:)' declared here}}

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -7,14 +7,24 @@
 @attached(peer) macro m1() = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
 
 @attached(peer) macro m2(_: Int) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
-// expected-note@-1{{candidate has partially matching parameter list (Int)}}
+// expected-note@-1{{'m2' declared here}}
 // expected-note@-2{{candidate expects value of type 'Int' for parameter #1 (got 'String')}}
 
 @attached(peer) macro m2(_: Double) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
-// expected-note@-1{{candidate has partially matching parameter list (Double)}}
-// expected-note@-2{{candidate expects value of type 'Double' for parameter #1 (got 'String')}}
+// expected-note@-1{{candidate expects value of type 'Double' for parameter #1 (got 'String')}}
 
 @attached(peer) macro m3(message: String) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
+// expected-note@-1{{'m3(message:)' declared here}}
+
+@attached(peer) macro m4(_ param1: Int, label2 param2: String) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
+// expected-note@-1{{'m4(_:label2:)' declared here}}
+// expected-note@-2{{'m4(_:label2:)' declared here}}
+// expected-note@-3{{'m4(_:label2:)' declared here}}
+
+@attached(peer) macro m5(label1: Int, label2: String) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
+// expected-note@-1{{'m5(label1:label2:)' declared here}}
+
+@attached(peer) macro m6(label: Int = 42) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacros", type: "StringifyMacro")
 // expected-warning@-1{{external macro implementation type 'MyMacros.StringifyMacro' could not be found for macro 'stringify'}}
@@ -22,7 +32,15 @@
 
 @m1 struct X1 { }
 
-@m2 struct X2 { } // expected-error{{no exact matches in call to macro 'm2'}}
+@m2 struct X2 { } // expected-error{{missing argument for parameter #1 in macro expansion}}{{4-4=(<#Int#>)}}
+
+@m3 struct X3 { } // expected-error{{missing argument for parameter 'message' in macro expansion}}{{4-4=(message: <#String#>)}}
+
+@m4 struct X4 { } // expected-error{{missing arguments for parameters #1, 'label2' in macro expansion}}{{4-4=(<#Int#>, label2: <#String#>)}}
+
+@m5 struct X5 { } // expected-error{{missing arguments for parameters 'label1', 'label2' in macro expansion}}{{4-4=(label1: <#Int#>, label2: <#String#>)}}
+
+@m6 struct X6 { }
 
 // Check for nesting rules.
 struct SkipNestedType {
@@ -54,6 +72,10 @@ struct TestMacroArgs {
 
   @m2(Nested.x) struct Args5 {}
 
+  @m4(10) struct Args6 { } // expected-error{{missing argument for parameter 'label2' in macro expansion}}{{9-9=, label2: <#String#>}}
+
+  @m4(label2: "test") struct Args7 { } // expected-error{{missing argument for parameter #1 in macro expansion}}{{7-7=<#Int#>, }}
+
   struct Nested {
     static let x = 10
 
@@ -62,15 +84,15 @@ struct TestMacroArgs {
     @m2(Nested.x) struct Args2 {}
   }
 
-  @m3(message: stringify(Nested.x).1) struct Args6 {}
+  @m3(message: stringify(Nested.x).1) struct Args8 {}
   // expected-error@-1{{expansion of macro 'stringify' requires leading '#'}}
 
-  @m3(message: #stringify().1) struct Args7 {}
+  @m3(message: #stringify().1) struct Args9 {}
   // expected-error@-1{{missing argument for parameter #1 in macro expansion}}
 
-  @m3(message: #stringify(Nested.x).1) struct Args8 {}
+  @m3(message: #stringify(Nested.x).1) struct Args10 {}
 
   // Allow macros to have arbitrary generic specialization lists, but warn
   // https://github.com/swiftlang/swift/issues/75500
-  @m1<UInt> struct Args9 {} // expected-warning {{cannot specialize a non-generic external macro 'm1()'}}
+  @m1<UInt> struct Args11 {} // expected-warning {{cannot specialize a non-generic external macro 'm1()'}}
 }


### PR DESCRIPTION
When diagnosing missing arguments without parentheses, the fix-it insertion location can be ambiguous. This update improves the logic by inserting necessary parentheses around the missing argument for the fix-it. If an insertion location cannot be determined, the function now returns early to prevent incorrect suggestions, enhancing error handling precision.

The test suite has been updated to reflect these changes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
