### PR TITLE
[cxx-interop] Fix IRGen for C++ types that use tail padding of their bases

### DIFF
--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -118,3 +118,17 @@ struct InheritFromStructsWithVirtualMethod: HasOneFieldWithVirtualMethod, HasTwo
   int d;
   virtual ~InheritFromStructsWithVirtualMethod() = default;
 };
+
+// MARK: Types that pack their fields into tail padding of a base class.
+
+struct BaseAlign8 {
+  long long field8 = 123;
+}; // sizeof=8, dsize=8, align=8
+
+struct DerivedHasTailPadding : public BaseAlign8 {
+  int field4 = 456;
+}; // sizeof=16, dsize=12, align=8
+
+struct DerivedUsesBaseTailPadding : public DerivedHasTailPadding {
+  short field2 = 789;
+}; // sizeof=16, dsize=14, align=8

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -117,4 +117,11 @@ FieldsTestSuite.test("Structs with virtual methods") {
   expectEqual(derived.d, 42)
 }
 
+FieldsTestSuite.test("Field in tail padding of base class") {
+  let usesBaseTailPadding = DerivedUsesBaseTailPadding()
+  expectEqual(usesBaseTailPadding.field2, 789)
+  expectEqual(usesBaseTailPadding.field4, 456)
+  expectEqual(usesBaseTailPadding.field8, 123)
+}
+
 runAllTests()


### PR DESCRIPTION
In C++, a field of a derived class might be placed into the tail padding of a base class. Swift was not handling this case correctly, causing an asserts-disabled compiler to run out of RAM, and an asserts-enabled compiler to fail with an assertion.

Fixes this IRGen assertion:
```
Assertion failed: (offset >= NextOffset && "adding fields out of order"), function addField, file GenStruct.cpp, line 1509.
```

rdar://138764929

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
