### PR TITLE
[test] Fix incorrect usage of swift_obj_root in unified builds

### DIFF
--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -92,8 +92,8 @@ def fixit_loc(start_col, orig_suffix):
 //
 
 // CHECK-LABEL: // Mappings from '#fileID' to '#filePath':
-// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}magic_identifier_file_conflicting.swift'
-// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}other_path_b{{[/\\]}}magic_identifier_file_conflicting.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{.*}}{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}magic_identifier_file_conflicting.swift'
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{.*}}{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}other_path_b{{[/\\]}}magic_identifier_file_conflicting.swift' (alternate)
 // CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'magic_identifier_file_conflicting.swift' (alternate)
 // CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting_other.swift' => 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}SILGen{{[/\\]}}Inputs{{[/\\]}}magic_identifier_file_conflicting_other.swift'
 // CHECK-NEXT:  //   'Foo/other_file_a.swift' => 'other_file_a.swift'

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2978,12 +2978,12 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitiz
         shell_quote(sys.executable),
         shell_quote(config.PathSanitizingFileCheck),
         # LLVM Lit performs realpath with the config path, so all paths are relative
-        # to the real path. swift_obj_root and swift_src_root come from CMake, which
+        # to the real path. cmake_binary_dir and swift_src_root come from CMake, which
         # might not do real path. Because we have to match what Lit uses against what
         # we provide we use realpath here. Because PathSanitizingFileCheck only
         # understands sanitize patterns with forward slashes, and realpath normalizes
         # the slashes, we have to replace them back to forward slashes.
-        shell_quote(lit.util.abs_path_preserve_drive(swift_obj_root).replace("\\", "/")),
+        shell_quote(lit.util.abs_path_preserve_drive(config.cmake_binary_dir).replace("\\", "/")),
         shell_quote(lit.util.abs_path_preserve_drive(config.swift_src_root).replace("\\", "/")),
         shell_quote(config.filecheck),
         '--color' if config.color_output else '',

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -16,6 +16,7 @@ import sys
 import lit.util
 
 config.cmake = "@CMAKE_COMMAND@"
+config.cmake_binary_dir = "@CMAKE_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -14,6 +14,7 @@ import sys
 import platform
 
 config.cmake = "@CMAKE_COMMAND@"
+config.cmake_binary_dir = "@CMAKE_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"


### PR DESCRIPTION
When doing an unified build (Swift being an external project of LLVM), the Swift build is at `<llvm build dir>/tools/swift`, and that is the value of `swift_obj_root`. However many products are actually placed in `<llvm build dir>`, like `bin/`, `include/` and things like `lib/swift/...` and others.

A couple of macros tests check the error messages printed by the compiler against `swift_obj_root` (by the replacement done in `PathSanitizingFileCheck` of `BUILD_DIR`) when it should have been checking them against the top-level build directory, which will work in both unified and non-unified builds (like `build-script` builds).