### PR TITLE
[DNM] CI: Include stdlib build for Wasm in the Linux buildbot

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -870,6 +870,9 @@ build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 build-embedded-stdlib-cross-compiling
 
+wasmkit
+build-wasm-stdlib
+
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
 


### PR DESCRIPTION
Check the current CI build time bottleneck