### PR TITLE
[cxx-interop] Refactoring reference semantic check for c++ records

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -353,7 +353,7 @@ SourceLoc extractNearestSourceLoc(CxxRecordSemanticsDescriptor desc);
 ///
 /// Do not evaluate this request before importing has started. For example, it
 /// is OK to invoke this request when importing a decl, but it is not OK to
-/// import this request when importing names. This is because when importing
+/// evaluate this request when importing names. This is because when importing
 /// names, Clang sema has not yet defined implicit special members, so the
 /// results will be flakey/incorrect.
 class CxxRecordSemantics

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -156,14 +156,10 @@ bool ClangImporter::Implementation::recordHasReferenceSemantics(
   if (!isa<clang::CXXRecordDecl>(decl) && !ctx.LangOpts.CForeignReferenceTypes)
     return false;
 
-  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_reference" ||
-                    // TODO: Remove this once libSwift hosttools no longer
-                    // requires it.
-                    swiftAttr->getAttribute() == "import_as_ref";
-           return false;
-         });
+  auto semanticsKind =
+      evaluateOrDefault(ctx.evaluator,
+                        CxxRecordSemantics({decl, ctx}), {});
+  return semanticsKind == CxxRecordSemanticsKind::Reference;
 }
 
 #ifndef NDEBUG


### PR DESCRIPTION
Minor refactoring so that we avoid code duplication in checking whether clang::RecordDecl has reference semantics.