### PR TITLE
[cxx-interop] Disambiguate template instantiations with parameter packs

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/class-template-variadic.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-variadic.h
@@ -25,6 +25,9 @@ struct IntWrapper {
   int getValue() const { return value; }
 };
 
+typedef Tuple<IntWrapper> Single;
 typedef Tuple<IntWrapper, IntWrapper> Pair;
+typedef Tuple<IntWrapper, IntWrapper, IntWrapper> Triple;
+typedef Tuple<Tuple<IntWrapper, IntWrapper>, Tuple<IntWrapper, IntWrapper>> Nested;
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_VARIADIC_H

--- a/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
@@ -1,11 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateInNamespace -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum Space {
-// CHECK:   struct Ship<_> {
-// CHECK:     init()
-// CHECK:   }
 // CHECK:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK:   struct Ship<> {
 // CHECK:   }
-// CHECK:   typealias Orbiter = Space.Ship<_>
+// CHECK:   typealias Orbiter = Space.Ship<((CBool) -> Void)>
 // CHECK: }

--- a/test/Interop/Cxx/templates/class-template-variardic-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-variardic-parameter-module-interface.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: @available(*, unavailable
+// CHECK: struct Tuple<Ts> {
+// CHECK: }
+
+// CHECK: typealias Single = Tuple<IntWrapper>
+// CHECK: typealias Pair = Tuple<IntWrapper, IntWrapper>
+// CHECK: typealias Triple = Tuple<IntWrapper, IntWrapper, IntWrapper>
+// CHECK: typealias Nested = Tuple<Tuple<IntWrapper, IntWrapper>, Tuple<IntWrapper, IntWrapper>>


### PR DESCRIPTION
This makes sure that different template instantiations of `std::tuple` get distinct Swift type names.

Similar to aa6804a3.

This also refactors `swift::importer::printClassTemplateSpecializationName` to follow a proper visitor pattern for the C++ template arguments.

rdar://139435937

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
