### PR TITLE
[ClangImporter] Fix build after LLVM #9573

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2445,10 +2445,14 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     if (auto moduleRef = clangModule->getASTFile()) {
       auto *moduleFile = Instance->getASTReader()->getModuleManager().lookup(
           *moduleRef);
+      llvm::SmallString<0> pathBuf;
+      pathBuf.reserve(256);
       Instance->getASTReader()->visitInputFileInfos(
           *moduleFile, /*IncludeSystem=*/true,
           [&](const clang::serialization::InputFileInfo &IFI, bool isSystem) {
-            SwiftDependencyTracker->addDependency(IFI.Filename, isSystem);
+            auto Filename = clang::ASTReader::ResolveImportedPath(
+                pathBuf, IFI.UnresolvedImportedFilename, *moduleFile);
+            SwiftDependencyTracker->addDependency(*Filename, isSystem);
           });
     }
   }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -172,9 +172,8 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
   for (auto &clangModuleDep : clangDependencies) {
     // File dependencies for this module.
     std::vector<std::string> fileDeps;
-    for (const auto &fileDep : clangModuleDep.FileDeps) {
-      fileDeps.push_back(fileDep.getKey().str());
-    }
+    clangModuleDep.forEachFileDep(
+        [&fileDeps](StringRef fileDep) { fileDeps.emplace_back(fileDep); });
 
     std::vector<std::string> swiftArgs;
     auto addClangArg = [&](Twine arg) {


### PR DESCRIPTION
Makes Swift correctly build with https://github.com/swiftlang/llvm-project/pull/9573.