### PR TITLE
[cmake] Enable new runtime build in Linux smoketest

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1095,6 +1095,9 @@ llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
   -DCLANG_DEFAULT_LINKER=gold
 
+swift-cmake-options=
+  -DSWIFT_ENABLE_NEW_RUNTIME_BUILD=ON
+
 [preset: buildbot_linux_1404_no_lldb]
 mixin-preset=buildbot_incremental_linux
 build-subdir=buildbot_linux


### PR DESCRIPTION
Enabling running the new build system in the Linux smoketests. This just enables running the build, it doesn't yet run the tests against the runtimes built by the new build system. This is mainly to help keep things in sync as the stdlib is being developed.