### PR TITLE
AST: Print opaque result types correctly in swiftinterfaces

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -366,6 +366,10 @@ struct PrintOptions {
   OpaqueReturnTypePrintingMode OpaqueReturnTypePrinting =
       OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
 
+  /// If non-null, opaque types that have this naming decl should be printed as
+  /// `some P1` instead of as a stable reference.
+  const ValueDecl *OpaqueReturnTypeNamingDecl = nullptr;
+
   /// Whether to print decl attributes that are only used internally,
   /// such as _silgen_name, transparent, etc.
   bool PrintUserInaccessibleAttrs = true;

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -50,6 +50,7 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
+// CHECK-LABEL: public struct Bar<T> : OpaqueResultTypes.AssocTypeInference
 @available(SwiftStdlib 5.1, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
@@ -257,5 +258,30 @@ public struct Zim: AssocTypeInference {
   @available(SwiftStdlib 5.1, *)
   public subscript() -> some Foo {
     return 123
+  }
+}
+
+public protocol PrimaryAssociatedTypeInference<Assoc> {
+  associatedtype Assoc
+
+  func foo(_: Int) -> Assoc
+}
+
+// CHECK-LABEL: public struct Baz : OpaqueResultTypes.PrimaryAssociatedTypeInference
+
+public struct Baz: PrimaryAssociatedTypeInference {
+  // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+  public func foo(_: Int) -> some Foo {
+    return 123
+  }
+
+  // CHECK-LABEL: public func callsFoo() -> @_opaqueReturnTypeOf("$s17OpaqueResultTypes3BazV3fooyQrSiF", 0) __
+  public func callsFoo() -> Assoc {
+    return foo(123)
+  }
+
+  // CHECK-LABEL: public func identity() -> some OpaqueResultTypes.PrimaryAssociatedTypeInference<@_opaqueReturnTypeOf("$s17OpaqueResultTypes3BazV3fooyQrSiF", 0) __>
+  public func identity() -> some PrimaryAssociatedTypeInference<Assoc> {
+    return self
   }
 }


### PR DESCRIPTION
Fixes a bug where references to the opaque types of other decls were printed with the `some Type` syntax, breaking the interface. Only the opaque type introduced by a declaration should be printed with the `some Type` syntax; other opaque types must always be printed as a stable addresses instead.

Resolves rdar://134582913.
