### PR TITLE
Attempt to reduce the number of embedded stdlib targets being built simultaneously.

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -83,6 +83,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   add_custom_target(embedded-darwin)
   add_dependencies(embedded-libraries embedded-darwin)
+
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS one_job=1)
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)
@@ -125,6 +127,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       INSTALL_IN_COMPONENT stdlib
       )
     add_dependencies(embedded-darwin embedded-darwin-${mod})
+    set_property(TARGET embedded-darwin-${mod} PROPERTY JOB_POOL_COMPILE one_job)
   endforeach()
 endif()
 


### PR DESCRIPTION
We are seeing strange crashes during embedded stdlib build stage on Ubuntu 24.04. These crashes only seem to occur when we dispatch many stdlib emit-module tasks at the same time. While we root-cause it, this change attempts to slow down the process to only two Embedded StdLib tasks at-a-time.

Workaround for rdar://137674862