### PR TITLE
[region-isolation] Refactor code so that I can more easily add additional error kinds

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionOpError.def
+++ b/include/swift/SILOptimizer/Utils/PartitionOpError.def
@@ -1,0 +1,63 @@
+//===--- PartitionOpError.def ----------------------------*- C++ -*--------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file contains macros for creating PartitionOpErrors for use with
+/// SendNonSendable. This just makes it easier to add these errors without
+/// needing to write so much boielr plate.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef PARTITION_OP_ERROR
+#define PARTITION_OP_ERROR(Name)
+#endif
+
+/// An error created if we discover a value was locally used after it
+/// was already sent.
+///
+/// The arguments in the type are:
+///
+/// 1. The PartitionOp that required the element to be alive.
+///
+/// 2. The element in the PartitionOp that was asked to be alive.
+///
+/// 3. The operand of the instruction that originally transferred the
+/// region. Can be used to get the immediate value transferred or the
+/// transferring instruction.
+PARTITION_OP_ERROR(LocalUseAfterSend)
+
+/// This is called if we detect a never sendable element that was actually sent.
+///
+/// E.x.: passing a main actor exposed value to a sending parameter.
+PARTITION_OP_ERROR(SentNeverSendable)
+
+/// This is emitted when a never sendable value is passed into a sending
+/// result. The sending result will be viewed in our caller as disconnected and
+/// able to be sent.
+PARTITION_OP_ERROR(AssignNeverSendableIntoSendingResult)
+
+/// This is emitted when an inout sending parameter has been sent in a function
+/// body but has not been reinitialized at the end of the function.
+PARTITION_OP_ERROR(InOutSendingNotInitializedAtExit)
+
+/// This is emitted when an inout sending parameter has been assigned a
+/// non-disconnected value (e.x.: a value exposed to main actor isolated code)
+/// at end of function without being reinitialized with something disconnected.
+PARTITION_OP_ERROR(InOutSendingNotDisconnectedAtExit)
+
+/// Used to signify an "unknown code pattern" has occured while performing
+/// dataflow.
+///
+/// DISCUSSION: Our dataflow cannot emit errors itself so this is a callback
+/// to our user so that we can emit that error as we process.
+PARTITION_OP_ERROR(UnknownCodePattern)
+
+#undef PARTITION_OP_ERROR

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -943,6 +943,146 @@ private:
   }
 };
 
