### PR TITLE
[cmake] Set SWIFT_STDLIB_HAS_COMMANDLINE

### DIFF
--- a/Runtimes/Core/CommandLineSupport/CMakeLists.txt
+++ b/Runtimes/Core/CommandLineSupport/CMakeLists.txt
@@ -3,6 +3,8 @@ if(SwiftCore_ENABLE_COMMANDLINE_SUPPORT)
   target_include_directories(swiftCommandLineSupport PRIVATE
     "${SwiftCore_SWIFTC_SOURCE_DIR}/include"
     "${PROJECT_BINARY_DIR}/include")
+  target_compile_definitions(swiftCommandLineSupport PUBLIC
+    -DSWIFT_STDLIB_HAS_COMMANDLINE)
 
   target_link_libraries(swiftCommandLineSupport PRIVATE
     swiftShims)


### PR DESCRIPTION
Set the SWIFT_STDLIB_HAS_COMMANDLINE macro when the stdlib has command line support. This is needed while building SwiftCore to ensure that it exports the appropriate symbols.