### PR TITLE
[ASTGen] Simplify diagnostics framework

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -69,7 +69,7 @@ class Boxed<Value> {
 }
 
 struct ASTGenVisitor {
-  fileprivate let diagnosticEngine: BridgedDiagnosticEngine
+  let diagnosticEngine: BridgedDiagnosticEngine
 
   let base: UnsafeBufferPointer<UInt8>
 
@@ -270,24 +270,6 @@ extension ASTGenVisitor {
       self.declContext = oldDeclContext
     }
     return body()
-  }
-}
-
-extension ASTGenVisitor {
-  /// Emits the given diagnostic via the C++ diagnostic engine.
-  @inline(__always)
-  func diagnose(_ diagnostic: Diagnostic) {
-    emitDiagnostic(
-      diagnosticEngine: self.diagnosticEngine,
-      sourceFileBuffer: self.base,
-      diagnostic: diagnostic,
-      diagnosticSeverity: diagnostic.diagMessage.severity
-    )
-  }
-
-  /// Emits the given diagnostics via the C++ diagnostic engine.
-  func diagnoseAll(_ diagnostics: [Diagnostic]) {
-    diagnostics.forEach(diagnose)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -340,7 +340,7 @@ extension ASTGenVisitor {
     case .`init`:
       return .`init`
     default:
-      self.diagnose(Diagnostic(node: specifier, message: UnknownAccessorSpecifierError(specifier)))
+      self.diagnose(.unknownAccessorSpecifier(specifier))
       return nil
     }
   }
@@ -448,7 +448,7 @@ extension ASTGenVisitor {
         let storage = primaryVar.asAbstractStorageDecl
         storage.setAccessors(generate(accessorBlock: accessors, for: storage))
       } else {
-        self.diagnose(Diagnostic(node: binding.pattern, message: NonTrivialPatternForAccessorError()))
+        self.diagnose(.nonTrivialPatternForAccessor(binding.pattern))
       }
     }
     return BridgedPatternBindingEntry(
@@ -667,9 +667,7 @@ extension ASTGenVisitor {
       fixity = value
     } else {
       fixity = .infix
-      self.diagnose(
-        Diagnostic(node: node.fixitySpecifier, message: UnexpectedTokenKindError(token: node.fixitySpecifier))
-      )
+      self.diagnose(.unexpectedTokenKind(token: node.fixitySpecifier))
     }
 
     return .createParsed(
@@ -712,9 +710,7 @@ extension ASTGenVisitor {
     }
 
     func diagnoseDuplicateSyntax(_ duplicate: some SyntaxProtocol, original: some SyntaxProtocol) {
-      self.diagnose(
-        Diagnostic(node: duplicate, message: DuplicateSyntaxError(duplicate: duplicate, original: original))
-      )
+      self.diagnose(.duplicateSyntax(duplicate: duplicate, original: original))
     }
 
     let body = node.groupAttributes.reduce(into: PrecedenceGroupBody()) { body, element in
@@ -735,7 +731,7 @@ extension ASTGenVisitor {
             body.lowerThanRelation = relation
           }
         default:
-          return self.diagnose(Diagnostic(node: keyword, message: UnexpectedTokenKindError(token: keyword)))
+          return self.diagnose(.unexpectedTokenKind(token: keyword))
         }
       case .precedenceGroupAssignment(let assignment):
         if let current = body.assignment {
@@ -757,7 +753,7 @@ extension ASTGenVisitor {
       if let value = BridgedAssociativity(from: token.keywordKind) {
         associativityValue = value
       } else {
-        self.diagnose(Diagnostic(node: token, message: UnexpectedTokenKindError(token: token)))
+        self.diagnose(.unexpectedTokenKind(token: token))
         associativityValue = .none
       }
     } else {
@@ -769,7 +765,7 @@ extension ASTGenVisitor {
       if token.keywordKind == .true {
         assignmentValue = true
       } else {
-        self.diagnose(Diagnostic(node: token, message: UnexpectedTokenKindError(token: token)))
+        self.diagnose(.unexpectedTokenKind(token: token))
         assignmentValue = false
       }
     } else {
@@ -824,7 +820,7 @@ extension ASTGenVisitor {
       if let value = BridgedImportKind(from: specifier.keywordKind) {
         importKind = value
       } else {
-        self.diagnose(Diagnostic(node: specifier, message: UnexpectedTokenKindError(token: specifier)))
+        self.diagnose(.unexpectedTokenKind(token: specifier))
         importKind = .module
       }
     } else {

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -406,14 +406,10 @@ extension ASTGenVisitor {
   func generate(functionCallExpr node: FunctionCallExprSyntax, postfixIfConfigBaseExpr: BridgedExpr? = nil) -> BridgedCallExpr {
     if !node.arguments.isEmpty || node.trailingClosure == nil {
       if node.leftParen == nil {
-        self.diagnose(
-          Diagnostic(node: node, message: MissingChildTokenError(parent: node, kindOfTokenMissing: .leftParen))
-        )
+        self.diagnose(.missingChildToken(parent: node, kindOfTokenMissing: .leftParen))
       }
       if node.rightParen == nil {
-        self.diagnose(
-          Diagnostic(node: node, message: MissingChildTokenError(parent: node, kindOfTokenMissing: .rightParen))
-        )
+        self.diagnose(.missingChildToken(parent: node, kindOfTokenMissing: .rightParen))
       }
     }
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -367,7 +367,7 @@ extension ASTGenVisitor {
             specifierLoc: self.generateSourceLoc(specifier)
           ).asTypeRepr
       } else {
-        self.diagnose(Diagnostic(node: specifier, message: UnexpectedTokenKindError(token: specifier)))
+        self.diagnose(.unexpectedTokenKind(token: specifier))
       }
     }
 


### PR DESCRIPTION
This simplifies both the diagnostic declarations and usages.

To create a new diangnostic message, create a static method in `ASTGen/Diagnostics.swift`:

```swift
    static func invalidToken(_ token: TokenSyntax) -> Self {
      Self( node: token, message: "invalid token: '\(token.trimmed)'")
    }
```

To use it in ASTGenVisitor:

```swift
  self.diagnose(.invalidToken(token))
```
