### PR TITLE
[Concurrency] Allow witnesses to adopt concurrency before requirements

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5412,35 +5412,38 @@ bool ConstraintSystem::repairFailures(
 
   if (auto *VD = getAsDecl<ValueDecl>(anchor)) {
     // Matching a witness to an protocol requirement.
-    if (isa<ProtocolDecl>(VD->getDeclContext()) &&
-        VD->isProtocolRequirement() &&
-        VD->preconcurrency() &&
-        path[0].is<LocatorPathElt::Witness>() &&
-        // Note that the condition below is very important,
-        // we need to wait until the very last moment to strip
-        // the concurrency annotations from the innermost type.
-        conversionsOrFixes.empty()) {
-      // Allow requirements to introduce `swift_attr` and other
-      // concurrency related annotations (e.g. `& Sendable` or `@Sendable`)
-      // (note that `swift_attr` in type contexts weren't supported
-      // before) and for witnesses to adopt them gradually by matching
-      // with a warning in non-strict concurrency mode.
-      if (!(Context.isSwiftVersionAtLeast(6) ||
-            Context.LangOpts.StrictConcurrencyLevel ==
-                StrictConcurrency::Complete)) {
-        auto strippedLHS = lhs->stripConcurrency(/*recursive=*/true,
-                                                 /*dropGlobalActor=*/true);
-        auto strippedRHS = rhs->stripConcurrency(/*recursive=*/true,
-                                                 /*dropGlobalActor=*/true);
+    if (auto witnessElt = path[0].getAs<LocatorPathElt::Witness>()) {
+      if (isa<ProtocolDecl>(VD->getDeclContext()) &&
+          VD->isProtocolRequirement()) {
+        auto *witness = witnessElt->getDecl();
+        if ((VD->preconcurrency() || witness->preconcurrency()) &&
+            // Note that the condition below is very important,
+            // we need to wait until the very last moment to strip
+            // the concurrency annotations from the innermost type.
+            conversionsOrFixes.empty()) {
+          // Allow requirements/witnesses to introduce `swift_attr` and other
+          // concurrency related annotations (e.g. `& Sendable` or `@Sendable`)
+          // (note that `swift_attr` in type contexts weren't supported
+          // before) and for witnesses to adopt them gradually by matching
+          // with a warning in non-strict concurrency mode.
+          if (!(Context.isSwiftVersionAtLeast(6) ||
+                Context.LangOpts.StrictConcurrencyLevel ==
+                    StrictConcurrency::Complete)) {
+            auto strippedLHS = lhs->stripConcurrency(/*recursive=*/true,
+                                                     /*dropGlobalActor=*/true);
+            auto strippedRHS = rhs->stripConcurrency(/*recursive=*/true,
+                                                     /*dropGlobalActor=*/true);
 
-        // If nothing got stripped there is no reason to re-match
-        // the types.
-        if (!strippedLHS->isEqual(lhs) || !strippedRHS->isEqual(rhs)) {
-          auto result = matchTypes(strippedLHS, strippedRHS, matchKind,
-                                   flags | TMF_ApplyingFix, locator);
-          if (!result.isFailure()) {
-            increaseScore(SK_MissingSynthesizableConformance, locator);
-            return true;
+            // If nothing got stripped there is no reason to re-match
+            // the types.
+            if (!strippedLHS->isEqual(lhs) || !strippedRHS->isEqual(rhs)) {
+              auto result = matchTypes(strippedLHS, strippedRHS, matchKind,
+                                       flags | TMF_ApplyingFix, locator);
+              if (!result.isFailure()) {
+                increaseScore(SK_MissingSynthesizableConformance, locator);
+                return true;
+              }
+            }
           }
         }
       }

--- a/test/Concurrency/witness_matching_with_sendable.swift
+++ b/test/Concurrency/witness_matching_with_sendable.swift
@@ -53,3 +53,18 @@ struct S4 : Q { // expected-error {{type 'S4' does not conform to protocol 'Q'}}
   func test(_: [() -> Any?]) {}
   // expected-note@-1 {{candidate has non-matching type '([() -> Any?]) -> ()'}}
 }
+
+// Test that client is allowed to adopt concurrency first.
+protocol PreConcurrency {
+  var prop: [String: Any] { get } // expected-swift6-note {{protocol requires property 'prop' with type '[String : Any]'}}
+  func req(_: [String: Any], _: ((Any)?) -> Void) // expected-swift6-note {{protocol requires function 'req' with type '([String : Any], (Any?) -> Void) -> ()'}}
+}
+
+class Adopter {
+  @preconcurrency var prop: [String: any Sendable] = [:] // expected-swift6-note {{candidate has non-matching type '[String : any Sendable]'}}
+}
+
+extension Adopter : PreConcurrency { // expected-swift6-error {{type 'Adopter' does not conform to protocol 'PreConcurrency'}} expected-swift6-note {{add stubs for conformance}}
+  @preconcurrency func req(_: [String: any Sendable], _: ((any Sendable)?) -> Void) {}
+  // expected-swift6-note@-1 {{candidate has non-matching type '([String : any Sendable], ((any Sendable)?) -> Void) -> ()'}}
+}


### PR DESCRIPTION
Allow witnesses to introduce `any Sendable` types into their interface before 
requirements (predicated on presence of `@preconcurrency` and Swift 5 
language mode) as a pathway for concurrency adoption.

Resolves: rdar://134503878

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
