### PR TITLE
[Sema] Consistently run MiscDiagnostics on macro arguments

### DIFF
--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -139,9 +139,9 @@ namespace swift {
     }
 
     MacroWalking getMacroWalkingBehavior() const override {
-      // Macro expansions will be walked when they're type-checked, not as
-      // part of the surrounding code.
-      return MacroWalking::None;
+      // We only want to walk macro arguments. Expansions will be walked when
+      // they're type-checked, not as part of the surrounding code.
+      return MacroWalking::Arguments;
     }
   };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -342,9 +342,9 @@ public:
   }
 
   MacroWalking getMacroWalkingBehavior() const override {
-    // Macro expansions will be walked when they're type-checked, not as
-    // part of the surrounding code.
-    return MacroWalking::None;
+    // We only want to walk macro arguments. Expansions will be walked when
+    // they're type-checked, not as part of the surrounding code.
+    return MacroWalking::Arguments;
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -224,3 +224,13 @@ func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{55-55=)}} 
   // expected-note@-3 {{provide a default value to avoid this warning}} {{55-55= ?? <#default value#>}}  
 }
+
+// Make sure we don't double diagnose
+_ = {
+  func foo(_ y: Int?) {
+    let _: Any = y // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+    // expected-note@-1 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+    // expected-note@-2 {{provide a default value to avoid this warning}}
+    // expected-note@-3 {{force-unwrap the value to avoid this warning}}
+  }
+}


### PR DESCRIPTION
Previously we would only run MiscDiagnostics passes on macro arguments for some statement diagnostics, update the expression walkers that inherit from BaseDiagnosticWalker such that we consistently do MiscDiagnostics on macro arguments.