### PR TITLE
[FixedArray] Fix BitwiseCopyable inference.

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -3385,11 +3385,12 @@ bool BuiltinType::isBitwiseCopyable() const {
     return false;
     
   case BuiltinTypeKind::BuiltinFixedArray: {
-    // Bitwise-copyability depends on the element type.
+    // FixedArray<N, X> : BitwiseCopyable whenever X : BitwiseCopyable
     auto bfa = cast<BuiltinFixedArrayType>(this);
     auto &C = bfa->getASTContext();
-    return (bool)lookupConformance(bfa->getElementType(),
-                           C.getProtocol(KnownProtocolKind::BitwiseCopyable));
+    return (bool)checkConformance(
+        bfa->getElementType(),
+        C.getProtocol(KnownProtocolKind::BitwiseCopyable));
   }
   }
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3000,6 +3000,7 @@ bool TypeConverter::visitAggregateLeaves(
     return isa<SILPackType>(ty) ||
            isa<TupleType>(ty) ||
            isa<PackExpansionType>(ty) ||
+           isa<BuiltinFixedArrayType>(ty) ||
            ty.getEnumOrBoundGenericEnum() ||
            ty.getStructOrBoundGenericStruct();
   };
@@ -3036,6 +3037,13 @@ bool TypeConverter::visitAggregateLeaves(
         insertIntoWorklist(expansion.getPatternType(),
                            origTy.getPackExpansionPatternType(),
                            field, index);
+      } else if (auto array = dyn_cast<BuiltinFixedArrayType>(ty)) {
+        auto origBFA = origTy.getAs<BuiltinFixedArrayType>();
+        insertIntoWorklist(
+            array->getElementType(),
+            AbstractionPattern(origTy.getGenericSignatureOrNull(),
+                               origBFA->getElementType()),
+            field, index);
       } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
         for (auto *structField : decl->getStoredProperties()) {
           auto subMap = ty->getContextSubstitutionMap();

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -1,11 +1,18 @@
-// RUN: %target-swift-frontend                                  \
-// RUN:     %s                                                  \
-// RUN:     -emit-silgen                                        \
-// RUN:     -target %target-swift-5.1-abi-triple                      \
-// RUN:     -enable-experimental-feature Sensitive              \
+// RUN: %target-swift-frontend                         \
+// RUN:     %s                                         \
+// RUN:     -emit-silgen                               \
+// RUN:     -disable-experimental-parser-round-trip    \
+// RUN:     -target %target-swift-5.1-abi-triple       \
+// RUN:     -enable-experimental-feature Sensitive     \
+// RUN:     -enable-experimental-feature ValueGenerics \
 // RUN:     -enable-builtin-module
 
+// FIXME: Remove -disable-experimental-parser-round-trip when it's not required for using ValueGenerics.
+
 // REQUIRES: swift_feature_Sensitive
+// REQUIRES: swift_feature_ValueGenerics
+
+// REQUIRES: asserts
 
 // Force verification of TypeLowering's isTrivial.
 
@@ -67,4 +74,11 @@ struct S_Explicit_Sensitive {
 }
 
 func takeS_Explicit_Sensitive(_ s: S_Explicit_Sensitive) {
+}
+
+import Builtin
+
+func foo() {
+  let bricks: Builtin.FixedArray<1, Conditional<Int>>
+  let bricks2: Builtin.FixedArray<1, Conditional<String>>
 }

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -1,11 +1,16 @@
 // RUN: %target-typecheck-verify-swift                       \
+// RUN:     -disable-experimental-parser-round-trip          \
 // RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
+// RUN:     -enable-experimental-feature ValueGenerics       \
 // RUN:     -enable-experimental-feature Sensitive           \
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
 
+// FIXME: Remove -disable-experimental-parser-round-trip when it's not required for using ValueGenerics.
+
 // REQUIRES: swift_feature_NonescapableTypes
+// REQUIRES: swift_feature_ValueGenerics
 // REQUIRES: swift_feature_Sensitive
 
 //==============================================================================
@@ -107,6 +112,17 @@ struct S_Implicit_Sensitive {
 func passS_Implicit_Sensitive(_ s: S_Implicit_Sensitive) {
   take1(s) // expected-error   {{type_does_not_conform_decl_owner}}
            // expected-note@-94 {{where_requirement_failure_one_subst}}
+}
+
+import Builtin
+
+func passFixedArray1N<T>(_ fa: Builtin.FixedArray<1, T>) {
+  take1(fa) // expected-error {{type_does_not_conform_decl_owner}}
+            // expected-note@-101 {{where_requirement_failure_one_subst}}
+}
+
+func passFixedArray1N<T : BitwiseCopyable>(_ fa: Builtin.FixedArray<1, T>) {
+  take1(fa)
 }
 
 //==============================================================================


### PR DESCRIPTION
`FixedArray<T> : BitwiseCopyable` iff `T : BitwiwseCopyable`; determining this requires using `checkConformance`, not `lookupConformance`.


Also fix type-lowering verification for FixedArray--the new aggregate type must be walked into--addressing an asserts-only disableable-via-flag assertion failure.

rdar://139448358
