### PR TITLE
[IRGen+Runtime] Fix tag bit mask handling for objc, unknown objects a…

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "TypeLayout.h"
+#include "ClassTypeInfo.h"
 #include "ConstantBuilder.h"
 #include "EnumPayload.h"
 #include "FixedTypeInfo.h"
@@ -1293,14 +1294,17 @@ bool ScalarTypeLayoutEntry::refCountString(IRGenModule &IGM,
   case ScalarKind::BlockReference:
     B.addRefCount(LayoutStringBuilder::RefCountingKind::Block, size);
     break;
-  case ScalarKind::ObjCReference:
-    if (typeInfo.hasFixedSpareBits()) {
+  case ScalarKind::ObjCReference: {
+    auto *classTI = dyn_cast<ClassTypeInfo>(&typeInfo);
+    assert(classTI);
+    if (!classTI->getClass()->hasClangNode()) {
       B.addRefCount(LayoutStringBuilder::RefCountingKind::NativeSwiftObjC,
                     size);
     } else {
       B.addRefCount(LayoutStringBuilder::RefCountingKind::ObjC, size);
     }
     break;
+  }
   case ScalarKind::ThickFunc:
     B.addSkip(IGM.getPointerSize().getValue());
     B.addRefCount(LayoutStringBuilder::RefCountingKind::NativeStrong,

--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -97,6 +97,16 @@ static uint64_t readTagBytes(const uint8_t *addr, uint8_t byteCount) {
   }
 }
 
+// This check is used to determine whether or not ObjC references can
+// be tagged pointers. If they can't, they have the same spare bits
+// as swift references, and we have to mask them out before passing the
+// reference to ref counting operations.
+static constexpr bool platformSupportsTaggedPointers() {
+  // Platforms that don't reserve bits for ObjC, don't support tagged
+  // pointers.
+  return _swift_abi_ObjCReservedBitsMask != 0;
+}
+
 #if defined(__APPLE__) && defined(__arm64__)
 
 #define CONTINUE_WITH_COPY(METADATA, READER, ADDR_OFFSET, DEST, SRC)           \
@@ -281,9 +291,12 @@ static void weakDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
 static void unknownDestroy(const Metadata *metadata,
                            LayoutStringReader1 &reader, uintptr_t &addrOffset,
                            uint8_t *addr) {
-  void *object = *(void**)(addr + addrOffset);
+  uintptr_t object = *(uintptr_t *)(addr + addrOffset);
   addrOffset += sizeof(void*);
-  swift_unknownObjectRelease(object);
+  if (!platformSupportsTaggedPointers()) {
+    object &= ~_swift_abi_SwiftSpareBitsMask;
+  }
+  swift_unknownObjectRelease((void *)object);
 }
 
 static void unknownUnownedDestroy(const Metadata *metadata,
@@ -769,9 +782,10 @@ multiPayloadEnumGeneric(const Metadata *metadata, LayoutStringReader1 &reader,
 static void blockDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
                          uintptr_t &addrOffset, uint8_t *addr) {
 #if SWIFT_OBJC_INTEROP
-  void* object = (void *)(addr + addrOffset);
+  uintptr_t object = *(uintptr_t *)(addr + addrOffset);
+  object &= ~_swift_abi_SwiftSpareBitsMask;
   addrOffset += sizeof(void*);
-  _Block_release(object);
+  _Block_release((void *)object);
 #else
   swift_unreachable("Blocks are not available on this platform");
 #endif
@@ -783,6 +797,11 @@ static void objcStrongDestroy(const Metadata *metadata,
 #if SWIFT_OBJC_INTEROP
   uintptr_t object = *(uintptr_t *)(addr + addrOffset);
   addrOffset += sizeof(objc_object*);
+
+  if (!platformSupportsTaggedPointers()) {
+    object &= ~_swift_abi_SwiftSpareBitsMask;
+  }
+
   objc_release((objc_object *)object);
 #else
   swift_unreachable("ObjC interop is not available on this platform");
@@ -959,10 +978,13 @@ static void weakCopyInit(const Metadata *metadata, LayoutStringReader1 &reader,
 static void unknownRetain(const Metadata *metadata, LayoutStringReader1 &reader,
                           uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
-  void *object = *(void **)(src + _addrOffset);
+  uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(void*));
   addrOffset = _addrOffset + sizeof(void *);
-  swift_unknownObjectRetain(object);
+  if (!platformSupportsTaggedPointers()) {
+    object &= ~_swift_abi_SwiftSpareBitsMask;
+  }
+  swift_unknownObjectRetain((void *)object);
 }
 
 static void unknownUnownedCopyInit(const Metadata *metadata,
@@ -1000,9 +1022,11 @@ static void blockCopy(const Metadata *metadata, LayoutStringReader1 &reader,
                       uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
 #if SWIFT_OBJC_INTEROP
   uintptr_t _addrOffset = addrOffset;
-  auto *copy = _Block_copy(*(void**)(src + _addrOffset));
-  memcpy(dest + _addrOffset, &copy, sizeof(void*));
+  uintptr_t object = *(uintptr_t *)(src + _addrOffset);
+  memcpy(dest + _addrOffset, &object, sizeof(void *));
   addrOffset = _addrOffset + sizeof(void*);
+  object &= ~_swift_abi_SwiftSpareBitsMask;
+  _Block_copy((void *)object);
 #else
   swift_unreachable("Blocks are not available on this platform");
 #endif
@@ -1016,6 +1040,11 @@ static void objcStrongRetain(const Metadata *metadata,
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(objc_object *));
   addrOffset = _addrOffset + sizeof(objc_object *);
+
+  if (!platformSupportsTaggedPointers()) {
+    object &= ~_swift_abi_SwiftSpareBitsMask;
+  }
+
   objc_retain((objc_object *)object);
 #else
   swift_unreachable("ObjC interop is not available on this platform");
@@ -1368,12 +1397,16 @@ static void unknownAssignWithCopy(const Metadata *metadata,
                                   uintptr_t &addrOffset, uint8_t *dest,
                                   uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
-  void *destObject = *(void **)(dest + _addrOffset);
-  void *srcObject = *(void **)(src + _addrOffset);
+  uintptr_t destObject = *(uintptr_t *)(dest + _addrOffset);
+  uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &srcObject, sizeof(void *));
   addrOffset = _addrOffset + sizeof(void *);
-  swift_unknownObjectRelease(destObject);
-  swift_unknownObjectRetain(srcObject);
+  if (!platformSupportsTaggedPointers()) {
+    destObject &= ~_swift_abi_SwiftSpareBitsMask;
+    srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+  }
+  swift_unknownObjectRelease((void *)destObject);
+  swift_unknownObjectRetain((void *)srcObject);
 }
 
 static void bridgeAssignWithCopy(const Metadata *metadata,
@@ -1431,10 +1464,14 @@ static void blockAssignWithCopy(const Metadata *metadata,
                              uint8_t *src) {
 #if SWIFT_OBJC_INTEROP
   uintptr_t _addrOffset = addrOffset;
-  _Block_release(*(void **)(dest + _addrOffset));
-  auto *copy = _Block_copy(*(void **)(src + _addrOffset));
-  memcpy(dest + _addrOffset, &copy, sizeof(void*));
+  uintptr_t destObject = *(uintptr_t *)(dest + _addrOffset);
+  uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
+  memcpy(dest + _addrOffset, &srcObject, sizeof(void *));
   addrOffset = _addrOffset + sizeof(void*);
+  destObject &= ~_swift_abi_SwiftSpareBitsMask;
+  srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+  _Block_release((void *)destObject);
+  _Block_copy((void *)srcObject);
 #else
   swift_unreachable("Blocks are not available on this platform");
 #endif
@@ -1451,6 +1488,11 @@ static void objcStrongAssignWithCopy(const Metadata *metadata,
   uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &srcObject, sizeof(objc_object*));
   addrOffset = _addrOffset + sizeof(objc_object*);
+
+  if (!platformSupportsTaggedPointers()) {
+    destObject &= ~_swift_abi_SwiftSpareBitsMask;
+    srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+  }
 
   objc_release((objc_object *)destObject);
   objc_retain((objc_object *)srcObject);

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -667,6 +667,12 @@ public enum ErrorWrapper {
     case y(Error)
 }
 
+public enum MultiPayloadAnyObject {
+    case x(AnyObject)
+    case y(AnyObject)
+    case z(AnyObject)
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1363,6 +1363,49 @@ func testMultiPayloadOneExtraTagValue() {
 
 testMultiPayloadOneExtraTagValue()
 
+func testMultiPayloadAnyObject() {
+    let ptr = UnsafeMutablePointer<MultiPayloadAnyObject>.allocate(capacity: 1)
+
+    // initWithCopy
+    do {
+        let x = MultiPayloadAnyObject.y(SimpleClass(x: 0))
+        testInit(ptr, to: x)
+    }
+
+    // assignWithTake
+    do {
+        let y = MultiPayloadAnyObject.z(SimpleClass(x: 1))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        var z = MultiPayloadAnyObject.z(SimpleClass(x: 2))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadAnyObject()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
…nd blocks

rdar://138487964

On platforms that don't have reserved bits in objc (including unknown) pointers, we use the spare bits for Swift enums, so they have to be masked out. Blocks don't have reserved bits on any platform.