### PR TITLE
Sema: TypeRefinementContextBuilder must not skip defer blocks

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -550,10 +550,6 @@ private:
   }
 
   bool shouldSkipDecl(Decl *D) const {
-    // Implicit decls don't have source locations so they cannot have a TRC.
-    if (D->isImplicit())
-      return true;
-
     // Only visit a node that has a corresponding concrete syntax node if we are
     // already walking that concrete syntax node.
     auto *concreteDecl = concreteSyntaxDeclForAvailableAttribute(D);
@@ -567,6 +563,12 @@ private:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     PrettyStackTraceDecl trace(stackTraceAction(), D);
+
+    // Implicit decls don't have source locations so they cannot have a TRC.
+    // However, some implicit nodes contain non-implicit nodes (e.g. defer
+    // blocks) so continue rather than skipping the node entirely.
+    if (D->isImplicit())
+      return Action::Continue();
 
     if (shouldSkipDecl(D))
       return Action::SkipNode();

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -208,6 +208,16 @@ func functionWithWhile() {
   }
 }
 
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithDefer()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (if_then version=52
+@available(OSX 51, *)
+func functionWithDefer() {
+  defer {
+    if #available(OSX 52, *) {}
+  }
+}
+
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
 // CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
 // CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInit

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -28,7 +28,22 @@ let ignored3: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAva
 
 // Functions without annotations should reflect the minimum deployment target.
 func functionWithoutAvailability() {
-      // expected-note@-1 2{{add @available attribute to enclosing global function}}
+      // expected-note@-1 5{{add @available attribute to enclosing global function}}
+
+  defer {
+    let _: Int = globalFuncAvailableOn10_9()
+    let _: Int = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+
+    if #available(OSX 51, *) {
+      let _: Int = globalFuncAvailableOn10_9()
+      let _: Int = globalFuncAvailableOn51()
+      let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-1 {{add 'if #available' version check}}
+    }
+  }
 
   let _: Int = globalFuncAvailableOn10_9()
 


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/76621 caused a regression by skipping the AST nodes nested under `defer` blocks. The node associated with a `defer` block is implicit because it is a kind of closure context synthesized by the compiler. However, the nodes it contains are not implicit and so they must be visited by the `TypeRefinementContextBuilder`.

Resolves rdar://139012152.