### PR TITLE
Improved Error._domain calculation

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -278,7 +278,7 @@ extension Error {
   }
 
   public var _domain: String {
-    return String(reflecting: type(of: self))
+    return _typeName(type(of: self), qualified: true)
   }
 
   public var _userInfo: AnyObject? {


### PR DESCRIPTION
Optimized `Error._domain` calculation.

`String(reflecting:)` for `Any.Type` objects eventually calls `_type(:qualified:)`. But `String(reflecting:)` call has overhead because of `as?` checks. 

All details are listed in [issue](https://github.com/swiftlang/swift-foundation/issues/1031).

Resolves https://github.com/swiftlang/swift-foundation/issues/1031

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
