### PR TITLE
[CSBindings] Don't favor application result types before application …

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -486,6 +486,10 @@ public:
   /// Determine whether this type variable represents a subscript result type.
   bool isSubscriptResultType() const;
 
+  /// Determine whether this type variable represents a result type of an
+  /// application i.e. a call, an operator, or a subscript.
+  bool isApplicationResultType() const;
+
   /// Determine whether this type variable represents an opened
   /// type parameter pack.
   bool isParameterPack() const;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1293,9 +1293,16 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
 
         return !hasConversions(binding.BindingType);
       })) {
-    // Result type of subscript could be l-value so we can't bind it early.
-    if (!TypeVar->getImpl().isSubscriptResultType() &&
-        llvm::none_of(Info.DelayedBy, [](const Constraint *constraint) {
+    bool isApplicationResultType = TypeVar->getImpl().isApplicationResultType();
+    if (llvm::none_of(Info.DelayedBy, [&isApplicationResultType](
+                                          const Constraint *constraint) {
+          // Let's not attempt to bind result type before application
+          // happens. For example because it could be discardable or
+          // l-value (subscript applications).
+          if (isApplicationResultType &&
+              constraint->getKind() == ConstraintKind::ApplicableFunction)
+            return true;
+
           return constraint->getKind() == ConstraintKind::Disjunction ||
                  constraint->getKind() == ConstraintKind::ValueMember;
         }))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -175,6 +175,16 @@ bool TypeVariableType::Implementation::isSubscriptResultType() const {
              KeyPathExpr::Component::Kind::UnresolvedSubscript;
 }
 
+bool TypeVariableType::Implementation::isApplicationResultType() const {
+  if (!(locator && locator->getAnchor()))
+    return false;
+
+  if (!locator->isLastElement<LocatorPathElt::FunctionResult>())
+    return false;
+
+  return isExpr<ApplyExpr>(locator->getAnchor()) || isSubscriptResultType();
+}
+
 bool TypeVariableType::Implementation::isParameterPack() const {
   return locator
       && locator->isForGenericParameter()

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -180,3 +180,20 @@ struct OverloadInImplicitAsyncClosure {
 
   init(int: Int) throws { }
 }
+
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) async throws {}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) -> String { "" }
+
+@available(SwiftStdlib 5.5, *)
+func compute(_: @escaping () -> Void) {}
+
+@available(SwiftStdlib 5.5, *)
+func test_sync_in_closure_context() {
+  compute {
+    test(42) // Ok (select sync overloads and discards the result)
+  }
+}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1267,3 +1267,19 @@ do {
 
 // Currently legal.
 let _: () -> Int = { return fatalError() }
+
+// Make sure that `Void` assigned to closure result doesn't get eagerly propagated into the body
+do {
+  class C {
+    func f(_: Any) -> Int! { fatalError() }
+    static func f(_: Any) -> Int! { fatalError() }
+  }
+
+  class G<T> {
+    func g<U>(_ u: U, _: (U, T) -> ()) {}
+
+    func g<U: C>(_ u: U) {
+        g(u) { $0.f($1) } // expected-warning {{result of call to 'f' is unused}}
+    }
+  }
+}


### PR DESCRIPTION
…happens

Until `ApplicableFunction` constraint is simplified result type associated with 
it cannot be bound because the binding set if incomplete.

Resolves: rdar://139237088

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