+/// Swift style enum we use to decouple and reduce boilerplate in between the
+/// diagnostic and non-diagnostic part of the infrastructure.
+class PartitionOpError {
+public:
+  using Element = PartitionPrimitives::Element;
+  using Region = PartitionPrimitives::Region;
+
+  enum Kind {
+#define PARTITION_OP_ERROR(NAME) NAME,
+#include "PartitionOpError.def"
+  };
+
+  struct UnknownCodePatternError {
+    const PartitionOp *op;
+
+    UnknownCodePatternError(const PartitionOp &op) : op(&op) {}
+  };
+
+  struct LocalUseAfterSendError {
+    const PartitionOp *op;
+    Element sentElement;
+    Operand *sendingOp;
+
+    LocalUseAfterSendError(const PartitionOp &op, Element elt,
+                           Operand *sendingOp)
+        : op(&op), sentElement(elt), sendingOp(sendingOp) {}
+  };
+
+  struct SentNeverSendableError {
+    const PartitionOp *op;
+    Element sentElement;
+    SILDynamicMergedIsolationInfo isolationRegionInfo;
+    std::optional<Element> actualSentElement;
+
+    SentNeverSendableError(const PartitionOp &op, Element sentElement,
+                           SILDynamicMergedIsolationInfo isolationRegionInfo,
+                           std::optional<Element> actualSentElement)
+        : op(&op), sentElement(sentElement),
+          isolationRegionInfo(isolationRegionInfo),
+          actualSentElement(actualSentElement) {}
+  };
+
+  struct AssignNeverSendableIntoSendingResultError {
+    const PartitionOp *op;
+    Element destElement;
+    SILFunctionArgument *destValue;
+    Element srcElement;
+    SILValue srcValue;
+    SILDynamicMergedIsolationInfo srcIsolationRegionInfo;
+
+    AssignNeverSendableIntoSendingResultError(
+        const PartitionOp &op, Element destElement,
+        SILFunctionArgument *destValue, Element srcElement, SILValue srcValue,
+        SILDynamicMergedIsolationInfo srcIsolationRegionInfo)
+        : op(&op), destElement(destElement), destValue(destValue),
+          srcElement(srcElement), srcValue(srcValue),
+          srcIsolationRegionInfo(srcIsolationRegionInfo) {}
+  };
+
+  struct InOutSendingNotInitializedAtExitError {
+    const PartitionOp *op;
+    Element sentElement;
+    Operand *sendingOp;
+
+    InOutSendingNotInitializedAtExitError(const PartitionOp &op, Element elt,
+                                          Operand *sendingOp)
+        : op(&op), sentElement(elt), sendingOp(sendingOp) {}
+  };
+
+  struct InOutSendingNotDisconnectedAtExitError {
+    const PartitionOp *op;
+    Element inoutSendingElement;
+    SILDynamicMergedIsolationInfo isolationInfo;
+
+    InOutSendingNotDisconnectedAtExitError(
+        const PartitionOp &op, Element elt,
+        SILDynamicMergedIsolationInfo isolation)
+        : op(&op), inoutSendingElement(elt), isolationInfo(isolation) {}
+  };
+
+#define PARTITION_OP_ERROR(NAME)                                               \
+  static_assert(std::is_copy_constructible_v<NAME##Error>,                     \
+                #NAME " must be copy constructable");
+#include "PartitionOpError.def"
+#define PARTITION_OP_ERROR(NAME)                                               \
+  static_assert(std::is_copy_assignable_v<NAME##Error>,                        \
+                #NAME " must be copy assignable");
+#include "PartitionOpError.def"
+
+private:
+  Kind kind;
+  std::variant<
+#define PARTITION_OP_ERROR(NAME) NAME##Error,
+#include "PartitionOpError.def"
+      bool // sentinel value to avoid syntax issues.
+      >
+      data;
+
+public:
+#define PARTITION_OP_ERROR(NAME)                                               \
+  PartitionOpError(NAME##Error error) : kind(Kind::NAME), data(error) {}
+#include "PartitionOpError.def"
+
+  PartitionOpError(const PartitionOpError &error)
+      : kind(error.kind), data(error.data) {
+    switch (getKind()) {
+#define PARTITION_OP_ERROR(NAME)                                               \
+  case NAME:                                                                   \
+    assert(std::holds_alternative<NAME##Error>(data) &&                        \
+           "Data has value that does not match kind?!");                       \
+    break;
+#include "PartitionOpError.def"
+    }
+  }
+
+  PartitionOpError &operator=(const PartitionOpError &error) {
+    kind = error.kind;
+    data = error.data;
+
+    switch (getKind()) {
+#define PARTITION_OP_ERROR(NAME)                                               \
+  case NAME:                                                                   \
+    assert(std::holds_alternative<NAME##Error>(data) &&                        \
+           "Data has value that does not match kind?!");                       \
+    break;
+#include "PartitionOpError.def"
+    }
+    return *this;
+  }
+
+  Kind getKind() const { return kind; }
+
+#define PARTITION_OP_ERROR(NAME)                                               \
+  NAME##Error get##NAME##Error() const {                                       \
+    assert(getKind() == Kind::NAME);                                           \
+    return std::get<NAME##Error>(data);                                        \
+  }
+#include "PartitionOpError.def"
+};
+
 /// A data structure that applies a series of PartitionOps to a single Partition
 /// that it modifies.
 ///
@@ -960,6 +1100,10 @@ public:
   using Region = PartitionPrimitives::Region;
   using TransferringOperandSetFactory =
       Partition::TransferringOperandSetFactory;
+
+#define PARTITION_OP_ERROR(NAME)                                               \
+  using NAME##Error = PartitionOpError::NAME##Error;
+#include "PartitionOpError.def"
 
 protected:
   TransferringOperandSetFactory &ptrSetFactory;
@@ -979,56 +1123,7 @@ public:
     return asImpl().shouldEmitVerboseLogging();
   }
 
-  /// Call handleUnknownCodePattern on our CRTP subclass.
-  void handleUnknownCodePattern(const PartitionOp &op) const {
-    return asImpl().handleUnknownCodePattern(op);
-  }
-
-  /// Call handleLocalUseAfterTransfer on our CRTP subclass.
-  void handleLocalUseAfterTransfer(const PartitionOp &op, Element elt,
-                                   Operand *transferringOp) const {
-    return asImpl().handleLocalUseAfterTransfer(op, elt, transferringOp);
-  }
-
-  /// Call handleTransferNonTransferrable on our CRTP subclass.
-  void handleTransferNonTransferrable(
-      const PartitionOp &op, Element elt,
-      SILDynamicMergedIsolationInfo isolationRegionInfo) const {
-    return asImpl().handleTransferNonTransferrable(op, elt,
-                                                   isolationRegionInfo);
-  }
-  /// Just call our CRTP subclass.
-  void handleTransferNonTransferrable(
-      const PartitionOp &op, Element elt, Element otherElement,
-      SILDynamicMergedIsolationInfo isolationRegionInfo) const {
-    return asImpl().handleTransferNonTransferrable(op, elt, otherElement,
-                                                   isolationRegionInfo);
-  }
-
-  /// Just call our CRTP subclass.
-  void handleAssignTransferNonTransferrableIntoSendingResult(
-      const PartitionOp &op, Element destElement,
-      SILFunctionArgument *destValue, Element srcElement, SILValue srcValue,
-      SILDynamicMergedIsolationInfo srcIsolationRegionInfo) const {
-    return asImpl().handleAssignTransferNonTransferrableIntoSendingResult(
-        op, destElement, destValue, srcElement, srcValue,
-        srcIsolationRegionInfo);
-  }
-
-  /// Call our CRTP subclass.
-  void handleInOutSendingNotInitializedAtExitError(
-      const PartitionOp &op, Element elt, Operand *transferringOp) const {
-    return asImpl().handleInOutSendingNotInitializedAtExitError(op, elt,
-                                                                transferringOp);
-  }
-
-  /// Call our CRTP subclass.
-  void handleInOutSendingNotDisconnectedAtExitError(
-      const PartitionOp &op, Element elt,
-      SILDynamicMergedIsolationInfo isolation) const {
-    return asImpl().handleInOutSendingNotDisconnectedAtExitError(op, elt,
-                                                                 isolation);
-  }
+  void handleError(PartitionOpError error) { asImpl().handleError(error); }
 
   /// Call isActorDerived on our CRTP subclass.
   bool isActorDerived(Element elt) const {
@@ -1117,7 +1212,7 @@ public:
   }
 
   /// Apply \p op to the partition op.
-  void apply(const PartitionOp &op) const {
+  void apply(const PartitionOp &op) {
     if (shouldEmitVerboseLogging()) {
       REGIONBASEDISOLATION_VERBOSE_LOG(llvm::dbgs() << "Applying: ";
                                        op.print(llvm::dbgs()));
@@ -1158,9 +1253,9 @@ public:
                 // assign an actor introducing inst.
                 auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
                 if (!dynamicRegionIsolation.isDisconnected()) {
-                  handleAssignTransferNonTransferrableIntoSendingResult(
+                  handleError(AssignNeverSendableIntoSendingResultError(
                       op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
-                      dynamicRegionIsolation);
+                      dynamicRegionIsolation));
                 }
               }
             }
@@ -1210,8 +1305,7 @@ public:
       auto pairOpt =
           getIsolationRegionInfo(transferredRegion, op.getSourceOp());
       if (!pairOpt) {
-        handleUnknownCodePattern(op);
-        return;
+        return handleError(UnknownCodePatternError(op));
       }
       std::tie(transferredRegionIsolation, isClosureCapturedElt) = *pairOpt;
 
@@ -1245,7 +1339,7 @@ public:
               state.isolationInfo.merge(transferredRegionIsolation)) {
         state.isolationInfo = *newInfo;
       } else {
-        handleUnknownCodePattern(op);
+        handleError(UnknownCodePatternError(op));
       }
       assert(state.isolationInfo && "Cannot have unknown");
       state.isolationHistory.pushCFGHistoryJoin(p.getIsolationHistory());
@@ -1283,9 +1377,9 @@ public:
                 // assign an actor introducing inst.
                 auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
                 if (!dynamicRegionIsolation.isDisconnected()) {
-                  handleAssignTransferNonTransferrableIntoSendingResult(
+                  handleError(AssignNeverSendableIntoSendingResultError(
                       op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
-                      dynamicRegionIsolation);
+                      dynamicRegionIsolation));
                 }
               }
             }
