### PR TITLE
[xcodegen] Remove todo items from README

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -101,8 +101,3 @@ MISC:
 OPTIONS:
   -h, --help              Show help information.
 ```
-
-## TODO
-
-- [ ] Add support for mixed Swift + Clang targets
-- [ ] More tests


### PR DESCRIPTION
These are now tracked with GitHub issues (https://github.com/swiftlang/swift/issues?q=is%3Aissue+is%3Aopen+label%3Aswift-xcodegen)