### PR TITLE
[Concurrency] Fix arm64e ptrauth violations in Embedded Swift Concurrency

### DIFF
--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -194,9 +194,17 @@ class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
  public:
   size_t size;
   size_t alignMask;
-  void (*initializeWithCopy)(OpaqueValue *, OpaqueValue *);
-  void (*storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned);
-  void (*destroy)(OpaqueValue *);
+
+  void (*__ptrauth_swift_value_witness_function_pointer(
+      SpecialPointerAuthDiscriminators::InitializeWithCopy)
+            initializeWithCopy)(OpaqueValue *, OpaqueValue *);
+
+  void (*__ptrauth_swift_value_witness_function_pointer(
+      SpecialPointerAuthDiscriminators::StoreEnumTagSinglePayload)
+            storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned);
+
+  void (*__ptrauth_swift_value_witness_function_pointer(
+      SpecialPointerAuthDiscriminators::Destroy) destroy)(OpaqueValue *);
 
   static bool classof(const TaskOptionRecord *record) {
     return record->getKind() == TaskOptionRecordKind::ResultTypeInfo;

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1782,9 +1782,14 @@ void DefaultActorImpl::deallocate() {
 void DefaultActorImpl::deallocateUnconditional() {
   concurrency::trace::actor_deallocate(this);
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   auto metadata = cast<ClassMetadata>(this->metadata);
   swift_deallocClassInstance(this, metadata->getInstanceSize(),
                              metadata->getInstanceAlignMask());
+#else
+  // Embedded Swift's runtime doesn't actually use the size/mask values.
+  swift_deallocClassInstance(this, 0, 0);
+#endif
 }
 
 bool DefaultActorImpl::tryLock(bool asDrainer) {
@@ -2107,12 +2112,16 @@ static bool isDefaultActorClass(const ClassMetadata *metadata) {
 }
 
 void swift::swift_defaultActor_deallocateResilient(HeapObject *actor) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   auto metadata = cast<ClassMetadata>(actor->metadata);
   if (isDefaultActorClass(metadata))
     return swift_defaultActor_deallocate(static_cast<DefaultActor*>(actor));
 
   swift_deallocObject(actor, metadata->getInstanceSize(),
                       metadata->getInstanceAlignMask());
+#else
+  return swift_defaultActor_deallocate(static_cast<DefaultActor*>(actor));
+#endif
 }
 
 /// FIXME: only exists for the quick-and-dirty MainActor implementation.
@@ -2546,12 +2555,16 @@ swift::swift_distributedActor_remote_initialize(const Metadata *actorType) {
 }
 
 bool swift::swift_distributed_actor_is_remote(HeapObject *_actor) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   const ClassMetadata *metadata = cast<ClassMetadata>(_actor->metadata);
   if (isDefaultActorClass(metadata)) {
     return asImpl(reinterpret_cast<DefaultActor *>(_actor))->isDistributedRemote();
   } else {
     return asImpl(reinterpret_cast<NonDefaultDistributedActor *>(_actor))->isDistributedRemote();
   }
+#else
+  return false;
+#endif
 }
 
 bool DefaultActorImpl::isDistributedRemote() {


### PR DESCRIPTION
Under arm64e ptrauth, we need to be more diligent on:

- (1) The "minimal value witness table" that IRGen generates for task_create (`ResultTypeInfoTaskOptionRecord`) needs its function pointers to be signed. This PR uses the same signing scheme as regular Swift's value witness tables, i.e. address-discriminated pointers with special values per witness index (e.g. `SpecialPointerAuthDiscriminators::InitializeWithCopy`).

- (2) Accessing HeapObject's metadata, which under Embedded Swift is not actually a `ClassMetadata` object.

rdar://138814877
