### PR TITLE
Cherrypick fixes for issue 74866 to release/6.0

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -80,6 +80,10 @@ class BridgedDeclBaseName {
   BridgedIdentifier Ident;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedDeclBaseName() : Ident() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedDeclBaseName(swift::DeclBaseName baseName) : Ident(baseName.Ident) {}
 
@@ -106,6 +110,10 @@ class BridgedDeclNameRef {
   void *_Nonnull opaque;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedDeclNameRef() : opaque() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedDeclNameRef(swift::DeclNameRef name) : opaque(name.getOpaqueValue()) {}
 
@@ -162,6 +170,10 @@ class BridgedASTContext {
   swift::ASTContext * _Nonnull Ctx;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedASTContext() : Ctx() {}
+
 #ifdef USED_IN_CPP_SOURCE
   SWIFT_UNAVAILABLE("Use init(raw:) instead")
   BridgedASTContext(swift::ASTContext &ctx) : Ctx(&ctx) {}
@@ -317,6 +329,10 @@ class BridgedDiagnosticArgument {
   int64_t storage[3];
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedDiagnosticArgument() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg) {
     *reinterpret_cast<swift::DiagnosticArgument *>(&storage) = arg;
@@ -334,6 +350,10 @@ class BridgedDiagnosticFixIt {
   int64_t storage[7];
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedDiagnosticFixIt() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedDiagnosticFixIt(const swift::DiagnosticInfo::FixIt &fixit){
     *reinterpret_cast<swift::DiagnosticInfo::FixIt *>(&storage) = fixit;
@@ -1333,6 +1353,10 @@ class BridgedStmtConditionElement {
   void *_Nonnull Raw;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedStmtConditionElement() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedStmtConditionElement(swift::StmtConditionElement elem)
       : Raw(elem.getOpaqueValue()) {}

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -23,6 +23,15 @@
 // Pure bridging mode does not permit including any C++/llvm/swift headers.
 // See also the comments for `BRIDGING_MODE` in the top-level CMakeLists.txt file.
 //
+//
+// Note: On Windows ARM64, how a C++ struct/class value type is
+// returned is sensitive to conditions including whether a
+// user-defined constructor exists, etc. See
+// https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170#return-values
+// So, if a C++ struct/class type is returned as a value between Swift
+// and C++, we need to be careful to match the return convention
+// matches between the non-USED_IN_CPP_SOURCE (Swift) side and the
+// USE_IN_CPP_SOURCE (C++) side.
 #include "swift/Basic/BridgedSwiftObject.h"
 #include "swift/Basic/Compiler.h"
 
@@ -228,6 +237,10 @@ class BridgedOwnedString {
   size_t Length;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedOwnedString() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedOwnedString(const std::string &stringToCopy);
 

--- a/include/swift/Parse/ParseBridging.h
+++ b/include/swift/Parse/ParseBridging.h
@@ -30,6 +30,10 @@ class BridgedLegacyParser {
   swift::Parser *_Nonnull const handle;
 
 public:
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedLegacyParser() : handle(nullptr) {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedLegacyParser(swift::Parser &P) : handle(&P) {}
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -82,6 +82,10 @@ struct BridgedResultInfo {
   swift::TypeBase * _Nonnull type;
   BridgedResultConvention convention;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedResultInfo() {}
+
 #ifdef USED_IN_CPP_SOURCE
   inline static BridgedResultConvention
   castToResultConvention(swift::ResultConvention convention) {
@@ -99,6 +103,10 @@ struct OptionalBridgedResultInfo {
   swift::TypeBase * _Nullable type = nullptr;
   BridgedResultConvention convention = BridgedResultConvention::Indirect;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  OptionalBridgedResultInfo() {}
+
 #ifdef USED_IN_CPP_SOURCE
   OptionalBridgedResultInfo(std::optional<swift::SILResultInfo> resultInfo) {
     if (resultInfo) {
@@ -112,6 +120,10 @@ struct OptionalBridgedResultInfo {
 
 struct BridgedResultInfoArray {
   BridgedArrayRef resultInfoArray;
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedResultInfoArray() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedResultInfoArray(llvm::ArrayRef<swift::SILResultInfo> results)
@@ -195,6 +207,10 @@ struct BridgedParameterInfo {
 struct BridgedParameterInfoArray {
   BridgedArrayRef parameterInfoArray;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedParameterInfoArray() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedParameterInfoArray(llvm::ArrayRef<swift::SILParameterInfo> parameters)
     : parameterInfoArray(parameters) {}
@@ -212,6 +228,10 @@ struct BridgedParameterInfoArray {
 
 struct BridgedYieldInfoArray {
   BridgedArrayRef yieldInfoArray;
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedYieldInfoArray() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedYieldInfoArray(llvm::ArrayRef<swift::SILYieldInfo> yields)
@@ -303,6 +323,10 @@ struct BridgedType {
   struct EnumElementIterator {
     uint64_t storage[4];
 
+    // Ensure that this struct value type will be indirectly returned on
+    // Windows ARM64
+    EnumElementIterator() {}
+
 #ifdef USED_IN_CPP_SOURCE
     EnumElementIterator(swift::EnumDecl::ElementRange::iterator i) {
       static_assert(sizeof(EnumElementIterator) >= sizeof(swift::EnumDecl::ElementRange::iterator));
@@ -315,6 +339,10 @@ struct BridgedType {
 
     SWIFT_IMPORT_UNSAFE BRIDGED_INLINE EnumElementIterator getNext() const;
   };
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedType() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedType(swift::SILType t) : opaqueValue(t.getOpaqueValue()) {}
@@ -698,6 +726,10 @@ struct BridgedTypeArray {
 struct BridgedSILTypeArray {
   BridgedArrayRef typeArray;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedSILTypeArray() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedSILTypeArray(llvm::ArrayRef<swift::SILType> silTypes)
       : typeArray(silTypes) {}
@@ -715,6 +747,10 @@ struct BridgedSILTypeArray {
 
 struct BridgedLocation {
   uint64_t storage[3];
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  BridgedLocation() {}
 
 #ifdef USED_IN_CPP_SOURCE
   BridgedLocation(const swift::SILDebugLocation &loc) {
@@ -741,6 +777,10 @@ struct BridgedGenericSpecializationInformation {
 
 struct OptionalBridgedSILDebugVariable {
   uint64_t storage[16];
+
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64
+  OptionalBridgedSILDebugVariable() {}
 
 #ifdef USED_IN_CPP_SOURCE
   using OptionalSILDebugVariable = std::optional<swift::SILDebugVariable>;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -674,6 +674,10 @@ struct BridgedSubstitutionMap {
 struct BridgedTypeArray {
   BridgedArrayRef typeArray;
 
+  // Ensure that this struct value type will be indirectly returned on
+  // Windows ARM64,
+  BridgedTypeArray() : typeArray() {}
+
 #ifdef USED_IN_CPP_SOURCE
   BridgedTypeArray(llvm::ArrayRef<swift::Type> types) : typeArray(types) {}
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -85,6 +85,10 @@ struct BridgedCalleeAnalysis {
   struct CalleeList {
     uint64_t storage[3];
 
+    // Ensure that this struct value type will be indirectly returned on
+    // Windows ARM64
+    CalleeList() {}
+
 #ifdef USED_IN_CPP_SOURCE
     CalleeList(swift::CalleeList list) {
       *reinterpret_cast<swift::CalleeList *>(&storage) = list;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2204,10 +2204,11 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
   // C++ operators +=, -=, *=, /= may return a reference to self. This is not
   // idiomatic in Swift, let's drop these return values.
   clang::OverloadedOperatorKind op = clangDecl->getOverloadedOperator();
-  if (op == clang::OverloadedOperatorKind::OO_PlusEqual ||
-      op == clang::OverloadedOperatorKind::OO_MinusEqual ||
-      op == clang::OverloadedOperatorKind::OO_StarEqual ||
-      op == clang::OverloadedOperatorKind::OO_SlashEqual)
+  if ((op == clang::OverloadedOperatorKind::OO_PlusEqual ||
+       op == clang::OverloadedOperatorKind::OO_MinusEqual ||
+       op == clang::OverloadedOperatorKind::OO_StarEqual ||
+       op == clang::OverloadedOperatorKind::OO_SlashEqual) &&
+      clangDecl->getReturnType()->isReferenceType())
     return {SwiftContext.getVoidType(), false};
 
   // Fix up optionality.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -358,7 +358,8 @@ static void addIndirectResultAttributes(IRGenModule &IGM,
                                         llvm::AttributeList &attrs,
                                         unsigned paramIndex, bool allowSRet,
                                         llvm::Type *storageType,
-                                        const TypeInfo &typeInfo) {
+                                        const TypeInfo &typeInfo,
+                                        bool useInReg = false) {
   llvm::AttrBuilder b(IGM.getLLVMContext());
   b.addAttribute(llvm::Attribute::NoAlias);
   // Bitwise takable value types are guaranteed not to capture
@@ -368,6 +369,8 @@ static void addIndirectResultAttributes(IRGenModule &IGM,
   if (allowSRet) {
     assert(storageType);
     b.addStructRetAttr(storageType);
+    if (useInReg)
+      b.addAttribute(llvm::Attribute::InReg);
   }
   attrs = attrs.addParamAttributes(IGM.getLLVMContext(), paramIndex, b);
 }
@@ -475,7 +478,7 @@ namespace {
 
   private:
     const TypeInfo &expand(SILParameterInfo param);
-    llvm::Type *addIndirectResult(SILType resultType);
+    llvm::Type *addIndirectResult(SILType resultType, bool useInReg = false);
 
     SILFunctionConventions getSILFuncConventions() const {
       return SILFunctionConventions(FnType, IGM.getSILModule());
@@ -533,11 +536,12 @@ namespace {
 } // end namespace irgen
 } // end namespace swift
 
-llvm::Type *SignatureExpansion::addIndirectResult(SILType resultType) {
+llvm::Type *SignatureExpansion::addIndirectResult(SILType resultType,
+                                                  bool useInReg) {
   const TypeInfo &resultTI = IGM.getTypeInfo(resultType);
   auto storageTy = resultTI.getStorageType();
   addIndirectResultAttributes(IGM, Attrs, ParamIRTypes.size(), claimSRet(),
-                              storageTy, resultTI);
+                              storageTy, resultTI, useInReg);
   addPointerParameter(storageTy);
   return IGM.VoidTy;
 }
@@ -1580,9 +1584,9 @@ void SignatureExpansion::expandExternalSignatureTypes() {
       // returned indirect values.
       emitArg(0);
       firstParamToLowerNormally = 1;
-      addIndirectResult(resultType);
+      addIndirectResult(resultType, returnInfo.getInReg());
     } else
-      addIndirectResult(resultType);
+      addIndirectResult(resultType, returnInfo.getInReg());
   }
 
   // Use a special IR type for passing block pointers.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1453,9 +1453,15 @@ void SignatureExpansion::expandExternalSignatureTypes() {
   // Generate function info for this signature.
   auto extInfo = clang::FunctionType::ExtInfo();
 
-  auto &FI = clang::CodeGen::arrangeFreeFunctionCall(IGM.ClangCodeGen->CGM(),
-                                             clangResultTy, paramTys, extInfo,
-                                             clang::CodeGen::RequiredArgs::All);
+  bool isCXXMethod =
+      FnType->getRepresentation() == SILFunctionTypeRepresentation::CXXMethod;
+  auto &FI = isCXXMethod ?
+      clang::CodeGen::arrangeCXXMethodCall(IGM.ClangCodeGen->CGM(),
+          clangResultTy, paramTys, extInfo, {},
+          clang::CodeGen::RequiredArgs::All) :
+      clang::CodeGen::arrangeFreeFunctionCall(IGM.ClangCodeGen->CGM(),
+          clangResultTy, paramTys, extInfo, {},
+          clang::CodeGen::RequiredArgs::All);
   ForeignInfo.ClangInfo = &FI;
 
   assert(FI.arg_size() == paramTys.size() &&
@@ -1577,9 +1583,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
   if (returnInfo.isIndirect()) {
     auto resultType = getSILFuncConventions().getSingleSILResultType(
         IGM.getMaximalTypeExpansionContext());
-    if (IGM.Triple.isWindowsMSVCEnvironment() &&
-        FnType->getRepresentation() ==
-            SILFunctionTypeRepresentation::CXXMethod) {
+    if (returnInfo.isSRetAfterThis()) {
       // Windows ABI places `this` before the
       // returned indirect values.
       emitArg(0);
@@ -2538,11 +2542,12 @@ public:
 
         // Windows ABI places `this` before the
         // returned indirect values.
-        bool isThisFirst = IGF.IGM.Triple.isWindowsMSVCEnvironment();
-        if (!isThisFirst)
+        auto &returnInfo =
+            getCallee().getForeignInfo().ClangInfo->getReturnInfo();
+        if (returnInfo.isIndirect() && !returnInfo.isSRetAfterThis())
           passIndirectResults();
         adjusted.add(arg);
-        if (isThisFirst)
+        if (returnInfo.isIndirect() && returnInfo.isSRetAfterThis())
           passIndirectResults();
       }
 
@@ -3119,9 +3124,10 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   assert(LastArgWritten == 1 && "emitting unnaturally to indirect result");
 
   Args[0] = result.getAddress();
-  if (IGF.IGM.Triple.isWindowsMSVCEnvironment() &&
-      getCallee().getRepresentation() ==
-          SILFunctionTypeRepresentation::CXXMethod &&
+
+  auto *FI = getCallee().getForeignInfo().ClangInfo;
+  if (FI && FI->getReturnInfo().isIndirect() &&
+      FI->getReturnInfo().isSRetAfterThis() &&
       Args[1] == getCallee().getCXXMethodSelf()) {
     // C++ methods in MSVC ABI pass `this` before the
     // indirectly returned value.
@@ -3486,10 +3492,10 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
       emitToMemory(temp, substResultTI, isOutlined);
       return;
     }
-    if (IGF.IGM.Triple.isWindowsMSVCEnvironment() &&
-        getCallee().getRepresentation() ==
-            SILFunctionTypeRepresentation::CXXMethod &&
-        substResultType.isVoid()) {
+
+    auto *FI = getCallee().getForeignInfo().ClangInfo;
+    if (FI && FI->getReturnInfo().isIndirect() &&
+        FI->getReturnInfo().isSRetAfterThis() && substResultType.isVoid()) {
       // Some C++ methods return a value but are imported as
       // returning `Void` (e.g. `operator +=`). In this case
       // we should allocate the correct temp indirect return

--- a/test/Interop/Cxx/class/method/Inputs/inreg-sret.h
+++ b/test/Interop/Cxx/class/method/Inputs/inreg-sret.h
@@ -1,0 +1,11 @@
+#ifndef TEST_INTEROP_CXX_CLASS_METHOD_INREG_SRET_H
+#define TEST_INTEROP_CXX_CLASS_METHOD_INREG_SRET_H
+
+struct OptionalBridgedBasicBlock {
+};
+
+struct BridgedFunction {
+  OptionalBridgedBasicBlock getFirstBlock() const { return {}; }
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_METHOD_INREG_SRET_H

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -14,3 +14,8 @@ module UnsafeProjections {
   
   export *
 }
+
+module InRegSRet {
+  header "inreg-sret.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -19,3 +19,8 @@ module InRegSRet {
   header "inreg-sret.h"
   requires cplusplus
 }
+
+module SRetWinARM64 {
+  header "sret-win-arm64.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/method/Inputs/sret-win-arm64.h
+++ b/test/Interop/Cxx/class/method/Inputs/sret-win-arm64.h
@@ -1,0 +1,84 @@
+#ifndef TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H
+#define TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H
+
+#include <stdint.h>
+
+namespace llvm {
+
+template<typename T>
+class ArrayRef {
+public:
+   const T *Data = nullptr;
+   size_t Length = 0;
+};
+
+} // namespace llvm
+
+namespace swift {
+
+class Type {
+};
+
+class SubstitutionMap {
+private:
+  void *storage = nullptr;
+
+public:
+  llvm::ArrayRef<Type> getReplacementTypes() const;
+};
+
+} // namespace swift
+
+class BridgedArrayRef {
+public:
+  const void * Data;
+  size_t Length;
+
+  BridgedArrayRef() : Data(nullptr), Length(0) {}
+
+#ifdef USED_IN_CPP_SOURCE
+  template <typename T>
+  BridgedArrayRef(llvm::ArrayRef<T> arr)
+      : Data(arr.Data), Length(arr.Length) {}
+
+  template <typename T>
+  llvm::ArrayRef<T> unbridged() const {
+    return {static_cast<const T *>(Data), Length};
+  }
+#endif
+};
+
+struct BridgedSubstitutionMap {
+  uint64_t storage[1];
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedSubstitutionMap(swift::SubstitutionMap map) {
+    *reinterpret_cast<swift::SubstitutionMap *>(&storage) = map;
+  }
+  swift::SubstitutionMap unbridged() const {
+    return *reinterpret_cast<const swift::SubstitutionMap *>(&storage);
+  }
+#endif
+
+  BridgedSubstitutionMap() {}
+};
+
+struct BridgedTypeArray {
+  BridgedArrayRef typeArray;
+
+#ifdef AFTER_FIX
+   BridgedTypeArray() : typeArray() {}
+#endif
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedTypeArray(llvm::ArrayRef<swift::Type> types) : typeArray(types) {}
+
+  llvm::ArrayRef<swift::Type> unbridged() const {
+    return typeArray.unbridged<swift::Type>();
+  }
+#endif
+
+  static BridgedTypeArray fromReplacementTypes(BridgedSubstitutionMap substMap);
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_METHOD_SRET_WIN_ARM64_H

--- a/test/Interop/Cxx/class/method/inreg-sret.swift
+++ b/test/Interop/Cxx/class/method/inreg-sret.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-cpu
+
+// REQUIRES: OS=windows-msvc
+
+import InRegSRet
+
+final public class BasicBlock {
+}
+
+extension OptionalBridgedBasicBlock {
+  public var block: BasicBlock? { nil }
+}
+
+final public class Function {
+  public var bridged: BridgedFunction {
+    BridgedFunction()
+  }
+
+  public var firstBlock : BasicBlock? { bridged.getFirstBlock().block }
+}
+
+// Check that inreg on the sret isn't missing
+
+// CHECK-x86_64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr noalias nocapture sret(%TSo25OptionalBridgedBasicBlockV) {{.*}})
+// CHECK-aarch64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr inreg noalias nocapture sret(%TSo25OptionalBridgedBasicBlockV) {{.*}})
+
+// CHECK-x86_64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})
+// CHECK-aarch64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr inreg noalias sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -12,7 +12,8 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], i32 42)
+// CHECK-x86_64: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], i32 42)
+// CHECK-aarch64: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr inreg noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], i32 42)
 
 // CHECK-x86_64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
 // CHECK-aarch64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr inreg noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
+++ b/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
@@ -57,7 +57,7 @@ public func test(_ result: VecStr) -> CInt {
 }
 
 // CHECK: swiftcc i32 @"$s4Test4testys5Int32VSo0014vecstr_yuJCataVF"({{.*}} %[[RESULT:.*]])
-// CHECK: call void @"?begin@?$vec@Vstr@@@@QEBA?AVIt@@XZ"(ptr %[[RESULT]], ptr sret{{.*}}
+// CHECK: call void @"?begin@?$vec@Vstr@@@@QEBA?AVIt@@XZ"(ptr %[[RESULT]], ptr {{.*}} sret{{.*}}
 
 public func passTempForIndirectRetToVoidCall() {
     var lhs = LoadableIntWrapper(value: 2)
@@ -65,7 +65,7 @@ public func passTempForIndirectRetToVoidCall() {
     lhs += rhs
 }
 
-// CHECK: void @"$sSo18LoadableIntWrapperV2peoiyyABz_ABtFZ"(ptr
-// CHECK: %[[OPRESULT:.*]] = alloca %struct.LoadableIntWrapper, align 16
-// CHECK-x86_64: call void @"??YLoadableIntWrapper@@QEAA?AU0@U0@@Z"(ptr {{.*}}, ptr sret(%struct.LoadableIntWrapper) %[[OPRESULT]], i32
-// CHECK-aarch64: call void @"??YLoadableIntWrapper@@QEAA?AU0@U0@@Z"(ptr {{.*}}, ptr sret(%struct.LoadableIntWrapper) %[[OPRESULT]], i64
+// CHECK: i32 @"$sSo18LoadableIntWrapperV2peoiyA2Bz_ABtFZ"(ptr
+// CHECK: %[[OPRESULT:.*]] = alloca %TSo18LoadableIntWrapperV, align 4
+// CHECK-x86_64: call void @"??YLoadableIntWrapper@@QEAA?AU0@U0@@Z"(ptr {{.*}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) %[[OPRESULT]], i32
+// CHECK-aarch64: call void @"??YLoadableIntWrapper@@QEAA?AU0@U0@@Z"(ptr {{.*}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) %[[OPRESULT]], i64

--- a/test/Interop/Cxx/class/method/sret-win-arm64.swift
+++ b/test/Interop/Cxx/class/method/sret-win-arm64.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s -check-prefix=CHECK-before-fix
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s -Xcc -DAFTER_FIX | %FileCheck %s -check-prefix=CHECK-after-fix
+
+// REQUIRES: OS=windows-msvc && CPU=aarch64
+
+import SRetWinARM64
+
+public struct OptionalTypeArray {
+  private let bridged: BridgedTypeArray
+  public init(bridged: BridgedTypeArray) {
+    self.bridged = bridged
+  }
+}
+
+public struct SubstitutionMap {
+  public let bridged: BridgedSubstitutionMap
+
+  public var replacementTypes: OptionalTypeArray {
+    let types = BridgedTypeArray.fromReplacementTypes(bridged)
+    return OptionalTypeArray(bridged: types)
+  }
+}
+
+public func test(sm: SubstitutionMap) -> OptionalTypeArray {
+  return sm.replacementTypes
+}
+
+// Check that BridgedTypeArray is indirectly returned via sret after the fix
+
+// CHECK-before-fix: declare {{.*}} [2 x i64] @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(i64)
+// CHECK-after-fix: declare {{.*}} void @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(ptr inreg sret(%struct.BridgedTypeArray) align 8, i64)

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -5,7 +5,7 @@ import MemberInline
 public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs - rhs }
 
 // CHECK-SYSV: call [[RESA:i32|i64]] [[NAMEA:@_ZN18LoadableIntWrappermiES_]](ptr {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
-// CHECK-WIN: call [[RESA:void]] [[NAMEA:@"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z"]](ptr {{%[0-9]+}}, ptr sret(%struct.LoadableIntWrapper) {{.*}}, i32 {{%[0-9]+}})
+// CHECK-WIN: call [[RESA:void]] [[NAMEA:@"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z"]](ptr {{%[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, i32 {{%[0-9]+}})
 
 public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
 

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -7,5 +7,5 @@ public func add(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> L
 // CHECK-SYSV: call {{i32|i64}} [[NAME:@_ZNK18LoadableIntWrapperplES_]](ptr %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\)}}{{.*}})
 // CHECK-SYSV: declare {{.*}}{{i32|i64}} [[NAME]](ptr {{.*}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* .*byval\(%struct.LoadableIntWrapper\)}}{{.*}})
 
-// CHECK-WIN: call void [[NAME:@"\?\?HLoadableIntWrapper@@QEBA\?AU0@U0@@Z"]](ptr %{{[0-9]+}}, ptr sret(%struct.LoadableIntWrapper) {{.*}}, i32 %{{[0-9]+}})
+// CHECK-WIN: call void [[NAME:@"\?\?HLoadableIntWrapper@@QEBA\?AU0@U0@@Z"]](ptr %{{[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, i32 %{{[0-9]+}})
 // CHECK-WIN: declare dso_local void [[NAME]](ptr {{.*}}, ptr sret(%struct.LoadableIntWrapper) {{.*}}, i32)


### PR DESCRIPTION
  - **Explanation**: This PR cherrypicks the fixes for the Bridged C++ class/struct indirect return ABI for Windows ARM64 that are necessary to fix the windows arm64 compiler.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: The changes are mostly localized to the MSVC ARM64 environment but includes a change to (appropriately) use `arrangeCXXMethodCall` for C++ methods instead of `arrangeFreeFunctionCall` in the IRGen.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift/issues/74866
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**:
    - https://github.com/swiftlang/swift/pull/76589
    - https://github.com/swiftlang/swift/pull/76324
    - https://github.com/swiftlang/swift/pull/76159
    - https://github.com/swiftlang/swift/pull/76433
    - https://github.com/llvm/llvm-project/pull/111597
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: The additional Bridged C++ class/struct constructors are low risk. The IRGen change could unintendedly affect the non-MSVC ARM64 environments but these are deemed a correct fix.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: The usual PR validating CIs and local multi-generation toolchain bootstrap builds using the (similarly patched) 5.10 toolchain (the first gen) and a cross-compile on Windows/X64 to Windows/ARM64 (the second gen) and a native Windows/ARM64 native toolchain build (the third gen) using the second gen toolchain.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: rjmccall eeckstein compnerd hyp egorzhdan
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->


