### PR TITLE
[test] Fail on test requiring features that are not used or had disappeared

### DIFF
--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -4,8 +4,6 @@
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_InferSendableFromCaptures
-// REQUIRES: swift_feature_IsolatedDefaultValues
-// REQUIRES: swift_feature_RegionBasedIsolation
 
 @globalActor
 actor SomeGlobalActor {

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_GlobalActorInferenceCutoff
 
 @MainActor
 protocol GloballyIsolated {}

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Interpreter/static_keypaths.swift
+++ b/test/Interpreter/static_keypaths.swift
@@ -20,7 +20,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -11,110 +11,119 @@ import sys
 # Tests that check for the behaviour of  experimental/upcoming features, so
 # they cannot automatically be checked.
 EXCEPTIONAL_FILES = [
-  pathlib.Path("test/Frontend/experimental-features-no-asserts.swift"),
-  pathlib.Path("test/Frontend/upcoming_feature.swift"),
+    pathlib.Path("test/Frontend/experimental-features-no-asserts.swift"),
+    pathlib.Path("test/Frontend/upcoming_feature.swift"),
 ]
 
-FEATURE_USAGE_RE = re.compile(r"-enable-(?:experimental|upcoming)-feature (?:-Xfrontend )?([A-Za-z0-9]*)")
+FEATURE_USAGE_RE = re.compile(
+    r"-enable-(?:experimental|upcoming)-feature (?:-Xfrontend )?([A-Za-z0-9]*)"
+)
 
 
 def find_test_files_with_features_usage(swift_src_root):
-  # Look for every test file in the test directories with `RUN` lines that
-  # mention `-enable-experimental-feature` or `-enable-upcoming-feature`.
-  # Be careful of not using REQUIRES or RUN with a colon after them or Lit will
-  # pick them up.
-  output = subprocess.check_output([
-    "grep",
-    "--extended-regexp",
-    "--recursive",
-    "-e",
-    "RUN[:].*-enable-(experimental|upcoming)-feature",
-    "--files-with-matches",
-    str(swift_src_root / "test"),
-    str(swift_src_root / "validation-test"),
-  ], text=True)
-  return output.splitlines()
+    # Look for every test file in the test directories with `RUN` lines that
+    # mention `-enable-experimental-feature` or `-enable-upcoming-feature`.
+    # Be careful of not using REQUIRES or RUN with a colon after them or Lit will
+    # pick them up.
+    output = subprocess.check_output([
+        "grep",
+        "--extended-regexp",
+        "--recursive",
+        "-e",
+        "RUN[:].*-enable-(experimental|upcoming)-feature",
+        "--files-with-matches",
+        str(swift_src_root / "test"),
+        str(swift_src_root / "validation-test"),
+    ], text=True)
+    return output.splitlines()
 
 
 def find_run_lines(test_file):
-  output = subprocess.check_output([
-    "grep",
-    "--extended-regexp",
-    "--no-filename",
-    "-e",
-    "RUN[:]",
-    str(test_file),
-  ], text=True)
-  return output.splitlines()
+    output = subprocess.check_output([
+        "grep",
+        "--extended-regexp",
+        "--no-filename",
+        "-e",
+        "RUN[:]",
+        str(test_file),
+    ], text=True)
+    return output.splitlines()
 
 
 def check_existing_requires(test_file, feature):
-  returncode = subprocess.call([
-    "grep",
-    "--extended-regexp",
-    "--quiet",
-    "-e",
-    "REQUIRES[:].*swift_feature_" + feature,
-    str(test_file),
-  ])
-  return returncode != 0
+    returncode = subprocess.call([
+        "grep",
+        "--extended-regexp",
+        "--quiet",
+        "-e",
+        "REQUIRES[:].*swift_feature_" + feature,
+        str(test_file),
+    ])
+    return returncode != 0
 
 
 def check_existing_error_message_checks(test_file, feature):
-  returncode = subprocess.call([
-    "grep",
-    "--extended-regexp",
-    "--quiet",
-    "-e",
-    "requires '-enable-(experimental|upcoming)-feature " + feature + "'",
-    str(test_file),
-  ])
-  return returncode != 0
+    returncode = subprocess.call([
+        "grep",
+        "--extended-regexp",
+        "--quiet",
+        "-e",
+        "requires '-enable-(experimental|upcoming)-feature " + feature + "'",
+        str(test_file),
+    ])
+    return returncode != 0
 
 
 def check_test_file_feature_usage(test_file):
-  run_lines = find_run_lines(test_file)
-  features = set(
-    feature
-    for line in run_lines
-    for feature in FEATURE_USAGE_RE.findall(line)
-  )
-  num_failures = 0
-  for feature in features:
-    # No warning if the necessary `REQUIRES` is already there
-    if not check_existing_requires(test_file, feature):
-      continue
+    run_lines = find_run_lines(test_file)
+    features = set(
+        feature
+        for line in run_lines
+        for feature in FEATURE_USAGE_RE.findall(line)
+    )
+    num_failures = 0
+    for feature in features:
+        # No warning if the necessary `REQUIRES` is already there
+        if not check_existing_requires(test_file, feature):
+            continue
 
-    # Some tests check for the errors themselves, so we can skip them as well
-    if not check_existing_error_message_checks(test_file, feature):
-      continue
+        # Some tests check for the errors themselves, so we can skip them as well
+        if not check_existing_error_message_checks(test_file, feature):
+            continue
 
-    # For everything else, print a warning and for an invalid exit code
-    print("error: {}: Missing '{}: swift_feature_{}'".format(str(test_file), "REQUIRES", feature))
-    num_failures += 1
-  return num_failures == 0
+        # For everything else, print a warning and add to the invalid exit code
+        print(
+            "error: {}: Missing '{}: swift_feature_{}'".format(
+                str(test_file),
+                "REQUIRES",
+                feature
+            )
+        )
+        num_failures += 1
+    return num_failures == 0
 
 
 def main():
-  if len(sys.argv) < 2:
-      print('Invalid number of arguments.')
-      sys.exit(1)
+    if len(sys.argv) < 2:
+        print('Invalid number of arguments.')
+        sys.exit(1)
 
-  swift_src_root = pathlib.Path(sys.argv[1])
+    swift_src_root = pathlib.Path(sys.argv[1])
 
-  num_failures = 0
-  test_files_with_features_usage = find_test_files_with_features_usage(swift_src_root)
-  for test_file in test_files_with_features_usage:
-    test_file = pathlib.Path(test_file)
-    # First lets check this is not one of the exceptional files
-    if test_file.relative_to(swift_src_root) in EXCEPTIONAL_FILES:
-      continue
+    num_failures = 0
+    test_files_with_features_usage = find_test_files_with_features_usage(swift_src_root)
+    for test_file in test_files_with_features_usage:
+        test_file = pathlib.Path(test_file)
+        # First lets check this is not one of the exceptional files
+        if test_file.relative_to(swift_src_root) in EXCEPTIONAL_FILES:
+            continue
 
-    if not check_test_file_feature_usage(test_file):
-      num_failures += 1
+        if not check_test_file_feature_usage(test_file):
+            num_failures += 1
 
-  if num_failures > 0:
-    sys.exit(1)
+    if num_failures > 0:
+        sys.exit(1)
+
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -18,6 +18,9 @@ EXCEPTIONAL_FILES = [
 FEATURE_USAGE_RE = re.compile(
     r"-enable-(?:experimental|upcoming)-feature (?:-Xfrontend )?([A-Za-z0-9]*)"
 )
+# Be careful of not using REQUIRES or RUN with a colon after them or Lit will
+# pick them up.
+FEATURE_LIT_MARKER_RE = re.compile(r"swift_feature_([A-Za-z0-9]*)")
 
 
 def find_test_files_with_features_usage(swift_src_root):
@@ -38,6 +41,24 @@ def find_test_files_with_features_usage(swift_src_root):
     return output.splitlines()
 
 
+def find_test_files_with_marker_usage(swift_src_root):
+    # Look for every test file in the test directories with `REQUIRES` lines
+    # that mention `swift_feature_`.
+    # Be careful of not using REQUIRES with a colon after them or Lit will
+    # pick them up.
+    output = subprocess.check_output([
+        "grep",
+        "--extended-regexp",
+        "--recursive",
+        "-e",
+        "REQUIRES[:].*swift_feature_",
+        "--files-with-matches",
+        str(swift_src_root / "test"),
+        str(swift_src_root / "validation-test"),
+    ], text=True)
+    return output.splitlines()
+
+
 def find_run_lines(test_file):
     output = subprocess.check_output([
         "grep",
@@ -50,6 +71,18 @@ def find_run_lines(test_file):
     return output.splitlines()
 
 
+def find_requires_lines(test_file):
+    output = subprocess.check_output([
+        "grep",
+        "--extended-regexp",
+        "--no-filename",
+        "-e",
+        "REQUIRES[:]",
+        str(test_file),
+    ], text=True)
+    return output.splitlines()
+
+
 def check_existing_requires(test_file, feature):
     returncode = subprocess.call([
         "grep",
@@ -57,6 +90,21 @@ def check_existing_requires(test_file, feature):
         "--quiet",
         "-e",
         "REQUIRES[:].*swift_feature_" + feature,
+        str(test_file),
+    ])
+    return returncode != 0
+
+
+def check_existing_feature_usage(test_file, feature):
+    returncode = subprocess.call([
+        "grep",
+        "--extended-regexp",
+        "--quiet",
+        "-e",
+        (
+            "RUN[:].*-enable-(experimental|upcoming)-feature (-Xfrontend )?"
+            + re.escape(feature)
+        ),
         str(test_file),
     ])
     return returncode != 0
@@ -103,6 +151,30 @@ def check_test_file_feature_usage(test_file):
     return num_failures == 0
 
 
+def check_test_file_marker_usage(test_file):
+    require_lines = find_requires_lines(test_file)
+    features = set(
+        feature
+        for line in require_lines
+        for feature in FEATURE_LIT_MARKER_RE.findall(line)
+    )
+    num_failures = 0
+    for feature in features:
+        # No warning if -enable-experimental/upcoming-feature is there
+        if not check_existing_feature_usage(test_file, feature):
+            continue
+
+        # For everything else, print a warning and add to the invalid exit code
+        print(
+            "error: {}: Missing '-enable-experimental/upcoming-feature: {}'".format(
+                str(test_file),
+                feature
+            )
+        )
+        num_failures += 1
+    return num_failures == 0
+
+
 def main():
     if len(sys.argv) < 2:
         print('Invalid number of arguments.')
@@ -119,6 +191,17 @@ def main():
             continue
 
         if not check_test_file_feature_usage(test_file):
+            num_failures += 1
+
+    test_files_with_marker_usage = find_test_files_with_marker_usage(swift_src_root)
+    for test_file in test_files_with_marker_usage:
+        test_file = pathlib.Path(test_file)
+
+        # First lets check this is not one of the exceptional files
+        if test_file.relative_to(swift_src_root) in EXCEPTIONAL_FILES:
+            continue
+
+        if not check_test_file_marker_usage(test_file):
             num_failures += 1
 
     if num_failures > 0:

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-emit-silgen -target %target-swift-5.1-abi-triple -disable-experimental-parser-round-trip -parse-stdlib -module-name keypaths %s | %FileCheck %s
 // FIXME: Remove '-disable-experimental-parser-round-trip'.
 
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
-
 
 import Swift
 

--- a/test/SILOptimizer/access_wmo_diagnose.swift
+++ b/test/SILOptimizer/access_wmo_diagnose.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
 
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
-
 // AccessEnforcementWMO assumes that the only way to address a global or static
 // property is via a formal begin_access. If we ever allow keypaths for static
 // properties, which I think is conceivable, then this test will fail to produce

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Macros
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
-
 var global = 42
 
 @dynamicMemberLookup

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library %s -verify
 
-// REQUIRES: swift_feature_KeyPathWithStaticMembers
-
 struct Sub: Hashable {
   static func ==(_: Sub, _: Sub) -> Bool { return true }
   func hash(into hasher: inout Hasher) {}


### PR DESCRIPTION
While doing #76740 I iteratively was adding new `REQUIRES:` as new usages of the features were found, but I did not realize that at the same time other people might be removing some of those usages. The tests in this commit had some `REQUIRES:` line for a previous `-enable-experimental/upcoming-feature`, but they not longer use those features, so the `REQUIRES:` were effectively disabling the tests (at least in the case of `KeyPathWithStaticMembers`. In other cases they might still had executed).