### PR TITLE
[cxx-interop] Disambiguate template instantiations with enum parameters

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -64,7 +64,7 @@ struct TemplateInstantiationNamePrinter
     return "_";
   }
 
-  std::string VisitRecordType(const clang::RecordType *type) {
+  std::string VisitTagType(const clang::TagType *type) {
     auto tagDecl = type->getAsTagDecl();
     if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(tagDecl)) {
       if (auto typeDefDecl = tagDecl->getTypedefNameForAnonDecl())

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-enum-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-enum-parameter.h
@@ -1,0 +1,17 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_ENUM_PARAMETER_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_ENUM_PARAMETER_H
+
+template <class T>
+struct Wrapper {
+  T t;
+};
+
+enum MyEnum { MyEnum_a, MyEnum_b };
+enum class MyEnumClass { a, b };
+typedef enum { MyTypedefEnum_a, MyTypedefEnum_b } MyTypedefEnum;
+
+typedef Wrapper<MyEnum> WrappedEnum;
+typedef Wrapper<MyEnumClass> WrappedEnumClass;
+typedef Wrapper<MyTypedefEnum> WrappedTypedefEnum;
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_ENUM_PARAMETER_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -8,6 +8,11 @@ module ClassTemplateWithPrimitiveArgument {
   requires cplusplus
 }
 
+module ClassTemplateWithEnumParameter {
+  header "class-template-with-enum-parameter.h"
+  requires cplusplus
+}
+
 module ClassTemplateWithFunctionParameter {
   header "class-template-with-function-parameter.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/class-template-with-enum-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-enum-parameter-module-interface.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithEnumParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: typealias WrappedEnum = Wrapper<MyEnum>
+// CHECK: typealias WrappedEnumClass = Wrapper<MyEnumClass>
+// CHECK: typealias WrappedTypedefEnum = Wrapper<MyTypedefEnum>


### PR DESCRIPTION
This makes sure that different class template instantiations with enum arguments get distinct generated Swift type names.

Similar to aa6804a3.

rdar://139437761 / resolves https://github.com/swiftlang/swift/issues/77358

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
