### PR TITLE
[BuildTransform] Fix `walkExplicitReturnStmts` to walk implicit state…

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1260,12 +1260,8 @@ static bool walkExplicitReturnStmts(const BraceStmt *BS,
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      if (S->isImplicit()) {
-        return Action::SkipNode(S);
-      }
-
       auto *returnStmt = dyn_cast<ReturnStmt>(S);
-      if (!returnStmt) {
+      if (!returnStmt || returnStmt->isImplicit()) {
         return Action::Continue(S);
       }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar139235128.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar139235128.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+
+@resultBuilder
+struct Builder {
+  static func buildExpression<T: BinaryInteger>(_: T) {}
+  static func buildBlock<T>(_: T) {}
+}
+
+enum E {
+  case a(Int)
+}
+
+protocol Test {
+  associatedtype V: BinaryInteger
+  @Builder var prop: V { get }
+}
+
+struct S : Test {
+  var flag: E
+
+  var prop: some BinaryInteger {
+    switch flag {
+    case .a:
+      test()
+      return 42
+    }
+  }
+
+  func test() {}
+}


### PR DESCRIPTION
…ments

Some statements introduce implicit braces and other things, `walkExplicitReturnStmts` cannot ignore that while trying to find explicit returns.

Resolves: rdar://139235128

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
