### PR TITLE
Distributed: allow @resolvable with primary associated types

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -130,7 +130,7 @@ extension DistributedResolvableMacro {
       return []
     }
 
-    var isGenericStub = false
+    var isGenericOverActorSystem = false
     var specificActorSystemRequirement: TypeSyntax?
 
     let accessModifiers = proto.accessControlModifiers
@@ -140,7 +140,7 @@ extension DistributedResolvableMacro {
       case .conformanceRequirement(let conformanceReq)
            where conformanceReq.leftType.isActorSystem:
         specificActorSystemRequirement = conformanceReq.rightType.trimmed
-        isGenericStub = true
+        isGenericOverActorSystem = true
 
       case .sameTypeRequirement(let sameTypeReq):
         switch sameTypeReq.leftType {
@@ -148,7 +148,7 @@ extension DistributedResolvableMacro {
           switch sameTypeReq.rightType.trimmed {
           case .type(let rightType):
             specificActorSystemRequirement = rightType
-            isGenericStub = false
+            isGenericOverActorSystem = false
 
           case .expr:
             throw DiagnosticsError(
@@ -167,41 +167,78 @@ extension DistributedResolvableMacro {
       }
     }
 
-    if isGenericStub, let specificActorSystemRequirement {
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed)<ActorSystem>: \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-          where ActorSystem: \(specificActorSystemRequirement) 
-        { }
-        """
-      ]
-    } else if let specificActorSystemRequirement {
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed): \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-        { 
-          \(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement)) 
-        }
-        """
-      ]
-    } else {
-      // there may be no `where` clause specifying an actor system,
-      // but perhaps there is a typealias (or extension with a typealias),
-      // specifying a concrete actor system so we let this synthesize
-      // an empty `$Greeter` -- this may fail, or succeed depending on
-      // surrounding code using a default distributed actor system,
-      // or extensions providing it.
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed): \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-        {
-        }
-        """
-      ]
+    var primaryAssociatedTypes: [PrimaryAssociatedTypeSyntax] = []
+    if let primaryTypes = proto.primaryAssociatedTypeClause?.primaryAssociatedTypes {
+      primaryAssociatedTypes.append(contentsOf: primaryTypes)
     }
+
+    // The $Stub is always generic over the actor system: $Stub<ActorSystem>
+    var primaryTypeParams: [String] = primaryAssociatedTypes.map {
+      $0.as(PrimaryAssociatedTypeSyntax.self)!.name.trimmed.text
+    }
+
+    // Don't duplicate the ActorSystem type parameter if it already was declared
+    // on the protocol as a primary associated type;
+    // otherwise, add it as first primary associated type.
+    let actorSystemTypeParam: [String] =
+      if primaryTypeParams.contains("ActorSystem") {
+        []
+      } else if isGenericOverActorSystem {
+        ["ActorSystem"]
+      } else {
+        []
+      }
+
+    // Prepend the actor system type parameter, as we want it to be the first one
+    primaryTypeParams = actorSystemTypeParam + primaryTypeParams
+    let typeParamsClause =
+      primaryTypeParams.isEmpty ? "" : "<" + primaryTypeParams.joined(separator: ", ") + ">"
+
+    var whereClause: String = ""
+    do {
+      let associatedTypeDecls = proto.associatedTypeDecls
+      var typeParamConstraints: [String] = []
+      for typeParamName in primaryTypeParams {
+        if let decl = associatedTypeDecls[typeParamName] {
+          if let inheritanceClause = decl.inheritanceClause {
+            typeParamConstraints.append("\(typeParamName)\(inheritanceClause)")
+          }
+        }
+      }
+
+      if isGenericOverActorSystem, let specificActorSystemRequirement {
+        typeParamConstraints = ["ActorSystem: \(specificActorSystemRequirement)"] + typeParamConstraints
+      }
+      
+      if !typeParamConstraints.isEmpty {
+        whereClause += "\n  where " + typeParamConstraints.joined(separator: ",\n  ")
+      }
+    }
+
+    let stubActorBody: String =
+      if isGenericOverActorSystem {
+        // there may be no `where` clause specifying an actor system,
+        // but perhaps there is a typealias (or extension with a typealias),
+        // specifying a concrete actor system so we let this synthesize
+        // an empty `$Greeter` -- this may fail, or succeed depending on
+        // surrounding code using a default distributed actor system,
+        // or extensions providing it.
+        ""
+      } else if let specificActorSystemRequirement {
+        "\(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement))"
+      } else {
+        ""
+      }
+
+    return [
+      """
+      \(proto.modifiers) distributed actor $\(proto.name.trimmed)\(raw: typeParamsClause): \(proto.name.trimmed), 
+        Distributed._DistributedActorStub \(raw: whereClause)
+      {
+        \(raw: stubActorBody)
+      }
+      """
+    ]
   }
 
   private static func typealiasActorSystem(access: DeclModifierListSyntax,
@@ -249,6 +286,23 @@ extension DeclModifierSyntax {
       return true
     default:
       return false
+    }
+  }
+}
+
+extension ProtocolDeclSyntax {
+  var associatedTypeDecls: [String: AssociatedTypeDeclSyntax] {
+    let visitor = AssociatedTypeDeclVisitor(viewMode: .all)
+    visitor.walk(self)
+    return visitor.associatedTypeDecls
+  }
+
+  final class AssociatedTypeDeclVisitor: SyntaxVisitor {
+    var associatedTypeDecls: [String: AssociatedTypeDeclSyntax] = [:]
+
+    override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
+      associatedTypeDecls[node.name.text] = node
+      return .skipChildren
     }
   }
 }

--- a/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
+++ b/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
@@ -14,7 +14,6 @@
 
 import Distributed
 
-
 // ==== Fake Transport ---------------------------------------------------------
 
 struct ActorAddress: Hashable, Sendable, Codable {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_primary_associatedtype.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_primary_associatedtype.swift
@@ -1,0 +1,69 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s 2>&1 | %FileCheck %s
+
+import Distributed
+
+typealias System = LocalTestingDistributedActorSystem
+
+@Resolvable
+protocol Base<Fruit>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  distributed func get() -> Fruit
+}
+// CHECK: distributed actor $Base<ActorSystem, Fruit>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable
+// CHECK-NEXT: {
+// CHECK: }
+
+@Resolvable
+protocol Base2<Fruit, Animal>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base2<ActorSystem, Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable
+// CHECK-NEXT: {
+// CHECK: }
+
+@Resolvable
+protocol Base3<Fruit, Animal>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable & Hashable
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base3<ActorSystem, Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable & Hashable
+// CHECK-NEXT: {
+// CHECK: }
+
+/// This type is not generic over the actor system because of the == constraint:
+@Resolvable
+protocol Base4<Fruit, Animal>: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem{
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable & Hashable
+
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base4<Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable & Hashable
+// CHECK-NEXT: {
+// CHECK: }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -22,7 +22,7 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 // CHECK-NEXT: Distributed._DistributedActorStub
 // CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK-NEXT: {
-// CHECK-NEXT: }
+// CHECK: }
 
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK-NEXT:   distributed func greet(name: String) -> String {

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
@@ -23,6 +23,19 @@ protocol GreeterProtocol: DistributedActor where ActorSystem: DistributedActorSy
   distributed func greet() -> String
 }
 
+protocol FruitProtocol: Codable {}
+struct Watermelon: FruitProtocol {}
+
+protocol AnimalProtocol: Codable {}
+struct Capybara: AnimalProtocol {}
+
+@Resolvable
+protocol FeederProtocol<Fruit, Animal>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: FruitProtocol
+  associatedtype Animal: AnimalProtocol
+  distributed func give(fruit: Fruit, to animal: Animal)
+}
+
 // ==== ------------------------------------------------------------------------
 
 distributed actor DAFR: GreeterProtocol {
@@ -35,9 +48,17 @@ distributed actor DAFL: GreeterProtocol {
   distributed func greet() -> String { "\(Self.self)" }
 }
 
+distributed actor Feeder: FeederProtocol {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  distributed func give(fruit: Watermelon, to animal: Capybara) {
+    // fake impl
+  }
+}
+
 @main struct Main {
   static func main() async throws {
     let fakeRoundtripSystem = FakeRoundtripActorSystem()
+
     let fr = DAFR(actorSystem: fakeRoundtripSystem)
     let frid = fr.id
     _ = DAFL(actorSystem: .init())


### PR DESCRIPTION
This allows @Resolvable to work with primary associated types in protocols.

resolves rdar://139332556