### PR TITLE
[macCatalyst] Add some build presets for CI testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2334,6 +2334,21 @@ skip-test-tvos
 skip-test-ios
 skip-reconfigure
 
+[preset: mixin_buildbot_incremental,test=macCatalyst,type=device]
+
+test
+validation-test
+lit-args=-v
+
+ios
+maccatalyst
+
+skip-test-ios
+skip-test-tvos
+skip-test-watchos
+skip-test-xros
+skip-reconfigure
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2368,6 +2383,11 @@ mixin-preset=
 mixin-preset=
     buildbot_incremental,tools=RA,stdlib=RD,build
     mixin_buildbot_incremental,test=watchOS,type=simulator
+
+[preset: buildbot_incremental,tools=RA,stdlib=RD,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RD,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
 
 #===------------------------------------------------------------------------===#
 # Swift Preset
@@ -2415,6 +2435,13 @@ mixin-preset=
 
 test-optimized
 
+[preset: buildbot_incremental,tools=RA,stdlib=RDA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RDA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2458,6 +2485,14 @@ mixin-preset=
 
 test-optimized
 
+[preset: buildbot_incremental,tools=RA,stdlib=DA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=DA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2497,6 +2532,14 @@ mixin-preset=
     mixin_buildbot_incremental,test=watchOS,type=simulator
 
 test-optimized
+
+[preset: buildbot_incremental,tools=RA,stdlib=RA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
 
 #===------------------------------------------------------------------------===#
 # Swift Preset


### PR DESCRIPTION
None of the presets exercise macCatalyst at the moment. The presets provided in this commit are not used by default, and will need to be invoked specially with the Swift CI bot, but at least it will allow testing the macCatalyst features.
