### PR TITLE
[Sema] Add logic to diagnose regex feature availability

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -28,6 +28,10 @@
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
+namespace llvm {
+template<typename T> class ArrayRef;
+}
+
 namespace swift {
 class Argument;
 class ASTContext;
@@ -42,6 +46,8 @@ class Identifier;
 class IfConfigClauseRangeInfo;
 struct LabeledStmtInfo;
 class ProtocolConformanceRef;
+class RegexLiteralPatternFeature;
+class RegexLiteralPatternFeatureKind;
 class Type;
 class CanType;
 class TypeBase;
@@ -1350,6 +1356,68 @@ SWIFT_NAME("BridgedPrefixUnaryExpr.createParsed(_:operator:operand:)")
 BridgedPrefixUnaryExpr
 BridgedPrefixUnaryExpr_createParsed(BridgedASTContext cContext,
                                     BridgedExpr oper, BridgedExpr operand);
+
+class BridgedRegexLiteralPatternFeatureKind final {
+  unsigned RawValue;
+
+public:
+  BRIDGED_INLINE
+  SWIFT_NAME("init(rawValue:)")
+  BridgedRegexLiteralPatternFeatureKind(SwiftInt rawValue);
+
+  using UnbridgedTy = swift::RegexLiteralPatternFeatureKind;
+
+  BRIDGED_INLINE
+  BridgedRegexLiteralPatternFeatureKind(UnbridgedTy kind);
+
+  BRIDGED_INLINE
+  UnbridgedTy unbridged() const;
+};
+
+class BridgedRegexLiteralPatternFeature final {
+  BridgedCharSourceRange Range;
+  BridgedRegexLiteralPatternFeatureKind Kind;
+
+public:
+  SWIFT_NAME("init(kind:at:)")
+  BridgedRegexLiteralPatternFeature(BridgedRegexLiteralPatternFeatureKind kind,
+                                    BridgedCharSourceRange range)
+      : Range(range), Kind(kind) {}
+
+  using UnbridgedTy = swift::RegexLiteralPatternFeature;
+
+  BRIDGED_INLINE
+  BridgedRegexLiteralPatternFeature(UnbridgedTy feature);
+
+  BRIDGED_INLINE
+  UnbridgedTy unbridged() const;
+};
+
+class BridgedRegexLiteralPatternFeatures final {
+  BridgedRegexLiteralPatternFeature *_Nullable Data;
+  SwiftInt Count;
+
+public:
+  BridgedRegexLiteralPatternFeatures() : Data(nullptr), Count(0) {}
+
+  SWIFT_NAME("init(baseAddress:count:)")
+  BridgedRegexLiteralPatternFeatures(
+      BridgedRegexLiteralPatternFeature *_Nullable data, SwiftInt count)
+      : Data(data), Count(count) {}
+
+  using UnbridgedTy = llvm::ArrayRef<BridgedRegexLiteralPatternFeature>;
+
+  BRIDGED_INLINE
+  UnbridgedTy unbridged() const;
+
+  SWIFT_IMPORT_UNSAFE
+  BridgedRegexLiteralPatternFeature *_Nullable getData() const {
+    return Data;
+  }
+  SwiftInt getCount() const {
+    return Count;
+  }
+};
 
 SWIFT_NAME("BridgedRegexLiteralExpr.createParsed(_:loc:regexText:)")
 BridgedRegexLiteralExpr

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -16,10 +16,12 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ArgumentList.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/IfConfigClauseRangeInfo.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
+#include "swift/Basic/Assertions.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -377,6 +379,40 @@ swift::IfConfigClauseRangeInfo BridgedIfConfigClauseRangeInfo::unbridged() const
                                         bodyLoc.unbridged(),
                                         endLoc.unbridged(),
                                         clauseKind);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedRegexLiteralPatternFeature
