### PR TITLE
[backtracing] Mark two test as REQUIRES: backtracing

### DIFF
--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: STDLIB_VARIANT=macosx-arm64
+// REQUIRES: backtracing
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)
 

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: STDLIB_VARIANT=macosx-x86_64
+// REQUIRES: backtracing
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)
 


### PR DESCRIPTION
These two tests are checking for symbols provided by the bactracing library, and will fail if the backtracing library is not build. Mark them as such to avoid failures when the backtracing library is not built.
