### PR TITLE
[Frontend] Add some printing/vistation options to `swift-synthesize-interface`.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1670,6 +1670,15 @@ def omit_extension_block_symbols: Flag<["-"], "omit-extension-block-symbols">,
         NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
   HelpText<"Directly associate members and conformances with the extended nominal when generating symbol graphs instead of emitting 'swift.extension' symbols for extensions to external types">;
 
+// swift-synthesize-interface-only options
+def include_submodules : Flag<["-"], "include-submodules">,
+  Flags<[NoDriverOption, SwiftSynthesizeInterfaceOption]>,
+  HelpText<"Also print the declarations synthesized for any Clang submodules">;
+
+def print_fully_qualified_types : Flag<["-"], "print-fully-qualified-types">,
+  Flags<[NoDriverOption, SwiftSynthesizeInterfaceOption]>,
+  HelpText<"Always print fully qualified type names">;
+
 // swift-symbolgraph-extract-only options
 def output_dir : Separate<["-"], "output-dir">,
   Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption,

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -200,11 +200,19 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
     return EXIT_FAILURE;
   }
 
-  StreamPrinter printer(fs);
   PrintOptions printOpts =
       PrintOptions::printModuleInterface(/*printFullConvention=*/true);
-  ide::printModuleInterface(M, /*GroupNames=*/{},
-                            /*TraversalOptions=*/std::nullopt, printer,
+  if (ParsedArgs.hasArg(OPT_print_fully_qualified_types)) {
+    printOpts.FullyQualifiedTypes = true;
+  }
+
+  swift::OptionSet<swift::ide::ModuleTraversal> traversalOpts = std::nullopt;
+  if (ParsedArgs.hasArg(OPT_include_submodules)) {
+    traversalOpts = swift::ide::ModuleTraversal::VisitSubmodules;
+  }
+
+  StreamPrinter printer(fs);
+  ide::printModuleInterface(M, /*GroupNames=*/{}, traversalOpts, printer,
                             printOpts, /*PrintSynthesizedExtensions=*/false);
 
   return EXIT_SUCCESS;

--- a/test/SynthesizeInterfaceTool/Inputs/ExplicitSubmodule.h
+++ b/test/SynthesizeInterfaceTool/Inputs/ExplicitSubmodule.h
@@ -1,0 +1,3 @@
+struct ExplicitSubmoduleStruct {
+  int value;
+};

--- a/test/SynthesizeInterfaceTool/Inputs/ImplicitSubmodule.h
+++ b/test/SynthesizeInterfaceTool/Inputs/ImplicitSubmodule.h
@@ -1,0 +1,3 @@
+struct ImplicitSubmoduleStruct {
+  int value;
+};

--- a/test/SynthesizeInterfaceTool/Inputs/TopLevelModule.h
+++ b/test/SynthesizeInterfaceTool/Inputs/TopLevelModule.h
@@ -1,0 +1,3 @@
+struct TopLevelModuleStruct {
+  int value;
+};

--- a/test/SynthesizeInterfaceTool/Inputs/module.modulemap
+++ b/test/SynthesizeInterfaceTool/Inputs/module.modulemap
@@ -6,3 +6,15 @@ module mcxx {
   requires cplusplus
   header "mcxx.h"
 }
+
+module TopLevelModule {
+  header "TopLevelModule.h"
+
+  module ImplicitSubmodule {
+    header "ImplicitSubmodule.h"
+  }
+
+  explicit module ExplicitSubmodule {
+    header "ExplicitSubmodule.h"
+  }
+}

--- a/test/SynthesizeInterfaceTool/fully-qualified-types.swift
+++ b/test/SynthesizeInterfaceTool/fully-qualified-types.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-synthesize-interface -module-name m1 -print-fully-qualified-types -I %S/Inputs -o - | %FileCheck %s
+
+// CHECK:     public struct MyStruct {
+// CHECK-DAG:     public init()
+// CHECK-DAG:     public init(value: Swift.Int32)
+// CHECK-DAG:     public var value: Swift.Int32
+// CHECK-DAG: }
+// CHECK-DAG: extension m1.MyStruct {
+// CHECK-DAG:     public func printValue()
+// CHECK-DAG: }

--- a/test/SynthesizeInterfaceTool/include-submodules.swift
+++ b/test/SynthesizeInterfaceTool/include-submodules.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-synthesize-interface -module-name TopLevelModule -I %S/Inputs -o - | %FileCheck %s
+// RUN: %target-swift-synthesize-interface -module-name TopLevelModule -include-submodules -I %S/Inputs -o - | %FileCheck %s --check-prefix=IMPLICIT
+// RUN: %target-swift-synthesize-interface -module-name TopLevelModule.ExplicitSubmodule -I %S/Inputs -o - | %FileCheck %s --check-prefix=EXPLICIT
+
+// CHECK:     import TopLevelModule.ExplicitSubmodule
+// CHECK-DAG: import TopLevelModule.ImplicitSubmodule
+// CHECK-DAG: public struct TopLevelModuleStruct {
+// CHECK-DAG:     public init()
+// CHECK-DAG:     public init(value: Int32)
+// CHECK-DAG:     public var value: Int32
+// CHECK-DAG: }
+
+// CHECK-NOT: ImplicitModuleStruct
+// CHECK-NOT: ExplicitModuleStruct
+
+// IMPLICIT:     import TopLevelModule.ExplicitSubmodule
+// IMPLICIT-DAG: import TopLevelModule.ImplicitSubmodule
+// IMPLICIT-DAG: public struct TopLevelModuleStruct {
+// IMPLICIT-DAG:     public init()
+// IMPLICIT-DAG:     public init(value: Int32)
+// IMPLICIT-DAG:     public var value: Int32
+// IMPLICIT-DAG: }
+// IMPLICIT-DAG: public struct ImplicitSubmoduleStruct {
+// IMPLICIT-DAG:     public init()
+// IMPLICIT-DAG:     public init(value: Int32)
+// IMPLICIT-DAG:     public var value: Int32
+// IMPLICIT-DAG: }
+
+// IMPLICIT-NOT: ExplicitSubmoduleStruct
+
+// EXPLICIT:     public struct ExplicitSubmoduleStruct {
+// EXPLICIT-DAG:     public init()
+// EXPLICIT-DAG:     public init(value: Int32)
+// EXPLICIT-DAG:     public var value: Int32
+// EXPLICIT-DAG: }
+
+// EXPLICIT-NOT: import TopLevelModule{{.*}}
+// EXPLICIT-NOT: TopLevelModuleStruct
+// EXPLICIT-NOT: ImplicitModuleStruct


### PR DESCRIPTION
The `-include-submodules` flag causes the synthesized interface to include implicit Clang submodules of the module being printed. Since these are automatically made visible when importing the corresponding top-level module, it's often useful to have them present in the same synthesized Swift interface instead of having to make separate invocations to get each submodule separately.

The `-print-fully-qualified-types` causes type names to be printed with full module qualification. This is useful when using the synthesized interface for some other kind of analysis, because it ensures that all type references explicitly indicate which module they came from, instead of having to guess scoping and import resolution rules to figure out which module a reference comes from.
