### PR TITLE
[Concurrency] Fix preconcurrency downgrade behavior for `Sendable` closures and generic requirements.

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -686,6 +686,30 @@ namespace swift {
     InFlightDiagnostic &limitBehaviorUntilSwiftVersion(
         DiagnosticBehavior limit, unsigned majorVersion);
 
+    /// Limits the diagnostic behavior to \c limit accordingly if
+    /// preconcurrency applies. Otherwise, the behavior limit only applies
+    /// prior to the given language mode.
+    ///
+    /// `@preconcurrency` applied to a nominal declaration or an import
+    /// statement will limit concurrency diagnostic behavior based on the
+    /// strict concurrency checking level. Under minimal checking,
+    /// preconcurrency will suppress the diagnostics. With strict concurrency
+    /// checking, including when building with the Swift 6 language mode,
+    /// preconcurrency errors are downgraded to warnings. This allows libraries
+    /// to stage in concurrency annotations even after their clients have
+    /// migrated to Swift 6 using `@preconcurrency` alongside the newly added
+    /// `@Sendable` or `@MainActor` annotations.
+    InFlightDiagnostic
+    &limitBehaviorWithPreconcurrency(DiagnosticBehavior limit,
+                                     bool preconcurrency,
+                                     unsigned languageMode = 6) {
+      if (preconcurrency) {
+        return limitBehavior(limit);
+      }
+
+      return limitBehaviorUntilSwiftVersion(limit, languageMode);
+    }
+
     /// Limit the diagnostic behavior to warning until the specified version.
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -294,10 +294,16 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
 
   // For a @preconcurrency callee outside of a strict concurrency
   // context, ignore.
-  if (cs.hasPreconcurrencyCallee(locator) &&
-      !contextRequiresStrictConcurrencyChecking(
-          cs.DC, GetClosureType{cs}, ClosureIsolatedByPreconcurrency{cs}))
+  if (cs.hasPreconcurrencyCallee(locator)) {
+    // Preconcurrency failures are always downgraded to warnings, even in
+    // Swift 6 mode.
+    if (contextRequiresStrictConcurrencyChecking(
+            cs.DC, GetClosureType{cs}, ClosureIsolatedByPreconcurrency{cs})) {
+      return FixBehavior::DowngradeToWarning;
+    }
+
     return FixBehavior::Suppress;
+  }
 
   // Otherwise, warn until Swift 6.
   if (!cs.getASTContext().LangOpts.isSwiftVersionAtLeast(6))

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -53,7 +53,8 @@ concreteSyntaxDeclForAvailableAttribute(const Decl *AbstractSyntaxDecl);
 static bool diagnoseExplicitUnavailability(
     SourceLoc loc, const RootProtocolConformance *rootConf,
     const ExtensionDecl *ext, const ExportContext &where,
-    bool warnIfConformanceUnavailablePreSwift6 = false);
+    bool warnIfConformanceUnavailablePreSwift6 = false,
+    bool preconcurrency = false);
 
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
@@ -2986,7 +2987,8 @@ getExplicitUnavailabilityDiagnosticInfo(const Decl *decl,
 bool diagnoseExplicitUnavailability(
     SourceLoc loc, const RootProtocolConformance *rootConf,
     const ExtensionDecl *ext, const ExportContext &where,
-    bool warnIfConformanceUnavailablePreSwift6) {
+    bool warnIfConformanceUnavailablePreSwift6,
+    bool preconcurrency) {
   // Invertible protocols are never unavailable.
   if (rootConf->getProtocol()->getInvertibleProtocolKind())
     return false;
@@ -3012,7 +3014,7 @@ bool diagnoseExplicitUnavailability(
   diags
       .diagnose(loc, diag::conformance_availability_unavailable, type, proto,
                 platform.empty(), platform, EncodedMessage.Message)
-      .limitBehaviorUntilSwiftVersion(behavior, 6)
+      .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
       .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
 
   switch (diagnosticInfo->getStatus()) {
@@ -4641,7 +4643,8 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       // FIXME: diagnoseExplicitUnavailability() should take unmet requirement
       if (diagnoseExplicitUnavailability(
               loc, rootConf, ext, where,
-              warnIfConformanceUnavailablePreSwift6)) {
+              warnIfConformanceUnavailablePreSwift6,
+              preconcurrency)) {
         maybeEmitAssociatedTypeNote();
         return true;
       }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -230,7 +230,8 @@ diagnoseConformanceAvailability(SourceLoc loc,
                                 const ExportContext &context,
                                 Type depTy=Type(),
                                 Type replacementTy=Type(),
-                                bool warnIfConformanceUnavailablePreSwift6 = false);
+                                bool warnIfConformanceUnavailablePreSwift6 = false,
+                                bool preconcurrency = false);
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1237,9 +1237,10 @@ bool swift::diagnoseNonSendableTypesInReference(
 }
 
 void swift::diagnoseMissingSendableConformance(
-    SourceLoc loc, Type type, const DeclContext *fromDC) {
+    SourceLoc loc, Type type, const DeclContext *fromDC, bool preconcurrency) {
+  SendableCheckContext sendableContext(fromDC, preconcurrency);
   diagnoseNonSendableTypes(
-      type, fromDC, /*inDerivedConformance*/Type(),
+      type, sendableContext, /*inDerivedConformance*/Type(),
       loc, diag::non_sendable_type);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -779,7 +779,10 @@ static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
   });
 }
 
