### PR TITLE
[build.ps1] build swift-lmdb using cmake

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2440,7 +2440,7 @@ function Test-Format {
 }
 
 function Build-LMDB() {
-  Build-SPMProject `
+  Build-CMakeProject `
     -Action Build `
     -Src $SourceCache\swift-lmdb `
     -Bin (Get-HostProjectBinaryCache LMDB) `

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2465,6 +2465,7 @@ function Build-IndexStoreDB($Arch) {
       BUILD_SHARED_LIBS = "NO";
       CMAKE_C_FLAGS = @("-I$SDKInstallRoot\usr\include", "-I$SDKInstallRoot\usr\include\Block");
       CMAKE_CXX_FLAGS = @("-I$SDKInstallRoot\usr\include", "-I$SDKInstallRoot\usr\include\Block");
+      LMDB_DIR = (Get-HostProjectCMakeModules LMDB);
     }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2439,6 +2439,17 @@ function Test-Format {
   }
 }
 
+function Build-LMDB() {
+  Build-SPMProject `
+    -Action Build `
+    -Src $SourceCache\swift-lmdb `
+    -Bin (Get-HostProjectBinaryCache LMDB) `
+    -Arch $HostArch `
+    -Platform Windows `
+    -UseBuiltCompilers C `
+    -BuildTargets default
+}
+
 function Build-IndexStoreDB($Arch) {
   $SDKInstallRoot = (Get-HostSwiftSDK);
 
@@ -2837,6 +2848,7 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-PackageManager $HostArch
   Invoke-BuildStep Build-Markdown $HostArch
   Invoke-BuildStep Build-Format $HostArch
+  Invoke-BuildStep Build-LMDB $HostArch
   Invoke-BuildStep Build-IndexStoreDB $HostArch
   Invoke-BuildStep Build-SourceKitLSP $HostArch
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2439,14 +2439,12 @@ function Test-Format {
   }
 }
 
-function Build-LMDB() {
+function Build-LMDB($Arch) {
   Build-CMakeProject `
-    -Action Build `
     -Src $SourceCache\swift-lmdb `
     -Bin (Get-HostProjectBinaryCache LMDB) `
-    -Arch $HostArch `
-    -Platform Windows `
-    -UseBuiltCompilers C `
+    -Arch $Arch `
+    -UseMSVCCompilers C `
     -BuildTargets default
 }
 


### PR DESCRIPTION
This is tracked by rdar://139431575 as a part of https://github.com/swiftlang/vscode-swift/issues/562

Build swift-lmdb on Windows using newly added cmake files in the repository. This change makes it so that IndexStoreDB uses the same version of LMDB as swift-docc and enables SourceKit-LSP to use swift-docc as a dependency to fulfill documentation requests on behalf of the VS Code Swift extension.
