### PR TITLE
Emit refs to collections initialized with a type shorthand expression.

### DIFF
--- a/test/Index/index_collection_init.swift
+++ b/test/Index/index_collection_init.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct Foo: Hashable {}
+
+_ = Array<Int>(repeating: 0, count: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(repeating:count:) | s:Sa9repeating5countSayxGx_Sitcfc | {{.*}}Ref
+_ = [Int](repeating: 0, count: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(repeating:count:) | s:Sa9repeating5countSayxGx_Sitcfc | {{.*}}Ref
+_ = Array<Foo>(repeating: Foo(), count: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(repeating:count:) | s:Sa9repeating5countSayxGx_Sitcfc | {{.*}}Ref
+// CHECK: [[@LINE-2]]:27 | constructor/Swift | init() | s:14swift_ide_test3FooVACycfc | Ref,Call
+_ = [Foo](repeating: Foo(), count: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(repeating:count:) | s:Sa9repeating5countSayxGx_Sitcfc | {{.*}}Ref
+// CHECK: [[@LINE-2]]:22 | constructor/Swift | init() | s:14swift_ide_test3FooVACycfc | Ref,Call
+
+_ = Dictionary<Foo, String>(minimumCapacity: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(minimumCapacity:) | s:SD15minimumCapacitySDyxq_GSi_tcfc | {{.*}}Ref
+_ = [Foo: String](minimumCapacity: 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(minimumCapacity:) | s:SD15minimumCapacitySDyxq_GSi_tcfc | {{.*}}Ref
+_ = [String: Int](uniqueKeysWithValues: zip(["one", "two", "three"], 1...3))
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(uniqueKeysWithValues:) | s:SD20uniqueKeysWithValuesSDyxq_Gqd__n_tcSTRd__x_q_t7ElementRtd__lufc | {{.*}}Ref
+
+extension Array where Element == Int {
+// CHECK: [[@LINE+1]]:3 | constructor/Swift | init(_:) | s:Sa14swift_ide_testSiRszlEySaySiGSicfc | {{.*}}Def
+  init(_ input: Int) {
+    self = [input]
+  }
+}
+
+_ = [Int](0)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(_:) | s:Sa14swift_ide_testSiRszlEySaySiGSicfc | {{.*}}Ref
+
+extension Dictionary {
+// CHECK: [[@LINE+1]]:3 | constructor/Swift | init(_:_:) | s:SD14swift_ide_testEySDyxq_Gx_q_tcfc | {{.*}}Def
+  init(_ k: Key, _ v: Value) {
+    self = [k: v]
+  }
+}
+
+_ = [Int: Int](0, 1)
+// CHECK: [[@LINE-1]]:5 | constructor/Swift | init(_:_:) | s:SD14swift_ide_testEySDyxq_Gx_q_tcfc | {{.*}}Ref


### PR DESCRIPTION
Normally references to initializers of collections like Array and Dict are emitted into the index data. It was missing any initializer called using the collection's literal type resentation instead of the type name.

For example:

```
_ = Array<Int>(repeating: 0, count: 1)  // Reference is emitted.
_ = [Int](repeating: 0, count: 1) // Reference is missing.
```

This PR fixes the inconsistency by emitting references for those collection initializers.

I had to handle these references in a fairly custom way, because most constructor-refs are emitted when the `TypeRepr` is visited. The AST walker keeps a list of  ctors and emits a reference to the matching ctor when visting the associated `TypeRepr`. This works fine for the ctor in `Array<Int>(...)` because there's a `TypeRepr` for `Array<Int>` that matches a ctor on the list of "seen" ctors. For the shorthand initialization like `[Int](...)`, the `TypeRepr` is an `ArrayTypeRepr` instead of a `DeclRefTypeRepr` so there's no associated decl when the AST walker gets to that `TypeRepr`.

Resolves #68974
