### PR TITLE
[CoroutineAccessors] Synthesize default requirement implementations.

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -272,10 +272,9 @@ private:
                                          ->getReferenceStorageReferent();
           if (mapIntoContext)
             valueTy = AD->mapTypeIntoContext(valueTy);
-          YieldTypeFlags flags(
-              isYieldingDefaultMutatingAccessor(AD->getAccessorKind())
-                  ? ParamSpecifier::InOut
-                  : ParamSpecifier::LegacyShared);
+          YieldTypeFlags flags(isYieldingMutableAccessor(AD->getAccessorKind())
+                                   ? ParamSpecifier::InOut
+                                   : ParamSpecifier::LegacyShared);
           buffer.push_back(AnyFunctionType::Yield(valueTy, flags));
           return buffer;
         }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6046,8 +6046,8 @@ public:
 
   /// Given that CoroutineAccessors is enabled, is _read/_modify required for
   /// ABI stability?
-  bool
-  requiresCorrespondingUnderscoredCoroutineAccessor(AccessorKind kind) const;
+  bool requiresCorrespondingUnderscoredCoroutineAccessor(
+      AccessorKind kind, AccessorDecl const *decl = nullptr) const;
 
   /// Does this storage have any explicit observers (willSet or didSet) attached
   /// to it?
@@ -6104,9 +6104,9 @@ public:
 
   /// Determine how this storage declaration should actually be accessed.
   AccessStrategy getAccessStrategy(AccessSemantics semantics,
-                                   AccessKind accessKind,
-                                   ModuleDecl *module,
-                                   ResilienceExpansion expansion) const;
+                                   AccessKind accessKind, ModuleDecl *module,
+                                   ResilienceExpansion expansion,
+                                   bool useOldABI) const;
 
   /// Do we need to use resilient access patterns outside of this
   /// property's resilience domain?

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8441,6 +8441,10 @@ public:
   /// accessed by it.
   ArrayRef<VarDecl *> getAccessedProperties() const;
 
+  /// Whether this accessor should have a body.  Note that this will be true
+  /// even when it does not have one _yet_.
+  bool doesAccessorHaveBody() const;
+
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Accessor;
   }

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -95,7 +95,7 @@ inline bool isYieldingAccessor(AccessorKind kind) {
   }
 }
 
-inline bool isYieldingDefaultNonmutatingAccessor(AccessorKind kind) {
+inline bool isYieldingImmutableAccessor(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Read:
   case AccessorKind::Read2:
@@ -114,7 +114,7 @@ inline bool isYieldingDefaultNonmutatingAccessor(AccessorKind kind) {
   }
 }
 
-inline bool isYieldingDefaultMutatingAccessor(AccessorKind kind) {
+inline bool isYieldingMutableAccessor(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Modify:
   case AccessorKind::Modify2:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3050,10 +3050,8 @@ bool AbstractStorageDecl::requiresOpaqueModify2Coroutine() const {
       false);
 }
 
-AccessorDecl *AbstractStorageDecl::getSynthesizedAccessor(AccessorKind kind) const {
-  if (auto *accessor = getAccessor(kind))
-    return accessor;
-
+AccessorDecl *
+AbstractStorageDecl::getSynthesizedAccessor(AccessorKind kind) const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
     SynthesizeAccessorRequest{const_cast<AbstractStorageDecl *>(this), kind},
@@ -7112,7 +7110,10 @@ void AbstractStorageDecl::setComputedSetter(AccessorDecl *setter) {
 void
 AbstractStorageDecl::setSynthesizedAccessor(AccessorKind kind,
                                             AccessorDecl *accessor) {
-  assert(!getAccessor(kind) && "accessor already exists");
+  if (auto *current = getAccessor(kind)) {
+    assert(current == accessor && "different accessor of this kind exists");
+    return;
+  }
   assert(accessor->getAccessorKind() == kind);
 
   auto accessors = Accessors.getPointer();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2819,7 +2819,8 @@ getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
 }
 
 static AccessStrategy
-getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch);
+getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch,
+                            bool useOldABI);
 static AccessStrategy
 getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch);
 
@@ -2834,7 +2835,7 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
     // If the storage isDynamic (and not @objc) use the accessors.
     if (storage->shouldUseNativeDynamicDispatch())
       return AccessStrategy::getMaterializeToTemporary(
-          getOpaqueReadAccessStrategy(storage, false),
+          getOpaqueReadAccessStrategy(storage, false, false),
           getOpaqueWriteAccessStrategy(storage, false));
     return AccessStrategy::getStorage();
   }
@@ -2872,7 +2873,13 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
 }
 
 static AccessStrategy
-getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) {
+getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch,
+                            bool useOldABI) {
+  if (useOldABI) {
+    assert(storage->requiresOpaqueRead2Coroutine());
+    assert(storage->requiresOpaqueReadCoroutine());
+    return AccessStrategy::getAccessor(AccessorKind::Read, dispatch);
+  }
   if (storage->requiresOpaqueRead2Coroutine())
     return AccessStrategy::getAccessor(AccessorKind::Read2, dispatch);
   if (storage->requiresOpaqueReadCoroutine())
@@ -2889,35 +2896,39 @@ getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) 
 
 static AccessStrategy
 getOpaqueReadWriteAccessStrategy(const AbstractStorageDecl *storage,
-                                 bool dispatch) {
+                                 bool dispatch, bool useOldABI) {
+  if (useOldABI) {
+    assert(storage->requiresOpaqueModify2Coroutine());
+    assert(storage->requiresOpaqueModifyCoroutine());
+    return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
+  }
   if (storage->requiresOpaqueModify2Coroutine())
     return AccessStrategy::getAccessor(AccessorKind::Modify2, dispatch);
   if (storage->requiresOpaqueModifyCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
   return AccessStrategy::getMaterializeToTemporary(
-           getOpaqueReadAccessStrategy(storage, dispatch),
-           getOpaqueWriteAccessStrategy(storage, dispatch));
+      getOpaqueReadAccessStrategy(storage, dispatch, false),
+      getOpaqueWriteAccessStrategy(storage, dispatch));
 }
 
 static AccessStrategy
 getOpaqueAccessStrategy(const AbstractStorageDecl *storage,
-                        AccessKind accessKind, bool dispatch) {
+                        AccessKind accessKind, bool dispatch, bool useOldABI) {
   switch (accessKind) {
   case AccessKind::Read:
-    return getOpaqueReadAccessStrategy(storage, dispatch);
+    return getOpaqueReadAccessStrategy(storage, dispatch, useOldABI);
   case AccessKind::Write:
+    assert(!useOldABI);
     return getOpaqueWriteAccessStrategy(storage, dispatch);
   case AccessKind::ReadWrite:
-    return getOpaqueReadWriteAccessStrategy(storage, dispatch);
+    return getOpaqueReadWriteAccessStrategy(storage, dispatch, useOldABI);
   }
   llvm_unreachable("bad access kind");
 }
 
-AccessStrategy
-AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
-                                       AccessKind accessKind,
-                                       ModuleDecl *module,
-                                       ResilienceExpansion expansion) const {
+AccessStrategy AbstractStorageDecl::getAccessStrategy(
+    AccessSemantics semantics, AccessKind accessKind, ModuleDecl *module,
+    ResilienceExpansion expansion, bool useOldABI) const {
   switch (semantics) {
   case AccessSemantics::DirectToStorage:
     assert(hasStorage() || getASTContext().Diags.hadAnyError());
@@ -2933,10 +2944,12 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
       // If the property is defined in a non-final class or a protocol, the
       // accessors are dynamically dispatched, and we cannot do direct access.
       if (isPolymorphic(this))
-        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ true);
+        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ true,
+                                       useOldABI);
 
       if (shouldUseNativeDynamicDispatch())
-        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
+        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false,
+                                       useOldABI);
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.
@@ -2958,7 +2971,8 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
         resilient = isResilient();
 
       if (resilient)
