### PR TITLE
[validation-test] Add missing REQUIRES: macosx-x86_64 to test

### DIFF
--- a/validation-test/SILOptimizer/rdar114699006.swift
+++ b/validation-test/SILOptimizer/rdar114699006.swift
@@ -17,6 +17,7 @@
 // No need to run this test that has a hard-coded target of macos10.13 on other
 // platforms.
 // REQUIRES: OS=macosx
+// REQUIRES: STDLIB_VARIANT=macosx-x86_64
 
 // Verify that after RetainSinking runs, the retain of the __EmptyArrayStorage
 // is _above_ the call to $sSD17dictionaryLiteralSDyxq_Gx_q_td_tcfCSS_SSTg5


### PR DESCRIPTION
This test forces the usage of macosx-x86_64 and will fail if the x86_64 slice of the stdlib has not been built. Mark it as only running on macosx-x86_64 to avoid the test failure in that case.
