### PR TITLE
[swift_snapshot_tool] Add support for SWIFT_LIBRARY_PATH so scripts has access to the .dylib path so they can run tests.

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -6,7 +6,7 @@ struct BisectToolchains: AsyncParsableCommand {
     commandName: "bisect",
     discussion: """
       Bisects on exit status of attached script. Passes in name of swift as the
-      environment variabless SWIFTC and SWIFT_FRONTEND
+      environment variables \(environmentVariables).
       """)
 
   @Flag var platform: Platform = .osx
@@ -22,8 +22,9 @@ struct BisectToolchains: AsyncParsableCommand {
 
   @Option(
     help: """
-      The script that should be run. The environment variable
-      SWIFT_EXEC is used by the script to know where swift-frontend is
+      The script that should be run. It runs a specific swift compilation and
+      optionally program using the passed in environment variables
+      \(environmentVariables)
       """)
   var script: String
 

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
@@ -144,9 +144,13 @@ func downloadToolchainAndRunTest(
 
     let swiftcPath = "\(toolchainDir)/usr/bin/swiftc"
     let swiftFrontendPath = "\(toolchainDir)/usr/bin/swift-frontend"
+    // Just for now just support macosx.
+    let platform = "macosx"
+    let swiftLibraryPath = "\(toolchainDir)/usr/lib/swift/\(platform)"
     log(shell("\(swiftcPath) --version").stdout)
     let exitCode = shell(
-      "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath],
+      "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath,
+        "SWIFT_LIBRARY_PATH": swiftLibraryPath],
       mustSucceed: false,
       verbose: verbose,
       extraArgs: extraArgs

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/misc_global_strings.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/misc_global_strings.swift
@@ -1,0 +1,13 @@
+//===--- misc_global_strings.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let environmentVariables = "SWIFTC, SWIFT_FRONTEND, and SWIFT_LIBRARY_PATH"

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -6,9 +6,9 @@ struct RunToolchains: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "run",
     discussion: """
-      Run a toolchain like bisect would. Passes in name of swift as the
-      environment variabless SWIFTC and SWIFT_FRONTEND
-      """)
+    Run a toolchain like bisect would. Passed the environment variables:
+    \(environmentVariables)
+    """)
 
   @Flag var platform: Platform = .osx
 


### PR DESCRIPTION
Just upstreaming a few changes I made to swift snapshot tool while I was using it to triage some bugs. In this case, I just added support for running scripts by providing to the running script a path to the SWIFT_LIBRARY_PATH along side SWIFTC and SWIFT_FRONTEND.