### PR TITLE
[Build] Remove libcxx from lldb smoketest preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -296,8 +296,6 @@ skip-test-xros-host
 
 # This is a mixin preset which builds and smoke-tests lldb.
 [preset: lldb-smoketest,tools=RA]
-# Build libcxx for tests
-libcxx
 # Build LLDB
 lldb
 


### PR DESCRIPTION
libcxx requires a newer compiler than what we have in CI. Skip until we've updated.