### PR TITLE
Remove -enable-ossa-modules for Synchronization and Distributed 

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -27,11 +27,12 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/BlockList.h"
 #include "swift/Basic/CASOptions.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Malloc.h"
-#include "swift/Basic/BlockList.h"
+#include "swift/Serialization/SerializationOptions.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/Basic/DarwinSDKInfo.h"
@@ -266,7 +267,8 @@ class ASTContext final {
       SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
-      SourceManager &SourceMgr, DiagnosticEngine &Diags,
+      SerializationOptions &serializationOpts, SourceManager &SourceMgr,
+      DiagnosticEngine &Diags,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
 
 public:
@@ -283,7 +285,8 @@ public:
       SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
-      SourceManager &SourceMgr, DiagnosticEngine &Diags,
+      SerializationOptions &serializationOpts, SourceManager &SourceMgr,
+      DiagnosticEngine &Diags,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
   ~ASTContext();
 
@@ -313,6 +316,9 @@ public:
 
   /// The CAS options used by this AST context.
   const CASOptions &CASOpts;
+
+  /// Options for Serialization
+  const SerializationOptions &SerializationOpts;
 
   /// The source manager object.
   SourceManager &SourceMgr;

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -102,7 +102,7 @@ DECL_ATTR(_semantics, Semantics,
   OnAbstractFunction | OnSubscript | OnNominalType | OnVar | AllowMultipleAttributes | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   21)
 SIMPLE_DECL_ATTR(_transparent, Transparent,
-  OnFunc | OnAccessor | OnConstructor | OnVar | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  OnFunc | OnAccessor | OnConstructor | OnVar | OnDestructor | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   26)
 SIMPLE_DECL_ATTR(requires_stored_property_inits, RequiresStoredPropertyInits,
   OnClass | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -901,6 +901,9 @@ ERROR(serialization_target_too_new_repl,none,
       "deployment target of %0 %3: %4",
       (StringRef, llvm::VersionTuple, Identifier, llvm::VersionTuple,
        StringRef))
+ERROR(serialization_non_ossa_module_incompatible, Fatal,
+      "cannot import non-OSSA module into an OSSA module",
+      (Identifier))
 
 ERROR(serialization_fatal,Fatal,
       "fatal error encountered while reading from module '%0'; "

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -188,6 +188,10 @@ public:
   /// If this is disabled we do not serialize in OSSA form when optimizing.
   bool EnableOSSAModules = false;
 
+  /// Allow recompilation of a non-OSSA module to an OSSA module when imported
+  /// from another OSSA module.
+  bool EnableRecompilationToOSSAModule = false;
+
   /// If set to true, compile with the SIL Opaque Values enabled.
   bool EnableSILOpaqueValues = false;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -104,6 +104,7 @@ class CompilerInvocation {
   TBDGenOptions TBDGenOpts;
   ModuleInterfaceOptions ModuleInterfaceOpts;
   CASOptions CASOpts;
+  SerializationOptions SerializationOpts;
   llvm::MemoryBuffer *IDEInspectionTargetBuffer = nullptr;
 
   /// The offset that IDEInspection wants to further examine in offset of bytes
@@ -326,6 +327,11 @@ public:
 
   IRGenOptions &getIRGenOptions() { return IRGenOpts; }
   const IRGenOptions &getIRGenOptions() const { return IRGenOpts; }
+
+  SerializationOptions &getSerializationOptions() { return SerializationOpts; }
+  const SerializationOptions &getSerializationOptions() const {
+    return SerializationOpts;
+  }
 
   void setParseStdlib() {
     FrontendOpts.ParseStdlib = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1226,6 +1226,9 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOptionIg
             "when optimizing ownership will be lowered before serializing SIL">;
 }
 
+def enable_recompilation_to_ossa_module : Flag<["-"], "enable-recompilation-to-ossa-module">,
+  HelpText<"Allow recompilation of a non-OSSA module to an OSSA module when imported from another OSSA module">;
+
 def enable_sil_opaque_values : Flag<["-"], "enable-sil-opaque-values">,
   HelpText<"Enable SIL Opaque Values">;
 

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -24,143 +24,144 @@
 
 namespace swift {
 
-  class SerializationOptions {
-  public:
-    SerializationOptions() = default;
-    SerializationOptions(SerializationOptions &&) = default;
-    SerializationOptions &operator=(SerializationOptions &&) = default;
-    SerializationOptions(const SerializationOptions &) = default;
-    SerializationOptions &operator=(const SerializationOptions &) = default;
-    ~SerializationOptions() = default;
+class SerializationOptions {
+public:
+  SerializationOptions() = default;
+  SerializationOptions(SerializationOptions &&) = default;
+  SerializationOptions &operator=(SerializationOptions &&) = default;
+  SerializationOptions(const SerializationOptions &) = default;
+  SerializationOptions &operator=(const SerializationOptions &) = default;
+  ~SerializationOptions() = default;
 
-    StringRef OutputPath;
-    StringRef DocOutputPath;
-    StringRef SourceInfoOutputPath;
-    std::string ABIDescriptorPath;
-    bool emptyABIDescriptor = false;
-    llvm::VersionTuple UserModuleVersion;
-    std::set<std::string> AllowableClients;
-    std::string SDKName;
-    std::string SDKVersion;
+  StringRef OutputPath;
+  StringRef DocOutputPath;
+  StringRef SourceInfoOutputPath;
+  std::string ABIDescriptorPath;
+  bool emptyABIDescriptor = false;
+  llvm::VersionTuple UserModuleVersion;
+  std::set<std::string> AllowableClients;
+  std::string SDKName;
+  std::string SDKVersion;
 
-    StringRef GroupInfoPath;
-    StringRef ImportedHeader;
-    StringRef ModuleLinkName;
-    StringRef ModuleInterface;
-    std::vector<std::string> ExtraClangOptions;
-    std::vector<swift::PluginSearchOption> PluginSearchOptions;
+  StringRef GroupInfoPath;
+  StringRef ImportedHeader;
+  StringRef ModuleLinkName;
+  StringRef ModuleInterface;
+  std::vector<std::string> ExtraClangOptions;
+  std::vector<swift::PluginSearchOption> PluginSearchOptions;
 
-    /// Path prefixes that should be rewritten in debug info.
-    PathRemapper DebuggingOptionsPrefixMap;
+  /// Path prefixes that should be rewritten in debug info.
+  PathRemapper DebuggingOptionsPrefixMap;
 
-    /// Obfuscate the serialized paths so we don't have the actual paths encoded
-    /// in the .swiftmodule file.
-    PathObfuscator PathObfuscator;
+  /// Obfuscate the serialized paths so we don't have the actual paths encoded
+  /// in the .swiftmodule file.
+  PathObfuscator PathObfuscator;
 
-    /// Describes a single-file dependency for this module, along with the
-    /// appropriate strategy for how to verify if it's up-to-date.
-    class FileDependency {
-      /// The size of the file on disk, in bytes.
-      uint64_t Size : 62;
+  /// Describes a single-file dependency for this module, along with the
+  /// appropriate strategy for how to verify if it's up-to-date.
+  class FileDependency {
+    /// The size of the file on disk, in bytes.
+    uint64_t Size : 62;
 
-      /// A dependency can be either hash-based or modification-time-based.
-      bool IsHashBased : 1;
+    /// A dependency can be either hash-based or modification-time-based.
+    bool IsHashBased : 1;
 
-      /// The dependency path can be absolute or relative to the SDK
-      bool IsSDKRelative : 1;
+    /// The dependency path can be absolute or relative to the SDK
+    bool IsSDKRelative : 1;
 
-      union {
-        /// The last modification time of the file.
-        uint64_t ModificationTime;
+    union {
+      /// The last modification time of the file.
+      uint64_t ModificationTime;
 
-        /// The xxHash of the full contents of the file.
-        uint64_t ContentHash;
-      };
-
-      /// The path to the dependency.
-      std::string Path;
-
-      FileDependency(uint64_t size, bool isHash, uint64_t hashOrModTime,
-                     StringRef path, bool isSDKRelative):
-        Size(size), IsHashBased(isHash), IsSDKRelative(isSDKRelative),
-        ModificationTime(hashOrModTime), Path(path) {}
-    public:
-      FileDependency() = delete;
-
-      /// Creates a new hash-based file dependency.
-      static FileDependency
-      hashBased(StringRef path, bool isSDKRelative, uint64_t size, uint64_t hash) {
-        return FileDependency(size, /*isHash*/true, hash, path, isSDKRelative);
-      }
-
-      /// Creates a new modification time-based file dependency.
-      static FileDependency
-      modTimeBased(StringRef path, bool isSDKRelative, uint64_t size, uint64_t mtime) {
-        return FileDependency(size, /*isHash*/false, mtime, path, isSDKRelative);
-      }
-
-      /// Updates the last-modified time of this dependency.
-      /// If the dependency is a hash-based dependency, it becomes
-      /// modification time-based.
-      void setLastModificationTime(uint64_t mtime) {
-        IsHashBased = false;
-        ModificationTime = mtime;
-      }
-
-      /// Updates the content hash of this dependency.
-      /// If the dependency is a modification time-based dependency, it becomes
-      /// hash-based.
-      void setContentHash(uint64_t hash) {
-        IsHashBased = true;
-        ContentHash = hash;
-      }
-
-      /// Determines if this dependency is hash-based and should be validated
-      /// based on content hash.
-      bool isHashBased() const { return IsHashBased; }
-
-      /// Determines if this dependency is absolute or relative to the SDK.
-      bool isSDKRelative() const { return IsSDKRelative; }
-
-      /// Determines if this dependency is hash-based and should be validated
-      /// based on modification time.
-      bool isModificationTimeBased() const { return !IsHashBased; }
-
-      /// Gets the modification time, if this is a modification time-based
-      /// dependency.
-      uint64_t getModificationTime() const {
-        assert(isModificationTimeBased() &&
-               "cannot get modification time for hash-based dependency");
-        return ModificationTime;
-      }
-
-      /// Gets the content hash, if this is a hash-based
-      /// dependency.
-      uint64_t getContentHash() const {
-        assert(isHashBased() &&
-               "cannot get content hash for mtime-based dependency");
-        return ContentHash;
-      }
-
-      StringRef getPath() const { return Path; }
-      uint64_t getSize() const { return Size; }
+      /// The xxHash of the full contents of the file.
+      uint64_t ContentHash;
     };
-    ArrayRef<FileDependency> Dependencies;
-    ArrayRef<std::string> PublicDependentLibraries;
 
-    bool AutolinkForceLoad = false;
-    bool SerializeAllSIL = false;
-    bool SerializeOptionsForDebugging = false;
-    bool IsSIB = false;
-    bool DisableCrossModuleIncrementalInfo = false;
-    bool StaticLibrary = false;
-    bool HermeticSealAtLink = false;
-    bool EmbeddedSwiftModule = false;
-    bool IsOSSA = false;
-    bool SkipNonExportableDecls = false;
-    bool ExplicitModuleBuild = false;
-    bool EnableSerializationRemarks = false;
+    /// The path to the dependency.
+    std::string Path;
+
+    FileDependency(uint64_t size, bool isHash, uint64_t hashOrModTime,
+                   StringRef path, bool isSDKRelative)
+        : Size(size), IsHashBased(isHash), IsSDKRelative(isSDKRelative),
+          ModificationTime(hashOrModTime), Path(path) {}
+
+  public:
+    FileDependency() = delete;
+
+    /// Creates a new hash-based file dependency.
+    static FileDependency hashBased(StringRef path, bool isSDKRelative,
+                                    uint64_t size, uint64_t hash) {
+      return FileDependency(size, /*isHash*/ true, hash, path, isSDKRelative);
+    }
+
+    /// Creates a new modification time-based file dependency.
+    static FileDependency modTimeBased(StringRef path, bool isSDKRelative,
+                                       uint64_t size, uint64_t mtime) {
+      return FileDependency(size, /*isHash*/ false, mtime, path, isSDKRelative);
+    }
+
+    /// Updates the last-modified time of this dependency.
+    /// If the dependency is a hash-based dependency, it becomes
+    /// modification time-based.
+    void setLastModificationTime(uint64_t mtime) {
+      IsHashBased = false;
+      ModificationTime = mtime;
+    }
+
+    /// Updates the content hash of this dependency.
+    /// If the dependency is a modification time-based dependency, it becomes
+    /// hash-based.
+    void setContentHash(uint64_t hash) {
+      IsHashBased = true;
+      ContentHash = hash;
+    }
+
+    /// Determines if this dependency is hash-based and should be validated
+    /// based on content hash.
+    bool isHashBased() const { return IsHashBased; }
+
+    /// Determines if this dependency is absolute or relative to the SDK.
+    bool isSDKRelative() const { return IsSDKRelative; }
+
+    /// Determines if this dependency is hash-based and should be validated
+    /// based on modification time.
+    bool isModificationTimeBased() const { return !IsHashBased; }
+
+    /// Gets the modification time, if this is a modification time-based
+    /// dependency.
+    uint64_t getModificationTime() const {
+      assert(isModificationTimeBased() &&
+             "cannot get modification time for hash-based dependency");
+      return ModificationTime;
+    }
+
+    /// Gets the content hash, if this is a hash-based
+    /// dependency.
+    uint64_t getContentHash() const {
+      assert(isHashBased() &&
+             "cannot get content hash for mtime-based dependency");
+      return ContentHash;
+    }
+
+    StringRef getPath() const { return Path; }
+    uint64_t getSize() const { return Size; }
   };
+  ArrayRef<FileDependency> Dependencies;
+  ArrayRef<std::string> PublicDependentLibraries;
+
+  bool AutolinkForceLoad = false;
+  bool SerializeAllSIL = false;
+  bool SerializeOptionsForDebugging = false;
+  bool IsSIB = false;
+  bool DisableCrossModuleIncrementalInfo = false;
+  bool StaticLibrary = false;
+  bool HermeticSealAtLink = false;
+  bool EmbeddedSwiftModule = false;
+  bool IsOSSA = false;
+  bool SkipNonExportableDecls = false;
+  bool ExplicitModuleBuild = false;
+  bool EnableSerializationRemarks = false;
+};
 
 } // end namespace swift
 #endif

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -25,13 +25,12 @@
 namespace swift {
 
   class SerializationOptions {
-    SerializationOptions(const SerializationOptions &) = delete;
-    void operator=(const SerializationOptions &) = delete;
-
   public:
     SerializationOptions() = default;
     SerializationOptions(SerializationOptions &&) = default;
     SerializationOptions &operator=(SerializationOptions &&) = default;
+    SerializationOptions(const SerializationOptions &) = default;
+    SerializationOptions &operator=(const SerializationOptions &) = default;
     ~SerializationOptions() = default;
 
     StringRef OutputPath;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -757,7 +757,8 @@ ASTContext *ASTContext::get(
     SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
-    SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    SerializationOptions &serializationOpts, SourceManager &SourceMgr,
+    DiagnosticEngine &Diags,
     llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend) {
   // If more than two data structures are concatentated, then the aggregate
   // size math needs to become more complicated due to per-struct alignment
@@ -771,8 +772,8 @@ ASTContext *ASTContext::get(
   new (impl) Implementation();
   return new (mem)
       ASTContext(langOpts, typecheckOpts, silOpts, SearchPathOpts,
-                 ClangImporterOpts, SymbolGraphOpts, casOpts, SourceMgr, Diags,
-                 std::move(OutputBackend));
+                 ClangImporterOpts, SymbolGraphOpts, casOpts, serializationOpts,
+                 SourceMgr, Diags, std::move(OutputBackend));
 }
 
 ASTContext::ASTContext(
@@ -780,17 +781,19 @@ ASTContext::ASTContext(
     SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
-    SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    SerializationOptions &SerializationOpts, SourceManager &SourceMgr,
+    DiagnosticEngine &Diags,
     llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend)
     : LangOpts(langOpts), TypeCheckerOpts(typecheckOpts), SILOpts(silOpts),
       SearchPathOpts(SearchPathOpts), ClangImporterOpts(ClangImporterOpts),
-      SymbolGraphOpts(SymbolGraphOpts), CASOpts(casOpts), SourceMgr(SourceMgr),
-      Diags(Diags), OutputBackend(std::move(OutBackend)),
-      evaluator(Diags, langOpts), TheBuiltinModule(createBuiltinModule(*this)),
+      SymbolGraphOpts(SymbolGraphOpts), CASOpts(casOpts),
+      SerializationOpts(SerializationOpts), SourceMgr(SourceMgr), Diags(Diags),
+      OutputBackend(std::move(OutBackend)), evaluator(Diags, langOpts),
+      TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
       blockListConfig(SourceMgr),
-      TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(
+      TheErrorType(new(*this, AllocationArena::Permanent) ErrorType(
           *this, Type(), RecursiveTypeProperties::HasError)),
       TheUnresolvedType(new(*this, AllocationArena::Permanent)
                             UnresolvedType(*this)),
@@ -801,17 +804,17 @@ ASTContext::ASTContext(
     The##SHORT_ID##Type(new (*this, AllocationArena::Permanent) \
                           ID##Type(*this)),
 #include "swift/AST/TypeNodes.def"
-      TheIEEE32Type(new (*this, AllocationArena::Permanent)
+      TheIEEE32Type(new(*this, AllocationArena::Permanent)
                         BuiltinFloatType(BuiltinFloatType::IEEE32, *this)),
-      TheIEEE64Type(new (*this, AllocationArena::Permanent)
+      TheIEEE64Type(new(*this, AllocationArena::Permanent)
                         BuiltinFloatType(BuiltinFloatType::IEEE64, *this)),
-      TheIEEE16Type(new (*this, AllocationArena::Permanent)
+      TheIEEE16Type(new(*this, AllocationArena::Permanent)
                         BuiltinFloatType(BuiltinFloatType::IEEE16, *this)),
-      TheIEEE80Type(new (*this, AllocationArena::Permanent)
+      TheIEEE80Type(new(*this, AllocationArena::Permanent)
                         BuiltinFloatType(BuiltinFloatType::IEEE80, *this)),
-      TheIEEE128Type(new (*this, AllocationArena::Permanent)
+      TheIEEE128Type(new(*this, AllocationArena::Permanent)
                          BuiltinFloatType(BuiltinFloatType::IEEE128, *this)),
-      ThePPC128Type(new (*this, AllocationArena::Permanent)
+      ThePPC128Type(new(*this, AllocationArena::Permanent)
                         BuiltinFloatType(BuiltinFloatType::PPC128, *this)) {
 
   // Initialize all of the known identifiers.

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -180,6 +180,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       workerCompilerInvocation->getClangImporterOptions(),
                       workerCompilerInvocation->getSymbolGraphOptions(),
                       workerCompilerInvocation->getCASOptions(),
+                      workerCompilerInvocation->getSerializationOptions(),
                       ScanASTContext.SourceMgr, Diagnostics));
   auto loader = std::make_unique<PluginLoader>(
       *workerASTContext, /*DepTracker=*/nullptr,

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -188,11 +188,12 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
+  SerializationOptions SerializationOpts;
   LangOpts.Target = Invocation.getTargetTriple();
   LangOpts.EnableObjCInterop = Invocation.enableObjCInterop();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
-      SymbolGraphOpts, CASOpts, SrcMgr, Instance.getDiags(),
+      SymbolGraphOpts, CASOpts, SerializationOpts, SrcMgr, Instance.getDiags(),
       llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -82,9 +82,10 @@ struct LibParseExecutor {
     ClangImporterOptions clangOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
     CASOptions casOpts;
-    std::unique_ptr<ASTContext> ctx(
-        ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                        clangOpts, symbolOpts, casOpts, SM, diagEngine));
+    SerializationOptions serializationOpts;
+    std::unique_ptr<ASTContext> ctx(ASTContext::get(
+        langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
+        casOpts, serializationOpts, SM, diagEngine));
 
     SourceFile::ParsingOptions parseOpts;
     parseOpts |= SourceFile::ParsingFlags::DisablePoundIfEvaluation;
@@ -153,13 +154,14 @@ struct ASTGenExecutor {
     ClangImporterOptions clangOpts;
     CASOptions casOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
+    SerializationOptions serializationOpts;
 
     // Enable ASTGen.
     langOpts.enableFeature(Feature::ParserASTGen);
 
-    std::unique_ptr<ASTContext> ctx(
-        ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                        clangOpts, symbolOpts, casOpts, SM, diagEngine));
+    std::unique_ptr<ASTContext> ctx(ASTContext::get(
+        langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
+        casOpts, serializationOpts, SM, diagEngine));
     registerParseRequestFunctions(ctx->evaluator);
     registerTypeCheckerRequestFunctions(ctx->evaluator);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2697,6 +2697,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   Opts.EnableARCOptimizations &= !Args.hasArg(OPT_disable_arc_opts);
   Opts.EnableOSSAModules |= Args.hasArg(OPT_enable_ossa_modules);
+  Opts.EnableRecompilationToOSSAModule |=
+      Args.hasArg(OPT_enable_recompilation_to_ossa_module);
   Opts.EnableOSSAOptimizations &= !Args.hasArg(OPT_disable_ossa_opts);
   Opts.EnableSILOpaqueValues = Args.hasFlag(
       OPT_enable_sil_opaque_values, OPT_disable_sil_opaque_values, false);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -302,7 +302,8 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
       Invocation.getLangOptions(), Invocation.getTypeCheckerOptions(),
       Invocation.getSILOptions(), Invocation.getSearchPathOptions(),
       Invocation.getClangImporterOptions(), Invocation.getSymbolGraphOptions(),
-      Invocation.getCASOptions(), SourceMgr, Diagnostics, OutputBackend));
+      Invocation.getCASOptions(), Invocation.getSerializationOptions(),
+      SourceMgr, Diagnostics, OutputBackend));
   if (!Invocation.getFrontendOptions().ModuleAliasMap.empty())
     Context->setModuleAliases(Invocation.getFrontendOptions().ModuleAliasMap);
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1785,8 +1785,11 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   GenericArgs.push_back("-disable-objc-attr-requires-foundation-module");
 
   // If we are supposed to use RequireOSSAModules, do so.
-  genericSubInvocation.getSILOptions().EnableOSSAModules =
-      bool(RequireOSSAModules);
+  if (RequireOSSAModules) {
+    genericSubInvocation.getSILOptions().EnableOSSAModules = true;
+    GenericArgs.push_back("-enable-ossa-modules");
+  }
+
   if (LangOpts.DisableAvailabilityChecking) {
     genericSubInvocation.getLangOptions().DisableAvailabilityChecking = true;
     GenericArgs.push_back("-disable-availability-checking");

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -128,11 +128,12 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   SILOptions silOpts = ctx.SILOpts;
   CASOptions casOpts = ctx.CASOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts = ctx.SymbolGraphOpts;
+  SerializationOptions serializationOpts = ctx.SerializationOpts;
 
   DiagnosticEngine tmpDiags(tmpSM);
   auto &tmpCtx =
       *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
-                       symbolOpts, casOpts, tmpSM, tmpDiags);
+                       symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags);
   registerParseRequestFunctions(tmpCtx.evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx.evaluator);
 

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -241,9 +241,11 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
   ClangImporterOptions clangOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts;
   CASOptions casOpts;
+  SerializationOptions serializationOpts =
+      CachedCI->getASTContext().SerializationOpts;
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
-                      symbolOpts, casOpts, tmpSM, tmpDiags));
+                      symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags));
   tmpCtx->CancellationFlag = CancellationFlag;
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -63,7 +63,8 @@ bool SyntacticMacroExpansionInstance::setup(
       invocation.getLangOptions(), invocation.getTypeCheckerOptions(),
       invocation.getSILOptions(), invocation.getSearchPathOptions(),
       invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
-      invocation.getCASOptions(), SourceMgr, Diags));
+      invocation.getCASOptions(), invocation.getSerializationOptions(),
+      SourceMgr, Diags));
   registerParseRequestFunctions(Ctx->evaluator);
   registerTypeCheckerRequestFunctions(Ctx->evaluator);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1126,6 +1126,7 @@ struct ParserUnit::Implementation {
   ClangImporterOptions clangImporterOpts;
   symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
   CASOptions CASOpts;
+  SerializationOptions SerializationOpts;
   DiagnosticEngine Diags;
   ASTContext &Ctx;
   SourceFile *SF;
@@ -1136,8 +1137,8 @@ struct ParserUnit::Implementation {
                  const SILOptions &silOpts, StringRef ModuleName)
       : LangOpts(Opts), TypeCheckerOpts(TyOpts), SILOpts(silOpts), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
-                             clangImporterOpts, symbolGraphOpts, CASOpts, SM,
-                             Diags)) {
+                             clangImporterOpts, symbolGraphOpts, CASOpts,
+                             SerializationOpts, SM, Diags)) {
     registerParseRequestFunctions(Ctx.evaluator);
 
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1190,7 +1190,12 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
                        moduleBufferID);
     break;
   case serialization::Status::NotInOSSA:
-    // soft reject, silently ignore.
+    // Diagnose only when explicit build modules is enabled
+    if (Ctx.SerializationOpts.ExplicitModuleBuild) {
+      Ctx.Diags.diagnose(diagLoc,
+                         diag::serialization_non_ossa_module_incompatible,
+                         ModuleName);
+    }
     break;
   case serialization::Status::RevisionIncompatible:
     Ctx.Diags.diagnose(diagLoc, diag::serialization_module_incompatible_revision,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1190,8 +1190,8 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
                        moduleBufferID);
     break;
   case serialization::Status::NotInOSSA:
-    // Diagnose only when explicit build modules is enabled
-    if (Ctx.SerializationOpts.ExplicitModuleBuild) {
+    if (Ctx.SerializationOpts.ExplicitModuleBuild ||
+        !Ctx.SILOpts.EnableRecompilationToOSSAModule) {
       Ctx.Diags.diagnose(diagLoc,
                          diag::serialization_non_ossa_module_incompatible,
                          ModuleName);

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1836,6 +1836,9 @@ endfunction()
 # INSTALL_WITH_SHARED
 #   Install a static library target alongside shared libraries
 #
+# IMPORTS_NON_OSSA
+#   Imports a non-ossa module
+#
 # MACCATALYST_BUILD_FLAVOR
 #   Possible values are 'ios-like', 'macos-like', 'zippered', 'unzippered-twin'
 #   Presence of a build flavor requires SWIFT_MODULE_DEPENDS_MACCATALYST to be
@@ -1895,7 +1898,8 @@ function(add_swift_target_library name)
         SHARED
         STATIC
         NO_LINK_NAME
-        INSTALL_WITH_SHARED)
+        INSTALL_WITH_SHARED
+        IMPORTS_NON_OSSA)
   set(SWIFTLIB_single_parameter_options
         DEPLOYMENT_VERSION_IOS
         DEPLOYMENT_VERSION_OSX
@@ -2057,8 +2061,11 @@ function(add_swift_target_library name)
   # behavior for their requirements.
   if (SWIFTLIB_IS_STDLIB)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
-    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
+  endif()
+
+  if (NOT DEFINED IMPORTS_NON_OSSA)
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
   endif()
 
   if(NOT DEFINED SWIFTLIB_INSTALL_BINARY_SWIFTMODULE)

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -20,7 +20,7 @@ set(swift_distributed_link_libraries
   swiftCore)
 
 
-add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IMPORTS_NON_OSSA 
   DistributedActor.cpp
   DistributedActor.swift
   DistributedActorSystem.swift

--- a/stdlib/public/Synchronization/Atomics/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomics/Atomic.swift
@@ -42,11 +42,10 @@ public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
     _address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
   }
 
-  // Deinit's can't be marked @_transparent. Do these things need all of these
-  // attributes..?
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
+  @_transparent
   deinit {
     let oldValue = Value.decodeAtomicRepresentation(_address.pointee)
     _ = consume oldValue

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -76,7 +76,7 @@ set(SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS
   "-enable-experimental-feature" "Extern"
 )
 
-add_swift_target_library(swiftSynchronization ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+add_swift_target_library(swiftSynchronization ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IMPORTS_NON_OSSA 
   ${SWIFT_SYNCHRONIZATION_SOURCES}
 
   GYB_SOURCES

--- a/test/ScanDependencies/enable-ossa-modules-pass-down.swift
+++ b/test/ScanDependencies/enable-ossa-modules-pass-down.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/Frameworks
+// RUN: mkdir -p %t/Frameworks/E.framework/
+// RUN: mkdir -p %t/Frameworks/E.framework/Modules
+// RUN: mkdir -p %t/Frameworks/E.framework/Modules/E.swiftmodule
+
+// Copy over the interface
+// RUN: cp %S/Inputs/Swift/E.swiftinterface %t/Frameworks/E.framework/Modules/E.swiftmodule/%module-target-triple.swiftinterface
+
+// Run the scan
+// RUN: %target-swift-frontend -scan-dependencies -enable-ossa-modules -disable-implicit-swift-modules -module-load-mode prefer-interface %s -o %t/deps.json -F %t/Frameworks/ -sdk %t
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+import E
+
+// CHECK: E.swiftmodule/{{.*}}.swiftinterface
+// CHECK: "commandLine": [
+// CHECK: "-enable-ossa-modules"
+// CHECK: ]

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -68,7 +68,7 @@ protocol ProtoWithTransparent {
 class TestTranspClass : ProtoWithTransparent {
   @_transparent  // expected-error{{'@_transparent' attribute is not supported on declarations within classes}} {{3-17=}}
   init () {}
-  @_transparent // expected-error{{'@_transparent' attribute cannot be applied to this declaration}} {{3-17=}}
+  @_transparent // expected-error{{'@_transparent' attribute is not supported on declarations within classes}} {{3-17=}}
   deinit {}
   @_transparent // expected-error{{'@_transparent' attribute is not supported on declarations within classes}} {{3-17=}}
   class func transStatic() {}

--- a/test/embedded/basic-modules-validation-no-stdlib.swift
+++ b/test/embedded/basic-modules-validation-no-stdlib.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -parse-stdlib -enable-experimental-feature Embedded -wmo
 
 // MyModule is not embedded - error
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -wmo
+// RUN: %target-swift-frontend -emit-module -enable-ossa-modules -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -wmo
 // RUN: not %target-swift-frontend -emit-ir -I %t %t/Main.swift -parse-stdlib -enable-experimental-feature Embedded -wmo 2>&1 | %FileCheck %s --check-prefix CHECK-A
 
 // main module is not embedded - error

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -36,7 +36,7 @@ static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
     : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                            ClangImporterOpts, SymbolGraphOpts, CASOpts,
-                           SourceMgr, Diags)) {
+                           SerializationOpts, SourceMgr, Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -36,6 +36,7 @@ public:
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
+  SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -80,11 +80,12 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::SearchPathOptions searchPathOpts;
   swift::symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
   swift::CASOptions casOpts;
+  swift::SerializationOptions serializationOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
-  std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-                      symbolGraphOpts, casOpts, sourceMgr, diags));
+  std::unique_ptr<ASTContext> context(ASTContext::get(
+      langOpts, typecheckOpts, silOpts, searchPathOpts, options,
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");
@@ -197,14 +198,15 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   swift::DiagnosticEngine diags(sourceMgr);
   ClangImporterOptions options;
   CASOptions casOpts;
+  SerializationOptions serializationOpts;
   options.clangPath = "/usr/bin/clang";
   options.ExtraArgs.push_back(
       (llvm::Twine("--gcc-toolchain=") + "/opt/rh/devtoolset-9/root/usr")
           .str());
   options.ExtraArgs.push_back("--gcc-toolchain");
-  std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-                      symbolGraphOpts, casOpts, sourceMgr, diags));
+  std::unique_ptr<ASTContext> context(ASTContext::get(
+      langOpts, typecheckOpts, silOpts, searchPathOpts, options,
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
 
   {
     LibStdCxxInjectionVFS vfs;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -104,9 +104,10 @@ protected:
     symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
     SILOptions silOpts;
     CASOptions casOpts;
+    SerializationOptions serializationOpts;
     auto ctx = ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts,
                                clangImpOpts, symbolGraphOpts, casOpts,
-                               sourceMgr, diags);
+                               serializationOpts, sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -29,9 +29,9 @@ using namespace swift::unittest;
 using namespace swift::constraints::inference;
 
 SemaTest::SemaTest()
-    : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts,
-                               SearchPathOpts, ClangImporterOpts,
-                               SymbolGraphOpts, CASOpts, SourceMgr, Diags)) {
+    : Context(*ASTContext::get(
+          LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
+          SymbolGraphOpts, CASOpts, SerializationOpts, SourceMgr, Diags)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -43,6 +43,7 @@ public:
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
+  SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 


### PR DESCRIPTION
`Synchronization` and `Distributed` are serialized in OSSA, they import `Darwin` which is non-ossa. With implicit modules builds, this results in a one time recompilation of `Darwin` with `-enable-ossa-modules`. 
However with Explicit Build Modules, all dependencies are treating equally and `-enable-ossa-modules` will be passed on only when present in the original compiler invocation. 

This PR removes `-enable-ossa-modules` for `Synchronization` and `Distributed` and adds a diagnostic whenever we are trying to import a non-ossa module into an ossa module when Explicit Build Modules are enabled. 

As a consequence one of the perf constraint tests in `Synchronization` started failing due to presence of copies which was previously eliminated due to being in ossa. I added @_transparent to the relevant stdlib function - `Atomic.deinit` to workaround this since `@_transparent` functions are always serialized as ossa irrespective of the presence of `-enable-ossa-modules`. 

This is a temporary fix until ossa modules are default. 

Fixes rdar://138407068