@@ -1318,8 +1412,8 @@ public:
       // transferred. In that case, we emit a special use after free error.
       if (auto *transferredOperandSet = p.getTransferred(op.getOpArgs()[0])) {
         for (auto transferredOperand : transferredOperandSet->data()) {
-          handleInOutSendingNotInitializedAtExitError(op, op.getOpArgs()[0],
-                                                      transferredOperand);
+          handleError(InOutSendingNotInitializedAtExitError(
+              op, op.getOpArgs()[0], transferredOperand));
         }
         return;
       }
@@ -1331,15 +1425,15 @@ public:
 
       // If we failed to merge emit an unknown pattern error so we fail.
       if (!dynamicRegionIsolation) {
-        handleUnknownCodePattern(op);
+        handleError(UnknownCodePatternError(op));
         return;
       }
 
       // Otherwise, emit the error if the dynamic region isolation is not
       // disconnected.
       if (!dynamicRegionIsolation.isDisconnected()) {
-        handleInOutSendingNotDisconnectedAtExitError(op, op.getOpArgs()[0],
-                                                     dynamicRegionIsolation);
+        handleError(InOutSendingNotDisconnectedAtExitError(
+            op, op.getOpArgs()[0], dynamicRegionIsolation));
       }
       return;
     }
@@ -1348,8 +1442,7 @@ public:
       p.trackNewElement(op.getOpArgs()[0]);
 
       // Then emit an unknown code pattern error.
