### PR TITLE
[cxx-interop] Import some C++ methods as Unsafe

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8202,18 +8202,27 @@ bool swift::importer::isMutabilityAttr(const clang::SwiftAttrAttr *swiftAttr) {
          swiftAttr->getAttribute() == "nonmutating";
 }
 
-static bool importAsUnsafe(ASTContext &context, const clang::RecordDecl *decl,
+static bool importAsUnsafe(ASTContext &context, const clang::NamedDecl *decl,
                            const Decl *MappedDecl) {
   if (!context.LangOpts.hasFeature(Feature::SafeInterop) ||
-      !context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute) || !decl)
+      !context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
     return false;
+
+  if (isa<clang::CXXMethodDecl>(decl) &&
+      !evaluateOrDefault(context.evaluator, IsSafeUseOfCxxDecl({decl, context}),
+                         {}))
+    return true;
 
   if (isa<ClassDecl>(MappedDecl))
     return false;
 
-  return evaluateOrDefault(
-             context.evaluator, ClangTypeEscapability({decl->getTypeForDecl()}),
-             CxxEscapability::Unknown) == CxxEscapability::Unknown;
+  if (const auto *record = dyn_cast<clang::RecordDecl>(decl))
+    return evaluateOrDefault(context.evaluator,
+                             ClangTypeEscapability({record->getTypeForDecl()}),
+                             CxxEscapability::Unknown) ==
+           CxxEscapability::Unknown;
+
+  return false;
 }
 
 void
@@ -8395,9 +8404,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
       }
     }
 
-    if (seenUnsafe ||
-        importAsUnsafe(SwiftContext, dyn_cast<clang::RecordDecl>(ClangDecl),
-                       MappedDecl)) {
+    if (seenUnsafe || importAsUnsafe(SwiftContext, ClangDecl, MappedDecl)) {
       auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/!seenUnsafe);
       MappedDecl->getAttrs().add(attr);
     }

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -42,6 +42,11 @@ struct UnknownEscapabilityAggregate {
     Unannotated unann;
 };
 
+struct MyContainer {
+    int begin() const { return 0; }
+    int end() const { return -1; }
+};
+
 //--- test.swift
 
 import Test
@@ -57,7 +62,8 @@ func useUnsafeParam2(x: UnsafeReference) { // expected-warning{{reference to uns
 func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-warning{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
 }
 
-func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate) {
+func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer) {
+    let _ = c.__beginUnsafe() // expected-warning{{call to unsafe instance method '__beginUnsafe'}}
 }
 
 func useCfType(x: CFArray) {


### PR DESCRIPTION
ClangImporter already had some logic in place to rename certain unsafe C++ methods to make sure their name indicates unsafety. With the recent push for auditability, we have a new @unsafe attribute so we can automate parts of the auditing process. This patch makes sure whenever we rename a method as "Unsafe", we also add the @unsafe attribute.
