### PR TITLE
SIL: change the textual SIL output of a re-borrow phi from `@reborrow @guaranteed` to `@reborrow`

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -703,7 +703,7 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
       *this << "@reborrow ";
     if (i.IsEscaping)
       *this << "@pointer_escape ";
-    if (i.OwnershipKind && *i.OwnershipKind != OwnershipKind::None) {
+    if (!i.IsReborrow && i.OwnershipKind && *i.OwnershipKind != OwnershipKind::None) {
       *this << "@" << i.OwnershipKind.value() << " ";
     }
     return *this << i.Type;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7175,9 +7175,14 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
 
         // If SILOwnership is enabled and we are not assuming that we are
         // parsing unqualified SIL, look for printed value ownership kinds.
-        if (F->hasOwnership() &&
-            parseSILOwnership(OwnershipKind))
-          return true;
+        if (F->hasOwnership()) {
+          if (P.Tok.is(tok::at_sign)) {
+            if (parseSILOwnership(OwnershipKind))
+              return true;
+          } else if (foundReborrow) {
+            OwnershipKind = OwnershipKind::Guaranteed;
+          }
+        }
 
         if (parseSILType(Ty))
           return true;

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -54,7 +54,7 @@ sil [ossa] @foo : $@convention(thin) () -> () {
 }
 
 // CHECK-LABEL: sil [ossa] @reborrowTest : $@convention(thin) (@owned C) -> () {
-// CHECK:       bb3([[ARG:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb3([[ARG:%.*]] : @reborrow $C):
 // CHECK-NEXT:    {{%.*}} = borrowed [[ARG]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'reborrowTest'
 sil [ossa] @reborrowTest : $@convention(thin) (@owned C) -> () {
@@ -69,7 +69,7 @@ bb2:
   %b2 = begin_borrow %0 : $C
   br bb3(%b2 : $C)
 
-bb3(%r : @reborrow @guaranteed $C):
+bb3(%r : @reborrow $C):
   %f = borrowed %r : $C from (%0 : $C)
   end_borrow %f : $C
   destroy_value %0 : $C

--- a/test/SIL/Parser/borrow_argument.sil
+++ b/test/SIL/Parser/borrow_argument.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 import Builtin
 
 // CHECK-LABEL: sil [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-// CHECK: bb1([[PHIBBARG:%.*]] : @reborrow @guaranteed $Builtin.NativeObject):
+// CHECK: bb1([[PHIBBARG:%.*]] : @reborrow $Builtin.NativeObject):
 // CHECK:   [[BF:%.*]] = borrowed [[PHIBBARG]] : $Builtin.NativeObject from (%0 : $Builtin.NativeObject)
 // CHECK: end_borrow [[BF]] : $Builtin.NativeObject
 sil [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {

--- a/test/SIL/Parser/ownership_arguments.sil
+++ b/test/SIL/Parser/ownership_arguments.sil
@@ -6,7 +6,7 @@ import Builtin
 
 // CHECK-LABEL: sil [ossa] @simple : $@convention(thin) (@owned Builtin.NativeObject, Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
 // CHECK: bb0({{%.*}} : @owned $Builtin.NativeObject, {{%.*}} : @unowned $Builtin.NativeObject, {{%.*}} : @guaranteed $Builtin.NativeObject, {{%.*}} : $Builtin.Int32):
-// CHECK: bb1({{%[0-9][0-9]*}} : @owned $Builtin.NativeObject, {{%[0-9][0-9]*}} : @unowned $Builtin.NativeObject, {{%[0-9][0-9]*}} : @reborrow @guaranteed $Builtin.NativeObject, {{%[0-9][0-9]*}} : $Builtin.Int32):
+// CHECK: bb1({{%[0-9][0-9]*}} : @owned $Builtin.NativeObject, {{%[0-9][0-9]*}} : @unowned $Builtin.NativeObject, {{%[0-9][0-9]*}} : @reborrow $Builtin.NativeObject, {{%[0-9][0-9]*}} : $Builtin.Int32):
 
 sil [ossa] @simple : $@convention(thin) (@owned Builtin.NativeObject, Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.Int32) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject, %2 : @guaranteed $Builtin.NativeObject, %3 : $Builtin.Int32):

--- a/test/SIL/Serialization/borrow_argument.sil
+++ b/test/SIL/Serialization/borrow_argument.sil
@@ -9,7 +9,7 @@ sil_stage canonical
 import Builtin
 
 // CHECK-LABEL: sil [serialized] [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-// CHECK: bb1([[PHIBBARG:%.*]] : @reborrow @guaranteed $Builtin.NativeObject):
+// CHECK: bb1([[PHIBBARG:%.*]] : @reborrow $Builtin.NativeObject):
 // CHECK:   [[BF:%.*]] = borrowed [[PHIBBARG]] : $Builtin.NativeObject from (%0 : $Builtin.NativeObject)
 // CHECK:   end_borrow [[BF]] : $Builtin.NativeObject
 sil [serialized] [ossa] @borrow_argument_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {

--- a/test/SIL/Serialization/ownershipflags.sil
+++ b/test/SIL/Serialization/ownershipflags.sil
@@ -45,7 +45,7 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [serialized] [ossa] @test_reborrow : $@convention(thin) (@owned Klass) -> () {
-// CHECK: bb3([[ARG:%.*]] : @reborrow @guaranteed $Klass):
+// CHECK: bb3([[ARG:%.*]] : @reborrow $Klass):
 // CHECK: } // end sil function 'test_reborrow'
 sil [serialized] [ossa] @test_reborrow : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -59,7 +59,7 @@ bb2:
   %b2 = begin_borrow %0 : $Klass
   br bb3(%b2 : $Klass)
 
-bb3(%r : @reborrow @guaranteed $Klass):
+bb3(%r : @reborrow $Klass):
   %rf = borrowed %r : $Klass from (%0 : $Klass)
   end_borrow %rf : $Klass
   destroy_value %0 : $Klass

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -201,7 +201,7 @@ exit:
 // paths, but should only appear in the introducer list once.
 //
 // CHECK-LABEL: introducer_revisit_reborrow: find_borrow_introducers with: %aggregate2
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C
 // CHECK: } // end sil function 'introducer_revisit_reborrow'
 // CHECK: Introducers:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
@@ -209,7 +209,7 @@ exit:
 // CHECK-NEXT: introducer_revisit_reborrow: find_borrow_introducers with: %aggregate2
 
 // CHECK-LABEL: introducer_revisit_reborrow: borrow_introducers with: %aggregate2
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C
 // CHECK: } // end sil function 'introducer_revisit_reborrow'
 // CHECK: Borrow introducers for:  %{{.*}} = struct $PairC (%{{.*}} : $C, %{{.*}} : $C)
 // CHECK-NEXT: %0 = argument of bb0 : $C
@@ -240,7 +240,7 @@ exit:
 // CHECK-LABEL: introducer_multiple_borrow: find_borrow_introducers with: %aggregate2
 // CHECK: begin_borrow %0 : $C  
 // CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C
 // CHECK: } // end sil function 'introducer_multiple_borrow'
 // CHECK: Introducers:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
@@ -251,7 +251,7 @@ exit:
 // CHECK-LABEL: introducer_multiple_borrow: borrow_introducers with: %aggregate2
 // CHECK: begin_borrow %0 : $C  
 // CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C
 // CHECK: } // end sil function 'introducer_multiple_borrow'
 // CHECK: Borrow introducers for: %{{.*}} = struct $PairC (%{{.*}} : $C, %{{.*}} : $C)
 // CHECK-NEXT: %0 = argument of bb0 : $C

--- a/test/SILOptimizer/borrowed_from_updater.sil
+++ b/test/SILOptimizer/borrowed_from_updater.sil
@@ -31,7 +31,7 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 // The introducer of an introducer is always itself.
 
 // CHECK-LABEL: sil [ossa] @introducer_identity :
-// CHECK:       bb1([[A:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B:%.*]] = borrowed [[A]] : $C from (%0 : $C)
 // CHECK-NEXT:    end_borrow [[B]]
 // CHECK:       } // end sil function 'introducer_identity'
@@ -89,7 +89,7 @@ bb2:
 // paths, but should only appear in the introducer list once.
 //
 // CHECK-LABEL: sil [ossa] @introducer_revisit_reborrow :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C, [[A2:%.*]] : @guaranteed $PairC):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C, [[A2:%.*]] : @guaranteed $PairC):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $PairC from ([[A1]] : $C, %0 : $C)
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'introducer_revisit_reborrow'
@@ -116,7 +116,7 @@ bb2:
 // CHECK-LABEL: sil [ossa] @introducer_multiple_borrow :
 // CHECK:         [[BB1:%.*]] = begin_borrow %0
 // CHECK:         [[BB2:%.*]] = begin_borrow %0
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C, [[A2:%.*]] : @guaranteed $PairC):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C, [[A2:%.*]] : @guaranteed $PairC):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $PairC from ([[BB2]] : $C, %0 : $C)
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'introducer_multiple_borrow'
@@ -140,7 +140,7 @@ bb2:
 }
 
 // CHECK-LABEL: sil [ossa] @testSelfIntroducer :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C, [[A2:%.*]] : @guaranteed $D):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C, [[A2:%.*]] : @guaranteed $D):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $D from ([[A1]] : $C)
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'testSelfIntroducer'
@@ -169,9 +169,9 @@ bb3:
 // one of the outer adjacent phis as and enclosing value for %inner.
 //
 // CHECK-LABEL: sil [ossa] @testEnclosingRevisitReborrow :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%0 : $C)
-// CHECK:       bb4([[A2:%.*]] : @owned $C, [[A3:%.*]] : @owned $C, [[A4:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb4([[A2:%.*]] : @owned $C, [[A3:%.*]] : @owned $C, [[A4:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A4]] : $C from ([[A3]] : $C, [[A2]] : $C)
 // CHECK:       } // end sil function 'testEnclosingRevisitReborrow'
 sil [ossa] @testEnclosingRevisitReborrow : $@convention(thin) (@owned C, @owned C) -> () {
@@ -197,7 +197,7 @@ bb4(%outer0 : @owned $C, %outer1 : @owned $C, %inner : @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @testLoadBorrow :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from ()
 // CHECK:       } // end sil function 'testLoadBorrow'
 sil [ossa] @testLoadBorrow : $@convention(thin) (@in_guaranteed C) -> () {
@@ -212,9 +212,9 @@ bb1(%3 : @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @testTwoLevels :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%0 : $C)
-// CHECK:       bb2([[A2:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb2([[A2:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'testTwoLevels'
 sil [ossa] @testTwoLevels : $@convention(thin) (@owned C) -> () {
@@ -222,10 +222,10 @@ bb0(%0 : @owned $C):
   %2 = begin_borrow %0 : $C
   br bb1(%2 : $C)
 
-bb1(%3 : @reborrow @guaranteed $C):
+bb1(%3 : @reborrow $C):
   br bb2(%3 : $C)
 
-bb2(%6 : @reborrow @guaranteed $C):
+bb2(%6 : @reborrow $C):
   end_borrow %6 : $C
   destroy_value %0 : $C
   %99 = tuple()
@@ -233,9 +233,9 @@ bb2(%6 : @reborrow @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @testTwoLevelsWithPair :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $C from (%1 : $C)
-// CHECK:       bb2([[A2:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb2([[A2:%.*]] : @reborrow $C):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $C from (%1 : $C)
 // CHECK:       } // end sil function 'testTwoLevelsWithPair'
 sil [ossa] @testTwoLevelsWithPair : $@convention(thin) (@owned PairC) -> () {
@@ -244,10 +244,10 @@ bb0(%0 : @owned $PairC):
   %3 = begin_borrow %1 : $C
   br bb1(%3 : $C)
 
-bb1(%4 : @reborrow @guaranteed $C):
+bb1(%4 : @reborrow $C):
   br bb2(%4 : $C)
 
-bb2(%6 : @reborrow @guaranteed $C):
+bb2(%6 : @reborrow $C):
   end_borrow %6 : $C
   destroy_value %1 : $C
   destroy_value %2 : $C
@@ -256,11 +256,11 @@ bb2(%6 : @reborrow @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @testTwoLevelReborrow :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $PairC, [[A2:%.*]] : @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $PairC, [[A2:%.*]] : @guaranteed $C):
 // CHECK-NEXT:    [[B2:%.*]] = borrowed [[A2]] : $C from ([[A1]] : $PairC)
 // CHECK-NEXT:    [[B1:%.*]] = borrowed [[A1]] : $PairC from (%0 : $PairC)
 // CHECK-NEXT:    br bb2([[B1]] : $PairC, [[B2]] : $C)
-// CHECK:       bb2([[A3:%.*]] : @reborrow @guaranteed $PairC, [[A4:%.*]] : @guaranteed $C):
+// CHECK:       bb2([[A3:%.*]] : @reborrow $PairC, [[A4:%.*]] : @guaranteed $C):
 // CHECK-NEXT:    [[B4:%.*]] = borrowed [[A4]] : $C from ([[A3]] : $PairC)
 // CHECK-NEXT:    [[B3:%.*]] = borrowed [[A3]] : $PairC from (%0 : $PairC)
 // CHECK-NEXT:    end_borrow [[B3]]
@@ -271,10 +271,10 @@ bb0(%0 : @owned $PairC):
   %3 = struct_extract %2 : $PairC, #PairC.first
   br bb1(%2 : $PairC, %3 : $C)
 
-bb1(%5 : @reborrow @guaranteed $PairC, %6 : @guaranteed $C):
+bb1(%5 : @reborrow $PairC, %6 : @guaranteed $C):
   br bb2(%5 : $PairC, %6 : $C)
 
-bb2(%8 : @reborrow @guaranteed $PairC, %9 : @guaranteed $C):
+bb2(%8 : @reborrow $PairC, %9 : @guaranteed $C):
   end_borrow %8 : $PairC
   destroy_value %0 : $PairC
   %99 = tuple()
@@ -282,9 +282,9 @@ bb2(%8 : @reborrow @guaranteed $PairC, %9 : @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @unreachable_block :
-// CHECK:       bb1([[A1:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A1:%.*]] : @reborrow $C):
 // CHECK-NEXT:    = borrowed [[A1]] : $C from ()
-// CHECK:       bb2([[A2:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb2([[A2:%.*]] : @reborrow $C):
 // CHECK-NEXT:    = borrowed [[A2]] : $C from (%0 : $C)
 // CHECK:       } // end sil function 'unreachable_block'
 sil [ossa] @unreachable_block : $@convention(thin) (@owned C) -> @owned C {

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -566,7 +566,7 @@ bb0(%0 : @guaranteed $HasObject):
 // CHECK:   br bb3([[CP]] : $C, [[BORROW]] : $C)
 // CHECK: bb2:
 // CHECK:   br bb3([[CP]] : $C, [[BORROW]] : $C)
-// CHECK: bb3([[OWNEDPHI:%.*]] : @owned $C, [[BORROWPHI:%.*]] : @reborrow @guaranteed $C):
+// CHECK: bb3([[OWNEDPHI:%.*]] : @owned $C, [[BORROWPHI:%.*]] : @reborrow $C):
 // CHECK:   [[R:%.*]] = borrowed [[BORROWPHI]] : $C from (%0 : $C)
 // CHECK:   end_borrow [[R]]
 // CHECK:   destroy_value [[OWNEDPHI]] : $C
@@ -606,7 +606,7 @@ bb3(%phi : @owned $C, %borrowphi : @guaranteed $C):
 //
 // CHECK-LABEL: sil [ossa] @testLiveCopyAfterReborrow : $@convention(thin) () -> () {
 // CHECK: [[ALLOC:%.*]] = alloc_ref $C
-// CHECK: bb3([[BORROWPHI:%.*]] : @reborrow @guaranteed $C):
+// CHECK: bb3([[BORROWPHI:%.*]] : @reborrow $C):
 // CHECK: [[R:%.*]] = borrowed [[BORROWPHI]] : $C from (%0 : $C)
 // CHECK: [[COPY:%.*]] = copy_value [[R]]
 // CHECK: end_borrow [[R]] : $C
@@ -655,7 +655,7 @@ bb3(%borrowphi : @guaranteed $C):
 //
 // CHECK-LABEL: sil [ossa] @testDeadCopyAfterReborrow : $@convention(thin) () -> () {
 // CHECK: [[ALLOC:%.*]] = alloc_ref $C
-// CHECK: bb3([[BORROWPHI:%.*]] : @reborrow @guaranteed $C):
+// CHECK: bb3([[BORROWPHI:%.*]] : @reborrow $C):
 // CHECK: [[R:%.*]] = borrowed [[BORROWPHI]] : $C from (%0 : $C)
 // CHECK-NOT: copy_value
 // CHECK: end_borrow [[R]] : $C
@@ -696,7 +696,7 @@ bb3(%borrowphi : @guaranteed $C):
 //
 // CHECK-LABEL: sil [ossa] @testNestedReborrowOutsideUse : $@convention(thin) () -> () {
 // CHECK:        [[ALLOC:%.*]] = alloc_ref $C
-// CHECK:      bb3([[BORROWPHI:%.*]] : @reborrow @guaranteed $C):
+// CHECK:      bb3([[BORROWPHI:%.*]] : @reborrow $C):
 // CHECK:        [[R:%.*]] = borrowed [[BORROWPHI]] : $C from (%0 : $C)
 // CHECK-NOT:    copy
 // CHECK:        end_borrow [[R]]
@@ -743,7 +743,7 @@ bb3(%borrowphi : @guaranteed $C):
 // CHECK: bb2:
 // CHECK:   begin_borrow %0 : $C
 // CHECK:   br bb3(%{{.*}} : $C, %0 : $C)
-// CHECK: bb3(%{{.*}} : @reborrow @guaranteed $C, [[COPYPHI:%.*]] : @owned $C):
+// CHECK: bb3(%{{.*}} : @reborrow $C, [[COPYPHI:%.*]] : @owned $C):
 // CHECK:   end_borrow
 // CHECK:   destroy_value [[COPYPHI]] : $C
 // CHECK-LABEL: } // end sil function 'testOwnedReborrow'
@@ -1218,7 +1218,7 @@ bb0(%0 : @guaranteed $HasObject):
   %3 = begin_borrow %2 : $C
   br bb1(%3 : $C)
 
-bb1(%5 : @reborrow @guaranteed $C):
+bb1(%5 : @reborrow $C):
   %6 = borrowed %5 : $C from (%2 : $C)
   end_borrow %6 : $C
   destroy_value %2 : $C

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -13,7 +13,7 @@ sil [ossa] @getX : $@convention(thin) () -> (@owned X)
 sil [ossa] @holdX : $@convention(thin) (@guaranteed X) -> ()
 
 // CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_endborrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $X from ([[VALUE]] : $X)
 // CHECK:         end_borrow [[BF]]
 // CHECK:         destroy_value [[VALUE]]
@@ -36,7 +36,7 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_endborrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[UNRELATED:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[UNRELATED:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         [[BF:%.*]] = borrowed [[UNRELATED]] : $X from (%0 : $X)
 // CHECK:         end_borrow [[BF]]
@@ -61,8 +61,8 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_reborrow_endborrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @reborrow @guaranteed $X, {{%[^,]+}} : @owned $X):
-// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @reborrow $X, {{%[^,]+}} : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $X from ([[VALUE]] : $X)
 // CHECK:         end_borrow [[BF]]
 // CHECK:         destroy_value [[VALUE]]
@@ -88,8 +88,8 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_reborrow_reborrow_endborrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @reborrow @guaranteed $X, {{%[^,]+}} : @owned $X):
-// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @reborrow $X, {{%[^,]+}} : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
 // CHECK:         destroy_value [[VALUE]]
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $X from (%0 : $X)
 // CHECK:         end_borrow [[BF]]
@@ -117,7 +117,7 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @nohoist_destroy_over_forward_reborrow_endborrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $X from ([[VALUE]] : $X)
 // CHECK:         end_borrow [[BF]]
 // CHECK:         destroy_value [[VALUE]]
@@ -143,7 +143,7 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_loop : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow @guaranteed $FakeOptional<X>, [[VALUE:%[^,]+]] : @owned $FakeOptional<X>):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $FakeOptional<X>, [[VALUE:%[^,]+]] : @owned $FakeOptional<X>):
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $FakeOptional<X> from ([[VALUE]] : $FakeOptional<X>)
 // CHECK:         cond_br undef, [[LOOP:bb[0-9]+]], [[BODY:bb[0-9]+]]
 // CHECK:       [[LOOP]]:
@@ -183,7 +183,7 @@ exit:
 // a non-lifetime ending use and extend liveness beyond the instruction where
 // the reborrow occurs.
 // CHECK-LABEL: sil [ossa] @reborrow_adjacent_to_consume_doesnt_extend_lifetime : {{.*}} {
-// CHECK:       bb1([[REBORROW:%[^,]+]] : @reborrow @guaranteed $X, [[VALUE:%[^,]+]] :
+// CHECK:       bb1([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] :
 // CHECK:         [[R:%.*]] = borrowed [[REBORROW]] : $X from ([[VALUE]] : $X)
 // CHECK:       {{bb[0-9]+}}:
 // CHECK:         end_borrow [[R]]
@@ -307,10 +307,10 @@ bb1(%4 : @guaranteed $X, %5 : @owned $X):
 // end_borrow/destroy maintain their position.
 //
 // CHECK-LABEL: sil [ossa] @reborrow_adjacent_to_consume : $@convention(thin) () -> () {
-// CHECK: bb1(%{{.*}} : @reborrow @guaranteed $X, %{{.*}} : @owned $X):
+// CHECK: bb1(%{{.*}} : @reborrow $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   borrowed
 // CHECK-NEXT:   br bb2
-// CHECK: bb2(%{{.*}} : @reborrow @guaranteed $X, %{{.*}} : @owned $X):
+// CHECK: bb2(%{{.*}} : @reborrow $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   borrowed
 // CHECK-NEXT:   end_borrow
 // CHECK-NEXT:   destroy_value
@@ -341,10 +341,10 @@ bb2(%6 : @guaranteed $X, %7 : @owned $X):
 // Lifetime analysis is successful; the copy/destroy in bb2 are removed.
 //
 // CHECK-LABEL: sil [ossa] @reborrow_no_adjacent_consume : $@convention(thin) () -> () {
-// CHECK: bb1(%{{.*}} : @reborrow @guaranteed $X, %{{.*}} : @owned $X):
+// CHECK: bb1(%{{.*}} : @reborrow $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   borrowed
 // CHECK-NEXT:   br bb2
-// CHECK: bb2(%{{.*}} : @reborrow @guaranteed $X):
+// CHECK: bb2(%{{.*}} : @reborrow $X):
 // CHECK-NEXT:   borrowed
 // CHECK-NEXT:   end_borrow
 // CHECK-NEXT:   destroy_value

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -380,7 +380,7 @@ bb0(%0 : @owned $TestStruct):
 }
 
 // CHECK-LABEL: sil [ossa] @dce_borrowlifetime1 :
-// CHECK: bb1([[ARG1:%.*]] : @owned $NonTrivialStruct, [[ARG2:%.*]] : @reborrow @guaranteed $NonTrivialStruct):
+// CHECK: bb1([[ARG1:%.*]] : @owned $NonTrivialStruct, [[ARG2:%.*]] : @reborrow $NonTrivialStruct):
 // CHECK-LABEL: } // end sil function 'dce_borrowlifetime1'
 sil [ossa] @dce_borrowlifetime1 : $@convention(thin) (@guaranteed NonTrivialStruct) -> @owned NonTrivialStruct {
 bb0(%0 : @guaranteed $NonTrivialStruct):
@@ -594,7 +594,7 @@ bb4:
 }
 
 // CHECK-LABEL: sil [ossa] @dce_reborrow_with_different_basevalues :
-// CHECK: bb3([[ARG1:%.*]] : @reborrow @guaranteed $NonTrivialStruct, [[ARG2:%.*]] : @owned $NonTrivialStruct, [[ARG3:%.*]] : @owned $NonTrivialStruct):
+// CHECK: bb3([[ARG1:%.*]] : @reborrow $NonTrivialStruct, [[ARG2:%.*]] : @owned $NonTrivialStruct, [[ARG3:%.*]] : @owned $NonTrivialStruct):
 // CHECK-LABEL: } // end sil function 'dce_reborrow_with_different_basevalues'
 sil [ossa] @dce_reborrow_with_different_basevalues : $@convention(thin) (@guaranteed NonTrivialStruct, @guaranteed NonTrivialStruct) -> @owned NonTrivialStruct {
 bb0(%0 : @guaranteed $NonTrivialStruct, %1 : @guaranteed $NonTrivialStruct):
@@ -804,7 +804,7 @@ exit:
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Klass):
 // CHECK:         [[OUTER_LIFETIME_1:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]([[OUTER_LIFETIME_1]] : $Klass)
-// CHECK:       [[EXIT]]([[OUTER_LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $Klass):
+// CHECK:       [[EXIT]]([[OUTER_LIFETIME_2:%[^,]+]] : @reborrow $Klass):
 // CHECK:         [[R:%.*]] = borrowed [[OUTER_LIFETIME_2]] : $Klass from (%0 : $Klass)
 // CHECK:         end_borrow [[R]]
 // CHECK:         destroy_value [[INSTANCE]]
@@ -828,10 +828,10 @@ exit(%outer_lifetime_2 : @guaranteed $Klass, %inner_lifetime_2 : @guaranteed $Kl
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Klass):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         br [[WORK:bb[0-9]+]]([[LIFETIME]] : $Klass)
-// CHECK:       [[WORK]]([[LIFETIME_1:%[^,]+]] : @reborrow @guaranteed $Klass):
+// CHECK:       [[WORK]]([[LIFETIME_1:%[^,]+]] : @reborrow $Klass):
 // CHECK:         [[R:%.*]] = borrowed [[LIFETIME_1]] : $Klass from (%0 : $Klass)
 // CHECK:         br [[EXIT:bb[0-9]+]]([[R]] : $Klass)
-// CHECK:       [[EXIT]]([[LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $Klass):
+// CHECK:       [[EXIT]]([[LIFETIME_2:%[^,]+]] : @reborrow $Klass):
 // CHECK:         [[R2:%.*]] = borrowed [[LIFETIME_2]] : $Klass from (%0 : $Klass)
 // CHECK:         end_borrow [[R2]]
 // CHECK:         destroy_value [[INSTANCE]]
@@ -912,7 +912,7 @@ exit(%inner_lifetime_2 : @guaranteed $Klass):
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : $*Klass):
 // CHECK:         [[LIFETIME:%[^,]+]] = load_borrow [[INSTANCE]]
 // CHECK:         br [[BASIC_BLOCK1:bb[0-9]+]]([[LIFETIME]] : $Klass)
-// CHECK:       [[BASIC_BLOCK1]]([[LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $Klass):
+// CHECK:       [[BASIC_BLOCK1]]([[LIFETIME_2:%[^,]+]] : @reborrow $Klass):
 // CHECK:         [[R:%.*]] = borrowed [[LIFETIME_2]] : $Klass from ()
 // CHECK:         end_borrow [[R]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
@@ -934,7 +934,7 @@ bb1(%4 : @guaranteed $Klass, %5 : @guaranteed $Klass):
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*Klass):
 // CHECK:         [[LIFETIME:%[^,]+]] = load_borrow [[ADDR]] : $*Klass
 // CHECK:         br [[EXIT:bb[0-9]+]]([[LIFETIME]] : $Klass)
-// CHECK:       [[EXIT]]([[LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $Klass):
+// CHECK:       [[EXIT]]([[LIFETIME_2:%[^,]+]] : @reborrow $Klass):
 // CHECK:         [[R:%.*]] = borrowed [[LIFETIME_2]] : $Klass from ()
 // CHECK:         end_borrow [[R]] : $Klass
 // CHECK:         [[EXIT:%[^,]+]] = tuple ()

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -187,7 +187,7 @@ bb3(%reborrow3 : @guaranteed $C):
 
 // CHECK-LABEL: enclosing_def_reborrow: find_enclosing_defs with: %reborrow_inner3
 // CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C, %{{.*}} : @reborrow @guaranteed $C):
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C, %{{.*}} : @reborrow $C):
 // CHECK: } // end sil function 'enclosing_def_reborrow'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
@@ -195,7 +195,7 @@ bb3(%reborrow3 : @guaranteed $C):
 
 // CHECK-LABEL: enclosing_def_reborrow: enclosing_values with: %reborrow_inner3
 // CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
-// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C, %{{.*}} : @reborrow @guaranteed $C):
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow $C, %{{.*}} : @reborrow $C):
 // CHECK: } // end sil function 'enclosing_def_reborrow'
 // CHECK: Enclosing values for: %{{.*}} = argument of bb2 : $C
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C

--- a/test/SILOptimizer/let-property-lowering.sil
+++ b/test/SILOptimizer/let-property-lowering.sil
@@ -290,7 +290,7 @@ bb2:
 }
 
 // CHECK-LABEL: sil [ossa] @test_reborrow :
-// CHECK:       bb1([[A:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A:%.*]] : @reborrow $C):
 // CHECK:         [[R:%.*]] = borrowed [[A]] : $C from (%2 : $C)
 // CHECK:         end_borrow [[R]]
 // CHECK-NEXT:    end_init_let_ref %2
@@ -302,7 +302,7 @@ bb0(%0 : @owned $C, %1 : $Int):
   %4 = ref_element_addr %3 : $C, #C.a
   store %1 to [trivial] %4 : $*Int
   br bb1(%3 : $C)
-bb1(%3a : @reborrow @guaranteed $C):
+bb1(%3a : @reborrow $C):
   end_borrow %3a : $C
   %7 = begin_borrow %2 : $C
   %8 = ref_element_addr %7 : $C, #C.a

--- a/test/SILOptimizer/lexical_destroy_hoisting.sil
+++ b/test/SILOptimizer/lexical_destroy_hoisting.sil
@@ -186,7 +186,7 @@ exit:
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         br [[WORK:bb[0-9]+]]([[LIFETIME]] : $C)
-// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @reborrow $C):
 // CHECK:         [[R:%.*]] = borrowed [[LIFETIME_2]] : $C from (%0 : $C)
 // CHECK:         end_borrow [[R]]
 // CHECK:         tuple ()

--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -174,7 +174,7 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @guaranteed_phi_argument : $@convention(thin) (@owned Klass) -> () {
-// CHECK:         {{bb[0-9]+}}({{%[^,]+}} : @reborrow @guaranteed $Klass):
+// CHECK:         {{bb[0-9]+}}({{%[^,]+}} : @reborrow $Klass):
 // CHECK-LABEL: } // end sil function 'guaranteed_phi_argument'
 sil [ossa] @guaranteed_phi_argument : $@convention(thin) (@owned Klass) -> () {
 entry(%instance : @owned $Klass):
@@ -203,7 +203,7 @@ exit:
 // A guaranteed value whose ownership has been forwarded must not be reborrowed. 
 //
 // CHECK-LABEL: sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
-// CHECK:   {{bb[0-9]+}}({{%[^,]+}} : @reborrow @guaranteed $BoxStruct, {{%[^,]+}} : @guaranteed $Klass):
+// CHECK:   {{bb[0-9]+}}({{%[^,]+}} : @reborrow $BoxStruct, {{%[^,]+}} : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'forwarded_borrow_cant_be_reborrowed'
 sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
 bb0(%0 : @owned $BoxStruct):

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -891,7 +891,7 @@ bb2:
 bb3:
   br bb4(%none_borrow : $Optional<@callee_guaranteed () -> ()>, %none : $Optional<@callee_guaranteed () -> ()>)
 
-bb4(%reborrow : @reborrow @guaranteed $Optional<@callee_guaranteed () -> ()>, %maybe : @owned $Optional<@callee_guaranteed () -> ()>):
+bb4(%reborrow : @reborrow $Optional<@callee_guaranteed () -> ()>, %maybe : @owned $Optional<@callee_guaranteed () -> ()>):
   %borrow = borrowed %reborrow : $Optional<@callee_guaranteed () -> ()> from (%maybe : $Optional<@callee_guaranteed () -> ()>)
   destroy_addr %addr : $*NonTrivialStructPair
   dealloc_stack %stack : $*NonTrivialStructPair

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -261,7 +261,7 @@ bb0(%0 : @guaranteed $M):
 // CHECK-LABEL: sil [ossa] @rdar130427564 : {{.*}} {
 // Verify that no instructions were inserted after backedge2's terminator.  (In
 // fact, if they were, the test would crash.)
-// CHECK:       bb2([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK:       bb2([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow $C):
 // CHECK-NEXT:    [[B0F:%[^,]+]] = borrowed [[B0]] : $C from ([[C0]] : $C)
 // CHECK-NEXT:    end_borrow [[B0F]]
 // CHECK-NEXT:    destroy_value [[C0]]
@@ -276,7 +276,7 @@ fn:
   %c = apply %getC() : $@convention(thin) () -> (@owned C)
   %b = begin_borrow %c : $C
   br header(%c : $C, %b : $C)
-header(%c0 : @owned $C, %b0 : @reborrow @guaranteed $C):
+header(%c0 : @owned $C, %b0 : @reborrow $C):
   %b0f = borrowed %b0 : $C from (%c0 : $C)
   end_borrow %b0f : $C
   destroy_value %c0 : $C
@@ -289,7 +289,7 @@ backedge:
   %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
   %b1 = begin_borrow %c1 : $C
   br backedge2(%c1 : $C, %b1 : $C)
-backedge2(%c2 : @owned $C, %b2 : @reborrow @guaranteed $C):
+backedge2(%c2 : @owned $C, %b2 : @reborrow $C):
   %b2f = borrowed %b2 : $C from (%c2 : $C)
   br header(%c2 : $C, %b2f : $C)
 ecit:

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -730,7 +730,7 @@ bb0(%existential : @owned $any P):
 // Verify that no instructions were inserted after backedge2's terminator.  (In
 // fact, if they were, the test would crash.)
 // CHECK-LABEL: sil [ossa] @root_of_reborrow : {{.*}} {
-// CHECK:       bb1([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow $C):
 // CHECK-NEXT:    [[B0F:%[^,]+]] = borrowed [[B0]] : $C from ([[C0]] : $C)
 // CHECK-NEXT:    end_borrow [[B0F]]
 // CHECK-NEXT:    destroy_value [[C0]]
@@ -743,7 +743,7 @@ entry:
   %c = apply %getC() : $@convention(thin) () -> (@owned C)
   %b = begin_borrow %c : $C
   br header(%c : $C, %b : $C)
-header(%c0 : @owned $C, %b0 : @reborrow @guaranteed $C):
+header(%c0 : @owned $C, %b0 : @reborrow $C):
   %b0f = borrowed %b0 : $C from (%c0 : $C)
   end_borrow %b0f : $C
   destroy_value %c0 : $C
@@ -756,7 +756,7 @@ backedge:
   %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
   %b1 = begin_borrow %c1 : $C
   br backedge2(%c1 : $C, %b1 : $C)
-backedge2(%c2 : @owned $C, %b2 : @reborrow @guaranteed $C):
+backedge2(%c2 : @owned $C, %b2 : @reborrow $C):
   %b2f = borrowed %b2 : $C from (%c2 : $C)
   specify_test "ossa_lifetime_completion %c2 availability"
   br header(%c2 : $C, %b2f : $C)
@@ -767,7 +767,7 @@ exit:
 
 // CHECK-LABEL: begin running test {{.*}} on test_borrowed_from: ossa_lifetime_completion
 // CHECK-LABEL: sil [ossa] @test_borrowed_from : {{.*}} {
-// CHECK:       bb1([[A:%.*]] : @reborrow @guaranteed $C):
+// CHECK:       bb1([[A:%.*]] : @reborrow $C):
 // CHECK:         [[BF:%.*]] = borrowed [[A]] : $C from (%0 : $C)
 // CHECK:       bb2:
 // CHECK-NEXT:    end_borrow [[BF]] : $C
@@ -779,7 +779,7 @@ bb0(%0 : @owned $C):
   %1 = begin_borrow %0 : $C
   br bb1(%1 : $C)
 
-bb1(%3 : @reborrow @guaranteed $C):
+bb1(%3 : @reborrow $C):
   %4 = borrowed %3 : $C from (%0 : $C)
   specify_test "ossa_lifetime_completion %3 availability"
   cond_br undef, bb2, bb3

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -305,7 +305,7 @@ exit:
 // CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
 // CHECK:   [[BORROW2:%[^,]+]] = begin_borrow %1
 // CHECK:   br [[EXIT:bb[0-9]+]]([[C]] : $C, [[BORROW1]] : $C, [[BORROW2]] :
-// CHECK: [[EXIT]]({{%[^,]+}} : @owned $C, [[GUARANTEED1:%[^,]+]] : @reborrow @guaranteed $C, [[GUARANTEED2:%[^,]+]] :
+// CHECK: [[EXIT]]({{%[^,]+}} : @owned $C, [[GUARANTEED1:%[^,]+]] : @reborrow $C, [[GUARANTEED2:%[^,]+]] :
 // CHECK: } // end sil function 'pay_the_phi'
 //
 // CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
@@ -331,7 +331,7 @@ exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaran
 }
 
 // CHECK-LABEL: pay_the_phi_forward: visit_inner_adjacent_phis with: %reborrow
-// CHECK: bb1(%{{.*}} : @reborrow @guaranteed $C, [[INNER:%.*]] : @guaranteed $D):    // Preds: bb0
+// CHECK: bb1(%{{.*}} : @reborrow $C, [[INNER:%.*]] : @guaranteed $D):    // Preds: bb0
 // CHECK: } // end sil function 'pay_the_phi_forward'
 // CHECK: [[INNER]] = argument of bb1 : $D
 // CHECK: pay_the_phi_forward: visit_inner_adjacent_phis with: %reborrow
@@ -1195,7 +1195,7 @@ bb2:
   %d2 = unchecked_ref_cast %0 : $C to $D
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
-bb3(%outer3 : @owned $C, %inner3 : @reborrow @guaranteed $C, %phi3 : @guaranteed $D):
+bb3(%outer3 : @owned $C, %inner3 : @reborrow $C, %phi3 : @guaranteed $D):
   specify_test "interior-liveness %inner3"
   specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
@@ -1245,7 +1245,7 @@ bb2:
   %d2 = unchecked_ref_cast %borrow2 : $C to $D
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
-bb3(%outer3 : @owned $C, %inner3 : @reborrow @guaranteed $C, %phi3 : @guaranteed $D):
+bb3(%outer3 : @owned $C, %inner3 : @reborrow $C, %phi3 : @guaranteed $D):
   specify_test "interior-liveness %inner3"
   specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1356,7 +1356,7 @@ bb0(%0 : @owned $SomeClass):
   %3 = load_borrow %1 : $*SomeClass
   br bb1(%3 : $SomeClass)
 
-bb1(%5 : @reborrow @guaranteed $SomeClass):
+bb1(%5 : @reborrow $SomeClass):
   end_borrow %5 : $SomeClass
   destroy_addr %1 : $*SomeClass
   dealloc_stack %1 : $*SomeClass

--- a/test/SILOptimizer/redundant_phi_elimination_ossa.sil
+++ b/test/SILOptimizer/redundant_phi_elimination_ossa.sil
@@ -188,7 +188,7 @@ bb3(%1 : @guaranteed $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>
 }
 
 // CHECK-LABEL: sil [ossa] @test_redundantguaranteedphiarg2 :
-// CHECK: bb3([[ARG1:%.*]] : @owned $FakeOptional<Klass>, [[ARG2:%.*]] : @reborrow @guaranteed $FakeOptional<Klass>):
+// CHECK: bb3([[ARG1:%.*]] : @owned $FakeOptional<Klass>, [[ARG2:%.*]] : @reborrow $FakeOptional<Klass>):
 // CHECK-LABEL: } // end sil function 'test_redundantguaranteedphiarg2'
 sil [ossa] @test_redundantguaranteedphiarg2 : $@convention(thin) () -> () {
 bb0:
@@ -210,7 +210,7 @@ bb3(%1 : @owned $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>):
 }
 
 // CHECK-LABEL: sil [ossa] @test_redundantguaranteedphiarg3 :
-// CHECK: bb3([[ARG3:%.*]] : @reborrow @guaranteed $FakeOptional<Klass>, [[ARG2:%.*]] : @reborrow @guaranteed $FakeOptional<Klass>):
+// CHECK: bb3([[ARG3:%.*]] : @reborrow $FakeOptional<Klass>, [[ARG2:%.*]] : @reborrow $FakeOptional<Klass>):
 // CHECK-LABEL: } // end sil function 'test_redundantguaranteedphiarg3'
 sil [ossa] @test_redundantguaranteedphiarg3 : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
+++ b/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
@@ -30,7 +30,7 @@ bb3(%copy : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed2 :
-// CHECK: bb3([[ARG1:%.*]] : @owned $Klass, [[ARG2:%.*]] : @reborrow @guaranteed $Klass)
+// CHECK: bb3([[ARG1:%.*]] : @owned $Klass, [[ARG2:%.*]] : @reborrow $Klass)
 // CHECK-LABEL: } // end sil function 'test_owned_to_guaranteed2'
 sil [ossa] @test_owned_to_guaranteed2 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
@@ -129,7 +129,7 @@ bb2(%4 : @owned $Klass):
   %5 = begin_borrow %4 : $Klass
   br bb3(%5 : $Klass)
 
-bb3(%7 : @reborrow @guaranteed $Klass):
+bb3(%7 : @reborrow $Klass):
   %8 = borrowed %7 : $Klass from (%4 : $Klass)
   end_borrow %8 : $Klass
   destroy_value %4 : $Klass

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -359,7 +359,7 @@ exit:
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         br [[WORK:bb[0-9]+]]([[LIFETIME]] : $C)
-// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @reborrow $C):
 // CHECK:         [[BF:%.*]] = borrowed [[LIFETIME_2]]
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:

--- a/test/SILOptimizer/sil_combine_misc_opts.sil
+++ b/test/SILOptimizer/sil_combine_misc_opts.sil
@@ -111,7 +111,7 @@ bb0(%0 : @guaranteed $S):
   %3 = begin_borrow %2 : $Klass
   br bb1(%3 : $Klass)
 
-bb1(%5 : @reborrow @guaranteed $Klass):
+bb1(%5 : @reborrow $Klass):
   %6 = borrowed %5 : $Klass from (%2 : $Klass)
   end_borrow %6 : $Klass
   destroy_value %2 : $Klass

--- a/test/Serialization/ossa_sil.sil
+++ b/test/Serialization/ossa_sil.sil
@@ -24,7 +24,7 @@ bb0(%0 : @guaranteed $AnyObject):
 // CHECK-NEXT:    {{%.*}} = begin_borrow %0 : $X
 // CHECK:       bb2:
 // CHECK-NEXT:    {{%.*}} = begin_borrow %0 : $X
-// CHECK:       bb3([[ARG:%.*]] : @reborrow @guaranteed $X):
+// CHECK:       bb3([[ARG:%.*]] : @reborrow $X):
 // CHECK-NEXT:    {{%.*}} = borrowed [[ARG]] : $X from (%0 : $X)
 // CHECK:       } // end sil function 'reborrowTest'
 sil [serialized] [ossa] @reborrowTest : $@convention(thin) (@owned X) -> () {
@@ -39,7 +39,7 @@ bb2:
   %b2 = begin_borrow %0 : $X
   br bb3(%b2 : $X)
 
-bb3(%r : @reborrow @guaranteed $X):
+bb3(%r : @reborrow $X):
   %f = borrowed %r : $X from (%0 : $X)
   end_borrow %f : $X
   destroy_value %0 : $X


### PR DESCRIPTION
It's redundant because only guaranteed phis can be reborrows.

Also keep supporting parsing the old `@reborrow @guaranteed` syntax.
