### PR TITLE
Frontend: Remove -disable-print-package-name-for-non-package-interface

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -72,10 +72,6 @@ struct ModuleInterfaceOptions {
   /// Print imports that are missing from the source and used in API.
   bool PrintMissingImports = true;
 
-  /// If true, package-name flag is not printed in either public or private
-  /// interface file.
-  bool DisablePackageNameForNonPackageInterface = false;
-
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -758,11 +758,6 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
-def disable_print_package_name_for_non_package_interface :
-  Flag<["-"], "disable-print-package-name-for-non-package-interface">,
-  Flags<[FrontendOption, NoDriverOption, ModuleInterfaceOption, HelpHidden]>,
-  HelpText<"Disable adding package name to public or private interface">;
-
 def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -524,7 +524,6 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   Opts.PrintMissingImports =
     !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
   Opts.ABIComments = Args.hasArg(OPT_abi_comments_in_module_interface);
-  Opts.DisablePackageNameForNonPackageInterface |= Args.hasArg(OPT_disable_print_package_name_for_non_package_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();
@@ -555,9 +554,7 @@ static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
 }
 
 static bool IsPackageInterfaceFlag(const Arg *A, ArgList &Args) {
-  return A->getOption().matches(options::OPT_package_name) &&
-         Args.hasArg(
-             options::OPT_disable_print_package_name_for_non_package_interface);
+  return false;
 }
 
 static bool IsPrivateInterfaceFlag(const Arg *A, ArgList &Args) {

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -1,48 +1,5 @@
 // RUN: %empty-directory(%t)
 
-/// Do not print package-name for public or private interfaces
-// RUN: %target-build-swift -emit-module %s -I %t \
-// RUN:   -module-name Bar -package-name foopkg \
-// RUN:   -enable-library-evolution -swift-version 6 \
-// RUN:   -package-name barpkg \
-// RUN:   -Xfrontend -disable-print-package-name-for-non-package-interface \
-// RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
-// RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
-
-// RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/Bar.swiftinterface
-// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/Bar.private.swiftinterface
-// RUN: %FileCheck %s --check-prefix=CHECK-PACKAGE < %t/Bar.package.swiftinterface
-
-// CHECK-PUBLIC-NOT: -package-name foopkg
-// CHECK-PUBLIC-NOT: -package-name barpkg
-// CHECK-PUBLIC-NOT: pkgVar
-// CHECK-PRIVATE-NOT: -package-name foopkg
-// CHECK-PRIVATE-NOT: -package-name barpkg
-// CHECK-PRIVATE-NOT: pkgVar
-// CHECK-PACKAGE-NOT: -package-name foopkg
-
-// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
-// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
-// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar -package-name barpkg
-
-/// Typechecking interface files (without package-name in non-package interface) should succeed.
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Bar.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Bar.private.swiftinterface -module-name Bar
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Bar.package.swiftinterface -module-name Bar
-
-/// Verify building modules from non-package interfaces succeeds without the package-name flag.
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: rm -rf %t/Bar.swiftmodule
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-// RUN: rm -rf %t/Bar.swiftmodule
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
-
-// RUN: rm -rf %t/Bar.swiftmodule
-// RUN: rm -rf %t/Bar.swiftinterface
-// RUN: rm -rf %t/Bar.private.swiftinterface
-// RUN: rm -rf %t/Bar.package.swiftinterface
-
 /// By default, -package-name is printed in all interfaces.
 // RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift \
 // RUN:   -emit-module %s -I %t \

--- a/test/Sema/package_enums_treat_exhaustive.swift
+++ b/test/Sema/package_enums_treat_exhaustive.swift
@@ -39,7 +39,6 @@
 // RUN:   -module-name Utils -I %t \
 // RUN:   -package-name mypkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
-// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module -emit-module-interface-path %t/Utils.swiftinterface \
 // RUN:   -emit-module -emit-package-module-interface-path %t/Utils.package.swiftinterface
 
@@ -297,12 +296,12 @@ public func k(_ arg: FrozenPublicEnum) -> Int {
 
 //--- ClientInPkgLoadPublicInterface.swift
 
-// Utils is built from public interface containing
-// package decls with @usableFromInline, but without
-// package-name; requires @unknown default.
+// Utils is built from public interface. Accessing
+// resilient enums from Utils should not require
+// @unknown default.
 import Utils
 
-package func n(_ arg: FrozenUfiPkgEnum) -> Int { // expected-error {{cannot find type 'FrozenUfiPkgEnum' in scope}}
+package func n(_ arg: FrozenUfiPkgEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1
@@ -311,17 +310,19 @@ package func n(_ arg: FrozenUfiPkgEnum) -> Int { // expected-error {{cannot find
   }
 }
 
-package func g(_ arg: UfiPkgEnum) -> Int { // expected-error {{cannot find type 'UfiPkgEnum' in scope}}
+package func g(_ arg: UfiPkgEnum) -> Int {
   switch arg {
   case .one:
     return 1
   case .two(let val):
     return 2 + val
+  @unknown default:
+    return 3
   }
 }
 
 @inlinable
-package func gi(_ arg: UfiPkgEnum) -> Int { // expected-error {{cannot find type 'UfiPkgEnum' in scope}}
+package func gi(_ arg: UfiPkgEnum) -> Int {
   switch arg {
   case .one:
     return 1
@@ -331,17 +332,19 @@ package func gi(_ arg: UfiPkgEnum) -> Int { // expected-error {{cannot find type
 }
 
 public func h(_ arg: PublicEnum) -> Int {
-  switch arg { // expected-error {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  switch arg { // no-warning
   case .one:
     return 1
   case .two(let val):
     return 2 + val
+  @unknown default:
+    return 3
   }
 }
 
 @inlinable
 public func hi(_ arg: PublicEnum) -> Int {
-  switch arg { // expected-error {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  switch arg { // no-warning
   case .one:
     return 1
   case .two(let val):


### PR DESCRIPTION
It is unsound to expose `package` declarations in textual interfaces without a package identity for them to belong to so we should not offer this flag.

Resolves rdar://139361524.
