### PR TITLE
[ASTGen] Use 'PURE' bridging mode to improve editor experience

### DIFF
--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -28,7 +28,7 @@ let swiftSourceDirectory = #filePath
 let swiftSetttings: [SwiftSetting] = [
   .interoperabilityMode(.Cxx),
   .unsafeFlags([
-    "-Xcc", "-DCOMPILED_WITH_SWIFT",
+    "-Xcc", "-DCOMPILED_WITH_SWIFT", "-Xcc", "-DPURE_BRIDGING_MODE",
     "-Xcc", "-UIBOutlet", "-Xcc", "-UIBAction", "-Xcc", "-UIBInspectable",
     "-Xcc", "-I\(swiftSourceDirectory)/include",
     "-Xcc", "-I\(swiftSourceDirectory)/../llvm-project/llvm/include",


### PR DESCRIPTION
'PURE' briding mode avoids importing things from `swift::` or `llvm::` namespaces. Since it significantly reduces the number of decls to import, editor experience is improved.
