### PR TITLE
[region-isolation] Cache getUnderlyingTrackedValue.

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -637,6 +637,285 @@ static bool canFunctionArgumentBeSent(SILFunctionArgument *arg) {
 }
 
 //===----------------------------------------------------------------------===//
+//                        MARK: RegionAnalysisValueMap
+//===----------------------------------------------------------------------===//
+
+SILInstruction *RegionAnalysisValueMap::maybeGetActorIntroducingInst(
+    Element trackableValueID) const {
+  if (auto value = getValueForId(trackableValueID)) {
+    auto rep = value->getRepresentative();
+    if (rep.hasRegionIntroducingInst())
+      return rep.getActorRegionIntroducingInst();
+  }
+
+  return nullptr;
+}
+
+std::optional<TrackableValue>
+RegionAnalysisValueMap::getValueForId(Element id) const {
+  auto iter = stateIndexToEquivalenceClass.find(id);
+  if (iter == stateIndexToEquivalenceClass.end())
+    return {};
+  auto iter2 = equivalenceClassValuesToState.find(iter->second);
+  if (iter2 == equivalenceClassValuesToState.end())
+    return {};
+  return {{iter2->first, iter2->second}};
+}
+
+SILValue
+RegionAnalysisValueMap::getRepresentative(Element trackableValueID) const {
+  return getValueForId(trackableValueID)->getRepresentative().getValue();
+}
+
+SILValue
+RegionAnalysisValueMap::maybeGetRepresentative(Element trackableValueID) const {
+  return getValueForId(trackableValueID)->getRepresentative().maybeGetValue();
+}
+
+RepresentativeValue
+RegionAnalysisValueMap::getRepresentativeValue(Element trackableValueID) const {
+  return getValueForId(trackableValueID)->getRepresentative();
+}
+
+SILIsolationInfo
+RegionAnalysisValueMap::getIsolationRegion(Element trackableValueID) const {
+  auto iter = getValueForId(trackableValueID);
+  if (!iter)
+    return {};
+  return iter->getValueState().getIsolationRegionInfo();
+}
+
+SILIsolationInfo
+RegionAnalysisValueMap::getIsolationRegion(SILValue value) const {
+  auto iter = equivalenceClassValuesToState.find(RepresentativeValue(value));
+  if (iter == equivalenceClassValuesToState.end())
+    return {};
+  return iter->getSecond().getIsolationRegionInfo();
+}
+
+std::pair<TrackableValue, bool>
+RegionAnalysisValueMap::initializeTrackableValue(
+    SILValue value, SILIsolationInfo newInfo) const {
+  auto info = getUnderlyingTrackedValue(value);
+  value = info.value;
+
+  auto *self = const_cast<RegionAnalysisValueMap *>(this);
+  auto iter = self->equivalenceClassValuesToState.try_emplace(
+      value, TrackableValueState(equivalenceClassValuesToState.size()));
+
+  // If we did not insert, just return the already stored value.
+  if (!iter.second) {
+    return {{iter.first->first, iter.first->second}, false};
+  }
+
+  // If we did not insert, just return the already stored value.
+  self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
+
+  // Before we do anything, see if we have a Sendable value.
+  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
+    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
+    return {{iter.first->first, iter.first->second}, true};
+  }
+
+  // Otherwise, we have a non-Sendable type... so wire up the isolation.
+  iter.first->getSecond().setIsolationRegionInfo(newInfo);
+
+  return {{iter.first->first, iter.first->second}, true};
+}
+
+/// If \p isAddressCapturedByPartialApply is set to true, then this value is
+/// an address that is captured by a partial_apply and we want to treat it as
+/// may alias.
+TrackableValue RegionAnalysisValueMap::getTrackableValue(
+    SILValue value, bool isAddressCapturedByPartialApply) const {
+  auto info = getUnderlyingTrackedValue(value);
+  value = info.value;
+
+  auto *self = const_cast<RegionAnalysisValueMap *>(this);
+  auto iter = self->equivalenceClassValuesToState.try_emplace(
+      value, TrackableValueState(equivalenceClassValuesToState.size()));
+
+  // If we did not insert, just return the already stored value.
+  if (!iter.second) {
+    return {iter.first->first, iter.first->second};
+  }
+
+  // If we did not insert, just return the already stored value.
+  self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
+
+  // Otherwise, we need to compute our flags.
+
+  // Treat function ref and class method as either actor isolated or
+  // sendable. Formally they are non-Sendable, so we do the check before we
+  // check the oracle.
+  if (isa<FunctionRefInst, ClassMethodInst>(value)) {
+    if (auto isolation = SILIsolationInfo::get(value)) {
+      iter.first->getSecond().setIsolationRegionInfo(isolation);
+      return {iter.first->first, iter.first->second};
+    }
+
+    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
+    return {iter.first->first, iter.first->second};
+  }
+
+  // Then check our oracle to see if the value is actually sendable. If we have
+  // a Sendable value, just return early.
+  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
+    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
+    return {iter.first->first, iter.first->second};
+  }
+
+  // Ok, at this point we have a non-Sendable value. First process addresses.
+  if (value->getType().isAddress()) {
+    // If we were able to find this was actor isolated from finding our
+    // underlying object, use that. It is never wrong.
+    if (info.actorIsolation) {
+      SILIsolationInfo isolation;
+      if (info.value->getType().isAnyActor()) {
+        isolation = SILIsolationInfo::getActorInstanceIsolated(
+            value, info.value, info.actorIsolation->getActor());
+      } else if (info.actorIsolation->isGlobalActor()) {
+        isolation = SILIsolationInfo::getGlobalActorIsolated(
+            value, info.actorIsolation->getGlobalActor());
+      }
+
+      if (isolation) {
+        iter.first->getSecond().setIsolationRegionInfo(isolation);
+      }
+    }
+
+    auto storage = AccessStorageWithBase::compute(value);
+    if (storage.storage) {
+      // Check if we have a uniquely identified address that was not captured
+      // by a partial apply... in such a case, we treat it as no-alias.
+      if (storage.storage.isUniquelyIdentified() &&
+          !isAddressCapturedByPartialApply) {
+        iter.first->getSecond().removeFlag(TrackableValueFlag::isMayAlias);
+      }
+
+      if (auto isolation = SILIsolationInfo::get(storage.base)) {
+        iter.first->getSecond().setIsolationRegionInfo(isolation);
+      }
+    }
+  }
+
+  // Check if we have a load or load_borrow from an address. In that case, we
+  // want to look through the load and find a better root from the address we
+  // loaded from.
+  if (isa<LoadInst, LoadBorrowInst>(iter.first->first.getValue())) {
+    auto *svi = cast<SingleValueInstruction>(iter.first->first.getValue());
+
+    // See if we can use get underlying tracked value to find if it is actor
+    // isolated.
+    //
+    // TODO: Instead of using AccessStorageBase, just use our own visitor
+    // everywhere. Just haven't done it due to possible perturbations.
+    auto parentAddrInfo = getUnderlyingTrackedValue(svi);
+    if (parentAddrInfo.actorIsolation) {
+      iter.first->getSecond().setIsolationRegionInfo(
+          SILIsolationInfo::getActorInstanceIsolated(
+              svi, parentAddrInfo.value,
+              parentAddrInfo.actorIsolation->getActor()));
+    }
+
+    auto storage = AccessStorageWithBase::compute(svi->getOperand(0));
+    if (storage.storage) {
+      if (auto isolation = SILIsolationInfo::get(storage.base)) {
+        iter.first->getSecond().setIsolationRegionInfo(isolation);
+      }
+    }
+
+    return {iter.first->first, iter.first->second};
+  }
+
+  // Ok, we have a non-Sendable type, see if we do not have any isolation
+  // yet. If we don't, attempt to infer its isolation.
+  if (!iter.first->getSecond().hasIsolationRegionInfo()) {
+    if (auto isolation = SILIsolationInfo::get(iter.first->first.getValue())) {
+      iter.first->getSecond().setIsolationRegionInfo(isolation);
+      return {iter.first->first, iter.first->second};
+    }
+  }
+
+  return {iter.first->first, iter.first->second};
+}
+
+std::optional<TrackableValue>
+RegionAnalysisValueMap::getTrackableValueForActorIntroducingInst(
+    SILInstruction *inst) const {
+  auto *self = const_cast<RegionAnalysisValueMap *>(this);
+  auto iter = self->equivalenceClassValuesToState.find(inst);
+  if (iter == self->equivalenceClassValuesToState.end())
+    return {};
+
+  // Otherwise, we need to compute our flags.
+  return {{iter->first, iter->second}};
+}
+
+std::optional<TrackableValue>
+RegionAnalysisValueMap::tryToTrackValue(SILValue value) const {
+  auto state = getTrackableValue(value);
+  if (state.isNonSendable())
+    return state;
+  return {};
+}
+
+TrackableValue RegionAnalysisValueMap::getActorIntroducingRepresentative(
+    SILInstruction *introducingInst, SILIsolationInfo actorIsolation) const {
+  auto *self = const_cast<RegionAnalysisValueMap *>(this);
+  auto iter = self->equivalenceClassValuesToState.try_emplace(
+      introducingInst,
+      TrackableValueState(equivalenceClassValuesToState.size()));
+
+  // If we did not insert, just return the already stored value.
+  if (!iter.second) {
+    return {iter.first->first, iter.first->second};
+  }
+
+  // Otherwise, wire up the value.
+  self->stateIndexToEquivalenceClass[iter.first->second.getID()] =
+      introducingInst;
+  iter.first->getSecond().setIsolationRegionInfo(actorIsolation);
+  return {iter.first->first, iter.first->second};
+}
+
+bool RegionAnalysisValueMap::valueHasID(SILValue value, bool dumpIfHasNoID) {
+  assert(getTrackableValue(value).isNonSendable() &&
+         "Can only accept non-Sendable values");
+  bool hasID = equivalenceClassValuesToState.count(value);
+  if (!hasID && dumpIfHasNoID) {
+    llvm::errs() << "FAILURE: valueHasID of ";
+    value->print(llvm::errs());
+    llvm::report_fatal_error("standard compiler error");
+  }
+  return hasID;
+}
+
+Element RegionAnalysisValueMap::lookupValueID(SILValue value) {
+  auto state = getTrackableValue(value);
+  assert(state.isNonSendable() &&
+         "only non-Sendable values should be entered in the map");
+  return state.getID();
+}
+
+void RegionAnalysisValueMap::print(llvm::raw_ostream &os) const {
+#ifndef NDEBUG
+  // Since this is just used for debug output, be inefficient to make nicer
+  // output.
+  std::vector<std::pair<unsigned, RepresentativeValue>> temp;
+  for (auto p : stateIndexToEquivalenceClass) {
+    temp.emplace_back(p.first, p.second);
+  }
+  std::sort(temp.begin(), temp.end());
+  for (auto p : temp) {
+    os << "%%" << p.first << ": ";
+    auto value = getValueForId(Element(p.first));
+    value->print(os);
+  }
+#endif
+}
+
+//===----------------------------------------------------------------------===//
 //                            MARK: TrackableValue
 //===----------------------------------------------------------------------===//
 
