### PR TITLE
[CoroutineAccessors] Key table membership off availability.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6029,15 +6029,14 @@ public:
     return getOpaqueReadOwnership() != OpaqueReadOwnership::Borrowed;
   }
 
-  /// Does this storage require a 'read' accessor in its opaque-accessors set?
-  bool requiresOpaqueReadCoroutine() const {
-    return getOpaqueReadOwnership() != OpaqueReadOwnership::Owned;
-  }
+  /// Does this storage require a '_read' accessor in its opaque-accessors set?
+  bool requiresOpaqueReadCoroutine() const;
 
   /// Does this storage require a 'set' accessor in its opaque-accessors set?
   bool requiresOpaqueSetter() const { return supportsMutation(); }
 
-  /// Does this storage require a 'modify' accessor in its opaque-accessors set?
+  /// Does this storage require a '_modify' accessor in its opaque-accessors
+  /// set?
   bool requiresOpaqueModifyCoroutine() const;
 
   /// Does this storage have any explicit observers (willSet or didSet) attached

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6032,12 +6032,19 @@ public:
   /// Does this storage require a '_read' accessor in its opaque-accessors set?
   bool requiresOpaqueReadCoroutine() const;
 
+  /// Does this storage require a 'read' accessor in its opaque-accessors set?
+  bool requiresOpaqueRead2Coroutine() const;
+
   /// Does this storage require a 'set' accessor in its opaque-accessors set?
   bool requiresOpaqueSetter() const { return supportsMutation(); }
 
   /// Does this storage require a '_modify' accessor in its opaque-accessors
   /// set?
   bool requiresOpaqueModifyCoroutine() const;
+
+  /// Does this storage require a 'modify' accessor in its opaque-accessors
+  /// set?
+  bool requiresOpaqueModify2Coroutine() const;
 
   /// Does this storage have any explicit observers (willSet or didSet) attached
   /// to it?

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5765,6 +5765,8 @@ private:
     unsigned RequiresOpaqueAccessors : 1;
     unsigned RequiresOpaqueModifyCoroutineComputed : 1;
     unsigned RequiresOpaqueModifyCoroutine : 1;
+    unsigned RequiresOpaqueModify2CoroutineComputed : 1;
+    unsigned RequiresOpaqueModify2Coroutine : 1;
   } LazySemanticInfo = { };
 
   /// The implementation info for the accessors.
@@ -6045,6 +6047,11 @@ public:
   /// Does this storage require a 'modify' accessor in its opaque-accessors
   /// set?
   bool requiresOpaqueModify2Coroutine() const;
+
+  /// Given that CoroutineAccessors is enabled, is _read/_modify required for
+  /// ABI stability?
+  bool
+  requiresCorrespondingUnderscoredCoroutineAccessor(AccessorKind kind) const;
 
   /// Does this storage have any explicit observers (willSet or didSet) attached
   /// to it?

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -80,6 +80,8 @@ FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 FEATURE(ValueGenericType,                               FUTURE)
 FEATURE(InitRawStructMetadata2,                         FUTURE)
+// TODO: CoroutineAccessors: Change to correct version number.
+FEATURE(CoroutineAccessors,                             FUTURE)
 
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1937,10 +1937,10 @@ public:
   void cacheResult(bool value) const;
 };
 
-class RequiresOpaqueModifyCoroutineRequest :
-    public SimpleRequest<RequiresOpaqueModifyCoroutineRequest,
-                         bool(AbstractStorageDecl *),
-                         RequestFlags::SeparatelyCached> {
+class RequiresOpaqueModifyCoroutineRequest
+    : public SimpleRequest<RequiresOpaqueModifyCoroutineRequest,
+                           bool(AbstractStorageDecl *, bool isUnderscored),
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1948,8 +1948,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool
-  evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, AbstractStorageDecl *decl,
+                bool isUnderscored) const;
 
 public:
   // Separate caching.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3018,6 +3018,10 @@ bool AbstractStorageDecl::requiresOpaqueAccessor(AccessorKind kind) const {
 }
 
 bool AbstractStorageDecl::requiresOpaqueReadCoroutine() const {
+  ASTContext &ctx = getASTContext();
+  if (ctx.LangOpts.hasFeature(Feature::CoroutineAccessors))
+    return requiresCorrespondingUnderscoredCoroutineAccessor(
+        AccessorKind::Read2);
   return getOpaqueReadOwnership() != OpaqueReadOwnership::Owned;
 }
 
@@ -3030,19 +3034,20 @@ bool AbstractStorageDecl::requiresOpaqueRead2Coroutine() const {
 
 bool AbstractStorageDecl::requiresOpaqueModifyCoroutine() const {
   ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-    RequiresOpaqueModifyCoroutineRequest{const_cast<AbstractStorageDecl *>(this)},
-    false);
+  return evaluateOrDefault(
+      ctx.evaluator,
+      RequiresOpaqueModifyCoroutineRequest{
+          const_cast<AbstractStorageDecl *>(this), /*isUnderscored=*/true},
+      false);
 }
 
 bool AbstractStorageDecl::requiresOpaqueModify2Coroutine() const {
   ASTContext &ctx = getASTContext();
-  if (!ctx.LangOpts.hasFeature(Feature::CoroutineAccessors))
-    return false;
-  return evaluateOrDefault(ctx.evaluator,
-                           RequiresOpaqueModifyCoroutineRequest{
-                               const_cast<AbstractStorageDecl *>(this)},
-                           false);
+  return evaluateOrDefault(
+      ctx.evaluator,
+      RequiresOpaqueModifyCoroutineRequest{
+          const_cast<AbstractStorageDecl *>(this), /*isUnderscored=*/false},
+      false);
 }
 
 AccessorDecl *AbstractStorageDecl::getSynthesizedAccessor(AccessorKind kind) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3006,6 +3006,10 @@ bool AbstractStorageDecl::requiresOpaqueAccessor(AccessorKind kind) const {
   llvm_unreachable("bad accessor kind");
 }
 
