### PR TITLE
[ObjC Bridging] Consistently bridge block types verbatim

### DIFF
--- a/test/Casting/Cast_Blocks.swift
+++ b/test/Casting/Cast_Blocks.swift
@@ -1,0 +1,76 @@
+// Casts.swift - Tests for conversion between types.
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Contains tests for non-trapping type conversions reported by users.
+///
+// -----------------------------------------------------------------------------
+// RUN: %empty-directory(%t)
+//
+// RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/Cast_Blocks/Cast_Blocks.m -c -o %t/Cast_Blocks.o -g
+//
+// RUN: %target-build-swift -I %S/Inputs/Cast_Blocks %t/Cast_Blocks.o -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
+// RUN: %target-codesign %t/a.swift6.Onone.out
+// RUN: %target-run %t/a.swift6.Onone.out
+//
+// RUN: %target-build-swift -I %S/Inputs/Cast_Blocks %t/Cast_Blocks.o -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
+// RUN: %target-codesign %t/a.swift6.O.out
+// RUN: %target-run %t/a.swift6.O.out
+//
+// RUN: %target-build-swift -I %S/Inputs/Cast_Blocks %t/Cast_Blocks.o -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
+// RUN: %target-codesign %t/a.swift5.Onone.out
+// RUN: %target-run %t/a.swift5.Onone.out
+//
+// RUN: %target-build-swift -I %S/Inputs/Cast_Blocks %t/Cast_Blocks.o -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
+// RUN: %target-codesign %t/a.swift5.O.out
+// RUN: %target-run %t/a.swift5.O.out
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+import Foundation
+import Cast_Blocks
+
+fileprivate func SwiftThinksObjectIsSwiftValue<T>(_ t: T) -> Bool {
+  let type = "\(type(of: t))"
+  return type == "__SwiftValue"
+}
+
+let CastsTests = TestSuite("Cast_Blocks")
+
+CastsTests.test("block closures should bridge without __SwiftValue")
+{
+  let x: @convention(block) () -> Void = {}
+
+  expectFalse(ObjCThinksObjectIsSwiftValue(x))
+
+  expectFalse(SwiftThinksObjectIsSwiftValue(x))
+
+  ObjCCanCallBlock(x);
+}
+
+// Bug:  @convention(block) closure used to be incorrectly wrapped in
+// SwiftValue box when bridged to Objective-C as a member of an array
+CastsTests.test("block closures in array should bridge without __SwiftValue")
+{
+  let f: @convention(block) () -> Void = {}
+  let x = ([f] as NSArray)[0]
+
+  expectFalse(ObjCThinksObjectIsSwiftValue(x))
+  expectFalse(SwiftThinksObjectIsSwiftValue(x))
+  ObjCCanCallBlock(x);
+}
+
+
+runAllTests()

--- a/test/Casting/Inputs/Cast_Blocks/Cast_Blocks.h
+++ b/test/Casting/Inputs/Cast_Blocks/Cast_Blocks.h
@@ -1,0 +1,9 @@
+#ifndef SWIFT_TEST_CAST_BLOCKS_H
+#define SWIFT_TEST_CAST_BLOCKS_H
+
+#import <Foundation/Foundation.h>
+
+BOOL ObjCThinksObjectIsSwiftValue(id obj);
+void ObjCCanCallBlock(id block_as_id);
+
+#endif

--- a/test/Casting/Inputs/Cast_Blocks/Cast_Blocks.m
+++ b/test/Casting/Inputs/Cast_Blocks/Cast_Blocks.m
@@ -1,0 +1,19 @@
+#import <objc/runtime.h>
+
+#import "Cast_Blocks.h"
+
+BOOL ObjCThinksObjectIsSwiftValue(id obj) {
+  Class cls = object_getClass(obj);
+  const char *name = class_getName(cls);
+  if (strcmp(name, "__SwiftValue") == 0) {
+    return TRUE;
+  } else {
+    return FALSE;
+  }
+}
+
+void ObjCCanCallBlock(id block_as_id) {
+  typedef void(^blockType)(void);
+  blockType block = (blockType)block_as_id;
+  block();
+}

--- a/test/Casting/Inputs/Cast_Blocks/module.modulemap
+++ b/test/Casting/Inputs/Cast_Blocks/module.modulemap
@@ -1,0 +1,4 @@
+module Cast_Blocks {
+  header "Cast_Blocks.h"
+  export *
+}


### PR DESCRIPTION
A `@convention(block)` closure in Swift is completely compatible with Objective-C and does not need to be wrapped in a `__SwiftValue` box for use.

Previously, it was bridged verbatim when appearing by itself, but could end up boxed when it went through array bridging.

The test verifies that:
* Objective-C does not see a `__SwiftValue` box
* Swift `type(of:)` does not see a `__SwiftValue` box
* Objective-C can actually call the closure

Resolves rdar://138132321