### PR TITLE
[6.0][Runtime] Add missing #include <utility> in PrebuiltStringMap.h.

### DIFF
--- a/include/swift/Runtime/PrebuiltStringMap.h
+++ b/include/swift/Runtime/PrebuiltStringMap.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <utility>
 
 namespace swift {
 


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/75953 to `release/6.0`.

This header is needed for std::pair.