### PR TITLE
[Tests] XFAIL IRGen/typed_throws_abi.swift on arm64e

### DIFF
--- a/test/IRGen/typed_throws_abi.swift
+++ b/test/IRGen/typed_throws_abi.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-irgen -enable-library-evolution | %FileCheck %s
 
+// XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
 struct Empty: Error {}


### PR DESCRIPTION
rdar://139555118

This test fails on arm64e, because of expected differences in code gen, because of ptrauth.
