### PR TITLE
Drop `-index-header-map`, adopt new `Module::Headers` API

### DIFF
--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -327,9 +327,6 @@ bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
       CCArgs.push_back("-iquote");
       CCArgs.push_back(Entry.Path);
       break;
-    case clang::frontend::IndexHeaderMap:
-      CCArgs.push_back("-index-header-map");
-      LLVM_FALLTHROUGH;
     case clang::frontend::Angled: {
       std::string Flag;
       if (Entry.IsFramework)

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -361,7 +361,7 @@ static void collectClangModuleHeaderIncludes(
     for (clang::Module::HeaderKind headerKind :
          {clang::Module::HK_Normal, clang::Module::HK_Textual}) {
       for (const clang::Module::Header &header :
-           clangModule->Headers[headerKind]) {
+           clangModule->getHeaders(headerKind)) {
         addHeader(header.Entry.getFileEntry().tryGetRealPathName(),
                   header.PathRelativeToRootModuleDirectory);
       }


### PR DESCRIPTION
Makes Swift correctly build with https://github.com/swiftlang/llvm-project/pull/9507.