### PR TITLE
[region-isolation] Fix an off by one error when mapping AST capture indices to SIL level parameter indices.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4284,7 +4284,8 @@ public:
   }
 
   /// Whether this closure should implicitly inherit the actor context from
-  /// where it was formed. This only affects @Sendable async closures.
+  /// where it was formed. This only affects @Sendable and sendable async
+  /// closures.
   bool inheritsActorContext() const {
     return Bits.ClosureExpr.InheritActorContext;
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4416,6 +4416,10 @@ public:
     Sending = 0x2,
 
     /// Set if the given parameter is isolated.
+    ///
+    /// This means that the value provides the functions isolation. This implies
+    /// that the parameter must be an Optional actor or something that conforms
+    /// to AnyActor.
     Isolated = 0x4,
   };
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1888,3 +1888,21 @@ func nonSendableAllocBoxConsumingVar() async throws {
     try await group.waitForAll()
   }
 }
+
+func offByOneWithImplicitPartialApply() {
+  class A {
+      var description = ""
+  }
+
+  class B {
+      let a = A()
+
+      func b() {
+          let asdf = ""
+          Task { @MainActor in
+            a.description = asdf // expected-tns-warning {{sending 'self' risks causing data races}}
+            // expected-tns-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          }
+      }
+  }
+}


### PR DESCRIPTION
This problem comes up with the following example:

```swift
class A {
    var description = ""
}

class B {
    let a = A()

    func b() {
        let asdf = ""
        Task { @MainActor in
            a.description = asdf // Sending 'asdf' risks causing data races
        }
    }
}
```

The specific issue is that the closure we generate actually includes an implicit(any) parameter at the SIL level which occurs after the callee operand but before the captures. This caused the captured variable index from the AST and the one we compute from the partial_apply to differ by 1. So we need to subtract 1 in such a case. That is why we used to print 'asdf' instead of 'a' above.

DISCUSSION: This shows an interesting difference between SIL applied arg indices and AST indices. SIL applied arg indices would include the implicit(any) parameter since it is a parameter in the SIL function type. In contrast, this doesn't show up in the formal AST parameters or captures. To make it easier to reason about this, I added a new API to ApplySite called ApplySite::getASTAppliedArgIndex and added large comments to getASTAppliedArgIndex and getAppliedArgIndex that explains the issue.

rdar://136593706
https://github.com/swiftlang/swift/issues/76648

