### PR TITLE
[cxx-interop] Use the locations imported from C++

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1011,6 +1011,7 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
     return getLocFromSource();
   switch(File->getKind()) {
   case FileUnitKind::Source:
+  case FileUnitKind::ClangModule:
     return getLocFromSource();
   case FileUnitKind::SerializedAST: {
     if (!SerializedOK)
@@ -1019,7 +1020,6 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
   }
   case FileUnitKind::Builtin:
   case FileUnitKind::Synthesized:
-  case FileUnitKind::ClangModule:
   case FileUnitKind::DWARFModule:
     return SourceLoc();
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1351,12 +1351,11 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   if (!attrSourceFile)
     return nullptr;
 
-  // If the declaration has no source location and comes from a Clang module,
+  // If the declaration comes from a Clang module,
   // pretty-print the declaration and use that location.
   SourceLoc attachedToLoc = attachedTo->getLoc();
   bool isPrettyPrintedDecl = false;
-  if (attachedToLoc.isInvalid() &&
-      isa<ClangModuleUnit>(dc->getModuleScopeContext())) {
+  if (isa<ClangModuleUnit>(dc->getModuleScopeContext())) {
     isPrettyPrintedDecl = true;
     attachedToLoc = evaluateOrDefault(
         ctx.evaluator, PrettyPrintDeclRequest{attachedTo}, SourceLoc());

--- a/test/ClangImporter/cfuncs_scope.swift
+++ b/test/ClangImporter/cfuncs_scope.swift
@@ -8,10 +8,7 @@ func testLocalVsFileScope() {
 
   theFunctionInQuestion()
   // CHECK: :[[@LINE-1]]:25: error: missing argument
-  // CHECK: LocalVsFileScope.theFunctionInQuestion:1:{{[0-9]+}}: note:
-  // This is not a wonderful test because it's relying on the diagnostic
-  // engine's synthesis of fake declarations to figure out what module the
-  // importer assigned the function to. But, well, that's what we get.
+  // CHECK: LocalVsFileScope.h:{{[0-9]+}}:{{[0-9]+}}: note:
 
   aFunctionInBase() // just make sure it's imported
   // CHECK-NOT: :[[@LINE-1]]:{{[0-9]+}}:

--- a/test/ClangImporter/diags-with-many-imports.swift
+++ b/test/ClangImporter/diags-with-many-imports.swift
@@ -108,4 +108,4 @@ import Module100
 obsoleted()
 // CHECK: [[@LINE-1]]:1: error:
 // CHECK: explicitly marked unavailable here
-// CHECK: func obsoleted()
+// CHECK: void obsoleted() __attribute__((unavailable));

--- a/test/ClangImporter/experimental_diagnostics_no_noise.swift
+++ b/test/ClangImporter/experimental_diagnostics_no_noise.swift
@@ -60,12 +60,12 @@ s.c = 5
 // CHECK-NEXT: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: built-in type 'Complex' not supported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
-// CHECK-NEXT: ctypes.PartialImport.a:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
-// CHECK-NEXT:     public var a: Int32
-// CHECK-NEXT:                ^
-// CHECK-NEXT: ctypes.PartialImport.b:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
-// CHECK-NEXT:     public var b: Int32
-// CHECK-NEXT:                ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
+// CHECK-NEXT:     int a;
+// CHECK-NEXT:         ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
+// CHECK-NEXT:     int b;
+// CHECK-NEXT:         ^
 
 // CHECK-NOT: note
 // CHECK-NOT: warning

--- a/test/ClangImporter/experimental_diagnostics_opt_out.swift
+++ b/test/ClangImporter/experimental_diagnostics_opt_out.swift
@@ -19,8 +19,8 @@ _ = bar.methodReturningForwardDeclaredInterface()
 let s: PartialImport
 s.c = 5
 // CHECK: experimental_diagnostics_opt_out.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'PartialImport' has no member 'c'
-// CHECK: ctypes.PartialImport.a:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
-// CHECK: ctypes.PartialImport.b:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
+// CHECK: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
+// CHECK: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
 // CHECK-NOT: warning
 // CHECK-NOT: error
 // CHECK-NOT: note

--- a/test/ClangImporter/generic_compatibility_alias.swift
+++ b/test/ClangImporter/generic_compatibility_alias.swift
@@ -11,12 +11,12 @@ import ObjCIRExtras
 
 func foo(_: SwiftConstrGenericNameAlias<String>) {
 // expected-error@-1 {{'SwiftConstrGenericNameAlias' requires that 'String' inherit from 'NSNumber'}}
-// expected-note@-2  {{requirement specified as 'T' : 'NSNumber' [with T = String]}}
+// TODO: validate node in imported Obj-C header.
 }
 
 func faz(_: SwiftGenericNameAlias<Int>) {
 // expected-error@-1 {{'SwiftGenericNameAlias' requires that 'Int' be a class type}}
-// expected-note@-2  {{requirement specified as 'T' : 'AnyObject' [with T = Int]}}
+// TODO: validate node in imported Obj-C header.
 }
 
 func bar(_: SwiftGenericNameAlias<NSNumber>) {} // Ok

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -88,12 +88,12 @@ func testImportedTypeParamRequirements() {
   let _ = PettableContainer<Rock>()
   let _ = PettableContainer<Porcupine>() // expected-error{{type 'Porcupine' does not conform to protocol 'Pettable'}}
   let _ = PettableContainer<Cat>()
-  let _ = AnimalContainer<Desk>() // expected-error{{'AnimalContainer' requires that 'Desk' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
-  let _ = AnimalContainer<Rock>() // expected-error{{'AnimalContainer' requires that 'Rock' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
+  let _ = AnimalContainer<Desk>() // expected-error{{'AnimalContainer' requires that 'Desk' inherit from 'Animal'}} // TODO: add test for note appearing in Obj-c header.
+  let _ = AnimalContainer<Rock>() // expected-error{{'AnimalContainer' requires that 'Rock' inherit from 'Animal'}} // TODO: add test for note appearing in Obj-c header.
   let _ = AnimalContainer<Porcupine>()
   let _ = AnimalContainer<Cat>()
-  let _ = PettableAnimalContainer<Desk>() // expected-error{{'PettableAnimalContainer' requires that 'Desk' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
-  let _ = PettableAnimalContainer<Rock>() // expected-error{{'PettableAnimalContainer' requires that 'Rock' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
+  let _ = PettableAnimalContainer<Desk>() // expected-error{{'PettableAnimalContainer' requires that 'Desk' inherit from 'Animal'}} // TODO: add test for note appearing in Obj-c header.
+  let _ = PettableAnimalContainer<Rock>() // expected-error{{'PettableAnimalContainer' requires that 'Rock' inherit from 'Animal'}} // TODO: add test for note appearing in Obj-c header.
   let _ = PettableAnimalContainer<Porcupine>() // expected-error{{type 'Porcupine' does not conform to protocol 'Pettable'}}
   let _ = PettableAnimalContainer<Cat>()
 }

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -26,9 +26,9 @@ class MyObject : NSObject {
   // directly.
   // IMPORT-CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}entity: ![[OVERLAY]]
 
-  // ALLOCCTOR-CHECK: ![[F:.*]] = !DIFile(filename: "<compiler-generated>",
   // ALLOCCTOR-CHECK: distinct !DISubprogram(name: "init", linkageName: "$sSo7NSArrayCABycfC"
-  // ALLOCCTOR-CHECK-SAME: file: ![[F]],
+  // ALLOCCTOR-CHECK-SAME: file: ![[F:[0-9]+]],
+  // ALLOCCTOR-CHECK: ![[F]] = !DIFile(filename: "{{.*}}/NSArray.h",
   @objc func foo(_ obj: MyObject) {
     return obj.foo(obj)
   }

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -179,7 +179,7 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
   - (void) myMethod:(NSInteger)value1 foo:(NSInteger)value2;
 @end
 
-@interface GenericObject<T> : NSObject
+@interface GenericObject<T> : NSObject // expected-note {{generic class 'GenericObject' does not conform to the 'Sendable' protocol}}
 - (void)doSomethingWithCompletionHandler:(void (^)(T _Nullable_result, NSError * _Nullable))completionHandler;
 - (void)doAnotherThingWithCompletionHandler:(void (^)(GenericObject<T> *_Nullable))completionHandler;
 @end
@@ -218,7 +218,7 @@ MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor"))) @protocol Tr
 
 SENDABLE @interface SendableClass : NSObject @end
 
-NONSENDABLE @interface NonSendableClass : NSObject @end
+NONSENDABLE @interface NonSendableClass : NSObject @end // expected-note {{class 'NonSendableClass' does not conform to the 'Sendable' protocol}}
 
 ASSUME_NONSENDABLE_BEGIN
 
@@ -232,14 +232,14 @@ SENDABLE @protocol SendableProtocol @end
 typedef NS_ENUM(unsigned, SendableEnum) {
   SendableEnumFoo, SendableEnumBar
 };
-typedef NS_ENUM(unsigned, NonSendableEnum) {
+typedef NS_ENUM(unsigned, NonSendableEnum) { // expected-note {{enum 'NonSendableEnum' does not conform to the 'Sendable' protocol}}
   NonSendableEnumFoo, NonSendableEnumBar
 } NONSENDABLE;
 
 typedef NS_OPTIONS(unsigned, SendableOptions) {
   SendableOptionsFoo = 1 << 0, SendableOptionsBar = 1 << 1
 };
-typedef NS_OPTIONS(unsigned, NonSendableOptions) {
+typedef NS_OPTIONS(unsigned, NonSendableOptions) { // expected-note {{struct 'NonSendableOptions' does not conform to the 'Sendable' protocol}}
   NonSendableOptionsFoo = 1 << 0, NonSendableOptionsBar = 1 << 1
 } NONSENDABLE;
 
@@ -264,10 +264,10 @@ UI_ACTOR
 @end
 
 typedef NSString *SendableStringEnum NS_STRING_ENUM;
-typedef NSString *NonSendableStringEnum NS_STRING_ENUM NONSENDABLE;
+typedef NSString *NonSendableStringEnum NS_STRING_ENUM NONSENDABLE; // expected-note {{struct 'NonSendableStringEnum' does not conform to the 'Sendable' protocol}}
 
 typedef NSString *SendableStringStruct NS_EXTENSIBLE_STRING_ENUM;
-typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE;
+typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE; // expected-note {{struct 'NonSendableStringStruct' does not conform to the 'Sendable' protocol}}
 
 SENDABLE
 typedef struct {

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -48,6 +48,7 @@ public func noAnnotations() -> View {
     // CHECK-NOT: nonescapable.h:19
     f2(nil, nil)
     // CHECK: nonescapable.h:23:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
+    // CHECKL nonescapable.h:23:6: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
     g(nil)
     return View()
 }

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -368,7 +368,7 @@ let strInterpolation = "This is a \(stringStr + "ing") interpolation"
 // CHECK13: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>testDefaultParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arg1</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type> = 0</decl.var.parameter>)</decl.function.free>
 
 // RUN: %sourcekitd-test -req=cursor -pos=34:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
-// CHECK14: source.lang.swift.ref.function.free ({{.*}}Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h:4:5-4:16)
+// CHECK14: source.lang.swift.ref.function.free ({{.*}}Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h:4:5-4:22)
 // CHECK14: fooSubFunc1
 // CHECK14: c:@F@fooSubFunc1
 // CHECK14: source.lang.objc

--- a/test/TypeDecoder/objc_classes.swift
+++ b/test/TypeDecoder/objc_classes.swift
@@ -87,8 +87,8 @@ do {
 // DEMANGLE-DECL: $sSo7NSCacheCySo8NSNumberCSo8NSStringCG
 // DEMANGLE-DECL: $sSo26NSPropertyListWriteOptionsa
 
-// CHECK-DECL: Foundation.(file).NSSet
-// CHECK-DECL: Foundation.(file).NSFastEnumeration
+// CHECK-DECL: Foundation.(file).NSSet@{{.*}}NSSet.h:{{[0-9]+}}:{{[0-9]+}}
+// CHECK-DECL: Foundation.(file).NSFastEnumeration@{{.*}}NSEnumerator.h:{{[0-9]+}}:{{[0-9]+}}
 // CHECK-DECL: objc_classes.(file).OurObjCProtocol
-// CHECK-DECL: Foundation.(file).NSCache
-// CHECK-DECL: Foundation.(file).PropertyListSerialization extension.WriteOptions
+// CHECK-DECL: Foundation.(file).NSCache@{{.*}}NSCache.h:{{[0-9]+}}:{{[0-9]+}}
+// CHECK-DECL: Foundation.(file).PropertyListSerialization extension.WriteOptions@{{.*}}NSPropertyList.h:{{[0-9]+}}:{{[0-9]+}}


### PR DESCRIPTION
A recent PR (#77204) started to import C++ source locations into Swift. This PR flips a switch so these locations are actually used more widely.
