### PR TITLE
Extract stdlib sources for new standard library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,17 @@ SortedCFDatabase.def
 htmlcov
 .coverage
 /benchmark/scripts/Benchmark_Driverc
+
+#==============================================================================#
+# Ignore copied Swift Stdlib files while migrating stdlib
+#==============================================================================#
+Runtimes/**/*.swift
+Runtimes/**/*.h
+Runtimes/**/*.cpp
+Runtimes/**/*.c
+Runtimes/**/*.m
+Runtimes/**/*.mm
+Runtimes/**/*.def
+Runtimes/**/*.gyb
+Runtimes/**/*.apinotes
+Runtimes/**/*.yaml

--- a/Runtimes/Readme.md
+++ b/Runtimes/Readme.md
@@ -1,0 +1,81 @@
+# Swift Runtime Libraries
+
+This directory contains the pieces of the Swift runtime libraries.
+
+## Layering
+
+```
+╔═══════════════╗
+║               ║
+║    Testing    ║
+║               ║
+╠───────────────╣
+│               │
+│ Supplemental  │
+│               │
+├───────────────┤
+│               │
+│    Overlay    │
+│               │
+├───────────────┤
+│               │
+│     Core      │
+│               │
+└───────────────┘
+```
+
+### Core
+
+The _Core_ project contains the basic datatypes and underpinnings used by the
+rest of the libraries that make up the standard library. The _Core_ libraries
+must be built first.
+The _Core_ project provides the following libraries:
+ - `swiftCore`
+ - `swift_Concurrency`
+ - `SwiftOnoneSupport`
+ - `CommandLine`
+ - `Demangling`
+ - `Runtime`
+ - `LLVMSupport`
+ - `StdlibStubs`
+ - `Threading`
+ - `SwiftShim`
+
+These libraries must work across the platforms that Swift supports.
+
+### Overlay
+
+The Overlay project contains a few default platform overlay libraries. A
+platform overlay is responsible for exposing the system libraries into Swift in
+an ergonomic fashion. On most systems, this exposes the C standard library and a
+few other libraries that are normally available on that system. The overlay
+libraries are allowed to depend on any of the runtime libraries provided by the
+_Core_ project and libraries distributed by the platform.
+
+The platform overlay is specific to the platform that it overlays and cannot be
+used across platforms.
+
+### Supplemental
+
+The supplemental libraries provide the remainder of the standard distribution of
+libraries provided by Swift.
+
+The Supplemental libraries include:
+ - `RegexParser`
+ - `StringProcessing`
+ - `RegexBuilder`
+ - `Cxx Interop`
+ - `Synchronization`
+ - `Distributed`
+ - `Observation`
+
+The behavior of these libraries may differ slightly based on the behavior of the
+underlying operating system. These libraries are allowed to depend on the
+platform overlay and the libraries provided by the _Core_ project.
+
+### Testing
+
+The testing project provides testing support for the libraries that make up the
+standard library. These libraries are optional and are not intended for
+shipping. They must be built last, after the Core, the Overlay, and the
+Supplemental libraries.

--- a/Runtimes/Readme.md
+++ b/Runtimes/Readme.md
@@ -2,6 +2,24 @@
 
 This directory contains the pieces of the Swift runtime libraries.
 
