### PR TITLE
[build-script][embedded] Conditionally force compiler-rt baremetal builtins

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -296,7 +296,7 @@ class LLVM(cmake_product.CMakeProduct):
         llvm_cmake_options.define('LLVM_ENABLE_LTO:STRING', self.args.lto_type)
         llvm_cmake_options.define('COMPILER_RT_INTERCEPT_LIBDISPATCH', 'ON')
 
-        if system() == 'Darwin':
+        if self.args.build_embedded_stdlib and system() == "Darwin":
             # Ask for Mach-O cross-compilation builtins (for Embedded Swift)
             llvm_cmake_options.define(
                 'COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS:STRING',


### PR DESCRIPTION
This change allows build-script to be invoked with the following combination:

```
--llvm-targets-to-build=host --build-embedded-stdlib=false
```

When `--build-embedded-stdlib=false` is used, it's unnecessary to force-configure
additional compiler-rt targets. Further, when `--llvm-targets-to-build` is used,
the resulting llvm usually won't support the force targets of armv6/armv7.
