### PR TITLE
RedundantLoadElimination: support redundant loads of array elements with non-constant index

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -334,7 +334,7 @@ struct AliasAnalysis {
     case .stack, .global, .argument, .storeBorrow:
       // Those access bases cannot be interior pointers of a borrowed value
       return .noEffects
-    case .pointer, .unidentified, .yield:
+    case .pointer, .index, .unidentified, .yield:
       // We don't know anything about this address -> get the conservative effects
       return defaultEffects(of: endBorrow, on: memLoc)
     case .box, .class, .tail:

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -337,7 +337,7 @@ private struct LifetimeVariable {
     case .pointer(let ptrToAddr):
       self.varDecl = nil
       self.sourceLoc = ptrToAddr.location.sourceLoc
-    case .unidentified:
+    case .index, .unidentified:
       self.varDecl = nil
       self.sourceLoc = nil
     }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -142,7 +142,7 @@ private extension LoadInst {
   }
 
   func isRedundant(complexityBudget: inout Int, _ context: FunctionPassContext) -> DataflowResult {
-    return isRedundant(at: address.accessPath, complexityBudget: &complexityBudget, context)
+    return isRedundant(at: address.constantAccessPath, complexityBudget: &complexityBudget, context)
   }
 
   func isRedundant(at accessPath: AccessPath, complexityBudget: inout Int, _ context: FunctionPassContext) -> DataflowResult {
@@ -282,7 +282,7 @@ private func provideValue(
   from availableValue: AvailableValue,
   _ context: FunctionPassContext
 ) -> Value {
-  let projectionPath = availableValue.address.accessPath.getMaterializableProjection(to: load.address.accessPath)!
+  let projectionPath = availableValue.address.constantAccessPath.getMaterializableProjection(to: load.address.constantAccessPath)!
 
   switch load.loadOwnership {
   case .unqualified:
@@ -483,7 +483,7 @@ private struct InstructionScanner {
         // This happens if the load is in a loop.
         return .available
       }
-      let precedingLoadPath = precedingLoad.address.accessPath
+      let precedingLoadPath = precedingLoad.address.constantAccessPath
       if precedingLoadPath.getMaterializableProjection(to: accessPath) != nil {
         availableValues.append(.viaLoad(precedingLoad))
         return .available
@@ -500,7 +500,7 @@ private struct InstructionScanner {
       if precedingStore.source is Undef {
         return .overwritten
       }
-      let precedingStorePath = precedingStore.destination.accessPath
+      let precedingStorePath = precedingStore.destination.constantAccessPath
       if precedingStorePath.getMaterializableProjection(to: accessPath) != nil {
         availableValues.append(.viaStore(precedingStore))
         return .available

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -467,7 +467,7 @@ private extension AccessBase {
         return .decidedInCaller(arg)
       case .yield, .pointer:
         return .unknown
-      case .unidentified:
+      case .index, .unidentified:
         // In the rare case of an unidentified access, just ignore it.
         // This should not happen in regular SIL, anyway.
         return .no

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -67,8 +67,16 @@ private func printAccessInfo(address: Value) {
     print("  Scope: base")
   }
 
-  print("  Base: \(ap.base)")
-  print("  Path: \"\(ap.projectionPath)\"")
+  let constAp = address.constantAccessPath
+  if constAp == ap {
+    print("  Base: \(ap.base)")
+    print("  Path: \"\(ap.projectionPath)\"")
+  } else {
+    print("  nonconst-base: \(ap.base)")
+    print("  nonconst-path: \"\(ap.projectionPath)\"")
+    print("  const-base: \(constAp.base)")
+    print("  const-path: \"\(constAp.projectionPath)\"")
+  }
 
   var arw = AccessStoragePathVisitor()
   if !arw.visitAccessStorageRoots(of: ap) {
@@ -79,18 +87,40 @@ private func printAccessInfo(address: Value) {
 private func checkAliasInfo(forArgumentsOf apply: ApplyInst, expectDistinct: Bool) {
   let address1 = apply.arguments[0]
   let address2 = apply.arguments[1]
-  let path1 = address1.accessPath
-  let path2 = address2.accessPath
 
+  checkIsDistinct(path1: address1.accessPath,
+                  path2: address2.accessPath,
+                  expectDistinct: expectDistinct,
+                  instruction: apply)
+
+  if !expectDistinct {
+    // Also check all combinations with the constant variant of access paths.
+    // Note: we can't do that for "isDistinct" because "isDistinct" might be more conservative in one of the variants.
+    checkIsDistinct(path1: address1.constantAccessPath,
+                    path2: address2.constantAccessPath,
+                    expectDistinct: false,
+                    instruction: apply)
+    checkIsDistinct(path1: address1.accessPath,
+                    path2: address2.constantAccessPath,
+                    expectDistinct: false,
+                    instruction: apply)
+    checkIsDistinct(path1: address1.constantAccessPath,
+                    path2: address2.accessPath,
+                    expectDistinct: false,
+                    instruction: apply)
+  }
+}
+
+private func checkIsDistinct(path1: AccessPath, path2: AccessPath, expectDistinct: Bool, instruction: Instruction) {
   if path1.isDistinct(from: path2) != expectDistinct {
-    print("wrong isDistinct result of \(apply)")
+    print("wrong isDistinct result of \(instruction)")
   } else if path2.isDistinct(from: path1) != expectDistinct {
-    print("wrong reverse isDistinct result of \(apply)")
+    print("wrong reverse isDistinct result of \(instruction)")
   } else {
     return
   }
-  
+
   print("in function")
-  print(apply.parentFunction)
+  print(instruction.parentFunction)
   fatalError()
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -464,7 +464,7 @@ enum AddressOwnershipLiveRange : CustomStringConvertible {
       }
     case .storeBorrow(let sb):
       return computeValueLiveRange(of: sb.source, context)
-    case .pointer, .unidentified:
+    case .pointer, .index, .unidentified:
       return nil
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -366,7 +366,7 @@ extension LifetimeDependence.Scope {
         return nil
       }
       self = scope
-    case .pointer, .unidentified:
+    case .pointer, .index, .unidentified:
       self = .unknown(address)
     }
   }
@@ -1094,7 +1094,7 @@ extension LifetimeDependenceDefUseWalker {
       break
     case .yield:
       return storeToYieldDependence(address: address, of: operand)
-    case .global, .class, .tail, .storeBorrow, .pointer, .unidentified:
+    case .global, .class, .tail, .storeBorrow, .pointer, .index, .unidentified:
       // An address produced by .storeBorrow should never be stored into.
       //
       // TODO: allow storing an immortal value into a global.

--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -626,3 +626,65 @@ bb0(%0 : @guaranteed $C):
   dealloc_stack %1 : $*C
   return %6 : $C
 }
+
+// CHECK-LABEL: Accesses for indexAddr
+// CHECK:       Value:   %6 = index_addr %3 : $*Int64, %4 : $Builtin.Word
+// CHECK:       Scope: base
+// CHECK:       Base: tail - %0 = argument of bb0 : $C
+// CHECK:       Path: "i4"
+// CHECK:         Storage: %0 = argument of bb0 : $C
+// CHECK:         Path: "ct.i4"
+// CHECK:          Value:   %7 = index_addr %3 : $*Int64, %5 : $Builtin.Word
+// CHECK:       Scope: base
+// CHECK:       Base: tail - %0 = argument of bb0 : $C
+// CHECK:       Path: "i5"
+// CHECK:         Storage: %0 = argument of bb0 : $C
+// CHECK:         Path: "ct.i5"
+// CHECK:          Value:   %8 = index_addr %3 : $*Int64, %1 : $Builtin.Word
+// CHECK:       Scope: base
+// CHECK:       nonconst-base: tail - %0 = argument of bb0 : $C
+// CHECK:       nonconst-path: "i*"
+// CHECK:       const-base: index -   %8 = index_addr %3 : $*Int64, %1 : $Builtin.Word
+// CHECK:       const-path: ""
+// CHECK:         Storage: %0 = argument of bb0 : $C
+// CHECK:         Path: "ct.i*"
+// CHECK:          Value:   %10 = struct_element_addr %9 : $*Int64, #Int64._value
+// CHECK:       Scope: base
+// CHECK:       nonconst-base: tail - %0 = argument of bb0 : $C
+// CHECK:       nonconst-path: "i*.s0"
+// CHECK:       const-base: index -   %9 = index_addr %3 : $*Int64, %2 : $Builtin.Word
+// CHECK:       const-path: "s0"
+// CHECK:         Storage: %0 = argument of bb0 : $C
+// CHECK:         Path: "ct.i*.s0"
+// CHECK-LABEL: End accesses for indexAddr
+sil @indexAddr : $@convention(thin) (@guaranteed C, Builtin.Word, Builtin.Word) -> () {
+bb0(%0 : $C, %1 : $Builtin.Word, %2 : $Builtin.Word):
+  %3 = ref_tail_addr %0 : $C, $Int64
+  %4 = integer_literal $Builtin.Word, 4
+  %5 = integer_literal $Builtin.Word, 5
+
+  %6 = index_addr %3 : $*Int64, %4 : $Builtin.Word
+  %7 = index_addr %3 : $*Int64, %5 : $Builtin.Word
+  %8 = index_addr %3 : $*Int64, %1 : $Builtin.Word
+  %9 = index_addr %3 : $*Int64, %2 : $Builtin.Word
+  %10 = struct_element_addr %9 : $*Int64, #Int64._value
+
+  %20 = load %6 : $*Int64
+  %21 = load %7 : $*Int64
+  %22 = load %8 : $*Int64
+  %23 = load %10 : $*Builtin.Int64
+
+  %isDistinct = function_ref @_isDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %isNotDistinct = function_ref @_isNotDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  apply %isDistinct<Int64, Int64>(%6, %7) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Int64>(%3, %6) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Int64>(%3, %8) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Builtin.Int64>(%3, %10) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Int64>(%6, %8) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Int64>(%8, %9) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  apply %isNotDistinct<Int64, Builtin.Int64>(%8, %10) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  %200 = tuple ()
+  return %200 : $()
+}

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -1288,6 +1288,38 @@ bb0(%0 : $Builtin.RawPointer):
   return %99 : $(Int, Int, Int, Int)
 }
 
+// CHECK-LABEL: sil [ossa] @non_const_index :
+// CHECK:         [[L:%.*]] = load
+// CHECK-NOT:     load
+// CHECK:         tuple ([[L]] : $Int, [[L]] : $Int)
+// CHECK-LABEL: } // end sil function 'non_const_index'
+sil [ossa] @non_const_index : $@convention(thin) (@guaranteed B, Builtin.Word) -> (Int, Int) {
+bb0(%0 : @guaranteed $B, %1 : $Builtin.Word):
+  %2 = ref_tail_addr %0 : $B, $Int
+  %3 = index_addr %2 : $*Int, %1 : $Builtin.Word
+  %4 = load [trivial] %3 : $*Int
+  %5 = load [trivial] %3 : $*Int
+  %6 = tuple (%4 : $Int, %5 : $Int)
+  return %6 : $(Int, Int)
+}
+
+// CHECK-LABEL: sil [ossa] @non_const_index_aliasing :
+// CHECK:         [[L1:%.*]] = load
+// CHECK:         store
+// CHECK:         [[L2:%.*]] = load
+// CHECK:         tuple ([[L1]] : $Int, [[L2]] : $Int)
+// CHECK-LABEL: } // end sil function 'non_const_index_aliasing'
+sil [ossa] @non_const_index_aliasing : $@convention(thin) (@guaranteed B, Builtin.Word, Int) -> (Int, Int) {
+bb0(%0 : @guaranteed $B, %1 : $Builtin.Word, %2 : $Int):
+  %3 = ref_tail_addr %0 : $B, $Int
+  %4 = index_addr %3 : $*Int, %1 : $Builtin.Word
+  %5 = load [trivial] %3 : $*Int
+  store %2 to [trivial] %4: $*Int
+  %7 = load [trivial] %3 : $*Int
+  %8 = tuple (%5 : $Int, %7 : $Int)
+  return %8 : $(Int, Int)
+}
+
 sil [ossa] @overwrite_int : $@convention(thin) (@inout Int, Int) -> ()
 
 // Make sure that the store is forwarded to the load, ie. the load is

--- a/test/SILOptimizer/redundant_load_elimination.swift
+++ b/test/SILOptimizer/redundant_load_elimination.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -parse-as-library -module-name test %s -O -emit-sil | %FileCheck %s
 
-// REQUIRES: swift_in_compiler
-
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 public final class C {
   let i: Int
@@ -23,5 +22,48 @@ public func testLetField(_ c: C, f: () -> ()) ->  (Int, Int) {
   f()
   let b = c.i
   return (a, b)
+}
+
+let globalLetArray = [1, 2, 3, 4]
+
+// CHECK-LABEL: sil @$s4test5test15indexS2i_tF :
+// CHECK:           load
+// CHECK:           [[L:%.*]] = load
+// CHECK-NOT:       load
+// CHECK:           builtin "sadd_with_overflow{{.*}}"([[L]] : {{.*}}, [[L]] :
+// CHECK:       } // end sil function '$s4test5test15indexS2i_tF'
+public func test1(index: Int) -> Int {
+  let elem1 = globalLetArray[index]
+  let elem2 = globalLetArray[index]
+  return elem1 + elem2
+}
+
+struct Wrapper {
+  let arr: Array<Int>
+  init() {
+    arr = [1, 2, 3, 4]
+  }
+}
+
+// CHECK-LABEL: sil @$s4test5test25indexS2i_tF :
+// CHECK:           [[L:%.*]] = load
+// CHECK-NOT:       load
+// CHECK:           builtin "sadd_with_overflow{{.*}}"([[L]] : {{.*}}, [[L]] :
+// CHECK:       } // end sil function '$s4test5test25indexS2i_tF'
+public func test2(index: Int) -> Int {
+  let w = Wrapper()
+  let elem1 = w.arr[index]
+  let elem2 = w.arr[index]
+  return elem1 + elem2
+}
+
+// CHECK-LABEL: sil @$s4test5test3_5indexSiSaySiG_SitF :
+// CHECK:           load
+// CHECK:           [[L:%.*]] = load
+// CHECK-NOT:       load
+// CHECK:           builtin "sadd_with_overflow{{.*}}"([[L]] : {{.*}}, [[L]] :
+// CHECK:       } // end sil function '$s4test5test3_5indexSiSaySiG_SitF'
+public func test3(_ arr: Array<Int>, index: Int) -> Int {
+  return arr[index] + arr[index]
 }
 


### PR DESCRIPTION
For example:
```
func test3(_ arr: Array<Int>, index: Int) -> Int {
  return arr[index] + arr[index]
}
```

rdar://138519664