### PR TITLE
Fix Builtin.FixedArray type reconstruction and change integer type mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -715,7 +715,7 @@ Types
   type ::= 'Xe'                              // error or unresolved type
 
 #if SWIFT_RUNTIME_VERSION >= 6.TBD
-  type ::= '$' 'n'? NATURAL_ZERO             // integer type
+  type ::= '$' 'n'? INDEX                    // integer type
 #endif
 
   bound-generic-type ::= type 'y' (type* '_')* type* retroactive-conformance* 'G'   // one type-list per nesting level of type

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -68,6 +68,15 @@ class ASTBuilder {
   /// For saving and restoring generic parameters.
   llvm::SmallVector<decltype(ParameterPacks), 2> ParameterPackStack;
 
+  /// The depth and index of each value parameter in the current generic
+  /// signature. We need this becasue the mangling for a type parameter
+  /// doesn't record whether it is a value or not; we find the correct
+  /// depth and index in this array, and use its value-ness.
+  llvm::SmallVector<std::tuple<std::pair<unsigned, unsigned>, Type>, 1> ValueParameters;
+
+  /// For saving and restoring generic parameters.
+  llvm::SmallVector<decltype(ValueParameters), 1> ValueParametersStack;
+
   /// This builder doesn't perform "on the fly" substitutions, so we preserve
   /// all pack expansions. We still need an active expansion stack though,
   /// for the dummy implementation of these methods:
@@ -93,6 +102,12 @@ public:
     for (auto *paramTy : genericSig.getGenericParams()) {
       if (paramTy->isParameterPack())
         ParameterPacks.emplace_back(paramTy->getDepth(), paramTy->getIndex());
+
+      if (paramTy->isValue()) {
+        auto pair = std::make_pair(paramTy->getDepth(), paramTy->getIndex());
+        auto tuple = std::make_tuple(pair, paramTy->getValueType());
+        ValueParameters.emplace_back(tuple);
+      }
     }
   }
 

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -250,6 +250,8 @@ public:
 
   Type createNegativeIntegerType(intptr_t value);
 
+  Type createBuiltinFixedArrayType(Type size, Type element);
+
   BuiltGenericSignature
   createGenericSignature(ArrayRef<BuiltType> params,
                          ArrayRef<BuiltRequirement> requirements);

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -455,7 +455,8 @@ void decodeRequirement(
     BuilderType &Builder) {
   for (auto &child : *node) {
     if (child->getKind() == Demangle::Node::Kind::DependentGenericParamCount ||
-        child->getKind() == Demangle::Node::Kind::DependentGenericParamPackMarker)
+        child->getKind() == Demangle::Node::Kind::DependentGenericParamPackMarker ||
+        child->getKind() == Demangle::Node::Kind::DependentGenericParamValueMarker)
       continue;
 
     if (child->getNumChildren() != 2)

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1530,6 +1530,23 @@ protected:
       return Builder.createNegativeIntegerType((intptr_t)Node->getIndex());
     }
 
+    case NodeKind::BuiltinFixedArray: {
+      if (Node->getNumChildren() < 2)
+        return MAKE_NODE_TYPE_ERROR(Node,
+                                    "fewer children (%zu) than required (2)",
+                                    Node->getNumChildren());
+
+      auto size = decodeMangledType(Node->getChild(0), depth + 1);
+      if (size.isError())
+        return size;
+
+      auto element = decodeMangledType(Node->getChild(1), depth + 1);
+      if (element.isError())
+        return element;
+
+      return Builder.createBuiltinFixedArrayType(size.getType(), element.getType());
+    }
+
     // TODO: Handle OpaqueReturnType, when we're in the middle of reconstructing
     // the defining decl
     default:

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -933,6 +933,12 @@ public:
     return nullptr;
   }
 
