### PR TITLE
Fix simplifySwitchEnumUnreachableBlocks for default cases in ossa

### DIFF
--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -3259,3 +3259,24 @@ bb21:
   %75 = tuple ()
   return %75 : $()
 }
+
+// CHECK-LABEL: sil @simplify_switch_enum_unreachable :
+// CHECK-NOT:     switch_enum
+// CHECK:       } // end sil function 'simplify_switch_enum_unreachable'
+sil @simplify_switch_enum_unreachable : $@convention(thin) (@owned Optional<String>) -> () {
+bb0(%0 : $Optional<String>):
+  switch_enum %0 : $Optional<String>, case #Optional.some!enumelt: bb5, case #Optional.none!enumelt: bb4
+
+bb4:
+  unreachable
+
+bb5:
+  %1 = unchecked_enum_data %0 : $Optional<String>, #Optional.some!enumelt
+  release_value %1 : $String
+  br bb6
+
+bb6:
+  %17 = tuple ()
+  return %17 : $()
+}
+

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1919,3 +1919,23 @@ bb6:
   %17 = tuple ()
   return %17 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @simplify_switch_enum_unreachable :
+// CHECK-NOT:     switch_enum
+// CHECK:       } // end sil function 'simplify_switch_enum_unreachable'
+sil [ossa] @simplify_switch_enum_unreachable : $@convention(thin) (A) -> () {
+bb0(%0 : $A):
+  switch_enum %0 : $A, case #A.B!enumelt: bb1, default bb2
+
+bb1:
+  unreachable
+
+bb2(%defaultArg : $A):
+  apply undef(%defaultArg) : $@convention(thin) (A) -> ()
+  br bb3
+
+bb3:
+  %t = tuple ()
+  return %t : $()
+}
+


### PR DESCRIPTION
Unlike non-ossa, ossa's switch_enum accepts an argument for the default case When all other cases are unreachable, replace the default block's phi with the switch_enum's operand and transform the switch_enum to a branch.

Fixes rdar://139441002

