### PR TITLE
[cmake] Provide private extension points to the build

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -31,7 +31,8 @@
 
 cmake_minimum_required(VERSION 3.26...3.29)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+set(SwiftCore_CMAKE_MODULES_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH ${SwiftCore_CMAKE_MODULES_DIR})
 include(CMakeWorkarounds)
 project(SwiftCore LANGUAGES C CXX Swift VERSION 6.1)
 
@@ -47,6 +48,13 @@ set(SwiftCore_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../"
   CACHE FILEPATH "Path to the root source directory of the Swift compiler")
 
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
+set(SwiftCore_VENDOR_MODULE_DIR "${SwiftCore_CMAKE_MODULES_DIR}/vendor"
+  CACHE FILEPATH "Location for private build system extension")
+
 include(GNUInstallDirs)
 include(AvailabilityMacros)
 include(CompilerSettings)
@@ -54,6 +62,8 @@ include(DefaultSettings)
 include(EmitSwiftInterface)
 include(PlatformInfo)
 include(gyb)
+
+include("${SwiftCore_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
 
 defaulted_option(SwiftCore_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries")
 

--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -66,12 +66,12 @@ defaulted_option(SwiftCore_ENABLE_COMMANDLINE_SUPPORT "Enable command line argum
 defaulted_option(SwiftCore_ENABLE_RUNTIME_FUNCTION_COUNTERS "Enable runtime function counter support")
 
 defaulted_option(SwiftCore_ENABLE_BACKTRACING "Enable backtracing runtime support")
-set(SwiftCore_BACKTRACER_PATH ${SwiftCore_BACKTRACER_PATH_default} CACHE STRING "Set a fixed path to the Swift backtracer")
+defaulted_set(SwiftCore_BACKTRACER_PATH STRING "Set a fixed path to the Swift backtracer")
 
 option(SwiftCore_ENABLE_CLOBBER_FREED_OBJECTS "" OFF)
 option(SwiftCore_ENABLE_RUNTIME_LEAK_CHECKER "" OFF)
 
-set(SwiftCore_OBJECT_FORMAT "${SwiftCore_OBJECT_FORMAT_default}" CACHE STRING "Object format")
+defaulted_set(SwiftCore_OBJECT_FORMAT STRING "Object format: ELF COFF")
 
 add_compile_definitions(
   $<$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>:-DSWIFT_OBJC_INTEROP>
@@ -82,7 +82,7 @@ add_compile_definitions(
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER=$<BOOL:${SwiftCore_ENABLE_RUNTIME_LEAK_CHECKER}>>
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_RUNTIME_CLOBBER_FREED_OBJECTS=$<BOOL:${SwiftCore_ENABLE_CLOBBER_FREED_OBJECTS}>>)
 
-add_compile_options( $<$<AND:$<COMPILE_LANGUAGE:Swift>,$<BOOL:${SwiftCore_ENABLE_LIBRARY_EVOLUTION}>>:-enable-library-evolution>)
+add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<BOOL:${SwiftCore_ENABLE_LIBRARY_EVOLUTION}>>:-enable-library-evolution>)
 
 include_directories(include)
 

--- a/Runtimes/Core/cmake/modules/DefaultSettings.cmake
+++ b/Runtimes/Core/cmake/modules/DefaultSettings.cmake
@@ -43,3 +43,5 @@ elseif(LINUX OR ANDROID OR BSD)
 elseif(WIN32)
   set(SwiftCore_OBJECT_FORMAT_default "coff")
 endif()
+
+include("${SwiftCore_VENDOR_MODULE_DIR}/DefaultSettings.cmake" OPTIONAL)

--- a/Runtimes/Core/cmake/modules/DefaultSettings.cmake
+++ b/Runtimes/Core/cmake/modules/DefaultSettings.cmake
@@ -2,6 +2,8 @@
 # that configuring a build for a given platform is likely to build
 # out-of-the-box without customization. This does not mean that it is the only
 # way that will work, or that it represents a shipping configuration.
+# User-specified configurations should be done through cache files or by setting
+# the variable with `-DSwiftCore_*` on the commandline.
 
 set(SwiftCore_ENABLE_BACKTRACING_default OFF) # TODO: enable this by default
 set(SwiftCore_ENABLE_COMMANDLINE_SUPPORT_default OFF) # TODO: enable this by default
@@ -10,6 +12,9 @@ set(SwiftCore_ENABLE_TYPE_PRINTING_default ON)
 
 set(SwiftCore_BACKTRACER_PATH_default "")
 
+# Provide a boolean option that a user can optionally enable.
+# Variables are defaulted based on the value of `<variable>_default`.
+# If no such default variable exists, the option is defaults to `OFF`.
 macro(defaulted_option variable helptext)
   if(NOT DEFINED ${variable}_default)
     set(${variable}_default OFF)
@@ -17,6 +22,9 @@ macro(defaulted_option variable helptext)
   option(${variable} ${helptext} ${${variable}_default})
 endmacro()
 
+# Create a defaulted cache entry
+# Entries are defaulted on the value of `<variable>_default`.
+# If no such default variable exists, the variable is not created.
 macro(defaulted_set variable type helptext)
   if(DEFINED ${variable}_default)
     set(${variable} ${variable}_default CACHE ${type} ${helptext})

--- a/Runtimes/Core/cmake/modules/DefaultSettings.cmake
+++ b/Runtimes/Core/cmake/modules/DefaultSettings.cmake
@@ -17,6 +17,12 @@ macro(defaulted_option variable helptext)
   option(${variable} ${helptext} ${${variable}_default})
 endmacro()
 
+macro(defaulted_set variable type helptext)
+  if(DEFINED ${variable}_default)
+    set(${variable} ${variable}_default CACHE ${type} ${helptext})
+  endif()
+endmacro()
+
 if(APPLE)
   set(SwiftCore_ENABLE_LIBRARY_EVOLUTION_default ON)
   set(SwiftCore_ENABLE_CRASH_REPORTER_CLIENT_default ON)


### PR DESCRIPTION
This patch provides extension points on the build system so that vendors can keep vendor-specific build system settings private, without having to worry about merge conflicts haunting them for the rest of time.

The location of the extension modules is set with the `SwiftCore_PRIVATE_MODULE_DIR` variable. If it is not specified, the default location is under `cmake/modules/private`.

Currently, there are extension points for the default settings, and for the global settings.