### PR TITLE
Revert "Make Atomic.deinit @_transparent"

### DIFF
--- a/stdlib/public/Synchronization/Atomics/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomics/Atomic.swift
@@ -42,10 +42,11 @@ public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
     _address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
   }
 
+  // Deinit's can't be marked @_transparent. Do these things need all of these
+  // attributes..?
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
-  @_transparent
   deinit {
     let oldValue = Value.decodeAtomicRepresentation(_address.pointee)
     _ = consume oldValue


### PR DESCRIPTION
`@_transparent` on `deinit` was diagnosed as an error in older compilers. Making `Atomic.deinit` `@_transparent` will break compiling newer sdk with older compilers. 

I originally added this to avoid failing performance constraints tests since Synchronization is no longer in ossa. But there aren't any such issues. If this ends up being needed we can reintroduce with an experimental feature. 

Fixes rdar://139194948

