### PR TITLE
Fix typos in VCRuntime modulemap.

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -259,7 +259,7 @@ module std [system] {
   }
 
   module any {
-    requires cpluplus17
+    requires cplusplus17
     header "any"
     export *
   }
@@ -566,7 +566,7 @@ module std [system] {
   }
 
   module spanstream {
-    requires cpluplus23
+    requires cplusplus23
     header "spanstream"
     export *
   }


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/77351

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

We found this issue as apart of our Swift/C++ interop on Windows observations on our Swift forums thread, [here](https://forums.swift.org/t/c-interoperability-is-broken-windows-platform/72462/52).