### PR TITLE
stdlib/Concurrency: Resolve or suppress a bunch of warnings

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -40,22 +40,22 @@ import SwiftPrivate
 import SwiftPrivateLibcExtras
 import SwiftPrivateThreadExtras
 #if canImport(Darwin)
-import Darwin
+internal import Darwin
 #elseif canImport(Glibc)
-import Glibc
+internal import Glibc
 #elseif canImport(Musl)
-import Musl
+internal import Musl
 #elseif canImport(Android)
-import Android
+internal import Android
 #elseif os(WASI)
-import WASILibc
+internal import WASILibc
 #elseif os(Windows)
-import CRT
-import WinSDK
+internal import CRT
+internal import WinSDK
 #endif
 
 #if _runtime(_ObjC)
-import ObjectiveC
+internal import ObjectiveC
 #else
 func autoreleasepool(invoking code: () -> Void) {
   // Native runtime does not have autorelease pools.  Execute the code

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -13,21 +13,21 @@
 import SwiftPrivate
 import SwiftPrivateLibcExtras
 #if canImport(Darwin)
-import Darwin
+internal import Darwin
 #elseif canImport(Glibc)
-import Glibc
+internal import Glibc
 #elseif canImport(Musl)
-import Musl
+internal import Musl
 #elseif canImport(Android)
-import Android
+internal import Android
 #elseif os(WASI)
-import WASILibc
+internal import WASILibc
 #elseif os(Windows)
-import CRT
+internal import CRT
 #endif
 
 #if _runtime(_ObjC)
-import Foundation
+internal import Foundation
 #endif
 
 //

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -17,25 +17,25 @@ import SwiftPrivateLibcExtras
 
 #if canImport(Darwin)
 #if _runtime(_ObjC)
-import Foundation
+internal import Foundation
 #endif
-import Darwin
-import var Darwin.errno
+internal import Darwin
+internal import var Darwin.errno
 #elseif canImport(Glibc)
-import Glibc
+internal import Glibc
 #elseif canImport(Musl)
-import Musl
+internal import Musl
 #elseif canImport(Android)
-import Android
+internal import Android
 #elseif os(WASI)
-import WASILibc
+internal import WASILibc
 #elseif os(Windows)
-import CRT
-import WinSDK
+internal import CRT
+internal import WinSDK
 #endif
 
 #if _runtime(_ObjC)
-import ObjectiveC
+internal import ObjectiveC
 #endif
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -29,9 +29,9 @@ let RequestPointerSize = "p"
 
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-import MachO
-import Darwin
-import var Darwin.errno
+internal import MachO
+internal import Darwin
+internal import var Darwin.errno
 
 #if arch(x86_64) || arch(arm64)
 typealias MachHeader = mach_header_64

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -583,8 +583,11 @@ SWIFT_CC(swiftasync)
 static void task_wait_throwing_resume_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context) {
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(_context);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
   auto resumeWithError =
       reinterpret_cast<AsyncVoidClosureEntryPoint *>(context->ResumeParent);
+#pragma clang diagnostic pop
   return resumeWithError(context->Parent, context->errorResult);
 }
 
@@ -959,8 +962,11 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     auto asyncContextPrefix = reinterpret_cast<AsyncContextPrefix *>(
         reinterpret_cast<char *>(allocation) + headerSize -
         sizeof(AsyncContextPrefix));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     asyncContextPrefix->asyncEntryPoint =
         reinterpret_cast<AsyncVoidClosureEntryPoint *>(function);
+#pragma clang diagnostic pop
     asyncContextPrefix->closureContext = closureContext;
     function = non_future_adapter;
     assert(sizeof(AsyncContextPrefix) == 3 * sizeof(void *));
@@ -968,8 +974,11 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     auto asyncContextPrefix = reinterpret_cast<FutureAsyncContextPrefix *>(
         reinterpret_cast<char *>(allocation) + headerSize -
         sizeof(FutureAsyncContextPrefix));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     asyncContextPrefix->asyncEntryPoint =
         reinterpret_cast<AsyncGenericClosureEntryPoint *>(function);