+//===----------------------------------------------------------------------===//
+
+BridgedRegexLiteralPatternFeatureKind::BridgedRegexLiteralPatternFeatureKind(
+    SwiftInt rawValue)
+    : RawValue(rawValue) {
+  ASSERT(rawValue >= 0);
+  ASSERT(rawValue == RawValue);
+}
+
+BridgedRegexLiteralPatternFeatureKind::BridgedRegexLiteralPatternFeatureKind(
+    UnbridgedTy kind)
+    : RawValue(kind.getRawValue()) {}
+
+BridgedRegexLiteralPatternFeatureKind::UnbridgedTy
+BridgedRegexLiteralPatternFeatureKind::unbridged() const {
+  return UnbridgedTy(RawValue);
+}
+
+BridgedRegexLiteralPatternFeature::BridgedRegexLiteralPatternFeature(
+    UnbridgedTy feature)
+    : Range(feature.getRange()), Kind(feature.getKind()) {}
+
+BridgedRegexLiteralPatternFeature::UnbridgedTy
+BridgedRegexLiteralPatternFeature::unbridged() const {
+  return UnbridgedTy(Kind.unbridged(), Range.unbridged());
+}
+
+BridgedRegexLiteralPatternFeatures::UnbridgedTy
+BridgedRegexLiteralPatternFeatures::unbridged() const {
+  return UnbridgedTy(Data, Count);
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -755,6 +755,9 @@ namespace swift {
     /// Add a character-based range to the currently-active diagnostic.
     InFlightDiagnostic &highlightChars(SourceLoc Start, SourceLoc End);
 
+    /// Add a character-based range to the currently-active diagnostic.
+    InFlightDiagnostic &highlightChars(CharSourceRange Range);
+
     static const char *fixItStringFor(const FixItID id);
 
     /// Get the best location where an 'import' fixit might be offered.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5962,6 +5962,10 @@ ERROR(regex_capture_types_failed_to_decode,none,
       "failed to decode capture types for regular expression literal; this may "
       "be a compiler bug", ())
 
+ERROR(regex_feature_unavailable, none,
+      "%0 is only available in %1 %2 or newer",
+      (StringRef, StringRef, llvm::VersionTuple))
+
 ERROR(must_import_regex_builder_module,none,
       "regex builder requires the 'RegexBuilder' module be imported'", ())
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -992,6 +992,50 @@ public:
   }
 };
 
