### PR TITLE
Sema: Report public imports of private modules as errors by default

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2411,16 +2411,9 @@ public:
         } else
           inFlight.fixItInsert(ID->getStartLoc(), "internal ");
 
-#ifndef NDEBUG
-        static bool enableTreatAsError = true;
-#else
-        static bool enableTreatAsError = getenv("ENABLE_PUBLIC_IMPORT_OF_PRIVATE_AS_ERROR");
-#endif
-
         bool isImportOfUnderlying = importer->getName() == target->getName();
         auto *SF = ID->getDeclContext()->getParentSourceFile();
-        bool treatAsError = enableTreatAsError &&
-                            !isImportOfUnderlying &&
+        bool treatAsError = !isImportOfUnderlying &&
                             SF->Kind != SourceFileKind::Interface;
         if (!treatAsError)
           inFlight.limitBehavior(DiagnosticBehavior::Warning);


### PR DESCRIPTION
Align the behavior between release and debug compilers to always report this as an error. Downstream compilers already make this an error.

The release behavior is already tested since https://github.com/swiftlang/swift/pull/76386/commits/20b4187e25fbff0da11894fa264edb4323a7a9d6. That test will be fixed by this PR.

rdar://136041870