### PR TITLE
[test] Ignore unused arguments in PrintAsObjC(++) tests

### DIFF
--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -15,6 +15,7 @@ config.substitutions.insert(0, ('%check-in-clang-cxx',
   '-fobjc-arc -fmodules -fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
   '-Wno-auto-import -Wno-c++98-compat-pedantic '
+  '-Wno-unused-command-line-argument '
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
The `%check-in-clang-cxx` seems to pass `-fmodule-cache-path` that is unused in some setups, but not in `%check-in-clang`. Turn the error back into a warning to avoid the test failing.