### PR TITLE
Concurrency: Look through l-value types in `ActorIsolation::getActor()`

### DIFF
--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -103,7 +103,7 @@ NominalTypeDecl *ActorIsolation::getActor() const {
   if (auto *instance = actorInstance.dyn_cast<VarDecl *>()) {
     actorType = instance->getTypeInContext();
   } else if (auto *expr = actorInstance.dyn_cast<Expr *>()) {
-    actorType = expr->getType();
+    actorType = expr->getType()->getRValueType();
   }
 
   if (actorType) {

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -541,6 +541,11 @@ func preciseIsolated(a: isolated MyActor) async {
   }
 }
 
+func testLValueIsolated() async {
+  var a = A() // expected-warning {{variable 'a' was never mutated}}
+  await sync(isolatedTo: a)
+}
+
 @MainActor func fromMain(ns: NotSendable) async -> NotSendable {
   await pass(value: ns, isolation: MainActor.shared)
 }


### PR DESCRIPTION
When computing the actor type for an expression, be sure to look through l-value types to get the underlying type.

Resolves rdar://139470254.
