### PR TITLE
[Demangler] Accept overly short type names if they are NUL terminated

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -804,6 +804,12 @@ NodePointer Demangler::demangleType(StringRef MangledName,
 bool Demangler::parseAndPushNodes() {
   const auto textSize = Text.size();
   while (Pos < textSize) {
+    // Programs may look up a type by NUL-terminated name with an excessive
+    // length. Keep them working by returning success if we encounter a NUL in
+    // the middle of the string where an operator is expected.
+    if (peekChar() == '\0')
+      return true;
+
     NodePointer Node = demangleOperator();
     if (!Node)
       return false;

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -566,5 +566,17 @@ if #available(SwiftStdlib 6.0, *) {
   }
 }
 
+if #available(SwiftStdlib 6.1, *) {
+  DemangleToMetadataTests.test("NUL-terminated name, excessive length value") {
+    let t = _getTypeByMangledNameInContext("4main1SV", 256,
+                                           genericContext: nil,
+                                           genericArguments: nil)
+    expectNotNil(t)
+    if let t {
+      expectEqual(type(of: S()), t)
+    }
+  }
+}
+
 runAllTests()
 


### PR DESCRIPTION
swift_getTypeByMangledNameInContext takes a pointer and a length, but some programs pass a pointer to a NUL-terminated C string and an excessive length, implicitly relying on the terminator to end the string early. This worked previously, but commit 7fe2befd311f558c895169b7abe1787f093511fb made the demangler more strict about bad data. This changes the demangler to successfully parse a name by terminating the name string at a 0 byte encountered where it expects to find an operator. All other cases of bad data continue to be rejected.

rdar://137430048