### PR TITLE
[CMake] Add a dependency on 'libSwiftScan' for 'swiftCore'

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -83,8 +83,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   add_custom_target(embedded-darwin)
   add_dependencies(embedded-libraries embedded-darwin)
-
-  set_property(GLOBAL APPEND PROPERTY JOB_POOLS one_job=1)
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)
@@ -127,7 +125,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       INSTALL_IN_COMPONENT stdlib
       )
     add_dependencies(embedded-darwin embedded-darwin-${mod})
-    set_property(TARGET embedded-darwin-${mod} PROPERTY JOB_POOL_COMPILE one_job)
   endforeach()
 endif()
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -398,12 +398,18 @@ if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
                     BOOTSTRAPPING 1)
 endif()
 
+set(tooling_stdlib_deps)
+if(TARGET libSwiftScan)
+  list(append tooling_stdlib_deps libSwiftScan)
+endif()
+
 add_swift_target_library(swiftCore
                   ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
                   ${swiftCore_common_options}
                   ${compile_flags_for_final_build}
                   FILE_DEPENDS
                     ${swiftCore_common_dependencies}
+                  DEPENDS ${tooling_stdlib_deps}
                   INSTALL_IN_COMPONENT
                     stdlib
                   MACCATALYST_BUILD_FLAVOR
@@ -446,6 +452,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       SDK "embedded"
       ARCHITECTURE "${arch}"
       FILE_DEPENDS ${swiftCore_common_dependencies}
+      DEPENDS ${tooling_stdlib_deps}
       INSTALL_IN_COMPONENT stdlib
       )
     add_dependencies(embedded-stdlib embedded-stdlib-${mod})


### PR DESCRIPTION
It appears that 'swiftCore' and following associated 'embedded-stdlib-*' targets may begin building before the libSwiftScan library has completed building, which may cause crashes if the compiler process building 'swiftCore' attempts to load it.

Resolves rdar://137674862