### PR TITLE
Make IsolatedDeinit non-experimental

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5959,9 +5959,6 @@ ERROR(isolated_deinit_no_isolation,none,
 ERROR(isolated_deinit_on_value_type,none,
       "only classes and actors can have isolated deinit",
       ())
-ERROR(isolated_deinit_experimental,none,
-      "'isolated' deinit requires frontend flag -enable-experimental-feature IsolatedDeinit "
-      "to enable the usage of this language feature", ())
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -414,7 +414,7 @@ EXPERIMENTAL_FEATURE(SafeInterop, true)
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 
 // Isolated deinit
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedDeinit, true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")
 
 // Enable values in generic signatures, e.g. <let N: Int>
 EXPERIMENTAL_FEATURE(ValueGenerics, true)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -112,14 +112,7 @@ public:
   }
 
   void diagnoseIsolatedDeinitInValueTypes(DeclAttribute *attr) {
-    auto &C = D->getASTContext();
-
     if (isa<DestructorDecl>(D)) {
-      if (!C.LangOpts.hasFeature(Feature::IsolatedDeinit)) {
-        diagnoseAndRemoveAttr(attr, diag::isolated_deinit_experimental);
-        return;
-      }
-
       if (auto nominal = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
         if (!isa<ClassDecl>(nominal)) {
           // only classes and actors can have isolated deinit.

--- a/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
+++ b/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
@@ -1,10 +1,9 @@
-// RUN: %target-run-simple-swift( -enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple %import-libdispatch -parse-as-library)
 
 // REQUIRES: executable_test
 // REQUIRES: libdispatch
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 // UNSUPPORTED: back_deployment_runtime
 
 import _Concurrency

--- a/test/Concurrency/Runtime/actor_recursive_deinit.swift
+++ b/test/Concurrency/Runtime/actor_recursive_deinit.swift
@@ -1,10 +1,9 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple -parse-stdlib -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -parse-stdlib -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 // UNSUPPORTED: back_deployment_runtime
 
 // Compiler crashes because builtin "ifdef_SWIFT_STDLIB_PRINT_DISABLED"() gets lowered as "i32 0",

--- a/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
+++ b/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -enable-experimental-feature IsolatedDeinit -plugin-path %swift-plugin-dir -enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
+// RUN: %target-build-swift -plugin-path %swift-plugin-dir -target %target-swift-5.1-abi-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
 

--- a/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
+++ b/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 
 var isDead: Bool = false
 

--- a/test/Concurrency/deinit_isolation.swift
+++ b/test/Concurrency/deinit_isolation.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -verify %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // Fixtures
 

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -3,20 +3,19 @@
 // RUN: cp -R $INPUT_DIR/Alpha.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule)
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Headers/)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -parse-as-library -module-name Alpha \
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -parse-as-library -module-name Alpha \
 // RUN:  -emit-module -o %t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule/%module-target-triple.swiftmodule \
 // RUN:  -enable-objc-interop -disable-objc-attr-requires-foundation-module \
 // RUN:  -emit-objc-header -emit-objc-header-path %t/Frameworks/Alpha.framework/Headers/Alpha-Swift.h $INPUT_DIR/Alpha.swift
 // RUN: cp -R $INPUT_DIR/Beta.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/Beta.framework/Headers/)
 // RUN: cp $INPUT_DIR/Beta.h %t/Frameworks/Beta.framework/Headers/Beta.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -typecheck -verify %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -typecheck -verify %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // Note: intentionally importing Alpha implicitly
 import Beta

--- a/test/Concurrency/deinit_isolation_in_value_types.swift
+++ b/test/Concurrency/deinit_isolation_in_value_types.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-experimental-feature IsolatedDeinit -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 @globalActor final actor FirstActor {
   static let shared = FirstActor()

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -1,10 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_IsolatedDeinit
 
 import Foundation
 

--- a/test/Concurrency/deinit_isolation_tbd.swift
+++ b/test/Concurrency/deinit_isolation_tbd.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 public class Foo {
   @MainActor

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: swift_feature_RegionBasedIsolation
-// REQUIRES: swift_feature_IsolatedDeinit
 
 func randomBool() -> Bool { return false }
 func logTransaction(_ i: Int) {}

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -enable-experimental-feature IsolatedDeinit -o %t/voucher_propagation
+// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -o %t/voucher_propagation
 // RUN: %target-codesign %t/voucher_propagation
 // RUN: MallocStackLogging=1 %target-run %t/voucher_propagation
 
@@ -13,7 +13,6 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // REQUIRES: OS=macosx
-// REQUIRES: swift_feature_IsolatedDeinit
 
 import Darwin
 import Dispatch // expected-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'Dispatch'}}

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-swift-5.7-abi-triple %import-libdispatch -enable-experimental-feature IsolatedDeinit -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.7-abi-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
 
@@ -7,7 +7,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -1,13 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -enable-experimental-feature IsolatedDeinit -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -enable-experimental-feature IsolatedDeinit -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift( -enable-experimental-feature IsolatedDeinit -target %target-swift-5.7-abi-triple -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift( -target %target-swift-5.7-abi-triple -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/ModuleInterface/isolated-deinit-compatibility.swift
+++ b/test/ModuleInterface/isolated-deinit-compatibility.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -emit-silgen -verify %s
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -emit-silgen -verify %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // MARK: Sync deinit in class
 

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature IsolatedDeinit -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
 @inlinable public func fragileFunction() {

--- a/test/SILOptimizer/stack_promotion_isolated_deinit.swift
+++ b/test/SILOptimizer/stack_promotion_isolated_deinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil -enable-experimental-feature IsolatedDeinit | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil | %FileCheck %s
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_IsolatedDeinit
 

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify %s  -disable-availability-checking -package-name myPkg -enable-experimental-feature IsolatedDeinit
+// RUN: %target-swift-frontend -typecheck -verify %s  -disable-availability-checking -package-name myPkg
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedDeinit
 
 actor SomeActor { }
 


### PR DESCRIPTION
After [fixing interaction with stack promotion optimization](https://github.com/swiftlang/swift/pull/76995) and [updating task-locals behavior](https://github.com/swiftlang/swift/pull/77249) as requested in the proposal review, we can now make [SE-0371](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md) non-experimental.