### PR TITLE
IRGen: Metadata lookup failure

### DIFF
--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -599,6 +599,17 @@ void IRGenFunction::setScopedLocalTypeData(LocalTypeDataKey key,
 
   getOrCreateLocalTypeData().addConcrete(getActiveDominancePoint(),
                                          isConditional, key, value);
+
+  // We query reified types in places so also put a key mapping in for them.
+  auto reified = IGM.getRuntimeReifiedType(key.Type);
+  if (reified != key.Type) {
+    auto reifiedKey = LocalTypeDataKey(reified, key.Kind);
+    if (isConditional) {
+      registerConditionalLocalTypeDataKey(reifiedKey);
+    }
+    getOrCreateLocalTypeData().addConcrete(getActiveDominancePoint(),
+                                           isConditional, reifiedKey, value);
+  }
 }
 
 void IRGenFunction::setUnscopedLocalTypeMetadata(CanType type,
@@ -627,6 +638,15 @@ void IRGenFunction::setUnscopedLocalTypeData(LocalTypeDataKey key,
 
   getOrCreateLocalTypeData().addConcrete(DominancePoint::universal(),
                                          /*conditional*/ false, key, value);
+
+  // We query reified types in places so also put a key mapping in for them.
+  auto reified = IGM.getRuntimeReifiedType(key.Type);
+  if (reified != key.Type) {
+    auto reifiedKey = LocalTypeDataKey(reified, key.Kind);
+    getOrCreateLocalTypeData().addConcrete(DominancePoint::universal(),
+                                           /*conditional*/ false, reifiedKey,
+                                           value);
+  }
 }
 
 void IRGenFunction::bindLocalTypeDataFromTypeMetadata(CanType type,

--- a/test/IRGen/metadata_lookup_generic_objc.sil
+++ b/test/IRGen/metadata_lookup_generic_objc.sil
@@ -2,6 +2,8 @@
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 
+// REQUIRES: objc_interop
+
 import Builtin
 import Swift
 import gizmo

--- a/test/IRGen/metadata_lookup_generic_objc.sil
+++ b/test/IRGen/metadata_lookup_generic_objc.sil
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
+
+import Builtin
+import Swift
+import gizmo
+
+protocol Q<T> {
+  associatedtype T
+  func f()
+}
+
+// This used to assert/crash on a local type metadata lookup.
+
+sil @metadata_lookup_crash : $@convention(method) (@in_guaranteed any Q<ObjcGenericClass<Gizmo>>, Builtin.Int1) -> () {
+bb0(%0 : $*any Q<ObjcGenericClass<Gizmo>>, %1: $Builtin.Int1):
+  %2 = open_existential_addr immutable_access %0 : $*any Q<ObjcGenericClass<Gizmo>> to $*@opened("AA505436-9CC9-11EF-8085-32F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self
+  %3 = witness_method $@opened("AA505436-9CC9-11EF-8085-32F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self, #Q.f : <Self where Self : Q> (Self) -> () -> (), %2 : $*@opened("AA505436-9CC9-11EF-8085-32F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> ()
+  %4 = apply %3<@opened("AA505436-9CC9-11EF-8085-32F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self>(%2) : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> ()
+  cond_br %1, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  %5 = open_existential_addr immutable_access %0 : $*any Q<ObjcGenericClass<Gizmo>> to $*@opened("AA505436-9CC9-11EF-8085-42F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self
+  %6 = witness_method $@opened("AA505436-9CC9-11EF-8085-42F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self, #Q.f : <Self where Self : Q> (Self) -> () -> (), %5 : $*@opened("AA505436-9CC9-11EF-8085-42F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> ()
+  %7 = apply %6<@opened("AA505436-9CC9-11EF-8085-42F16C24A34B", any Q<ObjcGenericClass<Gizmo>>) Self>(%5) : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> ()
+  br bb3
+
+bb3:
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK: define swiftcc void @metadata_lookup_crash
+// CHECK:   call ptr @__swift_project_boxed_opaque_existential_1
+// CHECK:   br i1
+
+// CHECK:   call ptr @__swift_project_boxed_opaque_existential_1
+// CHECK:   ret void


### PR DESCRIPTION
Metadata lookup uses getRuntimeReifiedType(X) in places, fill the cache with key entries for X and getRuntimeReifiedType(X) such that they can be found on lookup.

rdar://139234543