### PR TITLE
tests: add a missing REQUIRE in SILOptimizer/stack_promotion_isolated_deinit.swift

### DIFF
--- a/test/SILOptimizer/stack_promotion_isolated_deinit.swift
+++ b/test/SILOptimizer/stack_promotion_isolated_deinit.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil -enable-experimental-feature IsolatedDeinit | %FileCheck %s
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_IsolatedDeinit
 
 @globalActor actor AnotherActor: GlobalActor {
   static let shared = AnotherActor()


### PR DESCRIPTION
The require is needed since https://github.com/swiftlang/swift/pull/76740 and will be obsolete again once https://github.com/swiftlang/swift/pull/77364 is merged.