### PR TITLE
[Sema] A couple more MiscDiagnostics cleanups/fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5105,7 +5105,8 @@ ERROR(unknown_case_must_be_last,none,
       "'@unknown' can only be applied to the last case in a switch", ())
 
 WARNING(where_on_one_item, none,
-        "'where' only applies to the second pattern match in this case", ())
+        "'where' only applies to the second pattern match in this "
+        "'%select{case|catch}0'", (bool))
 
 NOTE(add_where_newline, none,
      "disambiguate by adding a line break between them if this is desired", ())

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1733,20 +1733,6 @@ private:
     return Type();
   }
 
-  ASTNode visit(Stmt *S, bool performSyntacticDiagnostics = true) {
-    auto rewritten = ASTVisitor::visit(S);
-    if (!rewritten)
-      return {};
-
-    if (performSyntacticDiagnostics) {
-      if (auto *stmt = getAsStmt(rewritten)) {
-        performStmtDiagnostics(stmt, context.getAsDeclContext());
-      }
-    }
-
-    return rewritten;
-  }
-
   bool visitPatternBindingDecl(PatternBindingDecl *PBD) {
     // If this is a placeholder variable with an initializer, we just need to
     // set the inferred type.
@@ -2274,7 +2260,7 @@ public:
 private:
   ASTNode visitDoStmt(DoStmt *doStmt) override {
     if (auto transformed = transformDo(doStmt)) {
-      return visit(transformed.get(), /*performSyntacticDiagnostics=*/false);
+      return visit(transformed.get());
     }
 
     auto newBody = visit(doStmt->getBody());

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -135,7 +135,11 @@ namespace swift {
 
   class BaseDiagnosticWalker : public ASTWalker {
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
+      // We don't walk into any nested local decls, except PatternBindingDecls,
+      // which are type-checked along with the parent, and MacroExpansionDecl,
+      // which needs to be visited to visit the macro arguments.
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(D) ||
+                                 isa<MacroExpansionDecl>(D));
     }
 
     MacroWalking getMacroWalkingBehavior() const override {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3561,7 +3561,7 @@ bool diagnoseExplicitUnavailability(
 }
 
 namespace {
-class ExprAvailabilityWalker : public ASTWalker {
+class ExprAvailabilityWalker : public BaseDiagnosticWalker {
   /// Models how member references will translate to accessor usage. This is
   /// used to diagnose the availability of individual accessors that may be
   /// called by the expression being checked.
@@ -3595,11 +3595,6 @@ class ExprAvailabilityWalker : public ASTWalker {
 public:
   explicit ExprAvailabilityWalker(const ExportContext &Where)
     : Context(Where.getDeclContext()->getASTContext()), Where(Where) {}
-
-  MacroWalking getMacroWalkingBehavior() const override {
-    // Expanded source should be type checked and diagnosed separately.
-    return MacroWalking::Arguments;
-  }
 
   PreWalkAction walkToArgumentPre(const Argument &Arg) override {
     // Arguments should be walked in their own member access context which

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3721,10 +3721,8 @@ public:
                                CE->getResultType(), E->getLoc(), Where);
     }
     if (AbstractClosureExpr *closure = dyn_cast<AbstractClosureExpr>(E)) {
-      if (shouldWalkIntoClosure(closure)) {
-        walkAbstractClosure(closure);
-        return Action::SkipChildren(E);
-      }
+      walkAbstractClosure(closure);
+      return Action::SkipChildren(E);
     }
 
     if (auto CE = dyn_cast<ExplicitCastExpr>(E)) {
@@ -3950,10 +3948,6 @@ private:
                              ? MemberAccessContext::Writeback
                              : AccessContext;
     walkInContext(E->getSubExpr(), accessContext);
-  }
-
-  bool shouldWalkIntoClosure(AbstractClosureExpr *closure) const {
-    return true;
   }
 
   /// Walk an abstract closure expression, checking for availability

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -211,12 +211,8 @@ bool isExported(const Decl *D);
 void diagnoseExprAvailability(const Expr *E, DeclContext *DC);
 
 /// Diagnose uses of unavailable declarations in statements (via patterns, etc)
-/// but not expressions, unless \p walkRecursively was specified.
-///
-/// \param walkRecursively Whether nested statements and expressions should
-/// be visited, too.
-void diagnoseStmtAvailability(const Stmt *S, DeclContext *DC,
-                              bool walkRecursively=false);
+/// but not expressions.
+void diagnoseStmtAvailability(const Stmt *S, DeclContext *DC);
 
 /// Checks both a TypeRepr and a Type, but avoids emitting duplicate
 /// diagnostics by only checking the Type if the TypeRepr succeeded.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1607,6 +1607,10 @@ public:
       BraceStmt *body = caseBlock->getBody();
       limitExhaustivityChecks |= typeCheckStmt(body);
       caseBlock->setBody(body);
+
+      // CaseStmts don't go through typeCheckStmt, so manually call into
+      // performStmtDiagnostics.
+      performStmtDiagnostics(caseBlock, DC);
     }
   }
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -1029,3 +1029,31 @@ func testMissingElementInEmptyBuilder() {
   func test2() -> Int {}
   // expected-error@-1 {{expected expression of type 'Int' in result builder 'SingleElementBuilder'}} {{24-24=<#T##Int#>}}
 }
+
+// https://github.com/swiftlang/swift/issues/77453
+func testNoDuplicateStmtDiags() {
+  @resultBuilder
+  struct Builder {
+    static func buildBlock<T>(_ components: T...) -> T {
+      components.first!
+    }
+    static func buildEither<T>(first component: T) -> T {
+      component
+    }
+    static func buildEither<T>(second component: T) -> T {
+      component
+    }
+  }
+
+  func takesClosure(_ fn: () -> Void) -> Int? { nil }
+
+  @Builder
+  func foo() -> Int {
+    if let x = takesClosure {} {
+      // expected-warning@-1 {{trailing closure in this context is confusable with the body of the statement}}
+      x
+    } else {
+      1
+    }
+  }
+}

--- a/test/Macros/macro_misc_diags.swift
+++ b/test/Macros/macro_misc_diags.swift
@@ -77,10 +77,16 @@ _ = #identity(deprecatedFunc())
 // CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-2]]{{.*}}identityfMf1_.swift:1:1: warning: 'deprecatedFunc()' is deprecated
 // CHECK-DIAG: Client.swift:[[@LINE-2]]:15: warning: 'deprecatedFunc()' is deprecated
 
-#makeBinding(deprecatedFunc())
-// CHECK-DIAG: Client.swift:[[@LINE-1]]:14: warning: 'deprecatedFunc()' is deprecated
-// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-3]]{{.*}}makeBindingfMf_.swift:1:9: warning: 'deprecatedFunc()' is deprecated
-// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-4]]{{.*}}makeBindingfMf_.swift:1:5: warning: initialization of immutable value 'x' was never used
+#makeBinding((deprecatedFunc(), Int, {
+  if let _ = takesClosure {} {}
+}()))
+// CHECK-DIAG: Client.swift:[[@LINE-2]]:27: warning: trailing closure in this context is confusable with the body of the statement
+// CHECK-DIAG: Client.swift:[[@LINE-4]]:33: error: expected member name or initializer call after type name
+// CHECK-DIAG: Client.swift:[[@LINE-5]]:15: warning: 'deprecatedFunc()' is deprecated
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-7]]{{.*}}makeBindingfMf_.swift:2:27: warning: trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-8]]{{.*}}makeBindingfMf_.swift:1:28: error: expected member name or initializer call after type name
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-9]]{{.*}}makeBindingfMf_.swift:1:10: warning: 'deprecatedFunc()' is deprecated
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-10]]{{.*}}makeBindingfMf_.swift:1:5: warning: initialization of immutable value
 
 struct S1 {
   #makeBinding(deprecatedFunc())

--- a/test/Macros/macro_misc_diags.swift
+++ b/test/Macros/macro_misc_diags.swift
@@ -80,12 +80,12 @@ _ = #identity(deprecatedFunc())
 #makeBinding((deprecatedFunc(), Int, {
   if let _ = takesClosure {} {}
 }()))
