### PR TITLE
Sema: Fix opaque type accessors with inactive availability conditions

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2535,7 +2535,7 @@ namespace {
 
           SmallVector<llvm::BasicBlock *, 4> conditionalTypes;
 
-          // Pre-allocate a basic block per condition, so there it's
+          // Pre-allocate a basic block per condition, so that it's
           // possible to jump between conditions.
           for (unsigned index : indices(substitutionSet)) {
             conditionalTypes.push_back(
@@ -2619,7 +2619,7 @@ namespace {
           auto universal = substitutionSet.back();
 
           assert(universal->getAvailability().size() == 1 &&
-                 universal->getAvailability()[0].first.isEmpty());
+                 universal->getAvailability()[0].first.isAll());
 
           IGF.Builder.CreateRet(
               getResultValue(IGF, genericEnv, universal->getSubstitutions()));

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3631,7 +3631,7 @@ public:
     // Add universally available choice as the last one.
     conditionalSubstitutions.push_back(
         OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-            Ctx, {{VersionRange::empty(), /*unavailable=*/false}},
+            Ctx, {{VersionRange::all(), /*unavailable=*/false}},
             std::get<1>(universallyAvailable)
                 .mapReplacementTypesOutOfContext()));
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4559,7 +4559,7 @@ public:
         } else {
           limitedAvailability.push_back(
               OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
-                  ctx, {{VersionRange::empty(), /*unavailability=*/false}},
+                  ctx, {{VersionRange::all(), /*unavailability=*/false}},
                   subMapOrError.get()));
 
           opaqueDecl->setConditionallyAvailableSubstitutions(limitedAvailability);

--- a/test/Serialization/Inputs/opaque_with_limited_availability.swift
+++ b/test/Serialization/Inputs/opaque_with_limited_availability.swift
@@ -44,7 +44,7 @@ public struct Example {
   }
 }
 
-public func test() -> some P {
+public func testAvailableQueryWithUniversalResult() -> some P {
   if #available(macOS 100.0.1, *) {
     return Tuple<(Int, Int)>((0, 0))
   }
@@ -52,7 +52,7 @@ public func test() -> some P {
   return Empty()
 }
 
-public func testUnavailable() -> some P {
+public func testUnavailableQueryWithLimitedResult() -> some P {
   if #unavailable(macOS 100.0.1) {
     return Tuple<(Int, Int)>((0, 1))
   }
@@ -60,7 +60,7 @@ public func testUnavailable() -> some P {
   return Empty()
 }
 
-public func test_return_from_conditional() -> some P {
+public func testAvailableQueryWithLimitedResult() -> some P {
   if #available(macOS 10.15, *) {
     return Named()
   }
@@ -68,13 +68,10 @@ public func test_return_from_conditional() -> some P {
   return Tuple<(String, Int)>(("", 0))
 }
 
-// This used to crash during serialization because
-// @available negates availability condition.
-@available(macOS, unavailable)
-public func testUnusable() -> some P {
+public func testInactiveAvailableQuery() -> some P {
   if #available(iOS 50, *) {
-    return Named()
+    return Empty()
   }
 
-  return Tuple<(String, Int)>(("", 0))
+  return Named()
 }

--- a/test/Serialization/opaque_with_availability_cross_module.swift
+++ b/test/Serialization/opaque_with_availability_cross_module.swift
@@ -39,7 +39,7 @@ public struct Test {
   }
 }
 
-let result = LimitedAvailOpaque.test()
+let result = LimitedAvailOpaque.testAvailableQueryWithUniversalResult()
 result.hello()
 // CHECK: Hello from Empty
 
@@ -47,10 +47,14 @@ Test().sayHello()
 // CHECK: Hello from Empty
 // CHECK: Hello from Tuple
 
-let conditionalR = LimitedAvailOpaque.test_return_from_conditional()
+let conditionalR = LimitedAvailOpaque.testAvailableQueryWithLimitedResult()
 conditionalR.hello()
 // CHECK: Hello from Named
 
-let unavailableTest = LimitedAvailOpaque.testUnavailable()
+let unavailableTest = LimitedAvailOpaque.testUnavailableQueryWithLimitedResult()
 unavailableTest.hello()
 // CHECK: Hello from Tuple
+
+let inactiveTest = LimitedAvailOpaque.testInactiveAvailableQuery()
+inactiveTest.hello()
+// CHECK: Hello from Empty


### PR DESCRIPTION
Opaque type metadata accessor functions could be miscompiled for functions that contain `if #available` checks for inactive platforms. For example, this function will always return `A` when compiled for macOS, but the opaque type accessor would instead return the type metadata for `B`:

```
func f() -> some P {
  if #available(iOS 99, *) {
    return A() // Returns an A on macOS
  } else {
    return B()
  }
}
```

Resolves rdar://139487970.