### PR TITLE
AST: Fix request cycle from ParameterizedProtocolType::getRequirements()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3754,10 +3754,18 @@ void ParameterizedProtocolType::getRequirements(
   for (unsigned i : indices(argTypes)) {
     auto argType = argTypes[i];
     auto *assocType = assocTypes[i];
-    // Do a general type substitution here because the associated type might be
-    // from an inherited protocol, in which case we will evaluate a non-trivial
-    // conformance path.
-    auto subjectType = assocType->getDeclaredInterfaceType().subst(subMap);
+
+    Type subjectType;
+    if (baseType->isTypeParameter()) {
+      // Fast path.
+      subjectType = DependentMemberType::get(baseType, assocType);
+    } else {
+      // Do a general type substitution here because the associated type might be
+      // from an inherited protocol, in which case we will evaluate a non-trivial
+      // conformance path.
+      subjectType = assocType->getDeclaredInterfaceType().subst(subMap);
+    }
+
     reqs.emplace_back(RequirementKind::SameType, subjectType, argType);
   }
 }

--- a/test/Generics/rdar139232031.swift
+++ b/test/Generics/rdar139232031.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {
+  associatedtype A
+  associatedtype B
+}
+
+protocol P2<A>: P1 where B: P2<A> {}


### PR DESCRIPTION
This fixes a regression from https://github.com/swiftlang/swift/pull/76585.

Fixes rdar://problem/139232031.