### PR TITLE
macCatalyst availability fixes

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -715,7 +715,7 @@ bool importer::isUnavailableInSwift(
     if (version.empty())
       continue;
     if (platformAvailability->treatDeprecatedAsUnavailable(
-            decl, version, /*isAsync=*/false)) {
+            decl, version, /*isAsync=*/false, attr->isImplicit())) {
       return true;
     }
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8672,7 +8672,7 @@ void ClangImporter::Implementation::importAttributes(
 
       if (!deprecated.empty()) {
         if (platformAvailability.treatDeprecatedAsUnavailable(
-                ClangDecl, deprecated, isAsync)) {
+                ClangDecl, deprecated, isAsync, avail->isImplicit())) {
           AnyUnavailable = true;
           PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
           if (message.empty()) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -338,7 +338,7 @@ public:
   /// unavailable.
   bool treatDeprecatedAsUnavailable(const clang::Decl *clangDecl,
                                     const llvm::VersionTuple &version,
-                                    bool isAsync) const;
+                                    bool isAsync, bool isAvailabilityImplicit) const;
 
   /// The message to embed for implicitly unavailability if a deprecated
   /// API is now unavailable.

--- a/test/ClangImporter/Inputs/custom-modules/AvailabilityExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/AvailabilityExtras.h
@@ -85,7 +85,35 @@ struct NSSwiftUnavailableStruct {
   int secrets;
 } __attribute__((availability(swift, unavailable)));
 
+struct UnavailableOniOS {
+  int foobar;
+} __attribute__((availability(ios,unavailable)));
+
+struct UnavailableOnMacCatalystOnly {
+  int foobar;
+} __attribute__((availability(maccatalyst,unavailable)));
+
+struct AvailableOnMacCatalystOnly {
+  int foobar;
+} __attribute__((availability(maccatalyst, introduced=13.1))) __attribute__((availability(ios, unavailable)));
+
 void unavailableWithOS() __attribute__((availability(ios, deprecated=8.0))) __attribute__((availability(swift, unavailable))) __attribute__((availability(macosx, deprecated=10.10))) ;
+
+void availableOnIOSButUnavailableOnmacCatalyst() __attribute__((availability(ios,introduced=7.0))) __attribute__((availability(maccatalyst,unavailable)));
+
+void availableOnIOSButDeprecatedOnmacCatalyst() __attribute__((availability(ios,introduced=7.0))) __attribute__((availability(maccatalyst,deprecated=9.0)));
+
+void unavailableOnIOS() __attribute__((availability(ios,unavailable)));
+
+void deprecatedOniOSButNotOnmacCatalyst() __attribute__((availability(ios,deprecated=13.1))) __attribute__((availability(maccatalyst,introduced=13.1)));
+
+void availableOnIOSButUnavailableOniOSAppExtension() __attribute__((availability(ios,introduced=7.0))) __attribute__((availability(ios_app_extension,unavailable)));
+
+void availableOnIOSButDeprecatedOniOSAppExtension() __attribute__((availability(ios,introduced=7.0))) __attribute__((availability(ios_app_extension,deprecated=7.0)));
+
+void availableOnIOSAppExtensionButUnavailableOnmacCatalystAppExtension() __attribute__((availability(ios_app_extension,introduced=7.0))) __attribute__((availability(maccatalyst_app_extension,unavailable)));
+
+void availableOnIOSAppExtensionButDeprecatedOnmacCatalystAppExtension() __attribute__((availability(ios_app_extension,introduced=7.0))) __attribute__((availability(maccatalyst_app_extension,deprecated=7.0)));
 
 typedef NS_ENUM(NSInteger, NSEnumAddedCasesIn2017) {
     NSEnumAddedCasesIn2017ExistingCaseOne,

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2334,6 +2334,21 @@ skip-test-tvos
 skip-test-ios
 skip-reconfigure
 
+[preset: mixin_buildbot_incremental,test=macCatalyst,type=device]
+
+test
+validation-test
+lit-args=-v
+
+ios
+maccatalyst
+
+skip-test-ios
+skip-test-tvos
+skip-test-watchos
+skip-test-xros
+skip-reconfigure
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2368,6 +2383,11 @@ mixin-preset=
 mixin-preset=
     buildbot_incremental,tools=RA,stdlib=RD,build
     mixin_buildbot_incremental,test=watchOS,type=simulator
+
+[preset: buildbot_incremental,tools=RA,stdlib=RD,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RD,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
 
 #===------------------------------------------------------------------------===#
 # Swift Preset
@@ -2415,6 +2435,13 @@ mixin-preset=
 
 test-optimized
 
+[preset: buildbot_incremental,tools=RA,stdlib=RDA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RDA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2458,6 +2485,14 @@ mixin-preset=
 
 test-optimized
 
+[preset: buildbot_incremental,tools=RA,stdlib=DA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=DA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: Release and Assertions
@@ -2497,6 +2532,14 @@ mixin-preset=
     mixin_buildbot_incremental,test=watchOS,type=simulator
 
 test-optimized
+
+[preset: buildbot_incremental,tools=RA,stdlib=RA,test=macCatalyst,type=device]
+mixin-preset=
+    buildbot_incremental,tools=RA,stdlib=RA,build
+    mixin_buildbot_incremental,test=macCatalyst,type=device
+
+test-optimized
+
 
 #===------------------------------------------------------------------------===#
 # Swift Preset


### PR DESCRIPTION
Based on the work from #77386

Trying to fix both `ClangImporteravailability_maccatalyst.swift` and `ClangImporter/availability_maccatalyst_app_extension.swift`. "Success" in the former, failure in the former.

It can be an incorrect recreation of the `AvailabilityExtras.h` missing pieces, but the logic and the influences of iOS app extensions in macCatalyst app extensions either requires a lot more code, or I have not been able to find the right incantation.

@tshortli: Can you have a look at this? (and maybe also the other failing tests in #77386?) I think there's some missing pieces in the open source implementation. I tried to guess them the best I can, but I cannot find the right code to make everything work. Thanks!