@@ -3567,285 +3846,6 @@ void RegionAnalysisFunctionInfo::runDataflow() {
       }
     }
   }
-}
-
-//===----------------------------------------------------------------------===//
-//                              MARK: Value Map
-//===----------------------------------------------------------------------===//
-
-SILInstruction *RegionAnalysisValueMap::maybeGetActorIntroducingInst(
-    Element trackableValueID) const {
-  if (auto value = getValueForId(trackableValueID)) {
-    auto rep = value->getRepresentative();
-    if (rep.hasRegionIntroducingInst())
-      return rep.getActorRegionIntroducingInst();
-  }
-
-  return nullptr;
-}
-
-std::optional<TrackableValue>
-RegionAnalysisValueMap::getValueForId(Element id) const {
-  auto iter = stateIndexToEquivalenceClass.find(id);
-  if (iter == stateIndexToEquivalenceClass.end())
-    return {};
-  auto iter2 = equivalenceClassValuesToState.find(iter->second);
-  if (iter2 == equivalenceClassValuesToState.end())
-    return {};
-  return {{iter2->first, iter2->second}};
-}
-
-SILValue
-RegionAnalysisValueMap::getRepresentative(Element trackableValueID) const {
-  return getValueForId(trackableValueID)->getRepresentative().getValue();
-}
-
-SILValue
-RegionAnalysisValueMap::maybeGetRepresentative(Element trackableValueID) const {
-  return getValueForId(trackableValueID)->getRepresentative().maybeGetValue();
-}
-
-RepresentativeValue
-RegionAnalysisValueMap::getRepresentativeValue(Element trackableValueID) const {
-  return getValueForId(trackableValueID)->getRepresentative();
-}
-
-SILIsolationInfo
-RegionAnalysisValueMap::getIsolationRegion(Element trackableValueID) const {
-  auto iter = getValueForId(trackableValueID);
-  if (!iter)
-    return {};
-  return iter->getValueState().getIsolationRegionInfo();
-}
-
-SILIsolationInfo
-RegionAnalysisValueMap::getIsolationRegion(SILValue value) const {
-  auto iter = equivalenceClassValuesToState.find(RepresentativeValue(value));
-  if (iter == equivalenceClassValuesToState.end())
-    return {};
-  return iter->getSecond().getIsolationRegionInfo();
-}
-
-std::pair<TrackableValue, bool>
-RegionAnalysisValueMap::initializeTrackableValue(
-    SILValue value, SILIsolationInfo newInfo) const {
-  auto info = getUnderlyingTrackedValue(value);
-  value = info.value;
-
-  auto *self = const_cast<RegionAnalysisValueMap *>(this);
-  auto iter = self->equivalenceClassValuesToState.try_emplace(
-      value, TrackableValueState(equivalenceClassValuesToState.size()));
-
-  // If we did not insert, just return the already stored value.
-  if (!iter.second) {
-    return {{iter.first->first, iter.first->second}, false};
-  }
-
-  // If we did not insert, just return the already stored value.
-  self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
-
-  // Before we do anything, see if we have a Sendable value.
-  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
-    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
-    return {{iter.first->first, iter.first->second}, true};
-  }
-
-  // Otherwise, we have a non-Sendable type... so wire up the isolation.
-  iter.first->getSecond().setIsolationRegionInfo(newInfo);
-
-  return {{iter.first->first, iter.first->second}, true};
-}
-
-/// If \p isAddressCapturedByPartialApply is set to true, then this value is
-/// an address that is captured by a partial_apply and we want to treat it as
-/// may alias.
-TrackableValue RegionAnalysisValueMap::getTrackableValue(
-    SILValue value, bool isAddressCapturedByPartialApply) const {
-  auto info = getUnderlyingTrackedValue(value);
-  value = info.value;
-
-  auto *self = const_cast<RegionAnalysisValueMap *>(this);
-  auto iter = self->equivalenceClassValuesToState.try_emplace(
-      value, TrackableValueState(equivalenceClassValuesToState.size()));
-
-  // If we did not insert, just return the already stored value.
-  if (!iter.second) {
-    return {iter.first->first, iter.first->second};
-  }
-
-  // If we did not insert, just return the already stored value.
-  self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
-
-  // Otherwise, we need to compute our flags.
-
-  // Treat function ref and class method as either actor isolated or
-  // sendable. Formally they are non-Sendable, so we do the check before we
-  // check the oracle.
-  if (isa<FunctionRefInst, ClassMethodInst>(value)) {
-    if (auto isolation = SILIsolationInfo::get(value)) {
-      iter.first->getSecond().setIsolationRegionInfo(isolation);
-      return {iter.first->first, iter.first->second};
-    }
-
-    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
-    return {iter.first->first, iter.first->second};
-  }
-
-  // Then check our oracle to see if the value is actually sendable. If we have
-  // a Sendable value, just return early.
-  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
-    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
-    return {iter.first->first, iter.first->second};
-  }
-
-  // Ok, at this point we have a non-Sendable value. First process addresses.
-  if (value->getType().isAddress()) {
-    // If we were able to find this was actor isolated from finding our
-    // underlying object, use that. It is never wrong.
-    if (info.actorIsolation) {
-      SILIsolationInfo isolation;
-      if (info.value->getType().isAnyActor()) {
-        isolation = SILIsolationInfo::getActorInstanceIsolated(
-            value, info.value, info.actorIsolation->getActor());
-      } else if (info.actorIsolation->isGlobalActor()) {
-        isolation = SILIsolationInfo::getGlobalActorIsolated(
-            value, info.actorIsolation->getGlobalActor());
-      }
-
-      if (isolation) {
-        iter.first->getSecond().setIsolationRegionInfo(isolation);
-      }
-    }
-
-    auto storage = AccessStorageWithBase::compute(value);
-    if (storage.storage) {
-      // Check if we have a uniquely identified address that was not captured
-      // by a partial apply... in such a case, we treat it as no-alias.
-      if (storage.storage.isUniquelyIdentified() &&
-          !isAddressCapturedByPartialApply) {
-        iter.first->getSecond().removeFlag(TrackableValueFlag::isMayAlias);
-      }
-
-      if (auto isolation = SILIsolationInfo::get(storage.base)) {
-        iter.first->getSecond().setIsolationRegionInfo(isolation);
-      }
-    }
-  }
-
-  // Check if we have a load or load_borrow from an address. In that case, we
-  // want to look through the load and find a better root from the address we
-  // loaded from.
-  if (isa<LoadInst, LoadBorrowInst>(iter.first->first.getValue())) {
-    auto *svi = cast<SingleValueInstruction>(iter.first->first.getValue());
-
-    // See if we can use get underlying tracked value to find if it is actor
-    // isolated.
-    //
-    // TODO: Instead of using AccessStorageBase, just use our own visitor
-    // everywhere. Just haven't done it due to possible perturbations.
-    auto parentAddrInfo = getUnderlyingTrackedValue(svi);
-    if (parentAddrInfo.actorIsolation) {
-      iter.first->getSecond().setIsolationRegionInfo(
-          SILIsolationInfo::getActorInstanceIsolated(
-              svi, parentAddrInfo.value,
-              parentAddrInfo.actorIsolation->getActor()));
-    }
-
-    auto storage = AccessStorageWithBase::compute(svi->getOperand(0));
-    if (storage.storage) {
-      if (auto isolation = SILIsolationInfo::get(storage.base)) {
-        iter.first->getSecond().setIsolationRegionInfo(isolation);
-      }
-    }
-
-    return {iter.first->first, iter.first->second};
-  }
-
-  // Ok, we have a non-Sendable type, see if we do not have any isolation
-  // yet. If we don't, attempt to infer its isolation.
-  if (!iter.first->getSecond().hasIsolationRegionInfo()) {
-    if (auto isolation = SILIsolationInfo::get(iter.first->first.getValue())) {
-      iter.first->getSecond().setIsolationRegionInfo(isolation);
-      return {iter.first->first, iter.first->second};
-    }
-  }
-
-  return {iter.first->first, iter.first->second};
-}
-
-std::optional<TrackableValue>
-RegionAnalysisValueMap::getTrackableValueForActorIntroducingInst(
-    SILInstruction *inst) const {
-  auto *self = const_cast<RegionAnalysisValueMap *>(this);
-  auto iter = self->equivalenceClassValuesToState.find(inst);
-  if (iter == self->equivalenceClassValuesToState.end())
-    return {};
-
-  // Otherwise, we need to compute our flags.
-  return {{iter->first, iter->second}};
-}
-
-std::optional<TrackableValue>
-RegionAnalysisValueMap::tryToTrackValue(SILValue value) const {
-  auto state = getTrackableValue(value);
-  if (state.isNonSendable())
-    return state;
-  return {};
-}
-
-TrackableValue RegionAnalysisValueMap::getActorIntroducingRepresentative(
-    SILInstruction *introducingInst, SILIsolationInfo actorIsolation) const {
-  auto *self = const_cast<RegionAnalysisValueMap *>(this);
-  auto iter = self->equivalenceClassValuesToState.try_emplace(
-      introducingInst,
-      TrackableValueState(equivalenceClassValuesToState.size()));
-
-  // If we did not insert, just return the already stored value.
-  if (!iter.second) {
-    return {iter.first->first, iter.first->second};
-  }
-
-  // Otherwise, wire up the value.
-  self->stateIndexToEquivalenceClass[iter.first->second.getID()] =
-      introducingInst;
-  iter.first->getSecond().setIsolationRegionInfo(actorIsolation);
-  return {iter.first->first, iter.first->second};
-}
-
-bool RegionAnalysisValueMap::valueHasID(SILValue value, bool dumpIfHasNoID) {
-  assert(getTrackableValue(value).isNonSendable() &&
-         "Can only accept non-Sendable values");
-  bool hasID = equivalenceClassValuesToState.count(value);
-  if (!hasID && dumpIfHasNoID) {
-    llvm::errs() << "FAILURE: valueHasID of ";
-    value->print(llvm::errs());
-    llvm::report_fatal_error("standard compiler error");
-  }
-  return hasID;
-}
-
-Element RegionAnalysisValueMap::lookupValueID(SILValue value) {
-  auto state = getTrackableValue(value);
-  assert(state.isNonSendable() &&
-         "only non-Sendable values should be entered in the map");
-  return state.getID();
-}
-
-void RegionAnalysisValueMap::print(llvm::raw_ostream &os) const {
-#ifndef NDEBUG
-  // Since this is just used for debug output, be inefficient to make nicer
-  // output.
-  std::vector<std::pair<unsigned, RepresentativeValue>> temp;
-  for (auto p : stateIndexToEquivalenceClass) {
-    temp.emplace_back(p.first, p.second);
-  }
-  std::sort(temp.begin(), temp.end());
-  for (auto p : temp) {
-    os << "%%" << p.first << ": ";
-    auto value = getValueForId(Element(p.first));
-    value->print(os);
-  }
-#endif
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
TLDR: Was looking at some performance traces and saw that we need to cache the
result of this value.

----

Specifically, I noticed that we were spending a lot of time computing this
operation. When I looked at the code I saw that we already had a cache along the
relevant code paths... but the cache was from equivalence class representative
-> state. Before we hit that cache, we were performing the work to map the value
to the equivalence class representative... so the work to perform the relevant
lookup from value -> state (which goes through the equivalence class
representative) was not just a hash table lookup. This operation makes it
cheaper by making it two cache lookups.

It may be possible to make this cheaper by redoing the actual mapping of
information so that we can go straight from value to state. I think it would be
slightly different since we would probably need to represent the state in a
separate array and map with indices... which is really just a more efficient
hash table. We could also use malloc/etc but lets not even talk about that.

rdar://139520959