-      handleUnknownCodePattern(op);
-      return;
+      return handleError(UnknownCodePatternError(op));
     }
 
     llvm_unreachable("Covered switch isn't covered?!");
@@ -1394,7 +1487,7 @@ private:
   // Private helper that squelches the error if our transfer instruction and our
   // use have the same isolation.
   void handleLocalUseAfterTransferHelper(const PartitionOp &op, Element elt,
-                                         Operand *transferringOp) const {
+                                         Operand *transferringOp) {
     if (shouldTryToSquelchErrors()) {
       if (SILValue equivalenceClassRep =
               getRepresentative(transferringOp->get())) {
@@ -1433,14 +1526,14 @@ private:
     }
 
     // Ok, we actually need to emit a call to the callback.
-    return handleLocalUseAfterTransfer(op, elt, transferringOp);
+    return handleError(LocalUseAfterSendError(op, elt, transferringOp));
   }
 
   // Private helper that squelches the error if our transfer instruction and our
   // use have the same isolation.
   void handleTransferNonTransferrableHelper(
       const PartitionOp &op, Element elt,
-      SILDynamicMergedIsolationInfo dynamicMergedIsolationInfo) const {
+      SILDynamicMergedIsolationInfo dynamicMergedIsolationInfo) {
     if (shouldTryToSquelchErrors()) {
       if (SILValue equivalenceClassRep =
               getRepresentative(op.getSourceOp()->get())) {
@@ -1467,7 +1560,8 @@ private:
     }
 
     // Ok, we actually need to emit a call to the callback.
-    return handleTransferNonTransferrable(op, elt, dynamicMergedIsolationInfo);
+    return handleError(
+        SentNeverSendableError(op, elt, dynamicMergedIsolationInfo, {}));
   }
 };
 
@@ -1491,57 +1585,6 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   /// PartitionOps.
   bool shouldEmitVerboseLogging() const { return true; }
 
-  /// A function called if we discover a transferred value was used after it
-  /// was transferred.
-  ///
-  /// The arguments passed to the closure are:
-  ///
-  /// 1. The PartitionOp that required the element to be alive.
-  ///
-  /// 2. The element in the PartitionOp that was asked to be alive.
-  ///
-  /// 3. The operand of the instruction that originally transferred the
-  /// region. Can be used to get the immediate value transferred or the
-  /// transferring instruction.
-  void handleLocalUseAfterTransfer(const PartitionOp &op, Element elt,
-                                   Operand *transferringOp) const {}
-
-  /// This is called if we detect a never transferred element that was passed to
-  /// a transfer instruction.
-  void handleTransferNonTransferrable(
-      const PartitionOp &op, Element elt,
-      SILDynamicMergedIsolationInfo regionInfo) const {}
-
-  /// Please see documentation on the CRTP version of this call for information
-  /// about this entrypoint.
-  void handleTransferNonTransferrable(
-      const PartitionOp &op, Element elt, Element otherElement,
-      SILDynamicMergedIsolationInfo isolationRegionInfo) const {}
-
-  /// Please see documentation on the CRTP version of this call for information
-  /// about this entrypoint.
-  void handleAssignTransferNonTransferrableIntoSendingResult(
-      const PartitionOp &partitionOp, Element destElement,
-      SILFunctionArgument *destValue, Element srcElement, SILValue srcValue,
-      SILDynamicMergedIsolationInfo srcIsolationRegionInfo) const {}
-
-  /// Used to signify an "unknown code pattern" has occured while performing
-  /// dataflow.
-  ///
-  /// DISCUSSION: Our dataflow cannot emit errors itself so this is a callback
-  /// to our user so that we can emit that error as we process.
-  void handleUnknownCodePattern(const PartitionOp &op) const {}
-
-  /// Called if we find an 'inout sending' parameter that is not live at exit.
-  void handleInOutSendingNotInitializedAtExitError(
-      const PartitionOp &op, Element elt, Operand *transferringOp) const {}
-
-  /// Called if we find an 'inout sending' parameter that is live at excit but
-  /// is actor isolated instead of disconnected.
-  void handleInOutSendingNotDisconnectedAtExitError(
-      const PartitionOp &op, Element elt,
-      SILDynamicMergedIsolationInfo actorIsolation) const {}
-
   /// This is used to determine if an element is actor derived. If we determine
   /// that a region containing such an element is transferred, we emit an error
   /// since actor regions cannot be transferred.
@@ -1550,6 +1593,9 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   /// This is used to determine if an element is in the same region as a task
   /// isolated value.
   bool isTaskIsolatedDerived(Element elt) const { return false; }
+
+  /// By default, do nothing upon error.
+  void handleError(PartitionOpError error) {}
 
   /// Returns the information about \p elt's isolation that we ascertained from
   /// SIL and the AST.

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -975,14 +975,11 @@ public:
     const PartitionOp *op;
     Element sentElement;
     SILDynamicMergedIsolationInfo isolationRegionInfo;
-    std::optional<Element> actualSentElement;
 
     SentNeverSendableError(const PartitionOp &op, Element sentElement,
-                           SILDynamicMergedIsolationInfo isolationRegionInfo,
-                           std::optional<Element> actualSentElement)
+                           SILDynamicMergedIsolationInfo isolationRegionInfo)
         : op(&op), sentElement(sentElement),