+#pragma clang diagnostic pop
     function = future_adapter;
     asyncContextPrefix->closureContext = closureContext;
     assert(sizeof(FutureAsyncContextPrefix) == 4 * sizeof(void *));
@@ -1035,6 +1044,8 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
                        " with parent %p at base pri %zu",
                        task, task->getTaskId(), parent, basePriority);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
   // Initialize the task-local allocator.
   initialContext->ResumeParent =
       runInlineOption ? &completeInlineTask
@@ -1042,6 +1053,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
                             asyncLet         ? &completeTask
                             : closureContext ? &completeTaskWithClosure
                                              : &completeTaskAndRelease);
+#pragma clang diagnostic pop
   if ((asyncLet || (runInlineOption && runInlineOption->getAllocation())) &&
       initialSlabSize > 0) {
     assert(parent || (runInlineOption && runInlineOption->getAllocation()));
@@ -1260,10 +1272,13 @@ AsyncTaskAndContext swift::swift_task_create(
             FutureAsyncSignature,
             SpecialPointerAuthDiscriminators::AsyncFutureFunction>(closureEntry);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     return swift_task_create_common(
         rawTaskCreateFlags, options, futureResultType,
         reinterpret_cast<TaskContinuationFunction *>(taskEntry), closureContext,
         initialContextSize);
+#pragma clang diagnostic pop
   }
 }
 
