### PR TITLE
[SIL] Add verifier check to abort_apply.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2120,6 +2120,12 @@ public:
   void checkAbortApplyInst(AbortApplyInst *AI) {
     require(getAsResultOf<BeginApplyInst>(AI->getOperand())->isBeginApplyToken(),
             "operand of abort_apply must be a begin_apply");
+    auto *mvi = getAsResultOf<BeginApplyInst>(AI->getOperand());
+    auto *bai = cast<BeginApplyInst>(mvi->getParent());
+    require(!bai->getSubstCalleeType()->isCalleeAllocatedCoroutine() ||
+                AI->getFunction()->getASTContext().LangOpts.hasFeature(
+                    Feature::CoroutineAccessorsUnwindOnCallerError),
+            "abort_apply of callee-allocated yield-once coroutine!?");
   }
 
   void checkEndApplyInst(EndApplyInst *AI) {

--- a/test/SIL/verifier_failures.sil
+++ b/test/SIL/verifier_failures.sil
@@ -8,6 +8,8 @@ import Builtin
 
 class C {}
 
+protocol Error {}
+
 // CHECK-LABEL: Begin Error in function end_borrow_1_addr_alloc_stack
 // CHECK:       SIL verification failed: end_borrow of an address not produced by store_borrow
 // CHECK-LABEL: End Error in function end_borrow_1_addr_alloc_stack
@@ -43,4 +45,26 @@ sil [ossa] @dealloc_box_dead_end : $@convention(thin) () -> () {
   dealloc_box [dead_end] %b : ${ var C }
   %retval = tuple()
   return %retval : $()
+}
+
+// CHECK-LABEL: Begin Error in function abort_apply_callee_allocated_coro
+// CHECK:       SIL verification failed: abort_apply of callee-allocated yield-once coroutine!?
+// CHECK:       Verifying instruction:
+// CHECK:          ({{%[^,]+}}, **[[TOKEN:%[^,]+]]**, {{%[^,]+}}) = begin_apply
+// CHECK:       ->   abort_apply [[TOKEN]]
+// CHECK-LABEL: End Error in function abort_apply_callee_allocated_coro
+sil [ossa] @abort_apply_callee_allocated_coro : $@convention(thin) () -> (@error any Error) {
+entry:
+  (%value, %token, %allocation) = begin_apply undef() : $@yield_once_2 @convention(thin) () -> @yields @in_guaranteed ()
+  try_apply undef() : $@convention(thin) () -> @error any Error, normal success, error failure
+
+success(%val : $()):
+  end_apply %token as $()
+  dealloc_stack %allocation : $*Builtin.SILToken
+  return undef : $()
+
+failure(%error : @owned $any Error):
+  abort_apply %token
+  dealloc_stack %allocation : $*Builtin.SILToken
+  throw %error : $any Error
 }


### PR DESCRIPTION
Ban `abort_apply` when the callee is callee-allocated.
