### PR TITLE
[CapturePromotion] dealloc_box doesn't mutate.

### DIFF
--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1071,12 +1071,8 @@ public:
   ALWAYS_NON_ESCAPING_INST(StrongRelease)
   ALWAYS_NON_ESCAPING_INST(DestroyValue)
   ALWAYS_NON_ESCAPING_INST(EndBorrow)
+  ALWAYS_NON_ESCAPING_INST(DeallocBox)
 #undef ALWAYS_NON_ESCAPING_INST
-
-  bool visitDeallocBoxInst(DeallocBoxInst *dbi) {
-    markCurrentOpAsMutation();
-    return true;
-  }
 
   bool visitEndAccessInst(EndAccessInst *) { return true; }
 

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1072,9 +1072,8 @@ public:
   ALWAYS_NON_ESCAPING_INST(DestroyValue)
   ALWAYS_NON_ESCAPING_INST(EndBorrow)
   ALWAYS_NON_ESCAPING_INST(DeallocBox)
+  ALWAYS_NON_ESCAPING_INST(EndAccess)
 #undef ALWAYS_NON_ESCAPING_INST
-
-  bool visitEndAccessInst(EndAccessInst *) { return true; }
 
   bool visitApplyInst(ApplyInst *ai) {
     auto argIndex = currentOp.get()->getOperandNumber() - 1;

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -553,3 +553,39 @@ bb0:
   %28 = tuple ()
   return %28 : $()
 }
+
+sil [ossa] @closable : $@convention(thin) (@guaranteed { var Bar }) -> Builtin.Int64 {
+entry(%box : @guaranteed ${ var Bar }):
+  %retval = integer_literal $Builtin.Int64, 0
+  return %retval : $Builtin.Int64
+}
+
+// Test that a dealloc_box is not regarded as a mutation which would obstruct promotion.
+// CHECK-LABEL: sil [ossa] @with_dealloc_box : {{.*}} {
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'with_dealloc_box'
+sil [ossa] @with_dealloc_box : $@convention(thin) (@owned Bar) -> () {
+entry(%idle_incoming : @owned $Bar):
+  %box = alloc_box ${ var Bar }
+  %box_borrow = begin_borrow [var_decl] %box : ${ var Bar }
+  %box_addr = project_box %box_borrow : ${ var Bar }, 0
+  store %idle_incoming to [init] %box_addr : $*Bar
+  %closable = function_ref @closable : $@convention(thin) (@guaranteed { var Bar }) -> Builtin.Int64
+  %box_copy = copy_value %box_borrow : ${ var Bar }
+  mark_function_escape %box_addr : $*Bar
+  %closure = partial_apply [callee_guaranteed] %closable(%box_copy) : $@convention(thin) (@guaranteed { var Bar }) -> Builtin.Int64
+  cond_br undef, exit, die
+
+die:
+  destroy_value %closure : $@callee_guaranteed () -> Builtin.Int64
+  end_borrow %box_borrow : ${ var Bar }
+  dealloc_box %box : ${ var Bar }
+  unreachable
+
+exit:
+  destroy_value %closure : $@callee_guaranteed () -> Builtin.Int64
+  end_borrow %box_borrow : ${ var Bar }
+  destroy_value %box : ${ var Bar }
+  %retval = tuple ()
+  return %retval :$()
+}


### PR DESCRIPTION
The instruction only deallocates the box, it doesn't destroy its contents.  It's even less mutating than a `destroy_value`, which is already regarded as non-mutating.

rdar://139235335
