### PR TITLE
[embedded] Add a riscv32-qemu-virt QEMU test configuration

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -547,6 +547,16 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
+
+  set(VARIANT_SUFFIX "-embedded-riscv32")
+  set(VARIANT_TRIPLE "riscv32-none-none-eabi")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "riscv32-qemu-virt")
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
 endif()
 
 # Add shortcuts for the default variant.

--- a/utils/embedded-test-support/embedded-test-support.py
+++ b/utils/embedded-test-support/embedded-test-support.py
@@ -63,6 +63,15 @@ def main():
         semihosting = False
         qemu_mode = "-bios"
         always_optimize_for_size = True
+    elif args.device == "riscv32-qemu-virt":
+        target = "riscv32-none-none-eabi"
+        qemu_binary = "qemu-system-riscv32"
+        qemu_machine = "virt"
+        mmcu = ""
+        entry_point = "start"
+        semihosting = False
+        qemu_mode = "-bios none -kernel"
+        always_optimize_for_size = True
     else:
         assert False
 

--- a/utils/embedded-test-support/riscv32-qemu-virt/linkerscript.ld
+++ b/utils/embedded-test-support/riscv32-qemu-virt/linkerscript.ld
@@ -1,0 +1,12 @@
+MEMORY
+{
+   ram   : ORIGIN = 0x80000000, LENGTH = 128K
+}
+
+SECTIONS
+{
+   .text     : { *(.start*) ; *(.text*) } > ram
+   .bss      : { *(.bss*) } > ram
+   .data     : { *(.data*) ; *(.rodata*) } > ram
+   /DISCARD/ : { *(.swift_modhash*) }
+}

--- a/utils/embedded-test-support/riscv32-qemu-virt/support.c
+++ b/utils/embedded-test-support/riscv32-qemu-virt/support.c
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stddef.h>
+#include <stdint.h>
+
+int puts(const char *p);
+
+__attribute__((naked))
+__attribute__((section(".start")))
+void start() {
+  asm volatile("la sp, stack + 8192 - 4");
+  asm volatile("call main");
+  asm volatile("call halt");
+}
+
+void halt(void) {
+  puts("HALT\n");
+  asm("unimp");
+}
+
+__attribute__((aligned(4))) char stack[8192];
+
+int putchar(int c) {
+  // This is only valid in an emulator (QEMU), and it's skipping a proper configuration of the UART device
+  // and waiting for a "ready to transit" state.
+
+  // QEMU riscv32-virt's specific location of the 16550A UART and its THR register
+  *(volatile uint8_t *)(0x10000000 + 0) = c;
+  return c;
+}


### PR DESCRIPTION
Similarly to the existing AVR and ARM configs, this adds a 32-bit RISC-V configuration for running baremetal Embedded Swift tests in QEMU.