### PR TITLE
[IRGen+Runtime] Differentiate between pure Swift and regular ObjC ref…

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -70,7 +70,7 @@ public:
     Bridge = 0x08,
     Block = 0x09,
     ObjC = 0x0a,
-    Custom = 0x0b,
+    NativeSwiftObjC = 0x0b,
 
     // reserved
     // Metatype = 0x0c,
@@ -1294,7 +1294,12 @@ bool ScalarTypeLayoutEntry::refCountString(IRGenModule &IGM,
     B.addRefCount(LayoutStringBuilder::RefCountingKind::Block, size);
     break;
   case ScalarKind::ObjCReference:
-    B.addRefCount(LayoutStringBuilder::RefCountingKind::ObjC, size);
+    if (typeInfo.hasFixedSpareBits()) {
+      B.addRefCount(LayoutStringBuilder::RefCountingKind::NativeSwiftObjC,
+                    size);
+    } else {
+      B.addRefCount(LayoutStringBuilder::RefCountingKind::ObjC, size);
+    }
     break;
   case ScalarKind::ThickFunc:
     B.addSkip(IGM.getPointerSize().getValue());

--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -127,15 +127,15 @@ static uint64_t readTagBytes(const uint8_t *addr, uint8_t byteCount) {
       uint64_t TAG = 0;                                                        \
       uintptr_t OFFSET = 0;                                                    \
                                                                                \
-      _Pragma("clang diagnostic push")                                         \
-          _Pragma("clang diagnostic ignored \"-Wgnu-label-as-value\"")         \
-              const void *dispatchTable[] = {                                  \
-                  &&done,       &&Error,   &&NativeStrong,   &&NativeUnowned,  \
-                  &&NativeWeak, &&Unknown, &&UnknownUnowned, &&UnknownWeak,    \
-                  &&Bridge,     &&Block,   &&ObjC,           &&Custom,         \
-                  &&Metatype,   &&Generic, &&Existential,    &&Resilient,      \
-                  &&Default,    &&Default, &&Default,        &&Default,        \
-                  &&Default,    &&Default, &&Default,                          \
+      _Pragma("clang diagnostic push") _Pragma(                                \
+          "clang diagnostic ignored \"-Wgnu-label-as-value\"")                 \
+          const void *dispatchTable[] = {                                      \
+              &&done,       &&Error,   &&NativeStrong,   &&NativeUnowned,      \
+              &&NativeWeak, &&Unknown, &&UnknownUnowned, &&UnknownWeak,        \
+              &&Bridge,     &&Block,   &&ObjC,           &&NativeSwiftObjC,    \
+              &&Metatype,   &&Generic, &&Existential,    &&Resilient,          \
+              &&Default,    &&Default, &&Default,        &&Default,            \
+              &&Default,    &&Default, &&Default,                              \
       };                                                                       \
                                                                                \
       [[clang::nomerge]] {                                                     \
@@ -194,8 +194,9 @@ static uint64_t readTagBytes(const uint8_t *addr, uint8_t byteCount) {
         CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
       }                                                                        \
       [[clang::nomerge]] {                                                     \
-      Custom:                                                                  \
-        swift_unreachable("");                                                 \
+      NativeSwiftObjC:                                                         \
+        FN_TABLE[11](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);              \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
       }                                                                        \
       [[clang::nomerge]] {                                                     \
       Metatype:                                                                \
@@ -782,9 +783,18 @@ static void objcStrongDestroy(const Metadata *metadata,
 #if SWIFT_OBJC_INTEROP
   uintptr_t object = *(uintptr_t *)(addr + addrOffset);
   addrOffset += sizeof(objc_object*);
-  if (object & _swift_abi_ObjCReservedBitsMask)
-    return;
+  objc_release((objc_object *)object);
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
+#endif
+}
 
+static void nativeSwiftObjcStrongDestroy(const Metadata *metadata,
+                                         LayoutStringReader1 &reader,
+                                         uintptr_t &addrOffset, uint8_t *addr) {
+#if SWIFT_OBJC_INTEROP
+  uintptr_t object = *(uintptr_t *)(addr + addrOffset);
+  addrOffset += sizeof(objc_object *);
   object &= ~_swift_abi_SwiftSpareBitsMask;
   objc_release((objc_object *)object);
 #else
@@ -838,7 +848,7 @@ constexpr DestrFn destroyTable[] = {
     &bridgeDestroy,
     &blockDestroy,
     &objcStrongDestroy,
-    nullptr, // Custom
+    &nativeSwiftObjcStrongDestroy,
     &metatypeDestroy,
     nullptr, // Generic
     &existentialDestroy,
@@ -1006,8 +1016,21 @@ static void objcStrongRetain(const Metadata *metadata,
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(objc_object *));
   addrOffset = _addrOffset + sizeof(objc_object *);
-  if (object & _swift_abi_ObjCReservedBitsMask)
-    return;
+  objc_retain((objc_object *)object);
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
+#endif
+}
+
+static void nativeSwiftObjcStrongRetain(const Metadata *metadata,
+                                        LayoutStringReader1 &reader,
+                                        uintptr_t &addrOffset, uint8_t *dest,
+                                        uint8_t *src) {
+#if SWIFT_OBJC_INTEROP
+  uintptr_t _addrOffset = addrOffset;
+  uintptr_t object = *(uintptr_t *)(src + _addrOffset);
+  memcpy(dest + _addrOffset, &object, sizeof(objc_object *));
+  addrOffset = _addrOffset + sizeof(objc_object *);
   object &= ~_swift_abi_SwiftSpareBitsMask;
   objc_retain((objc_object *)object);
 #else
@@ -1069,7 +1092,7 @@ constexpr InitFn initWithCopyTable[] = {
     &bridgeRetain,
     &blockCopy,
     &objcStrongRetain,
-    nullptr, // Custom
+    &nativeSwiftObjcStrongRetain,
     &metatypeInitWithCopy,
     nullptr, // Generic
     &existentialInitWithCopy,
@@ -1429,15 +1452,29 @@ static void objcStrongAssignWithCopy(const Metadata *metadata,
   memcpy(dest + _addrOffset, &srcObject, sizeof(objc_object*));
   addrOffset = _addrOffset + sizeof(objc_object*);
 
-  if (!(destObject & _swift_abi_ObjCReservedBitsMask)) {
-    destObject &= ~_swift_abi_SwiftSpareBitsMask;
-    objc_release((objc_object *)destObject);
-  }
+  objc_release((objc_object *)destObject);
+  objc_retain((objc_object *)srcObject);
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
+#endif
+}
 
-  if (!(srcObject & _swift_abi_ObjCReservedBitsMask)) {
-    srcObject &= ~_swift_abi_SwiftSpareBitsMask;
-    objc_retain((objc_object *)srcObject);
-  }
+static void nativeSwiftObjcStrongAssignWithCopy(const Metadata *metadata,
+                                                LayoutStringReader1 &reader,
+                                                uintptr_t &addrOffset,
+                                                uint8_t *dest, uint8_t *src) {
+#if SWIFT_OBJC_INTEROP
+  uintptr_t _addrOffset = addrOffset;
+  uintptr_t destObject = *(uintptr_t *)(dest + _addrOffset);
+  uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
+  memcpy(dest + _addrOffset, &srcObject, sizeof(objc_object *));
+  addrOffset = _addrOffset + sizeof(objc_object *);
+
+  destObject &= ~_swift_abi_SwiftSpareBitsMask;
+  objc_release((objc_object *)destObject);
+
+  srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+  objc_retain((objc_object *)srcObject);
 #else
   swift_unreachable("ObjC interop is not available on this platform");
 #endif
@@ -1873,7 +1910,7 @@ constexpr InitFn assignWithCopyTable[] = {
     &bridgeAssignWithCopy,
     &blockAssignWithCopy,
     &objcStrongAssignWithCopy,
-    nullptr, // Custom
+    &nativeSwiftObjcStrongAssignWithCopy,
     &metatypeAssignWithCopy,
     nullptr, // Generic
     &existentialAssignWithCopy,

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -36,7 +36,7 @@ enum class RefCountingKind : uint8_t {
   Bridge = 0x08,
   Block = 0x09,
   ObjC = 0x0a,
-  Custom = 0x0b,
+  NativeSwiftObjC = 0x0b,
 
   Metatype = 0x0c,
   Generic = 0x0d,

--- a/test/Interpreter/layout_string_witnesses_objc.swift
+++ b/test/Interpreter/layout_string_witnesses_objc.swift
@@ -92,3 +92,44 @@ func testMultiPayloadObjCExistentialWrapper() {
 }
 
 testMultiPayloadObjCExistentialWrapper()
+
+@objc
+class SwiftObjC: NSObject {
+    deinit {
+        print("SwiftObjC deinitialized!")
+    }
+}
+
+enum MultiPayloadNativeSwiftObjC {
+    case x(SwiftObjC)
+    case y(SwiftObjC)
+    case z(SwiftObjC)
+}
+
+func testMultiPayloadNativeSwiftObjC() {
+    let ptr = allocateInternalGenericPtr(of: MultiPayloadNativeSwiftObjC.self)
+
+    do {
+        let x = MultiPayloadNativeSwiftObjC.y(SwiftObjC())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = MultiPayloadNativeSwiftObjC.z(SwiftObjC())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SwiftObjC deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SwiftObjC deinitialized!
+    testGenericDestroy(ptr, of: MultiPayloadNativeSwiftObjC.self)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadNativeSwiftObjC()


### PR DESCRIPTION
…erences in CVW

rdar://139106139

Regular ObjC references do not have unused bits or extra inhabitants for storing enum tags, because they may be tagged pointers. However, ObjC classes that are implemented in Swift do, so we must differentiate between the two.
