### PR TITLE
[C++ parser] Make sure break out of a parser loop on ill-formed macro expansion of members

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8320,8 +8320,8 @@ void Parser::parseExpandedMemberList(SmallVectorImpl<ASTNode> &items) {
 
   bool previousHadSemi = true;
 
-  SourceLoc startingLoc = Tok.getLoc();
   while (!Tok.is(tok::eof)) {
+    SourceLoc startingLoc = Tok.getLoc();
     parseDeclItem(previousHadSemi, [&](Decl *d) { items.push_back(d); });
 
     if (Tok.getLoc() == startingLoc)

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2704,3 +2704,30 @@ public struct AddGetterMacro: AccessorMacro {
     return ["get { 0 }"]
   }
 }
+
+public struct HangingMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let variableDecl = declaration.as(VariableDeclSyntax.self) else {
+      return []
+    }
+
+    guard let binding: PatternBindingSyntax = variableDecl.bindings.first else {
+      return []
+    }
+
+    guard let typeAnnotation = binding.typeAnnotation else {
+      return []
+    }
+
+    let mockProperty = try VariableDeclSyntax("var BadThing: \(typeAnnotation.type)") {
+    }
+
+    return [
+      DeclSyntax(mockProperty)
+    ]
+  }
+}

--- a/test/Macros/expand_peers_hang.swift
+++ b/test/Macros/expand_peers_hang.swift
@@ -1,0 +1,16 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking
+
+@attached(peer, names: named(BadThing))
+macro HangingMacro() = #externalMacro(module: "MacroDefinition", type: "HangingMacro")
+
+// expected-note@+1{{in declaration of 'Foo'}}
+class Foo {
+  init() {}
+
+  // expected-note@+1 2{{in expansion of macro 'HangingMacro' on property 'result' here}}
+  @HangingMacro var result: Int // This comment makes it hang.
+}


### PR DESCRIPTION
The condition to make sure that the parser makes progress when there is an ill-formed macro expansion to members was incorrect, causing an infinite loop if there was at least one well-formed declaration followed by ill-formed code (in this case, a `}`). Fix the condition.

Fixes rdar://137828917.
