### PR TITLE
[ModuleInterface] NFC: Write `-interface-compiler-version` directly i…

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -124,16 +124,14 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
         !Opts.PackageFlags.IgnorableFlags.empty())
       ignorableFlags.push_back(Opts.PackageFlags.IgnorableFlags);
 
-    ignorableFlags.push_back("-interface-compiler-version");
-    ignorableFlags.push_back(version::getCompilerVersion());
+    out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": ";
 
-    if (!ignorableFlags.empty()) {
-      out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": ";
-      llvm::interleave(
-          ignorableFlags, [&out](StringRef str) { out << str; },
-          [&out] { out << " "; });
-      out << "\n";
-    }
+    llvm::interleave(
+        ignorableFlags, [&out](StringRef str) { out << str; },
+        [&out] { out << " "; });
+
+    out << " -interface-compiler-version " << version::getCompilerVersion();
+    out << "\n";
   }
 }
 


### PR DESCRIPTION
…nto the output

Instead of storing it in an ignorable attributes, let's emit the 
option directly into the output stream to apeace ASAN checker.

Resolves rdar://138824654.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
