### PR TITLE
Try harder than #77509 to disable tests on wasm

### DIFF
--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -4,6 +4,8 @@
 
 // wasm currently disables aggressive reg2mem
 // UNSUPPORTED: wasm
+// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 
 public struct LargeThing {
     var  s0 : String = ""

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -7,6 +7,8 @@
 
 // wasm currently disables aggressive reg2mem
 // UNSUPPORTED: wasm
+// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
 
 import Builtin
 import Swift


### PR DESCRIPTION
PR#77502 disabled aggresive reg2mem heuristic for wasm. These two tests check IR patterns that are influenced by said heuristic.