### PR TITLE
[Mangling] Fix StringRef assertion failure when mangling identifiers with invalid UTF-8.

### DIFF
--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -127,7 +127,8 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
     // with an initial '00' and Punycode the identifier string.
     std::string punycodeBuf;
     Punycode::encodePunycodeUTF8(ident, punycodeBuf,
-                                 /*mapNonSymbolChars*/ true);
+                                 /*mapNonSymbolChars*/ true,
+                                 /*repairInvalidUTF8*/ true);
     StringRef pcIdent = punycodeBuf;
     M.Buffer << "00" << pcIdent.size();
     if (isDigit(pcIdent[0]) || pcIdent[0] == '_')

--- a/include/swift/Demangling/Punycode.h
+++ b/include/swift/Demangling/Punycode.h
@@ -54,9 +54,15 @@ bool decodePunycode(StringRef InputPunycode,
 ///
 /// If \p mapNonSymbolChars is true, non-symbol ASCII characters (characters
 /// except [$_a-zA-Z0-9]) are also encoded like non-ASCII unicode characters.
-/// Returns false if \p InputUTF8 contains surrogate code points.
+///
+/// If \p repairInvalidUTF8 is true, invalid UTF-8 sequences will be replaced
+/// with one or more Unicode replacement characters.
+///
+/// Returns false if \p InputUTF8 contains surrogate code points and
+/// repairInvalidUTF8 is false.
 bool encodePunycodeUTF8(StringRef InputUTF8, std::string &OutPunycode,
-                        bool mapNonSymbolChars = false);
+                        bool mapNonSymbolChars = false,
+                        bool repairInvalidUTF8 = false);
 
 bool decodePunycodeUTF8(StringRef InputPunycode, std::string &OutUTF8);
 

--- a/unittests/Remangler/RemangleTest.cpp
+++ b/unittests/Remangler/RemangleTest.cpp
@@ -125,3 +125,55 @@ TEST(TestSwiftRemangler, DependentGenericConformanceRequirement) {
     ASSERT_FALSE(b.remangleSuccess(n));
   }
 }
+
+TEST(TestSwiftRemangler, InvalidUTF8) {
+  using namespace swift::Demangle;
+  using Kind = swift::Demangle::Node::Kind;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xb0");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xc0");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xe0");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xf0");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xf8");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xff");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xc0\xff");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xe0\x80\xff");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xf0\x80\xff");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    NodePointer n = b.Node(Kind::Identifier, "\xf0\x80\x80\xff");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+  {
+    // Valid UTF-8 sequence, but decoding to an invalid code point.
+    NodePointer n = b.Node(Kind::Identifier, "\xed\xa2\x80");
+    ASSERT_TRUE(b.remangleSuccess(n));
+  }
+}


### PR DESCRIPTION
mangleIdentifier gets a zero-length string if encodePunycodeUTF8 fails, and then tries to access index 0 of it.

Add an option to encodePunycodeUTF8 to repair invalid UTF-8 rather than rejecting it, and have mangleIdentifier use this option.

rdar://134362682