-          isolationRegionInfo(isolationRegionInfo),
-          actualSentElement(actualSentElement) {}
+          isolationRegionInfo(isolationRegionInfo) {}
   };
 
   struct AssignNeverSendableIntoSendingResultError {
@@ -1561,7 +1558,7 @@ private:
 
     // Ok, we actually need to emit a call to the callback.
     return handleError(
-        SentNeverSendableError(op, elt, dynamicMergedIsolationInfo, {}));
+        SentNeverSendableError(op, elt, dynamicMergedIsolationInfo));
   }
 };
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -460,7 +460,7 @@ enum class PartitionOpKind : uint8_t {
   /// parameter is reinitialized with a disconnected value.
   ///
   /// Takes one parameter, the inout parameter that we need to check.
-  RequireInOutSendingAtFunctionExit,
+  InOutSendingAtFunctionExit,
 };
 
 /// PartitionOp represents a primitive operation that can be performed on
@@ -568,9 +568,9 @@ public:
     return PartitionOp(PartitionOpKind::UnknownPatternError, elt, sourceInst);
   }
 
-  static PartitionOp
-  RequireInOutSendingAtFunctionExit(Element elt, SILInstruction *sourceInst) {
-    return PartitionOp(PartitionOpKind::RequireInOutSendingAtFunctionExit, elt,
+  static PartitionOp InOutSendingAtFunctionExit(Element elt,
+                                                SILInstruction *sourceInst) {
+    return PartitionOp(PartitionOpKind::InOutSendingAtFunctionExit, elt,
                        sourceInst);
   }
 
@@ -1399,7 +1399,7 @@ public:
         }
       }
       return;
