### PR TITLE
[build] Make the RegexParser requirement to build ASTGen explicit

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -1,20 +1,21 @@
 add_subdirectory(Sources)
 
-# If requested, build the regular expression parser into the compiler itself.
-if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
-  file(GLOB_RECURSE _COMPILER_REGEX_PARSER_SOURCES
-    "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_RegexParser/*.swift")
-  set(COMPILER_REGEX_PARSER_SOURCES)
-  foreach(source ${_COMPILER_REGEX_PARSER_SOURCES})
-    file(TO_CMAKE_PATH "${source}" source)
-    list(APPEND COMPILER_REGEX_PARSER_SOURCES ${source})
-  endforeach()
-  message(STATUS "Using Experimental String Processing library for _CompilerRegexParser (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
-
-  add_pure_swift_host_library(_CompilerRegexParser STATIC
-    "${COMPILER_REGEX_PARSER_SOURCES}"
-  )
-else()
-  # Dummy target for dependencies
-  add_custom_target(_CompilerRegexParser)
+if(NOT SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
+  message(FATAL_ERROR
+    "Unable to build ASTGen without Regex Parser support. "
+    "Please enable SWIFT_BUILD_REGEX_PARSER_IN_COMPILER.")
 endif()
+
+# Build the regular expression parser into the compiler itself.
+file(GLOB_RECURSE _COMPILER_REGEX_PARSER_SOURCES
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_RegexParser/*.swift")
+set(COMPILER_REGEX_PARSER_SOURCES)
+foreach(source ${_COMPILER_REGEX_PARSER_SOURCES})
+  file(TO_CMAKE_PATH "${source}" source)
+  list(APPEND COMPILER_REGEX_PARSER_SOURCES ${source})
+endforeach()
+message(STATUS "Using Experimental String Processing library for _CompilerRegexParser (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
+
+add_pure_swift_host_library(_CompilerRegexParser STATIC
+  "${COMPILER_REGEX_PARSER_SOURCES}"
+)


### PR DESCRIPTION
This makes the requirement to have RegexParser build enabled more obvious to someone not familiar with ASTGen.

This also removes the dummy target that was triggering build failures: certain Swift code in ASTGen was using `#if canImport(_CompilerRegexParser)` to determine whether RegexParser is available, and the dummy target was causing this to always resolve to true. That obscured the underlying reason for compilation errors:
```
ASTGen/Sources/ASTGen/Regex.swift:51:30: error: cannot find 'swiftCompilerLexRegexLiteral' in scope
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
