### PR TITLE
Sema: Allow calls to @_unavailableInEmbedded functions in compatible contexts

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -44,18 +44,18 @@ private:
 
   AvailabilityContext(const Storage *info) : Info(info) { assert(info); };
 
-public:
-  /// Retrieves the default `AvailabilityContext`, which is maximally available.
-  /// The platform availability range will be set to the deployment target (or
-  /// minimum inlining target when applicable).
-  static AvailabilityContext getDefault(ASTContext &ctx);
-
   /// Retrieves a uniqued `AvailabilityContext` with the given platform
   /// availability parameters.
   static AvailabilityContext
   get(const AvailabilityRange &platformAvailability,
       std::optional<PlatformKind> unavailablePlatform, bool deprecated,
       ASTContext &ctx);
+
+public:
+  /// Retrieves the default `AvailabilityContext`, which is maximally available.
+  /// The platform availability range will be set to the deployment target (or
+  /// minimum inlining target when applicable).
+  static AvailabilityContext getDefault(ASTContext &ctx);
 
   /// Returns the range of platform versions which may execute code in the
   /// availability context, starting at its introduction version.
@@ -73,6 +73,9 @@ public:
 
   /// Returns true if this context is deprecated on the current platform.
   bool isDeprecated() const;
+
+  /// Returns true if this context is `@_unavailableInEmbedded`.
+  bool isUnavailableInEmbedded() const;
 
   /// Constrain with another `AvailabilityContext`.
   void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -49,17 +49,7 @@ struct AvailabilityContext::PlatformInfo {
   /// availability is more restrictive. Returns true if any field was updated.
   bool constrainWith(const Decl *decl);
 
-  bool constrainRange(const AvailabilityRange &other) {
-    if (!other.isContainedIn(Range))
-      return false;
-
-    Range = other;
-    return true;
-  }
-
   bool constrainUnavailability(std::optional<PlatformKind> unavailablePlatform);
-
-  bool constrainDeprecated(bool deprecated);
 
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const PlatformInfo &other) const;

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -36,6 +36,9 @@ struct AvailabilityContext::PlatformInfo {
   /// platform.
   unsigned IsUnavailable : 1;
 
+  /// Whether or not the context is `@_unavailableInEmbedded`.
+  unsigned IsUnavailableInEmbedded : 1;
+
   /// Whether or not the context is considered deprecated on the current
   /// platform.
   unsigned IsDeprecated : 1;
@@ -57,6 +60,7 @@ struct AvailabilityContext::PlatformInfo {
   void Profile(llvm::FoldingSetNodeID &ID) const {
     Range.getRawVersionRange().Profile(ID);
     ID.AddBoolean(IsUnavailable);
+    ID.AddBoolean(IsUnavailableInEmbedded);
     ID.AddInteger(static_cast<uint8_t>(UnavailablePlatform));
     ID.AddBoolean(IsDeprecated);
   }

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -311,7 +311,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 
     @available(*, unavailable, message: "use '$myTaskLocal.withValue(_:do:)' instead")
     set {
-      fatalError("Illegal attempt to set a \(Self.self) value, use `withValue(...) { ... }` instead.")
+      fatalError("Illegal attempt to set a TaskLocal value, use `withValue(...) { ... }` instead.")
     }
   }
 

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -3,8 +3,12 @@
 @available(*, unavailable)
 func unavailable_foo() {} // expected-note {{'unavailable_foo()' has been explicitly marked unavailable here}}
 
+@_unavailableInEmbedded // no-op without -enable-experimental-feature Embedded
+public func unavailable_in_embedded() { }
+
 func test() {
   unavailable_foo() // expected-error {{'unavailable_foo()' is unavailable}}
+  unavailable_in_embedded() // ok
 }
 
 @available(*,unavailable,message: "use 'Int' instead")

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -12,11 +12,11 @@ public struct UniverallyUnavailable {}
 
 @_unavailableInEmbedded
 public func unavailable_in_embedded() { }
-// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+// expected-note@-1 2 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public func universally_unavailable() { }
-// expected-note@-1 {{'universally_unavailable()' has been explicitly marked unavailable here}}
+// expected-note@-1 3 {{'universally_unavailable()' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unused() { } // no error
@@ -50,7 +50,7 @@ public func also_unavailable_in_embedded(
   _ uu: UniverallyUnavailable // FIXME: should be an error
 ) {
   unavailable_in_embedded() // OK
-  universally_unavailable() // FIXME: should be an error
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
   has_unavailable_in_embedded_overload(.init()) // FIXME: should be ambiguous
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }
@@ -60,8 +60,8 @@ public func also_universally_unavailable(
   _ uie: UnavailableInEmbedded, // OK
   _ uu: UniverallyUnavailable // OK
 ) {
-  unavailable_in_embedded() // FIXME: should be an error
-  universally_unavailable() // FIXME: should be an error
+  unavailable_in_embedded() // expected-error {{'unavailable_in_embedded()' is unavailable: unavailable in embedded Swift}}
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
   has_unavailable_in_embedded_overload(.init()) // not ambiguous, selects available overload
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -1,24 +1,67 @@
-// Building with regular Swift should succeed
-// RUN: %target-swift-emit-ir %s -parse-stdlib  -wmo
-
-// Building with embedded Swift should produce unavailability errors
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature Embedded  -wmo
+// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature Embedded
 
 // REQUIRES: swift_in_compiler
 
 @_unavailableInEmbedded
-public func embedded() { }
-public func regular() {
-	embedded() // expected-error {{'embedded()' is unavailable: unavailable in embedded Swift}}
-	// expected-note@-3 {{'embedded()' has been explicitly marked unavailable here}}
-}
+public struct UnavailableInEmbedded {}
+// expected-note@-1 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, message: "always unavailable")
+public struct UniverallyUnavailable {}
+// expected-note@-1 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
+
+@_unavailableInEmbedded
+public func unavailable_in_embedded() { }
+// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, message: "always unavailable")
+public func universally_unavailable() { }
+// expected-note@-1 {{'universally_unavailable()' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unused() { } // no error
 
+public struct S1 {}
+public struct S2 {}
+
 @_unavailableInEmbedded
-public func called_from_unavailable() { }
+public func has_unavailable_in_embedded_overload(_ s1: S1) { }
+
+public func has_unavailable_in_embedded_overload(_ s2: S2) { }
+
+@available(*, unavailable)
+public func has_universally_unavailable_overload(_ s1: S1) { }
+
+public func has_universally_unavailable_overload(_ s2: S2) { }
+
+public func available(
+  _ uie: UnavailableInEmbedded, // expected-error {{'UnavailableInEmbedded' is unavailable: unavailable in embedded Swift}}
+  _ uu: UniverallyUnavailable // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
+) {
+  unavailable_in_embedded() // expected-error {{'unavailable_in_embedded()' is unavailable: unavailable in embedded Swift}}
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  has_unavailable_in_embedded_overload(.init())
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
+}
+
 @_unavailableInEmbedded
-public func also_embedded() { 
-	called_from_unavailable() // no error
+public func also_unavailable_in_embedded(
+  _ uie: UnavailableInEmbedded, // OK
+  _ uu: UniverallyUnavailable // FIXME: should be an error
+) {
+  unavailable_in_embedded() // OK
+  universally_unavailable() // FIXME: should be an error
+  has_unavailable_in_embedded_overload(.init()) // FIXME: should be ambiguous
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
+}
+
+@available(*, unavailable)
+public func also_universally_unavailable(
+  _ uie: UnavailableInEmbedded, // OK
+  _ uu: UniverallyUnavailable // OK
+) {
+  unavailable_in_embedded() // FIXME: should be an error
+  universally_unavailable() // FIXME: should be an error
+  has_unavailable_in_embedded_overload(.init()) // not ambiguous, selects available overload
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }


### PR DESCRIPTION
Treat `@_unavailableInEmbedded` as if it were `@available(Embedded, unavailable)` and apply platform compatibility logic in the availability checker. Revert back to disallowing calls to universally unavailable functions (`@available(*, unavailable)`) in all contexts.

This change revealed that the implementation of `TaskLocal.projectedValue`'s setter was incompatible with Embedded Swift, since it relied on string interpolation. Just use a `StaticString` instead for the `fatalError()` in that method.

Unblocks https://github.com/swiftlang/swift/pull/77258.