+## Development
+
+While we're bringing up the new standard library build, please do not commit the
+standard library source files. Use the `Resync.cmake` file to copy the files as
+needed.
+
+```sh
+$ cmake -P Resync.cmake
+```
+
+> [!IMPORTANT]
+> Re-run this script after updating your Swift checkout to ensure that you are
+> building the latest standard library sources.
+
+Once the migration is completed, we will be deleting this script. It
+is a temporary workaround to avoid trying to keep multiple sets of files in
+sync.
+
 ## Layering
 
 ```

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -1,0 +1,70 @@
+# This CMake script keeps the files in the new standard library build in sync
+# with the existing standard library.
+
+# TODO: Once the migration is completed, we can delete this file
+
+cmake_minimum_required(VERSION 3.21)
+
+# Where the standard library lives today
+set(StdlibSources "${CMAKE_CURRENT_LIST_DIR}/../stdlib")
+
+message(STATUS "Source dir: ${StdlibSources}")
+
+# Copy the files under the "name" directory in the standard library into the new
+# location under Runtimes
+function(copy_library_sources name from_prefix to_prefix)
+  message(STATUS "${name}[${StdlibSources}/${from_prefix}/${name}] -> ${to_prefix}/${name} ")
+
+  file(GLOB_RECURSE filenames
+    FOLLOW_SYMLINKS
+    LIST_DIRECTORIES FALSE
+    RELATIVE "${StdlibSources}/${from_prefix}"
+    "${StdlibSources}/${from_prefix}/${name}/*.swift"
+    "${StdlibSources}/${from_prefix}/${name}/*.h"
+    "${StdlibSources}/${from_prefix}/${name}/*.cpp"
+    "${StdlibSources}/${from_prefix}/${name}/*.c"
+    "${StdlibSources}/${from_prefix}/${name}/*.mm"
+    "${StdlibSources}/${from_prefix}/${name}/*.m"
+    "${StdlibSources}/${from_prefix}/${name}/*.def"
+    "${StdlibSources}/${from_prefix}/${name}/*.gyb"
+    "${StdlibSources}/${from_prefix}/${name}/*.apinotes"
+    "${StdlibSources}/${from_prefix}/${name}/*.yaml")
+
+  foreach(file ${filenames})
+    # Get and create the directory
+    get_filename_component(dirname ${file} DIRECTORY)
+    file(MAKE_DIRECTORY "${to_prefix}/${dirname}")
+    file(COPY_FILE
+      "${StdlibSources}/${from_prefix}/${file}"         # From
+      "${CMAKE_CURRENT_LIST_DIR}/${to_prefix}/${file}"  # To
+      RESULT _output
+      ONLY_IF_DIFFERENT)
+    if(_output)
+      message(SEND_ERROR
+        "Copy ${from_prefix}/${file} -> ${to_prefix}/${file} Failed: ${_output}")
+    endif()
+  endforeach()
+endfunction()
+
+# Directories in the existing standard library that make up the Core project
+
+# Copy shared core headers
+copy_library_sources(include "" "Core")
+
+set(CoreLibs
+  LLVMSupport)
+
+  # Add these as we get them building
+  # core
+  # Concurrency
+  # SwiftOnoneSUpport
+  # CommandLineSupport
+  # Demangling
+  # runtime)
+
+foreach(library ${CoreLibs})
+  copy_library_sources(${library} "public" "Core")
+endforeach()
+
+# TODO: Add source directories for the platform overlays, supplemental
+# libraries, and test support libraries.


### PR DESCRIPTION
This patch adds a readme and a cmake script for extracting the standard library sources into the new layout.
To avoid merge conflicts, the sources extracted can't be checked into the repository. Once the build split is complete, we'll go ahead and delete the script and use `git mv` to move the sources to retain the commit history.

With Darwin pulling the overlay out of the Swift build, I want to keep the platforms building in a similar manner.
Some of the stdlib pieces depend on the platform overlay, while the platform overlay depends on swiftCore and folks want to depend on Concurrency. While we could use a bunch of flags and options to mask out parts of the build depending on which platform you're on, this is pretty awkward and will likely be prone to forgotten flags. I'd rather just break it into three pieces, one for Core and Concurrency, one for the overlay, and one for the libraries sit on top of both of those. Then it's a matter of building Core first, building the overlay with the built and installed swiftCore libraries, and finally building the desired supplemental libraries against the built swiftCore and platform overlay. Then all platforms are built with roughly the same flow.

To get started, use the resync script (`cmake -P Resync.cmake`) to copy the sources from the current stdlib directory into the new layout. That will put the files in the appropriate subproject (once they're implemented).

rdar://139218858