### PR TITLE
[CSBindings] Don't delay bindings inferred through `inout` conversion

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1518,11 +1518,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
       if (auto pointeeTy = second->lookThroughAllOptionalTypes()
                                ->getAnyPointerElementType()) {
         if (!pointeeTy->isTypeVariableOrMember()) {
-          // The binding is as a fallback in this case because $T could
-          // also be Array<X> or C-style pointer.
-          if (constraint->getKind() >= ConstraintKind::ArgumentConversion)
-            DelayedBy.push_back(constraint);
-
           return PotentialBinding(pointeeTy, AllowedBindingKind::Exact,
                                   constraint);
         }

--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -69,3 +69,22 @@ do {
     test(&outputs[name]!) // Ok
   }
 }
+
+do {
+  func test<O>(_ initialValue: O, _ action: (inout O) -> Void) -> O {
+  }
+
+  func compute(_: UnsafeMutablePointer<UInt8>!) {
+  }
+
+  let result1 = test(0) { // `0` should be inferred as `UInt8`
+    compute(&$0)
+  }
+
+  let result2 = test([0]) { // `0` should be inferred as `UInt8`
+      compute(&$0)
+  }
+
+  let _: UInt8 = result1 // Ok
+  let _: [UInt8] = result2 // Ok
+}


### PR DESCRIPTION
Delaying such bindings is too restrictive and leads to subpar selections.

For `$T1` to be array or C-style pointer it would have to be connected either to a type variable that could be bound to array/pointer or directly to array/pointer type which would result in the solver either selecting the other type variable first (because it appears in adjacent variables of `$T1`) or provide an additional binding(s) for `$T1` (including literals).

Consider the following constraint system:

```
$T2 arg conv $T1
$T2 conforms ExpressibleByIntegerLiteral

inout $T1 arg conv UnsafeMutablePointer<UInt8>?
```

If `$T1` and `$T2` are the only viable type variables delaying `$T1` would mean that `$T2` is picked to attempt its default type `Int` which is incorrect (it doesn't get `UInt8` because there is no transitive inference through conversions).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
