### PR TITLE
Disable two tests on wasm

### DIFF
--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
+// wasm currently disables aggressive reg2mem
+// UNSUPPORTED: wasm
+
 public struct LargeThing {
     var  s0 : String = ""
     var  s1 : String = ""

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -5,6 +5,9 @@
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_ValueGenerics
 
+// wasm currently disables aggressive reg2mem
+// UNSUPPORTED: wasm
+
 import Builtin
 import Swift
 


### PR DESCRIPTION
PR#77502 disabled aggresive reg2mem heuristic for wasm. These two tests check IR patterns that are influenced by said heuristic.