### PR TITLE
[span] express correct lifetimes for initializers

### DIFF
--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -61,8 +61,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   @inline(__always)
-  //FIXME: should be @lifetime(borrow pointer) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   internal init(
     _unchecked pointer: borrowing UnsafeRawPointer?,
     byteCount: Int
@@ -90,8 +89,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
   ) {
@@ -110,8 +108,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
@@ -128,8 +125,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
   ) {
@@ -138,8 +134,7 @@ extension RawSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
@@ -158,8 +153,7 @@ extension RawSpan {
   ///   - byteCount: the number of initialized bytes in the span.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: borrowing UnsafeRawPointer,
     byteCount: Int
@@ -178,8 +172,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing UnsafeBufferPointer<T>
   ) {
@@ -196,8 +189,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
   ) {
@@ -216,8 +208,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<T>
   ) {
@@ -234,8 +225,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
   ) {
@@ -256,8 +246,7 @@ extension RawSpan {
   ///   - byteCount: the number of initialized bytes in the span.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: borrowing UnsafePointer<T>,
     count: Int
@@ -275,8 +264,10 @@ extension RawSpan {
   ///           `RawSpan`'s lifetime and the memory it represents.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(span)
-  public init<Element: BitwiseCopyable>(_elements span: consuming Span<Element>) {
+  @lifetime(borrow span)
+  public init<Element: BitwiseCopyable>(
+    _elements span: borrowing Span<Element>
+  ) {
     self.init(
       _unchecked: span._pointer,
       byteCount: span.count &* MemoryLayout<Element>.stride

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -63,8 +63,7 @@ public struct Span<Element: ~Copyable & ~Escapable>
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   @inline(__always)
-  //FIXME: should be @lifetime(borrow pointer) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   internal init(
     _unchecked pointer: borrowing UnsafeRawPointer?,
     count: Int
@@ -92,8 +91,7 @@ extension Span where Element: ~Copyable {
   ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: borrowing UnsafeBufferPointer<Element>
   ) {
@@ -116,8 +114,7 @@ extension Span where Element: ~Copyable {
   ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<Element>
   ) {
@@ -136,8 +133,7 @@ extension Span where Element: ~Copyable {
   ///   - count: the number of initialized elements in the span.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: borrowing UnsafePointer<Element>,
     count: Int
@@ -161,8 +157,7 @@ extension Span {
   ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<Element>>
   ) {
@@ -179,8 +174,7 @@ extension Span {
   ///   - buffer: an `UnsafeMutableBufferPointer` to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
@@ -206,8 +200,7 @@ extension Span where Element: BitwiseCopyable {
   ///   - buffer: a buffer to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
   ) {
@@ -239,8 +232,7 @@ extension Span where Element: BitwiseCopyable {
   ///   - buffer: a buffer to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
   ) {
@@ -263,8 +255,7 @@ extension Span where Element: BitwiseCopyable {
   ///   - byteCount: the number of initialized elements in the span.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: borrowing UnsafeRawPointer,
     byteCount: Int
@@ -287,8 +278,7 @@ extension Span where Element: BitwiseCopyable {
   ///   - buffer: a buffer to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
@@ -309,8 +299,7 @@ extension Span where Element: BitwiseCopyable {
   ///   - buffer: a buffer to initialized elements.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  //FIXME: should be @lifetime(borrow <argname>) rdar://138672380
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {


### PR DESCRIPTION
In the initial `Span` pull request (https://github.com/swiftlang/swift/pull/76406,) the underscored initializers returned "immortal" instances due to a gap in the new parser. Now that the parser is fixed (https://github.com/swiftlang/swift-syntax/pull/2894,) this annotates the initializers with the correct lifetime.

Addresses rdar://139668469