-bool SendableCheckContext::isExplicitSendableConformance() const {
+bool SendableCheckContext::warnInMinimalChecking() const {
+  if (preconcurrencyContext)
+    return false;
+
   if (!conformanceCheck)
     return false;
 
@@ -797,7 +800,7 @@ bool SendableCheckContext::isExplicitSendableConformance() const {
 DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
   // If we're not supposed to diagnose existing data races from this context,
   // ignore the diagnostic entirely.
-  if (!isExplicitSendableConformance() &&
+  if (!warnInMinimalChecking() &&
       !shouldDiagnoseExistingDataRaces(fromDC))
     return DiagnosticBehavior::Ignore;
 
@@ -816,9 +819,7 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
     LLVM_FALLTHROUGH;
 
   case StrictConcurrency::Minimal:
-    // Explicit Sendable conformances always diagnose, even when strict
-    // strict checking is disabled.
-    if (isExplicitSendableConformance())
+    if (warnInMinimalChecking())
       return DiagnosticBehavior::Warning;
 
     return DiagnosticBehavior::Ignore;
@@ -832,6 +833,13 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 /// nominal type.
 DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     NominalTypeDecl *nominal) const {
+  // If we're in a preconcurrency context, don't override the default behavior
+  // based on explicit conformances. For example, a @preconcurrency @Sendable
+  // closure should not warn about an explicitly unavailable Sendable
+  // conformance in minimal checking.
+  if (preconcurrencyContext)
+    return defaultDiagnosticBehavior();
+
   if (hasExplicitSendableConformance(nominal))
     return DiagnosticBehavior::Warning;
 
@@ -2759,11 +2767,16 @@ namespace {
           continue;
 
         auto *closure = localFunc.getAbstractClosureExpr();
+        auto *explicitClosure = dyn_cast_or_null<ClosureExpr>(closure);
+
+        bool preconcurrency = false;
+        if (explicitClosure) {
+          preconcurrency = explicitClosure->isIsolatedByPreconcurrency();
+        }
 
         // Diagnose a `self` capture inside an escaping `sending`
         // `@Sendable` closure in a deinit, which almost certainly
         // means `self` would escape deinit at runtime.
-        auto *explicitClosure = dyn_cast_or_null<ClosureExpr>(closure);
         auto *dc = getDeclContext();
         if (explicitClosure && isa<DestructorDecl>(dc) &&
             !explicitClosure->getType()->isNoEscape() &&
@@ -2773,7 +2786,8 @@ namespace {
           if (var && var->isSelfParameter()) {
             ctx.Diags.diagnose(explicitClosure->getLoc(),
                                diag::self_capture_deinit_task)
-                .warnUntilSwiftVersion(6);
+                .limitBehaviorWithPreconcurrency(DiagnosticBehavior::Warning,
+                                                 preconcurrency);
           }
         }
 
@@ -2801,6 +2815,9 @@ namespace {
         if (type->hasError())
           continue;
 
+        SendableCheckContext sendableContext(getDeclContext(),
+                                             preconcurrency);
+
         if (closure && closure->isImplicit()) {
           auto *patternBindingDecl = getTopPatternBindingDecl();
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
@@ -2811,20 +2828,20 @@ namespace {
 
           // Fallback to a generic implicit capture missing sendable
           // conformance diagnostic.
-          diagnoseNonSendableTypes(type, getDeclContext(),
+          diagnoseNonSendableTypes(type, sendableContext,
                                    /*inDerivedConformance*/Type(),
                                    capture.getLoc(),
                                    diag::implicit_non_sendable_capture,
                                    decl->getName());
         } else if (fnType->isSendable()) {
-          diagnoseNonSendableTypes(type, getDeclContext(),
+          diagnoseNonSendableTypes(type, sendableContext,
                                    /*inDerivedConformance*/Type(),
                                    capture.getLoc(),
                                    diag::non_sendable_capture,
                                    decl->getName(),
                                    /*closure=*/closure != nullptr);
         } else {
-          diagnoseNonSendableTypes(type, getDeclContext(),
+          diagnoseNonSendableTypes(type, sendableContext,
                                    /*inDerivedConformance*/Type(),
                                    capture.getLoc(),
                                    diag::non_sendable_isolated_capture,
@@ -4066,7 +4083,12 @@ namespace {
       if (!mayExecuteConcurrentlyWith(dc, findCapturedDeclContext(value)))
         return false;
 
-      SendableCheckContext sendableBehavior(dc);
+      bool preconcurrency = false;
+      if (auto *closure = dyn_cast<ClosureExpr>(dc)) {
+        preconcurrency = closure->isIsolatedByPreconcurrency();
+      }
+
+      SendableCheckContext sendableBehavior(dc, preconcurrency);
       auto limit = sendableBehavior.defaultDiagnosticBehavior();
 
       // Check whether this is a local variable, in which case we can
@@ -4096,7 +4118,7 @@ namespace {
             ctx.Diags
                 .diagnose(loc, diag::concurrent_access_of_inout_param,
                           param->getName())
-                .limitBehaviorUntilSwiftVersion(limit, 6);
+                .limitBehaviorWithPreconcurrency(limit, preconcurrency);
             return true;
           }
         }
@@ -4111,7 +4133,7 @@ namespace {
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),
             var)
-          .limitBehaviorUntilSwiftVersion(limit, 6);
+          .limitBehaviorWithPreconcurrency(limit, preconcurrency);
         return true;
       }
 
@@ -4121,7 +4143,7 @@ namespace {
 
         func->diagnose(diag::local_function_executed_concurrently, func)
           .fixItInsert(func->getAttributeInsertionLoc(false), "@Sendable ")
-          .limitBehaviorUntilSwiftVersion(limit, 6);
+          .limitBehaviorWithPreconcurrency(limit, preconcurrency);
 
         // Add the @Sendable attribute implicitly, so we don't diagnose
         // again.
@@ -4131,7 +4153,8 @@ namespace {
       }
 
       // Concurrent access to some other local.
-      ctx.Diags.diagnose(loc, diag::concurrent_access_local, value);
+      ctx.Diags.diagnose(loc, diag::concurrent_access_local, value)
+        .limitBehaviorWithPreconcurrency(limit, preconcurrency);
       value->diagnose(
           diag::kind_declared_here, value->getDescriptiveKind());
       return true;
@@ -6194,7 +6217,8 @@ bool swift::contextRequiresStrictConcurrencyChecking(
     const DeclContext *dc,
     llvm::function_ref<Type(const AbstractClosureExpr *)> getType,
     llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency) {
-  switch (dc->getASTContext().LangOpts.StrictConcurrencyLevel) {
+  auto concurrencyLevel = dc->getASTContext().LangOpts.StrictConcurrencyLevel;
+  switch (concurrencyLevel) {
   case StrictConcurrency::Complete:
     return true;
 
@@ -6214,7 +6238,20 @@ bool swift::contextRequiresStrictConcurrencyChecking(
 
         // Don't take any more cues if this only got its type information by
         // being provided to a `@preconcurrency` operation.
+        //
+        // FIXME: contextRequiresStrictConcurrencyChecking is called from
+        // within the constraint system, but closures are only set to be isolated
+        // by preconcurrency in solution application because it's dependent on
+        // overload resolution. The constraint system either needs to check its
+        // own state on the current path, or not make type inference decisions based
+        // on concurrency checking level.
         if (isolatedByPreconcurrency(explicitClosure)) {
+          // If we're in minimal checking, preconcurrency always suppresses
+          // diagnostics. Targeted checking will still produce diagnostics if
+          // the outer context has adopted explicit concurrency features.
+          if (concurrencyLevel == StrictConcurrency::Minimal)
+            return false;
+
           dc = dc->getParent();
           continue;
         }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -324,7 +324,7 @@ bool diagnoseNonSendableTypesInReference(
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(
-    SourceLoc loc, Type type, const DeclContext *fromDC);
+    SourceLoc loc, Type type, const DeclContext *fromDC, bool preconcurrency);
 
 /// If the given nominal type is public and does not explicitly
 /// state whether it conforms to Sendable, provide a diagnostic.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -378,12 +378,23 @@ static inline bool isImplicitSendableCheck(SendableCheck check) {
 /// Describes the context in which a \c Sendable check occurs.
 struct SendableCheckContext {
   const DeclContext * const fromDC;
+  bool preconcurrencyContext;
   const std::optional<SendableCheck> conformanceCheck;
 
   SendableCheckContext(
       const DeclContext *fromDC,
       std::optional<SendableCheck> conformanceCheck = std::nullopt)
-      : fromDC(fromDC), conformanceCheck(conformanceCheck) {}
+      : fromDC(fromDC),
+        preconcurrencyContext(false),
+        conformanceCheck(conformanceCheck) {}
+
+  SendableCheckContext(
+      const DeclContext *fromDC,
+      bool preconcurrencyContext,
+      std::optional<SendableCheck> conformanceCheck = std::nullopt)
+      : fromDC(fromDC),
+        preconcurrencyContext(preconcurrencyContext),
+        conformanceCheck(conformanceCheck) {}
 
   /// Determine the default diagnostic behavior for a missing/unavailable
   /// Sendable conformance in this context.
@@ -400,8 +411,8 @@ struct SendableCheckContext {
       Decl *decl,
       bool ignoreExplicitConformance = false) const;
 
-  /// Whether we are in an explicit conformance to Sendable.
-  bool isExplicitSendableConformance() const;
+  /// Whether to warn about a Sendable violation even in minimal checking.
+  bool warnInMinimalChecking() const;
 };
 
 /// Diagnose any non-Sendable types that occur within the given type, using
@@ -447,11 +458,14 @@ bool diagnoseNonSendableTypes(
   return diagnoseNonSendableTypes(
       type, fromContext, derivedConformance, typeLoc,
       [&](Type specificType, DiagnosticBehavior behavior) {
+        // FIXME: Reconcile preconcurrency declaration vs preconcurrency
+        // import behavior.
         auto preconcurrency =
           fromContext.preconcurrencyBehavior(specificType->getAnyNominal());
 
         ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
-            .limitBehaviorUntilSwiftVersion(behavior, 6)
+            .limitBehaviorWithPreconcurrency(behavior,
+                                             fromContext.preconcurrencyContext)
             .limitBehaviorIf(preconcurrency);
 
         return (behavior == DiagnosticBehavior::Ignore ||

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -21,12 +21,12 @@ class NotSendable {}
 @MainActor func testWarnings() {
   var x = 0
   _ = AsyncStream {
-    x += 1 // expected-warning {{mutation of captured var 'x' in concurrently-executing code; this is an error in the Swift 6 language mode}}
+    x += 1 // expected-warning {{mutation of captured var 'x' in concurrently-executing code}}
     return 0
   }
 
   _ = AsyncThrowingStream {
-    x += 1 // expected-warning {{mutation of captured var 'x' in concurrently-executing code; this is an error in the Swift 6 language mode}}
+    x += 1 // expected-warning {{mutation of captured var 'x' in concurrently-executing code}}
     return
   }
 }

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -1,10 +1,8 @@
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=minimal
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted -verify-additional-prefix targeted-complete-
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_RegionBasedIsolation
 
 @preconcurrency @MainActor func f() { }
 // expected-note @-1 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
@@ -31,7 +29,7 @@ func test() {
   var mutableVariable = 0
   preconcurrencyFunc {
     mutableVariable += 1 // no sendable warning unless we have complete
-    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in the Swift 6 language mode}}
+    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code}}
   }
   mutableVariable += 1
 }
@@ -49,7 +47,7 @@ func testAsync() async {
 
   var mutableVariable = 0
   preconcurrencyFunc {
-    mutableVariable += 1 // expected-warning{{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in the Swift 6 language mode}}
+    mutableVariable += 1 // expected-targeted-complete-warning{{mutation of captured var 'mutableVariable' in concurrently-executing code}}
   }
   mutableVariable += 1
 }

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -198,7 +198,7 @@ func requireSendable<T: Sendable>(_: T) {}
 @preconcurrency
 struct RequireSendable<T: Sendable> {}
 
-class NotSendable {} // expected-note 2 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+class NotSendable {} // expected-note 4 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
 typealias T = RequireSendable<NotSendable>
 // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
@@ -206,4 +206,25 @@ typealias T = RequireSendable<NotSendable>
 func testRequirementDowngrade(ns: NotSendable) {
   requireSendable(ns)
   // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+}
+
+
+protocol P2 {}
+
+extension NotSendable: P2 {}
+
+@preconcurrency
+func requireSendableExistential(_: any P2 & Sendable) {}
+
+func requireSendableExistentialAlways(_: any P2 & Sendable) {}
+
+func testErasureDowngrade(ns: NotSendable) {
+  requireSendableExistential(ns)
+  // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+  withSendableClosure {
+    let ns = NotSendable()
+    requireSendableExistentialAlways(ns)
+    // expected-error@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+  }
 }

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -191,3 +191,19 @@ func conversionDowngrade() {
   withSendableClosure(ns)
   // expected-warning@-1 {{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
 }
+
+@preconcurrency
+func requireSendable<T: Sendable>(_: T) {}
+
+@preconcurrency
+struct RequireSendable<T: Sendable> {}
+
+class NotSendable {} // expected-note 2 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+typealias T = RequireSendable<NotSendable>
+// expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+func testRequirementDowngrade(ns: NotSendable) {
+  requireSendable(ns)
+  // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+}

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -200,12 +200,24 @@ struct RequireSendable<T: Sendable> {}
 
 class NotSendable {} // expected-note 4 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
+class UnavailableSendable {}
+
+@available(*, unavailable)
+extension UnavailableSendable: @unchecked Sendable {}
+// expected-note@-1 4 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+
 typealias T = RequireSendable<NotSendable>
 // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
 
-func testRequirementDowngrade(ns: NotSendable) {
+typealias T2 = RequireSendable<UnavailableSendable>
+// expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
+
+func testRequirementDowngrade(ns: NotSendable, us: UnavailableSendable) {
   requireSendable(ns)
   // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+  requireSendable(us)
+  // expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
 }
 
 
@@ -213,18 +225,27 @@ protocol P2 {}
 
 extension NotSendable: P2 {}
 
+extension UnavailableSendable: P2 {}
+
 @preconcurrency
 func requireSendableExistential(_: any P2 & Sendable) {}
 
 func requireSendableExistentialAlways(_: any P2 & Sendable) {}
 
-func testErasureDowngrade(ns: NotSendable) {
+func testErasureDowngrade(ns: NotSendable, us: UnavailableSendable) {
   requireSendableExistential(ns)
   // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+  requireSendableExistential(us)
+  // expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
 
   withSendableClosure {
     let ns = NotSendable()
     requireSendableExistentialAlways(ns)
     // expected-error@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+    let us = UnavailableSendable()
+    requireSendableExistentialAlways(us)
+    // expected-error@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
   }
 }

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -180,3 +180,14 @@ do {
     }
   }
 }
+
+
+
+@preconcurrency
+func withSendableClosure(_: @Sendable () -> Void) {}
+
+func conversionDowngrade() {
+  let ns: () -> Void = {}
+  withSendableClosure(ns)
+  // expected-warning@-1 {{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+}

--- a/test/Concurrency/sendable_checking_captures_swift5.swift
+++ b/test/Concurrency/sendable_checking_captures_swift5.swift
@@ -51,3 +51,21 @@ do {
     }
   }
 }
+
+class NotSendable {} // expected-complete-note {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+@available(*, unavailable)
+extension NotSendable : @unchecked Sendable {}
+
+@preconcurrency func withSendableClosure(_: @Sendable () -> Void) {}
+
+func testPreconcurrencyDowngrade(ns: NotSendable) {
+  var x = 0
+  withSendableClosure {
+    _ = ns
+    // expected-complete-warning@-1 {{capture of 'ns' with non-sendable type 'NotSendable' in a `@Sendable` closure}}
+
+    x += 1
+    // expected-complete-warning@-1 {{mutation of captured var 'x' in concurrently-executing code}}
+  }
+}

--- a/test/Concurrency/sendable_checking_captures_swift6.swift
+++ b/test/Concurrency/sendable_checking_captures_swift6.swift
@@ -45,8 +45,8 @@ do {
 
     sendable_preconcurrency {
       test.update()
-      // expected-error@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
-      // expected-error@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
+      // expected-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
+      // expected-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
   }
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -116,13 +116,13 @@ func test_sendable_attr_in_type_context(test: Test) {
 
   // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableID().add(MyValue())
-  // expected-error@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
+  // expected-warning@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 
   TestWithSendableSuperclass().add(SendableMyValue()) // Ok
 
   // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableSuperclass().add(MyValue())
-  // expected-error@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
+  // expected-warning@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 }
 
 class TestConformanceWithStripping : InnerSendableTypes {


### PR DESCRIPTION
Sendable violations inside `@preconcurrency @Sendable` closures should be suppressed in minimal checking, and diagnosed as warnings under complete checking, including the Swift 6 language mode. This change fixes an issue where warnings were still produced in minimal checking, and errors were still produced under `-swift-version 6`, which means that libraries cannot stage in new `Sendable` annotations if their clients have already migrated to Swift 6.

The preconcurrency downgrade infrastructure is currently pretty difficult to follow, because the information is passed through `SendableCheckContext` throughout the `diagnoseNonSendableTypes` APIs, and there are different code paths for `@preconcurrency` on nominal declarations versus import statements. This PR does not attempt to clean any of this code up, because I'd like to cherry pick the bug fix to `release/6.0`. I'll look at clarifying this code in a follow up change.

This change also downgrades `Sendable` requirement failures when the requirement is on a `@preconcurrency` declaration. However, the change in this PR is not sufficient for requirement inference, e.g.

```swift

// module A
@preconcurrency
struct RequireSendable<T: Sendable> {}

// module B

class NotSendable {}

func f<T, U: Sendable>(_: T, _: U) -> RequireSendable<T>? { nil }

func call(ns: NotSendable) {
  f(ns, ns)
}
```

A case like the above requires more careful handling. `@preconcurrency` can't simply be inferred on `f`,  because that would break ABI by stripping `U: Sendable` from the generic signature. `@preconcurrency` may need to apply per requirement in order to maintain source compatibility without breaking ABI.

Resolves: rdar://138535438, rdar://139234188, https://github.com/swiftlang/swift/issues/76652