-        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
+        return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false,
+                                       useOldABI);
     }
 
     LLVM_FALLTHROUGH;

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -109,7 +109,7 @@ static ValueOwnership getLoweredOwnership(AbstractFunctionDecl *afd) {
   }
   if (auto *ad = dyn_cast<AccessorDecl>(afd)) {
     if (ad->getAccessorKind() == AccessorKind::Set ||
-        isYieldingDefaultMutatingAccessor(ad->getAccessorKind())) {
+        isYieldingMutableAccessor(ad->getAccessorKind())) {
       return ValueOwnership::InOut;
     }
   }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -883,9 +883,13 @@ SynthesizeAccessorRequest::getCachedResult() const {
   auto *storage = std::get<0>(getStorage());
   auto kind = std::get<1>(getStorage());
   auto *accessor = storage->getAccessor(kind);
-  if (accessor)
-    return accessor;
-  return std::nullopt;
+  if (!accessor)
+    return std::nullopt;
+
+  if (accessor->doesAccessorHaveBody() && !accessor->hasBody())
+    return std::nullopt;
+
+  return accessor;
 }
 
 void SynthesizeAccessorRequest::cacheResult(AccessorDecl *accessor) const {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2202,7 +2202,7 @@ static void destructureYieldsForCoroutine(TypeConverter &TC,
     return;
 
   // 'modify' yields an inout of the target type.
-  if (isYieldingDefaultMutatingAccessor(accessor->getAccessorKind())) {
+  if (isYieldingMutableAccessor(accessor->getAccessorKind())) {
     auto loweredValueTy =
         TC.getLoweredType(origType, canValueType, expansion);
     yields.push_back(SILYieldInfo(loweredValueTy.getASTType(),
@@ -2210,7 +2210,7 @@ static void destructureYieldsForCoroutine(TypeConverter &TC,
   } else {
     // 'read' yields a borrowed value of the target type, destructuring
     // tuples as necessary.
-    assert(isYieldingDefaultNonmutatingAccessor(accessor->getAccessorKind()));
+    assert(isYieldingImmutableAccessor(accessor->getAccessorKind()));
     destructureYieldsForReadAccessor(TC, expansion, origType, canValueType,
                                      yields);
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1928,12 +1928,11 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   if (decl->isResilient(M.getSwiftModule(), expansion))
     return false;
 
-  auto strategy = decl->getAccessStrategy(AccessSemantics::Ordinary,
-                                          decl->supportsMutation()
-                                            ? AccessKind::ReadWrite
-                                            : AccessKind::Read,
-                                          M.getSwiftModule(),
-                                          expansion);
+  auto strategy = decl->getAccessStrategy(
+      AccessSemantics::Ordinary,
+      decl->supportsMutation() ? AccessKind::ReadWrite : AccessKind::Read,
+      M.getSwiftModule(), expansion,
+      /*useOldABI=*/false);
   switch (strategy.getKind()) {
   case AccessStrategy::Storage: {
     // Keypaths rely on accessors to handle the special behavior of weak,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3649,8 +3649,8 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
 
   auto semantics = AccessSemantics::Ordinary;
   auto strategy = property->getAccessStrategy(semantics, AccessKind::Write,
-                                              SGM.M.getSwiftModule(),
-                                              expansion);
+                                              SGM.M.getSwiftModule(), expansion,
+                                              /*useOldABI=*/false);
 
   LValueOptions lvOptions;
   lv.addMemberComponent(subSGF, loc, property, subs, lvOptions,
@@ -4211,12 +4211,11 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     return true;
   };
 
-  auto strategy = storage->getAccessStrategy(AccessSemantics::Ordinary,
-                                             storage->supportsMutation()
-                                               ? AccessKind::ReadWrite
-                                               : AccessKind::Read,
-                                             M.getSwiftModule(),
-                                             expansion);
+  auto strategy = storage->getAccessStrategy(
+      AccessSemantics::Ordinary,
+      storage->supportsMutation() ? AccessKind::ReadWrite : AccessKind::Read,
+      M.getSwiftModule(), expansion,
+      /*useOldABI=*/false);
 
   AbstractStorageDecl *externalDecl = nullptr;
   SubstitutionMap externalSubs;

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2227,7 +2227,7 @@ namespace {
       auto decl = cast<AccessorDecl>(Accessor.getFuncDecl());
 
       // 'modify' always returns an address of the right type.
-      if (isYieldingDefaultMutatingAccessor(decl->getAccessorKind())) {
+      if (isYieldingMutableAccessor(decl->getAccessorKind())) {
         assert(yields.size() == 1);
         return yields[0];
       }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3070,7 +3070,8 @@ public:
     auto accessSemantics = e->getAccessSemantics();
     AccessStrategy strategy = var->getAccessStrategy(
         accessSemantics, getFormalAccessKind(accessKind),
-        SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion());
+        SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
+        /*useOldABI=*/false);
 
     auto baseFormalType = getBaseFormalType(e->getBase());
     LValue lv = visit(
@@ -3292,9 +3293,9 @@ static LValue emitLValueForNonMemberVarDecl(
     subs = SGF.F.getForwardingSubstitutionMap();
 
   auto access = getFormalAccessKind(accessKind);
-  auto strategy =
-      var->getAccessStrategy(semantics, access, SGF.SGM.M.getSwiftModule(),
-                             SGF.F.getResilienceExpansion());
+  auto strategy = var->getAccessStrategy(
+      semantics, access, SGF.SGM.M.getSwiftModule(),
+      SGF.F.getResilienceExpansion(), /*useOldABI=*/false);
 
   lv.addNonMemberVarComponent(SGF, loc, var, subs, options, accessKind,
                               strategy, formalRValueType, actorIso);
@@ -3887,6 +3888,25 @@ static bool isCurrentFunctionAccessor(SILGenFunction &SGF,
          contextAccessorDecl->getAccessorKind() == accessorKind;
 }
 
+static bool isSynthesizedDefaultImplementionatThunk(SILGenFunction &SGF) {
+  if (!SGF.FunctionDC)
+    return false;
+
+  auto *decl = SGF.FunctionDC->getAsDecl();
+  if (!decl)
+    return false;
+
+  auto *dc = decl->getDeclContext();
+  if (!dc)
+    return false;
+
+  auto *proto = dyn_cast<ProtocolDecl>(dc);
+  if (!proto)
+    return false;
+
+  return true;
+}
+
 LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
                                         SGFAccessKind accessKind,
                                         LValueOptions options) {
@@ -3908,11 +3928,10 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   }
 
   auto accessSemantics = e->getAccessSemantics();
-  AccessStrategy strategy =
-    var->getAccessStrategy(accessSemantics,
-                           getFormalAccessKind(accessKind),
-                           SGF.SGM.M.getSwiftModule(),
-                           SGF.F.getResilienceExpansion());
+  AccessStrategy strategy = var->getAccessStrategy(
+      accessSemantics, getFormalAccessKind(accessKind),
+      SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
+      /*useOldABI=*/isSynthesizedDefaultImplementionatThunk(SGF));
 
   bool isOnSelfParameter = isCallToSelfOfCurrentFunction(SGF, e);
 
@@ -3931,10 +3950,9 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;
       strategy = var->getAccessStrategy(
-          accessSemantics,
-          getFormalAccessKind(accessKind),
-          SGF.SGM.M.getSwiftModule(),
-          SGF.F.getResilienceExpansion());
+          accessSemantics, getFormalAccessKind(accessKind),
+          SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
+          /*useOldABI=*/false);
     }
   }
   
@@ -4119,11 +4137,10 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
 
 
   auto accessSemantics = e->getAccessSemantics();
-  auto strategy =
-    decl->getAccessStrategy(accessSemantics,
-                            getFormalAccessKind(accessKind),
-                            SGF.SGM.M.getSwiftModule(),
-                            SGF.F.getResilienceExpansion());
+  auto strategy = decl->getAccessStrategy(
+      accessSemantics, getFormalAccessKind(accessKind),
+      SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
+      /*useOldABI=*/isSynthesizedDefaultImplementionatThunk(SGF));
 
   bool isOnSelfParameter = isCallToSelfOfCurrentFunction(SGF, e);
   bool isContextRead = isCurrentFunctionAccessor(SGF, AccessorKind::Read);
@@ -4141,10 +4158,9 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;
       strategy = decl->getAccessStrategy(
-          accessSemantics,
-          getFormalAccessKind(accessKind),
-          SGF.SGM.M.getSwiftModule(),
-          SGF.F.getResilienceExpansion());
+          accessSemantics, getFormalAccessKind(accessKind),
+          SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
+          /*useOldABI=*/false);
     }
   }
 
@@ -4597,11 +4613,9 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
   auto baseType = base.getType().getASTType();
   auto subMap = baseType->getContextSubstitutionMap(ivar->getDeclContext());
 
-  AccessStrategy strategy =
-    ivar->getAccessStrategy(semantics,
-                            getFormalAccessKind(accessKind),
-                            SGM.M.getSwiftModule(),
-                            F.getResilienceExpansion());
+  AccessStrategy strategy = ivar->getAccessStrategy(
+      semantics, getFormalAccessKind(accessKind), SGM.M.getSwiftModule(),
+      F.getResilienceExpansion(), /*useOldABI=*/false);
 
   auto baseAccessKind =
     getBaseAccessKind(SGM, ivar, accessKind, strategy, baseFormalType,
@@ -5316,10 +5330,9 @@ RValue SILGenFunction::emitRValueForStorageLoad(
     SubstitutionMap substitutions,
     AccessSemantics semantics, Type propTy, SGFContext C,
     bool isBaseGuaranteed) {
-  AccessStrategy strategy =
-    storage->getAccessStrategy(semantics, AccessKind::Read,
-                               SGM.M.getSwiftModule(),
-                               F.getResilienceExpansion());
+  AccessStrategy strategy = storage->getAccessStrategy(
+      semantics, AccessKind::Read, SGM.M.getSwiftModule(),
+      F.getResilienceExpansion(), /*useOldABI=*/false);
 
   // If we should call an accessor of some kind, do so.
   if (strategy.getKind() != AccessStrategy::Storage) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3316,11 +3316,11 @@ static bool isBorrowableSubject(SILGenFunction &SGF,
   }
   
   // Check the access strategy used to read the storage.
-  auto strategy = storage->getAccessStrategy(access,
-                                             AccessKind::Read,
-                                             SGF.SGM.SwiftModule,
-                                             SGF.F.getResilienceExpansion());
-                                             
+  auto strategy =
+      storage->getAccessStrategy(access, AccessKind::Read, SGF.SGM.SwiftModule,
+                                 SGF.F.getResilienceExpansion(),
+                                 /*useOldABI=*/false);
+
   switch (strategy.getKind()) {
   case AccessStrategy::Kind::Storage:
     // Accessing storage directly benefits from borrowing.

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -423,24 +423,22 @@ public:
 
     // If it's not an accessor, just look for the witness.
     if (!reqAccessor) {
-      if (!storage) {
-        if (auto witness = asDerived().getWitness(reqDecl)) {
-          auto newDecl = requirementRef.withDecl(witness.getDecl());
-          // Only import C++ methods as foreign. If the following
-          // Objective-C function is imported as foreign:
-          //   () -> String
-          // It will be imported as the following type:
-          //   () -> NSString
-          // But the first is correct, so make sure we don't mark this witness
-          // as foreign.
-          if (dyn_cast_or_null<clang::CXXMethodDecl>(
-                  witness.getDecl()->getClangDecl()))
-            newDecl = newDecl.asForeign();
-          return addMethodImplementation(
-              requirementRef, getWitnessRef(newDecl, witness), witness);
-        }
-        return asDerived().addMissingMethod(requirementRef);
-      } // else, fallthrough to the usual accessor handling!
+      if (auto witness = asDerived().getWitness(reqDecl)) {
+        auto newDecl = requirementRef.withDecl(witness.getDecl());
+        // Only import C++ methods as foreign. If the following
+        // Objective-C function is imported as foreign:
+        //   () -> String
+        // It will be imported as the following type:
+        //   () -> NSString
+        // But the first is correct, so make sure we don't mark this witness
+        // as foreign.
+        if (dyn_cast_or_null<clang::CXXMethodDecl>(
+                witness.getDecl()->getClangDecl()))
+          newDecl = newDecl.asForeign();
+        return addMethodImplementation(
+            requirementRef, getWitnessRef(newDecl, witness), witness);
+      }
+      return asDerived().addMissingMethod(requirementRef);
     } else {
       // Otherwise, we need to map the storage declaration and then get
       // the appropriate accessor for it.

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -274,7 +274,7 @@ void DifferentiableActivityInfo::propagateVariedInwardsThroughProjections(
     if (auto *bai = dyn_cast<BeginApplyInst>(inst)) {
       if (auto *calleeFn = bai->getCalleeFunction()) {
         auto kind = getAccessorKind(calleeFn);
-        if (kind && isYieldingDefaultMutatingAccessor(*kind))
+        if (kind && isYieldingMutableAccessor(*kind))
           for (auto inoutArg : bai->getInoutArguments())
             propagateVariedInwardsThroughProjections(inoutArg, i);
       }
@@ -353,7 +353,7 @@ void DifferentiableActivityInfo::propagateUseful(
     if (auto *bai = dyn_cast<BeginApplyInst>(inst)) {
       if (auto *calleeFn = bai->getCalleeFunction()) {
         auto kind = getAccessorKind(calleeFn);
-        if (kind && isYieldingDefaultMutatingAccessor(*kind))
+        if (kind && isYieldingMutableAccessor(*kind))
           for (auto yield : bai->getYieldedValues())
             setUsefulAndPropagateToOperands(yield, i);
       }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -266,7 +266,8 @@ public:
       EndBorrow->eraseFromParent();
 
     if (auto allocation = BeginApply->getCalleeAllocationResult()) {
-      for (auto *user : allocation->getUsers()) {
+      SmallVector<SILInstruction *, 4> users(allocation->getUsers());
+      for (auto *user : users) {
         auto *dsi = cast<DeallocStackInst>(user);
         dsi->eraseFromParent();
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4345,7 +4345,8 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
       // direct-to-storage in order for the conversion to be non-ephemeral.
       auto access = asd->getAccessStrategy(
           AccessSemantics::Ordinary, AccessKind::ReadWrite,
-          DC->getParentModule(), DC->getResilienceExpansion());
+          DC->getParentModule(), DC->getResilienceExpansion(),
+          /*useOldABI=*/false);
       return access.getKind() == AccessStrategy::Storage;
     };
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1509,9 +1509,10 @@ DeferredDiags swift::findSyntacticErrorForConsume(
         break;
       }
       partial = true;
-      AccessStrategy strategy = vd->getAccessStrategy(
-          mre->getAccessSemantics(), AccessKind::Read,
-          module, ResilienceExpansion::Minimal);
+      AccessStrategy strategy =
+          vd->getAccessStrategy(mre->getAccessSemantics(), AccessKind::Read,
+                                module, ResilienceExpansion::Minimal,
+                                /*useOldABI=*/false);
       if (strategy.getKind() != AccessStrategy::Storage) {
         if (noncopyable) {
           result.emplace_back(loc, diag::consume_expression_non_storage);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -382,12 +382,12 @@ public:
     // capture of the storage address - not a capture of the getter/setter.
     if (auto var = dyn_cast<VarDecl>(D)) {
       if (var->getAccessStrategy(DRE->getAccessSemantics(),
-                                 var->supportsMutation()
-                                   ? AccessKind::ReadWrite
-                                   : AccessKind::Read,
+                                 var->supportsMutation() ? AccessKind::ReadWrite
+                                                         : AccessKind::Read,
                                  CurDC->getParentModule(),
-                                 CurDC->getResilienceExpansion())
-          .getKind() == AccessStrategy::Storage)
+                                 CurDC->getResilienceExpansion(),
+                                 /*useOldABI=*/false)
+              .getKind() == AccessStrategy::Storage)
         Flags |= CapturedValue::IsDirect;
     }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2630,6 +2630,10 @@ SynthesizeAccessorRequest::evaluate(Evaluator &evaluator,
                                     AccessorKind kind) const {
   auto &ctx = storage->getASTContext();
 
+  if (auto *accessor = storage->getAccessor(kind)) {
+    return accessor;
+  }
+
   switch (kind) {
   case AccessorKind::Get:
   case AccessorKind::DistributedGet:

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -928,7 +928,8 @@ buildIndexForwardingParamList(AbstractStorageDecl *storage,
   return ParameterList::create(context, elements);
 }
 
-static bool doesAccessorHaveBody(AccessorDecl *accessor) {
+bool AccessorDecl::doesAccessorHaveBody() const {
+  auto *accessor = this;
   // Protocol requirements don't have bodies.
   //
   // FIXME: Revisit this if we ever get 'real' default implementations.
@@ -2349,7 +2350,7 @@ static void finishImplicitAccessor(AccessorDecl *accessor,
   if (ctx.Stats)
     ++ctx.Stats->getFrontendCounters().NumAccessorsSynthesized;
 
-  if (doesAccessorHaveBody(accessor))
+  if (accessor->doesAccessorHaveBody())
     accessor->setBodySynthesizer(&synthesizeAccessorBody);
 }
 
@@ -2828,7 +2829,7 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
   if (!accessor->isImplicit())
     return false;
 
-  if (!doesAccessorHaveBody(accessor))
+  if (!accessor->doesAccessorHaveBody())
     return false;
 
   auto *DC = accessor->getDeclContext();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2731,7 +2731,7 @@ bool AbstractStorageDecl::requiresCorrespondingUnderscoredCoroutineAccessor(
   if (!isExported(this))
     return false;
 
-  // The the non-underscored accessor is not present, the underscored accessor
+  // The non-underscored accessor is not present, the underscored accessor
   // won't be either.
   // TODO: CoroutineAccessors: What if only the underscored is written out?
   auto *accessor = getOpaqueAccessor(kind);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2275,7 +2275,7 @@ synthesizeRead2CoroutineBody(AccessorDecl *read, ASTContext &ctx) {
   return synthesizeCoroutineAccessorBody(read, ctx);
 }
 
-/// Synthesize the body of a modify coroutine.
+/// Synthesize the body of a _modify coroutine.
 static std::pair<BraceStmt *, bool>
 synthesizeModifyCoroutineBody(AccessorDecl *modify, ASTContext &ctx) {
 #ifndef NDEBUG

--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -1,0 +1,258 @@
+// RUN: %empty-directory(%t)
+
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     %t/Library.swift   \
+// RUN:     %t/LibImpl.underscored.swift   \
+// RUN:     -emit-module       \
+// RUN:     -module-name Library \
+// RUN:     -parse-as-library  \
+// RUN:     -enable-library-evolution \
+// RUN:     -emit-module-path %t/Library.swiftmodule \
+// RUN:     -validate-tbd-against-ir=none
+
+// RUN: %target-swift-frontend \
+// RUN:     %t/Executable.swift \
+// RUN:     -c \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Executable \
+// RUN:     -I %t \
+// RUN:     -o %t/Executable.o \
+// RUN:     -validate-tbd-against-ir=none
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Library)) \
+// RUN:     %t/Library.swift \
+// RUN:     %t/LibImpl.nonunderscored.swift   \
+// RUN:     -emit-module \
+// RUN:     -enable-library-evolution \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -emit-module-path %t/Library.swiftmodule \
+// RUN:     -module-name Library \
+// RUN:     -Xfrontend -validate-tbd-against-ir=none
+
+// RUN: %target-build-swift \
+// RUN:     %t/Executable.o \
+// RUN:     -lLibrary \
+// RUN:     -L %t \
+// RUN:     %target-rpath(%t) \
+// RUN:     -o %t/main
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(Library) | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: executable_test
+
+//--- Library.swift
+public protocol P {
+  @_borrowed
+  var i : Int { get set }
+  @_borrowed
+  subscript(i : Int) -> Int { get set }
+}
+
+public func readFromSomeP<T : P>(_ p: T) {
+  print(#function, "p.i", p.i)
+  print(#function, "p[5]", p[5])
+}
+
+public func increment(int: inout Int) {
+  print(#function, "before increment", int)
+  int += 1
+  print(#function, "after increment", int)
+}
+
+public func modifySomeP<T : P>(_ p: inout T) {
+  print(#function, "begin")
+  increment(int: &p.i)
+  increment(int: &p[5])
+  print(#function, "end")
+}
+
+public func getSomeP() -> some P {
+  return I()
+}
+
+public func getAnyP() -> any P {
+  return I()
+}
+
+//--- LibImpl.underscored.swift
+
+struct I : P {
+  var i : Int = 0
+  subscript(i : Int) -> Int { 
+    _read {
+      let i = 0
+      yield i
+    }
+    _modify {
+      var i = 0
+      yield &i
+    }
+  }
+}
+
+//--- LibImpl.nonunderscored.swift
+
+struct I : P {
+  var _iImpl : Int
+  var i : Int {
+    read {
+      print(#function, "before yield", _iImpl)
+      yield _iImpl
+      print(#function, "after yield", _iImpl)
+    }
+    modify {
+      print(#function, "before yield", _iImpl)
+      yield &_iImpl
+      print(#function, "after yield", _iImpl)
+    }
+  }
+  var _sImpl: [Int]
+  subscript(i : Int) -> Int {
+    read {
+      print(#function, "before yield", _sImpl[i])
+      yield _sImpl[i]
+      print(#function, "after yield", _sImpl[i])
+    }
+    modify {
+      print(#function, "before yield", _sImpl[i])
+      yield &_sImpl[i]
+      print(#function, "after yield", _sImpl[i])
+    }
+  }
+  init() {
+    self._iImpl = 42
+    self._sImpl = [1, 1, 2, 3, 5, 8, 13, 21]
+  }
+}
+
+//--- Executable.swift
+import Library
+
+public struct S : P {
+  var _iImpl : Int
+  public var i : Int {
+    _read {
+      print(#function, "before yield", _iImpl)
+      yield _iImpl
+      print(#function, "after yield", _iImpl)
+    }
+    _modify {
+      print(#function, "before yield", _iImpl)
+      yield &_iImpl
+      print(#function, "after yield", _iImpl)
+    }
+  }
+  var _sImpl: [Int]
+  public subscript(i : Int) -> Int {
+    _read {
+      print(#function, "before yield", _sImpl[i])
+      yield _sImpl[i]
+      print(#function, "after yield", _sImpl[i])
+    }
+    _modify {
+      print(#function, "before yield", _sImpl[i])
+      yield &_sImpl[i]
+      print(#function, "after yield", _sImpl[i])
+    }
+  }
+  init() {
+    self._iImpl = 42
+    self._sImpl = [1, 1, 2, 3, 5, 8, 13, 21]
+  }
+}
+
+func readFromSomePLocal<T : P>(_ p: T) {
+  print(#function, "p.i", p.i)
+  print(#function, "p[5]", p[5])
+}
+
+func modifySomePLocal<T : P>(_ p: inout T) {
+  print(#function, "begin")
+  increment(int: &p.i)
+  increment(int: &p[5])
+  print(#function, "end")
+}
+
+@main struct M {
+  static func main() {
+    var s = S()
+// CHECK:      i before yield 42
+// CHECK-NEXT: i after yield 42
+// CHECK-NEXT: readFromSomeP(_:) p.i 42
+// CHECK-NEXT: subscript(_:) before yield 8
+// CHECK-NEXT: subscript(_:) after yield 8
+// CHECK-NEXT: readFromSomeP(_:) p[5] 8
+    readFromSomeP(s)
+// CHECK-NEXT: modifySomeP(_:) begin
+// CHECK-NEXT: i before yield 42
+// CHECK-NEXT: increment(int:) before increment 42
+// CHECK-NEXT: increment(int:) after increment 43
+// CHECK-NEXT: i after yield 43
+// CHECK-NEXT: subscript(_:) before yield 8
+// CHECK-NEXT: increment(int:) before increment 8
+// CHECK-NEXT: increment(int:) after increment 9
+// CHECK-NEXT: subscript(_:) after yield 9
+// CHECK-NEXT: modifySomeP(_:) end
+    modifySomeP(&s)
+// CHECK-NEXT: modifySomePLocal(_:) begin
+// CHECK-NEXT: i before yield 43
+// CHECK-NEXT: increment(int:) before increment 43
+// CHECK-NEXT: increment(int:) after increment 44
+// CHECK-NEXT: i after yield 44
+// CHECK-NEXT: subscript(_:) before yield 9
+// CHECK-NEXT: increment(int:) before increment 9
+// CHECK-NEXT: increment(int:) after increment 10
+// CHECK-NEXT: subscript(_:) after yield 10
+// CHECK-NEXT: modifySomePLocal(_:) end
+    modifySomePLocal(&s)
+// CHECK-NEXT: i before yield 44
+// CHECK-NEXT: i after yield 44
+// CHECK-NEXT: readFromSomePLocal(_:) p.i 44
+// CHECK-NEXT: subscript(_:) before yield 10
+// CHECK-NEXT: subscript(_:) after yield 10
+// CHECK-NEXT: readFromSomePLocal(_:) p[5] 10
+    readFromSomePLocal(s)
+    var sp = getSomeP()
+// CHECK-NEXT: i before yield 42
+// CHECK-NEXT: i after yield 42
+// CHECK-NEXT: readFromSomePLocal(_:) p.i 42
+// CHECK-NEXT: subscript(_:) before yield 8
+// CHECK-NEXT: subscript(_:) after yield 8
+// CHECK-NEXT: readFromSomePLocal(_:) p[5] 8
+    readFromSomePLocal(sp)
+// CHECK-NEXT: modifySomePLocal(_:) begin
+// CHECK-NEXT: i before yield 42
+// CHECK-NEXT: increment(int:) before increment 42
+// CHECK-NEXT: increment(int:) after increment 43
+// CHECK-NEXT: i after yield 43
+// CHECK-NEXT: subscript(_:) before yield 8
+// CHECK-NEXT: increment(int:) before increment 8
+// CHECK-NEXT: increment(int:) after increment 9
+// CHECK-NEXT: subscript(_:) after yield 9
+// CHECK-NEXT: modifySomePLocal(_:) end
+    modifySomePLocal(&sp)
+// CHECK-NEXT: modifySomeP(_:) begin
+// CHECK-NEXT: i before yield 43
+// CHECK-NEXT: increment(int:) before increment 43
+// CHECK-NEXT: increment(int:) after increment 44
+// CHECK-NEXT: i after yield 44
+// CHECK-NEXT: subscript(_:) before yield 9
+// CHECK-NEXT: increment(int:) before increment 9
+// CHECK-NEXT: increment(int:) after increment 10
+// CHECK-NEXT: subscript(_:) after yield 10
+// CHECK-NEXT: modifySomeP(_:) end
+    modifySomeP(&sp)
+// CHECK-NEXT: i before yield 44
+// CHECK-NEXT: i after yield 44
+// CHECK-NEXT: readFromSomeP(_:) p.i 44
+// CHECK-NEXT: subscript(_:) before yield 10
+// CHECK-NEXT: subscript(_:) after yield 10
+// CHECK-NEXT: readFromSomeP(_:) p[5] 10
+    readFromSomeP(sp)
+  }
+}
+

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -316,21 +316,21 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 // CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
 // CHECK:         yield [[VALUE_BORROW]]
 // CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
-// CHECK:       [[SUCCESS]]:                                              
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
 // CHECK:         return
-// CHECK:       [[FAILURE]]:                                              
+// CHECK:       [[FAILURE]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind                                          
+// CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplAUnderscoredCoroutineAccessorsV4ubgsAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplAUnderscoredCoroutineAccessorsVAA2P1A2aDP4ubgsAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
@@ -422,21 +422,21 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
 // CHECK:         yield [[VALUE_BORROW]]
 // CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
-// CHECK:       [[SUCCESS]]:                                              
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
 // CHECK:         return
-// CHECK:       [[FAILURE]]:                                              
+// CHECK:       [[FAILURE]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind                                          
+// CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplBUnderscoredCoroutineAccessorsV3ursAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplBUnderscoredCoroutineAccessorsVAA2P2A2aDP3ursAA1UVvyTW : {{.*}} {
 // CHECK:       bb0(
@@ -506,21 +506,21 @@ public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         [[VALUE_BORROW:%[^,]+]] = begin_borrow [[VALUE_COPY]]
 // CHECK:         yield [[VALUE_BORROW]]
 // CHECK-SAME:        resume [[SUCCESS:bb[0-9]+]]
-// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]          
-// CHECK:       [[SUCCESS]]:                                              
+// CHECK-SAME:        unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
 // CHECK:         return
-// CHECK:       [[FAILURE]]:                                              
+// CHECK:       [[FAILURE]]:
 // CHECK:         end_borrow [[VALUE_BORROW]]
 // CHECK:         destroy_value [[VALUE_COPY]]
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         end_borrow [[SELF_BORROW]]
 // CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         unwind                                          
+// CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements34ImplCUnderscoredCoroutineAccessorsV2urAA1UVvy'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements34ImplCUnderscoredCoroutineAccessorsVAA2P3A2aDP2urAA1UVvrTW : {{.*}} {
 // CHECK:       bb0(
@@ -1289,7 +1289,7 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-SAME:      [[SELF:%[^:]+]] :
 // CHECK-SAME:  ):
 // CHECK:         [[UNSAFE_POINTER:%[^,]+]] = struct_extract [[SELF]]
-// CHECK:             #ImplCUnsafeAddressors.iAddr 
+// CHECK:             #ImplCUnsafeAddressors.iAddr
 // CHECK:         return [[UNSAFE_POINTER]]
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvlu'
 // CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements21ImplCUnsafeAddressorsV2urAA1UVvr : {{.*}} {

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1532,3 +1532,24 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK-NEXT:    method #P3.ur!read2
 // CHECK-SAME:      : @$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW
 // CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_default_witness_table P1 {
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_default_witness_table P2 {
+// CHECK-unstable: no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-unstable: no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_default_witness_table P3 {
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:  }

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -14,8 +14,6 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError
 
-// For CoroutineAccessorsUnwindOnCallerError
-
 // A read requirement may be satisfied by
 // - a stored property
 // - a _read accessor


### PR DESCRIPTION
When a protocol which has a `read` (or `modify`) requirement is built with the `CoroutineAccessors` feature, it gains a `read2` (or `modify2`, respectively) requirement.  For this to be compatible with binaries built without the feature, a default implementation for these new requirements must be provided.  Cause these new accessor requirements to have default implementations by returning `true` from `doesAccessorHaveBody` when the context is a `ProtocolDecl` and the relevant availability check passes.
