### PR TITLE
Missing playground results for `init`/`deinit` in a class wrapped in a struct

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -308,7 +308,7 @@ public:
   Decl *transformDecl(Decl *D) {
     if (D->isImplicit())
       return D;
-    if (auto *FD = dyn_cast<FuncDecl>(D)) {
+    if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
       if (BraceStmt *B = FD->getTypecheckedBody()) {
         const ParameterList *PL = FD->getParameters();
         TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Return);

--- a/test/PlaygroundTransform/nested_init.swift
+++ b/test/PlaygroundTransform/nested_init.swift
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+
+// Build PlaygroundSupport module
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+
+// -playground
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
+
+// -pc-macro -playground
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
+
+// RUN: %target-codesign %t/main5a
+// RUN: %target-codesign %t/main5b
+// RUN: %target-codesign %t/main6a
+// RUN: %target-codesign %t/main6b
+
+// RUN: %target-run %t/main5a | %FileCheck %s
+// RUN: %target-run %t/main5b | %FileCheck %s
+// RUN: %target-run %t/main6a | %FileCheck %s
+// RUN: %target-run %t/main6b | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+// First make sure we get results in constructors, destructors, and regular functions for an unwrapped class.
+class MyClass {
+    init() {
+        let x = 1
+    }
+    func f() {
+        let y = 2
+    }
+    deinit {
+        let z = 3
+    }
+}
+do {
+    let c = MyClass()
+    c.f()
+}
+
+// CHECK:      [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[x='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[z='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+
+// Now make sure we get results in constructors, destructors, and regular functions for a wrapped class too.
+struct Playground {
+    static func doit() {
+        class MyClass {
+            init() {
+                let x = 1
+            }
+            func f() {
+                let y = 2
+            }
+            deinit {
+                let z = 3
+            }
+        }
+        do {
+            let c = MyClass()
+            c.f()
+        }
+    }
+}
+Playground.doit()
+
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[x='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[z='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit


### PR DESCRIPTION
When a decl that has `init` or `deinit` is nested inside another type, those `init` or `deinit` implementations aren't playground-transformed.
 
### Details

The reason is that the playground transform uses an `ASTWalker` to get to the top-level structure, but then once it’s inside a type, it does directly nested `transformDecl()` calls.  And that inner check was for too narrow of a type.

The problem in this case was that the `dyn_cast<FuncDecl>(D)` was too narrow and didn’t include constructors/destructors.  We want `dyn_cast<AbstractFunctionDecl>(D)`.

### Future work

It's unfortunate that the playground transform reaches decls in two different ways (using an `ASTWalker` to get to the top-level decls but then using directly nested calls below).  This seems to be worth resolving at some point (perhaps by using the `ASTWalker` for the whole traversal?), but that’s a larger change, and so this is worth addressing with a safer short-term fix.

Also, there are still missing results with accessors that are associated with properties in nested types.  The fix for that will follow in a separate PR with its own unit test.  _Edit: The follow-on fix is here: https://github.com/swiftlang/swift/pull/77530_

### Changes

- change a `dyn_cast<FuncDecl>` to a `dyn_cast<AbstractFunctionDecl>` in PlaygroundTransform.cpp
- add a unit test nested `init` and `deinit` (this test also tests the unnested case)
    
rdar://137316110