### PR TITLE
Missing playground results for property accessors in a class wrapped in a struct

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -322,6 +322,10 @@ public:
       for (Decl *Member : NTD->getMembers()) {
         transformDecl(Member);
       }
+    } else if (auto *VD = dyn_cast<AbstractStorageDecl>(D)) {
+      VD->visitParsedAccessors([&](AccessorDecl * ACC) {
+        transformDecl(ACC);
+      });
     }
 
     return D;

--- a/test/PlaygroundTransform/nested_accessors.swift
+++ b/test/PlaygroundTransform/nested_accessors.swift
@@ -1,0 +1,187 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+
+// Build PlaygroundSupport module
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+
+// -playground
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
+
+// -pc-macro -playground
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
+
+// RUN: %target-codesign %t/main5a
+// RUN: %target-codesign %t/main5b
+// RUN: %target-codesign %t/main6a
+// RUN: %target-codesign %t/main6b
+
+// RUN: %target-run %t/main5a | %FileCheck %s
+// RUN: %target-run %t/main5b | %FileCheck %s
+// RUN: %target-run %t/main6a | %FileCheck %s
+// RUN: %target-run %t/main6b | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+// First make sure we get results in accessors and regular functions for an unwrapped class.
+class MyClass {
+    func f() {
+        let x = 1
+    }
+    var v1: Int {
+        return 2
+    }
+    var v2: Int {
+        get {
+            return 3
+        }
+        set {
+            let y = 4
+        }
+    }
+    var v3: Int = 5 {
+        didSet {
+            let z = 6
+        }
+    }
+    subscript(index: Int) -> Int {
+        get {
+            return 7
+        }
+        set {
+            let y = 8
+        }
+    }
+}
+do {
+    let c = MyClass()
+    c.f()
+    c.v1
+    c.v2 = 7
+    c.v2
+    c.v3 = 8
+    c[9]
+    c[9] = 10
+}
+
+// CHECK:      [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[x='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[newValue='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='4']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[z='6']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[index='9']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='10']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[newValue='10']
+// CHECK-NEXT: [{{.*}}] __builtin_log[index='9']
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='8']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+
+// Now make sure we get results in accessors and regular functions for a wrapped class too.
+struct Playground {
+    static func doit() {
+        class MyClass {
+            func f() {
+                let x = 1
+            }
+            var v1: Int {
+                return 2
+            }
+            var v2: Int {
+                get {
+                    return 3
+                }
+                set {
+                    let y = 4
+                }
+            }
+            var v3: Int = 5 {
+                didSet {
+                    let z = 6
+                }
+            }
+            subscript(index: Int) -> Int {
+                get {
+                    return 7
+                }
+                set {
+                    let y = 8
+                }
+            }
+        }
+        do {
+            let c = MyClass()
+            c.f()
+            c.v1
+            c.v2 = 7
+            c.v2
+            c.v3 = 8
+            c[9]
+            c[9] = 10
+        }
+    }
+}
+Playground.doit()
+
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[x='1']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='2']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[newValue='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='4']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='3']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[z='6']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[c='main{{.*}}.MyClass']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[index='9']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log[='7']
+// CHECK-NEXT: [{{.*}}] __builtin_log[='10']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log[newValue='10']
+// CHECK-NEXT: [{{.*}}] __builtin_log[index='9']
+// CHECK-NEXT: [{{.*}}] __builtin_log[y='8']
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit


### PR DESCRIPTION
When a decl that has properties with accessors (`get`, `set`, `willSet`, `didSet`, etc) is nested inside another type, those accessor implementations aren't playground-transformed.
 
### Details

The reason is that the playground transform uses an `ASTWalker` to get to the top-level structure, but then once it’s inside a type, it does directly nested `transformDecl()` calls.  And that inner check is missing a case for accessors.

This is a follow-on fix to https://github.com/swiftlang/swift/pull/77498.

### Future work

It's unfortunate that the playground transform reaches decls in two different ways (using an `ASTWalker` to get to the top-level decls but then using directly nested calls below).  This seems to be worth resolving at some point (perhaps by using the `ASTWalker` for the whole traversal?), but that’s a larger change, and so this is worth addressing with a safer short-term fix.

### Changes

- add an else-clause that checks if the declaration is a `VarDecl`, and if so, calls `transformDecl()` on each accessor in PlaygroundTransform.cpp
- add a unit test for nested accessors (this test also tests the unnested case)

rdar://139656464