### PR TITLE
[observation] Mark two tests as REQUIRES: observation

### DIFF
--- a/test/abi/macOS/arm64/observation-asserts.swift
+++ b/test/abi/macOS/arm64/observation-asserts.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_stdlib_asserts
 // REQUIRES: STDLIB_VARIANT=macosx-arm64
+// REQUIRES: observation
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)
 

--- a/test/abi/macOS/arm64/observation.swift
+++ b/test/abi/macOS/arm64/observation.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: STDLIB_VARIANT=macosx-arm64
+// REQUIRES: observation
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)
 


### PR DESCRIPTION
These two tests are checking for symbols provided by the observation library, and will fail if the observation library is not build. Mark them as such to avoid failures when the observation library is not built.