### PR TITLE
Parse expression macro expansion buffers as expressions

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2095,6 +2095,8 @@ ERROR(unexpected_attribute_expansion,PointsToFirstBadToken,
 ERROR(unexpected_member_expansion,PointsToFirstBadToken,
       "unexpected token '%0' in expanded member list",
       (StringRef))
+ERROR(extra_tokens_after_expression,PointsToFirstBadToken,
+      "extra tokens after expression in macro expansion", ())
 
 ERROR(parser_round_trip_error,none,
       "source file did not round-trip through the new Swift parser", ())

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -180,10 +180,27 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
       break;
 
     case GeneratedSourceInfo::ExpressionMacroExpansion:
+    case GeneratedSourceInfo::DefaultArgument: {
+      // Prime the lexer.
+      if (parser.Tok.is(tok::NUM_TOKENS))
+        parser.consumeTokenWithoutFeedingReceiver();
+
+      ParserResult<Expr> resultExpr = parser.parseExpr(diag::expected_expr);
+      if (auto expr = resultExpr.getPtrOrNull())
+        items.push_back(expr);
+
+      if (!parser.Tok.is(tok::eof)) {
+        parser.diagnose(parser.Tok, diag::extra_tokens_after_expression);
+        while (!parser.Tok.is(tok::eof))
+          parser.consumeToken();
+      }
+
+      break;
+    }
+
     case GeneratedSourceInfo::PreambleMacroExpansion:
     case GeneratedSourceInfo::ReplacedFunctionBody:
-    case GeneratedSourceInfo::PrettyPrinted:
-    case GeneratedSourceInfo::DefaultArgument: {
+    case GeneratedSourceInfo::PrettyPrinted:{
       parser.parseTopLevelItems(items);
       break;
     }

--- a/test/Macros/macro_expand_other.swift
+++ b/test/Macros/macro_expand_other.swift
@@ -36,4 +36,9 @@ func testFreestandingExpansionOfOther() {
   #endif
 }
 
+@freestanding(expression)
+macro myLineMacro() -> Int = #line
+
+var thisLine = #myLineMacro
+
 testFreestandingExpansionOfOther()


### PR DESCRIPTION
This started out as a crash, where an expression macro could not be defined in terms of one of the builtin macros (e.g., `#line`), because we were expecting a macro expansion expression but didn't get one. Easy fix.

However, this uncovered a second bug, which is that we couldn't handle an expression macro expansino to `#line`. This is because we were parsing the macro expansion buffer as "top level items", which treats `#line` at the start of a line as a deprecated alias of `#sourceLocation`. Switch over to parsing a single expression in these contexts, and fix up an issue where `#isolation` didn't even have that expression.

Fixes rdar://139372780.
