### PR TITLE
Tests: Add tests for deprecated property wrapper diagnostics

### DIFF
--- a/test/Sema/property_wrapper_availability.swift
+++ b/test/Sema/property_wrapper_availability.swift
@@ -15,9 +15,15 @@ struct Available51Wrapper<T> {
   var wrappedValue: T
 }
 
+@available(*, deprecated)
+@propertyWrapper
+struct DeprecatedWrapper<T> {
+  var wrappedValue: T
+}
+
 @available(*, unavailable)
 @propertyWrapper
-struct UnavailableWrapper<T> { // expected-note 6 {{'UnavailableWrapper' has been explicitly marked unavailable here}}
+struct UnavailableWrapper<T> { // expected-note 8 {{'UnavailableWrapper' has been explicitly marked unavailable here}}
   var wrappedValue: T
 }
 
@@ -26,7 +32,7 @@ struct WrappedValueUnavailableOnMacOS<T> {
   init(wrappedValue: T) { fatalError() }
 
   @available(macOS, unavailable)
-  var wrappedValue: T { // expected-note 6 {{'wrappedValue' has been explicitly marked unavailable here}}
+  var wrappedValue: T { // expected-note 9 {{'wrappedValue' has been explicitly marked unavailable here}}
     get { fatalError() }
     set { fatalError() }
   }
@@ -49,7 +55,10 @@ struct AlwaysAvailableStruct { // expected-note 3 {{add @available attribute to 
 
   @Available51Wrapper var available51Explicit: S // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
   @Available51Wrapper var available51Inferred = S() // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
-  
+
+  @DeprecatedWrapper var deprecatedExplicit: S // expected-warning {{'DeprecatedWrapper' is deprecated}}
+  @DeprecatedWrapper var deprecatedInferred = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
+
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
 
@@ -64,7 +73,10 @@ struct Available51Struct {
 
   @Available51Wrapper var available51Explicit: S
   @Available51Wrapper var available51Inferred = S()
-  
+
+  @DeprecatedWrapper var deprecatedExplicit: S // expected-warning {{'DeprecatedWrapper' is deprecated}}
+  @DeprecatedWrapper var deprecatedInferred = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
+
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
 
@@ -79,6 +91,9 @@ struct UnavailableStruct {
   
   @Available51Wrapper var available51Explicit: S
   @Available51Wrapper var available51Inferred = S()
+
+  @DeprecatedWrapper var deprecatedExplicit: S
+  @DeprecatedWrapper var deprecatedInferred = S()
 
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
@@ -95,6 +110,9 @@ struct UnavailableOnMacOSStruct {
   @Available51Wrapper var available51Explicit: S
   @Available51Wrapper var available51Inferred = S()
 
+  @DeprecatedWrapper var deprecatedExplicit: S
+  @DeprecatedWrapper var deprecatedInferred = S()
+
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
 
@@ -102,37 +120,69 @@ struct UnavailableOnMacOSStruct {
   @WrappedValueAvailable51 var wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
-func alwaysAvailableFunc( // expected-note 2 {{add @available attribute to enclosing global function}}
+func alwaysAvailableFunc( // expected-note 4 {{add @available attribute to enclosing global function}}
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
   @Available51Wrapper _ available51: S, // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
+  @DeprecatedWrapper _ deprecated: S, // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper _ unavailable: S, // expected-error {{'UnavailableWrapper' is unavailable}}
   @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
   @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
-) {}
+) {
+  @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
+  @Available51Wrapper var available51Local = S() // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
+  @DeprecatedWrapper var deprecatedLocal = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
+  @UnavailableWrapper var unavailableLocal = S() // expected-error {{'UnavailableWrapper' is unavailable}}
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
+  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
+}
 
 @available(macOS 51, *)
 func available51Func(
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
   @Available51Wrapper _ available51: S,
+  @DeprecatedWrapper _ deprecated: S, // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper _ unavailable: S, // expected-error {{'UnavailableWrapper' is unavailable}}
   @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
   @WrappedValueAvailable51 _ wrappedValueAavailable51: S
-) {}
+) {
+  @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
+  @Available51Wrapper var available51Local = S()
+  @DeprecatedWrapper var deprecatedLocal = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
+  @UnavailableWrapper var unavailableLocal = S() // expected-error {{'UnavailableWrapper' is unavailable}}
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
+  @WrappedValueAvailable51 var wrappedValueAavailable51 = S()
+}
 
 @available(*, unavailable)
 func unavailableFunc(
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
   @Available51Wrapper _ available51: S,
+  @DeprecatedWrapper _ deprecated: S,
   @UnavailableWrapper _ unavailable: S,
   @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
   @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
-) {}
+) {
+  @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
+  @Available51Wrapper var available51Local = S()
+  @DeprecatedWrapper var deprecatedLocal = S()
+  @UnavailableWrapper var unavailableLocal = S()
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
+  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
+}
 
 @available(macOS, unavailable)
 func unavailableOnMacOSFunc(
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
   @Available51Wrapper _ available51: S,
+  @DeprecatedWrapper _ deprecated: S,
   @UnavailableWrapper _ unavailable: S,
   @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S,
   @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
-) {}
+) {
+  @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
+  @Available51Wrapper var available51Local = S()
+  @DeprecatedWrapper var deprecatedLocal = S()
+  @UnavailableWrapper var unavailableLocal = S()
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S()
+  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
+}


### PR DESCRIPTION
Also, test property wrapper availability diagnostics on wrapped local vars.

Inspired by https://github.com/swiftlang/swift/issues/63139, though it doesn't seem to reproduce.
