### PR TITLE
[Build] Update CMake to 3.29.8

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -151,7 +151,7 @@
                 "swift-xcode-playground-support": "main",
                 "ninja": "v1.11.1",
                 "yams": "5.0.6",
-                "cmake": "v3.24.2",
+                "cmake": "v3.29.8",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main",


### PR DESCRIPTION
3.29 has many fixes for Swift support, the most notable being that it now adds compile jobs separate to the link job. This has a huge benefit for the swift-foundation toolchain install, which can now just re-link rather than rebuild.