### PR TITLE
Serialization: Recover from errors under `loadObjCMethods`

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -712,8 +712,15 @@ void ModuleFile::loadObjCMethods(
       continue;
 
     // Deserialize the method and add it to the list.
+    // Drop methods with errors.
+    auto funcOrError = getDeclChecked(std::get<2>(result));
+    if (!funcOrError) {
+      diagnoseAndConsumeError(funcOrError.takeError());
+      continue;
+    }
+
     if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(
-                      getDecl(std::get<2>(result)))) {
+                      funcOrError.get())) {
       methods.push_back(func);
     }
   }

--- a/test/Serialization/Recovery/objc_report_method_override.swift
+++ b/test/Serialization/Recovery/objc_report_method_override.swift
@@ -1,0 +1,38 @@
+/// Recover under diagnoseUnintendedObjCMethodOverrides.
+/// rdar://138764733
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend -emit-module %t/HiddenDep.swift -I %t \
+// RUN:   -o %t/HiddenDep.swiftmodule \
+// RUN:   -disable-objc-attr-requires-foundation-module
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -I %t \
+// RUN:   -o %t/Lib.swiftmodule \
+// RUN:   -swift-version 6 -enable-library-evolution \
+// RUN:   -disable-objc-attr-requires-foundation-module
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -disable-objc-attr-requires-foundation-module
+
+//--- HiddenDep.swift
+@objc
+public class HiddenType {}
+
+//--- Lib.swift
+internal import HiddenDep
+
+@objc public class Redecl {
+  @objc
+  func methodWithXref() -> HiddenType { fatalError() }
+}
+
+//--- Client.swift
+import Lib
+
+extension Redecl {
+  @objc(methodWithXref)
+  func methodWithXref_alias() { }
+}


### PR DESCRIPTION
The diagnostics about unintended override of Objective-C methods deserialize more decls than strictly necessary. Any of these could trigger a deserialization failure if they rely on hidden dependencies. Simply ignore methods failing to deserialize instead of crashing.

We could improve further if necessary, this logic may ignore methods that are actually colliding. Instead we could put more information in the lookup table to avoid the need to fully deserializing the decls.

rdar://138764733