### PR TITLE
[SE-0449] Remove `GlobalActorInferenceCutoff` feature flag.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -219,7 +219,6 @@ UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
 UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
 UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
-UPCOMING_FEATURE(GlobalActorInferenceCutoff, 0449, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -197,7 +197,6 @@ UNINTERESTING_FEATURE(FixedArrays)
 UNINTERESTING_FEATURE(GroupActorErrors)
 UNINTERESTING_FEATURE(SameElementRequirements)
 UNINTERESTING_FEATURE(UnspecifiedMeansMainActorIsolated)
-UNINTERESTING_FEATURE(GlobalActorInferenceCutoff)
 UNINTERESTING_FEATURE(GenerateForceToMainActorThunks)
 
 static bool usesFeatureSendingArgsAndResults(Decl *decl) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7153,15 +7153,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   // 'nonisolated' can be applied to global and static/class variables
   // that do not have storage.
   auto dc = D->getDeclContext();
-  auto &ctx = D->getASTContext();
-
-  if (!ctx.LangOpts.hasFeature(Feature::GlobalActorInferenceCutoff)) {
-    if (isa<ProtocolDecl>(D) || isa<ExtensionDecl>(D) || isa<ClassDecl>(D) ||
-        isa<StructDecl>(D) || isa<EnumDecl>(D)) {
-      diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr);
-      return;
-    }
-  }
 
   // nonisolated(unsafe) is unsafe, but only under strict concurrency.
   if (attr->isUnsafe() &&
@@ -7184,14 +7175,12 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
           }
         }
 
-        if (ctx.LangOpts.hasFeature(Feature::GlobalActorInferenceCutoff)) {
           // Additionally, a stored property of a non-'Sendable' type can be
           // explicitly marked 'nonisolated'.
           if (auto parentDecl = dc->getDeclaredTypeInContext())
             if (!parentDecl->isSendableType()) {
               canBeNonisolated = true;
             }
-        }
 
         // Otherwise, this stored property has to be qualified as 'unsafe'.
         if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
@@ -7203,15 +7192,12 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
         // 'nonisolated' without '(unsafe)' is not allowed on non-Sendable
         // variables, unless they are a member of a non-'Sendable' type.
-        if (!attr->isUnsafe() && !type->hasError()) {
-          if (!(canBeNonisolated &&
-                ctx.LangOpts.hasFeature(Feature::GlobalActorInferenceCutoff))) {
-            bool diagnosed = diagnoseIfAnyNonSendableTypes(
-                type, SendableCheckContext(dc), Type(), SourceLoc(),
-                attr->getLocation(), diag::nonisolated_non_sendable);
-            if (diagnosed)
-              return;
-          }
+        if (!attr->isUnsafe() && !type->hasError() && !canBeNonisolated) {
+          bool diagnosed = diagnoseIfAnyNonSendableTypes(
+              type, SendableCheckContext(dc), Type(), SourceLoc(),
+              attr->getLocation(), diag::nonisolated_non_sendable);
+          if (diagnosed)
+            return;
         }
       }
 


### PR DESCRIPTION
SE-0449 has been [accepted](https://forums.swift.org/t/accepted-se-0449-allow-nonisolated-to-prevent-global-actor-interference/75539). 

Since there are no ABI/source breaking changes in SE-0449, and parts of SE-0434 the proposal builds on are not under the feature flag today, remove the `GlobalActorInferenceCutoff` flag entirely.

Resolves rdar://138644230.