-    case PartitionOpKind::RequireInOutSendingAtFunctionExit: {
+    case PartitionOpKind::InOutSendingAtFunctionExit: {
       assert(op.getOpArgs().size() == 1 &&
              "Require PartitionOp should be passed 1 argument");
       assert(p.isTrackingElement(op.getOpArgs()[0]) &&

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -291,6 +291,13 @@ public:
     llvm::dbgs() << '\n';
   }
 
+  /// Prints out the message for a diagnostic that states that the value is
+  /// exposed to a specific code.
+  ///
+  /// We do this programatically since task-isolated code needs a very different
+  /// form of diagnostic than other cases.
+  void printForCodeDiagnostic(llvm::raw_ostream &os) const;
+
   void printForDiagnostics(llvm::raw_ostream &os) const;
 
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
@@ -523,6 +530,10 @@ public:
 
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
     innerInfo.dumpForDiagnostics();
+  }
+
+  void printForCodeDiagnostic(llvm::raw_ostream &os) const {
+    innerInfo.printForCodeDiagnostic(os);
   }
 
   void printForOneLineLogging(llvm::raw_ostream &os) const {

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -78,9 +78,9 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
     os << "unknown pattern error ";
     os << "%%" << opArgs[0];
     break;
-  case PartitionOpKind::RequireInOutSendingAtFunctionExit:
+  case PartitionOpKind::InOutSendingAtFunctionExit:
     constexpr static char extraSpaceLiteral[10] = "     ";
-    os << "require_inout_sending_at_function_exit ";
+    os << "inout_sending_at_function_exit ";
     if (extraSpace)
       os << extraSpaceLiteral;
     os << "%%" << opArgs[0];

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -100,7 +100,7 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
       llvm_unreachable("Unsupported");
     case PartitionOpError::LocalUseAfterSend: {
       auto state = error.getLocalUseAfterSendError();
-      failureCallback(state.op, state.sentElement, state.sendingOp);
+      failureCallback(*state.op, state.sentElement, state.sendingOp);
     }
     }
   }


### PR DESCRIPTION
This is a part of a larger commit that I am splitting off from a larger commit since it can stand alone as a refactor.

----

This PR modifies the way region isolation moves error information to make it easier to add additional types of errors. Specifically perviously, for each error kind, there was a CRTP entry point on PartitionOpEvaluator. The actual handling of the entry point in the CRTP subclass would involve doing some post-processing to create some kind of error object (or suppress the error). This error object would be appended to a specific array in the DiagnosticEmitter. This array would need to be threaded throughout the implementation.

As one can tell from the above there is a bunch of boilerplate:

1. Adding a CRTP entry point for every type of error means that /all/ PartitionOpEvaluators had to be updated whenever a new interesting CRTP was added. This isn't necessary.
2. By having the state passed from the DiagnosticEvaluator to the rest of the diagnostic infrastructure be created on the other side and without that having a homogeneous representation, we are forced to add tons of references to various arrays and propagate those around as reference fields and parameters.

This makes adding a new error type a bit of a pain in the butt. I realized this when I was working on a forthcoming patch that this is chopped off of when I started to try and cram new error kinds into the handlers for other similarish errors to avoid having to write the boilerplate. When one recognizes this impulse in one's self, it is /always/ a sign that one should refactor the given code.

With all of that said, what this PR does is that it adds a new Swift-style C++ enum struct called PartitionOpError. This is effectively an AnyError that abstracts over the various error kinds (I will go into its implementation in a second). Using this abstract form of error, we can create an interface in between the emitters and the error kinds by just calling a single CRTP entry point called handleError. This then lets us just phrase all of the middle level boilerplate in terms of these AnyErrors. For example, the diagnostic emitter can just stash these errors into an any error. And we can just loop over them in the diagnostic emitter and invoke specific code for each one. To avoid the need to create a bunch of additional C++ boilerplate, I added a .def file to macro-out some of the boiler plate for individual error kinds. Using this, to add a new error kind, one:

1. Creates a new error kind in the .def.
2. Defines the error struct itself.
3. In PartitionOpEvaluator::apply, one just creates the error type and passes it to handleError.
4. In TransferNonSendable.cpp, update the covered switch as the entry point to define behavior. Generally this means creating a functor object that one uses to perform the diagnostic computation upon the error.
