### PR TITLE
Add REQUIRES: asserts to Concurrency/sending_conditional_suppression.swift

### DIFF
--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-swift-frontend -enable-upcoming-feature SendingArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - -target %target-swift-5.1-abi-triple -Xllvm -swift-ast-printer-number-suppression-checks %s | %FileCheck %s
 
+// REQUIRES: asserts
 // REQUIRES: swift_feature_SendingArgsAndResults
 
 public class NonSendableKlass {}


### PR DESCRIPTION
Test is failing in release+noasserts mode.

 -swift-ast-printer-number-suppression-check is only available with NDEBUG.