### PR TITLE
[5.10] Add support for swiftlang and apple org repo in update checkout

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -675,7 +675,10 @@ repositories.
 
     cross_repos_pr = {}
     if github_comment:
-        regex_pr = r'(apple/[-a-zA-Z0-9_]+/pull/\d+|apple/[-a-zA-Z0-9_]+#\d+)'
+        regex_pr = r'(apple/[-a-zA-Z0-9_]+/pull/\d+'\
+            r'|apple/[-a-zA-Z0-9_]+#\d+'\
+            r'|swiftlang/[-a-zA-Z0-9_]+/pull/\d+'\
+            r'|swiftlang/[-a-zA-Z0-9_]+#\d+)'
         repos_with_pr = re.findall(regex_pr, github_comment)
         print("Found related pull requests:", str(repos_with_pr))
         repos_with_pr = [pr.replace('/pull/', '#') for pr in repos_with_pr]


### PR DESCRIPTION
  - **Explanation**: This cherrypick is necessary for the cross-repo testing on the `release/5.10` CI to work because the repo ID of the `llvm-project` changed from `apple/llvm-project` to `swiftlang/llvm-project` as a result of  https://github.com/swiftlang/swift/pull/77489
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: The cross-repo testing in `release/5.10`.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift/issues/77535
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**:
    - https://github.com/swiftlang/swift/pull/74955
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: The cross-repo testing could be affected.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: The CI
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: shahmishal
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->