### PR TITLE
Sema: Fix handling of appliedPropertyWrappers in ConstraintSystem::replaySolution()

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3812,7 +3812,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
         directReferencesForTypeRepr(evaluator, ctx, typeRepr, dc,
                                     defaultDirectlyReferencedTypeLookupOptions);
   } else if (Type type = attr->getType()) {
-    decls = directReferencesForType(type);
+    return type->getAnyNominal();
   }
 
   // Dig out the nominal type declarations.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6403,6 +6403,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     arg.setExpr(convertedArg);
     newArgs.push_back(arg);
   }
+
+  ASSERT(appliedWrapperIndex == appliedPropertyWrappers.size());
   return ArgumentList::createTypeChecked(ctx, args, newArgs);
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -5047,6 +5047,10 @@ void ConstraintSystem::removePropertyWrapper(Expr *anchor) {
   auto &wrappers = found->second;
   ASSERT(!wrappers.empty());
   wrappers.pop_back();
+  if (wrappers.empty()) {
+    bool erased = appliedPropertyWrappers.erase(anchor);
+    ASSERT(erased);
+  }
 }
 
 ConstraintSystem::TypeMatchResult

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -431,11 +431,10 @@ void ConstraintSystem::replaySolution(const Solution &solution,
   for (const auto &appliedWrapper : solution.appliedPropertyWrappers) {
     auto found = appliedPropertyWrappers.find(appliedWrapper.first);
     if (found == appliedPropertyWrappers.end()) {
-      appliedPropertyWrappers.insert(appliedWrapper);
+      for (auto applied : appliedWrapper.second)
+        applyPropertyWrapper(getAsExpr(appliedWrapper.first), applied);
     } else {
-      auto &existing = found->second;
-      ASSERT(existing.size() <= appliedWrapper.second.size());
-      existing = appliedWrapper.second;
+      ASSERT(found->second.size() == appliedWrapper.second.size());
     }
   }
 

--- a/validation-test/Sema/SwiftUI/rdar139237781.swift
+++ b/validation-test/Sema/SwiftUI/rdar139237781.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx12
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct V: View {
+    struct M: Identifiable {
+        let id: String
+    }
+
+    class C: ObservableObject {
+        @Published var m: [M]
+
+        init() {
+            self.m = []
+        }
+    }
+
+    @ObservedObject var c: C
+
+    var body: some View {
+        Table($c.m) {
+            TableColumn("") { $entry in
+                Text("hi")
+            }
+        }
+    }
+}


### PR DESCRIPTION
When we replay a solution, we must record changes in the trail, so fix the logic to do that. This fixes the first assertion failure with this test case.

The test case also exposed a second issue. We synthesize a CustomAttr in applySolutionToClosurePropertyWrappers() with a type returned by simplifyType(). Eventually, CustomAttrNominalRequest::evaluate() looks at this type, and passes it to directReferencesForType(). Unfortunately, this entry point does not understand type aliases whose underlying type is a type parameter. However, directReferencesForType() is the wrong thing to use here, and we can just call getAnyNominal() instead.

Fixes rdar://139237781.
