### PR TITLE
SIL: Skip visiting bad extensions in SILSymbolVisitor

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -735,6 +735,9 @@ public:
 
   void visitExtensionDecl(ExtensionDecl *ED) {
     auto nominal = ED->getExtendedNominal();
+    if (!nominal)
+      return;
+
     if (canSkipNominal(nominal))
       return;
 

--- a/test/TBD/lazy-typecheck-errors.swift
+++ b/test/TBD/lazy-typecheck-errors.swift
@@ -8,3 +8,7 @@ public protocol P {
 // expected-error@+1 {{type 'S' does not conform to protocol 'P'}}
 public struct S: P {
 }
+
+extension DoesNotExist {
+  public func method() {}
+}


### PR DESCRIPTION
When lazy typechecking is enabled, extensions that do not typecheck can make it to TBDGen, which would crash during its AST walk because `SILSymbolVisitor` tried to dereference the null nominal type for the extension.

Resolves rdar://139320515.
