### PR TITLE
Sema: Correctly treat overloads in unavailable extensions as unavailable

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4676,20 +4676,14 @@ void ConstraintSystem::diagnoseFailureFor(SyntacticElementTarget target) {
 
 bool ConstraintSystem::isDeclUnavailable(const Decl *D,
                                          ConstraintLocator *locator) const {
-  // First check whether this declaration is universally unavailable.
-  if (D->getAttrs().isUnavailable(getASTContext()))
-    return true;
+  SourceLoc loc;
+  if (locator) {
+    if (auto anchor = locator->getAnchor())
+      loc = getLoc(anchor);
+  }
 
-  return TypeChecker::isDeclarationUnavailable(D, DC, [&] {
-    SourceLoc loc;
-
-    if (locator) {
-      if (auto anchor = locator->getAnchor())
-        loc = getLoc(anchor);
-    }
-
-    return TypeChecker::overApproximateAvailabilityAtLocation(loc, DC);
-  });
+  auto availabilityContext = TypeChecker::availabilityAtLocation(loc, DC);
+  return checkDeclarationAvailability(D, DC, availabilityContext).has_value();
 }
 
 bool ConstraintSystem::isConformanceUnavailable(ProtocolConformanceRef conformance,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2205,6 +2205,8 @@ diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
                                 const AvailabilityRange &Availability,
                                 bool WarnBeforeDeploymentTarget = false) {
   ASTContext &Context = ReferenceDC->getASTContext();
+  if (Context.LangOpts.DisableAvailabilityChecking)
+    return false;
 
   bool IsError;
   {
@@ -3100,8 +3102,6 @@ swift::checkDeclarationAvailability(const Decl *decl,
                                     const DeclContext *declContext,
                                     AvailabilityContext availabilityContext) {
   auto &ctx = declContext->getASTContext();
-  if (ctx.LangOpts.DisableAvailabilityChecking)
-    return std::nullopt;
 
   // Generic parameters are always available.
   if (isa<GenericTypeParamDecl>(decl))
@@ -4150,6 +4150,7 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
 
   auto *DC = Where.getDeclContext();
   auto &ctx = DC->getASTContext();
+
   auto unmetRequirement =
       checkDeclarationAvailability(D, DC, Where.getAvailability());
   auto requiredRange =

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -39,6 +39,9 @@
 ///     is called.
 @_transparent
 @_unavailableInEmbedded
+#if $Embedded
+@_disfavoredOverload
+#endif
 public func assert(
   _ condition: @autoclosure () -> Bool,
   _ message: @autoclosure () -> String = String(),
@@ -99,6 +102,9 @@ public func assert(
 ///     `precondition(_:_:file:line:)` is called.
 @_transparent
 @_unavailableInEmbedded
+#if $Embedded
+@_disfavoredOverload
+#endif
 public func precondition(
   _ condition: @autoclosure () -> Bool,
   _ message: @autoclosure () -> String = String(),
@@ -162,6 +168,9 @@ public func precondition(
 @inlinable
 @inline(__always)
 @_unavailableInEmbedded
+#if $Embedded
+@_disfavoredOverload
+#endif
 public func assertionFailure(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
@@ -221,6 +230,9 @@ public func assertionFailure(
 ///     line number where `preconditionFailure(_:file:line:)` is called.
 @_transparent
 @_unavailableInEmbedded
+#if $Embedded
+@_disfavoredOverload
+#endif
 public func preconditionFailure(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
@@ -264,6 +276,9 @@ public func preconditionFailure(
 ///     line number where `fatalError(_:file:line:)` is called.
 @_transparent
 @_unavailableInEmbedded
+#if $Embedded
+@_disfavoredOverload
+#endif
 public func fatalError(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -64,3 +64,25 @@ extension Box where T == Int {
   // memberwise initializer.
   _ = Box(value: 42)
 }
+
+// rdar://87403752 - ambiguity with member declared in unavailable extension
+struct HasUnavailableExtesion {
+}
+
+@available(*, unavailable)
+extension HasUnavailableExtesion {
+  static var foo: Self = HasUnavailableExtesion()
+}
+
+func test_contextual_member_with_unavailable_extension() {
+  struct A {
+    static var foo: A = A()
+  }
+
+  struct Test {
+    init(_: A) {}
+    init(_: HasUnavailableExtesion) {}
+  }
+
+  _ = Test(.foo) // Ok `A.foo` since `foo` from `HasUnavailableExtesion` is unavailable
+}

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -21,8 +21,8 @@ public func universally_unavailable() { }
 @_unavailableInEmbedded
 public func unused() { } // no error
 
-public struct S1 {}
-public struct S2 {}
+public struct S1 {} // expected-note {{found this candidate}}
+public struct S2 {} // expected-note {{found this candidate}}
 
 @_unavailableInEmbedded
 public func has_unavailable_in_embedded_overload(_ s1: S1) { }
@@ -47,11 +47,11 @@ public func available(
 @_unavailableInEmbedded
 public func also_unavailable_in_embedded(
   _ uie: UnavailableInEmbedded, // OK
-  _ uu: UniverallyUnavailable // FIXME: should be an error
+  _ uu: UniverallyUnavailable // OK
 ) {
   unavailable_in_embedded() // OK
   universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
-  has_unavailable_in_embedded_overload(.init()) // FIXME: should be ambiguous
+  has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }
 


### PR DESCRIPTION
Instead of checking for unavailability attributes directly in the solver, which does not correctly handle members of unavailable extensions, query `checkDeclarationAvailability()` instead. By using the same underlying logic as the availability checker the constraint solver can be confident in the accuracy of this result.

Now that availability of overloads is being checked consistently, an ambiguity in Embedded Swift has been revealed. Functions like `fatalError()` have overloads for Embedded Swift only that take `StaticString` instead of `String`, since `String` is unavailable. Unfortunately, many of these overloads create the opportunity for ambiguity in certain unavailable contexts. The easiest way to avoid the ambiguities is to mark each of the overloads taking `String` as `@_disfavoredOverload`. Another approach that could work would be to remove the default arguments from the `String` variants in Embedded Swift only, but that would create even more duplication of source code so it doesn't seem worth it.

Resolves rdar://87403752.
