### PR TITLE
[Tests] Add missing executable_test requirement to Interpreter/typed_…

### DIFF
--- a/test/Interpreter/typed_throws_abi.swift
+++ b/test/Interpreter/typed_throws_abi.swift
@@ -4,6 +4,8 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(TypedThrowsABI) | %FileCheck %s
 
+// REQUIRES: executable_test
+
 import TypedThrowsABI
 
 func invoke<E: Error, each T>(_ f: () async throws(E) -> (repeat each T)) async {


### PR DESCRIPTION
…throws_abi.swift

rdar://139480718

Executable tests need to be marked as such to prevent failures in non-executable test environments.