### PR TITLE
Revert removal of `-package-name` from swiftinterfaces

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2913,14 +2913,6 @@ public:
   /// \c \@usableFromInline, \c \@inlinalbe, and \c \@_alwaysEmitIntoClient
   bool isUsableFromInline() const;
 
-  /// Treat as public and allow skipping access checks if the following conditions
-  /// are met:
-  /// - This decl has a package access level,
-  /// - Has a @usableFromInline (or other inlinable) attribute,
-  /// - And is defined in a module built from a public or private
-  ///   interface that does not contain package-name.
-  bool isInterfacePackageEffectivelyPublic() const;
-
   /// Returns \c true if this declaration is *not* intended to be used directly
   /// by application developers despite the visibility.
   bool shouldHideFromEditor() const;

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -72,6 +72,10 @@ struct ModuleInterfaceOptions {
   /// Print imports that are missing from the source and used in API.
   bool PrintMissingImports = true;
 
+  /// If true, package-name flag is not printed in either public or private
+  /// interface file.
+  bool DisablePackageNameForNonPackageInterface = false;
+
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -761,11 +761,7 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
 def disable_print_package_name_for_non_package_interface :
   Flag<["-"], "disable-print-package-name-for-non-package-interface">,
   Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
-  HelpText<"No op; package name is only printed in package interface by default">;
-def print_package_name_in_non_package_interface :
-  Flag<["-"], "print-package-name-in-non-package-interface">,
-  Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
-  HelpText<"Print package name in public or private interface">;
+  HelpText<"Disable adding package name to public or private interface">;
 
 def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -760,7 +760,7 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
 
 def disable_print_package_name_for_non_package_interface :
   Flag<["-"], "disable-print-package-name-for-non-package-interface">,
-  Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
+  Flags<[FrontendOption, NoDriverOption, ModuleInterfaceOption, HelpHidden]>,
   HelpText<"Disable adding package name to public or private interface">;
 
 def lto : Joined<["-"], "lto=">,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1016,8 +1016,7 @@ public:
         PrettyStackTraceDecl debugStack("verifying access", D);
         if (!D->getASTContext().isAccessControlDisabled()) {
           if (D->getFormalAccessScope().isPublic() &&
-              D->getFormalAccess() < AccessLevel::Public &&
-              !D->isInterfacePackageEffectivelyPublic()) {
+              D->getFormalAccess() < AccessLevel::Public) {
             Out << "non-public decl has no formal access scope\n";
             D->dump(Out);
             abort();

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -524,6 +524,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   Opts.PrintMissingImports =
     !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
   Opts.ABIComments = Args.hasArg(OPT_abi_comments_in_module_interface);
+  Opts.DisablePackageNameForNonPackageInterface |= Args.hasArg(OPT_disable_print_package_name_for_non_package_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();
@@ -555,8 +556,8 @@ static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
 
 static bool IsPackageInterfaceFlag(const Arg *A, ArgList &Args) {
   return A->getOption().matches(options::OPT_package_name) &&
-         !Args.hasArg(
-             options::OPT_print_package_name_in_non_package_interface);
+         Args.hasArg(
+             options::OPT_disable_print_package_name_for_non_package_interface);
 }
 
 static bool IsPrivateInterfaceFlag(const Arg *A, ArgList &Args) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4312,9 +4312,6 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           requiredAccessScope.requiredAccessForDiagnostics();
         auto proto = conformance->getProtocol();
         auto protoAccessScope = proto->getFormalAccessScope(DC);
-        if (proto->isInterfacePackageEffectivelyPublic())
-          return;
-
         bool protoForcesAccess =
           requiredAccessScope.hasEqualDeclContextWith(protoAccessScope);
         auto diagKind = protoForcesAccess

--- a/test/ModuleInterface/load_package_interface.swift
+++ b/test/ModuleInterface/load_package_interface.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name foopkg -package-name barpkg \
 // RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
@@ -32,8 +31,7 @@
 // RUN:   -package-name barpkg \
 // RUN:   -Rmodule-loading 2> %t/load-pkg-off.output
 // RUN: %FileCheck -check-prefix=CHECK-LOAD-PKG-OFF %s < %t/load-pkg-off.output
-// CHECK-LOAD-PKG-OFF: remark: loaded module 'Bar'; source: '{{.*}}Bar.private.swiftinterface', loaded: '{{.*}}Bar-{{.*}}.swiftmodule'
-// CHECK-LOAD-PKG-OFF: error: cannot find 'PkgKlass' in scope; did you mean 'PubKlass'?
+// CHECK-LOAD-PKG-OFF: error: module 'Bar' is in package 'barpkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface:{{.*}}Bar.private.swiftinterface
 
 /// Client loads a private interface since the package-name is different from the loaded module's.
 // RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
@@ -47,15 +45,13 @@
 // RUN: rm -rf %t/*.swiftmodule
 // RUN: rm -rf %t/Bar.package.swiftinterface
 
-/// Client loads a private interface since package interface doesn't exist. It should error since the
-/// loaded module is not built from a package interface.
+/// Client loads a private interface since package interface doesn't exist. It should error since the loaded module is not built from a package interface.
 // RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -package-name barpkg \
 // RUN:   -experimental-package-interface-load \
 // RUN:   -Rmodule-loading 2> %t/load-priv.output
 // RUN: %FileCheck -check-prefix=CHECK-LOAD-PRIV %s < %t/load-priv.output
-// CHECK-LOAD-PRIV: remark: loaded module 'Bar'; source: '{{.*}}Bar.private.swiftinterface', loaded: '{{.*}}Bar-{{.*}}.swiftmodule'
-// CHECK-LOAD-PRIV: error: cannot find 'PkgKlass' in scope; did you mean 'PubKlass'?
+// CHECK-LOAD-PRIV: no such module 'Bar'
 
 // RUN: rm -rf %t/*.swiftmodule
 // RUN: rm -rf %t/Bar.private.swiftinterface
@@ -68,8 +64,7 @@
 // RUN:   -Rmodule-loading 2> %t/load-pub.output
 
 // RUN: %FileCheck -check-prefix=CHECK-LOAD-PUB %s < %t/load-pub.output
-// CHECK-LOAD-PUB: remark: loaded module 'Bar'; source: '{{.*}}Bar.swiftinterface', loaded: '{{.*}}Bar-{{.*}}.swiftmodule'
-// CHECK-LOAD-PUB: error: cannot find 'PkgKlass' in scope; did you mean 'PubKlass'?
+// CHECK-LOAD-PUB: no such module 'Bar'
 
 //--- Bar.swift
 public class PubKlass {

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -23,6 +23,7 @@ public enum PubEnum {
   case red, green
 }
 
+// CHECK: -package-name barpkg
 // CHECK: public enum PubEnum {
 // CHECK:   case red, green
 // CHECK:   public static func == (a: Bar.PubEnum, b: Bar.PubEnum) -> Swift.Bool

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
 
 /// Do not print package-name for public or private interfaces
-// RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
+// RUN: %target-build-swift -emit-module %s -I %t \
 // RUN:   -module-name Bar -package-name foopkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -package-name barpkg \
@@ -23,9 +22,9 @@
 // CHECK-PRIVATE-NOT: pkgVar
 // CHECK-PACKAGE-NOT: -package-name foopkg
 
-// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -module-name Bar
-// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -module-name Bar
-// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -module-name Bar -package-name barpkg
+// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
+// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
+// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar -package-name barpkg
 
 /// Typechecking interface files (without package-name in non-package interface) should succeed.
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Bar.swiftinterface
@@ -34,17 +33,10 @@
 
 /// Verify building modules from non-package interfaces succeeds without the package-name flag.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -verify
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -verify
-
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -verify
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -verify
-
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -experimental-package-interface-load -verify
 
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: rm -rf %t/Bar.swiftinterface
@@ -53,7 +45,7 @@
 
 /// By default, -package-name is printed in all interfaces.
 // RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift \
-// RUN:   -emit-module %t/Bar.swift -I %t \
+// RUN:   -emit-module %s -I %t \
 // RUN:   -module-name Bar -package-name barpkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
@@ -68,51 +60,12 @@
 
 /// Building modules from non-package interfaces with package-name (default mode) should succeed.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/ExpectFail.swift -I %t -package-name barpkg -verify
-
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/ExpectFail.swift -I %t -package-name barpkg -verify
-
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -experimental-package-interface-load -verify
 
-//--- Bar.swift
-public struct PubStruct {
-  public var pubVar: Int
-  package var pkgVar: Int
-}
-
+public struct PubStruct {}
 @_spi(bar) public struct SPIStruct {}
 
 package struct PkgStruct {}
-
-@usableFromInline
-package struct UfiPkgStruct {
-  @usableFromInline
-  package var ufiPkgVar: PubStruct
-  
-  package var pkgVar: PubStruct
-  
-  @usableFromInline
-  package init(_ x: PubStruct, _ y: PubStruct) {
-    ufiPkgVar = x
-    pkgVar = y
-  }
-}
-
-
-//--- Use.swift
-import Bar
-
-func use(_ arg: PubStruct) -> PubStruct {
-  return UfiPkgStruct(arg, arg).ufiPkgVar
-}
-
-//--- ExpectFail.swift
-import Bar // expected-error {{module 'Bar' is in package 'barpkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface}}
-
-func use(_ arg: PubStruct) -> PubStruct {
-  return UfiPkgStruct(arg, arg).ufiPkgVar
-}

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// By default, package-name is only printed in package interface
+/// Do not print package-name for public or private interfaces
 // RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name foopkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -package-name barpkg \
+// RUN:   -Xfrontend -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
@@ -50,14 +51,11 @@
 // RUN: rm -rf %t/Bar.private.swiftinterface
 // RUN: rm -rf %t/Bar.package.swiftinterface
 
-/// Print -package-name in public or private interface.
-/// Note the order of arguments differs across old/new driver, so force old
-/// driver for now.
+/// By default, -package-name is printed in all interfaces.
 // RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift \
 // RUN:   -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name barpkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
-// RUN:   -Xfrontend -print-package-name-in-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface

--- a/test/Sema/accessibility_package_inline_interface.swift
+++ b/test/Sema/accessibility_package_inline_interface.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend -module-name Utils1 %t/Utils.swift -emit-module -emit-module-path %t/Utils1.swiftmodule -package-name myLib -swift-version 5
 // RUN: test -f %t/Utils1.swiftmodule
 
-// RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-interface-path %t/Utils.swiftinterface -package-name myLib -enable-library-evolution -swift-version 5 -disable-print-package-name-for-non-package-interface
-
+// RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-interface-path %t/Utils.swiftinterface -package-name myLib -enable-library-evolution -swift-version 5
 // RUN: test -f %t/Utils.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/Utils.swiftinterface) -I%t
 
 // RUN: %FileCheck %s -check-prefix CHECK-UTILS < %t/Utils.swiftinterface
 // CHECK-UTILS: -module-name Utils
+// CHECK-UTILS: -package-name myLib
 // CHECK-UTILS: @usableFromInline
 // CHECK-UTILS: package class PackageKlassProto {
 // CHECK-UTILS:   @usableFromInline
@@ -70,7 +70,7 @@
 // CHECK-UTILS: }
 
 
-//--- Utils.swift
+// BEGIN Utils.swift
 package protocol PackageProto {
   var pkgVar: Double { get set }
   func pkgFunc()

--- a/test/Sema/accessibility_package_interface.swift
+++ b/test/Sema/accessibility_package_interface.swift
@@ -5,7 +5,7 @@
 // RUN:   -module-name Utils -swift-version 5 -I %t \
 // RUN:   -package-name swift-utils.log \
 // RUN:   -enable-library-evolution \
-// RUN:   -disable-print-package-name-for-non-package-interface \
+// RUN:   -emit-module-path %t/Utils.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Utils.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Utils.private.swiftinterface
 
@@ -18,6 +18,7 @@
 // CHECK-PUBLIC-UTILS-NOT: package class PackageKlass
 // CHECK-PUBLIC-UTILS-NOT: package var pkgVar
 // CHECK-PUBLIC-UTILS: -module-name Utils
+// CHECK-PUBLIC-UTILS: -package-name swift-utils.log
 // CHECK-PUBLIC-UTILS: public func publicFunc()
 // CHECK-PUBLIC-UTILS: @usableFromInline
 // CHECK-PUBLIC-UTILS: package func ufiPackageFunc()
@@ -38,6 +39,7 @@
 // CHECK-PRIVATE-UTILS-NOT: package class PackageKlass
 // CHECK-PRIVATE-UTILS-NOT: package var pkgVar
 // CHECK-PRIVATE-UTILS: -module-name Utils
+// CHECK-PRIVATE-UTILS: -package-name swift-utils.log
 // CHECK-PRIVATE-UTILS: public func publicFunc()
 // CHECK-PRIVATE-UTILS: @usableFromInline
 // CHECK-PRIVATE-UTILS: package func ufiPackageFunc()
@@ -49,19 +51,20 @@
 // CHECK-PRIVATE-UTILS: @usableFromInline
 // CHECK-PRIVATE-UTILS: package var ufiPkgVar
 
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Utils.private.swiftinterface  -module-name Utils -I %t -o %t/Utils.swiftmodule
-
 // RUN: %target-swift-frontend -emit-module %t/Client.swift \
 // RUN:   -module-name Client -swift-version 5 -I %t \
 // RUN:   -package-name swift-utils.log \
 // RUN:   -enable-library-evolution \
-// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/Client.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
 
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: rm -rf %t/Client.swiftmodule
+
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t -verify
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC-CLIENT < %t/Client.swiftinterface
+// CHECK-PUBLIC-CLIENT: -package-name swift-utils.log
 // CHECK-PUBLIC-CLIENT: @inlinable public func clientFunc()
 // CHECK-PUBLIC-CLIENT: publicFunc()
 // CHECK-PUBLIC-CLIENT: ufiPackageFunc()
@@ -110,7 +113,6 @@ import Utils
 @inlinable public func clientFunc() -> String {
   publicFunc()
   ufiPackageFunc()
-//  return UfiPackageKlass().ufiPkgVar
   let u = UfiPackageKlass()
   return u.ufiPkgVar
 }

--- a/test/Sema/package_enums_treat_exhaustive.swift
+++ b/test/Sema/package_enums_treat_exhaustive.swift
@@ -302,7 +302,7 @@ public func k(_ arg: FrozenPublicEnum) -> Int {
 // package-name; requires @unknown default.
 import Utils
 
-package func n(_ arg: FrozenUfiPkgEnum) -> Int {
+package func n(_ arg: FrozenUfiPkgEnum) -> Int { // expected-error {{cannot find type 'FrozenUfiPkgEnum' in scope}}
   switch arg { // no-warning
   case .one:
     return 1
@@ -311,8 +311,8 @@ package func n(_ arg: FrozenUfiPkgEnum) -> Int {
   }
 }
 
-package func g(_ arg: UfiPkgEnum) -> Int {
-  switch arg { // expected-error {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+package func g(_ arg: UfiPkgEnum) -> Int { // expected-error {{cannot find type 'UfiPkgEnum' in scope}}
+  switch arg {
   case .one:
     return 1
   case .two(let val):
@@ -321,8 +321,8 @@ package func g(_ arg: UfiPkgEnum) -> Int {
 }
 
 @inlinable
-package func gi(_ arg: UfiPkgEnum) -> Int {
-  switch arg { // expected-error {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+package func gi(_ arg: UfiPkgEnum) -> Int { // expected-error {{cannot find type 'UfiPkgEnum' in scope}}
+  switch arg {
   case .one:
     return 1
   case .two(let val):

--- a/test/Serialization/load_package_module.swift
+++ b/test/Serialization/load_package_module.swift
@@ -12,7 +12,6 @@
 // RUN:   -module-name LibInterface -swift-version 5 -I %t \
 // RUN:   -package-name libPkg \
 // RUN:   -enable-library-evolution \
-// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/LibBinary.swiftmodule \
 // RUN:   -emit-module-interface-path %t/LibInterface.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/LibInterface.private.swiftinterface
@@ -20,12 +19,20 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.swiftinterface) -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/LibInterface.swiftinterface
 // CHECK-PUBLIC: -module-name LibInterface
+// CHECK-PUBLIC: -package-name
 
-// RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.private.swiftinterface) -module-name LibInterface -I %t -verify
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.private.swiftinterface) -module-name LibInterface -I %t
+// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/LibInterface.private.swiftinterface
+// CHECK-PRIVATE: -package-name libPkg
 
-// RUN: %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name otherPkg -I %t -verify
+// RUN: not %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name otherPkg -I %t 2> %t/resultX.output
+// RUN: %FileCheck %s -check-prefix CHECK-X < %t/resultX.output
+// CHECK-X: error: cannot find 'packageLog' in scope
 
-// RUN: %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name libPkg -I %t -verify
+// RUN: not %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name libPkg -I %t 2> %t/resultY.output
+// RUN: %FileCheck %s -check-prefix CHECK-Y < %t/resultY.output
+// CHECK-Y: error: module 'LibInterface' is in package 'libPkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface: {{.*}}LibInterface.private.swiftinterface
+
 
 //--- Lib.swift
 public func publicLog(_ level: Int) {}
@@ -38,7 +45,7 @@ import LibInterface
 
 func someFunc() {
   publicLog(1)
-  packageLog(2) // expected-error {{cannot find 'packageLog' in scope}}
+  packageLog(2)
 }
 
 //--- ClientLoadBinary.swift

--- a/test/Serialization/module_package_name.swift
+++ b/test/Serialization/module_package_name.swift
@@ -6,15 +6,17 @@
 // RUN: llvm-bcanalyzer -dump %t/Logging.swiftmodule | %FileCheck %s -check-prefix CHECK-BLOB
 // CHECK-BLOB: <MODULE_PACKAGE_NAME abbrevid=5/> blob data = 'MyLoggingPkg'
 
-// RUN: %target-swift-frontend -module-name Logging -package-name MyLoggingPkg %t/File.swift -emit-module -emit-module-interface-path %t/Logging.swiftinterface -emit-private-module-interface-path %t/Logging.private.swiftinterface -swift-version 5 -enable-library-evolution -I %t -disable-print-package-name-for-non-package-interface
+// RUN: %target-swift-frontend -module-name Logging -package-name MyLoggingPkg %t/File.swift -emit-module -emit-module-interface-path %t/Logging.swiftinterface -emit-private-module-interface-path %t/Logging.private.swiftinterface -swift-version 5 -enable-library-evolution -I %t
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Logging.swiftinterface) -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/Logging.swiftinterface
 // CHECK-PUBLIC: -module-name Logging
+// CHECK-PUBLIC: -package-name
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Logging.private.swiftinterface) -module-name Logging -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/Logging.private.swiftinterface
 // CHECK-PRIVATE: -module-name Logging
+// CHECK-PRIVATE: -package-name MyLoggingPkg
 
 //--- File.swift
 public func log(level: Int) {}


### PR DESCRIPTION
In an attempt to work around some bugs, `-package-name` was removed from public and private `.swiftinterface` files (https://github.com/swiftlang/swift/pull/76244). This has the side effect of breaking access level checking for `@usableFromInline package` declarations in `.swiftinterfaces`, so another workaround was implemented to give them special behavior (https://github.com/swiftlang/swift/pull/75745). The combination of these changes has caused source compatibility regressions because `@usableFromInline package` members of SDK modules are now accessible to name lookup where they were not previously, which can result in ambiguities.

There was another fix for the root cause of the original problem that motivated removing `-package-name` from non-package interfaces, so we can safely revert both of https://github.com/swiftlang/swift/pull/76244 and https://github.com/swiftlang/swift/pull/75745. They should not be reattempted as it is not sound to disassociate `package` declarations from their package context.

Resolves rdar://139236053.