### PR TITLE
Fix missing serialization type registration code on Builtin.FixedArray

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 898; // interface-compiler-version
+const uint16_t SWIFTMODULE_VERSION_MINOR = 899; // Builtin.FixedArray serialize
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -6134,6 +6134,7 @@ void Serializer::writeAllDeclsAndTypes() {
   BCBlockRAII restoreBlock(Out, DECLS_AND_TYPES_BLOCK_ID, 9);
   using namespace decls_block;
   registerDeclTypeAbbr<BuiltinAliasTypeLayout>();
+  registerDeclTypeAbbr<BuiltinFixedArrayTypeLayout>();
   registerDeclTypeAbbr<TypeAliasTypeLayout>();
   registerDeclTypeAbbr<GenericTypeParamDeclLayout>();
   registerDeclTypeAbbr<AssociatedTypeDeclLayout>();

--- a/test/Prototypes/Vector.swift
+++ b/test/Prototypes/Vector.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-target %module-target-future -enable-experimental-feature ValueGenerics -enable-experimental-feature BuiltinModule -Xfrontend -disable-experimental-parser-round-trip) | %FileCheck %s
+// RUN: %target-swift-frontend -target %module-target-future -enable-experimental-feature ValueGenerics -enable-experimental-feature BuiltinModule -disable-experimental-parser-round-trip -emit-module %s -o %t/Vector.swiftmodule
 
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Without this, serialization currently crashes when serializing Builtin.FixedArray:
```
Assertion failed: (AbbrevNo < CurAbbrevs.size() && "Invalid abbrev #!"), function EmitRecordWithAbbrevImpl, file BitstreamWriter.h, line 387.
...
7  swift-frontend           0x0000000106347fe4 void llvm::BitstreamWriter::EmitAbbreviatedField<unsigned long long>(llvm::BitCodeAbbrevOp const&, unsigned long long) (.cold.1) + 0
8  swift-frontend           0x0000000100dcb380 void llvm::BitstreamWriter::EmitRecordWithAbbrevImpl<unsigned long long>(unsigned int, llvm::ArrayRef<unsigned long long>, llvm::StringRef, std::__1::optional<unsigned int>) + 1128
```

Added -emit-module to the existing test in test/Prototypes/Vector.swift.
