### PR TITLE
[🍒 swift 6.0.x] Default Linux toolchain linker to gold

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -917,7 +917,7 @@ reconfigure
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
 llvm-cmake-options=
-  -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+  -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++;-DCLANG_DEFAULT_LINKER=gold'
   -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux]
@@ -1088,6 +1088,11 @@ reconfigure
 test-optimized
 skip-test-swiftdocc
 
+# gcc version on amazon linux 2 is too old to configure and build tablegen.
+# Use the clang that we install in the path for macros
+llvm-cmake-options=
+  -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux_1404_no_lldb]
 mixin-preset=buildbot_incremental_linux
@@ -1167,6 +1172,8 @@ reconfigure
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_incremental_linux]
 mixin-preset=
@@ -1831,6 +1838,9 @@ skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
+
 # Builds enough of the toolchain to build a swift package on macOS.
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_macos_platform
@@ -1853,6 +1863,8 @@ mixin-preset=mixin_swiftpm_linux_platform
 skip-test-llbuild
 skip-test-swiftpm
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 #===------------------------------------------------------------------------===#
 # Test swiftPM on macOS builder
@@ -2124,6 +2136,9 @@ skip-test-cmark
 skip-test-swift
 skip-test-libdispatch
 skip-test-foundation
+
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 #===------------------------------------------------------------------------===#
 # Remote Mirror Library
@@ -2953,6 +2968,9 @@ install-libdispatch
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
+
 [preset: source_compat_suite_macos_DA]
 mixin-preset=source_compat_suite_macos_base
 debug
@@ -3042,3 +3060,6 @@ skip-test-cmark
 skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
+
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold


### PR DESCRIPTION
The BFD linker on most of the Linux box is unable to link Swift objects. Currently the Swift driver hard-codes forcing the default linker to gold, but we want to support configuring this, so we need build-script to force it at the clang level instead.

Cherry-Picks:
  d63152fd8070
  7596d0091600
  826255254e8f

Was originally https://github.com/swiftlang/swift/pull/77209.
The PR that was merged instead missed a few changes, so this pulls all of them across, working around the mishandled relocation by bfd:
```
/usr/bin/ld: src/swift/CMakeFiles/swiftDispatch.dir/Block.swift.o: relocation R_X86_64_PC32 against protected symbol `$s8Dispatch0A13WorkItemFlagsVSYAAMc' can not be used when making a shared object
```
