### PR TITLE
Emit a relationship between a typealias and the referenced type(s)

### DIFF
--- a/test/Index/Store/record-sourcefile.swift
+++ b/test/Index/Store/record-sourcefile.swift
@@ -26,7 +26,7 @@
 // CHECK: instance-property/subscript/Swift | subscript(_:) | s:{{.*}} | <no-cgname> | Def,RelChild -
 // CHECK: instance-method/acc-get/Swift | getter:subscript(_:) | s:{{.*}} | <no-cgname> | Def,RelChild,RelAcc -
 // CHECK: protocol/Swift | P1 | s:{{.*}} | <no-cgname> | Def -
-// CHECK: type-alias/associated-type/Swift | AT | s:{{.*}} | <no-cgname> | Def,Ref,RelChild -
+// CHECK: type-alias/associated-type/Swift | AT | s:{{.*}} | <no-cgname> | Def,Ref,RelChild,RelCont -
 // CHECK: type-alias/Swift | TA | s:{{.*}} | <no-cgname> | Def,RelChild -
 // CHECK: class/Swift | C1 | s:{{.*}} | <no-cgname> | Def,Ref,RelBase,RelCont -
 // CHECK: instance-method/Swift | method() | s:{{.*}} | <no-cgname> | Def,Ref,Call,Dyn,RelChild,RelRec,RelCall,RelCont -
@@ -111,9 +111,10 @@ protocol P1 {
 // CHECK: [[@LINE+2]]:18 | type-alias/associated-type/Swift | s:{{.*}} | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | [[P1_USR]]
   associatedtype AT
-// CHECK: [[@LINE+3]]:13 | type-alias/Swift | s:{{.*}} | Def,RelChild | rel: 1
+// CHECK: [[@LINE+4]]:13 | type-alias/Swift | [[TA_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | [[P1_USR]]
-// CHECK: [[@LINE+1]]:18 | type-alias/associated-type/Swift | s:{{.*}} | Ref | rel: 0
+// CHECK: [[@LINE+2]]:18 | type-alias/associated-type/Swift | s:{{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | [[TA_USR]]
   typealias TA = AT
 }
 

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -86,8 +86,10 @@ class CompositionType: BaseMultiConf & P1 { // CHECK: [[@LINE]]:7 | class/Swift 
 }
 
 typealias CompositionTypeAlias = BaseMultiConf & P1 // CHECK: [[@LINE]]:11 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref | rel: 0
-  // CHECK: [[@LINE-2]]:50 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]]
+  // CHECK: [[@LINE-3]]:50 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]]
 
 class CompositionTypeViaAlias: CompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionTypeViaAlias | [[CompositionTypeViaAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:32 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
@@ -97,8 +99,10 @@ class CompositionTypeViaAlias: CompositionTypeAlias { // CHECK: [[@LINE]]:7 | cl
 }
 
 typealias NestedCompositionTypeAlias = CompositionTypeAlias & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:40 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
-  // CHECK: [[@LINE-2]]:63 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:40 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR]]
+  // CHECK: [[@LINE-3]]:63 | protocol/Swift | P2 | [[P2_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR]]
 
 class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionViaNestedAlias | [[CompositionViaNestedAlias_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:34 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR]] | Ref | rel: 0
@@ -109,8 +113,10 @@ class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]
 }
 
 typealias ProtocolsOnly = P1 & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR:.*]] | Def
-  // CHECK: [[@LINE-1]]:27 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
-  // CHECK: [[@LINE-2]]:32 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:27 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR]]
+  // CHECK: [[@LINE-3]]:32 | protocol/Swift | P2 | [[P2_USR]] | Ref,RelCont | rel: 1
+  // CHECK-NEXT: RelCont | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR]]
 
 class NoInherited {} // CHECK: [[@LINE]]:7 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Def
 extension NoInherited: ProtocolsOnly { // CHECK: [[@LINE]]:11 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Ref

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -164,7 +164,8 @@ extension AProtocol { func extFn() }
 // TypeAlias
 typealias SomeAlias = AStruct
 // CHECK: [[@LINE-1]]:11 | type-alias/Swift | SomeAlias | s:14swift_ide_test9SomeAliasa | Def | rel: 0
-// CHECK: [[@LINE-2]]:23 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Ref | rel: 0
+// CHECK: [[@LINE-2]]:23 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | type-alias/Swift | SomeAlias | s:14swift_ide_test9SomeAliasa 
 
 // GenericTypeParam
 struct GenericStruct<ATypeParam> {}


### PR DESCRIPTION
I've opted to use RelationContains, but I'm not really tied to it. I'm open to any other relation if something else works better.

It is helpful to connect the type(s) referenced in a typealias declaration back to that declaration. The references were already emitted but didn't have any connection to how they were being used in the file. This is kind of like how a type conforming to a protocol emits a relationship so that the reference can be connected to the declaration.

This change allows analysis and IDE support to definitively verify that a type reference is part of a typealias.