### PR TITLE
Sema: fix reporting reexporting submodules imports as unused in API

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2517,8 +2517,11 @@ void swift::recordRequiredImportAccessLevelForDecl(
   if (auto attributedImport = sf->getImportAccessLevel(definingModule)) {
     auto importedModule = attributedImport->module.importedModule;
 
-    // If the defining module is transitively imported, mark the responsible
-    // module as requiring the minimum access level too.
+    // Ignore submodules, same behavior from `getModuleContext` above.
+    importedModule = importedModule->getTopLevelModule();
+
+    // If the defining module is transitively imported, mark the locally
+    // imported  module as requiring the minimum access level too.
     if (importedModule != definingModule)
       sf->registerRequiredAccessLevelForModule(importedModule, accessLevel);
 

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -32,6 +32,9 @@
 // RUN: %target-swift-frontend -typecheck %t/ClientOfClangModules.swift -I %t \
 // RUN:   -package-name pkg -Rmodule-api-import \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
+// RUN: %target-swift-frontend -typecheck %t/ClientOfClangReexportedSubmodules.swift -I %t \
+// RUN:   -package-name pkg -Rmodule-api-import \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -swift-version 5 -verify
 
@@ -283,6 +286,21 @@ module ClangTopModule {
   }
 }
 
+module ClangReexportedSubmodulePublic {
+  header "ClangReexportedSubmodulePublic.h"
+  module ClangReexportedSubmodulePublicSub {
+    header "ClangReexportedSubmodulePublicSub.h"
+    export *
+  }
+}
+
+module ClangReexportedSubmoduleTop {
+  header "ClangReexportedSubmoduleTop.h"
+  module ClangReexportedSubmoduleSub {
+    header "ClangReexportedSubmoduleSub.h"
+  }
+}
+
 //--- ClangSimpleUnused.h
 //--- ClangSimple.h
 struct ClangSimpleType {};
@@ -298,6 +316,15 @@ struct ClangSubmoduleSubmoduleType {};
 struct ClangTopModuleType {};
 //--- ClangTopModuleSubmodule.h
 
+//--- ClangReexportedSubmodulePublic.h
+//--- ClangReexportedSubmodulePublicSub.h
+#include <ClangReexportedSubmoduleSub.h>
+
+//--- ClangReexportedSubmoduleTop.h
+//--- ClangReexportedSubmoduleSub.h
+typedef struct _TypedefTypeUnderlying {
+} TypedefType;
+
 //--- ClientOfClangModules.swift
 public import ClangSimple
 public import ClangSimpleUnused // expected-warning {{public import of 'ClangSimpleUnused' was not used in public declarations or inlinable code}}
@@ -310,3 +337,9 @@ public import ClangTopModule.ClangTopModuleSubmodule
 public func clangUser(a: ClangSimpleType) {} // expected-remark {{struct 'ClangSimpleType' is imported via 'ClangSimple'}}
 public func clangUser(a: ClangSubmoduleSubmoduleType) {} // expected-remark {{struct 'ClangSubmoduleSubmoduleType' is imported via 'ClangSubmodule'}}
 public func clangUser(a: ClangTopModuleType) {} // expected-remark {{struct 'ClangTopModuleType' is imported via 'ClangTopModule'}}
+
+//--- ClientOfClangReexportedSubmodules.swift
+public import ClangReexportedSubmodulePublic.ClangReexportedSubmodulePublicSub
+
+public func useTypedefed(a: TypedefType) {} // expected-remark 2 {{typealias underlying type struct '_TypedefTypeUnderlying' is imported via 'ClangReexportedSubmodulePublicSub', which reexports definition from 'ClangReexportedSubmoduleTop'}}
+// expected-remark @-1 {{type alias 'TypedefType' is imported via 'ClangReexportedSubmodulePublicSub', which reexports definition from 'ClangReexportedSubmoduleTop'}}


### PR DESCRIPTION
Importing a clang submodule from Swift implies importing the top-level module too. We make sure we don't warn on the import of the top-level module as being unused when the submodule is used by associating all references to the top-level module instead of submodules. This change applies the same logic for transitive imports, marking the import of the top-level module as used instead of the submodule with the `export *`.

In the updated test, this silences the following warning:
```
public import of 'ClangReexportedSubmodulePublic' was not used in public
declarations or inlinable code
```

rdar://139492772