### PR TITLE
[Build] Temporarily remove lldb smoketest from linux preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1071,7 +1071,6 @@ mixin-preset=
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts
     mixin_linux_installation
-    lldb-smoketest,tools=RA
 build-subdir=buildbot_linux
 lldb
 release


### PR DESCRIPTION
This preset adds `libcxx`, which neither the full test or toolchain jobs run.