### PR TITLE
[unittests] Use enum name instead of literal 0 (NFC)

### DIFF
--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -332,7 +332,8 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_startOnMainActorImpl) {
 
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_isCurrentExecutorWithFlags) {
-  swift_task_isCurrentExecutorWithFlags(swift_task_getMainExecutor(), 0);
+  swift_task_isCurrentExecutorWithFlags(
+      swift_task_getMainExecutor(), swift_task_is_current_executor_flag::None);
 }
 
 #if RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST


### PR DESCRIPTION
For some reason this piece of code was triggering an error when building unified in which a suitable overload for `0` (and `int`) could not be found. Use the named enum value instead to avoid the problem.
