### PR TITLE
[build.ps1] Emit full debug info in Release builds again

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -979,6 +979,10 @@ function Build-CMakeProject {
         $UseBuiltCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("CXX") -Or
         $UsePinnedCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("CXX")) {
       if ($DebugInfo -and $Platform -eq "Windows") {
+        $DebugFlag = if ($EnableCaching) { "/Z7" } else { "/Zi" }
+        Append-FlagsDefine $Defines CMAKE_C_FLAGS_RELEASE $DebugFlag
+        Append-FlagsDefine $Defines CMAKE_CXX_FLAGS_RELEASE $DebugFlag
+        # The following settings only handle Debug and RelWithDebInfo modes
         Append-FlagsDefine $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
         Append-FlagsDefine $Defines CMAKE_POLICY_CMP0141 NEW
         # Add additional linker flags for generating the debug info.


### PR DESCRIPTION
This patch re-introduces debug info generation for Release builds. `/Z7` is a legacy option that results in larger and less well optimized binaries. We use it only for compatibility with sccache and otherwise prefer `/Zi`. Please find more details below.

With [CMP0141](https://cmake.org/cmake/help/latest/policy/CMP0141.html) (or version 3.25+) CMake leaves debug information format flags out of the default `CMAKE_C/CXX_FLAGS_<CONFIG>` where compilers target the MSVC ABI. Instead it generates them depending on the value of the  `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` variable.

We use this approach since https://github.com/swiftlang/swift/commit/fe90ed91a68c44dc290870786e70bf9383dd6b23. This silently dropped the flags in release mode, because [the new setting](https://cmake.org/cmake/help/v3.25/prop_tgt/MSVC_DEBUG_INFORMATION_FORMAT.html) only applies in build modes Debug and RelWithDebInfo. We still get PDBs, because the linker's flag `/debug` remains, but they will be mostly empty and only contain debug-info from stdlib and system libs.

This might have gotten worse with https://github.com/swiftlang/swift/commit/7978272185ad65c69af6f4bd5ce00d03978451f3, which added support for object caching and hard-coded the build mode to Release instead of defaulting to it. In particular, `utils/build-windows-toolchain.bat` was considering an environment variable in the past.