+bool AbstractStorageDecl::requiresOpaqueReadCoroutine() const {
+  return getOpaqueReadOwnership() != OpaqueReadOwnership::Owned;
+}
+
 bool AbstractStorageDecl::requiresOpaqueModifyCoroutine() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3132,6 +3132,9 @@ void AbstractStorageDecl::visitExpectedOpaqueAccessors(
   if (requiresOpaqueReadCoroutine())
     visit(AccessorKind::Read);
 
+  if (requiresOpaqueRead2Coroutine())
+    visit(AccessorKind::Read2);
+
   // All mutable storage should have a setter.
   if (requiresOpaqueSetter())
     visit(AccessorKind::Set);
@@ -3139,6 +3142,9 @@ void AbstractStorageDecl::visitExpectedOpaqueAccessors(
   // Include the modify coroutine if it's required.
   if (requiresOpaqueModifyCoroutine())
     visit(AccessorKind::Modify);
+
+  if (requiresOpaqueModify2Coroutine())
+    visit(AccessorKind::Modify2);
 }
 
 void AbstractStorageDecl::visitOpaqueAccessors(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2849,8 +2849,13 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
                                        /*dispatch*/ false);
   case ReadWriteImplKind::StoredWithDidSet:
   case ReadWriteImplKind::InheritedWithDidSet:
-    if (storage->requiresOpaqueModifyCoroutine() &&
+    if (storage->requiresOpaqueModify2Coroutine() &&
         storage->getParsedAccessor(AccessorKind::DidSet)->isSimpleDidSet()) {
+      return AccessStrategy::getAccessor(AccessorKind::Modify2,
+                                         /*dispatch*/ false);
+    } else if (storage->requiresOpaqueModifyCoroutine() &&
+               storage->getParsedAccessor(AccessorKind::DidSet)
+                   ->isSimpleDidSet()) {
       return AccessStrategy::getAccessor(AccessorKind::Modify,
                                          /*dispatch*/ false);
     } else {
@@ -2868,6 +2873,8 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
 
 static AccessStrategy
 getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) {
+  if (storage->requiresOpaqueRead2Coroutine())
+    return AccessStrategy::getAccessor(AccessorKind::Read2, dispatch);
   if (storage->requiresOpaqueReadCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Read, dispatch);
   return AccessStrategy::getAccessor(AccessorKind::Get, dispatch);
@@ -2883,6 +2890,8 @@ getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) 
 static AccessStrategy
 getOpaqueReadWriteAccessStrategy(const AbstractStorageDecl *storage,
                                  bool dispatch) {
+  if (storage->requiresOpaqueModify2Coroutine())
+    return AccessStrategy::getAccessor(AccessorKind::Modify2, dispatch);
   if (storage->requiresOpaqueModifyCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
   return AccessStrategy::getMaterializeToTemporary(

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -795,15 +795,29 @@ void RequiresOpaqueAccessorsRequest::cacheResult(bool value) const {
 std::optional<bool>
 RequiresOpaqueModifyCoroutineRequest::getCachedResult() const {
   auto *storage = std::get<0>(getStorage());
-  if (storage->LazySemanticInfo.RequiresOpaqueModifyCoroutineComputed)
-    return static_cast<bool>(storage->LazySemanticInfo.RequiresOpaqueModifyCoroutine);
+  auto isUnderscored = std::get<1>(getStorage());
+  if (isUnderscored) {
+    if (storage->LazySemanticInfo.RequiresOpaqueModifyCoroutineComputed)
+      return static_cast<bool>(
+          storage->LazySemanticInfo.RequiresOpaqueModifyCoroutine);
+  } else {
+    if (storage->LazySemanticInfo.RequiresOpaqueModify2CoroutineComputed)
+      return static_cast<bool>(
+          storage->LazySemanticInfo.RequiresOpaqueModify2Coroutine);
+  }
   return std::nullopt;
 }
 
 void RequiresOpaqueModifyCoroutineRequest::cacheResult(bool value) const {
   auto *storage = std::get<0>(getStorage());
-  storage->LazySemanticInfo.RequiresOpaqueModifyCoroutineComputed = 1;
-  storage->LazySemanticInfo.RequiresOpaqueModifyCoroutine = value;
+  auto isUnderscored = std::get<1>(getStorage());
+  if (isUnderscored) {
+    storage->LazySemanticInfo.RequiresOpaqueModifyCoroutineComputed = 1;
+    storage->LazySemanticInfo.RequiresOpaqueModifyCoroutine = value;
+  } else {
+    storage->LazySemanticInfo.RequiresOpaqueModify2CoroutineComputed = 1;
+    storage->LazySemanticInfo.RequiresOpaqueModify2Coroutine = value;
+  }
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2185,12 +2185,14 @@ public:
                                 SubstitutionMap subs,
                                 ArrayRef<SILValue> args);
 
-  std::pair<MultipleValueInstructionResult *, CleanupHandle>
+  std::tuple<MultipleValueInstructionResult *, CleanupHandle, SILValue,
+             CleanupHandle>
   emitBeginApplyWithRethrow(SILLocation loc, SILValue fn, SILType substFnType,
                             SubstitutionMap subs, ArrayRef<SILValue> args,
                             SmallVectorImpl<SILValue> &yields);
   void emitEndApplyWithRethrow(SILLocation loc,
-                               MultipleValueInstructionResult *token);
+                               MultipleValueInstructionResult *token,
+                               SILValue allocation);
 
   ManagedValue emitExtractFunctionIsolation(SILLocation loc,
                                         ArgumentSource &&fnValue);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2710,9 +2710,67 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-bool
-RequiresOpaqueModifyCoroutineRequest::evaluate(Evaluator &evaluator,
-                                               AbstractStorageDecl *storage) const {
+/// When the CoroutineAccessors feature is available, the coroutine accessor
+/// _could_ be required.  That non-underscored accessor would be preferred to
+/// its underscored counterpart accessor.
+///
+/// The underscored accessor could, however, still be required for ABI
+/// stability.
+bool AbstractStorageDecl::requiresCorrespondingUnderscoredCoroutineAccessor(
+    AccessorKind kind) const {
+  auto &ctx = getASTContext();
+  assert(ctx.LangOpts.hasFeature(Feature::CoroutineAccessors));
+  assert(kind == AccessorKind::Modify2 || kind == AccessorKind::Read2);
+
+  // Non-stable modules have no ABI to keep stable.
+  if (getModuleContext()->getResilienceStrategy() !=
+      ResilienceStrategy::Resilient)
+    return false;
+
+  // Non-exported storage has no ABI to keep stable.
+  if (!isExported(this))
+    return false;
+
+  // The the non-underscored accessor is not present, the underscored accessor
+  // won't be either.
+  // TODO: CoroutineAccessors: What if only the underscored is written out?
+  auto *accessor = getOpaqueAccessor(kind);
+  if (!accessor)
+    return false;
+
+  // Availability checks are only relevant on targets which support versioned
+  // availability.  Otherwise, since we're building with library evolution,
+  // conservatively assume that the binary must keep ABI compatibility with its
+  // prior versions, and emit the underscored variant.
+  if (!ctx.supportsVersionedAvailability())
+    return true;
+
+  auto modifyAvailability = TypeChecker::availabilityAtLocation({}, accessor);
+  auto featureAvailability = ctx.getCoroutineAccessorsRuntimeAvailability();
+  // If accessor was introduced only after the feature was, there's no old ABI
+  // to maintain.
+  if (modifyAvailability.getPlatformRange().isContainedIn(featureAvailability))
+    return false;
+
+  // The underscored accessor is required for ABI stability.
+  return true;
+}
+
+bool RequiresOpaqueModifyCoroutineRequest::evaluate(
+    Evaluator &evaluator, AbstractStorageDecl *storage,
+    bool isUnderscored) const {
+  auto &ctx = storage->getASTContext();
+  bool hasModifyFeature = ctx.LangOpts.hasFeature(Feature::CoroutineAccessors);
+
+  // No `modify` accessor without the feature.
+  if (!hasModifyFeature && !isUnderscored)
+    return false;
+
+  if (hasModifyFeature && isUnderscored) {
+    return storage->requiresCorrespondingUnderscoredCoroutineAccessor(
+        AccessorKind::Modify2);
+  }
+
   // Only for mutable storage.
   if (!storage->supportsMutation())
     return false;

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-irgen                             \
 // RUN:     %s                                               \
 // RUN:     -enable-experimental-feature CoroutineAccessors  \
+// RUN:     -enable-library-evolution                        \
 // RUN: | %IRGenFileCheck %s --check-prefix=CHECK-OLD
 
 // For now, a crash is expected when attempting to use the callee-allocated ABI: 
@@ -13,6 +14,7 @@
 
 // REQUIRES: asserts
 
+@frozen
 public struct S {
 public var o: any AnyObject
 public var _i: Int = 0

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -179,13 +179,13 @@ class OverridableGetter : ReadableTitle {
   var title: String = ""
 }
 //   The read witness thunk does a direct call to the concrete read accessor.
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvrTW
-// CHECK:       function_ref @$s19coroutine_accessors17OverridableGetterC5titleSSvr
-// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvrTW'
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvyTW
+// CHECK:       function_ref @$s19coroutine_accessors17OverridableGetterC5titleSSvy
+// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterCAA13ReadableTitleA2aDP5titleSSvyTW'
 //   The concrete read accessor is generated on-demand and does a class dispatch to the getter.
-// CHECK-LABEL: sil shared [ossa] @$s19coroutine_accessors17OverridableGetterC5titleSSvr
+// CHECK-LABEL: sil shared [ossa] @$s19coroutine_accessors17OverridableGetterC5titleSSvy
 // CHECK:       class_method %0 : $OverridableGetter, #OverridableGetter.title!getter
-// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterC5titleSSvr'
+// CHECK-LABEL: // end sil function '$s19coroutine_accessors17OverridableGetterC5titleSSvy'
 
 class ImplementedReader : ReadableTitle {
   var _title: String = ""
@@ -214,10 +214,11 @@ protocol GettableTitle {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^,]+]] :
 // CHECK-SAME:  ):
-// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!read
-// CHECK:         ([[TITLE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         [[READER:%[^,]+]] = class_method [[SELF]] : $OverridableReader, #OverridableReader.title!read2
+// CHECK:         ([[TITLE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]]]) = begin_apply [[READER]]([[SELF]])
 // CHECK:         [[RETVAL:%[^,]+]] = copy_value [[TITLE]]
 // CHECK:         end_apply [[TOKEN]] as $()
+// CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function '$s19coroutine_accessors17OverridableReaderC5titleSSvg'
 

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -1,16 +1,19 @@
 // RUN: %target-swift-emit-silgen                           \
 // RUN:     %s                                              \
+// RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
+// RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
 
 // REQUIRES: asserts
 
+@frozen
 public struct S {
 public var o: any AnyObject
 public var _i: Int = 0

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -17,7 +17,7 @@ public var _i: Int = 0
 
 public var irm: Int {
 // CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivy :
-// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      $@yield_once_2
 // CHECK-SAME:      @convention(method)
 // CHECK-SAME:      (@guaranteed S)
 // CHECK-SAME:      ->
@@ -28,7 +28,7 @@ public var irm: Int {
     yield _i
   }
 // CHECK-LABEL: sil [ossa] @$s19coroutine_accessors1SV3irmSivx :
-// CHECK-SAME:      $@yield_once
+// CHECK-SAME:      $@yield_once_2
 // CHECK-SAME:      @convention(method)
 // CHECK-SAME:      (@inout S)
 // CHECK-SAME:      ->

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -21,6 +21,8 @@
 // - a get accessor
 // - an unsafeAddress accessor
 
+// TODO: CoroutineAccessors: Replace SwiftStdlib 9999 with SwiftStdlib X.Y.
+
 @frozen
 public struct U : ~Copyable {}
 
@@ -30,9 +32,11 @@ public protocol P1 : ~Copyable {
   @_borrowed
   var ubgs: U { get set }
 }
+@available(SwiftStdlib 9999, *)
 public protocol P2 : ~Copyable {
   var urs: U { read set }
 }
+@available(SwiftStdlib 6.0, *)
 public protocol P3 : ~Copyable {
   var ur: U { read }
 }
@@ -83,6 +87,7 @@ public struct ImplAStored : ~Copyable & P1 {
 }
 
 @frozen
+@available(SwiftStdlib 9999, *)
 public struct ImplBStored : ~Copyable & P2 {
   var dummy: ()
   public var urs: U
@@ -130,6 +135,7 @@ public struct ImplBStored : ~Copyable & P2 {
 }
 
 @frozen
+@available(SwiftStdlib 6.0, *)
 public struct ImplCStored : ~Copyable & P3 {
   var dummy: ()
   public var ur: U
@@ -229,6 +235,7 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 }
 
 @frozen
+@available(SwiftStdlib 9999, *)
 public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
   var _i: U
   public var urs: U {
@@ -282,6 +289,7 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 }
 
 @frozen
+@available(SwiftStdlib 6.0, *)
 public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
   var _i: U
   public var ur: U {
@@ -395,6 +403,7 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 }
 
 @frozen
+@available(SwiftStdlib 9999, *)
 public struct ImplBCoroutineAccessors : ~Copyable & P2 {
   var _i: U
   public var urs: U {
@@ -480,6 +489,7 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 }
 
 @frozen
+@available(SwiftStdlib 6.0, *)
 public struct ImplCCoroutineAccessors : ~Copyable & P3 {
   var _i: U
   public var ur: U {
@@ -622,6 +632,7 @@ public struct ImplAGetSet : P1 {
 }
 
 @frozen
+@available(SwiftStdlib 9999, *)
 public struct ImplBGetSet : P2 {
   var _i: U {
     get { return U() }
@@ -682,6 +693,7 @@ public struct ImplBGetSet : P2 {
 }
 
 @frozen
+@available(SwiftStdlib 6.0, *)
 public struct ImplCGetSet : P3 {
   var _i: U {
     get { return U() }
@@ -803,6 +815,7 @@ public struct ImplAUnsafeAddressors : P1 {
 }
 
 @frozen
+@available(SwiftStdlib 9999, *)
 public struct ImplBUnsafeAddressors : P2 {
   var iAddr: UnsafePointer<U>
   var iMutableAddr: UnsafeMutablePointer<U> {
@@ -868,6 +881,7 @@ public struct ImplBUnsafeAddressors : P2 {
 }
 
 @frozen
+@available(SwiftStdlib 6.0, *)
 public struct ImplCUnsafeAddressors : P3 {
   var iAddr: UnsafePointer<U>
   var iMutableAddr: UnsafeMutablePointer<U> {

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -946,116 +946,116 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW'
 }
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAStored: P1 module read_requirements {
-// CHECK:         method #P1.ubgs!read
+// CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK:         method #P1.ubgs!setter
+// CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvsTW
-// CHECK:         method #P1.ubgs!modify
+// CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
-// CHECK:         method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW
-// CHECK:         method #P2.urs!setter
+// CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK:         method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCStored: P3 module read_requirements {
-// CHECK:         method #P3.ur!read
+// CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnderscoredCoroutineAccessors: P1 module read_requirements {
-// CHECK:         method #P1.ubgs!read
+// CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK:         method #P1.ubgs!setter
+// CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
-// CHECK:         method #P1.ubgs!modify
+// CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
-// CHECK:         method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
-// CHECK:         method #P2.urs!setter
+// CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK:         method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnderscoredCoroutineAccessors: P3 module read_requirements {
-// CHECK:         method #P3.ur!read
+// CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplACoroutineAccessors: P1 module read_requirements {
-// CHECK:         method #P1.ubgs!read
+// CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK:         method #P1.ubgs!setter
+// CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
-// CHECK:         method #P1.ubgs!modify
+// CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
-// CHECK:         method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
-// CHECK:         method #P2.urs!setter
+// CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK:         method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCCoroutineAccessors: P3 module read_requirements {
-// CHECK:         method #P3.ur!read
+// CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAGetSet: P1 module read_requirements {
-// CHECK:         method #P1.ubgs!read
+// CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK:         method #P1.ubgs!setter
+// CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvsTW
-// CHECK:         method #P1.ubgs!modify
+// CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
-// CHECK:         method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW
-// CHECK:         method #P2.urs!setter
+// CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK:         method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCGetSet: P3 module read_requirements {
-// CHECK:         method #P3.ur!read
+// CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnsafeAddressors: P1 module read_requirements {
-// CHECK:         method #P1.ubgs!read
+// CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW
-// CHECK:         method #P1.ubgs!setter
+// CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvsTW
-// CHECK:         method #P1.ubgs!modify
+// CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
-// CHECK:         method #P2.urs!read
+// CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW
-// CHECK:         method #P2.urs!setter
+// CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK:         method #P2.urs!modify
+// CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvMTW
-// CHECK:       }
+// CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnsafeAddressors: P3 module read_requirements {
-// CHECK:         method #P3.ur!read
+// CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW
-// CHECK:       }
+// CHECK-NEXT:  }

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -2,14 +2,14 @@
 // RUN:     %s                                              \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL,CHECK-%target-abi-stability
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND,CHECK-%target-abi-stability
 
 // For CoroutineAccessorsUnwindOnCallerError
 // REQUIRES: asserts
@@ -134,28 +134,6 @@ public struct ImplAStored : ~Copyable & P1 {
 public struct ImplBStored : ~Copyable & P2 {
   var dummy: ()
   public var urs: U
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         debug_value [[COPY]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
-// CHECK-SAME:        #ImplBStored.urs
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -178,25 +156,6 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBStoredV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -479,25 +438,6 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         destroy_value [[SELF_COPY]]
 // CHECK:         unwind                                          
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]] : $U
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -656,6 +596,25 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         abort_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -688,25 +647,6 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -764,57 +704,6 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
-// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
-// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[BORROW]])
-// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
-// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
-// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
-// CHECK:         yield [[VALUE_BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[VALUE_BORROW]]
-// CHECK:         destroy_value [[VALUE_COPY]]
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]] : $ImplBCoroutineAccessors
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         end_borrow [[SELF]] : $ImplBCoroutineAccessors
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -1066,25 +955,6 @@ public struct ImplBGetSet : P2 {
 // CHECK:         [[VALUE:%[^,]+]] = apply [[_I_GETTER]]([[SELF]])
 // CHECK:         return [[VALUE]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvg'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetV3ursAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvg
-// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
-// CHECK:         yield [[BORROW]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetV3ursAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -1104,23 +974,6 @@ public struct ImplBGetSet : P2 {
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -1370,30 +1223,6 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:             #ImplBUnsafeAddressors.iAddr
 // CHECK:         return [[UNSAFE_POINTER]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu
-// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
-// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
-// CHECK:             #UnsafePointer._rawValue
-// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
-// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
-// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
-// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         end_access [[ACCESS_UNCHECKED]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]] :
@@ -1418,23 +1247,6 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy'
-// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
-// CHECK:       bb0(
-// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
-// CHECK-SAME:  ):
-// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
-// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr
-// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF]])
-// CHECK:         yield [[VALUE]]
-// CHECK:             resume [[SUCCESS:bb[0-9]+]]
-// CHECK:             unwind [[FAILURE:bb[0-9]+]]
-// CHECK:       [[SUCCESS]]:
-// CHECK:         end_apply [[TOKEN]]
-// CHECK:         return
-// CHECK:       [[FAILURE]]:
-// CHECK:         abort_apply [[TOKEN]]
-// CHECK:         unwind
-// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -1580,14 +1392,12 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
-// CHECK-NEXT:    method #P2.urs!read
-// CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:    method #P2.urs!read2
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-NEXT:    method #P2.urs!modify
-// CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:    method #P2.urs!modify2
 // CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1613,14 +1423,12 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
-// CHECK-NEXT:    method #P2.urs!read
-// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:    method #P2.urs!read2
 // CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-NEXT:    method #P2.urs!modify
-// CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:    method #P2.urs!modify2
 // CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1646,14 +1454,12 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
-// CHECK-NEXT:    method #P2.urs!read
-// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:    method #P2.urs!read2
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-NEXT:    method #P2.urs!modify
-// CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:    method #P2.urs!modify2
 // CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1679,14 +1485,12 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
-// CHECK-NEXT:    method #P2.urs!read
-// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:  method #P2.urs!read2
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-NEXT:    method #P2.urs!modify
-// CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:  method #P2.urs!modify2
 // CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
@@ -1712,14 +1516,12 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
-// CHECK-NEXT:    method #P2.urs!read
-// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-unstable:    method #P2.urs!read
 // CHECK-NEXT:    method #P2.urs!read2
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
-// CHECK-NEXT:    method #P2.urs!modify
-// CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-unstable:    method #P2.urs!modify
 // CHECK-NEXT:    method #P2.urs!modify2
 // CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -2,7 +2,7 @@
 // RUN:     %s                                              \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
@@ -65,6 +65,27 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplAStored.ubgs
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredV4ubgsAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -84,6 +105,28 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplAStoredV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE:%[^,]+]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       bb1:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       bb2:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvyTW'
 }
 
 @frozen
@@ -113,6 +156,28 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         debug_value [[COPY]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplBStored.urs
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredV3ursAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -132,6 +197,28 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplBStoredV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW'
 }
 
 @frozen
@@ -160,6 +247,27 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplCStored.ur
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredV2urAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -179,6 +287,28 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCStoredV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW'
 }
 
 @frozen
@@ -213,6 +343,36 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
+// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
+// CHECK:       [[SUCCESS]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         unwind                                          
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -232,6 +392,28 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW'
 }
 
 @frozen
@@ -267,6 +449,36 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         destroy_value [[COPY]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
+// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
+// CHECK:       [[SUCCESS]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         unwind                                          
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -286,6 +498,28 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW'
 }
 
 @frozen
@@ -297,6 +531,57 @@ public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
       yield _i
     }
   }
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_UNCHECKED]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[VALUE:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK-SAME:        #ImplCUnderscoredCoroutineAccessors._i
+// CHECK:         yield [[VALUE]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF_COPY_UNCHECKED:%[^,]+]] = copy_value [[SELF]]
+// CHECK:         [[SELF_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[SELF_COPY_UNCHECKED]]
+// CHECK:         [[SELF_BORROW:%[^,]+]] = begin_borrow [[SELF_COPY]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvr
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply [[READER]]([[SELF_BORROW]])
+// CHECK:         [[VALUE_COPY_UNCHECKED:%[^,]+]] = copy_value [[VALUE]]
+// CHECK:         [[VALUE_COPY:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[VALUE_COPY_UNCHECKED]]
+// CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
+// CHECK:         yield [[VALUE_BORROW]]
+// CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
+// CHECK:       [[SUCCESS]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:                                              
+// CHECK:         end_borrow [[VALUE_BORROW]]
+// CHECK:         destroy_value [[VALUE_COPY]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_borrow [[SELF_BORROW]]
+// CHECK:         destroy_value [[SELF_COPY]]
+// CHECK:         unwind                                          
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
@@ -316,6 +601,28 @@ public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW'
 }
 
 struct ImplACoroutineAccessors : ~Copyable & P1 {
@@ -400,6 +707,28 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplACoroutineAccessorsV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW'
 }
 
 @frozen
@@ -486,6 +815,28 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]] : $ImplBCoroutineAccessors
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplBCoroutineAccessorsV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW'
 }
 
 @frozen
@@ -569,6 +920,28 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load_borrow [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements23ImplCCoroutineAccessorsV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         end_borrow [[SELF]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW'
 }
 
 @frozen
@@ -612,6 +985,25 @@ public struct ImplAGetSet : P1 {
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetV4ubgsAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR]]
@@ -629,6 +1021,26 @@ public struct ImplAGetSet : P1 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplAGetSetV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW'
 }
 
 @frozen
@@ -673,6 +1085,25 @@ public struct ImplBGetSet : P2 {
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetV3ursAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetV3ursAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -690,6 +1121,26 @@ public struct ImplBGetSet : P2 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]]
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READ2ER:%[^,]+]] = function_ref @$s17read_requirements11ImplBGetSetV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW'
 }
 
 @frozen
@@ -731,6 +1182,25 @@ public struct ImplCGetSet : P3 {
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetV2urAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvg
+// CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]([[SELF]])
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[VALUE]]
+// CHECK:         yield [[BORROW]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetV2urAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -748,6 +1218,26 @@ public struct ImplCGetSet : P3 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements11ImplCGetSetV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW'
 }
 
 @frozen
@@ -795,6 +1285,29 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]] : $UnsafePointer<U>, #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR]]
@@ -812,6 +1325,26 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplAUnsafeAddressorsV4ubgsAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW'
 }
 
 @frozen
@@ -861,6 +1394,30 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
+// CHECK:             #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -878,6 +1435,26 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplBUnsafeAddressorsV3ursAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW'
 }
 
 @frozen
@@ -927,6 +1504,30 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         end_access [[ACCESS_UNCHECKED]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvy : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[UNSAFE_ADDRESSOR:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu
+// CHECK:         [[UNSAFE_POINTER:%[^,]+]] = apply [[UNSAFE_ADDRESSOR]]([[SELF]])
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[UNSAFE_POINTER]]
+// CHECK:             #UnsafePointer._rawValue
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS_UNCHECKED:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// CHECK:         [[ACCESS:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS_UNCHECKED]]
+// CHECK:         [[VALUE:%[^,]+]] = load [copy] [[ACCESS]]
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_access [[ACCESS_UNCHECKED]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
@@ -944,118 +1545,188 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         abort_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW'
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[SELF_ADDR:%[^:]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[SELF:%[^,]+]] = load [trivial] [[SELF_ADDR]]
+// CHECK:         [[READER:%[^,]+]] = function_ref @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvy
+// CHECK:         ([[VALUE:%[^,]+]], [[TOKEN:%[^,]+]], [[ALLOCATION:%[^,]+]]) = begin_apply [[READ2ER]]([[SELF]])
+// CHECK:         yield [[VALUE]]
+// CHECK:             resume [[SUCCESS:bb[0-9]+]]
+// CHECK:             unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         return
+// CHECK:       [[FAILURE]]:
+// CHECK-NORMAL:  end_apply [[TOKEN]]
+// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW'
 }
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAStored: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-SAME:      : @$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBStored: P2 module read_requirements {
 // CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-SAME:      : @$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCStored: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnderscoredCoroutineAccessors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-SAME:      : @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnderscoredCoroutineAccessors: P2 module read_requirements {
 // CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-SAME:      : @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnderscoredCoroutineAccessors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-SAME:      : @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplACoroutineAccessors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-SAME:      : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-SAME:      : @$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBCoroutineAccessors: P2 module read_requirements {
 // CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-SAME:      : @$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCCoroutineAccessors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-SAME:      : @$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAGetSet: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-NEXT:  method #P1.ubgs!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-NEXT:  method #P1.ubgs!modify2
+// CHECK-SAME:      : @$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBGetSet: P2 module read_requirements {
 // CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-NEXT:  method #P2.urs!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-NEXT:  method #P2.urs!modify2
+// CHECK-SAME:      : @$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCGetSet: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-NEXT:  method #P3.ur!read2
+// CHECK-SAME:      : @$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplAUnsafeAddressors: P1 module read_requirements {
 // CHECK-NEXT:    method #P1.ubgs!read
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW
+// CHECK-NEXT:    method #P1.ubgs!read2
+// CHECK-SAME:      : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW
 // CHECK-NEXT:    method #P1.ubgs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvsTW
 // CHECK-NEXT:    method #P1.ubgs!modify
 // CHECK-SAME:        : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvMTW
+// CHECK-NEXT:    method #P1.ubgs!modify2
+// CHECK-SAME:      : @$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplBUnsafeAddressors: P2 module read_requirements {
 // CHECK-NEXT:    method #P2.urs!read
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW
+// CHECK-NEXT:    method #P2.urs!read2
+// CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW
 // CHECK-NEXT:    method #P2.urs!setter
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvsTW
 // CHECK-NEXT:    method #P2.urs!modify
 // CHECK-SAME:        : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvMTW
+// CHECK-NEXT:    method #P2.urs!modify2
+// CHECK-SAME:      : @$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvxTW
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_witness_table{{.*}} ImplCUnsafeAddressors: P3 module read_requirements {
 // CHECK-NEXT:    method #P3.ur!read
 // CHECK-SAME:        : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvrTW
+// CHECK-NEXT:    method #P3.ur!read2
+// CHECK-SAME:      : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1,10 +1,12 @@
 // RUN: %target-swift-emit-silgen                           \
 // RUN:     %s                                              \
+// RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
+// RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
@@ -19,23 +21,25 @@
 // - a get accessor
 // - an unsafeAddress accessor
 
-struct U : ~Copyable {}
+@frozen
+public struct U : ~Copyable {}
 
 // Protocols are split up to improve the ordering of the functions in the output
 // (implementation, then conformance thunk).
-protocol P1 : ~Copyable {
+public protocol P1 : ~Copyable {
   @_borrowed
   var ubgs: U { get set }
 }
-protocol P2 : ~Copyable {
+public protocol P2 : ~Copyable {
   var urs: U { read set }
 }
-protocol P3 : ~Copyable {
+public protocol P3 : ~Copyable {
   var ur: U { read }
 }
 
-struct ImplAStored : ~Copyable & P1 {
-  var ubgs: U
+@frozen
+public struct ImplAStored : ~Copyable & P1 {
+  public var ubgs: U
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplAStoredV4ubgsAA1UVvr : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -78,9 +82,10 @@ struct ImplAStored : ~Copyable & P1 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAStoredVAA2P1A2aDP4ubgsAA1UVvrTW'
 }
 
-struct ImplBStored : ~Copyable & P2 {
+@frozen
+public struct ImplBStored : ~Copyable & P2 {
   var dummy: ()
-  var urs: U
+  public var urs: U
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplBStoredV3ursAA1UVvr : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -124,9 +129,10 @@ struct ImplBStored : ~Copyable & P2 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBStoredVAA2P2A2aDP3ursAA1UVvrTW'
 }
 
-struct ImplCStored : ~Copyable & P3 {
+@frozen
+public struct ImplCStored : ~Copyable & P3 {
   var dummy: ()
-  var ur: U
+  public var ur: U
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements11ImplCStoredV2urAA1UVvr : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF:%[^:]+]]
@@ -169,10 +175,10 @@ struct ImplCStored : ~Copyable & P3 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCStoredVAA2P3A2aDP2urAA1UVvrTW'
 }
 
-struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
-  typealias Property = U
+@frozen
+public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
   var _i: U
-  var ubgs: U {
+  public var ubgs: U {
     _read {
       yield _i
     }
@@ -222,10 +228,10 @@ struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
 }
 
-struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
-  typealias Property = U
+@frozen
+public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
   var _i: U
-  var urs: U {
+  public var urs: U {
     _read {
       yield _i
     }
@@ -275,10 +281,10 @@ struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
 }
 
-struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
-  typealias Property = U
+@frozen
+public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
   var _i: U
-  var ur: U {
+  public var ur: U {
     _read {
       yield _i
     }
@@ -388,9 +394,10 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplACoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW'
 }
 
-struct ImplBCoroutineAccessors : ~Copyable & P2 {
+@frozen
+public struct ImplBCoroutineAccessors : ~Copyable & P2 {
   var _i: U
-  var urs: U {
+  public var urs: U {
     read {
       yield _i
     }
@@ -472,9 +479,10 @@ struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplBCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvrTW'
 }
 
-struct ImplCCoroutineAccessors : ~Copyable & P3 {
+@frozen
+public struct ImplCCoroutineAccessors : ~Copyable & P3 {
   var _i: U
-  var ur: U {
+  public var ur: U {
     read {
       yield _i
     }
@@ -553,12 +561,13 @@ struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements23ImplCCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW'
 }
 
-struct ImplAGetSet : P1 {
+@frozen
+public struct ImplAGetSet : P1 {
   var _i: U {
     get { return U() }
     set {}
   }
-  var ubgs: U {
+  public var ubgs: U {
     get {
       return _i
     }
@@ -612,12 +621,13 @@ struct ImplAGetSet : P1 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvrTW'
 }
 
-struct ImplBGetSet : P2 {
+@frozen
+public struct ImplBGetSet : P2 {
   var _i: U {
     get { return U() }
     set {}
   }
-  var urs: U {
+  public var urs: U {
     get {
       return _i
     }
@@ -671,12 +681,13 @@ struct ImplBGetSet : P2 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvrTW'
 }
 
-struct ImplCGetSet : P3 {
+@frozen
+public struct ImplCGetSet : P3 {
   var _i: U {
     get { return U() }
     set {}
   }
-  var ur: U {
+  public var ur: U {
     get {
       return _i
     }
@@ -727,12 +738,13 @@ struct ImplCGetSet : P3 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvrTW'
 }
 
-struct ImplAUnsafeAddressors : P1 {
+@frozen
+public struct ImplAUnsafeAddressors : P1 {
   var iAddr: UnsafePointer<U>
   var iMutableAddr: UnsafeMutablePointer<U> {
     .init(mutating: iAddr)
   }
-  var ubgs: U {
+  public var ubgs: U {
     unsafeAddress {
       return iAddr
     }
@@ -790,12 +802,13 @@ struct ImplAUnsafeAddressors : P1 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvrTW'
 }
 
-struct ImplBUnsafeAddressors : P2 {
+@frozen
+public struct ImplBUnsafeAddressors : P2 {
   var iAddr: UnsafePointer<U>
   var iMutableAddr: UnsafeMutablePointer<U> {
     .init(mutating: iAddr)
   }
-  var urs: U {
+  public var urs: U {
     unsafeAddress {
       return iAddr
     }
@@ -854,12 +867,13 @@ struct ImplBUnsafeAddressors : P2 {
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvrTW'
 }
 
-struct ImplCUnsafeAddressors : P3 {
+@frozen
+public struct ImplCUnsafeAddressors : P3 {
   var iAddr: UnsafePointer<U>
   var iMutableAddr: UnsafeMutablePointer<U> {
     .init(mutating: iAddr)
   }
-  var ur: U {
+  public var ur: U {
     unsafeAddress {
       return iAddr
     }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -962,12 +962,14 @@ if run_vendor == 'apple':
         config.pre_stable_abi_triple = config.stable_abi_triple
         config.next_stable_abi_triple = config.stable_abi_triple
         config.future_abi_triple = '%s-%s-ios99-macabi' % (run_cpu, run_vendor)
+        config.abi_stability = 'stable'
         config.available_features.add('swift_stable_abi')
     else:
         # iOS 12.2 does not support 32-bit targets, so we cannot run tests that
         # want to deploy to an iOS that has Swift in the OS.
         if run_os == 'ios' and run_ptrsize == '32':
             pre_stable_version = '10'
+            config.abi_stability = 'unstable'
         else:
             config.available_features.add('swift_stable_abi')
             PRE_STABLE_VERSION = {
@@ -1015,12 +1017,14 @@ if run_vendor == 'apple':
         future_version = FUTURE_VERSION.get(run_os, '')
         config.future_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
                                                  future_version, run_environment)
+        config.abi_stability = 'stable'
 
 else:
     config.pre_stable_abi_triple = config.variant_triple
     config.stable_abi_triple = config.variant_triple
     config.next_stable_abi_triple = config.variant_triple
     config.future_triple = config.variant_triple
+    config.abi_stability = 'unstable'
 
 # On Apple platforms, this substitution names the maximum OS version *without*
 # Swift in the OS. On non-Apple platforms this is equivalent to %target-triple.
@@ -1039,6 +1043,9 @@ config.substitutions.append(('%target-next-stable-abi-triple',
 
 config.substitutions.append(('%target-future-triple',
                              config.future_triple))
+
+config.substitutions.append(('%target-abi-stability',
+                             config.abi_stability))
 
 config.substitutions.append(('%target-cpu', run_cpu))
 


### PR DESCRIPTION
Visit the new accessors when they're required (which always requires the new feature, among other things), adding them to witness and virtual tables.  For `modify2`, cache the required-ness in the same way that it is cached for `modify`.

Base the existence of the requirement for the underscored accessors on the availability of the non-underscored accessors.  If the (non-underscored) accessor's was available earlier than the feature, interpret that to mean that the underscored version was available in that earlier version, and require the underscored version.  The goal is to ensure that the ABI is preserved, so long as the simplest migration is done (namely, deleting the underscores from the old accessors).
