### PR TITLE
DeadCodeElimination: don't remove end_lifetime instructions with address operands

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -317,6 +317,11 @@ void DCE::markLive() {
         break;
       }
       case SILInstructionKind::EndLifetimeInst: {
+        if (I.getOperand(0)->getType().isAddress()) {
+          // DCE cannot reason about values in memory.
+          markInstructionLive(&I);
+          break;
+        }
         // The instruction is live only if it's operand value is also live
         addReverseDependency(I.getOperand(0), &I);
         break;

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -22,7 +22,12 @@ struct CAndBit {
 }
 
 struct MO: ~Copyable {
-    deinit
+  var x: Int
+  deinit
+}
+
+struct Outer : ~Copyable {
+  var x: MO
 }
 
 sil @dummy : $@convention(thin) () -> ()
@@ -487,3 +492,18 @@ sil [ossa] @dont_delete_move_value_lexical : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_remove_addr_end_lifetime :
+// CHECK:         end_lifetime
+// CHECK-LABEL: } // end sil function 'dont_remove_addr_end_lifetime'
+sil [ossa] @dont_remove_addr_end_lifetime : $@convention(thin) (@owned Outer) -> () {
+bb0(%0 : @owned $Outer):
+  %1 = alloc_stack $Outer
+  store %0 to [init] %1 : $*Outer 
+  %3 = struct_element_addr %1 : $*Outer, #Outer.x
+  end_lifetime %3 : $*MO
+  dealloc_stack %1 : $*Outer
+  %6 = tuple ()
+  return %6 : $()
+}
+


### PR DESCRIPTION
DCE cannot reason about values in memory.

Fixes a memory lifetime verification error
rdar://139779406
