### PR TITLE
[cxx-interop] Infer SWIFT_SHARED_REFERENCE for types inheriting from a C++ foreign reference type

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -273,7 +273,9 @@ ERROR(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
       "a SWIFT_SHARED_REFERENCE type",
       (const clang::NamedDecl *))
 
-// TODO: make this case an error in next cxx-interop versions rdar://138806722
+// TODO: In the next C++ interop version, convert this warning into an error and
+// stop importing unannotated C++ APIs that return SWIFT_SHARED_REFERENCE.
+// rdar://138806722
 WARNING(no_returns_retained_returns_unretained, none,
         "%0 should be annotated with either SWIFT_RETURNS_RETAINED or "
         "SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE",
@@ -284,6 +286,15 @@ WARNING(returns_retained_returns_unretained_on_overloaded_operator, none,
         "yet for overloaded C++ %0. Overloaded C++ operators always "
         "return "
         "SWIFT_SHARED_REFERENCE types as owned ",
+        (const clang::NamedDecl *))
+
+// TODO: In the next C++ interop version, convert this warning into an error and
+// stop importing C++ types that inherit from SWIFT_SHARED_REFERENCE if the
+// Swift compiler cannot find unique retain/release functions.
+// rdar://145194375
+WARNING(cant_infer_frt_in_cxx_inheritance, none,
+        "unable to infer SWIFT_SHARED_REFERENCE for %0, although one of its "
+        "transitive base types is marked as SWIFT_SHARED_REFERENCE",
         (const clang::NamedDecl *))
 
 NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -342,6 +342,7 @@ enum class CxxRecordSemanticsKind {
 struct CxxRecordSemanticsDescriptor final {
   const clang::RecordDecl *decl;
   ASTContext &ctx;
+  ClangImporter::Implementation *importerImpl;
 
   /// Whether to emit warnings for missing destructor or copy constructor
   /// whenever the classification of the type assumes that they exist (e.g. for
@@ -349,8 +350,9 @@ struct CxxRecordSemanticsDescriptor final {
   bool shouldDiagnoseLifetimeOperations;
 
   CxxRecordSemanticsDescriptor(const clang::RecordDecl *decl, ASTContext &ctx,
+                               ClangImporter::Implementation *importerImpl,
                                bool shouldDiagnoseLifetimeOperations = true)
-      : decl(decl), ctx(ctx),
+      : decl(decl), ctx(ctx), importerImpl(importerImpl),
         shouldDiagnoseLifetimeOperations(shouldDiagnoseLifetimeOperations) {}
 
   friend llvm::hash_code hash_value(const CxxRecordSemanticsDescriptor &desc) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6602,9 +6602,11 @@ bool ClassDecl::isForeignReferenceType() const {
   if (!clangRecordDecl)
     return false;
 
+  // `importerImpl` is set to nullptr here to avoid diagnostics during this
+  // CxxRecordSemantics evaluation.
   CxxRecordSemanticsKind kind = evaluateOrDefault(
       getASTContext().evaluator,
-      CxxRecordSemantics({clangRecordDecl, getASTContext()}), {});
+      CxxRecordSemantics({clangRecordDecl, getASTContext(), nullptr}), {});
   return kind == CxxRecordSemanticsKind::Reference;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1406,10 +1406,10 @@ ClangImporter::create(ASTContext &ctx,
   // Install a Clang module file extension to build Swift name lookup tables.
   importer->Impl.Invocation->getFrontendOpts().ModuleFileExtensions.push_back(
       std::make_shared<SwiftNameLookupExtension>(
-          importer->Impl.BridgingHeaderLookupTable,
-          importer->Impl.LookupTables, importer->Impl.SwiftContext,
+          importer->Impl.BridgingHeaderLookupTable, importer->Impl.LookupTables,
+          importer->Impl.SwiftContext,
           importer->Impl.getBufferImporterForDiagnostics(),
-          importer->Impl.platformAvailability));
+          importer->Impl.platformAvailability, &importer->Impl));
 
   // Create a compiler instance.
   {
@@ -1557,7 +1557,7 @@ ClangImporter::create(ASTContext &ctx,
 
   importer->Impl.nameImporter.reset(new NameImporter(
       importer->Impl.SwiftContext, importer->Impl.platformAvailability,
-      importer->Impl.getClangSema()));
+      importer->Impl.getClangSema(), &importer->Impl));
 
   // FIXME: These decls are not being parsed correctly since (a) some of the
   // callbacks are still being added, and (b) the logic to parse them has
@@ -7678,7 +7678,146 @@ bool importer::isForeignReferenceTypeWithoutImmortalAttrs(const clang::QualType 
          !hasImmortalAtts(pointeeType->getDecl());
 }
 
+static bool hasDiamondInheritanceRefType(const clang::CXXRecordDecl *decl) {
+  if (!decl->hasDefinition() || decl->isDependentType())
+    return false;
+
+  llvm::DenseSet<const clang::CXXRecordDecl *> seenBases;
+  bool hasRefDiamond = false;
+
+  decl->forallBases([&](const clang::CXXRecordDecl *Base) {
+    if (hasImportAsRefAttr(Base) && !seenBases.insert(Base).second &&
+        !decl->isVirtuallyDerivedFrom(Base))
+      hasRefDiamond = true;
+    return true;
+  });
+
+  return hasRefDiamond;
+}
+
+// Returns the given declaration along with all its parent declarations that are
+// reference types.
+static llvm::SmallVector<const clang::RecordDecl *, 4>
+getRefParentDecls(const clang::RecordDecl *decl, ASTContext &ctx,
+                  ClangImporter::Implementation *importerImpl) {
+  assert(decl && "decl is null inside getRefParentDecls");
+
+  llvm::SmallVector<const clang::RecordDecl *, 4> matchingDecls;
+
+  if (hasImportAsRefAttr(decl))
+    matchingDecls.push_back(decl);
+
+  if (const auto *cxxRecordDecl = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
+    if (!cxxRecordDecl->hasDefinition())
+      return matchingDecls;
+    if (hasDiamondInheritanceRefType(cxxRecordDecl)) {
+      if (importerImpl) {
+        if (!importerImpl->DiagnosedCxxRefDecls.count(decl)) {
+          HeaderLoc loc(decl->getLocation());
+          importerImpl->diagnose(loc, diag::cant_infer_frt_in_cxx_inheritance,
+                                 decl);
+          importerImpl->DiagnosedCxxRefDecls.insert(decl);
+        }
+      } else {
+        ctx.Diags.diagnose({}, diag::cant_infer_frt_in_cxx_inheritance, decl);
+        assert(false && "nullpointer passeed for importerImpl when calling "
+                        "getRefParentOrDiag");
+      }
+      return matchingDecls;
+    }
+    cxxRecordDecl->forallBases([&](const clang::CXXRecordDecl *baseDecl) {
+      if (hasImportAsRefAttr(baseDecl))
+        matchingDecls.push_back(baseDecl);
+      return true;
+    });
+  }
+
+  return matchingDecls;
+}
+
+static llvm::SmallVector<ValueDecl *, 1>
+getValueDeclsForName(const clang::Decl *decl, ASTContext &ctx, StringRef name) {
+  llvm::SmallVector<ValueDecl *, 1> results;
+  auto *clangMod = decl->getOwningModule();
+  if (clangMod && clangMod->isSubModule())
+    clangMod = clangMod->getTopLevelModule();
+  if (clangMod) {
+    auto parentModule =
+        ctx.getClangModuleLoader()->getWrapperForModule(clangMod);
+    ctx.lookupInModule(parentModule, name, results);
+  } else {
+    // There is no Clang module for this declaration, so perform lookup from
+    // the main module. This will find declarations from the bridging header.
+    namelookup::lookupInModule(
+        ctx.MainModule, ctx.getIdentifier(name), results,
+        NLKind::UnqualifiedLookup, namelookup::ResolutionKind::Overloadable,
+        ctx.MainModule, SourceLoc(), NL_UnqualifiedDefault);
+
+    // Filter out any declarations that didn't come from Clang.
+    auto newEnd =
+        std::remove_if(results.begin(), results.end(),
+                       [&](ValueDecl *decl) { return !decl->getClangDecl(); });
+    results.erase(newEnd, results.end());
+  }
+  return results;
+}
+
+static const clang::RecordDecl *
+getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
+                   ClangImporter::Implementation *importerImpl) {
+  auto refParentDecls = getRefParentDecls(decl, ctx, importerImpl);
+  if (refParentDecls.empty())
+    return nullptr;
+
+  std::unordered_set<ValueDecl *> uniqueRetainDecls{}, uniqueReleaseDecls{};
+  constexpr StringRef retainPrefix = "retain:";
+  constexpr StringRef releasePrefix = "release:";
+
+  for (const auto *refParentDecl : refParentDecls) {
+    assert(refParentDecl && "refParentDecl is null inside getRefParentOrDiag");
+    for (const auto *attr : refParentDecl->getAttrs()) {
+      if (const auto swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr)) {
+        const auto &attribute = swiftAttr->getAttribute();
+        llvm::SmallVector<ValueDecl *, 1> valueDecls;
+        if (attribute.starts_with(retainPrefix)) {
+          auto name = attribute.drop_front(retainPrefix.size()).str();
+          valueDecls = getValueDeclsForName(decl, ctx, name);
+          uniqueRetainDecls.insert(valueDecls.begin(), valueDecls.end());
+        } else if (attribute.starts_with(releasePrefix)) {
+          auto name = attribute.drop_front(releasePrefix.size()).str();
+          valueDecls = getValueDeclsForName(decl, ctx, name);
+          uniqueReleaseDecls.insert(valueDecls.begin(), valueDecls.end());
+        }
+      }
+    }
+  }
+
+  // Ensure that exactly one unique retain function and one unique release
+  // function are found.
+  if (uniqueRetainDecls.size() != 1 || uniqueReleaseDecls.size() != 1) {
+    if (importerImpl) {
+      if (!importerImpl->DiagnosedCxxRefDecls.count(decl)) {
+        HeaderLoc loc(decl->getLocation());
+        importerImpl->diagnose(loc, diag::cant_infer_frt_in_cxx_inheritance,
+                               decl);
+        importerImpl->DiagnosedCxxRefDecls.insert(decl);
+      }
+    } else {
+      ctx.Diags.diagnose({}, diag::cant_infer_frt_in_cxx_inheritance, decl);
+      assert(false && "nullpointer passed for importerImpl when calling "
+                      "getRefParentOrDiag");
+    }
+    return nullptr;
+  }
+
+  return refParentDecls.front();
+}
+
 // Is this a pointer to a foreign reference type.
+// TODO: We need to review functions like this to ensure that
+// CxxRecordSemantics::evaluate is consistently invoked wherever we need to
+// determine whether a C++ type qualifies as a foreign reference type
+// rdar://145184659
 static bool isForeignReferenceType(const clang::QualType type) {
   if (!type->isPointerType())
     return false;
@@ -7927,10 +8066,10 @@ CxxRecordSemanticsKind
 CxxRecordSemantics::evaluate(Evaluator &evaluator,
                              CxxRecordSemanticsDescriptor desc) const {
   const auto *decl = desc.decl;
-
-  if (hasImportAsRefAttr(decl)) {
+  ClangImporter::Implementation *importerImpl = desc.importerImpl;
+  if (hasImportAsRefAttr(decl) ||
+      getRefParentOrDiag(decl, desc.ctx, importerImpl))
     return CxxRecordSemanticsKind::Reference;
-  }
 
   auto cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl);
   if (!cxxDecl) {
@@ -7943,15 +8082,16 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
   if (!hasDestroyTypeOperations(cxxDecl) ||
       (!hasCopyTypeOperations(cxxDecl) && !hasMoveTypeOperations(cxxDecl))) {
     if (desc.shouldDiagnoseLifetimeOperations) {
+      HeaderLoc loc(decl->getLocation());
       if (hasUnsafeAPIAttr(cxxDecl))
-        desc.ctx.Diags.diagnose({}, diag::api_pattern_attr_ignored,
-                                "import_unsafe", decl->getNameAsString());
+        importerImpl->diagnose(loc, diag::api_pattern_attr_ignored,
+                               "import_unsafe", decl->getNameAsString());
       if (hasOwnedValueAttr(cxxDecl))
-        desc.ctx.Diags.diagnose({}, diag::api_pattern_attr_ignored,
-                                "import_owned", decl->getNameAsString());
+        importerImpl->diagnose(loc, diag::api_pattern_attr_ignored,
+                               "import_owned", decl->getNameAsString());
       if (hasIteratorAPIAttr(cxxDecl))
-        desc.ctx.Diags.diagnose({}, diag::api_pattern_attr_ignored,
-                                "import_iterator", decl->getNameAsString());
+        importerImpl->diagnose(loc, diag::api_pattern_attr_ignored,
+                               "import_iterator", decl->getNameAsString());
     }
 
     return CxxRecordSemanticsKind::MissingLifetimeOperation;
@@ -8158,6 +8298,12 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
                                  : "release:";
 
   auto decl = cast<clang::RecordDecl>(swiftDecl->getClangDecl());
+
+  if (!hasImportAsRefAttr(decl)) {
+    if (auto parentRefDecl = getRefParentOrDiag(decl, ctx, nullptr))
+      decl = parentRefDecl;
+  }
+
   if (!decl->hasAttrs())
     return {CustomRefCountingOperationResult::noAttribute, nullptr, ""};
 
@@ -8184,27 +8330,8 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
   if (name == "immortal")
     return {CustomRefCountingOperationResult::immortal, nullptr, name};
 
-  llvm::SmallVector<ValueDecl *, 1> results;
-  auto *clangMod = swiftDecl->getClangDecl()->getOwningModule();
-  if (clangMod && clangMod->isSubModule())
-    clangMod = clangMod->getTopLevelModule();
-  if (clangMod) {
-    auto parentModule = ctx.getClangModuleLoader()->getWrapperForModule(clangMod);
-    ctx.lookupInModule(parentModule, name, results);
-  } else {
-    // There is no Clang module for this declaration, so perform lookup from
-    // the main module. This will find declarations from the bridging header.
-    namelookup::lookupInModule(
-        ctx.MainModule, ctx.getIdentifier(name), results,
-        NLKind::UnqualifiedLookup, namelookup::ResolutionKind::Overloadable,
-        ctx.MainModule, SourceLoc(), NL_UnqualifiedDefault);
-
-    // Filter out any declarations that didn't come from Clang.
-    auto newEnd = std::remove_if(results.begin(), results.end(), [&](ValueDecl *decl) {
-      return !decl->getClangDecl();
-    });
-    results.erase(newEnd, results.end());
-  }
+  llvm::SmallVector<ValueDecl *, 1> results =
+      getValueDeclsForName(swiftDecl->getClangDecl(), ctx, name);
   if (results.size() == 1)
     return {CustomRefCountingOperationResult::foundOperation, results.front(),
             name};

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -162,9 +162,11 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
   }
 }
 
-bool ClangImporter::Implementation::recordHasReferenceSemantics(
-    const clang::RecordDecl *decl, ASTContext &ctx) {
-  if (!isa<clang::CXXRecordDecl>(decl) && !ctx.LangOpts.CForeignReferenceTypes)
+bool importer::recordHasReferenceSemantics(
+    const clang::RecordDecl *decl,
+    ClangImporter::Implementation *importerImpl) {
+  if (!isa<clang::CXXRecordDecl>(decl) &&
+      !importerImpl->SwiftContext.LangOpts.CForeignReferenceTypes)
     return false;
 
   // At this point decl might not be fully imported into Swift yet, which
@@ -178,9 +180,9 @@ bool ClangImporter::Implementation::recordHasReferenceSemantics(
   // missing lifetime operations would get diagnosed later, once their members
   // are fully instantiated.
   auto semanticsKind = evaluateOrDefault(
-      ctx.evaluator,
-      CxxRecordSemantics(
-          {decl, ctx, /* shouldDiagnoseLifetimeOperations */ false}),
+      importerImpl->SwiftContext.evaluator,
+      CxxRecordSemantics({decl, importerImpl->SwiftContext, importerImpl,
+                          /* shouldDiagnoseLifetimeOperations */ false}),
       {});
   return semanticsKind == CxxRecordSemanticsKind::Reference;
 }
@@ -2025,14 +2027,13 @@ namespace {
     }
 
     bool recordHasReferenceSemantics(const clang::RecordDecl *decl) {
-      return ClangImporter::Implementation::recordHasReferenceSemantics(
-          decl, Impl.SwiftContext);
+      return importer::recordHasReferenceSemantics(decl, &Impl);
     }
 
     bool recordHasMoveOnlySemantics(const clang::RecordDecl *decl) {
       auto semanticsKind = evaluateOrDefault(
           Impl.SwiftContext.evaluator,
-          CxxRecordSemantics({decl, Impl.SwiftContext}), {});
+          CxxRecordSemantics({decl, Impl.SwiftContext, &Impl}), {});
       return semanticsKind == CxxRecordSemanticsKind::MoveOnly;
     }
 
@@ -2924,9 +2925,9 @@ namespace {
 
       // It is import that we bail on an unimportable record *before* we import
       // any of its members or cache the decl.
-      auto semanticsKind =
-          evaluateOrDefault(Impl.SwiftContext.evaluator,
-                            CxxRecordSemantics({decl, Impl.SwiftContext}), {});
+      auto semanticsKind = evaluateOrDefault(
+          Impl.SwiftContext.evaluator,
+          CxxRecordSemantics({decl, Impl.SwiftContext, &Impl}), {});
       if (semanticsKind == CxxRecordSemanticsKind::MissingLifetimeOperation &&
           // Let un-specialized class templates through. We'll sort out their
           // members once they're instranciated.
@@ -3270,7 +3271,7 @@ namespace {
               decl->getAnonField()->getParent())) {
         auto semanticsKind = evaluateOrDefault(
             Impl.SwiftContext.evaluator,
-            CxxRecordSemantics({parent, Impl.SwiftContext}), {});
+            CxxRecordSemantics({parent, Impl.SwiftContext, &Impl}), {});
         if (semanticsKind == CxxRecordSemanticsKind::MissingLifetimeOperation)
           return nullptr;
       }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -19,12 +19,13 @@
 
 #include "ImportEnumInfo.h"
 #include "SwiftLookupTable.h"
-#include "swift/Basic/StringExtras.h"
-#include "swift/Basic/Version.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/Basic/StringExtras.h"
+#include "swift/Basic/Version.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "clang/Sema/Sema.h"
 
 namespace swift {
@@ -416,13 +417,16 @@ class NameImporter {
 
   bool importSymbolicCXXDecls;
 
+  ClangImporter::Implementation *importerImpl;
+
 public:
   NameImporter(ASTContext &ctx, const PlatformAvailability &avail,
-               clang::Sema &cSema)
+               clang::Sema &cSema, ClangImporter::Implementation *importerImpl)
       : swiftCtx(ctx), availability(avail), clangSema(cSema),
         enumInfos(clangSema.getPreprocessor()),
         importSymbolicCXXDecls(
-            ctx.LangOpts.hasFeature(Feature::ImportSymbolicCXXDecls)) {}
+            ctx.LangOpts.hasFeature(Feature::ImportSymbolicCXXDecls)),
+        importerImpl(importerImpl) {}
 
   /// Determine the Swift name for a Clang decl
   ImportedName importName(const clang::NamedDecl *decl,
@@ -458,6 +462,7 @@ public:
 
   ASTContext &getContext() { return swiftCtx; }
   const LangOptions &getLangOpts() const { return swiftCtx.LangOpts; }
+  ClangImporter::Implementation *getImporterImpl() { return importerImpl; }
 
   Identifier getIdentifier(StringRef name) {
     return swiftCtx.getIdentifier(name);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2314,7 +2314,10 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     if (auto recordType = returnType->getAsCXXRecordDecl()) {
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
-              CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
+              // `importerImpl` is set to nullptr here to avoid diagnostics
+              // during this CxxRecordSemantics evaluation.
+              CxxRecordAsSwiftType({recordType, SwiftContext, nullptr}),
+              nullptr)) {
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
           Type t = ClassType::get(cd, Type(), SwiftContext);
           return ImportedType(t, /*implicitlyUnwraps=*/false);
@@ -2568,7 +2571,10 @@ ClangImporter::Implementation::importParameterType(
 
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
-              CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
+              // `importerImpl` is set to nullptr here to avoid diagnostics
+              // during this CxxRecordSemantics evaluation.
+              CxxRecordAsSwiftType({recordType, SwiftContext, nullptr}),
+              nullptr)) {
 
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4206,8 +4206,10 @@ void MissingMemberFailure::diagnoseUnsafeCxxMethod(SourceLoc loc,
     } else if (cxxMethod->getReturnType()->isRecordType()) {
       if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(
               cxxMethod->getReturnType()->getAsRecordDecl())) {
+        // `importerImpl` is set to nullptr here to avoid diagnostics during
+        // this CxxRecordSemantics evaluation.
         auto methodSemantics = evaluateOrDefault(
-            ctx.evaluator, CxxRecordSemantics({cxxRecord, ctx}), {});
+            ctx.evaluator, CxxRecordSemantics({cxxRecord, ctx, nullptr}), {});
         if (methodSemantics == CxxRecordSemanticsKind::Iterator) {
           ctx.Diags.diagnose(loc, diag::iterator_method_unavailable,
                              name.getBaseIdentifier().str());

--- a/test/Interop/Cxx/class/conforms-to.swift
+++ b/test/Interop/Cxx/class/conforms-to.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/conforms-to-imported.swift -module-name ImportedModule -emit-module -emit-module-path %t/ImportedModule.swiftmodule
 
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -enable-experimental-cxx-interop
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-5.9
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-6
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=upcoming-swift
 
 import ConformsTo
 import ImportedModule

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "visibility.h"
+
 // A wrapper around C++'s static_cast(), which allows Swift to get around interop's current lack of support for inheritance.
 template <class I, class O> O cxxCast(I i) { return static_cast<O>(i); }
 
@@ -68,3 +70,303 @@ DerivedOutOfOrder : public BaseT, public DerivedWithVirtualDestructor {
       return singleton;
     }
 };
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+namespace ImmortalRefereceExample {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) ImmortalRefType {};
+
+ImmortalRefType *returnImmortalRefType() { return new ImmortalRefType(); };
+
+// Doubt: Is it fine to not infer in the case of SWIFT_IMMORTAL_REFERENCE
+// rdar://145193396
+struct DerivedFromImmortalRefType : ImmortalRefType {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'DerivedFromImmortalRefType', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() {
+    return new DerivedFromImmortalRefType();
+};
+
+} // namespace ImmortalRefereceExample
+
+namespace ExplicitAnnotationHasPrecedence1 {
+struct ValueType {};
+ValueType *returnValueType() { return new ValueType(); }
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:ret1")))
+__attribute__((swift_attr("release:rel1"))) RefType {};
+RefType *returnRefType() { return new RefType(); } // expected-warning {{'returnRefType' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE}}
+
+struct DerivedFromValueType : ValueType {};
+DerivedFromValueType *returnDerivedFromValueType() {
+    return new DerivedFromValueType();
+}
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:ret2")))
+__attribute__((swift_attr("release:rel2"))) DerivedFromValueTypeAndAnnotated
+    : ValueType {};
+DerivedFromValueTypeAndAnnotated *returnDerivedFromValueTypeAndAnnotated() { // expected-warning {{'returnDerivedFromValueTypeAndAnnotated' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE}}
+    return new DerivedFromValueTypeAndAnnotated();
+}
+
+struct DerivedFromRefType : RefType {};
+DerivedFromRefType *returnDerivedFromRefType() {
+    return new DerivedFromRefType();
+}
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:ret3")))
+__attribute__((swift_attr("release:rel3"))) DerivedFromRefTypeAndAnnotated
+    : RefType {};
+DerivedFromRefTypeAndAnnotated *returnDerivedFromRefTypeAndAnnotated() { // expected-warning {{'returnDerivedFromRefTypeAndAnnotated' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE}}
+    return new DerivedFromRefTypeAndAnnotated();
+}
+} // namespace ExplicitAnnotationHasPrecedence1
+
+void ret1(ExplicitAnnotationHasPrecedence1::RefType *v) {};
+void rel1(ExplicitAnnotationHasPrecedence1::RefType *v) {};
+
+void ret2(
+    ExplicitAnnotationHasPrecedence1::DerivedFromValueTypeAndAnnotated *v) {};
+void rel2(
+    ExplicitAnnotationHasPrecedence1::DerivedFromValueTypeAndAnnotated *v) {};
+
+void ret3(ExplicitAnnotationHasPrecedence1::DerivedFromRefTypeAndAnnotated *v) {
+};
+void rel3(ExplicitAnnotationHasPrecedence1::DerivedFromRefTypeAndAnnotated *v) {
+};
+
+namespace ExplicitAnnotationHasPrecedence2 {
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain_A")))
+__attribute__((swift_attr("release:release_A"))) RefTypeA {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain_B")))
+__attribute__((swift_attr("release:release_B"))) RefTypeB {};
+
+struct DerivedFromRefTypeAAndB : RefTypeA, RefTypeB {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'DerivedFromRefTypeAAndB', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+DerivedFromRefTypeAAndB *returnDerivedFromRefTypeAAndB() {
+    return new DerivedFromRefTypeAAndB();
+}
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain_C")))
+__attribute__((swift_attr("release:release_C"))) DerivedFromRefTypeAAndBAnnotated
+    : RefTypeA,
+        RefTypeB {};
+DerivedFromRefTypeAAndBAnnotated *returnDerivedFromRefTypeAAndBAnnotated() { // expected-warning {{'returnDerivedFromRefTypeAAndBAnnotated' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE}}
+    return new DerivedFromRefTypeAAndBAnnotated();
+}
+} // namespace ExplicitAnnotationHasPrecedence2
+
+void retain_A(ExplicitAnnotationHasPrecedence2::RefTypeA *v) {};
+void release_A(ExplicitAnnotationHasPrecedence2::RefTypeA *v) {};
+void retain_B(ExplicitAnnotationHasPrecedence2::RefTypeB *v) {};
+void release_B(ExplicitAnnotationHasPrecedence2::RefTypeB *v) {};
+void retain_C(
+    ExplicitAnnotationHasPrecedence2::DerivedFromRefTypeAAndBAnnotated *v) {};
+void release_C(
+    ExplicitAnnotationHasPrecedence2::DerivedFromRefTypeAAndBAnnotated *v) {};
+
+namespace BasicInheritanceExample {
+struct ValueType {};
+ValueType *returnValueType() { return new ValueType(); };
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:RCRetain")))
+__attribute__((swift_attr("release:RCRelease"))) RefType {};
+
+RefType *returnRefType() { return new RefType(); }; // expected-warning {{'returnRefType' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENC}}
+
+struct DerivedFromRefType : RefType {};
+DerivedFromRefType *returnDerivedFromRefType() { // TODO: rdar://145098078 Missing SWIFT_RETURNS_(UN)RETAINED annotation warning should trigger for inferred foreeign reference types as well
+  return new DerivedFromRefType();
+};
+} // namespace BasicInheritanceExample
+
+void RCRetain(BasicInheritanceExample::RefType *v) {}
+void RCRelease(BasicInheritanceExample::RefType *v) {}
+
+namespace MultipleInheritanceExample1 {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:baseRetain1")))
+__attribute__((swift_attr("release:baseRelease1"))) BaseRef1 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:baseRetain2")))
+__attribute__((swift_attr("release:baseRelease2"))) BaseRef2 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:baseRetain1")))
+__attribute__((swift_attr("release:baseRelease1"))) BaseRef3 : BaseRef1 {};
+
+struct DerivedFromBaseRef1AndBaseRef2 : BaseRef1, BaseRef2 {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'DerivedFromBaseRef1AndBaseRef2', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+DerivedFromBaseRef1AndBaseRef2 *returnDerivedFromBaseRef1AndBaseRef2() {
+  return new DerivedFromBaseRef1AndBaseRef2();
+};
+
+struct DerivedFromBaseRef3 : BaseRef3 {};
+DerivedFromBaseRef3 *returnDerivedFromBaseRef3() {
+  return new DerivedFromBaseRef3();
+};
+} // namespace MultipleInheritanceExample1
+
+void baseRetain1(MultipleInheritanceExample1::BaseRef1 *v) {}
+void baseRelease1(MultipleInheritanceExample1::BaseRef1 *v) {}
+
+void baseRetain2(MultipleInheritanceExample1::BaseRef2 *v) {}
+void baseRelease2(MultipleInheritanceExample1::BaseRef2 *v) {}
+
+namespace MultipleInheritanceExample2 {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:bRetain1")))
+__attribute__((swift_attr("release:bRelease1"))) B1 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:bRetain2")))
+__attribute__((swift_attr("release:bRelease2"))) B2 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:bRetain3")))
+__attribute__((swift_attr("release:bRelease3"))) B3 {};
+
+struct D : B1, B2, B3 {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'D', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+D *returnD() { return new D(); };
+} // namespace MultipleInheritanceExample2
+
+void bRetain1(MultipleInheritanceExample2::B1 *v) {}
+void bRelease1(MultipleInheritanceExample2::B1 *v) {}
+
+void bRetain2(MultipleInheritanceExample2::B2 *v) {}
+void bRelease2(MultipleInheritanceExample2::B2 *v) {}
+
+void bRetain3(MultipleInheritanceExample2::B3 *v) {}
+void bRelease3(MultipleInheritanceExample2::B3 *v) {}
+
+// To check for x, y, x kind of pattern in parent's retain/release function name
+// when infering SWIFT_SHARED_REFERENCE
+namespace MultipleInheritanceExample3 {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain1")))
+__attribute__((swift_attr("release:release1"))) B1 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain2")))
+__attribute__((swift_attr("release:release2"))) B2 {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain1")))
+__attribute__((swift_attr("release:release1"))) B3 : B1 {};
+
+struct D : B1, B2, B3 {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'D', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+D *returnD() { return new D(); };
+} // namespace MultipleInheritanceExample3
+
+void retain1(MultipleInheritanceExample3::B1 *v) {}
+void release1(MultipleInheritanceExample3::B1 *v) {}
+
+void retain2(MultipleInheritanceExample3::B2 *v) {}
+void release2(MultipleInheritanceExample3::B2 *v) {}
+
+namespace OverloadedRetainRelease {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:sameretain")))
+__attribute__((swift_attr("release:samerelease"))) B1 {}; // expected-error {{multiple functions 'sameretain' found; there must be exactly one retain function for reference type 'B1'}}
+                                                          // expected-error@-1 {{multiple functions 'samerelease' found; there must be exactly one release function for reference type 'B1'}}
+
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:sameretain")))
+__attribute__((swift_attr("release:samerelease"))) B2 {};  // expected-error {{multiple functions 'sameretain' found; there must be exactly one retain function for reference type 'B2'}}
+                                                            // expected-error@-1 {{multiple functions 'samerelease' found; there must be exactly one release function for reference type 'B2'}}
+
+struct D : B1, B2 {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'D', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+D *returnD() { return new D(); };
+} // namespace OverloadedRetainRelease
+
+void sameretain(OverloadedRetainRelease::B1 *v) {}
+void samerelease(OverloadedRetainRelease::B1 *v) {}
+
+void sameretain(OverloadedRetainRelease::B2 *v) {}
+void samerelease(OverloadedRetainRelease::B2 *v) {}
+
+namespace RefTypeDiamondInheritance {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainA")))
+__attribute__((swift_attr("release:releaseA"))) A {};
+
+
+struct B : A {};
+
+struct C : A {};
+
+struct Diamond : B, C {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'Diamond', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+Diamond *returnDiamond() { return new Diamond(); };
+
+struct BVirtual : virtual A {};
+
+struct CVirtual : virtual A {};
+
+struct VirtualDiamond : BVirtual, CVirtual {};
+VirtualDiamond *returnVirtualDiamond() { return new VirtualDiamond(); };
+} // namespace RefTypeDiamondInheritance
+
+void retainA(RefTypeDiamondInheritance::A *a) {};
+void releaseA(RefTypeDiamondInheritance::A *a) {};
+
+namespace NonRefTypeDiamondInheritance {
+struct A {};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainB")))
+__attribute__((swift_attr("release:releaseB"))) B : A {};
+
+struct C : A {};
+
+struct Diamond : B, C {};
+Diamond *returnDiamond() { return new Diamond(); };
+
+} // namespace NonRefTypeDiamondInheritance
+
+void retainB(NonRefTypeDiamondInheritance::B *a) {};
+void releaseB(NonRefTypeDiamondInheritance::B *a) {};
+
+namespace InheritingTemplatedRefType {
+
+template <class T>
+class __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:forestRetain"))) __attribute__((
+    swift_attr("release:forestRelease"))) IntrusiveRefCountedTemplate {
+public:
+    IntrusiveRefCountedTemplate() : referenceCount(1) {}
+    IntrusiveRefCountedTemplate(const IntrusiveRefCountedTemplate &) = delete;
+    void retain() { ++referenceCount; }
+
+    void release() {
+    --referenceCount;
+    if (referenceCount == 0)
+        delete static_cast<T *>(this);
+    }
+
+private:
+    int referenceCount;
+};
+
+class Forest : public IntrusiveRefCountedTemplate<Forest> {};
+Forest *returnForest() { return new Forest(); };
+} // namespace InheritingTemplatedRefType
+
+void forestRetain(InheritingTemplatedRefType::IntrusiveRefCountedTemplate<
+                    InheritingTemplatedRefType::Forest> *forest) {
+    forest->retain();
+}
+void forestRelease(InheritingTemplatedRefType::IntrusiveRefCountedTemplate<
+                    InheritingTemplatedRefType::Forest> *forest) {
+    forest->release();
+}  
+
+SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -1,0 +1,40 @@
+// RUN: rm -rf %t
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
+
+// TODO: Fix this lit test failure on windows rdar://145218056
+// XFAIL: OS=windows-msvc
+
+import Inheritance
+
+let _ = ImmortalRefereceExample.returnImmortalRefType()
+let _ = ImmortalRefereceExample.returnDerivedFromImmortalRefType()
+
+let _ = ExplicitAnnotationHasPrecedence1.returnValueType()
+let _ = ExplicitAnnotationHasPrecedence1.returnRefType()
+let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueType()
+let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueTypeAndAnnotated()
+let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromRefType()
+let _ = ExplicitAnnotationHasPrecedence1.returnDerivedFromRefTypeAndAnnotated()
+
+let _ = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndB()
+let _ = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndBAnnotated()
+
+let _ = BasicInheritanceExample.returnValueType()
+let _ = BasicInheritanceExample.returnRefType()
+let _ = BasicInheritanceExample.returnDerivedFromRefType()
+
+let _ = MultipleInheritanceExample1.returnDerivedFromBaseRef1AndBaseRef2()
+let _ = MultipleInheritanceExample1.returnDerivedFromBaseRef3()
+
+let _ = MultipleInheritanceExample2.returnD()
+
+let _ = MultipleInheritanceExample3.returnD()
+
+let _ = OverloadedRetainRelease.returnD()
+
+let _ = RefTypeDiamondInheritance.returnDiamond()
+let _ = RefTypeDiamondInheritance.returnVirtualDiamond()
+
+let _ = NonRefTypeDiamondInheritance.returnDiamond()
+
+let _ = InheritingTemplatedRefType.returnForest()

--- a/test/Interop/Cxx/foreign-reference/inheritance-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions -disable-availability-checking
+// RUN: %target-swift-emit-ir -Onone %s -I %S/Inputs -cxx-interoperability-mode=default -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
 
 // This ensured we do not crash during IRGen for inherited C++ foreign reference types.
 
@@ -12,3 +12,26 @@ let x = DerivedOutOfOrder.getInstance()
 blackHole(x.baseField)
 blackHole(x.derivedField)
 blackHole(x.leafField)
+
+// CHECK: call ptr @{{.*}}returnValueType{{.*}}
+// CHECK-NOT: call void @{{.*}}RCRetain@{{.*}}ValueType(ptr @{{.*}})
+var x1 = BasicInheritanceExample.returnValueType()
+
+// CHECK: call ptr @{{.*}}returnRefType{{.*}}
+// CHECK: call void @{{.*}}RCRetain{{.*}}RefType{{.*}}(ptr {{.*}})
+var x2 = BasicInheritanceExample.returnRefType()
+
+// CHECK: call ptr @{{.*}}returnDerivedFromRefType{{.*}}
+// CHECK: call void @{{.*}}RCRetain{{.*}}RefType{{.*}}(ptr {{.*}})
+var x3 = BasicInheritanceExample.returnDerivedFromRefType()
+
+func foo(
+  x1: BasicInheritanceExample.ValueType, x2: BasicInheritanceExample.RefType,
+  x3: BasicInheritanceExample.DerivedFromRefType
+) {
+}
+
+foo(x1: x1.pointee, x2: x2, x3: x3)
+
+// CHECK: call void @{{.*}}RCRelease{{.*}}RefType{{.*}}(ptr {{.*}})
+// CHECK: call void @{{.*}}RCRelease{{.*}}RefType{{.*}}(ptr {{.*}})

--- a/test/Interop/Cxx/foreign-reference/inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-module-interface.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Inheritance -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default  | %FileCheck %s
+
+// CHECK-NOT: class ValueType {
+// CHECK: struct ValueType {
+// CHECK:   init()
+// CHECK: }
+
+// CHECK-NOT: func returnValueType() -> BasicInheritanceExample.ValueType
+// CHECK: func returnValueType() -> UnsafeMutablePointer<BasicInheritanceExample.ValueType>
+
+// CHECK-NOT: struct RefType {
+// CHECK-NOT:   init()
+// CHECK: class RefType {
+// CHECK: }
+
+// CHECK-NOT: func returnRefType() -> UnsafeMutablePointer<BasicInheritanceExample.RefType>
+// CHECK: func returnRefType() -> BasicInheritanceExample.RefType
+
+// CHECK-NOT: struct DerivedFromRefType {
+// CHECK-NOT:   init()
+// CHECK: class DerivedFromRefType {
+// CHECK: }
+
+// CHECK-NOT: func returnDerivedFromRefType() -> UnsafeMutablePointer<BasicInheritanceExample.DerivedFromRefType>
+// CHECK: func returnDerivedFromRefType() -> BasicInheritanceExample.DerivedFromRefType

--- a/test/Interop/Cxx/foreign-reference/inheritance-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-silgen.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+
+import Inheritance
+
+var x = BasicInheritanceExample.returnValueType()
+// CHECK: function_ref {{.*}}returnValueType{{.*}} : $@convention(c) () -> UnsafeMutablePointer<BasicInheritanceExample.ValueType>
+// CHECK-NEXT: apply {{.*}} $@convention(c) () -> UnsafeMutablePointer<BasicInheritanceExample.ValueType>
+// CHECK-NOT: strong_retain {{.*}}
+
+var y = BasicInheritanceExample.returnRefType()
+// CHECK: function_ref {{.*}}returnRefType{{.*}} : $@convention(c) () -> BasicInheritanceExample.RefType
+// CHECK-NEXT: apply {{.*}} $@convention(c) () -> BasicInheritanceExample.RefType
+// CHECK-NEXT: strong_retain {{.*}}
+
+var z = BasicInheritanceExample.returnDerivedFromRefType()
+// CHECK: function_ref {{.*}}returnDerivedFromRefType{{.*}} : $@convention(c) () -> BasicInheritanceExample.DerivedFromRefType
+// CHECK-NEXT: apply {{.*}} $@convention(c) () -> BasicInheritanceExample.DerivedFromRefType
+// CHECK-NEXT: strong_retain {{.*}}
+
+func foo(
+  x: BasicInheritanceExample.ValueType, y: BasicInheritanceExample.RefType,
+  z: BasicInheritanceExample.DerivedFromRefType
+) {
+}
+
+foo(x: x.pointee, y: y, z: z)
+// CHECK: function_ref {{.*}}foo{{.*}} : $@convention(thin) (BasicInheritanceExample.ValueType, BasicInheritanceExample.RefType, BasicInheritanceExample.DerivedFromRefType)

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -1,40 +1,157 @@
 // REQUIRES: executable_test
 // RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs)
 
-import StdlibUnittest
+// TODO: Fix this lit test failure on windows rdar://145218056
+// XFAIL: OS=windows-msvc
+
 import Inheritance
+import StdlibUnittest
 
 // A function whose explicit type annotations specializes the cxxCast function.
 //
 // In Swift, the generic type parameters of cxxCast I and O should be respectively instantiated to SubT and BaseT.
 // However, since these are foreign reference types, this instantiates (and calls) cxxCast<SubT *, BaseT *> in C++.
 func cast(_ s: SubT) -> BaseT {
-    return cxxCast(s)
+  return cxxCast(s)
 }
 
 var TemplatingTestSuite = TestSuite("Foreign references work with templates")
 
 TemplatingTestSuite.test("SubT") {
-    let s: SubT = SubT.getSubT()
-    expectFalse(s.isBase)
-    let sc: BaseT = cast(s)
-    expectFalse(sc.isBase)
-    let sx: BaseT = cxxCast(s)      // should instantiate I to SubT and O to BaseT
-    expectFalse(sc.isBase)
+  let s: SubT = SubT.getSubT()
+  expectFalse(s.isBase)
+  let sc: BaseT = cast(s)
+  expectFalse(sc.isBase)
+  let sx: BaseT = cxxCast(s)  // should instantiate I to SubT and O to BaseT
+  expectFalse(sc.isBase)
 }
 
 TemplatingTestSuite.test("BaseT") {
-    let b: BaseT = BaseT.getBaseT()
-    expectTrue(b.isBase)
-    let bc: BaseT = cxxCast(b)      // should instantiate I and O both to BaseT
-    expectTrue(bc.isBase)
+  let b: BaseT = BaseT.getBaseT()
+  expectTrue(b.isBase)
+  let bc: BaseT = cxxCast(b)  // should instantiate I and O both to BaseT
+  expectTrue(bc.isBase)
 }
 
 TemplatingTestSuite.test("DerivedOutOfOrder") {
-    let d = DerivedOutOfOrder.getInstance()
-    expectEqual(123, d.baseField)
-    expectEqual(456, d.derivedField)
-    expectEqual(789, d.leafField)
+  let d = DerivedOutOfOrder.getInstance()
+  expectEqual(123, d.baseField)
+  expectEqual(456, d.derivedField)
+  expectEqual(789, d.leafField)
+}
+
+var FrtInheritanceTestSuite = TestSuite("Foreign references in C++ inheritance")
+
+FrtInheritanceTestSuite.test("ParentChild") {
+  let immortalRefType = ImmortalRefereceExample.returnImmortalRefType()
+  expectTrue(
+    type(of: immortalRefType) is AnyObject.Type,
+    "Expected immortalRefType to be a reference type, but it’s a value type")
+
+  let derivedFromImmortalRefType = ImmortalRefereceExample.returnDerivedFromImmortalRefType()
+  expectTrue(
+    !(type(of: derivedFromImmortalRefType) is AnyObject.Type),
+    "Expected derivedFromImmortalRefType to be a value type, but it’s a reference type")
+
+  let valType = ExplicitAnnotationHasPrecedence1.returnValueType()
+  expectTrue(
+    !(type(of: valType) is AnyObject.Type),
+    "Expected valType to be a value type, but it’s a reference type")
+
+  let referenceType = ExplicitAnnotationHasPrecedence1.returnRefType()
+  expectTrue(
+    type(of: referenceType) is AnyObject.Type,
+    "Expected referenceType to be a reference type, but it’s a value type")
+
+  let derivedFromValType = ExplicitAnnotationHasPrecedence1.returnDerivedFromValueType()
+  expectTrue(
+    !(type(of: derivedFromValType) is AnyObject.Type),
+    "Expected derivedFromValType to be a value type, but it’s a reference type")
+
+  let derivedFromRefTypeAAndB = ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndB()
+  expectTrue(
+    !(type(of: derivedFromRefTypeAAndB) is AnyObject.Type),
+    "Expected derivedFromRefTypeAAndB to be a value type, but it’s a reference type")
+
+  let derivedFromRefTypeAAndBAnnotated =
+    ExplicitAnnotationHasPrecedence2.returnDerivedFromRefTypeAAndBAnnotated()
+  expectTrue(
+    type(of: derivedFromRefTypeAAndBAnnotated) is AnyObject.Type,
+    "Expected derivedFromRefTypeAAndBAnnotated to be a reference type, but it’s a value type")
+
+  let derivedFromValueTypeAndAnnotated =
+    ExplicitAnnotationHasPrecedence1.returnDerivedFromValueTypeAndAnnotated()
+  expectTrue(
+    type(of: derivedFromValueTypeAndAnnotated) is AnyObject.Type,
+    "Expected derivedFromValueTypeAndAnnotated to be a reference type, but it’s a value type")
+
+  let derivedFromReferenceType = ExplicitAnnotationHasPrecedence1.returnDerivedFromRefType()
+  expectTrue(
+    type(of: derivedFromReferenceType) is AnyObject.Type,
+    "Expected derivedFromReferenceType to be a reference type, but it’s a value type")
+
+  let derivedFromReferenceTypeAndAnnotated =
+    ExplicitAnnotationHasPrecedence1.returnDerivedFromRefTypeAndAnnotated()
+  expectTrue(
+    type(of: derivedFromReferenceTypeAndAnnotated) is AnyObject.Type,
+    "Expected derivedFromReferenceTypeAndAnnotated to be a reference type, but it’s a value type"
+  )
+
+  let valueType = BasicInheritanceExample.returnValueType()
+  expectTrue(
+    !(type(of: valueType) is AnyObject.Type),
+    "Expected valueType to be a value type, but it’s a reference type")
+
+  let refType = BasicInheritanceExample.returnRefType()
+  expectTrue(
+    type(of: refType) is AnyObject.Type,
+    "Expected refType to be a reference type, but it’s a value type")
+
+  let derivedFromRefType = BasicInheritanceExample.returnDerivedFromRefType()
+  expectTrue(
+    type(of: derivedFromRefType) is AnyObject.Type,
+    "Expected derivedFromRefType to be a reference type, but it’s a value type")
+
+  let derivedFromBaseRef1AndBaseRef2 =
+    MultipleInheritanceExample1.returnDerivedFromBaseRef1AndBaseRef2()
+  expectTrue(
+    !(type(of: derivedFromBaseRef1AndBaseRef2) is AnyObject.Type),
+    "Expected derivedFromBaseRef1AndBaseRef2 to be a value type, but it’s a reference type")
+
+  let derivedFromBaseRef3 = MultipleInheritanceExample1.returnDerivedFromBaseRef3()
+  expectTrue(
+    type(of: derivedFromBaseRef3) is AnyObject.Type,
+    "Expected derivedFromBaseRef3 to be a reference type, but it’s a value type")
+
+  let d2 = MultipleInheritanceExample2.returnD()
+  expectTrue(
+    !(type(of: d2) is AnyObject.Type),
+    "Expected d2 to be a value type, but it’s a reference type")
+
+  let d3 = MultipleInheritanceExample2.returnD()
+  expectTrue(
+    !(type(of: d3) is AnyObject.Type),
+    "Expected d3 to be a value type, but it’s a reference type")
+
+  let refTypeDiamond = RefTypeDiamondInheritance.returnDiamond()
+  expectTrue(
+    !(type(of: refTypeDiamond) is AnyObject.Type),
+    "Expected refTypeDiamond to be a value type, but it’s a reference type")
+
+  let virtualDiamond = RefTypeDiamondInheritance.returnVirtualDiamond()
+  expectTrue(
+    type(of: virtualDiamond) is AnyObject.Type,
+    "Expected virtualDiamond to be a reference type, but it’s a value type")
+
+  let nonRefTypeDiamond = NonRefTypeDiamondInheritance.returnDiamond()
+  expectTrue(
+    type(of: nonRefTypeDiamond) is AnyObject.Type,
+    "Expected nonRefTypeDiamond to be a reference type, but it’s a value type")
+
+  let forest = InheritingTemplatedRefType.returnForest()
+  expectTrue(
+    type(of: forest) is AnyObject.Type,
+    "Expected forest to be a reference type, but it’s a value type")
 }
 
 runAllTests()


### PR DESCRIPTION
Propagating `SWIFT_SHARED_REFERENCE` annotation from base (parent) to derived (chid) structs/classes in C++ inheritance. In other words importing C++ class/struct as a foreign reference type if it inherits from a foreign reference type.

rdar://97914474