### PR TITLE
[Dependency Scanning] Copy the set of already-seen clang modules before parallel Clang identifier query

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -35,21 +35,17 @@ public:
       DependencyTracker &DependencyTracker, DiagnosticEngine &diags);
 
 private:
-  /// Retrieve the module dependencies for the module with the given name.
-  ModuleDependencyVector
-  scanFilesystemForModuleDependency(Identifier moduleName,
-                                    const ModuleDependenciesCache &cache,
-                                    bool isTestableImport = false);
-
   /// Retrieve the module dependencies for the Clang module with the given name.
   ModuleDependencyVector
   scanFilesystemForClangModuleDependency(Identifier moduleName,
-                                         const ModuleDependenciesCache &cache);
+                                         StringRef moduleOutputPath,
+                                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenModules,
+                                         llvm::PrefixMapper *prefixMapper);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
   ModuleDependencyVector
-  scanFilesystemForSwiftModuleDependency(Identifier moduleName,
-                                         const ModuleDependenciesCache &cache,
+  scanFilesystemForSwiftModuleDependency(Identifier moduleName, StringRef moduleOutputPath,
+                                         llvm::PrefixMapper *prefixMapper,
                                          bool isTestableImport = false);
 
   // Worker-specific instance of CompilerInvocation


### PR DESCRIPTION
This set, belonging to 'ModuleDependenciesCache', is only updated in a critical section behind a lock in the scanner. However, it is queried unsynchronized inside the Clang scanner itself. If an update causes a re-hash to happen, chaose can ensue with concurrent lookups.

Since this set only affects the produced set of results from teh Clang scanning query, we should simply pass in an immutable copy to scanning queries and rely on downstream de-duplication of scanning results.

Resolves rdar://139414443
