### PR TITLE
[CoroutineAccessors] Ban read+_read and modify+_modify.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -9696,8 +9696,11 @@ const ParamDecl *getParameterAt(const ValueDecl *source, unsigned index);
 /// nullptr if the source does not have a parameter list.
 const ParamDecl *getParameterAt(const DeclContext *source, unsigned index);
 
-StringRef getAccessorNameForDiagnostic(AccessorDecl *accessor, bool article);
-StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind, bool article);
+StringRef
+getAccessorNameForDiagnostic(AccessorDecl *accessor, bool article,
+                             std::optional<bool> underscored = std::nullopt);
+StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind, bool article,
+                                       bool underscored);
 
 void simple_display(llvm::raw_ostream &out,
                     OptionSet<NominalTypeDecl::LookupDirectFlags> options);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2391,12 +2391,6 @@ void PrintAST::printSelfAccessKindModifiersIfNeeded(const FuncDecl *FD) {
   }
 }
 
-static bool
-shouldPrintUnderscoredCoroutineAccessors(const AbstractStorageDecl *ASD) {
-  // TODO: CoroutineAccessors: Print only when necessary.
-  return true;
-}
-
 void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
   if (isa<VarDecl>(ASD) && !Options.PrintPropertyAccessors)
     return;
@@ -2573,7 +2567,7 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
       break;
     case ReadImplKind::Read2:
       if (ASD->getAccessor(AccessorKind::Read) &&
-          shouldPrintUnderscoredCoroutineAccessors(ASD)) {
+          Options.SuppressCoroutineAccessors) {
         AddAccessorToPrint(AccessorKind::Read);
       }
       AddAccessorToPrint(AccessorKind::Read2);
@@ -2607,7 +2601,7 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
       break;
     case WriteImplKind::Modify2:
       if (ASD->getAccessor(AccessorKind::Modify) &&
-          shouldPrintUnderscoredCoroutineAccessors(ASD)) {
+          Options.SuppressCoroutineAccessors) {
         AddAccessorToPrint(AccessorKind::Modify);
       }
       AddAccessorToPrint(AccessorKind::Modify2);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8336,16 +8336,45 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
   storage->setAccessors(LBLoc, Accessors, RBLoc);
 }
 
+static std::optional<AccessorKind>
+getCorrespondingUnderscoredAccessorKind(AccessorKind kind) {
+  switch (kind) {
+  case AccessorKind::Read2:
+    return {AccessorKind::Read};
+  case AccessorKind::Modify2:
+    return {AccessorKind::Modify};
+  case AccessorKind::Get:
+  case AccessorKind::DistributedGet:
+  case AccessorKind::Set:
+  case AccessorKind::Read:
+  case AccessorKind::Modify:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
+  case AccessorKind::Address:
+  case AccessorKind::MutableAddress:
+  case AccessorKind::Init:
+    return std::nullopt;
+  }
+}
+
 static void diagnoseConflictingAccessors(Parser &P, AccessorDecl *first,
                                          AccessorDecl *&second) {
   if (!second) return;
-  P.diagnose(second->getLoc(), diag::conflicting_accessor,
-             isa<SubscriptDecl>(first->getStorage()),
-             getAccessorNameForDiagnostic(second, /*article*/ true),
-             getAccessorNameForDiagnostic(first, /*article*/ true));
-  P.diagnose(first->getLoc(), diag::previous_accessor,
-             getAccessorNameForDiagnostic(first, /*article*/ false),
-             /*already*/ false);
+  bool underscored =
+      (getCorrespondingUnderscoredAccessorKind(first->getAccessorKind()) ==
+       second->getAccessorKind()) ||
+      (getCorrespondingUnderscoredAccessorKind(second->getAccessorKind()) ==
+       first->getAccessorKind()) ||
+      first->getASTContext().LangOpts.hasFeature(Feature::CoroutineAccessors);
+  P.diagnose(
+      second->getLoc(), diag::conflicting_accessor,
+      isa<SubscriptDecl>(first->getStorage()),
+      getAccessorNameForDiagnostic(second, /*article*/ true, underscored),
+      getAccessorNameForDiagnostic(first, /*article*/ true, underscored));
+  P.diagnose(
+      first->getLoc(), diag::previous_accessor,
+      getAccessorNameForDiagnostic(first, /*article*/ false, underscored),
+      /*already*/ false);
   second->setInvalid();
 }
 
