### PR TITLE
[Completion] Type-check parent closures for local functions

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -515,12 +515,12 @@ public:
         const_cast<DeclContext *>(this)->getInnermostSkippedFunctionContext();
   }
 
-  /// Returns the innermost context that is a ClosureExpr, which defines how
-  /// self behaves, unless within a type context that redefines self.
+  /// Returns the innermost ClosureExpr context that can propagate its captures
+  /// to this DeclContext.
   LLVM_READONLY
-  ClosureExpr *getInnermostClosureForSelfCapture();
-  const ClosureExpr *getInnermostClosureForSelfCapture() const {
-    return const_cast<DeclContext *>(this)->getInnermostClosureForSelfCapture();
+  ClosureExpr *getInnermostClosureForCaptures();
+  const ClosureExpr *getInnermostClosureForCaptures() const {
+    return const_cast<DeclContext *>(this)->getInnermostClosureForCaptures();
   }
 
   /// Returns the semantic parent of this context.  A context has a

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -362,7 +362,7 @@ ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) c
   // Perform an unqualified lookup for the base decl of this result. This
   // handles cases where self was rebound (e.g. `guard let self = self`)
   // earlier in this closure or some outer closure.
-  auto closureExpr = DC->getInnermostClosureForSelfCapture();
+  auto closureExpr = DC->getInnermostClosureForCaptures();
   if (!closureExpr) {
     return nullptr;
   }

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -74,7 +74,7 @@ void PostfixCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
   Expr *fallbackExpr = CompletionExpr;
   DeclContext *fallbackDC = DC;
 
-  CompletionContextFinder finder(DC);
+  auto finder = CompletionContextFinder::forFallback(DC);
   if (finder.hasCompletionExpr()) {
     if (auto fallback = finder.getFallbackCompletionExpr()) {
       fallbackExpr = fallback->E;

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -24,7 +24,7 @@ using namespace swift::constraints;
 void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
   assert(!GotCallback);
 
-  CompletionContextFinder finder(DC);
+  auto finder = CompletionContextFinder::forFallback(DC);
   if (!finder.hasCompletionExpr())
     return;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5620,16 +5620,20 @@ namespace {
             .fixItInsert(coercion->getStartLoc(), "consume ");
       }
 
-      // Type-check any local decls encountered.
-      for (auto *D : LocalDeclsToTypeCheck)
-        TypeChecker::typeCheckDecl(D);
+      // If we're doing code completion, avoid doing any further type-checking,
+      // that should instead be handled by TypeCheckASTNodeAtLocRequest.
+      if (!ctx.CompletionCallback) {
+        // Type-check any local decls encountered.
+        for (auto *D : LocalDeclsToTypeCheck)
+          TypeChecker::typeCheckDecl(D);
 
-      // Expand any macros encountered.
-      // FIXME: Expansion should be lazy.
-      auto &eval = cs.getASTContext().evaluator;
-      for (auto *E : MacrosToExpand) {
-        (void)evaluateOrDefault(eval, ExpandMacroExpansionExprRequest{E},
-                                std::nullopt);
+        // Expand any macros encountered.
+        // FIXME: Expansion should be lazy.
+        auto &eval = cs.getASTContext().evaluator;
+        for (auto *E : MacrosToExpand) {
+          (void)evaluateOrDefault(eval, ExpandMacroExpansionExprRequest{E},
+                                  std::nullopt);
+        }
       }
     }
 

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -86,6 +86,17 @@ CompletionContextFinder::walkToExprPost(Expr *E) {
   return Action::Continue(E);
 }
 
+ASTWalker::PreWalkAction CompletionContextFinder::walkToDeclPre(Decl *D) {
+  // Look through any decl if we're looking for any viable fallback expression.
+  if (ForFallback)
+    return Action::Continue();
+
+  // Otherwise, follow the same rule as the ConstraintSystem, where only
+  // nested PatternBindingDecls are solved as part of the system. Local decls
+  // are handled by TypeCheckASTNodeAtLocRequest.
+  return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
+}
+
 size_t CompletionContextFinder::getKeyPathCompletionComponentIndex() const {
   size_t ComponentIndex = 0;
   auto Components = getKeyPathContainingCompletionComponent()->getComponents();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2221,7 +2221,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         return nullptr;
       }
 
-      return parentContext->getInnermostClosureForSelfCapture();
+      return parentContext->getInnermostClosureForCaptures();
     }
 
     bool shouldRecordClosure(const AbstractClosureExpr *E) {

--- a/test/IDE/complete_if_switch_expr.swift
+++ b/test/IDE/complete_if_switch_expr.swift
@@ -252,15 +252,22 @@ func testSkipTypeChecking9() -> E {
 }
 
 func testSkipTypeChecking10() -> E {
-  // We only need to type-check the inner-most function for this.
+  // Similar to the above case, we need to type-check everything for this since
+  // the type-checking of 'takesArgAndClosure' is required to correctly handle
+  // any potential captures in 'foo'.
   if Bool.random() {
-    NO.TYPECHECK
+    .e
   } else {
-    takesArgAndClosure(NO.TYPECHECK) {
+    takesArgAndClosure(0) {
       func foo() {
+        // We can however skip unrelated elements in the local function.
+        let x = NO.TYPECHECK
+        if NO.TYPECHECK {
+          takesE(NO.TYPECHECK)
+        }
         takesE(.#^DOT21?check=DOT^#)
       }
-      return NO.TYPECHECK
+      return .e
     }
   }
 }
@@ -320,7 +327,7 @@ func testSkipTypeChecking14() -> E {
   }
 }
 
-func testSkipTypeChecking14() -> E {
+func testSkipTypeChecking15() -> E {
   switch Bool.random() {
   case true:
     .#^DOT26?check=DOT^#
@@ -336,7 +343,7 @@ func testSkipTypeChecking14() -> E {
   }
 }
 
-func testSkipTypechecking15(_ x: inout Int) -> E {
+func testSkipTypechecking16(_ x: inout Int) -> E {
   switch Bool.random() {
   case true:
     .#^DOT27?check=DOT^#

--- a/test/IDE/complete_issue-77305.swift
+++ b/test/IDE/complete_issue-77305.swift
@@ -1,0 +1,31 @@
+// RUN: %batch-code-completion
+
+// https://github.com/swiftlang/swift/issues/77305
+
+struct S {
+  var x: Int
+}
+
+func withFoo(_ x: (S) -> Void) {}
+
+withFoo { foo in
+  func bar() {
+    foo.#^FN_IN_CLOSURE^#
+    // FN_IN_CLOSURE: Decl[InstanceVar]/CurrNominal: x[#Int#]; name=x
+  }
+}
+
+withFoo { x in
+  _ = { y in
+    func bar() {
+      _ = { z in
+        func baz() {
+          func qux() {
+            z.#^VERY_NESTED_FN_IN_CLOSURE^#
+            // VERY_NESTED_FN_IN_CLOSURE: Decl[InstanceVar]/CurrNominal: x[#Int#]; name=x
+          }
+        }
+      }(y)
+    }
+  }(x)
+}


### PR DESCRIPTION
Local functions can capture variables from parent closures, so we need to make sure we type-check parent closures when doing completion in a local function. Ideally we ought to be able to be more selective about the elements of the parent closure that we type-check, but that's a more complex change I'm leaving as future work for now.

Resolves #77305