### PR TITLE
[cxx-interop] Disambiguate template instantiations with array type parameters

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -137,6 +137,17 @@ struct TemplateInstantiationNamePrinter
             Visit(type->getElementType().getTypePtr()) + ">")
         .str();
   }
+
+  std::string VisitArrayType(const clang::ArrayType *type) {
+    return (Twine("[") + Visit(type->getElementType().getTypePtr()) + "]")
+        .str();
+  }
+
+  std::string VisitConstantArrayType(const clang::ConstantArrayType *type) {
+    return (Twine("Vector<") + Visit(type->getElementType().getTypePtr()) +
+            ", " + std::to_string(type->getSExtSize()) + ">")
+        .str();
+  }
 };
 
 std::string swift::importer::printClassTemplateSpecializationName(

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-primitive-argument.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-primitive-argument.h
@@ -19,11 +19,19 @@ typedef MagicWrapper<const long> WrappedMagicLongConst;
 typedef MagicWrapper<int*> WrappedMagicIntPtr;
 typedef MagicWrapper<const int*> WrappedMagicIntConstPtr;
 typedef MagicWrapper<int**> WrappedMagicIntPtrPtr;
+typedef MagicWrapper<int[]> WrappedMagicIntArr;
+typedef MagicWrapper<long[]> WrappedMagicLongArr;
+typedef MagicWrapper<int[123]> WrappedMagicIntFixedSizeArr1;
+typedef MagicWrapper<int[124]> WrappedMagicIntFixedSizeArr2;
 
 typedef DoubleWrapper<MagicWrapper<int>> DoubleWrappedInt;
 typedef DoubleWrapper<MagicWrapper<const int>> DoubleWrappedIntConst;
 typedef DoubleWrapper<MagicWrapper<const long>> DoubleWrappedLongConst;
 typedef DoubleWrapper<MagicWrapper<int*>> DoubleWrappedIntPtr;
 typedef DoubleWrapper<MagicWrapper<const int*>> DoubleWrappedIntConstPtr;
+typedef DoubleWrapper<MagicWrapper<int[]>> DoubleWrappedMagicIntArr;
+typedef DoubleWrapper<MagicWrapper<long[]>> DoubleWrappedMagicLongArr;
+typedef DoubleWrapper<MagicWrapper<int[42]>> DoubleWrappedMagicIntFixedSizeArr1;
+typedef DoubleWrapper<MagicWrapper<int[43]>> DoubleWrappedMagicIntFixedSizeArr2;
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_PRIMITIVE_ARGUMENT_H

--- a/test/Interop/Cxx/templates/class-template-with-primitive-argument-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-primitive-argument-module-interface.swift
@@ -13,9 +13,17 @@
 // CHECK: typealias WrappedMagicIntPtr = MagicWrapper<UnsafeMutablePointer<CInt>>
 // CHECK: typealias WrappedMagicIntConstPtr = MagicWrapper<UnsafePointer<CInt>>
 // CHECK: typealias WrappedMagicIntPtrPtr = MagicWrapper<UnsafeMutablePointer<UnsafeMutablePointer<CInt>>>
+// CHECK: typealias WrappedMagicIntArr = MagicWrapper<[CInt]>
+// CHECK: typealias WrappedMagicLongArr = MagicWrapper<[CLong]>
+// CHECK: typealias WrappedMagicIntFixedSizeArr1 = MagicWrapper<Vector<CInt, 123>>
+// CHECK: typealias WrappedMagicIntFixedSizeArr2 = MagicWrapper<Vector<CInt, 124>>
 
 // CHECK: typealias DoubleWrappedInt = DoubleWrapper<MagicWrapper<CInt>>
 // CHECK: typealias DoubleWrappedIntConst = DoubleWrapper<MagicWrapper<CInt_const>>
 // CHECK: typealias DoubleWrappedLongConst = DoubleWrapper<MagicWrapper<CLong_const>>
 // CHECK: typealias DoubleWrappedIntPtr = DoubleWrapper<MagicWrapper<UnsafeMutablePointer<CInt>>>
 // CHECK: typealias DoubleWrappedIntConstPtr = DoubleWrapper<MagicWrapper<UnsafePointer<CInt>>>
+// CHECK: typealias DoubleWrappedMagicIntArr = DoubleWrapper<MagicWrapper<[CInt]>>
+// CHECK: typealias DoubleWrappedMagicLongArr = DoubleWrapper<MagicWrapper<[CLong]>>
+// CHECK: typealias DoubleWrappedMagicIntFixedSizeArr1 = DoubleWrapper<MagicWrapper<Vector<CInt, 42>>>
+// CHECK: typealias DoubleWrappedMagicIntFixedSizeArr2 = DoubleWrapper<MagicWrapper<Vector<CInt, 43>>>


### PR DESCRIPTION
When Swift imports C++ template class instantiations, it generates a human-readable Swift name for each instantiation.

Having name collisions causes multiple Swift type with the same name, which confuses the compiler.

`MyClass<int[]>` and `MyClass<long[]>` were both being imported as `MyClass<_>` into Swift. This patch fixes that:

* `MyClass<int[]>` is now imported as `MyClass<[CInt]>`
* `MyClass<int[123]>` is now imported as `MyClass<Vector<CInt, 123>>`

rdar://138921102

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