@@ -8388,12 +8417,13 @@ void Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
 
   // Okay, observers are out of the way.
 
-  // 'get', 'read', and a non-mutable addressor are all exclusive.
+  // 'get', '_read', 'read' and a non-mutable addressor are all exclusive.
   if (Get) {
     diagnoseConflictingAccessors(P, Get, Read);
     diagnoseConflictingAccessors(P, Get, Read2);
     diagnoseConflictingAccessors(P, Get, Address);
   } else if (Read) {
+    diagnoseConflictingAccessors(P, Read, Read2);
     diagnoseConflictingAccessors(P, Read, Address);
   } else if (Read2) {
     diagnoseConflictingAccessors(P, Read2, Address);
@@ -8422,11 +8452,13 @@ void Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
     }
   }
 
-  // A mutable addressor is exclusive with 'set' and 'modify', but
-  // 'set' and 'modify' can appear together.
+  // '_modify', 'modify' and 'unsafeMutableAddress' are all mutually exclusive.
+  // 'unsafeMutableAddress' and 'set' are mutually exclusive, but 'set' and
+  // 'modify' can appear together.
   if (Set) {
     diagnoseConflictingAccessors(P, Set, MutableAddress);
   } else if (Modify) {
+    diagnoseConflictingAccessors(P, Modify, Modify2);
     diagnoseConflictingAccessors(P, Modify, MutableAddress);
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7914,7 +7914,8 @@ bool Parser::parseAccessorAfterIntroducer(
   if (requiresFeatureCoroutineAccessors(Kind) &&
       !Context.LangOpts.hasFeature(Feature::CoroutineAccessors)) {
     diagnose(Tok, diag::accessor_requires_coroutine_accessors,
-             getAccessorNameForDiagnostic(Kind, /*article*/ false));
+             getAccessorNameForDiagnostic(Kind, /*article*/ false,
+                                          /*underscored*/ false));
   }
 
   // There should be no body in the limited syntax; diagnose unexpected
@@ -7922,7 +7923,8 @@ bool Parser::parseAccessorAfterIntroducer(
   if (parsingLimitedSyntax) {
     if (Tok.is(tok::l_brace))
       diagnose(Tok, diag::unexpected_getset_implementation_in_protocol,
-               getAccessorNameForDiagnostic(Kind, /*article*/ false));
+               getAccessorNameForDiagnostic(Kind, /*article*/ false,
+                                            /*underscored*/ false));
     return false;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3644,7 +3644,7 @@ static FuncDecl *findSimilarAccessor(DeclNameRef replacedVarName,
         origStorage->getWriteImpl() == WriteImplKind::Stored)) {
     Diags.diagnose(attr->getLocation(),
                    diag::dynamic_replacement_accessor_not_explicit,
-                   getAccessorNameForDiagnostic(origAccessor->getAccessorKind(),
+                   getAccessorNameForDiagnostic(origAccessor,
                                                 /*article=*/false),
                    origStorage->getName());
     attr->setInvalid();

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -12,9 +12,7 @@ var _i: Int = 0
 
 // CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
 // CHECK-NEXT: public var i: Swift.Int {
-// CHECK-NEXT:   _read
 // CHECK-NEXT:   read
-// CHECK-NEXT:   _modify
 // CHECK-NEXT:   modify
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
@@ -24,14 +22,8 @@ var _i: Int = 0
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 public var i: Int {
-  _read {
-    yield _i
-  }
   read {
     yield _i
-  }
-  _modify {
-    yield &_i
   }
   modify {
     yield &_i

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -30,14 +30,16 @@ var _i: Int = 0
 // disabled: implicit getter.
 var ir_r: Int {
   read { // expected-disabled-error{{cannot_find_in_scope}}
+         // expected-enabled-error@-1{{variable cannot provide both a 'read' accessor and a '_read' accessor}}
     fatalError()
   }
   _read { // expected-disabled-error{{cannot_find_in_scope}}
+         // expected-enabled-note@-1{{previous_accessor}}
     fatalError()
   }
 }
 
-// enabled: ok
+// enabled: conflicting accessors
 var igr: Int {
   get {
     1
@@ -255,14 +257,16 @@ var iumam: Int {
   }
 }
 
-// enabled: need a reader.
+// enabled: conflicting accessors.  need a reader.
 // disabled: implicit getter.
 var im_m: Int {
   modify { // expected-disabled-error{{cannot_find_in_scope}}
+           // expected-enabled-error@-1{{variable cannot provide both a 'modify' accessor and a '_modify' accessor}}
     fatalError()
   }
   _modify { // expected-enabled-error{{variable with a '_modify' accessor must also have a getter, addressor, or 'read' accessor}}
             // expected-disabled-error@-1{{cannot_find_in_scope}}
+            // expected-enabled-note@-2{{previous_accessor}}
     fatalError()
   }
 }
@@ -272,9 +276,11 @@ var im_m: Int {
 var i_mm: Int {
   _modify { // expected-enabled-error{{variable with a '_modify' accessor must also have a getter, addressor, or 'read' accessor}}
             // expected-disabled-error@-1{{variable with a 'modify' accessor must also have a getter, addressor, or 'read' accessor}}
+            // expected-note@-2{{previous_accessor}}
     fatalError()
   }
   modify { // expected-disabled-error{{'modify' accessor is only valid when experimental feature coroutine accessors is enabled}}
+           // expected-error@-1{{variable cannot provide both a 'modify' accessor and a '_modify' accessor}}
     fatalError()
   }
 }
@@ -304,9 +310,10 @@ var i_rm_m: Int {
     yield _i
   }
   modify { // expected-disabled-error{{'modify' accessor is only valid when experimental feature coroutine accessors is enabled}}
+           // expected-error@-1{{variable cannot provide both a 'modify' accessor and a '_modify' accessor}}
     yield &_i
   }
-  _modify {
+  _modify { // expected-note{{previous_accessor}}
     yield &_i
   }
 }
@@ -315,15 +322,19 @@ var i_rm_m: Int {
 // disabled: implicit getter
 var ir_rm_m: Int {
   read { // expected-disabled-error{{cannot_find_in_scope}}
+         // expected-enabled-error@-1{{variable cannot provide both a 'read' accessor and a '_read' accessor}}
     fatalError()
   }
   _read { // expected-disabled-error{{cannot_find_in_scope}}
+          // expected-enabled-note@-1{{previous_accessor}}
     fatalError()
   }
   modify { // expected-disabled-error{{cannot_find_in_scope}}
+           // expected-enabled-error@-1{{variable cannot provide both a 'modify' accessor and a '_modify' accessor}}
     fatalError()
   }
   _modify { // expected-disabled-error{{cannot_find_in_scope}}
+            // expected-enabled-note@-1{{previous_accessor}}
     fatalError()
   }
 }

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -261,8 +261,8 @@ var im_m: Int {
   modify { // expected-disabled-error{{cannot_find_in_scope}}
     fatalError()
   }
-  _modify { // expected-enabled-error{{variable with a 'modify' accessor must also have a getter, addressor, or 'read' accessor}}
-             // expected-disabled-error@-1{{cannot_find_in_scope}}
+  _modify { // expected-enabled-error{{variable with a '_modify' accessor must also have a getter, addressor, or 'read' accessor}}
+            // expected-disabled-error@-1{{cannot_find_in_scope}}
     fatalError()
   }
 }
@@ -270,7 +270,8 @@ var im_m: Int {
 // enabled: need a reader.
 // disabled: implicit getter.
 var i_mm: Int {
-  _modify { // expected-error{{variable with a 'modify' accessor must also have a getter, addressor, or 'read' accessor}}
+  _modify { // expected-enabled-error{{variable with a '_modify' accessor must also have a getter, addressor, or 'read' accessor}}
+            // expected-disabled-error@-1{{variable with a 'modify' accessor must also have a getter, addressor, or 'read' accessor}}
     fatalError()
   }
   modify { // expected-disabled-error{{'modify' accessor is only valid when experimental feature coroutine accessors is enabled}}

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -26,7 +26,7 @@ var _i: Int = 0
 // Two reads
 // =============================================================================
 
-// enabled: ok
+// enabled: conflicting accessors
 // disabled: implicit getter.
 var ir_r: Int {
   read { // expected-disabled-error{{cannot_find_in_scope}}

--- a/test/Sema/coroutine_accessors.swift
+++ b/test/Sema/coroutine_accessors.swift
@@ -34,7 +34,7 @@ var ingnsn_m: Int {
 var ignsn_m: Int {
   mutating get { 0 }
   nonmutating set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the getter is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the getter is 'mutating'}}
                         // expected-note@-3{{getter defined here}}
     var fake: Int
     yield &fake
@@ -43,7 +43,7 @@ var ignsn_m: Int {
 var ingsn_m: Int {
   get { 0 }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
                         // expected-note@-2{{setter defined here}}
     var fake: Int
     yield &fake
@@ -52,7 +52,7 @@ var ingsn_m: Int {
 var igsn_m: Int {
   mutating get { 0 }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the getter is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the getter is 'mutating'}}
                         // expected-note@-2{{setter defined here}}
                         // expected-note@-4{{getter defined here}}
     var fake: Int
@@ -62,7 +62,7 @@ var igsn_m: Int {
 var ingns_m: Int {
   get { 0 }
   nonmutating set {}
-  _modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the getter is not 'mutating'}}
+  _modify { // expected-error{{'_modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the getter is not 'mutating'}}
             // expected-note@-2{{setter defined here}}
             // expected-note@-4{{getter defined here}}
     yield &i
@@ -116,8 +116,8 @@ var in_rnsn_m: Int {
 var i_rnsn_m: Int {
   mutating _read { yield i }
   nonmutating set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the 'read' accessor is 'mutating'}}
-                        // expected-note@-3{{'read' accessor defined here}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the '_read' accessor is 'mutating'}}
+                        // expected-note@-3{{'_read' accessor defined here}}
     var fake: Int
     yield &fake
   }
@@ -125,7 +125,7 @@ var i_rnsn_m: Int {
 var in_rsn_m: Int {
   _read { yield i }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
                         // expected-note@-2{{setter defined here}}
     var fake: Int
     yield &fake
@@ -134,9 +134,9 @@ var in_rsn_m: Int {
 var i_rsn_m: Int {
   mutating _read { yield i }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the 'read' accessor is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the '_read' accessor is 'mutating'}}
                         // expected-note@-2{{setter defined here}}
-                        // expected-note@-4{{'read' accessor defined here}}
+                        // expected-note@-4{{'_read' accessor defined here}}
     var fake: Int
     yield &fake
   }
@@ -144,9 +144,9 @@ var i_rsn_m: Int {
 var in_rns_m: Int {
   _read { yield i }
   nonmutating set {}
-  _modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the 'read' accessor is not 'mutating'}}
+  _modify { // expected-error{{'_modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the '_read' accessor is not 'mutating'}}
             // expected-note@-2{{setter defined here}}
-            // expected-note@-4{{'read' accessor defined here}}
+            // expected-note@-4{{'_read' accessor defined here}}
     yield &i
   }
 }
@@ -198,7 +198,7 @@ var inrnsn_m: Int {
 var irnsn_m: Int {
   mutating read { yield i }
   nonmutating set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the 'read' accessor is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the 'read' accessor is 'mutating'}}
                         // expected-note@-3{{'read' accessor defined here}}
     var fake: Int
     yield &fake
@@ -207,7 +207,7 @@ var irnsn_m: Int {
 var inrsn_m: Int {
   read { yield i }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
                         // expected-note@-2{{setter defined here}}
     var fake: Int
     yield &fake
@@ -216,7 +216,7 @@ var inrsn_m: Int {
 var irsn_m: Int {
   mutating read { yield i }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the 'read' accessor is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the 'read' accessor is 'mutating'}}
                         // expected-note@-2{{setter defined here}}
                         // expected-note@-4{{'read' accessor defined here}}
     var fake: Int
@@ -226,7 +226,7 @@ var irsn_m: Int {
 var inrns_m: Int {
   read { yield i }
   nonmutating set {}
-  _modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the 'read' accessor is not 'mutating'}}
+  _modify { // expected-error{{'_modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the 'read' accessor is not 'mutating'}}
             // expected-note@-2{{setter defined here}}
             // expected-note@-4{{'read' accessor defined here}}
     yield &i
@@ -280,7 +280,7 @@ var inuansn_m: Int {
 var iuansn_m: Int {
   mutating unsafeAddress { UnsafePointer(bitPattern: 0x0)! }
   nonmutating set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the addressor is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the addressor is 'mutating'}}
                         // expected-note@-3{{addressor defined here}}
     var fake: Int
     yield &fake
@@ -289,7 +289,7 @@ var iuansn_m: Int {
 var inuasn_m: Int {
   unsafeAddress { UnsafePointer(bitPattern: 0x0)! }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when the setter is not 'nonmutating'}}
                         // expected-note@-2{{setter defined here}}
     var fake: Int
     yield &fake
@@ -298,7 +298,7 @@ var inuasn_m: Int {
 var iuasn_m: Int {
   mutating unsafeAddress { UnsafePointer(bitPattern: 0x0)! }
   set {}
-  nonmutating _modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the addressor is 'mutating'}}
+  nonmutating _modify { // expected-error{{'_modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the addressor is 'mutating'}}
                         // expected-note@-2{{setter defined here}}
                         // expected-note@-4{{addressor defined here}}
     var fake: Int
@@ -308,7 +308,7 @@ var iuasn_m: Int {
 var inuans_m: Int {
   unsafeAddress { UnsafePointer(bitPattern: 0x0)! }
   nonmutating set {}
-  _modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the addressor is not 'mutating'}}
+  _modify { // expected-error{{'_modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the addressor is not 'mutating'}}
             // expected-note@-2{{setter defined here}}
             // expected-note@-4{{addressor defined here}}
     yield &i
@@ -444,8 +444,8 @@ var in_rnsnm: Int {
 var i_rnsnm: Int {
   mutating _read { yield i }
   nonmutating set {}
-  nonmutating modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the 'read' accessor is 'mutating'}}
-                        // expected-note@-3{{'read' accessor defined here}}
+  nonmutating modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when the '_read' accessor is 'mutating'}}
+                        // expected-note@-3{{'_read' accessor defined here}}
     var fake: Int
     yield &fake
   }
@@ -462,9 +462,9 @@ var in_rsnm: Int {
 var i_rsnm: Int {
   mutating _read { yield i }
   set {}
-  nonmutating modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the 'read' accessor is 'mutating'}}
+  nonmutating modify { // expected-error{{'modify' accessor cannot be 'nonmutating' when either the setter is not 'nonmutating' or the '_read' accessor is 'mutating'}}
                         // expected-note@-2{{setter defined here}}
-                        // expected-note@-4{{'read' accessor defined here}}
+                        // expected-note@-4{{'_read' accessor defined here}}
     var fake: Int
     yield &fake
   }
@@ -472,9 +472,9 @@ var i_rsnm: Int {
 var in_rnsm: Int {
   _read { yield i }
   nonmutating set {}
-  modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the 'read' accessor is not 'mutating'}}
+  modify { // expected-error{{'modify' accessor cannot be 'mutating' when both the setter is 'nonmutating' and the '_read' accessor is not 'mutating'}}
             // expected-note@-2{{setter defined here}}
-            // expected-note@-4{{'read' accessor defined here}}
+            // expected-note@-4{{'_read' accessor defined here}}
     yield &i
   }
 }


### PR DESCRIPTION
They are mutually exclusive.
