### PR TITLE
[cxx-interop] Stop importing unannotated C++ APIs retuning FRT in the next Cxx-Interop version

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -259,23 +259,27 @@ ERROR(failed_base_method_call_synthesis,none,
       (ValueDecl *, ValueDecl *))
 
 ERROR(both_returns_retained_returns_unretained, none,
-      "%0 cannot be annotated with both swift_attr('returns_retained') and "
-      "swift_attr('returns_unretained') attributes",
+      "%0 cannot be annotated with both 'SWIFT_RETURNS_RETAINED' and "
+      "'SWIFT_RETURNS_UNRETAINED'",
       (const clang::NamedDecl *))
 
 ERROR(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
-      "%0 cannot be annotated with either swift_attr('returns_retained') or "
-      "swift_attr('returns_unretained') attribute because it is not returning "
+      "%0 cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or "
+      "'SWIFT_RETURNS_UNRETAINED' because it is not returning "
       "a 'SWIFT_SHARED_REFERENCE' type",
       (const clang::NamedDecl *))
 
-// TODO: make this case an error in next cxx-interop versions rdar://138806722
-WARNING(
-    no_returns_retained_returns_unretained, none,
-    "%0 is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated "
-    "with either swift_attr('returns_retained') or "
-    "swift_attr('returns_unretained') attributes",
-    (const clang::NamedDecl *))
+WARNING(no_returns_retained_returns_unretained_warn, none,
+        "%0 would not be imported in a later version of Swift because it is "
+        "returning a 'SWIFT_SHARED_REFERENCE' type but it is not annotated with "
+        "either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'",
+        (const clang::NamedDecl *))
+
+ERROR(no_returns_retained_returns_unretained_error, none,
+      "%0 is not imported in Swift because it is returning a "
+      "'SWIFT_SHARED_REFERENCE' type but it is not annotated with either "
+      "'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'",
+      (const clang::NamedDecl *))
 
 NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))
 NOTE(record_field_not_imported, none, "field %0 unavailable (cannot import)", (const clang::NamedDecl*))

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
@@ -1,43 +1,45 @@
 // RUN: rm -rf %t
-// RUN: not %target-swift-frontend -typecheck -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift 2>&1 | %FileCheck %s --check-prefix=CHECK-UPCOMING-SWIFT
+// RUN: not %target-swift-frontend -typecheck -I %S/Inputs  %s -cxx-interoperability-mode=default 2>&1 | %FileCheck %s --check-prefix=CHECK-DEFAULT
 
 import FunctionsAndMethodsReturningFRT
 
 let frtLocalVar1 = global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained()
-// CHECK: error: 'global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained' cannot be annotated with both swift_attr('returns_retained') and swift_attr('returns_unretained') attributes
+// CHECK-DEFAULT: error: 'global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained' cannot be annotated with both 'SWIFT_RETURNS_RETAINED' and 'SWIFT_RETURNS_UNRETAINED'
 
 let frtLocalVar2 = StructWithStaticMethodsReturningFRTWithBothAttributesReturnsRetainedAndReturnsUnretained.StaticMethodReturningFRT()
-// CHECK: error: 'StaticMethodReturningFRT' cannot be annotated with both swift_attr('returns_retained') and swift_attr('returns_unretained') attributes
-
+// CHECK-DEFAULT: error: 'StaticMethodReturningFRT' cannot be annotated with both 'SWIFT_RETURNS_RETAINED' and 'SWIFT_RETURNS_UNRETAINED'
 let frtLocalVar3 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrt()
-// CHECK: warning: 'StaticMethodReturningCxxFrt' is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attributes
+// CHECK-DEFAULT: warning: 'StaticMethodReturningCxxFrt' would not be imported in a later version of Swift because it is returning a 'SWIFT_SHARED_REFERENCE' type but it is not annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'
+// CHECK-UPCOMING-SWIFT: error: 'StaticMethodReturningCxxFrt' is not imported in Swift because it is returning a 'SWIFT_SHARED_REFERENCE' type but it is not annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'
 let frtLocalVar4 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrtWithAnnotation()
 
 let frtLocalVar5 = global_function_returning_cxx_frt()
-// CHECK: warning: 'global_function_returning_cxx_frt' is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attributes
+// CHECK-DEFAULT: warning: 'global_function_returning_cxx_frt' would not be imported in a later version of Swift because it is returning a 'SWIFT_SHARED_REFERENCE' type but it is not annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'
+// CHECK-UPCOMING-SWIFT: error: 'global_function_returning_cxx_frt' is not imported in Swift because it is returning a 'SWIFT_SHARED_REFERENCE' type but it is not annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED'
 let frtLocalVar6 = global_function_returning_cxx_frt_with_annotations()
 
 let frtLocalVar7 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrt()
 let frtLocalVar8 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrtWithAnnotation()
-// CHECK: error: 'StaticMethodReturningNonCxxFrtWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'StaticMethodReturningNonCxxFrtWithAnnotation' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
 
 let frtLocalVar9 = global_function_returning_non_cxx_frt()
 let frtLocalVar10 = global_function_returning_non_cxx_frt_with_annotations()
-// CHECK: error: 'global_function_returning_non_cxx_frt_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'global_function_returning_non_cxx_frt_with_annotations' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
 
 let frtLocalVar11 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReference()
 let frtLocalVar12 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReferenceWithAnnotation()
-// CHECK: error: 'StaticMethodReturningImmortalReferenceWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'StaticMethodReturningImmortalReferenceWithAnnotation' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
 
 let frtLocalVar13 = global_function_returning_immortal_reference()
 let frtLocalVar14 = global_function_returning_immortal_reference_with_annotations()
-// CHECK: error: 'global_function_returning_immortal_reference_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'global_function_returning_immortal_reference_with_annotations' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
 
 let frtLocalVar15 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReference()
 let frtLocalVar16 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReferenceWithAnnotation()
-// CHECK: error: 'StaticMethodReturningUnsafeReferenceWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'StaticMethodReturningUnsafeReferenceWithAnnotation' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
 
 let frtLocalVar17 = global_function_returning_unsafe_reference()
 let frtLocalVar18 = global_function_returning_unsafe_reference_with_annotations()
-// CHECK: error: 'global_function_returning_unsafe_reference_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK-DEFAULT: error: 'global_function_returning_unsafe_reference_with_annotations' cannot be annotated with either 'SWIFT_RETURNS_RETAINED' or 'SWIFT_RETURNS_UNRETAINED' because it is not returning a 'SWIFT_SHARED_REFERENCE' type
  

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import FunctionsAndMethodsReturningFRT
 


### PR DESCRIPTION
Convert the warning introduced by https://github.com/swiftlang/swift/pull/76798/ into error for next cxx-Interop version.