### PR TITLE
[cxx-interop] Fix crash trying to export read accesors

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1949,8 +1949,9 @@ private:
 
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Documentation.
-      auto *getter = VD->getOpaqueAccessor(AccessorKind::Get);
-      printAbstractFunctionAsMethod(getter, /*isStatic=*/VD->isStatic());
+      // TODO: support read/modify accessors.
+      if (auto *getter = VD->getOpaqueAccessor(AccessorKind::Get))
+        printAbstractFunctionAsMethod(getter, /*isStatic=*/VD->isStatic());
       if (auto *setter = VD->getOpaqueAccessor(AccessorKind::Set))
         printAbstractFunctionAsMethod(setter, /*isStatic=*/VD->isStatic());
       return;

--- a/test/Interop/SwiftToCxx/stdlib/swift-synchronization-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-synchronization-in-cxx.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseSynchronization -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/UseSynchronization.h
+// RUN: %FileCheck %s < %t/UseSynchronization.h
+
+// REQUIRES: synchronization
+
+import Synchronization
+
+public class SomeClass { }
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
+public class Thing {
+    public static let rc = Mutex(SomeClass())
+}
+
+// CHECK: class SWIFT_AVAILABILITY(visionos,introduced=2) SWIFT_AVAILABILITY(watchos,introduced=11) SWIFT_AVAILABILITY(tvos,introduced=18) SWIFT_AVAILABILITY(ios,introduced=18) SWIFT_AVAILABILITY(macos,introduced=15) SWIFT_SYMBOL("s:18UseSynchronization5ThingC") Thing;


### PR DESCRIPTION
This is not yet supported, so skip exporting those accessors for now.

Fixes #77304

rdar://138944832