-// CHECK-DIAG: Client.swift:[[@LINE-2]]:27: warning: trailing closure in this context is confusable with the body of the statement
-// CHECK-DIAG: Client.swift:[[@LINE-4]]:33: error: expected member name or initializer call after type name
-// CHECK-DIAG: Client.swift:[[@LINE-5]]:15: warning: 'deprecatedFunc()' is deprecated
-// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-7]]{{.*}}makeBindingfMf_.swift:2:27: warning: trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning
-// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-8]]{{.*}}makeBindingfMf_.swift:1:28: error: expected member name or initializer call after type name
-// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-9]]{{.*}}makeBindingfMf_.swift:1:10: warning: 'deprecatedFunc()' is deprecated
+// CHECK-DIAG: Client.swift:[[@LINE-3]]:33: error: expected member name or initializer call after type name
+// CHECK-DIAG: Client.swift:[[@LINE-4]]:15: warning: 'deprecatedFunc()' is deprecated
+// CHECK-DIAG: Client.swift:[[@LINE-4]]:27: warning: trailing closure in this context is confusable with the body of the statement
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-7]]{{.*}}makeBindingfMf_.swift:1:28: error: expected member name or initializer call after type name
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-8]]{{.*}}makeBindingfMf_.swift:1:10: warning: 'deprecatedFunc()' is deprecated
+// CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-9]]{{.*}}makeBindingfMf_.swift:2:27: warning: trailing closure in this context is confusable with the body of the statement
 // CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-10]]{{.*}}makeBindingfMf_.swift:1:5: warning: initialization of immutable value
 
 struct S1 {
@@ -104,8 +104,8 @@ func takesClosure(_ fn: () -> Void) -> Int? { nil }
 
 _ = #trailingClosure {
   if let _ = takesClosure {} {}
-  // CHECK-DIAG: Client.swift:[[@LINE-1]]:27: warning: trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning
-  // CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-4]]{{.*}}trailingClosurefMf_.swift:2:27: warning: trailing closure in this context is confusable with the body of the statement
+  // CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-3]]{{.*}}trailingClosurefMf_.swift:2:27: warning: trailing closure in this context is confusable with the body of the statement
+  // CHECK-DIAG: Client.swift:[[@LINE-2]]:27: warning: trailing closure in this context is confusable with the body of the statement
 }
 
 func testOptionalToAny(_ y: Int?) {

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -476,7 +476,7 @@ func r25178926(_ a : Type) {
   switch a { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{missing case: '.Bar'}}
   case .Foo, .Bar where 1 != 100:
-    // expected-warning @-1 {{'where' only applies to the second pattern match in this case}}
+    // expected-warning @-1 {{'where' only applies to the second pattern match in this 'case'}}
     // expected-note @-2 {{disambiguate by adding a line break between them if this is desired}} {{14-14=\n       }}
     // expected-note @-3 {{duplicate the 'where' on both patterns to check both patterns}} {{12-12= where 1 != 100}}
     break
@@ -501,6 +501,34 @@ func r25178926(_ a : Type) {
   // expected-note@-3 {{add missing cases}}
   case .Foo where 1 != 100, .Bar where 1 != 100:
     break
+  }
+}
+
+func testAmbiguousWhereInCatch() {
+  protocol P1 {}
+  protocol P2 {}
+  func throwingFn() throws {}
+  do {
+    try throwingFn()
+  } catch is P1, is P2 where .random() {
+    // expected-warning @-1 {{'where' only applies to the second pattern match in this 'catch'}}
+    // expected-note @-2 {{disambiguate by adding a line break between them if this is desired}} {{18-18=\n          }}
+    // expected-note @-3 {{duplicate the 'where' on both patterns to check both patterns}} {{16-16= where .random()}}
+  } catch {
+
+  }
+  do {
+    try throwingFn()
+  } catch is P1,
+          is P2 where .random() {
+  } catch {
+
+  }
+  do {
+    try throwingFn()
+  } catch is P1 where .random(), is P2 where .random() {
+  } catch {
+
   }
 }
 

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -149,3 +149,99 @@ struct SubscriptWhere {
 struct OuterGeneric<T> {
   func contextuallyGenericMethod() where T == any HasAssoc {}
 }
+
+typealias HasAssocAlias = HasAssoc
+
+func testExistentialInCase(_ x: Any) {
+  switch x {
+  case is HasAssoc:
+    // expected-error@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+    break
+  default:
+    break
+  }
+  _ = {
+    switch x {
+    case is HasAssoc:
+      // expected-error@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+      break
+    default:
+      break
+    }
+  }
+  switch x {
+  case is HasAssocAlias:
+    // expected-error@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+    break
+  default:
+    break
+  }
+  _ = {
+    switch x {
+    case is HasAssocAlias:
+      // expected-error@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+      break
+    default:
+      break
+    }
+  }
+  switch x {
+  case is ~Copyable:
+    // expected-error@-1 {{constraint that suppresses conformance requires 'any'}}
+    // expected-warning@-2 {{'is' test is always true}}
+    break
+  default:
+    break
+  }
+  _ = {
+    switch x {
+    case is ~Copyable:
+      // expected-error@-1 {{constraint that suppresses conformance requires 'any'}}
+      // expected-warning@-2 {{'is' test is always true}}
+      break
+    default:
+      break
+    }
+  }
+}
+
+func throwingFn() throws {}
+
+// These are downgraded to warnings until Swift 7, see protocol_types_swift7.swift.
+// https://github.com/swiftlang/swift/issues/77553
+func testExistentialInCatch() throws {
+  do {
+    try throwingFn()
+  } catch is HasAssoc {}
+  // expected-warning@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+  _ = {
+    do {
+      try throwingFn()
+    } catch is HasAssoc {}
+    // expected-warning@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+  }
+  do {
+    try throwingFn()
+  } catch is HasAssocAlias {}
+  // expected-warning@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+  _ = {
+    do {
+      try throwingFn()
+    } catch is HasAssocAlias {}
+    // expected-warning@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+  }
+  do {
+    try throwingFn()
+  } catch is ~Copyable {}
+  // expected-warning@-1 {{constraint that suppresses conformance requires 'any'}}
+  // expected-warning@-2 {{'is' test is always true}}
+
+  // FIXME: We shouldn't emit a duplicate 'always true' warning here.
+  _ = {
+    do {
+      try throwingFn()
+    } catch is ~Copyable {}
+    // expected-warning@-1 {{constraint that suppresses conformance requires 'any'}}
+    // expected-warning@-2 2{{'is' test is always true}}
+  }
+}

--- a/test/type/protocol_types_swift7.swift
+++ b/test/type/protocol_types_swift7.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -swift-version 7
+// REQUIRES: swift7
+
+protocol HasAssoc {
+  associatedtype Assoc
+}
+
+typealias HasAssocAlias = HasAssoc
+
+func throwingFn() throws {}
+
+// In Swift 6 we previously missed this diagnostic.
+// https://github.com/swiftlang/swift/issues/77553
+func testExistentialInCatch() throws {
+  do {
+    try throwingFn()
+  } catch is HasAssoc {}
+  // expected-error@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+  _ = {
+    do {
+      try throwingFn()
+    } catch is HasAssoc {}
+    // expected-error@-1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+  }
+  do {
+    try throwingFn()
+  } catch is HasAssocAlias {}
+  // expected-error@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+  _ = {
+    do {
+      try throwingFn()
+    } catch is HasAssocAlias {}
+    // expected-error@-1 {{use of 'HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any HasAssocAlias' (aka 'any HasAssoc')}}
+  }
+  do {
+    try throwingFn()
+  } catch is ~Copyable {}
+  // expected-error@-1 {{constraint that suppresses conformance requires 'any'}}
+  // expected-warning@-2 {{'is' test is always true}}
+
+  // FIXME: We shouldn't emit a duplicate 'always true' warning here.
+  _ = {
+    do {
+      try throwingFn()
+    } catch is ~Copyable {}
+    // expected-error@-1 {{constraint that suppresses conformance requires 'any'}}
+    // expected-warning@-2 2{{'is' test is always true}}
+  }
+}


### PR DESCRIPTION
- Avoid calling `performStmtDiagnostics` in CSApply, instead leaving it up to the SyntacticDiagnosticWalker
- Ensure we run `performStmtDiagnostics` for `catch` clauses, including allowing the ambiguous where clause diagnostic to be emitted for it
- Cleanup `diagnoseStmtAvailability` + `ExprAvailabilityWalker` a bit
- Make sure we visit MacroExpansionDecl args, I missed this in #77534

Resolves #77453
Resolves #77553