### PR TITLE
[CS] Fix source range for `for` loop result builder transform

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -693,18 +693,20 @@ protected:
       return failTransform(forEachStmt);
 
     SmallVector<ASTNode, 4> doBody;
+    SourceLoc startLoc = forEachStmt->getStartLoc();
     SourceLoc endLoc = forEachStmt->getEndLoc();
 
     // Build a variable that is going to hold array of results produced
-    // by each iteration of the loop.
+    // by each iteration of the loop. Note we need to give it the start loc of
+    // the for loop to ensure the implicit 'do' has a correct source range.
     //
     // Not that it's not going to be initialized here, that would happen
     // only when a solution is found.
     VarDecl *arrayVar = buildPlaceholderVar(
-        forEachStmt->getEndLoc(), doBody,
+        startLoc, doBody,
         ArraySliceType::get(PlaceholderType::get(ctx, forEachVar.get())),
-        ArrayExpr::create(ctx, /*LBrace=*/endLoc, /*Elements=*/{},
-                          /*Commas=*/{}, /*RBrace=*/endLoc));
+        ArrayExpr::create(ctx, /*LBrace=*/startLoc, /*Elements=*/{},
+                          /*Commas=*/{}, /*RBrace=*/startLoc));
 
     NullablePtr<Expr> bodyVarRef;
     std::optional<UnsupportedElt> unsupported;

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -379,3 +379,34 @@ func testOverloadedCallArgs() {
   }
 
 }
+
+// https://github.com/swiftlang/swift/issues/77283
+func testInForLoop(_ x: [Int]) {
+  @resultBuilder
+  struct Builder {
+    static func buildBlock<T>(_ components: T...) -> T {
+      components.first!
+    }
+    static func buildArray<T>(_ components: [T]) -> T {
+      components.first!
+    }
+  }
+  struct S {
+    init() {}
+    func baz() -> Int { 0 }
+  }
+  struct R {
+    init<T>(@Builder _ x: () -> T) {}
+  }
+  _ = R {
+    for _ in x {
+      S().#^IN_FOR_LOOP^#
+      // IN_FOR_LOOP: Decl[InstanceMethod]/CurrNominal:   baz()[#Int#]; name=baz()
+    }
+  }
+  _ = R {
+    for _ in S().#^IN_FOR_LOOP_SEQ^# {
+      // IN_FOR_LOOP_SEQ: Decl[InstanceMethod]/CurrNominal:   baz()[#Int#]; name=baz()
+    }
+  }
+}


### PR DESCRIPTION
Ensure the implicit `do` statement has a source range that covers the `for` loop by changing the source location for the initial binding. This ensures we correctly detect the code completion child and avoid skipping it.

Resolves #77283