### PR TITLE
[stdlib] Elide some null-pointer checks in UM[R]BP bulk-copy functions

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -946,7 +946,9 @@ extension UnsafeMutableBufferPointer {
         $0.count <= self.count,
         "buffer cannot contain every element from source."
       )
-      baseAddress?.initialize(from: sourceAddress, count: $0.count)
+      baseAddress.unsafelyUnwrapped.initialize(
+        from: sourceAddress, count: $0.count
+      )
       return $0.count
     }
     if let count {
@@ -1049,7 +1051,7 @@ extension UnsafeMutableBufferPointer {
         $0.count <= self.count,
         "buffer cannot contain every element from source."
       )
-      baseAddress?.update(from: sourceAddress, count: $0.count)
+      baseAddress.unsafelyUnwrapped.update(from: sourceAddress, count: $0.count)
       return $0.count
     }
     if let count {
@@ -1117,7 +1119,9 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
       source.count <= self.count,
       "buffer cannot contain every element from source."
     )
-    baseAddress?.moveInitialize(from: sourceAddress, count: source.count)
+    baseAddress.unsafelyUnwrapped.moveInitialize(
+      from: sourceAddress, count: source.count
+    )
     return startIndex.advanced(by: source.count)
   }
 }
@@ -1191,7 +1195,9 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
       source.count <= self.count,
       "buffer cannot contain every element from source."
     )
-    baseAddress?.moveUpdate(from: sourceAddress, count: source.count)
+    baseAddress.unsafelyUnwrapped.moveUpdate(
+      from: sourceAddress, count: source.count
+    )
     return startIndex.advanced(by: source.count)
   }
 }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -869,7 +869,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         $0.count * MemoryLayout<C.Element>.stride <= self.count,
         "buffer cannot contain every element from source collection."
       )
-      let start = baseAddress?.initializeMemory(
+      let start = baseAddress.unsafelyUnwrapped.initializeMemory(
         as: C.Element.self, from: sourceAddress, count: $0.count
       )
       return .init(start: start, count: $0.count)
@@ -955,7 +955,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       source.count * MemoryLayout<T>.stride <= self.count,
       "buffer cannot contain every element from source."
     )
-    let initialized = baseAddress?.moveInitializeMemory(
+    let initialized = baseAddress.unsafelyUnwrapped.moveInitializeMemory(
       as: T.self, from: sourceAddress, count: source.count
     )
     return .init(start: initialized, count: source.count)


### PR DESCRIPTION
Writing these functions with calls through optional chaining (the `?` operator) meant that an extra `nil` check could never be elided from code that uses them. We replace the `?` operator with `unsafelyUnwrapped` instead, providing safety in debug mode in the presence of a malformed `UnsafeMutableBufferPointer`, while eliding the nil check in release mode.