### PR TITLE
[xcodegen] Add buildable folder support

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -90,6 +90,15 @@ PROJECT CONFIGURATION:
   --prefer-folder-refs/--no-prefer-folder-refs
                           Whether to prefer folder references for groups containing non-source
                           files (default: --no-prefer-folder-refs)
+  --buildable-folders/--no-buildable-folders
+                          Requires Xcode 16: Enables the use of "buildable folders", allowing
+                          folder references to be used for compatible targets. This allows new
+                          source files to be added to a target without needing to regenerate the
+                          project.
+
+                          Only supported for targets that have no per-file build settings. This
+                          unfortunately means some Clang targes such as 'lib/Basic' and 'stdlib'
+                          cannot currently use buildable folders. (default: --no-buildable-folders)
 
 MISC:
   --project-root-dir <project-root-dir>

--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -87,6 +87,9 @@ PROJECT CONFIGURATION:
                           on the build arguments of surrounding files. This is mainly useful for
                           files that aren't built in the default config, but are still useful to
                           edit (e.g sourcekitdAPI-InProc.cpp). (default: --infer-args)
+  --prefer-folder-refs/--no-prefer-folder-refs
+                          Whether to prefer folder references for groups containing non-source
+                          files (default: --no-prefer-folder-refs)
 
 MISC:
   --project-root-dir <project-root-dir>

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
@@ -83,6 +83,11 @@ struct ClangBuildArgsProvider {
     return .init(for: .clang, args: fileArgs.sorted())
   }
 
