### PR TITLE
[cxx-interop] Simplify name generation for template arguments of builtin types

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -35,33 +35,19 @@ struct TemplateInstantiationNamePrinter
   }
 
   std::string VisitBuiltinType(const clang::BuiltinType *type) {
-    Type swiftType = nullptr;
     switch (type->getKind()) {
     case clang::BuiltinType::Void:
-      swiftType =
-          swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(), "Void");
-      break;
+      return "Void";
+
 #define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)                  \
-      case clang::BuiltinType::CLANG_BUILTIN_KIND:                             \
-        swiftType = swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(),     \
-                                               #SWIFT_TYPE_NAME);              \
-        break;
-#define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)            \
-      case clang::BuiltinType::CLANG_BUILTIN_KIND:                             \
-        swiftType = swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(),     \
-                                               #SWIFT_TYPE_NAME);              \
-        break;
+    case clang::BuiltinType::CLANG_BUILTIN_KIND:                               \
+      return #SWIFT_TYPE_NAME;
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
     default:
       break;
     }
 
-    if (swiftType) {
-      if (swiftType->is<NominalType>() || swiftType->isVoid()) {
-        return swiftType->getStringAsComponent();
-      }
-    }
-    return "_";
+    return VisitType(type);
   }
 
   std::string VisitTagType(const clang::TagType *type) {


### PR DESCRIPTION
We were searching for types in the Swift stdlib by name, just to get the names back from the types. Let's just return the type name without performing the search.

No user-facing change intended.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
