### PR TITLE
Sema: Only diagnose explicit unavailable Clang enum elements

### DIFF
--- a/test/ClangImporter/availability_macosx.swift
+++ b/test/ClangImporter/availability_macosx.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: OS=macosx
 
+import AppKit
 import Foundation
 import AvailabilityExtras
 
@@ -13,4 +14,36 @@ func test_unavailable_because_deprecated() {
 
 func test_swift_unavailable_wins() {
   unavailableWithOS() // expected-error {{'unavailableWithOS()' is unavailable in Swift}}
+}
+
+func bezierPathElementToInteger(_ e: NSBezierPathElement) -> Int {
+  switch e {
+  case .moveTo: return 1
+  case .lineTo: return 2
+  case .curveTo: return 3 // no error
+  case .cubicCurveTo: return 3
+  case .closePath: return 4
+  case .quadraticCurveTo: return 5
+  @unknown default: return -1
+  }
+}
+
+func integerToBezierPathElement(_ i: Int) -> NSBezierPathElement {
+  // expected-note@-1 2 {{add @available attribute to enclosing global function}}
+  switch i {
+  case 1:
+    return .moveTo
+  case 2:
+    return .lineTo
+  case 3:
+    return .curveTo // expected-error {{'curveTo' is only available in}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  case 4:
+    return .closePath
+  case 5:
+    return .quadraticCurveTo // expected-error {{'quadraticCurveTo' is only available in}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    fatalError()
+  }
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -306,3 +306,12 @@ typedef NSPoint *NSPointPointer;
 @interface NSDocument (URL)
 @property (copy,nonnull) NSURL *URL;
 @end
+
+typedef NS_ENUM(NSUInteger, NSBezierPathElement) {
+    NSBezierPathElementMoveTo,
+    NSBezierPathElementLineTo,
+    NSBezierPathElementCubicCurveTo __attribute__((availability(macosx,introduced=52))),
+    NSBezierPathElementClosePath,
+    NSBezierPathElementQuadraticCurveTo __attribute__((availability(macosx,introduced=52))),
+    NSBezierPathElementCurveTo __attribute__((availability(macosx,introduced=51,deprecated=52,message="Use NSBezierPathElementCubicCurveTo"))) = NSBezierPathElementCubicCurveTo,
+};


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/77236 caused a source compatibility regression because `extractEnumElement()` does not suppress its diagnostics in the context of pattern matching. Potentially unavailable enum elements should not be diagnosed when pattern matching since the generated code will not retrieve the potentially unavailable element value on versions where it is unavailable.

Fixes rdar://138771328.
