### PR TITLE
SIL: Fix SILType::isLoweringOf() to correctly handle opaque archetypes

### DIFF
--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -778,12 +778,11 @@ bool SILType::hasAbstractionDifference(SILFunctionTypeRepresentation rep,
 
 bool SILType::isLoweringOf(TypeExpansionContext context, SILModule &Mod,
                            CanType formalType) {
+  formalType =
+      substOpaqueTypesWithUnderlyingTypes(formalType, context)
+        ->getCanonicalType();
+
   SILType loweredType = *this;
-  if (formalType->hasOpaqueArchetype() &&
-      context.shouldLookThroughOpaqueTypeArchetypes() &&
-      loweredType.getASTType() ==
-          Mod.Types.getLoweredRValueType(context, formalType))
-    return true;
 
   // Optional lowers its contained type.
   SILType loweredObjectType = loweredType.getOptionalObjectType();

--- a/test/SILGen/opaque_result_type_structural.swift
+++ b/test/SILGen/opaque_result_type_structural.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s
+// RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 public protocol P {}
 
@@ -36,3 +36,22 @@ extension P {
   }
 }
 
+// Issues with metatypes
+struct G<T> {}
+struct S: P {}
+extension G: P where T: P {}
+
+func f2() -> G<some P>.Type {
+  return G<S>.self
+}
+
+func g() -> Any {
+  return f2()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s29opaque_result_type_structural1gypyF : $@convention(thin) () -> @out Any {
+// CHECK: bb0(%0 : $*Any):
+// CHECK: [[METATYPE:%.*]] = metatype $@thick G<S>.Type
+// CHECK: [[ADDR:%.*]] = init_existential_addr %0 : $*Any, $G<@_opaqueReturnTypeOf("$s29opaque_result_type_structural2f2AA1GVyQrGmyF", 0) __>.Type
+// CHECK: store [[METATYPE]] to [trivial] [[ADDR]] : $*@thick G<S>.Type
+// CHECK: return

--- a/validation-test/compiler_crashers_2_fixed/rdar138655637.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar138655637.swift
@@ -1,0 +1,110 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.9-abi-triple %s
+
+protocol P {
+    var p: Int { get }
+}
+
+protocol Q {
+    func p(content: Int) -> Int
+}
+
+struct Zero: P {
+    var p: Int { 0 }
+}
+
+struct One: P {
+    var p: Int { 1 }
+}
+
+struct Add: Q {
+    let rhs: Int
+
+    func p(content: Int) -> Int {
+        content + rhs
+    }
+}
+
+struct Multiply: Q {
+    let rhs: Int
+
+    func p(content: Int) -> Int {
+        content * rhs
+    }
+}
+
+struct G<Content: P, each Modifier: Q>: P {
+    var content: Content
+    var modifiers: (repeat each Modifier)
+
+    init(content: Content, modifiers: (repeat each Modifier)) {
+        self.content = content
+        self.modifiers = modifiers
+    }
+
+    var p: Int {
+        var r = content.p
+        for m in repeat each modifiers {
+            r = m.p(content: r)
+        }
+        return r
+    }
+}
+
+extension G: Equatable where Content: Equatable,
+    repeat each Modifier: Equatable
+{
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        guard lhs.content == rhs.content else { return false}
+        for (left, right) in repeat (each lhs.modifiers, each rhs.modifiers) {
+            guard left == right else { return false }
+        }
+        return true
+    }
+}
+
+
+extension G {
+    func modifier<T>(_ modifier: T) -> G<Content, repeat each Modifier, T> {
+        .init(content: content, modifiers: (repeat each modifiers, modifier))
+    }
+
+    func add(_ rhs: Int) -> G<Content, repeat each Modifier, some Q> {
+        modifier(Add(rhs: rhs))
+    }
+
+    func multiply(_ rhs: Int) -> G<Content, repeat each Modifier, some Q> {
+        modifier(Multiply(rhs: rhs))
+    }
+}
+
+extension P {
+    func modifier<T>(_ modifier: T) -> G<Self, T> {
+        return G(content: self, modifiers: modifier)
+    }
+
+    func add(_ rhs: Int) -> G<Self, some Q> {
+        modifier(Add(rhs: rhs))
+    }
+
+    func multiply(_ rhs: Int) -> G<Self, some Q> {
+        modifier(Multiply(rhs: rhs))
+    }
+}
+
+public func test() {
+    let r = Zero()
+        .multiply(1)
+        .multiply(2)
+        .add(3)
+        .multiply(4)
+        .add(2)
+        .multiply(6)
+        .add(2)
+        .multiply(6)
+        .add(2)
+        .multiply(6)
+
+    print(type(of: r))
+}
+
+test()


### PR DESCRIPTION
This predicate is meant to ask if the loweredType is equal to `getLoweredType(pattern, formalType)` for *some* abstraction pattern.

If the formal type contained an opaque archetype, we performed a different check, because we asked if loweredEqual is equal to `getLoweredType(AbstractionPattern(formalType), formalType)`.

This caused a spurious SIL verifier failure when the payload of an existential contained an opaque archetype, because we lower the payload with the most general AbstractionPattern, so that `@thin` metatypes become `@thick`, etc.

The regression test exercises this bug, and also another bug that was present in 6.0 but was already fixed on main by one of my earlier refactorings.

Fixes rdar://problem/138655637.