### PR TITLE
LargeTypesReg2Mem: Add a new heuristic that trys harder to keep large     values on the stack

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
@@ -75,7 +75,7 @@ let deadStoreElimination = FunctionPass(name: "dead-store-elimination") {
 }
 
 private func tryEliminate(store: StoreInst, complexityBudget: inout Int, _ context: FunctionPassContext) {
-  if !store.hasValidOwnershipForDeadStoreElimination {
+  if !store.hasValidOwnershipForDeadStoreElimination || !store.source.type.shouldExpand(context) {
     return
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -97,6 +97,9 @@ private func eliminateRedundantLoads(in function: Function, ignoreArrays: Bool, 
         {
           continue
         }
+        if !load.type.shouldExpand(context) {
+           continue
+        }
         tryEliminate(load: load, complexityBudget: &complexityBudget, context)
       }
     }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -20,6 +20,10 @@ struct Options {
     _bridged.enableStackProtection()
   }
 
+  var useAggressiveReg2MemForCodeSize : Bool {
+    _bridged.useAggressiveReg2MemForCodeSize()
+  }
+
   var enableMoveInoutStackProtection: Bool {
     _bridged.enableMoveInoutStackProtection()
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -809,3 +809,12 @@ extension CheckedCastAddrBranchInst {
     }
   }
 }
+
+extension Type {
+  func shouldExpand(_ context: some Context) -> Bool {
+    if !context.options.useAggressiveReg2MemForCodeSize {
+      return true
+    }
+    return context._bridged.shouldExpand(self.bridged)
+  }
+}

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -318,6 +318,10 @@ public:
   /// for the debugger?
   bool ShouldFunctionsBePreservedToDebugger = true;
 
+  /// Block expanding and register promotion more aggressively throughout the
+  /// optimizer.
+  bool UseAggressiveReg2MemForCodeSize = false;
+
   SILOptions() {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1294,6 +1294,13 @@ def disable_lifetime_dependence_diagnostics :
   Flag<["-"], "disable-lifetime-dependence-diagnostics">,
   HelpText<"Disable lifetime dependence diagnostics for Nonescapable types.">;
 
+def enable_aggressive_reg2mem :
+  Flag<["-"], "enable-aggressive-reg2mem">,
+  HelpText<"Enable a more aggresive reg2mem heuristic">;
+def disable_aggressive_reg2mem :
+  Flag<["-"], "disable-aggresive-reg2mem">,
+  HelpText<"Disable a more aggresive reg2mem heuristic">;
+
 def enable_collocate_metadata_functions :
   Flag<["-"], "enable-collocate-metadata-functions">,
   HelpText<"Enable collocate metadata functions">;

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -261,6 +261,8 @@ struct BridgedPassContext {
   BRIDGED_INLINE bool optimizeMemoryAccesses(BridgedFunction f) const;
   BRIDGED_INLINE bool eliminateDeadAllocations(BridgedFunction f) const;
 
+  BRIDGED_INLINE bool shouldExpand(BridgedType type) const;
+
   // IRGen
 
   SwiftInt getStaticSize(BridgedType type) const;
@@ -372,6 +374,7 @@ struct BridgedPassContext {
     Unchecked = 2
   };
 
+  BRIDGED_INLINE bool useAggressiveReg2MemForCodeSize() const;
   BRIDGED_INLINE bool enableStackProtection() const;
   BRIDGED_INLINE bool hasFeature(BridgedFeature feature) const;
   BRIDGED_INLINE bool enableMoveInoutStackProtection() const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -556,9 +556,19 @@ bool BridgedPassContext::enableMoveInoutStackProtection() const {
   return mod->getOptions().EnableMoveInoutStackProtection;
 }
 
+bool BridgedPassContext::useAggressiveReg2MemForCodeSize() const {
+  swift::SILModule *mod = invocation->getPassManager()->getModule();
+  return mod->getOptions().UseAggressiveReg2MemForCodeSize;
+}
+
 BridgedPassContext::AssertConfiguration BridgedPassContext::getAssertConfiguration() const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
   return (AssertConfiguration)mod->getOptions().AssertConfig;
+}
+
+bool BridgedPassContext::shouldExpand(BridgedType ty) const {
+  swift::SILModule &mod = *invocation->getPassManager()->getModule();
+  return swift::shouldExpand(mod, ty.unbridged());
 }
 
 static_assert((int)BridgedPassContext::SILStage::Raw == (int)swift::SILStage::Raw);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3738,6 +3738,7 @@ bool CompilerInvocation::parseArgs(
     SILOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
     SILOpts.EmbeddedSwift = true;
+    SILOpts.UseAggressiveReg2MemForCodeSize = true;
     // OSSA modules are required for deinit de-virtualization.
     SILOpts.EnableOSSAModules = true;
     // -g is promoted to -gdwarf-types in embedded Swift
@@ -3750,6 +3751,11 @@ bool CompilerInvocation::parseArgs(
       return true;
     }
   }
+
+  SILOpts.UseAggressiveReg2MemForCodeSize =
+    ParsedArgs.hasFlag(OPT_enable_aggressive_reg2mem,
+                       OPT_disable_aggressive_reg2mem,
+                       SILOpts.UseAggressiveReg2MemForCodeSize);
 
   // With Swift 6, enable @_spiOnly by default. This also enables proper error
   // reporting of ioi references from spi decls.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5346,7 +5346,8 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
                                                 IRGenFunction &IGF,
                                                 Explosion &fromNonNative,
                                                 SILType type,
-                                                bool isOutlined) const {
+                                                bool isOutlined,
+                                                bool mayPeepholeLoad) const {
   if (fromNonNative.empty()) {
     assert(empty() && "Empty explosion must match the native convention");
     return Explosion();
@@ -5424,6 +5425,82 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
   llvm::StructType *largerCoercion = coercionSize >= overlappedCoercionSize
                                          ? coercionTy
                                          : overlappedCoercionTy;
+
+  if (mayPeepholeLoad) {
+    auto succeeded = [&]() -> bool {
+      if (!overlappedCoercionTy->isEmptyTy())
+        return false;
+      auto load = dyn_cast<llvm::LoadInst>(*fromNonNative.begin());
+      if (!load)
+        return false;
+      auto *gep = dyn_cast<llvm::GetElementPtrInst>(load->getPointerOperand());
+      if (!gep)
+        return false;
+      auto *alloca = dyn_cast<llvm::AllocaInst>(getUnderlyingObject(gep));
+      if (!alloca)
+        return false;
+      auto numExplosions = fromNonNative.size();
+      if (numExplosions < 2)
+        return false;
+      for (unsigned i = 0, e = numExplosions; i < e; ++i) {
+        auto *otherLoad = dyn_cast<llvm::LoadInst>(*(fromNonNative.begin() + i));
+        if (!otherLoad)
+          return false;
+        auto otherAlloca = dyn_cast<llvm::AllocaInst>(
+          getUnderlyingObject(otherLoad->getPointerOperand()));
+        if (!otherAlloca || otherAlloca != alloca)
+          return false;
+        load = otherLoad;
+      }
+      auto allocaSize =
+        DataLayout.getTypeSizeInBits(alloca->getAllocatedType());
+
+      Address origAlloca(alloca, alloca->getAllocatedType(),
+                         Alignment(alloca->getAlign().value()));
+
+      IRBuilder Builder(*IGM.LLVMContext, false);
+      Builder.SetInsertPoint(load);
+
+      if (allocaSize < coercionSize) {
+        auto coerced = IGF.createAlloca(coercionTy, Alignment(alloca->getAlign().value()) , "tmp.coerce");
+        // Copy the defined bytes.
+        Builder.CreateMemCpy(coerced, origAlloca, Size(allocaSize/8));
+        origAlloca = coerced;
+      }
+
+      adjustAllocaAlignment(DataLayout, origAlloca, coercionTy);
+
+
+      unsigned expandedMapIdx = 0;
+      SmallVector<llvm::Value *, 8> expandedElts(expandedTys.size(), nullptr);
+      auto structAddr = Builder.CreateElementBitCast(origAlloca, coercionTy);
+      for (auto eltIndex : indices(coercionTy->elements())) {
+        auto layout = DataLayout.getStructLayout(coercionTy);
+        auto eltTy = coercionTy->getElementType(eltIndex);
+        // Skip padding fields.
+        if (eltTy->isArrayTy())
+          continue;
+        Address eltAddr = Builder.CreateStructGEP(structAddr, eltIndex, layout);
+        llvm::Value *elt = Builder.CreateLoad(eltAddr);
+        auto index = expandedTyIndicesMap[expandedMapIdx];
+        assert(expandedElts[index] == nullptr);
+        expandedElts[index] = elt;
+        ++expandedMapIdx;
+      }
+
+      // Add the values to the explosion.
+      for (auto *val : expandedElts)
+        nativeExplosion.add(val);
+      assert(expandedTys.size() == nativeExplosion.size());
+
+      return true;
+    }();
+
+    if (succeeded) {
+      (void)fromNonNative.claimAll();
+      return nativeExplosion;
+    }
+  }
 
   // Allocate a temporary for the coercion.
   Address temporary;
@@ -5514,7 +5591,8 @@ Explosion IRGenFunction::coerceValueTo(SILType fromTy, Explosion &from,
 
 void IRGenFunction::emitScalarReturn(SILType returnResultType,
                                      SILType funcResultType, Explosion &result,
-                                     bool isSwiftCCReturn, bool isOutlined) {
+                                     bool isSwiftCCReturn, bool isOutlined,
+                                     bool mayPeepholeLoad) {
   if (result.empty()) {
     assert(IGM.getTypeInfo(returnResultType)
                .nativeReturnValueSchema(IGM)
@@ -5533,7 +5611,8 @@ void IRGenFunction::emitScalarReturn(SILType returnResultType,
     assert(!nativeSchema.requiresIndirect());
 
     Explosion native = nativeSchema.mapIntoNative(IGM, *this, result,
-                                                  funcResultType, isOutlined);
+                                                  funcResultType, isOutlined,
+                                                  mayPeepholeLoad);
     if (native.size() == 1) {
       Builder.CreateRet(native.claimNext());
       return;

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -102,7 +102,7 @@ public:
   Explosion collectParameters();
   void emitScalarReturn(SILType returnResultType, SILType funcResultType,
                         Explosion &scalars, bool isSwiftCCReturn,
-                        bool isOutlined);
+                        bool isOutlined, bool mayPeepholeLoad = false);
   void emitScalarReturn(llvm::Type *resultTy, Explosion &scalars);
   
   void emitBBForReturn();

--- a/lib/IRGen/NativeConventionSchema.h
+++ b/lib/IRGen/NativeConventionSchema.h
@@ -57,7 +57,7 @@ public:
   /// calling convention's schema.
   Explosion mapIntoNative(IRGenModule &IGM, IRGenFunction &IGF,
                           Explosion &fromNonNative, SILType type,
-                          bool isOutlined) const;
+                          bool isOutlined, bool mayPeepholeLoad = false) const;
 
   /// Map form a native explosion that follows the native calling convention's
   /// schema to a non-native explosion whose schema is described by

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -3154,6 +3154,12 @@ static AllocationInst *getOptimizableAllocation(SILInstruction *i) {
   if (getMemoryType(alloc).isMoveOnly())
     return nullptr;
 
+  // Don't promote large types.
+  auto &mod = alloc->getFunction()->getModule();
+  if (mod.getOptions().UseAggressiveReg2MemForCodeSize &&
+      !shouldExpand(mod, alloc->getType().getObjectType()))
+    return nullptr;
+
   // Otherwise we are good to go. Lets try to optimize this memory!
   return alloc;
 }

--- a/test/IRGen/Inputs/arg_and_result_peepholes.h
+++ b/test/IRGen/Inputs/arg_and_result_peepholes.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct BigStruct {
+  char a[32];
+};
+
+struct BigStruct useBigStruct(struct BigStruct x);

--- a/test/IRGen/arg_and_result_peepholes.swift
+++ b/test/IRGen/arg_and_result_peepholes.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend %s  -import-objc-header %S/Inputs/arg_and_result_peepholes.h -emit-ir 2>&1 | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+// CHECK: define{{.*}} swiftcc { i64, i64, i64, i64 } @"$s24arg_and_result_peepholes05test_D0ySo9BigStructVADF"(i64 %0, i64 %1, i64 %2, i64 %3)
+// CHECK: entry:
+// CHECK:   [[TMP:%.*]] = alloca { i64, i64, i64, i64 }
+// CHECK:   [[RES_MEM:%.*]] = alloca %TSo9BigStructV
+// CHECK:   [[ARG_MEM:%.*]] = alloca %TSo9BigStructV
+// CHECK:   [[TMP2:%.*]] = alloca %TSo9BigStructV
+// CHECK:   [[CALL:%.*]] = alloca %TSo9BigStructV
+// CHECK:   call void @llvm.lifetime.start.p0(i64 256, ptr [[TMP]])
+// CHECK:   [[A1:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 0
+// CHECK:   store i64 %0, ptr [[A1]]
+// CHECK:   [[A2:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 1
+// CHECK:   store i64 %1, ptr [[A2]]
+// CHECK:   [[A3:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 2
+// CHECK:   store i64 %2, ptr [[A3]]
+// CHECK:   [[A4:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[TMP]], i32 0, i32 3
+// CHECK:   store i64 %3, ptr [[A4]]
+
+// CHECK:  call void @llvm.lifetime.start.p0(i64 32, ptr [[ARG_MEM]])
+// CHECK:  call void @llvm.memcpy.p0.p0.i64(ptr{{.*}} [[ARG_MEM]], ptr{{.*}} [[TMP]], i64 32, i1 false)
+
+// CHECK:  call void @llvm.lifetime.start.p0(i64 32, ptr [[TMP2]])
+// CHECK:  call void @llvm.memcpy.p0.p0.i64(ptr{{.*}} [[TMP2]], ptr{{.*}} [[ARG_MEM]], i64 32, i1 false)
+// CHECK:  call void @llvm.lifetime.start.p0(i64 32, ptr [[CALL]])
+// CHECK:  call void @useBigStruct(ptr{{.*}} [[CALL]], ptr{{.*}} [[TMP2]])
+// CHECK:  call void @llvm.lifetime.end.p0(i64 32, ptr [[TMP2]])
+
+// CHECK: call void @llvm.memcpy.p0.p0.i64(ptr{{.*}} [[RES_MEM]], ptr{{.*}} [[CALL]], i64 32, i1 false)
+
+// CHECK:  [[A5:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[RES_MEM]], i32 0, i32 0
+// CHECK:  [[R1:%.*]] = load i64, ptr [[A5]]
+// CHECK:  [[A6:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[RES_MEM]], i32 0, i32 1
+// CHECK:  [[R2:%.*]] = load i64, ptr [[A6]]
+// CHECK:  [[A7:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[RES_MEM]], i32 0, i32 2
+// CHECK:  [[R3:%.*]] = load i64, ptr [[A7]]
+// CHECK:  [[A8:%.*]] = getelementptr inbounds { i64, i64, i64, i64 }, ptr [[RES_MEM]], i32 0, i32 3
+// CHECK:  [[R4:%.*]] = load i64, ptr [[A8]]
+// CHECK:  call void @llvm.lifetime.end.p0(i64 32, ptr [[ARG_MEM]])
+// CHECK:  call void @llvm.lifetime.end.p0(i64 32, ptr [[RES_MEM]])
+
+// CHECK:  [[R5:%.*]] = insertvalue { i64, i64, i64, i64 } undef, i64 [[R1]], 0
+// CHECK:  [[R6:%.*]] = insertvalue { i64, i64, i64, i64 } [[R5]], i64 [[R2]], 1
+// CHECK:  [[R7:%.*]] = insertvalue { i64, i64, i64, i64 } [[R6]], i64 [[R3]], 2
+// CHECK:  [[R8:%.*]] = insertvalue { i64, i64, i64, i64 } [[R7]], i64 [[R4]], 3
+// CHECK:  ret { i64, i64, i64, i64 } [[R8]]
+
+public func test_peepholes(_ v: BigStruct) -> BigStruct {
+  return useBigStruct(v)
+}

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -20,6 +20,10 @@ struct PairOfInt {
   var rhs : Builtin.Int32
 }
 
+struct ContainsTuple {
+  var tuple : (Builtin.Int32, Builtin.Int32)
+}
+
 // CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $*Builtin.Int32):
 // CHECK: [[LOAD2:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
@@ -453,6 +457,24 @@ die:
 
 exit:
   dealloc_box %b : ${ var C }
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @destructure_tuple_peephole : $@convention(thin) (ContainsTuple) -> () {
+// CHECK: bb0([[ARG:%.*]] : $ContainsTuple):
+// CHECK:  [[S:%.*]] = alloc_stack $(Builtin.Int32, Builtin.Int32)
+// CHECK:  [[T:%.*]] = struct_extract [[ARG]] : $ContainsTuple, #ContainsTuple.tuple
+// CHECK:  store [[T]] to [[S]] : $*(Builtin.Int32, Builtin.Int32)
+// CHECK: } // end sil function 'destructure_tuple_peephole'
+sil [ossa] @destructure_tuple_peephole : $@convention(thin) (ContainsTuple) -> () {
+entry(%arg : $ContainsTuple):
+  %stk = alloc_stack $(Builtin.Int32, Builtin.Int32)
+  %tpl = struct_extract %arg : $ContainsTuple, #ContainsTuple.tuple
+  (%1, %2) = destructure_tuple %tpl : $(Builtin.Int32, Builtin.Int32)
+  %3 = tuple (%1 : $Builtin.Int32, %2 : $Builtin.Int32)
+  store %3 to [trivial] %stk : $*(Builtin.Int32, Builtin.Int32)
+  dealloc_stack %stk : $*(Builtin.Int32, Builtin.Int32)
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -20,13 +20,10 @@ func test_foo(x: Builtin.Int1, y: Builtin.Int1) -> Builtin.Int1 {
 // SIL: [[TUP:%.*]] = tuple ([[ARG0]] : $Builtin.Int64, [[ARG1]] : $Builtin.NativeObject)
 // SIL: retain_value [[TUP]]
 // SIL: [[CASTED_PTR:%.*]] = pointer_to_address [[ARG2]]
-// SIL: [[CASTED_PTR_0:%.*]] = tuple_element_addr [[CASTED_PTR]] : $*(Builtin.Int64, Builtin.NativeObject), 0
-// SIL: store [[ARG0]] to [[CASTED_PTR_0]]
-// SIL: [[CASTED_PTR_1:%.*]] = tuple_element_addr [[CASTED_PTR]] : $*(Builtin.Int64, Builtin.NativeObject), 1
-// SIL: [[OLD_VALUE:%.*]] = load [[CASTED_PTR_1]]
-// SIL: store [[ARG1]] to [[CASTED_PTR_1]]
-// SIL: strong_release [[OLD_VALUE]]
-// SIL: } // end sil function '$s19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF' 
+// SIL: [[OLD_VALUE:%.*]] = load [[CASTED_PTR]]
+// SIL: store [[TUP]] to [[CASTED_PTR]]
+// SIL: release_value [[OLD_VALUE]]
+// SIL: } // end sil function '$s19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF'
 func test_tuple(x: (Builtin.Int64, Builtin.NativeObject),
                 y: Builtin.RawPointer) {
   assign_tuple(x: x, y: y)


### PR DESCRIPTION
This heuristic can be enabled by passing -Xfrontend  -enable-aggressive-reg2mem.

rdar://123916109