### PR TITLE
SIL: avoid creating SIL functions for not used imported specialization attributes

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -399,6 +399,10 @@ private:
 
   BasicBlockNameMapType basicBlockNames;
 
+  // Specialization attributes which need to be added to a function once it is created.
+  // The key of this map is the function name.
+  llvm::StringMap<std::vector<SILSpecializeAttr *>> pendingSpecializeAttrs;
+
   SILModule(llvm::PointerUnion<FileUnit *, ModuleDecl *> context,
             Lowering::TypeConverter &TC, const SILOptions &Options,
             const IRGenOptions *irgenOptions = nullptr);
@@ -1081,6 +1085,10 @@ public:
   /// Gather prespecialized from extensions.
   void performOnceForPrespecializedImportedExtensions(
       llvm::function_ref<void(AbstractFunctionDecl *)> action);
+
+  void addPendingSpecializeAttr(StringRef functionName, SILSpecializeAttr *attr) {
+    pendingSpecializeAttrs[functionName].push_back(attr);
+  }
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -194,6 +194,14 @@ SILFunction *SILFunction::create(
   else
     M.functions.push_back(fn);
 
+  auto iter = M.pendingSpecializeAttrs.find(name);
+  if (iter != M.pendingSpecializeAttrs.end()) {
+    for (auto *attr : iter->second) {
+      fn->addSpecializeAttr(attr);
+    }
+    M.pendingSpecializeAttrs.erase(iter);
+  }
+
   return fn;
 }
 

--- a/test/SILOptimizer/implicit_imports.swift
+++ b/test/SILOptimizer/implicit_imports.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend  -primary-file %s -O -emit-sil | %FileCheck %s
+
+// Check that no Array code is de-serialized due to specialization attributes
+
+// CHECK-NOT: Array
+
+@inline(never)
+func foo<T>(_ x: T) {
+}
+
+public func test() {
+  foo(27)
+}


### PR DESCRIPTION
This ended up in creating a lot of Array functions, even if a program didn't use Array at all. Now, only add specialization attributes if a function is already there. Otherwise remember the attributes and add them to a function once it is created.
