### PR TITLE
[RemoteMirror] Add API to check if an address contains an unrealized ObjC class.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -284,6 +284,12 @@ protected:
   }
 
 public:
+  /// The raw storage for the Kind field. Class metadata may have a value here
+  /// which is not a MetadataKind. Use with caution.
+  StoredPointer getRawKind() const {
+    return Kind;
+  }
+
   /// Is this a class object--the metadata record for a Swift class (which also
   /// serves as the class object), or the class object for an ObjC class (which
   /// is not metadata)?

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -479,6 +479,24 @@ swift_reflection_ptr_t
 swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
                          swift_reflection_ptr_t JobPtr);
 
+/// Determine if a given pointer points to an unrealized Objective-C class. This
+/// is done with a heuristic looking at the contents of the candidate class, and
+/// following the superclass chain until a known realized class is reached. The
+/// IsKnownRealizedClass callback must be implemented by the caller to check,
+/// by whatever means at its disposal, whether a given pointer is a realized
+/// Objective-C class.
+///
+/// Returns NULL on success, with OutIsUnrealizedObjCClass set to 1 if it was
+/// recognized as an unrealized class, or 0 if it was not. On error, returns a
+/// pointer to a C string describing the error. This pointer remains valid until
+/// the next swift_reflection call on the given context.
+SWIFT_REMOTE_MIRROR_LINKAGE
+const char *swift_reflection_pointerIsUnrealizedObjCClass(
+    SwiftReflectionContextRef ContextRef,
+    swift_reflection_ptr_t CandidateClassPtr,
+    bool (*IsKnownRealizedClass)(void *Context, swift_reflection_ptr_t Ptr),
+    void *IsKnownRealizedClassContext, int *OutIsUnrealizedObjCClass);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -209,6 +209,7 @@ public enum InstanceKind: UInt8 {
   case Enum
   case EnumValue
   case AsyncTask
+  case MaybeUnrealizedObjCClass
 }
 
 /// Represents a section in a loaded image in this process.
@@ -640,6 +641,12 @@ public func reflect(function: @escaping (Int, String, AnyObject?) -> Void) {
 /// Reflect an AsyncTask.
 public func reflect(asyncTask: UInt) {
   reflect(instanceAddress: asyncTask, kind: .AsyncTask)
+}
+
+// Reflect a potential unrealized ObjC class.
+public func reflect(maybeUnrealizedObjCClass: UnsafeRawPointer) {
+  reflect(instanceAddress: UInt(bitPattern: maybeUnrealizedObjCClass),
+          kind: .MaybeUnrealizedObjCClass);
 }
 
 /// Call this function to indicate to the parent that there are

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -1073,3 +1073,20 @@ swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
     return Context->nextJob(JobPtr);
   });
 }
+
+const char *swift_reflection_pointerIsUnrealizedObjCClass(
+    SwiftReflectionContextRef ContextRef,
+    swift_reflection_ptr_t CandidateClassPtr,
+    bool (*IsKnownRealizedClass)(void *Context, swift_reflection_ptr_t Ptr),
+    void *IsKnownRealizedClassContext, int *OutIsUnrealizedObjCClass) {
+  return ContextRef->withContext<const char *>([&](auto *Context) {
+    auto IsKnownClassAdaptor = [&](auto Ptr) {
+      return IsKnownRealizedClass(IsKnownRealizedClassContext, Ptr);
+    };
+    auto [Error, IsUnrealizedClass] =
+        Context->isUnrealizedObjCClass(CandidateClassPtr, IsKnownClassAdaptor);
+
+    *OutIsUnrealizedObjCClass = IsUnrealizedClass ? 1 : 0;
+    return returnableCString(ContextRef, Error);
+  });
+}

--- a/stdlib/tools/swift-reflection-test/messages.h
+++ b/stdlib/tools/swift-reflection-test/messages.h
@@ -29,5 +29,6 @@ typedef enum InstanceKind {
   Closure,
   Enum,
   EnumValue,
-  AsyncTask
+  AsyncTask,
+  MaybeUnrealizedObjCClass,
 } InstanceKind;

--- a/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.h
+++ b/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.h
@@ -18,4 +18,11 @@
 @property void *z;
 @end
 
+// Direct access to FirstClass for tests that need it.
+
+static inline void *FirstClassPointerRaw(void) {
+  extern char OBJC_CLASS_$_FirstClass;
+  return &OBJC_CLASS_$_FirstClass;
+}
+
 #endif


### PR DESCRIPTION
This is implemented with a heuristic:

1. Are the isa and superclass pointers aligned?
2. Does the cache pointer point to _objc_empty_cache?
3. Is the superclass a known realized class, or does it recursively meet these requirements?

If all are true, it's an unrealized ObjC class. Nothing else has a reason to point to _objc_empty_cache, so this should be very reliable.

rdar://139228894