### PR TITLE
[sil] Move mark_unresolved_move_addr in SILNodes.def so it is not classified as a SingleValueInstruction.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -518,12 +518,6 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   SINGLE_VALUE_INST(CopyableToMoveOnlyWrapperAddrInst,
                     copyable_to_moveonlywrapper_addr, SingleValueInstruction,
                     None, DoesNotRelease)
-  // A move_addr is a Raw SIL only instruction that is equivalent to a copy_addr
-  // [init]. It is lowered during the diagnostic passes to a copy_addr [init] if
-  // the move checker found uses that prevented us from converting this to a
-  // move or if we do not find such uses, a copy_addr [init] [take].
-  NON_VALUE_INST(MarkUnresolvedMoveAddrInst, mark_unresolved_move_addr,
-                 SILInstruction, None, DoesNotRelease)
 
   // IsUnique does not actually write to memory but should be modeled
   // as such. Its operand is a pointer to an object reference. The
@@ -892,6 +886,13 @@ NON_VALUE_INST(PackElementSetInst, pack_element_set,
 // FIXME: Special MemBehavior for runtime failure?
 NON_VALUE_INST(CondFailInst, cond_fail,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
+
+// A move_addr is a Raw SIL only instruction that is equivalent to a copy_addr
+// [init]. It is lowered during the diagnostic passes to a copy_addr [init] if
+// the move checker found uses that prevented us from converting this to a
+// move or if we do not find such uses, a copy_addr [init] [take].
+NON_VALUE_INST(MarkUnresolvedMoveAddrInst, mark_unresolved_move_addr,
+               SILInstruction, None, DoesNotRelease)
 
 NON_VALUE_INST(IncrementProfilerCounterInst, increment_profiler_counter,
                SILInstruction, MayReadWrite, DoesNotRelease)


### PR DESCRIPTION
The specific problem here is that this causes MarkUnresolvedMoveAddr to be within the SINGLE_VALUE_INST_RANGE which defines the classify method used to determine if casting to a SingleValueInstruction is ok. This is of course not ok in this case since mark_unresolved_move_addr is actually a NonValueInst.

I noticed this b/c I made the same mistake with a new instruction I am added and hit a crash in the tests as a result of it being classified as a single value instruction. After fixing that, I checked for any more instances of this issue and found that mark_unresolved_move_addr was similarly afflicted.

----

Just chopping off layers of the onion of a larger commit that can stand alone.