### PR TITLE
IRGen: Make sure loadable error types are mapped into the generic environment too

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2191,7 +2191,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     bool isIndirectError = fnConv.hasIndirectSILErrorResults();
 
     if (isTypedError && !isIndirectError) {
-      auto &errorTI = cast<FixedTypeInfo>(IGF.getTypeInfo(errorType));
+      auto &errorTI = cast<FixedTypeInfo>(IGF.getTypeInfo(inContextErrorType));
       IGF.setCallerTypedErrorResultSlot(Address(
           emission->getCallerTypedErrorResultArgument(),
           errorTI.getStorageType(),

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -91,3 +91,8 @@ func testit() throws (S) {
 public struct TypeH {
   public var method: (Int) throws(MyBigError) -> String
 }
+
+// Used to crash with null GenericSignature -- https://github.com/swiftlang/swift/issues/77297
+struct LoadableGeneric<E>: Error {}
+
+func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {}


### PR DESCRIPTION
- Fixes https://github.com/swiftlang/swift/issues/77297
- Fixes rdar://problem/139000360