@@ -1348,7 +1363,10 @@ void swift_task_future_wait_throwingImpl(
   waitingTask->ResumeTask = task_wait_throwing_resume_adapter;
   waitingTask->ResumeContext = callContext;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
   auto resumeFn = reinterpret_cast<TaskContinuationFunction *>(resumeFunction);
+#pragma clang diagnostic pop
 
   // Wait on the future.
   assert(task->isFuture());

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -364,6 +364,8 @@ static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   free(task);
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
+
 static SerialExecutorRef executorForEnqueuedJob(Job *job) {
 #if !SWIFT_CONCURRENCY_ENABLE_DISPATCH
   return SerialExecutorRef::generic();
@@ -391,8 +393,6 @@ static void jobInvoke(void *obj, void *unused, uint32_t flags) {
 
 // Magic constant to identify Swift Job vtables to Dispatch.
 static const unsigned long dispatchSwiftObjectType = 1;
-
-#if !SWIFT_CONCURRENCY_EMBEDDED
 
 static FullMetadata<DispatchClassMetadata> jobHeapMetadata = {
   {

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -138,6 +138,7 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
 
   RuntimeErrorDetails::Thread secondaryThread = {
     .description = oldAccess,
+    .threadID = 0,
     .numFrames = 1,
     .frames = &oldPC
   };
@@ -148,7 +149,11 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     .framesToSkip = framesToSkip,
     .memoryAddress = pointer,
     .numExtraThreads = 1,
-    .threads = &secondaryThread
+    .threads = &secondaryThread,
+    .numFixIts = 0,
+    .fixIts = nullptr,
+    .numNotes = 0,
+    .notes = nullptr,
   };
   _swift_reportToDebugger(RuntimeErrorFlagFatal, message, &details);
 }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -7791,7 +7791,13 @@ diagnoseMetadataDependencyCycle(llvm::ArrayRef<MetadataDependency> links) {
       .errorType = "type-metadata-cycle",
       .currentStackDescription = "fetching metadata", // TODO?
       .framesToSkip = 1, // skip out to the check function
-      .memoryAddress = links.front().Value
+      .memoryAddress = links.front().Value,
+      .numExtraThreads = 0,
+      .threads = nullptr,
+      .numFixIts = 0,
+      .fixIts = nullptr,
+      .numNotes = 0,
+      .notes = nullptr,
       // TODO: describe the cycle using notes instead of one huge message?
     };
 #pragma GCC diagnostic pop

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -134,7 +134,7 @@ template<> void ProtocolConformanceDescriptor::dump() const {
     return "<unknown addr>";
   };
 
-  switch (auto kind = getTypeKind()) {
+  switch (getTypeKind()) {
   case TypeReferenceKind::DirectObjCClassName:
     printf("direct Objective-C class name %s", getDirectObjCClassName());
     break;

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1627,6 +1627,13 @@ bool swift::swift_isEscapingClosureAtFileLocation(const HeapObject *object,
           .errorType = "escaping-closure-violation",
           .currentStackDescription = "Closure has escaped",
           .framesToSkip = 1,
+          .memoryAddress = nullptr,
+          .numExtraThreads = 0,
+          .threads = nullptr,
+          .numFixIts = 0,
+          .fixIts = nullptr,
+          .numNotes = 0,
+          .notes = nullptr,
       };
       _swift_reportToDebugger(RuntimeErrorFlagFatal, log, &details);
     }
@@ -1728,7 +1735,13 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   RuntimeErrorDetails details = {
     .version = RuntimeErrorDetails::currentVersion,
     .errorType = "implicit-objc-entrypoint",
+    .currentStackDescription = nullptr,
     .framesToSkip = 1,
+    .memoryAddress = nullptr,
+    .numExtraThreads = 0,
+    .threads = nullptr,
+    .numFixIts = 0,
+    .fixIts = nullptr,
     .numNotes = 1,
     .notes = &note
   };

--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -30,7 +30,9 @@ struct OverrideSection {
   Override_ ## name name;
 #include "CompatibilityOverride.def"
 };
-  
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
 OverrideSection Swift50Overrides
 __attribute__((used, section("__DATA,__swift_hooks"))) = {
   .version = 0,
@@ -41,6 +43,7 @@ __attribute__((used, section("__DATA,__swift_hooks"))) = {
   // the Compatibility51 library is always linked when the 50 library is.
   .conformsToSwiftProtocol = swift51override_conformsToSwiftProtocol,
 };
+#pragma clang diagnostic pop
 
 // Allow this library to get force-loaded by autolinking
 __attribute__((weak, visibility("hidden")))

--- a/stdlib/toolchain/Compatibility51/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility51/Overrides.cpp
@@ -29,12 +29,15 @@ struct OverrideSection {
   Override_ ## name name;
 #include "CompatibilityOverride.def"
 };
-  
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
 OverrideSection Swift51Overrides
 __attribute__((used, section("__DATA,__swift51_hooks"))) = {
   .version = 0,
   .conformsToSwiftProtocol = swift51override_conformsToSwiftProtocol,
 };
+#pragma clang diagnostic pop
 
 // Allow this library to get force-loaded by autolinking
 __attribute__((weak, visibility("hidden")))

--- a/stdlib/toolchain/Compatibility56/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility56/Overrides.cpp
@@ -39,6 +39,8 @@ struct ConcurrencyOverrideSection {
 
 #undef OVERRIDE
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
 __attribute__((visibility("hidden")))
 ConcurrencyOverrideSection Swift56ConcurrencyOverrides
 __attribute__((used, section("__DATA,__s_async_hook"))) = {
@@ -55,6 +57,7 @@ RuntimeOverrideSection Swift56RuntimeOverrides
 __attribute__((used, section("__DATA,__swift56_hooks"))) = {
   .version = 0,
 };
+#pragma clang diagnostic pop
 
 // Allow this library to get force-loaded by autolinking
 __attribute__((weak, visibility("hidden")))

--- a/test/Interop/Cxx/templates/enable-if-typechecker.swift
+++ b/test/Interop/Cxx/templates/enable-if-typechecker.swift
@@ -4,6 +4,7 @@
 import StdlibUnittest
 import EnableIf
 
+
 let x = HasMethodWithEnableIf()
 x.onlyEnabledForBool("a")
-// CHECK: error: could not substitute parameters for C++ function template 'HasMethodWithEnableIf::onlyEnabledForBool': NSString *
+// CHECK: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'HasMethodWithEnableIf::onlyEnabledForBool' could not be converted: String

--- a/unittests/Threading/LockingHelpers.h
+++ b/unittests/Threading/LockingHelpers.h
@@ -144,6 +144,7 @@ void scopedUnlockUnderScopedLockThreaded(M &mutex) {
 
   ASSERT_EQ(count1, 500);
   ASSERT_EQ(count2, 500);
+  (void)badCount; // FIXME: Is this value meant to be tested?
 }
 
 // Test a critical section


### PR DESCRIPTION
There are a bunch of warnings emitted when building the runtime and some unit tests. Address or suppress them.