### PR TITLE
[CSSolver] DynamicMemberLookup: Ignore disabled choices while filteri…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1781,6 +1781,9 @@ ConstraintSystem::filterDisjunction(
         return SolutionKind::Unsolved;
 
       for (auto *currentChoice : disjunction->getNestedConstraints()) {
+        if (currentChoice->isDisabled())
+          continue;
+
         if (currentChoice != choice)
           solverState->disableConstraint(currentChoice);
       }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar139314763.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar139314763.swift
@@ -1,0 +1,33 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+class A {}
+
+struct B {}
+
+@dynamicMemberLookup
+enum DynMember {
+  subscript<T>(_: T.Type) -> T {
+    get { fatalError() }
+  }
+
+  subscript<T>(dynamicMember keyPath: KeyPath<B, T>) -> T {
+    fatalError()
+  }
+}
+
+@dynamicMemberLookup
+class Test {
+  subscript<T>(_: KeyPath<A, T>) -> T {
+    self[setting: T.self]
+  }
+
+  subscript<T>(setting: T.Type) -> T {
+    get {
+      fatalError()
+    }
+  }
+
+  subscript<T>(dynamicMember keyPath: KeyPath<DynMember, T>) -> T {
+    fatalError()
+  }
+}


### PR DESCRIPTION
…ng disjunctions

`filterDisjunction` should ignore the choices that are already disabled while attempting to optimize disjunctions related to dynamic member lookup.

Resolves: rdar://139314763

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
