### PR TITLE
Infer @PointerBounds macro from clang __counted_by parameters

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -406,6 +406,10 @@ EXPERIMENTAL_FEATURE(WarnUnsafe, true)
 /// Import unsafe C and C++ constructs as @unsafe.
 EXPERIMENTAL_FEATURE(SafeInterop, true)
 
+// Import bounds safety and lifetime attributes from interop headers to
+// generate Swift wrappers with safe pointer types.
+EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
+
 /// Ignore resilience errors due to C++ types.
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -792,6 +792,11 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def enable_experimental_bounds_safety_interop :
+  Flag<["-"], "enable-experimental-bounds-safety-interop">,
+  Flags<[NoDriverOption, FrontendOption, HelpHidden, ModuleInterfaceOption]>,
+  HelpText<"Enable experimental C bounds safety interop code generation and config directives">;
+
 def enable_experimental_cxx_interop :
   Flag<["-"], "enable-experimental-cxx-interop">,
   Flags<[NoDriverOption, FrontendOption, HelpHidden, ModuleInterfaceOption]>,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -321,6 +321,7 @@ static bool usesFeatureAllowUnsafeAttribute(Decl *decl) {
 
 UNINTERESTING_FEATURE(WarnUnsafe)
 UNINTERESTING_FEATURE(SafeInterop)
+UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(CoroutineAccessorsAllocateInCallee)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -578,6 +578,9 @@ void importer::getNormalInvocationArguments(
     }
   }
 
+  if (LangOpts.hasFeature(Feature::SafeInteropWrappers))
+    invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
+
   // Set C language options.
   if (triple.isOSDarwin()) {
     invocationArgStrs.insert(invocationArgStrs.end(), {

--- a/test/Interop/C/pointer-bounds/Inputs/counted-by.h
+++ b/test/Interop/C/pointer-bounds/Inputs/counted-by.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+void simple(int len, int * __counted_by(len) p);
+
+void swiftAttr(int len, int * p) __attribute__((swift_attr("@PointerBounds(.countedBy(pointer: 2, count: \"len\"))")));
+
+void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
+
+void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
+
+void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
+
+void nonnull(int len, int * __counted_by(len) _Nonnull p);
+
+void nullable(int len, int * __counted_by(len) _Nullable p);

--- a/test/Interop/C/pointer-bounds/Inputs/module.modulemap
+++ b/test/Interop/C/pointer-bounds/Inputs/module.modulemap
@@ -1,0 +1,5 @@
+module CountedByClang {
+    header "counted-by.h"
+    export *
+}
+

--- a/test/Interop/C/pointer-bounds/counted-by.swift
+++ b/test/Interop/C/pointer-bounds/counted-by.swift
@@ -1,0 +1,47 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: pointer_bounds
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -disable-availability-checking -plugin-path %swift-plugin-dir -o %t/CountedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+
+// Check that ClangImporter correctly infers and expands @PointerBounds macros for functions with __counted_by parameters.
+
+import CountedByClang
+
+@inlinable
+public func callSimple(_ p: UnsafeMutableBufferPointer<CInt>) {
+  simple(p)
+}
+
+// Check that macros from swift_attr work the same as inferred macros.
+@inlinable
+public func callSwiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  swiftAttr(p)
+}
+
+@inlinable
+public func callShared(_ len: CInt, _ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  shared(len, p1, p2)
+}
+
+@inlinable
+public func callComplexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  complexExpr(len, offset, p)
+}
+
+
+@inlinable
+public func callNullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
+  nullUnspecified(p)
+}
+
+@inlinable
+public func callNonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
+  nonnull(p)
+}
+
+@inlinable
+public func callNullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
+  nullable(p)
+}
+


### PR DESCRIPTION
This results in an automatic wrapper function with safe pointer types
when the imported function has bounds attributes. This exercises similar
pathways as the recently added functionality for specifying macros from
swift_attr, and fixes some bugs related to macro source file management.

Includes some unmerged commits from #76969.
