### PR TITLE
Temporarily put uses of "Span" and "RawSpan" behind an experimental feature flag

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7912,6 +7912,10 @@ ERROR(noncopyable_cannot_have_read_set_accessor,none,
 ERROR(nonescapable_types_attr_disabled,none,
       "attribute requires '-enable-experimental-feature NonescapableTypes'", ())
 
+ERROR(span_requires_feature_flag,none,
+      "'%0' requires -enable-experimental-feature Span",
+      (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Init accessors
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -234,6 +234,7 @@ EXPERIMENTAL_FEATURE(MacrosOnImports, true)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(FullTypedThrows, false)
 EXPERIMENTAL_FEATURE(SameElementRequirements, false)
+EXPERIMENTAL_FEATURE(Span, true)
 
 // Whether to enable @_used and @_section attributes
 EXPERIMENTAL_FEATURE(SymbolLinkageMarkers, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -197,6 +197,7 @@ UNINTERESTING_FEATURE(GroupActorErrors)
 UNINTERESTING_FEATURE(SameElementRequirements)
 UNINTERESTING_FEATURE(UnspecifiedMeansMainActorIsolated)
 UNINTERESTING_FEATURE(GenerateForceToMainActorThunks)
+UNINTERESTING_FEATURE(Span)
 
 static bool usesFeatureSendingArgsAndResults(Decl *decl) {
   auto isFunctionTypeWithSending = [](Type type) {

--- a/test/Macros/PointerBounds/CountedBy/MutableSpan.swift
+++ b/test/Macros/PointerBounds/CountedBy/MutableSpan.swift
@@ -1,7 +1,9 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
-// XFAIL: OS=windows-msvc
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// REQUIRES: swift_feature_Span
+
+// RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span > %t.log 2>&1
+// RUN: %FileCheck --match-full-lines %s < %t.log
 
 @PointerBounds(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {

--- a/test/Macros/PointerBounds/CountedBy/SimpleSpan.swift
+++ b/test/Macros/PointerBounds/CountedBy/SimpleSpan.swift
@@ -1,7 +1,8 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
+// REQUIRES: swift_feature_Span
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
 @PointerBounds(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {

--- a/test/Macros/PointerBounds/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/PointerBounds/CountedBy/SimpleSpanWithReturn.swift
@@ -1,7 +1,8 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
+// REQUIRES: swift_feature_Span
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
 @PointerBounds(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {

--- a/test/Macros/PointerBounds/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/PointerBounds/SizedBy/MutableRawSpan.swift
@@ -1,7 +1,9 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
-// XFAIL: OS=windows-msvc
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// REQUIRES: swift_feature_Span
+
+// RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span > %t.log 2>&1
+// RUN: %FileCheck --match-full-lines %s < %t.log
 
 @PointerBounds(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {

--- a/test/Macros/PointerBounds/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/PointerBounds/SizedBy/SimpleRawSpan.swift
@@ -1,7 +1,8 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
+// REQUIRES: swift_feature_Span
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
 @PointerBounds(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {

--- a/test/Macros/PointerBounds/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/PointerBounds/SizedBy/SimpleRawSpanWithReturn.swift
@@ -1,7 +1,8 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: pointer_bounds
+// REQUIRES: swift_feature_Span
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
 @PointerBounds(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {

--- a/test/stdlib/span_requires_feature.swift
+++ b/test/stdlib/span_requires_feature.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix missing-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Span
+// REQUIRES: swift_feature_Span
+
+@available(SwiftStdlib 6.1, *)
+func f(_: Span<Int>) { }
+// expected-missing-error@-1{{'Span' requires -enable-experimental-feature Span}}
+
+
+@available(SwiftStdlib 6.1, *)
+func g(_: RawSpan) { }
+// expected-missing-error@-1{{'RawSpan' requires -enable-experimental-feature Span}}


### PR DESCRIPTION
While Span is present, we don't yet have an official way to create Span instances. Until then, put uses of Span and RawSpan behind an experimental feature flag (`Span`) that must be set to use these.

Addresses rdar://139308307.
