### PR TITLE
[SymbolGraphGen] improve handling of underscored protocols

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -315,9 +315,13 @@ bool SymbolGraph::synthesizedMemberIsBestCandidate(const ValueDecl *VD,
 }
 
 void SymbolGraph::recordConformanceSynthesizedMemberRelationships(Symbol S) {
-  if (!Walker.Options.EmitSynthesizedMembers || Walker.Options.SkipProtocolImplementations) {
-    return;
-  }
+  // Even if we don't want to emit synthesized members or protocol
+  // implementations, we still want to emit synthesized members from hidden
+  // underscored protocols. Save this check so we can skip emitting members
+  // later if needed.
+  bool dropSynthesizedMembers = !Walker.Options.EmitSynthesizedMembers ||
+                                Walker.Options.SkipProtocolImplementations;
+
   const auto D = S.getLocalSymbolDecl();
   const NominalTypeDecl *OwningNominal = nullptr;
   if (const auto *ThisNominal = dyn_cast<NominalTypeDecl>(D)) {
@@ -341,59 +345,89 @@ void SymbolGraph::recordConformanceSynthesizedMemberRelationships(Symbol S) {
       PrintOptions::printModuleInterface(
           OwningNominal->getASTContext().TypeCheckerOpts.PrintFullConvention));
   auto MergeGroupKind = SynthesizedExtensionAnalyzer::MergeGroupKind::All;
-  ExtensionAnalyzer.forEachExtensionMergeGroup(MergeGroupKind,
-      [&](ArrayRef<ExtensionInfo> ExtensionInfos){
-    for (const auto &Info : ExtensionInfos) {
-      if (!Info.IsSynthesized) {
-        continue;
-      }
+  ExtensionAnalyzer.forEachExtensionMergeGroup(
+      MergeGroupKind, [&](ArrayRef<ExtensionInfo> ExtensionInfos) {
+        const auto StdlibModule =
+            OwningNominal->getASTContext().getStdlibModule(
+                /*loadIfAbsent=*/true);
 
-      // We are only interested in synthesized members that come from an
-      // extension that we defined in our module.
-      if (Info.EnablingExt) {
-        const auto *ExtM = Info.EnablingExt->getModuleContext();
-        if (!Walker.isOurModule(ExtM))
-          continue;
-      }
-
-      // If D is not the OwningNominal, it is an ExtensionDecl. In that case
-      // we only want to get members that were enabled by this exact extension.
-      if (D != OwningNominal && Info.EnablingExt != D) {
-        continue;
-      }
-  
-      for (const auto ExtensionMember : Info.Ext->getMembers()) {
-        if (const auto SynthMember = dyn_cast<ValueDecl>(ExtensionMember)) {
-          if (SynthMember->isObjC()) {
+        for (const auto &Info : ExtensionInfos) {
+          if (!Info.IsSynthesized) {
             continue;
           }
 
-          const auto StdlibModule = OwningNominal->getASTContext()
-              .getStdlibModule(/*loadIfAbsent=*/true);
+          // We are only interested in synthesized members that come from an
+          // extension that we defined in our module.
+          if (Info.EnablingExt) {
+            const auto *ExtM = Info.EnablingExt->getModuleContext();
+            if (!Walker.isOurModule(ExtM))
+              continue;
+          }
 
-          // There can be synthesized members on effectively private protocols
-          // or things that conform to them. We don't want to include those.
-          if (isImplicitlyPrivate(SynthMember,
-              /*IgnoreContext =*/
-              SynthMember->getModuleContext() == StdlibModule)) {
+          // If D is not the OwningNominal, it is an ExtensionDecl. In that case
+          // we only want to get members that were enabled by this exact
+          // extension.
+          if (D != OwningNominal && Info.EnablingExt != D) {
             continue;
           }
 
-          if (!synthesizedMemberIsBestCandidate(SynthMember, OwningNominal)) {
+          // Extensions to protocols should generate synthesized members only if
+          // that protocol would otherwise be hidden.
+          if (auto *Nominal = Info.Ext->getExtendedNominal()) {
+            if (dropSynthesizedMembers &&
+                !isImplicitlyPrivate(
+                    Nominal, /*IgnoreContext =*/Nominal->getModuleContext() ==
+                                 StdlibModule))
+              continue;
+          } else if (dropSynthesizedMembers) {
             continue;
           }
 
-          auto ExtendedSG = Walker.getModuleSymbolGraph(OwningNominal);
+          for (const auto ExtensionMember : Info.Ext->getMembers()) {
+            if (const auto SynthMember = dyn_cast<ValueDecl>(ExtensionMember)) {
+              if (SynthMember->isObjC()) {
+                continue;
+              }
 
-          Symbol Source(this, SynthMember, OwningNominal);
+              // There can be synthesized members on effectively private
+              // protocols or things that conform to them. We don't want to
+              // include those.
+              if (isImplicitlyPrivate(SynthMember,
+                                      /*IgnoreContext =*/
+                                      SynthMember->getModuleContext() ==
+                                          StdlibModule)) {
+                continue;
+              }
 
-          ExtendedSG->Nodes.insert(Source);
+              if (!synthesizedMemberIsBestCandidate(SynthMember,
+                                                    OwningNominal)) {
+                continue;
+              }
 
-          ExtendedSG->recordEdge(Source, S, RelationshipKind::MemberOf());
-         }
-      }
-    }
-  });
+              Symbol Source(this, SynthMember, OwningNominal);
+
+              if (auto *InheritedDecl = Source.getInheritedDecl()) {
+                if (auto *ParentDecl =
+                        InheritedDecl->getDeclContext()->getAsDecl()) {
+                  if (dropSynthesizedMembers &&
+                      !isImplicitlyPrivate(
+                          ParentDecl,
+                          /*IgnoreContext =*/ParentDecl->getModuleContext() ==
+                              StdlibModule)) {
+                    continue;
+                  }
+                }
+              }
+
+              auto ExtendedSG = Walker.getModuleSymbolGraph(OwningNominal);
+
+              ExtendedSG->Nodes.insert(Source);
+
+              ExtendedSG->recordEdge(Source, S, RelationshipKind::MemberOf());
+            }
+          }
+        }
+      });
 }
 
 void

--- a/test/SymbolGraph/ClangImporter/ErrorEnum.swift
+++ b/test/SymbolGraph/ClangImporter/ErrorEnum.swift
@@ -1,0 +1,48 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-symbolgraph-extract -sdk %sdk -module-name MyError -I %t/MyError -output-dir %t -pretty-print -v -skip-protocol-implementations
+// RUN: %FileCheck %s --input-file %t/MyError.symbols.json
+
+// CHECK-NOT: "sourceOrigin"
+
+// CHECK-NOT: "displayName": "_BridgedStoredNSError.Code"
+
+// == is implemented as part of the hidden _BridgedStoredNSError protocol,
+// but it should be hidden since it ultimately comes from Equatable
+// CHECK-NOT: "precise": "s:10Foundation21_BridgedStoredNSErrorPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:SC11MyErrorCodeLeV"
+
+// hash(into:) is implemented as part of an extension on that same protocol,
+// but it should be hidden for a similar reason
+// CHECK-NOT: "precise": "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@MyErrorCode"
+
+// MyErrorCode.Code
+// CHECK-DAG: "precise": "c:@E@MyErrorCode"
+
+// MyErrorCode.Code.init(rawValue:)
+// CHECK-DAG: "precise": "s:So11MyErrorCodeV8rawValueABSgs5Int32V_tcfc"
+
+// the following header and module map were copied from test/SourceKit/DocSupport/Inputs
+//--- MyError/module.modulemap
+module "MyError" {
+  header "MyError.h"
+  export *
+}
+
+//--- MyError/MyError.h
+@import Foundation;
+
+#define NS_ERROR_ENUM(_type, _name, _domain)  \
+  enum _name : _type _name; enum __attribute__((ns_error_domain(_domain))) _name : _type
+
+@class NSString;
+extern const NSString *const MyErrorDomain;
+/// This is my cool error code.
+typedef NS_ERROR_ENUM(int, MyErrorCode, MyErrorDomain) {
+  /// This is first error.
+  MyErrFirst,
+  /// This is second error.
+  MyErrSecond,
+};

--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -36,10 +36,9 @@
 // There should only be three symbols with sourceOrigin information:
 // - SomeStruct.otherFunc()
 // - ExtraStruct.Inner
-// - HiddenStruct.T
 // (ExtraStruct.Inner will have two sourceOrigins because it has two relationships: a memberOf and a
 // conformsTo)
-// COUNT-COUNT-4: sourceOrigin
+// COUNT-COUNT-3: sourceOrigin
 // COUNT-NOT: sourceOrigin
 
 public protocol SomeProtocol {

--- a/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
+++ b/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
@@ -2,14 +2,34 @@
 // RUN: %target-build-swift %s -module-name UnderscoredProtocols -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name UnderscoredProtocols -I %t -pretty-print -output-dir %t
 
+// RUN: %FileCheck %s --input-file %t/UnderscoredProtocols.symbols.json
+
 // Make sure that underscored protocols do not appear in public symbol graphs, but their
 // requirements do appear on types which conform to them.
 
+// Also ensure that default implementations of underscored protocols appear on implementing types as
+// if they were native children of that type. No 'sourceOrigin' information should appear in their
+// relationships and no implementation relationships should exist.
+
+// CHECK-DAG: "precise": "s:20UnderscoredProtocols10SomeStructV8someFuncyyF",
+// CHECK-DAG: "precise": "s:20UnderscoredProtocols15_HiddenProtocolPAAE9bonusFuncyyF::SYNTHESIZED::s:20UnderscoredProtocols10SomeStructV"
+
 // CHECK-NOT: "precise": "s:20UnderscoredProtocols15_HiddenProtocolP",
-// CHECK:     "precise": "s:20UnderscoredProtocols10SomeStructV8someFuncyyF",
+
+// CHECK-NOT: "defaultImplementationOf"
+// CHECK-NOT: "requirementOf"
+// CHECK-NOT: "optionalRequirementOf"
+// CHECK-NOT: "overrides"
+
+// CHECK-NOT: "sourceOrigin"
+// CHECK-NOT: "s:20UnderscoredProtocols15_HiddenProtocolPAAE9bonusFuncyyF"
 
 public protocol _HiddenProtocol {
     func someFunc()
+}
+
+extension _HiddenProtocol {
+    public func bonusFunc() {}
 }
 
 public struct SomeStruct {}

--- a/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
+++ b/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
@@ -1,7 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name UnderscoredProtocols -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name UnderscoredProtocols -I %t -pretty-print -output-dir %t
 
+// RUN: %target-swift-symbolgraph-extract -module-name UnderscoredProtocols -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnderscoredProtocols.symbols.json
+
+// RUN: %target-swift-symbolgraph-extract -module-name UnderscoredProtocols -I %t -skip-protocol-implementations -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/UnderscoredProtocols.symbols.json
 
 // Make sure that underscored protocols do not appear in public symbol graphs, but their


### PR DESCRIPTION
Resolves rdar://124483146, resolves rdar://128143861

This PR aims to improve SymbolGraphGen's handling of "underscored protocols". These protocols are meant to be treated as an implementation detail and not surfaced in public documentation themselves, even if their methods are meant to be public. An example is the standard library's `_ArrayProtocol`, which a handful of types conform to as part of their Collection conformances. Currently, the symbols that are synthesized as part of `_ArrayProtocol` contain `sourceOrigin` information that surfaces this protocol, which Swift-DocC then uses to sort these symbols under an `_ArrayProtocol Implementations` collection page. These methods should instead be treated as native children of the conforming type, discarding any trace of the actual protocol itself.

In addition, extensions on these underscored protocols are discarded due to their owning extension adding them to a "private" symbol. We should treat these symbols as natively public and add them to documentation.

This PR also changes the "synthesized symbols" behavior to add synthesized symbols for underscored protocols, even when the user has asked to ignore synthesized symbols or protocol implementations. This should improve the handling of projects that build with `-skip-protocol-implementations` but use underscored protocols, even indirectly via Foundation or the like.