### PR TITLE
Frontend: Fix crash when -stats-output-dir used with -typecheck-module-from-interface

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -563,7 +563,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
     return true;
   }
 
-  setupStatsReporter();
+  if (hasASTContext()) {
+    setupStatsReporter();
+  }
 
   if (setupDiagnosticVerifierIfNeeded()) {
     Error = "Setting up diagnostics verifier failed";

--- a/test/Misc/stats_dir_verify_module_interface.swift
+++ b/test/Misc/stats_dir_verify_module_interface.swift
@@ -1,0 +1,3 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/foo.swiftinterface) %s -module-name foo
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/foo.swiftinterface -stats-output-dir %t


### PR DESCRIPTION
There's no ASTContext in this case, so we just skip initializing stats if the driver passes this flag down to us.
