### PR TITLE
[Test] Enable some new parser round-tripping.

### DIFF
--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -1,13 +1,10 @@
 // RUN: %target-swift-frontend                         \
 // RUN:     %s                                         \
 // RUN:     -emit-silgen                               \
-// RUN:     -disable-experimental-parser-round-trip    \
 // RUN:     -target %target-swift-5.1-abi-triple       \
 // RUN:     -enable-experimental-feature Sensitive     \
 // RUN:     -enable-experimental-feature ValueGenerics \
 // RUN:     -enable-builtin-module
-
-// FIXME: Remove -disable-experimental-parser-round-trip when it's not required for using ValueGenerics.
 
 // REQUIRES: swift_feature_Sensitive
 // REQUIRES: swift_feature_ValueGenerics

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -1,13 +1,10 @@
 // RUN: %target-typecheck-verify-swift                       \
-// RUN:     -disable-experimental-parser-round-trip          \
 // RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
 // RUN:     -enable-experimental-feature ValueGenerics       \
 // RUN:     -enable-experimental-feature Sensitive           \
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
-
-// FIXME: Remove -disable-experimental-parser-round-trip when it's not required for using ValueGenerics.
 
 // REQUIRES: swift_feature_NonescapableTypes
 // REQUIRES: swift_feature_ValueGenerics


### PR DESCRIPTION
It shouldn't be necessary for ValueGenerics anymore.