+  /// Whether the given path has any unique args not covered by `parent`.
+  func hasUniqueArgs(for path: RelativePath, parent: RelativePath) -> Bool {
+    args.hasUniqueArgs(for: path, parent: parent)
+  }
+
   /// Whether the given file has build arguments.
   func hasBuildArgs(for path: RelativePath) -> Bool {
     !args.getArgs(for: path).isEmpty

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/CommandArgTree.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/CommandArgTree.swift
@@ -46,4 +46,14 @@ struct CommandArgTree {
   ) -> Set<Command.Argument> {
     getArgs(for: path).subtracting(getArgs(for: parent))
   }
+
+  /// Whether the given path has any unique args not covered by `parent`.
+  func hasUniqueArgs(for path: RelativePath, parent: RelativePath) -> Bool {
+    let args = getArgs(for: path)
+    guard !args.isEmpty else { return false }
+    // Assuming `parent` is an ancestor of path, the arguments for parent is
+    // guaranteed to be a subset of the arguments for `path`. As such, we
+    // only have to compare sizes here.
+    return args.count != getArgs(for: parent).count
+  }
 }

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectGenerator.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectGenerator.swift
@@ -199,10 +199,10 @@ fileprivate final class ProjectGenerator {
 
   @discardableResult
   private func getOrCreateRepoRef(
-    _ ref: ProjectSpec.PathReference, allowExcluded: Bool = false
+    _ ref: ProjectSpec.PathReference
   ) -> Xcode.FileReference? {
     let path = ref.path
-    guard allowExcluded || checkNotExcluded(path) else { return nil }
+    guard checkNotExcluded(path) else { return nil }
     return getOrCreateProjectRef(ref.withPath(repoRelativePath.appending(path)))
   }
 
@@ -629,8 +629,7 @@ fileprivate final class ProjectGenerator {
 
     // First add file/folder references.
     for ref in spec.referencesToAdd {
-      // Allow important references to bypass exclusion checks.
-      getOrCreateRepoRef(ref, allowExcluded: ref.isImportant)
+      getOrCreateRepoRef(ref)
     }
 
     // Gather the Swift targets to generate, including any dependencies.

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
@@ -83,14 +83,11 @@ extension ProjectSpec {
     var kind: Kind
     var path: RelativePath
 
-    /// Whether this reference should bypass exclusion checks.
-    var isImportant: Bool
-
-    static func file(_ path: RelativePath, isImportant: Bool = false) -> Self {
-      .init(kind: .file, path: path, isImportant: isImportant)
+    static func file(_ path: RelativePath) -> Self {
+      .init(kind: .file, path: path)
     }
-    static func folder(_ path: RelativePath, isImportant: Bool = false) -> Self {
-      .init(kind: .folder, path: path, isImportant: isImportant)
+    static func folder(_ path: RelativePath) -> Self {
+      .init(kind: .folder, path: path)
     }
 
     func withPath(_ newPath: RelativePath) -> Self {
@@ -145,20 +142,10 @@ extension ProjectSpec {
     self.knownUnbuildables.insert(path)
   }
 
-  public mutating func addReference(
-    to path: RelativePath, isImportant: Bool = false
-  ) {
+  public mutating func addReference(to path: RelativePath) {
     guard let path = mapPath(path, for: "file") else { return }
-    if repoRoot.appending(path).isDirectory {
-      if isImportant {
-        // Important folder references should block anything being added under
-        // them.
-        excludedPaths.append(.init(path: path))
-      }
-      referencesToAdd.append(.folder(path, isImportant: isImportant))
-    } else {
-      referencesToAdd.append(.file(path, isImportant: isImportant))
-    }
+    let isDir = repoRoot.appending(path).isDirectory
+    referencesToAdd.append(isDir ? .folder(path) : .file(path))
   }
 
   public mutating func addHeaders(in path: RelativePath) {

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
@@ -36,6 +36,10 @@ public struct ProjectSpec {
   /// on the build arguments of surrounding files.
   public var inferArgs: Bool
 
+  /// Whether to prefer using folder references for groups containing non-source
+  /// files.
+  public var preferFolderRefs: Bool
+
   /// If provided, the paths added will be implicitly appended to this path.
   let mainRepoDir: RelativePath?
 
@@ -50,7 +54,7 @@ public struct ProjectSpec {
     _ name: String, for buildDir: RepoBuildDir, runnableBuildDir: RepoBuildDir,
     addClangTargets: Bool, addSwiftTargets: Bool,
     addSwiftDependencies: Bool, addRunnableTargets: Bool,
-    addBuildForRunnableTargets: Bool, inferArgs: Bool,
+    addBuildForRunnableTargets: Bool, inferArgs: Bool, preferFolderRefs: Bool,
     mainRepoDir: RelativePath? = nil
   ) {
     self.name = name
@@ -62,6 +66,7 @@ public struct ProjectSpec {
     self.addRunnableTargets = addRunnableTargets
     self.addBuildForRunnableTargets = addBuildForRunnableTargets
     self.inferArgs = inferArgs
+    self.preferFolderRefs = preferFolderRefs
     self.mainRepoDir = mainRepoDir
   }
 
@@ -150,6 +155,10 @@ extension ProjectSpec {
 
   public mutating func addHeaders(in path: RelativePath) {
     guard let path = mapPath(path, for: "headers") else { return }
+    if preferFolderRefs {
+      referencesToAdd.append(.folder(path))
+      return
+    }
     do {
       for header in try buildDir.getHeaderFilePaths(for: path) {
         referencesToAdd.append(.file(header))
@@ -171,6 +180,10 @@ extension ProjectSpec {
 
   public mutating func addDocsGroup(at path: RelativePath) {
     guard let path = mapPath(path, for: "docs") else { return }
+    if preferFolderRefs {
+      referencesToAdd.append(.folder(path))
+      return
+    }
     do {
       for doc in try buildDir.getAllRepoSubpaths(of: path) where doc.isDocLike {
         referencesToAdd.append(.file(doc))

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
@@ -40,6 +40,9 @@ public struct ProjectSpec {
   /// files.
   public var preferFolderRefs: Bool
 
+  /// Whether to enable the use of buildable folders for targets.
+  public var useBuildableFolders: Bool
+
   /// If provided, the paths added will be implicitly appended to this path.
   let mainRepoDir: RelativePath?
 
@@ -55,7 +58,7 @@ public struct ProjectSpec {
     addClangTargets: Bool, addSwiftTargets: Bool,
     addSwiftDependencies: Bool, addRunnableTargets: Bool,
     addBuildForRunnableTargets: Bool, inferArgs: Bool, preferFolderRefs: Bool,
-    mainRepoDir: RelativePath? = nil
+    useBuildableFolders: Bool, mainRepoDir: RelativePath? = nil
   ) {
     self.name = name
     self.buildDir = buildDir
@@ -67,6 +70,7 @@ public struct ProjectSpec {
     self.addBuildForRunnableTargets = addBuildForRunnableTargets
     self.inferArgs = inferArgs
     self.preferFolderRefs = preferFolderRefs
+    self.useBuildableFolders = useBuildableFolders
     self.mainRepoDir = mainRepoDir
   }
 

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
@@ -127,8 +127,11 @@ extension PathProtocol {
 }
 
 extension Collection where Element: PathProtocol {
+  /// Computes the common parent for a collection of paths. If there is only
+  /// a single unique path, this returns the parent for that path.
   var commonAncestor: Element? {
     guard let first = self.first else { return nil }
-    return dropFirst().reduce(first, { $0.commonAncestor(with: $1) })
+    let result = dropFirst().reduce(first, { $0.commonAncestor(with: $1) })
+    return result == first ? result.parentDir : result
   }
 }

--- a/utils/swift-xcodegen/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/utils/swift-xcodegen/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -135,8 +135,12 @@ public struct Xcode {
     public var objectID: String?
     public var fileType: String?
     public var isDirectory: Bool
-    
-    init(path: String, isDirectory: Bool, pathBase: RefPathBase = .groupDir, name: String? = nil, fileType: String? = nil, objectID: String? = nil) {
+    public fileprivate(set) var isBuildableFolder: Bool = false
+
+    init(
+      path: String, isDirectory: Bool, pathBase: RefPathBase = .groupDir,
+      name: String? = nil, fileType: String? = nil, objectID: String? = nil
+    ) {
       self.isDirectory = isDirectory
       super.init(path: path, pathBase: pathBase, name: name)
       self.objectID = objectID
@@ -189,6 +193,7 @@ public struct Xcode {
     public var buildPhases: [BuildPhase]
     public var productReference: FileReference?
     public var dependencies: [TargetDependency]
+    public private(set) var buildableFolders: [FileReference]
     public enum ProductType: String {
       case application = "com.apple.product-type.application"
       case staticArchive = "com.apple.product-type.library.static"
@@ -205,6 +210,7 @@ public struct Xcode {
       self.buildSettings = BuildSettingsTable()
       self.buildPhases = []
       self.dependencies = []
+      self.buildableFolders = []
     }
     
     // FIXME: There's a lot repetition in these methods; using generics to
@@ -266,7 +272,14 @@ public struct Xcode {
     public func addDependency(on target: Target) {
       dependencies.append(TargetDependency(target: target))
     }
-    
+
+    /// Turn a given folder reference into a buildable folder for this target.
+    public func addBuildableFolder(_ fileRef: FileReference) {
+      precondition(fileRef.isDirectory)
+      fileRef.isBuildableFolder = true
+      buildableFolders.append(fileRef)
+    }
+
     /// A simple wrapper to prevent ownership cycles in the `dependencies`
     /// property.
     public struct TargetDependency {

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -193,6 +193,15 @@ struct ProjectOptions: ParsableArguments {
   )
   var inferArgs: Bool = true
 
+  @Flag(
+    name: .customLong("prefer-folder-refs"), inversion: .prefixedNo,
+    help: """
+      Whether to prefer folder references for groups containing non-source
+      files
+      """
+  )
+  var preferFolderRefs: Bool = false
+
   @Option(help: .hidden)
   var blueFolders: String = ""
 }

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -202,6 +202,21 @@ struct ProjectOptions: ParsableArguments {
   )
   var preferFolderRefs: Bool = false
 
+  @Flag(
+    name: .customLong("buildable-folders"), inversion: .prefixedNo,
+    help: """
+      Requires Xcode 16: Enables the use of "buildable folders", allowing
+      folder references to be used for compatible targets. This allows new
+      source files to be added to a target without needing to regenerate the
+      project.
+      
+      Only supported for targets that have no per-file build settings. This
+      unfortunately means some Clang targes such as 'lib/Basic' and 'stdlib' 
+      cannot currently use buildable folders.
+      """
+  )
+  var useBuildableFolders: Bool = false
+
   @Option(help: .hidden)
   var blueFolders: String = ""
 }

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -192,7 +192,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
           mayHaveUnbuildableFiles: true
         )
         if self.addTestFolders {
-          spec.addReference(to: "../clang-tools-extra/test", isImportant: true)
+          spec.addReference(to: "../clang-tools-extra/test")
         } else {
           // Avoid adding any headers present in the test folder.
           spec.addExcludedPath("../clang-tools-extra/test")
@@ -263,7 +263,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
         below: "../compiler-rt", addingPrefix: "extra-"
       )
       if self.addTestFolders {
-        spec.addReference(to: "../compiler-rt/test", isImportant: true)
+        spec.addReference(to: "../compiler-rt/test")
       } else {
         // Avoid adding any headers present in the test folder.
         spec.addExcludedPath("../compiler-rt/test")

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -71,7 +71,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
       addSwiftDependencies: self.addSwiftDependencies,
       addRunnableTargets: false,
       addBuildForRunnableTargets: self.addBuildForRunnableTargets,
-      inferArgs: self.inferArgs,
+      inferArgs: self.inferArgs, preferFolderRefs: self.preferFolderRefs,
       mainRepoDir: mainRepoDir
     )
   }

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -72,7 +72,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
       addRunnableTargets: false,
       addBuildForRunnableTargets: self.addBuildForRunnableTargets,
       inferArgs: self.inferArgs, preferFolderRefs: self.preferFolderRefs,
-      mainRepoDir: mainRepoDir
+      useBuildableFolders: self.useBuildableFolders, mainRepoDir: mainRepoDir
     )
   }
 


### PR DESCRIPTION
Generate buildable folders for compatible targets when `--buildable-folders` is passed. Currently disabled by default, I'd like to live on it for a bit before enabling by default, and ideally we'd also split up "umbrella" targets like `stdlib` + `unittests` such that they can benefit from it.

#77418