### PR TITLE
Preserve extend_lifetime during dead instruction code elimination.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -308,6 +308,10 @@ extension Instruction {
       // Don't remove UncheckedEnumDataInst in OSSA in case it is responsible
       // for consuming an enum value.
       return !parentFunction.hasOwnership
+    case is ExtendLifetimeInst:
+      // An extend_lifetime can only be removed if the operand is also removed.
+      // If its operand is trivial, it will be removed by MandatorySimplification.
+      return false
     default:
       break
     }

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -637,3 +637,40 @@ bb0:
   %13 = tuple ()
   return %13 : $()
 }
+
+// Remove trivial move_value + extend_lifetime
+//
+// CHECK-LABEL: sil [ossa] @move_extend_lifetime : $@convention(thin) (@thin Trivial.Type) -> () {
+// CHECK: bb0(%0 : $@thin Trivial.Type):
+// CHECK-NOT: move_value
+// CHECK-NOT: extend_lifetime
+// CHECK-LABEL: } // end sil function 'move_extend_lifetime'
+sil [ossa] @move_extend_lifetime : $@convention(thin) (@thin Trivial.Type) -> () {
+bb0(%0 : $@thin Trivial.Type):
+  %mv = move_value [var_decl] %0 : $@thin Trivial.Type
+  extend_lifetime %mv : $@thin Trivial.Type
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @captureType : $@convention(thin) (@thin Trivial.Type) -> ()
+sil @takeClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+
+// SILGen pattern binding can (incorrectly) create a local variable to hold the value a function argument. This results
+// in an extend_lifetime that directly uses the argument value. Ensure that MoveOnlyTypeEliminator erases the
+// extend_lifetime.
+//
+// CHECK-LABEL: sil [ossa] @arg_extend_lifetime : $@convention(thin) (@thin Trivial.Type) -> () {
+// CHECK-NOT: extend_lifetime
+// CHECK-LABEL: } // end sil function 'arg_extend_lifetime'
+sil [ossa] @arg_extend_lifetime : $@convention(thin) (@thin Trivial.Type) -> () {
+bb0(%0 : $@thin Trivial.Type):
+  %cf = function_ref @captureType : $@convention(thin) (@thin Trivial.Type) -> ()
+  %closure = partial_apply [callee_guaranteed] [on_stack] %cf(%0) : $@convention(thin) (@thin Trivial.Type) -> ()
+  %f = function_ref @takeClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %6 = apply %f(%closure) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  destroy_value %closure : $@noescape @callee_guaranteed () -> ()
+  extend_lifetime %0 : $@thin Trivial.Type
+  %13 = tuple ()
+  return %13 : $()
+}

--- a/test/SILOptimizer/simplify_extend_lifetime.sil
+++ b/test/SILOptimizer/simplify_extend_lifetime.sil
@@ -1,0 +1,21 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+// extend_lifetime should not be eliminated as dead code.
+//
+// CHECK-LABEL: sil [ossa] @do_not_remove_extend : $@convention(thin) (Int) -> () {
+// CHECK:       extend_lifetime %0 : $Int
+// CHECK-LABEL: } // end sil function 'do_not_remove_extend'
+sil [ossa] @do_not_remove_extend : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  extend_lifetime %0 : $Int
+  %4 = tuple ()
+  return %4 : $()
+}


### PR DESCRIPTION
And remove all trivial extend_lifetime instructions during the MoveOnlyWrappedTypeEliminator pass.