### PR TITLE
Sema: Fix `-disable-availability-checking`

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -276,11 +276,9 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     FrontendStatsTracer tracer(Ctx.Stats,
                                "Type checking and Semantic analysis");
 
-    if (!Ctx.LangOpts.DisableAvailabilityChecking) {
-      // Build the type refinement hierarchy for the primary
-      // file before type checking.
-      TypeChecker::buildTypeRefinementContextHierarchy(*SF);
-    }
+    // Build the type refinement hierarchy for the primary
+    // file before type checking.
+    TypeChecker::buildTypeRefinementContextHierarchy(*SF);
 
     // Type check the top-level elements of the source file.
     for (auto D : SF->getTopLevelDecls()) {

--- a/test/ModuleInterface/sil-opt-availability.swift
+++ b/test/ModuleInterface/sil-opt-availability.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-module %s -enable-library-evolution -swift-version 5 -module-name Library -emit-module-interface-path %t/Library.swiftinterface -o %t/Library.swiftmodule
+
+// RUN: echo "import Library" > %t/Client.swift
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -module-name Client -o %t/Client.swiftmodule -I %t
+
+// RUN: rm %t/Library.swiftmodule
+// RUN: %target-sil-opt -enable-sil-verify-all %t/Client.swiftmodule -module-name Client
+
+@available(*, unavailable)
+public struct Unavailable {}
+
+@available(*, unavailable)
+public func usesUnavailable(_ u: Unavailable) {}

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -86,15 +86,3 @@ struct DeferBody {
     // expected-error@-1 {{'No' is unavailable}}
   }
 }
-
-struct NotP {}
-
-protocol P {}
-
-@available(*, unavailable)
-extension NotP: P {} // expected-note {{conformance of 'NotP' to 'P' has been explicitly marked unavailable here}}
-
-@available(SwiftStdlib 5.1, *)
-func requireP() -> some P {
-  NotP() // expected-error {{conformance of 'NotP' to 'P' is unavailable}}
-}

--- a/test/type/opaque_availability.swift
+++ b/test/type/opaque_availability.swift
@@ -1,13 +1,21 @@
-// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.9 -typecheck -verify %s
-// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.15 -typecheck %s
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.9 -typecheck %s -verify -verify-additional-prefix only-available-
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.15 -typecheck %s -verify
 // REQUIRES: OS=macosx
 
 protocol P {}
 struct X: P {}
 
-func alwaysOpaque() -> some P { return X() } // expected-error{{'some' return types are only available}} expected-note{{add @available}}
+func alwaysOpaque() -> some P { return X() } // expected-only-available-error{{'some' return types are only available}} expected-only-available-note{{add @available}}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 func sometimesOpaque() -> some P { return X() }
 
+struct NotP {}
 
+@available(*, unavailable)
+extension NotP: P {} // expected-note {{conformance of 'NotP' to 'P' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func requireP() -> some P {
+  NotP() // expected-error {{conformance of 'NotP' to 'P' is unavailable}}
+}


### PR DESCRIPTION
Suppression of diagnostics about use of unavailable declarations in equivalently unavailable contexts now relies on querying the `TypeRefinementContext` hierarchy. Generation of the `TypeRefinementContext` tree was suppressed when `-disable-availability-checking` was specified, though, causing some unavailability diagnostics to be emitted when they ought to be suppressed.

Instead of refusing to generate a `TypeRefinementContext` hierarchy, instead just avoid populating nodes for `if #available` checks for OS versions since these checks are meant to have no effect when `-disable-availability-checking` is specified.

Resolves rdar://138987918.