### PR TITLE
[xcodegen] Allow `output` to be missing in `compile_commands.json`

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -74,7 +74,7 @@ PROJECT CONFIGURATION:
                           Generate a target for C/C++ files in the standard library (default: --stdlib)
   --stdlib-swift/--no-stdlib-swift
                           Generate targets for Swift files in the standard library. This requires
-                          using Xcode with with a main development snapshot (and as such is disabled
+                          using Xcode with a main development snapshot (and as such is disabled
                           by default). (default: --no-stdlib-swift)
   --test-folders/--no-test-folders
                           Add folder references for test files (default: --test-folders)

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
@@ -34,16 +34,17 @@ struct ClangBuildArgsProvider {
     // Gather the candidates for each file to get build arguments for. We may
     // have multiple outputs, in which case, pick the first one that exists.
     var commandsToAdd: [RelativePath:
-                          (output: AbsolutePath, args: [Command.Argument])] = [:]
+                          (output: AbsolutePath?, args: [Command.Argument])] = [:]
     for command in parsed {
       guard command.command.executable.knownCommand == .clang,
             let relFilePath = command.file.removingPrefix(repoPath)
       else {
         continue
       }
-      let output = command.directory.appending(command.output)
+      let output = command.output.map { command.directory.appending($0) }
       if let existing = commandsToAdd[relFilePath],
-         existing.output.exists || !output.exists {
+         let existingOutput = existing.output,
+          output == nil || existingOutput.exists || !output!.exists {
         continue
       }
       commandsToAdd[relFilePath] = (output, command.command.args)

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CompileCommands.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CompileCommands.swift
@@ -27,7 +27,7 @@ extension CompileCommands {
   struct Element: Decodable {
     var directory: AbsolutePath
     var file: AbsolutePath
-    var output: RelativePath
+    var output: RelativePath?
     var command: Command
   }
 }

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -164,7 +164,7 @@ struct ProjectOptions: ParsableArguments {
     name: .customLong("stdlib-swift"), inversion: .prefixedNo,
     help: """
       Generate targets for Swift files in the standard library. This requires
-      using Xcode with with a main development snapshot (and as such is disabled
+      using Xcode with a main development snapshot (and as such is disabled
       by default).
       """
   )

--- a/validation-test/BuildSystem/swift-xcodegen.test
+++ b/validation-test/BuildSystem/swift-xcodegen.test
@@ -8,8 +8,6 @@
 # REQUIRES: standalone_build
 # REQUIRES: target-same-as-host
 
-# REQUIRES: issue_77407
-
 # First copy swift-xcodegen to the temporary location
 # so we don't touch the user's build, and make sure
 # we're doing a clean build.


### PR DESCRIPTION
This may not always be present for toolchain builds.

Resolves #77407