### PR TITLE
[embedded] Make Bool string-interpolatable in Embedded Swift, clarify support in docs

### DIFF
--- a/docs/EmbeddedSwift/EmbeddedSwiftStatus.md
+++ b/docs/EmbeddedSwift/EmbeddedSwiftStatus.md
@@ -38,9 +38,12 @@ This status table describes which of the following standard library features can
 | Collection algorithms (sort, reverse)                      | Yes    |
 | CustomStringConvertible, CustomDebugStringConvertible      | Yes, except those that require reflection (e.g. Array's .description)     |
 | Dictionary (dynamic heap-allocated container)              | Yes    |
+| Floating-point conversion to string                        | No     |
+| Floating-point parsing                                     | No     |
 | FixedWidthInteger + related protocols                      | Yes    |
 | Hashable, Equatable, Comparable protocols                  | Yes    |
 | InputStream, OutputStream                                  | No     |
+| Integer conversion to string                               | Yes    |
 | Integer parsing                                            | No     |
 | KeyPaths                                                   | Partial (only compile-time constant key paths to stored properties supported, only usable in MemoryLayout and UnsafePointer APIs)     |
 | Lazy collections                                           | No     |
@@ -55,7 +58,7 @@ This status table describes which of the following standard library features can
 | SIMD types                                                 | Yes    |
 | StaticString                                               | Yes    |
 | String (dynamic)                                           | Yes    |
-| String Interpolations                                      | Yes    |
+| String interpolations                                      | Partial (only strings, integers, booleans, and custom types that are CustomStringConvertible can be interpolated)    |
 | Unicode                                                    | Yes    |
 | Unsafe\[Mutable\]\[Raw\]\[Buffer\]Pointer                  | Yes    |
 | VarArgs                                                    | No     |
@@ -66,7 +69,7 @@ This status table describes which of the following Swift features can be used in
 
 | **Swift Feature**                                          | **Currently Supported In Embedded Swift?**          |
 |------------------------------------------------------------|-----------------------------------------------------|
-| Synchronization module                                     | Yes    |
+| Synchronization module                                     | Partial (only Atomic types, no Mutex)    |
 | Swift Concurrency                                          | Partial, experimental (basics of actors and tasks work in single-threaded concurrency mode) |
 | C interop                                                  | Yes    | 
 | C++ interop                                                | Yes    |

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -170,7 +170,6 @@ extension Bool: _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLiteral
   }
 }
 
-@_unavailableInEmbedded
 extension Bool: CustomStringConvertible {
   /// A textual representation of the Boolean value.
   @inlinable

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -92,7 +92,6 @@ public struct ${Self} {
 }
 
 ${Availability(bits)}
-@_unavailableInEmbedded
 extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
   ///
@@ -115,7 +114,6 @@ extension ${Self}: CustomStringConvertible {
 }
 
 ${Availability(bits)}
-@_unavailableInEmbedded
 extension ${Self}: CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
   ///
@@ -131,7 +129,6 @@ extension ${Self}: CustomDebugStringConvertible {
 }
 
 ${Availability(bits)}
-@_unavailableInEmbedded
 extension ${Self}: TextOutputStreamable {
   public func write<Target>(to target: inout Target) where Target: TextOutputStream {
     var (buffer, length) = _float${bits}ToString(self, debug: true)

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -296,7 +296,6 @@ extension StaticString: ExpressibleByStringLiteral {
   }
 }
 
-@_unavailableInEmbedded
 extension StaticString: CustomStringConvertible {
 
   /// A textual representation of the static string.
@@ -305,7 +304,6 @@ extension StaticString: CustomStringConvertible {
   }
 }
 
-@_unavailableInEmbedded
 extension StaticString: CustomDebugStringConvertible {
 
   /// A textual representation of the static string, suitable for debugging.

--- a/test/embedded/string-interpolation-types.swift
+++ b/test/embedded/string-interpolation-types.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-Osize -swift-version 5 -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@main
+struct Main {
+  static func main() {
+    print("string: \("string")")
+    // CHECK: string: string
+
+    print("static string: \("string" as StaticString)")
+    // CHECK: static string: string
+
+    print("integers: \(42) \(-42) \(0xffffffff)")
+    // CHECK: integers: 42 -42 4294967295
+    
+    print("booleans: \(true) \(false)")
+    // CHECK: booleans: true false
+  }
+}


### PR DESCRIPTION
Mainly clarifying what works and what doesn't in the docs, and making Bool and StaticString CustomStringConvertible, which makes them work in string interpolations.