### PR TITLE
[cxx-interop] Workaround build error in SwiftCompilerSources

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7656,6 +7656,10 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
       namespaceContext->getName() == "__gnu_cxx" && decl->getIdentifier() &&
       decl->getName() == "__normal_iterator")
     return true;
+  // Hack for certain build configurations of SwiftCompilerSources
+  // (rdar://138924133).
+  if (decl->getIdentifier() && decl->getName() == "BridgedSwiftObject")
+    return true;
 
   // If we have no way of copying the type we can't import the class
   // at all because we cannot express the correct semantics as a swift


### PR DESCRIPTION
Certain build configurations of SwiftCompilerSources now incorrectly treat `BridgedSwiftObject` as a non-copyable type, causing compiler errors. This is a short-term workaround for these errors.

rdar://138924133

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