+  const TypeRef *createBuiltinFixedArrayType(const TypeRef *size,
+                                             const TypeRef *element) {
+    // FIXME: implement
+    return nullptr;
+  }
+
   // Construct a bound generic type ref along with the parent type info
   // The parent list contains every parent type with at least 1 generic
   // type parameter.

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1065,6 +1065,11 @@ Type ASTBuilder::createNegativeIntegerType(intptr_t value) {
   return IntegerType::get(std::to_string(value), /*isNegative*/ true, Ctx);
 }
 
+Type ASTBuilder::createBuiltinFixedArrayType(Type size, Type element) {
+  return BuiltinFixedArrayType::get(size->getCanonicalType(),
+                                    element->getCanonicalType());
+}
+
 GenericSignature
 ASTBuilder::createGenericSignature(ArrayRef<BuiltType> builtParams,
                                    ArrayRef<BuiltRequirement> requirements) {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3629,10 +3629,17 @@ void ASTMangler::appendGenericSignatureParts(
   ArrayRef<Requirement> requirements = parts.requirements;
   ArrayRef<InverseRequirement> inverseRequirements = parts.inverses;
 
-  // Mangle which generic parameters are pack parameters.
+  // Mangle the kind for each generic parameter.
   for (auto param : params) {
+    // Regular type parameters have no marker.
+
     if (param->isParameterPack())
       appendOpWithGenericParamIndex("Rv", param);
+
+    if (param->isValue()) {
+      appendType(param->getValueType(), sig);
+      appendOpWithGenericParamIndex("RV", param);
+    }
   }
 
   // Mangle the requirements.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1685,11 +1685,14 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
       appendOperator("$");
 
+      auto value = integer->getValue().getSExtValue();
+
       if (integer->isNegative()) {
-        appendOperator("n");
+        appendOperator("n", Index(-value));
+      } else {
+        appendOperator("", Index(value));
       }
 
-      appendOperator(integer->getDigitsText());
       return;
     }
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4450,11 +4450,11 @@ NodePointer Demangler::demangleIntegerType() {
   switch (peekChar()) {
   case 'n':
     nextChar();
-    integer = createNode(Node::Kind::NegativeInteger, -demangleNatural());
+    integer = createNode(Node::Kind::NegativeInteger, -demangleIndex());
     break;
 
   default:
-    integer = createNode(Node::Kind::Integer, demangleNatural());
+    integer = createNode(Node::Kind::Integer, demangleIndex());
     break;
   }
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1066,7 +1066,8 @@ private:
       auto child = Node->getChild(firstRequirement);
       if (child->getKind() == Node::Kind::Type)
         child = child->getChild(0);
-      if (child->getKind() != Node::Kind::DependentGenericParamPackMarker) {
+      if (child->getKind() != Node::Kind::DependentGenericParamPackMarker &&
+          child->getKind() != Node::Kind::DependentGenericParamValueMarker) {
         break;
       }
     }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -4009,9 +4009,10 @@ ManglingError Remangler::mangleNegativeInteger(Node *node, unsigned int depth) {
 
 ManglingError Remangler::mangleDependentGenericParamValueMarker(Node *node,
                                                                unsigned depth) {
-  DEMANGLER_ASSERT(node->getNumChildren() == 1, node);
-  DEMANGLER_ASSERT(node->getChild(0)->getKind() == Node::Kind::Type, node);
-  RETURN_IF_ERROR(mangleType(node->getChild(0)->getChild(1), depth + 1));
+  DEMANGLER_ASSERT(node->getNumChildren() == 2, node);
+  DEMANGLER_ASSERT(node->getChild(0)->getChild(0)->getKind() == Node::Kind::DependentGenericParamType, node);
+  DEMANGLER_ASSERT(node->getChild(1)->getKind() == Node::Kind::Type, node);
+  RETURN_IF_ERROR(mangleType(node->getChild(1), depth + 1));
   Buffer << "RV";
   mangleDependentGenericParamIndex(node->getChild(0)->getChild(0));
   return ManglingError::Success;

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -3996,13 +3996,15 @@ mangleNonUniqueExtendedExistentialTypeShapeSymbolicReference(Node *node,
 }
 
 ManglingError Remangler::mangleInteger(Node *node, unsigned int depth) {
-  Buffer << "$" << node->getIndex();
+  Buffer << "$";
+  mangleIndex(node->getIndex());
 
   return ManglingError::Success;
 }
 
 ManglingError Remangler::mangleNegativeInteger(Node *node, unsigned int depth) {
-  Buffer << "$n" << -node->getIndex();
+  Buffer << "$n";
+  mangleIndex(-node->getIndex());
 
   return ManglingError::Success;
 }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2454,6 +2454,13 @@ public:
   TypeLookupErrorOr<BuiltType> createNegativeIntegerType(intptr_t value) {
     return BuiltType(value);
   }
+
+  TypeLookupErrorOr<BuiltType> createBuiltinFixedArrayType(BuiltType size,
+                                                           BuiltType element) {
+    return BuiltType(swift_getFixedArrayTypeMetadata(MetadataState::Abstract,
+                                                     size.getValue(),
+                                                     element.getMetadata()));
+  }
 };
 
 }

--- a/test/DebugInfo/value-generics.swift
+++ b/test/DebugInfo/value-generics.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -enable-builtin-module -enable-experimental-feature ValueGenerics -disable-experimental-parser-round-trip -disable-availability-checking -o - | %FileCheck %s
+
+import Builtin
+
+struct Vector<let N: Int, Element: ~Copyable>: ~Copyable {
+  let storage: Builtin.FixedArray<N, Element>
+}
+
+extension Vector: Copyable where Element: Copyable {}
+
+// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$sxq_BVD"
+func genericBA<let N: Int, Element>(_: Builtin.FixedArray<N, Element>) {}
+
+// CHECK-DAG: !DICompositeType({{.*}}name: "$s4main6VectorVyxq_GD"
+func genericV<let N: Int, Element>(_: Vector<N, Element>) {}
+
+// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$s$4SiBVD"
+func concreteBA(_: Builtin.FixedArray<4, Int>) {}
+
+// CHECK-DAG: !DICompositeType({{.*}}name: "$s4main6VectorVy$2SiGD"
+func concreteV(_: Vector<2, Int>) {}

--- a/test/DebugInfo/value-generics.swift
+++ b/test/DebugInfo/value-generics.swift
@@ -14,8 +14,8 @@ func genericBA<let N: Int, Element>(_: Builtin.FixedArray<N, Element>) {}
 // CHECK-DAG: !DICompositeType({{.*}}name: "$s4main6VectorVyxq_GD"
 func genericV<let N: Int, Element>(_: Vector<N, Element>) {}
 
-// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$s$4SiBVD"
+// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$s$3_SiBVD"
 func concreteBA(_: Builtin.FixedArray<4, Int>) {}
 
-// CHECK-DAG: !DICompositeType({{.*}}name: "$s4main6VectorVy$2SiGD"
+// CHECK-DAG: !DICompositeType({{.*}}name: "$s4main6VectorVy$1_SiGD"
 func concreteV(_: Vector<2, Int>) {}

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -480,3 +480,6 @@ $s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
 $s2hi1SVIetMIy_TC  ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
 $s4mainAAyyycAA1CCFTTI ---> identity thunk of main.main(main.C) -> () -> ()
 $s4mainAAyyycAA1CCFTTH ---> hop to main actor thunk of main.main(main.C) -> () -> ()
+
+$s4main6VectorVy$1_SiG ---> main.Vector<2, Swift.Int>
+$s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>


### PR DESCRIPTION
We forgot to implement type decoder support for `Builtin.FixedArray`, so this patch adds that support which fixes type mangling round tripping. Also, the current integer type mangling can sometimes appear before other naturals in the mangling which creates an ambiguity, e.g. `$415Synchronization` where the integer type is `$4` and `15Synchronization` is the module name. Change the mangling to use the index mangling instead so that it'd be `$3_15Synchronization`.

Resolves: rdar://138798183