### PR TITLE
utils: correct function name for PS style

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1182,7 +1182,7 @@ function Build-CMakeProject {
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$(Get-CMark-BinaryCache($Arch))\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
+      $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$(Get-CMarkBinaryCache $Arch)\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
     } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
@@ -1347,15 +1347,16 @@ function Build-WiXProject() {
   Invoke-Program $msbuild @MSBuildArgs
 }
 
-function Get-CMark-BinaryCache($Arch) {
+function Get-CMarkBinaryCache($Arch) {
   return "$($Arch.BinaryCache)\cmark-gfm-0.29.0.gfm.13"
 }
+
 function Build-CMark($Arch) {
   $ArchName = $Arch.LLVMName
 
   Build-CMakeProject `
     -Src $SourceCache\cmark `
-    -Bin (Get-CMark-BinaryCache($Arch)) `
+    -Bin (Get-CMarkBinaryCache $Arch) `
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Defines @{
@@ -1424,7 +1425,7 @@ function Build-Compilers() {
     $BuildTools = Join-Path -Path (Get-BuildProjectBinaryCache BuildTools) -ChildPath bin
 
     if ($TestClang -or $TestLLD -or $TestLLDB -or $TestLLVM -or $TestSwift) {
-      $env:Path = "$(Get-CMark-BinaryCache($Arch))\src;$CompilersBinaryCache\tools\swift\libdispatch-windows-$($Arch.LLVMName)-prefix\bin;$CompilersBinaryCache\bin;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostArch.VSName);$UnixToolsBinDir"
+      $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$CompilersBinaryCache\tools\swift\libdispatch-windows-$($Arch.LLVMName)-prefix\bin;$CompilersBinaryCache\bin;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostArch.VSName);$UnixToolsBinDir"
       $Targets = @()
       $TestingDefines = @{
         SWIFT_BUILD_DYNAMIC_SDK_OVERLAY = "YES";
@@ -1769,7 +1770,7 @@ function Build-Runtime([Platform]$Platform, $Arch) {
 
 
   Isolate-EnvVars {
-    $env:Path = "$(Get-CMark-BinaryCache($Arch))\src;$(Get-PinnedToolchainRuntime);${env:Path}"
+    $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$(Get-PinnedToolchainRuntime);${env:Path}"
 
     $CompilersBinaryCache = if ($IsCrossCompiling) {
       Get-BuildProjectBinaryCache Compilers
@@ -2410,8 +2411,8 @@ function Test-Format {
     "-Xswiftc", "-I$($SourceCache)\cmark\src\include",
     "-Xswiftc", "-I$($SourceCache)\cmark\extensions\include",
     "-Xlinker", "-I$($SourceCache)\cmark\extensions\include",
-    "-Xlinker", "$(Get-CMark-BinaryCache($HostArch))\src\cmark-gfm.lib",
-    "-Xlinker", "$(Get-CMark-BinaryCache($HostArch))\extensions\cmark-gfm-extensions.lib",
+    "-Xlinker", "$(Get-CMarkBinaryCache $HostArch)\src\cmark-gfm.lib",
+    "-Xlinker", "$(Get-CMarkBinaryCache $HostArch)\extensions\cmark-gfm-extensions.lib",
     # swift-markdown
     "-Xlinker", "$(Get-HostProjectBinaryCache Markdown)\lib\CAtomic.lib",
     "-Xswiftc", "-I$($SourceCache)\swift-markdown\Sources\CAtomic\include",
@@ -2485,8 +2486,8 @@ function Test-SourceKitLSP {
     "-Xswiftc", "-I$($SourceCache)\cmark\src\include",
     "-Xswiftc", "-I$($SourceCache)\cmark\extensions\include",
     "-Xlinker", "-I$($SourceCache)\cmark\extensions\include",
-    "-Xlinker", "$(Get-CMark-BinaryCache($HostArch))\src\cmark-gfm.lib",
-    "-Xlinker", "$(Get-CMark-BinaryCache($HostArch))\extensions\cmark-gfm-extensions.lib",
+    "-Xlinker", "$(Get-CMarkBinaryCache $HostArch)\src\cmark-gfm.lib",
+    "-Xlinker", "$(Get-CMarkBinaryCache $HostArch)\extensions\cmark-gfm-extensions.lib",
     # swift-system
     "-Xswiftc", "-I$($SourceCache)\swift-system\Sources\CSystem\include",
     "-Xswiftc", "-I$(Get-HostProjectBinaryCache System)\swift",


### PR DESCRIPTION
The functions should be named [verb]-[noun], remove the extraneous `-` in the name. Also homogenise the call to avoid the parenthesis.