### PR TITLE
[NFC] Restrict 'embedded-darwin' top-level target to one-job pool

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -85,6 +85,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_dependencies(embedded-libraries embedded-darwin)
 
   set_property(GLOBAL APPEND PROPERTY JOB_POOLS one_job=1)
+  set_property(TARGET embedded-darwin PROPERTY JOB_POOL_COMPILE one_job)
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/77495, restricting the top-level target in order to serialize all the variants of embedded stdlib builds.
