### PR TITLE
Add cache for `USRBasedTypeContext::typeRelation`

### DIFF
--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -251,12 +251,6 @@ class USRBasedType {
       : USR(USR), Supertypes(Supertypes),
         CustomAttributeKinds(CustomAttributeKinds) {}
 
-  /// Implementation of \c typeRelation. \p VisistedTypes keeps track which
-  /// types have already been visited.
-  CodeCompletionResultTypeRelation
-  typeRelationImpl(const USRBasedType *ResultType, const USRBasedType *VoidType,
-                   SmallPtrSetImpl<const USRBasedType *> &VisitedTypes) const;
-
 public:
   /// A null \c USRBasedType that's represented by an empty USR and has no
   /// supertypes.

--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -207,6 +207,10 @@ private:
   /// allocated.
   const USRBasedTypeArena &Arena;
 
+  /// A cached set of type relations for this given type context.
+  mutable llvm::DenseMap<const USRBasedType *, CodeCompletionResultTypeRelation>
+      CachedTypeRelations;
+
   SmallVector<ContextualType, 4> ContextualTypes;
 
   /// See \c ExpectedTypeContext::ExpectedAttributeKinds.


### PR DESCRIPTION
This brings the time taken for the cached completion:

```swift
import SwiftUI

Table(#^CC^#
```

down from ~400ms to ~190ms.