### PR TITLE
[🍒 Swift 6.0.x] Use toolchain clang on macOS

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1670,8 +1670,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -2782,8 +2785,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -3074,8 +3080,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     # Set the build options for this host
     set_build_options_for_host $host


### PR DESCRIPTION
Cherry-Picking PR: https://github.com/swiftlang/swift/pull/74033

Don't use the just-built clang on macOS. macOS does this more "right" than the Linux build. Linux will sometimes use the just-built Swift-driver with the just-built clang, but sometimes would use the system clang instead. macOS uses the toolchain Swift-driver with the toolchain clang. This is correct, but it means that if we force the other clang, we'll get mismatched sanitizer runtimes so the ASAN bot will fail.

rdar://139245838