+/// The opaque kind of a RegexLiteralExpr feature, which should only be
+/// interpreted by the compiler's regex parsing library.
+class RegexLiteralPatternFeatureKind final {
+  unsigned RawValue;
+
+public:
+  RegexLiteralPatternFeatureKind(unsigned rawValue) : RawValue(rawValue) {}
+
+  unsigned getRawValue() const { return RawValue; }
+
+  AvailabilityRange getAvailability(ASTContext &ctx) const;
+  StringRef getDescription(ASTContext &ctx) const;
+
+  friend llvm::hash_code
+  hash_value(const RegexLiteralPatternFeatureKind &kind) {
+    return llvm::hash_value(kind.getRawValue());
+  }
+
+  friend bool operator==(const RegexLiteralPatternFeatureKind &lhs,
+                         const RegexLiteralPatternFeatureKind &rhs) {
+    return lhs.getRawValue() == rhs.getRawValue();
+  }
+
+  friend bool operator!=(const RegexLiteralPatternFeatureKind &lhs,
+                         const RegexLiteralPatternFeatureKind &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+/// A specific feature used in a RegexLiteralExpr, needed for availability
+/// diagnostics.
+class RegexLiteralPatternFeature final {
+  RegexLiteralPatternFeatureKind Kind;
+  CharSourceRange Range;
+
+public:
+  RegexLiteralPatternFeature(RegexLiteralPatternFeatureKind kind,
+                             CharSourceRange range)
+      : Kind(kind), Range(range) {}
+
+  RegexLiteralPatternFeatureKind getKind() const { return Kind; }
+  CharSourceRange getRange() const { return Range; }
+};
+
 /// A regular expression literal e.g '(a|c)*'.
 class RegexLiteralExpr : public LiteralExpr {
   ASTContext *Ctx;
@@ -1020,6 +1064,9 @@ public:
 
   /// Retrieve the version of the regex string.
   unsigned getVersion() const;
+
+  /// Retrieve any features used in the regex pattern.
+  ArrayRef<RegexLiteralPatternFeature> getPatternFeatures() const;
 
   SourceRange getSourceRange() const { return Loc; }
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5110,6 +5110,7 @@ struct RegexLiteralPatternInfo {
   StringRef RegexToEmit;
   Type RegexType;
   size_t Version;
+  ArrayRef<RegexLiteralPatternFeature> Features;
 };
 
 /// Parses the regex pattern for a given regex literal using the
@@ -5130,6 +5131,47 @@ private:
 public:
   bool isCached() const { return true; }
 };
+
+/// The description for a given regex pattern feature. This is cached since
+/// the resulting string is allocated in the ASTContext for ease of bridging.
+class RegexLiteralFeatureDescriptionRequest
+    : public SimpleRequest<RegexLiteralFeatureDescriptionRequest,
+                           StringRef(RegexLiteralPatternFeatureKind,
+                                     ASTContext *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  StringRef evaluate(Evaluator &evaluator, RegexLiteralPatternFeatureKind kind,
+                     ASTContext *ctx) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+/// The availability range for a given regex pattern feature.
+class RegexLiteralFeatureAvailabilityRequest
+    : public SimpleRequest<RegexLiteralFeatureAvailabilityRequest,
+                           AvailabilityRange(RegexLiteralPatternFeatureKind,
+                                             ASTContext *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  AvailabilityRange evaluate(Evaluator &evaluator,
+                             RegexLiteralPatternFeatureKind kind,
+                             ASTContext *ctx) const;
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    RegexLiteralPatternFeatureKind kind);
+SourceLoc extractNearestSourceLoc(RegexLiteralPatternFeatureKind kind);
 
 class IsUnsafeRequest
     : public SimpleRequest<IsUnsafeRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -595,6 +595,12 @@ SWIFT_REQUEST(TypeChecker, SuppressesConformanceRequest,
 SWIFT_REQUEST(TypeChecker, RegexLiteralPatternInfoRequest,
               RegexLiteralPatternInfo(const RegexLiteralExpr *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RegexLiteralFeatureDescriptionRequest,
+              StringRef(RegexLiteralPatternFeatureKind, ASTContext *),
+              Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RegexLiteralFeatureAvailabilityRequest,
+              AvailabilityRange(RegexLiteralPatternFeatureKind, ASTContext *),
+              Uncached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, CaptureInfoRequest,
               CaptureInfo(AbstractFunctionDecl *),

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -413,6 +413,25 @@ public:
 #endif
 };
 
+//===----------------------------------------------------------------------===//
+// MARK: BridgedSwiftVersion
+//===----------------------------------------------------------------------===//
+
+class BridgedSwiftVersion {
+  unsigned Major;
+  unsigned Minor;
+
+public:
+  BridgedSwiftVersion() : Major(0), Minor(0) {}
+
+  BRIDGED_INLINE
+  SWIFT_NAME("init(major:minor:)")
+  BridgedSwiftVersion(SwiftInt major, SwiftInt minor);
+
+  unsigned getMajor() const { return Major; }
+  unsigned getMinor() const { return Minor; }
+};
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #ifndef PURE_BRIDGING_MODE

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_BASIC_BASICBRIDGINGIMPL_H
 #define SWIFT_BASIC_BASICBRIDGINGIMPL_H
 
+#include "swift/Basic/Assertions.h"
+
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 //===----------------------------------------------------------------------===//
@@ -121,6 +123,16 @@ BridgedCharSourceRange::BridgedCharSourceRange(swift::CharSourceRange range)
 
 swift::CharSourceRange BridgedCharSourceRange::unbridged() const {
   return swift::CharSourceRange(Start.unbridged(), ByteLength);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedSwiftVersion
+//===----------------------------------------------------------------------===//
+
+BridgedSwiftVersion::BridgedSwiftVersion(SwiftInt major, SwiftInt minor)
+    : Major(major), Minor(minor) {
+  ASSERT(major >= 0 && minor >= 0);
+  ASSERT(major == Major && minor == Minor);
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -103,12 +103,22 @@ bool swift_ASTGen_lexRegexLiteral(const char *_Nonnull *_Nonnull curPtrPtr,
                                   bool mustBeRegex,
                                   BridgedNullableDiagnosticEngine diagEngine);
 
-bool swift_ASTGen_parseRegexLiteral(BridgedStringRef inputPtr,
-                                    size_t *_Nonnull versionOut,
-                                    void *_Nonnull UnsafeMutableRawPointer,
-                                    size_t captureStructureSize,
-                                    BridgedSourceLoc diagLoc,
-                                    BridgedDiagnosticEngine diagEngine);
+bool swift_ASTGen_parseRegexLiteral(
+    BridgedStringRef inputPtr, size_t *_Nonnull versionOut,
+    void *_Nonnull UnsafeMutableRawPointer, size_t captureStructureSize,
+    BridgedRegexLiteralPatternFeatures *_Nonnull featuresOut,
+    BridgedSourceLoc diagLoc, BridgedDiagnosticEngine diagEngine);
+
+void swift_ASTGen_freeBridgedRegexLiteralPatternFeatures(
+    BridgedRegexLiteralPatternFeatures features);
+
+void swift_ASTGen_getSwiftVersionForRegexPatternFeature(
+    BridgedRegexLiteralPatternFeatureKind kind,
+    BridgedSwiftVersion *_Nonnull versionOut);
+
+void swift_ASTGen_getDescriptionForRegexPatternFeature(
+    BridgedRegexLiteralPatternFeatureKind kind, BridgedASTContext astContext,
+    BridgedStringRef *_Nonnull descriptionOut);
 
 intptr_t swift_ASTGen_configuredRegions(
     BridgedASTContext astContext,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -225,6 +225,13 @@ InFlightDiagnostic &InFlightDiagnostic::highlightChars(SourceLoc Start,
   return *this;
 }
 
+InFlightDiagnostic &InFlightDiagnostic::highlightChars(CharSourceRange Range) {
+  assert(IsActive && "Cannot modify an inactive diagnostic");
+  if (Engine && Range.getStart().isValid())
+    Engine->getActiveDiagnostic().addRange(Range);
+  return *this;
+}
+
 /// Add an insertion fix-it to the currently-active diagnostic.  The
 /// text is inserted immediately *after* the token specified.
 ///

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2772,6 +2772,28 @@ unsigned RegexLiteralExpr::getVersion() const {
       .Version;
 }
 
+ArrayRef<RegexLiteralPatternFeature>
+RegexLiteralExpr::getPatternFeatures() const {
+  auto &eval = getASTContext().evaluator;
+  return evaluateOrDefault(eval, RegexLiteralPatternInfoRequest{this}, {})
+      .Features;
+}
+
+StringRef
+RegexLiteralPatternFeatureKind::getDescription(ASTContext &ctx) const {
+  auto &eval = ctx.evaluator;
+  return evaluateOrDefault(
+      eval, RegexLiteralFeatureDescriptionRequest{*this, &ctx}, {});
+}
+
+AvailabilityRange
+RegexLiteralPatternFeatureKind::getAvailability(ASTContext &ctx) const {
+  auto &eval = ctx.evaluator;
+  return evaluateOrDefault(eval,
+                           RegexLiteralFeatureAvailabilityRequest{*this, &ctx},
+                           AvailabilityRange::alwaysAvailable());
+}
+
 TypeJoinExpr::TypeJoinExpr(llvm::PointerUnion<DeclRefExpr *, TypeBase *> result,
                            ArrayRef<Expr *> elements, SingleValueStmtExpr *SVE)
     : Expr(ExprKind::TypeJoin, /*implicit=*/true, Type()), Var(nullptr),

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -99,6 +99,15 @@ void swift::simple_display(llvm::raw_ostream &out, const TypeLoc source) {
   out << ")";
 }
 
+void swift::simple_display(llvm::raw_ostream &out,
+                           RegexLiteralPatternFeatureKind kind) {
+  out << "regex pattern feature " << kind.getRawValue();
+}
+
+SourceLoc swift::extractNearestSourceLoc(RegexLiteralPatternFeatureKind kind) {
+  return SourceLoc();
+}
+
 //----------------------------------------------------------------------------//
 // Inherited type computation.
 //----------------------------------------------------------------------------//

--- a/lib/ASTGen/Sources/ASTGen/Regex.swift
+++ b/lib/ASTGen/Sources/ASTGen/Regex.swift
@@ -98,6 +98,7 @@ public func _RegexLiteralParsingFn(
   _ versionOut: UnsafeMutablePointer<UInt>,
   _ captureStructureOut: UnsafeMutableRawPointer,
   _ captureStructureSize: UInt,
+  _ patternFeaturesOut: UnsafeMutablePointer<BridgedRegexLiteralPatternFeatures>,
   _ bridgedDiagnosticBaseLoc: BridgedSourceLoc,
   _ bridgedDiagnosticEngine: BridgedDiagnosticEngine
 ) -> Bool {
@@ -113,6 +114,8 @@ public func _RegexLiteralParsingFn(
       str,
       captureBufferOut: captureBuffer
     )
+    // TODO: -> [Feature(opaque kind, (String.Index, length))]
+    patternFeaturesOut.pointee = .init(baseAddress: nil, count: 0)
     versionOut.pointee = UInt(version)
     return false
   } catch let error as CompilerParseError {
@@ -134,6 +137,36 @@ public func _RegexLiteralParsingFn(
   } catch {
     fatalError("Expected CompilerParseError")
   }
+}
+
+@_cdecl("swift_ASTGen_freeBridgedRegexLiteralPatternFeatures")
+func freeBridgedRegexLiteralPatternFeatures(
+  _ features: BridgedRegexLiteralPatternFeatures
+) {
+  let buffer = UnsafeMutableBufferPointer(
+    start: features.getData(), count: features.getCount()
+  )
+  buffer.deinitialize()
+  buffer.deallocate()
+}
+
+@_cdecl("swift_ASTGen_getSwiftVersionForRegexPatternFeature")
+func getSwiftVersionForRegexPatternFeature(
+  _ featureKind: BridgedRegexLiteralPatternFeatureKind,
+  _ versionOut: UnsafeMutablePointer<BridgedSwiftVersion>
+) {
+  // TODO: FeatureKind(opaque kind) -> Version(major, minor)
+  fatalError("Unimplemented")
+}
+
+@_cdecl("swift_ASTGen_getDescriptionForRegexPatternFeature")
+func getDescriptionForRegexPatternFeature(
+  _ featureKind: BridgedRegexLiteralPatternFeatureKind,
+  _ context: BridgedASTContext,
+  _ descriptionOut: UnsafeMutablePointer<BridgedStringRef>
+) {
+  // TODO: FeatureKind(opaque kind) -> String
+  fatalError("Unimplemented")
 }
 
 #else  // canImport(_CompilerRegexParser)

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2098,15 +2098,15 @@ static void fixAvailability(SourceRange ReferenceRange,
 }
 
 static void diagnosePotentialUnavailability(
-    SourceRange ReferenceRange, Diag<StringRef, llvm::VersionTuple> Diag,
+    SourceRange ReferenceRange,
+    llvm::function_ref<InFlightDiagnostic(StringRef, llvm::VersionTuple)>
+        Diagnose,
     const DeclContext *ReferenceDC, const AvailabilityRange &Availability) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
   {
-    auto Err = Context.Diags.diagnose(
-        ReferenceRange.Start, Diag,
-        Context.getTargetPlatformStringForDiagnostics(),
-        Availability.getRawMinimumVersion());
+    auto Err = Diagnose(Context.getTargetPlatformStringForDiagnostics(),
+                        Availability.getRawMinimumVersion());
 
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(
@@ -2116,10 +2116,11 @@ static void diagnosePotentialUnavailability(
   fixAvailability(ReferenceRange, ReferenceDC, Availability, Context);
 }
 
-bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
-                                    AvailabilityRange RequiredAvailability,
-                                    Diag<StringRef, llvm::VersionTuple> Diag,
-                                    const DeclContext *ReferenceDC) {
+bool TypeChecker::checkAvailability(
+    SourceRange ReferenceRange, AvailabilityRange RequiredAvailability,
+    const DeclContext *ReferenceDC,
+    llvm::function_ref<InFlightDiagnostic(StringRef, llvm::VersionTuple)>
+        Diagnose) {
   ASTContext &ctx = ReferenceDC->getASTContext();
   if (ctx.LangOpts.DisableAvailabilityChecking)
     return false;
@@ -2128,12 +2129,25 @@ bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
       TypeChecker::overApproximateAvailabilityAtLocation(ReferenceRange.Start,
                                                          ReferenceDC);
   if (!availabilityAtLocation.isContainedIn(RequiredAvailability)) {
-    diagnosePotentialUnavailability(ReferenceRange, Diag, ReferenceDC,
+    diagnosePotentialUnavailability(ReferenceRange, Diagnose, ReferenceDC,
                                     RequiredAvailability);
     return true;
   }
 
   return false;
+}
+
+bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
+                                    AvailabilityRange RequiredAvailability,
+                                    Diag<StringRef, llvm::VersionTuple> Diag,
+                                    const DeclContext *ReferenceDC) {
+  auto &Diags = ReferenceDC->getASTContext().Diags;
+  return TypeChecker::checkAvailability(
+      ReferenceRange, RequiredAvailability, ReferenceDC,
+      [&](StringRef platformName, llvm::VersionTuple version) {
+        return Diags.diagnose(ReferenceRange.Start, Diag, platformName,
+                              version);
+      });
 }
 
 void TypeChecker::checkConcurrencyAvailability(SourceRange ReferenceRange,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1052,6 +1052,12 @@ checkConformanceAvailability(const RootProtocolConformance *Conf,
                              const ExtensionDecl *Ext,
                              const ExportContext &Where);
 
+bool checkAvailability(
+    SourceRange ReferenceRange, AvailabilityRange RequiredAvailability,
+    const DeclContext *ReferenceDC,
+    llvm::function_ref<InFlightDiagnostic(StringRef, llvm::VersionTuple)>
+        Diagnose);
+
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityRange RequiredAvailability,
                        Diag<StringRef, llvm::VersionTuple> Diag,


### PR DESCRIPTION
Add the necessary compiler-side logic to allow the regex parsing library to hand back a set of features for a regex literal, which can then be diagnosed by ExprAvailabilityWalker if the availability context isn't sufficient. No tests as this only adds the necessary infrastructure, we don't yet hand back the features from the regex parsing library.