### PR TITLE
[CAS] Add an utility action to swift-cache-tool to print cache key

### DIFF
--- a/include/swift/Frontend/CompileJobCacheKey.h
+++ b/include/swift/Frontend/CompileJobCacheKey.h
@@ -23,6 +23,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 
@@ -43,6 +44,11 @@ llvm::Expected<llvm::cas::ObjectRef>
 createCompileJobCacheKeyForOutput(llvm::cas::ObjectStore &CAS,
                                   llvm::cas::ObjectRef BaseKey,
                                   unsigned InputIndex);
+
+/// Print the CompileJobKey for debugging purpose.
+llvm::Error printCompileJobCacheKey(llvm::cas::ObjectStore &CAS,
+                                    llvm::cas::ObjectRef Key,
+                                    llvm::raw_ostream &os);
 } // namespace swift
 
 #endif

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -31,6 +31,12 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib @%t/MyApp.cmd > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %t/Test.swift > %t/key
 
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-compile-cache-key @%t/key | %FileCheck %s --check-prefix=CACHE-KEY
+// CACHE-KEY: Cache Key llvmcas://
+// CACHE-KEY-NEXT: Swift Compiler Invocation Info:
+// CACHE-KEY-NEXT: command-line
+// CACHE-KEY: Input index: 0
+
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \


### PR DESCRIPTION
Add an utility action to print information contained in the swift compile cache key. This is useful to figure out why cache key is different.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
