### PR TITLE
Sema: Allow closure parameter lists to reference opaque parameter declarations

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4287,48 +4287,50 @@ void TypeChecker::checkParameterList(ParameterList *params,
     }
 
     // Opaque types cannot occur in parameter position.
-    Type interfaceType = param->getInterfaceType();
-    if (interfaceType->hasTypeParameter()) {
-      interfaceType.findIf([&](Type type) {
-        if (auto fnType = type->getAs<FunctionType>()) {
-          for (auto innerParam : fnType->getParams()) {
-            auto paramType = innerParam.getPlainType();
-            if (!paramType->hasTypeParameter())
-              continue;
+    if (!isa<ClosureExpr>(owner)) {
+      Type interfaceType = param->getInterfaceType();
+      if (interfaceType->hasTypeParameter()) {
+        interfaceType.findIf([&](Type type) {
+          if (auto fnType = type->getAs<FunctionType>()) {
+            for (auto innerParam : fnType->getParams()) {
+              auto paramType = innerParam.getPlainType();
+              if (!paramType->hasTypeParameter())
+                continue;
 
-            bool hadError = paramType.findIf([&](Type innerType) {
-              auto genericParam = innerType->getAs<GenericTypeParamType>();
-              if (!genericParam)
-                return false;
+              bool hadError = paramType.findIf([&](Type innerType) {
+                auto genericParam = innerType->getAs<GenericTypeParamType>();
+                if (!genericParam)
+                  return false;
 
-              auto genericParamDecl = genericParam->getOpaqueDecl();
-              if (!genericParamDecl)
-                return false;
+                auto genericParamDecl = genericParam->getOpaqueDecl();
+                if (!genericParamDecl)
+                  return false;
 
-              param->diagnose(
-                 diag::opaque_type_in_parameter, true, interfaceType);
-              return true;
-            });
+                param->diagnose(
+                   diag::opaque_type_in_parameter, true, interfaceType);
+                return true;
+              });
 
-            if (hadError)
-              return true;
+              if (hadError)
+                return true;
+            }
+
+            return false;
           }
 
           return false;
-        }
-
-        return false;
-      });
+        });
+      }
     }
 
     if (param->hasAttachedPropertyWrapper())
       (void) param->getPropertyWrapperInitializerInfo();
 
-    auto *SF = param->getDeclContext()->getParentSourceFile();
     if (!param->isInvalid()) {
+      auto *SF = owner->getParentSourceFile();
       param->visitAuxiliaryDecls([&](VarDecl *auxiliaryDecl) {
         if (!isa<ParamDecl>(auxiliaryDecl))
-          DeclChecker(param->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
+          DeclChecker(SF->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
       });
     }
 

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -131,3 +131,18 @@ struct I61387_1 {
     }
   }
 }
+
+// However, it's fine if the inferred type of a closure refers to opaque parameters from the outer scope.
+public func combinator<T>(_: T, _: ((T) -> ()) -> ()) {}
+
+public func closureWithOpaqueParameterInConsumingPosition(p: some Any) {
+  // Single-expression
+  combinator(p) { $0(p) }
+
+  // Multi-expression
+  combinator(p) { fn in
+    let result: () = fn(p)
+    return result
+  }
+}
+


### PR DESCRIPTION
A function declaration cannot have an opaque parameter type appearing in consuming position:

    func f(_: (some P) -> ()) {}

However, we should skip this check for a closure, because if the closure's parameter list references an opaque parameter declaration, it means something else: namely, the inferred type of the closure refers to an opaque parameter from an outer scope. That's allowed.

This unnecessary prohibition has been there ever since the check was added, but only for multi-statement closures, so nobody seemed to notice.

When https://github.com/swiftlang/swift/pull/76473 made it so we always call TypeChecker::checkParameterList(), this exposed the problem in a single-expression closure in an existing project.

Fixes rdar://139237671.