### PR TITLE
[Test] Fix assertion failure building demangleToMetadata.swift.

### DIFF
--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -568,9 +568,7 @@ if #available(SwiftStdlib 6.0, *) {
 
 if #available(SwiftStdlib 6.1, *) {
   DemangleToMetadataTests.test("NUL-terminated name, excessive length value") {
-    let t = _getTypeByMangledNameInContext("4main1SV", 256,
-                                           genericContext: nil,
-                                           genericArguments: nil)
+    let t = _typeByName("4main1SV\0random stuff here")
     expectNotNil(t)
     if let t {
       expectEqual(type(of: S()), t)


### PR DESCRIPTION
The direct call to _getTypeByMangledName made the compiler angry when doing an optimizd simulator build. Instead, use _typeByName with a string that has an embedded NUL to achieve the same effect.

rdar://139264622