### PR TITLE
[Concurrency] Fix getTaskId.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -347,7 +347,7 @@ void AsyncTask::setTaskId() {
 uint64_t AsyncTask::getTaskId() {
   // Reconstitute a full 64-bit task ID from the 32-bit job ID and the upper
   // 32 bits held in _private().
-  return (uint64_t)Id << _private().Id;
+  return ((uint64_t)_private().Id << 32) | (uint64_t)Id;
 }
 
 SWIFT_CC(swift)


### PR DESCRIPTION
We should build a 64-bit value from the two 32-bit Id fields, but we were shifting one field by the other. Coincidentally, this managed to produce the correct value until the ID goes beyond 2^32, but after that it's weird and wrong.