### PR TITLE
[Distributed] Protocol mangling and primary associated type fixes

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -119,6 +119,7 @@ PROTOCOL(Differentiable)
 
 // Distributed Actors
 PROTOCOL(DistributedActor)
+PROTOCOL_(DistributedActorStub)
 PROTOCOL(DistributedActorSystem)
 PROTOCOL(DistributedTargetInvocationEncoder)
 PROTOCOL(DistributedTargetInvocationDecoder)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4464,8 +4464,9 @@ void ASTMangler::appendDistributedThunk(
     auto M = thunk->getModuleContext();
 
     SmallVector<ValueDecl *, 1> stubClassLookupResults;
-    C.lookupInModule(M, ("$" + P->getNameStr()).str(), stubClassLookupResults);
+    C.lookupInModule(M, llvm::Twine("$", P->getNameStr()).str(), stubClassLookupResults);
 
+    assert(stubClassLookupResults.size() <= 1 && "Found multiple distributed stub types!");
     if (stubClassLookupResults.size() > 0) {
       stubActorDecl =
           dyn_cast_or_null<NominalTypeDecl>(stubClassLookupResults.front());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4453,12 +4453,32 @@ void ASTMangler::appendDistributedThunk(
     return nullptr;
   };
 
-  if (auto *P = referenceInProtocolContextOrRequirement()) {
-    appendContext(P->getDeclContext(), base,
-                  thunk->getAlternateModuleName());
-    appendIdentifier(Twine("$", P->getNameStr()).str());
-    appendOperator("C"); // necessary for roundtrip, though we don't use it
+  // Determine if we should mangle with a $Target substitute decl context,
+  // this matters for @Resolvable calls / protocol calls where the caller
+  // does not know the type of the recipient distributed actor, and we use the
+  // $Target type as substitute to then generically invoke it on the type of the
+  // recipient, whichever 'protocol Type'-conforming type it will be.
+  NominalTypeDecl *stubActorDecl = nullptr;
+  if (auto P = referenceInProtocolContextOrRequirement()) {
+    auto &C = thunk->getASTContext();
+    auto M = thunk->getModuleContext();
+
+    SmallVector<ValueDecl *, 1> stubClassLookupResults;
+    C.lookupInModule(M, ("$" + P->getNameStr()).str(), stubClassLookupResults);
+
+    if (stubClassLookupResults.size() > 0) {
+      stubActorDecl =
+          dyn_cast_or_null<NominalTypeDecl>(stubClassLookupResults.front());
+    }
+  }
+
+  if (stubActorDecl) {
+    // Effectively mangle the thunk as if it was declared on the $StubTarget
+    // type, rather than on a `protocol Target`.
+    appendContext(stubActorDecl, base, thunk->getAlternateModuleName());
   } else {
+    // There's no need to replace the context, this is a normal concrete type
+    // remote call identifier.
     appendContextOf(thunk, base);
   }
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -379,8 +379,8 @@ void IRGenModule::emitDistributedTargetAccessor(ThunkOrRequirement target) {
   IRGenMangler mangler;
 
   addAccessibleFunction(AccessibleFunction::forDistributed(
-      mangler.mangleDistributedThunkRecord(targetDecl),
-      mangler.mangleDistributedThunk(targetDecl),
+      /*recordName=*/mangler.mangleDistributedThunkRecord(targetDecl),
+      /*accessorName=*/mangler.mangleDistributedThunk(targetDecl),
       accessor.getTargetType(),
       getAddrOfAsyncFunctionPointer(accessorRef)));
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6956,6 +6956,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Identifiable:
   case KnownProtocolKind::Actor:
   case KnownProtocolKind::DistributedActor:
+  case KnownProtocolKind::DistributedActorStub:
   case KnownProtocolKind::DistributedActorSystem:
   case KnownProtocolKind::DistributedTargetInvocationEncoder:
   case KnownProtocolKind::DistributedTargetInvocationDecoder:

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -130,7 +130,7 @@ extension DistributedResolvableMacro {
       return []
     }
 
-    var isGenericStub = false
+    var isGenericOverActorSystem = false
     var specificActorSystemRequirement: TypeSyntax?
 
     let accessModifiers = proto.accessControlModifiers
@@ -140,7 +140,7 @@ extension DistributedResolvableMacro {
       case .conformanceRequirement(let conformanceReq)
            where conformanceReq.leftType.isActorSystem:
         specificActorSystemRequirement = conformanceReq.rightType.trimmed
-        isGenericStub = true
+        isGenericOverActorSystem = true
 
       case .sameTypeRequirement(let sameTypeReq):
         switch sameTypeReq.leftType {
@@ -148,7 +148,7 @@ extension DistributedResolvableMacro {
           switch sameTypeReq.rightType.trimmed {
           case .type(let rightType):
             specificActorSystemRequirement = rightType
-            isGenericStub = false
+            isGenericOverActorSystem = false
 
           case .expr:
             throw DiagnosticsError(
@@ -167,41 +167,78 @@ extension DistributedResolvableMacro {
       }
     }
 
-    if isGenericStub, let specificActorSystemRequirement {
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed)<ActorSystem>: \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-          where ActorSystem: \(specificActorSystemRequirement) 
-        { }
-        """
-      ]
-    } else if let specificActorSystemRequirement {
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed): \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-        { 
-          \(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement)) 
-        }
-        """
-      ]
-    } else {
-      // there may be no `where` clause specifying an actor system,
-      // but perhaps there is a typealias (or extension with a typealias),
-      // specifying a concrete actor system so we let this synthesize
-      // an empty `$Greeter` -- this may fail, or succeed depending on
-      // surrounding code using a default distributed actor system,
-      // or extensions providing it.
-      return [
-        """
-        \(proto.modifiers) distributed actor $\(proto.name.trimmed): \(proto.name.trimmed), 
-          Distributed._DistributedActorStub
-        {
-        }
-        """
-      ]
+    var primaryAssociatedTypes: [PrimaryAssociatedTypeSyntax] = []
+    if let primaryTypes = proto.primaryAssociatedTypeClause?.primaryAssociatedTypes {
+      primaryAssociatedTypes.append(contentsOf: primaryTypes)
     }
+
+    // The $Stub is always generic over the actor system: $Stub<ActorSystem>
+    var primaryTypeParams: [String] = primaryAssociatedTypes.map {
+      $0.as(PrimaryAssociatedTypeSyntax.self)!.name.trimmed.text
+    }
+
+    // Don't duplicate the ActorSystem type parameter if it already was declared
+    // on the protocol as a primary associated type;
+    // otherwise, add it as first primary associated type.
+    let actorSystemTypeParam: [String] =
+      if primaryTypeParams.contains("ActorSystem") {
+        []
+      } else if isGenericOverActorSystem {
+        ["ActorSystem"]
+      } else {
+        []
+      }
+
+    // Prepend the actor system type parameter, as we want it to be the first one
+    primaryTypeParams = actorSystemTypeParam + primaryTypeParams
+    let typeParamsClause =
+      primaryTypeParams.isEmpty ? "" : "<" + primaryTypeParams.joined(separator: ", ") + ">"
+
+    var whereClause: String = ""
+    do {
+      let associatedTypeDecls = proto.associatedTypeDecls
+      var typeParamConstraints: [String] = []
+      for typeParamName in primaryTypeParams {
+        if let decl = associatedTypeDecls[typeParamName] {
+          if let inheritanceClause = decl.inheritanceClause {
+            typeParamConstraints.append("\(typeParamName)\(inheritanceClause)")
+          }
+        }
+      }
+
+      if isGenericOverActorSystem, let specificActorSystemRequirement {
+        typeParamConstraints = ["ActorSystem: \(specificActorSystemRequirement)"] + typeParamConstraints
+      }
+      
+      if !typeParamConstraints.isEmpty {
+        whereClause += "\n  where " + typeParamConstraints.joined(separator: ",\n  ")
+      }
+    }
+
+    let stubActorBody: String =
+      if isGenericOverActorSystem {
+        // there may be no `where` clause specifying an actor system,
+        // but perhaps there is a typealias (or extension with a typealias),
+        // specifying a concrete actor system so we let this synthesize
+        // an empty `$Greeter` -- this may fail, or succeed depending on
+        // surrounding code using a default distributed actor system,
+        // or extensions providing it.
+        ""
+      } else if let specificActorSystemRequirement {
+        "\(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement))"
+      } else {
+        ""
+      }
+
+    return [
+      """
+      \(proto.modifiers) distributed actor $\(proto.name.trimmed)\(raw: typeParamsClause): \(proto.name.trimmed), 
+        Distributed._DistributedActorStub \(raw: whereClause)
+      {
+        \(raw: stubActorBody)
+      }
+      """
+    ]
   }
 
   private static func typealiasActorSystem(access: DeclModifierListSyntax,
@@ -249,6 +286,23 @@ extension DeclModifierSyntax {
       return true
     default:
       return false
+    }
+  }
+}
+
+extension ProtocolDeclSyntax {
+  var associatedTypeDecls: [String: AssociatedTypeDeclSyntax] {
+    let visitor = AssociatedTypeDeclVisitor(viewMode: .all)
+    visitor.walk(self)
+    return visitor.associatedTypeDecls
+  }
+
+  final class AssociatedTypeDeclVisitor: SyntaxVisitor {
+    var associatedTypeDecls: [String: AssociatedTypeDeclSyntax] = [:]
+
+    override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
+      associatedTypeDecls[node.name.text] = node
+      return .skipChildren
     }
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -180,14 +180,14 @@ extension DistributedResolvableMacro {
     // Don't duplicate the ActorSystem type parameter if it already was declared
     // on the protocol as a primary associated type;
     // otherwise, add it as first primary associated type.
-    let actorSystemTypeParam: [String] =
-      if primaryTypeParams.contains("ActorSystem") {
-        []
-      } else if isGenericOverActorSystem {
-        ["ActorSystem"]
-      } else {
-        []
-      }
+    let actorSystemTypeParam: [String]
+    if primaryTypeParams.contains("ActorSystem") {
+      actorSystemTypeParam = []
+    } else if isGenericOverActorSystem {
+      actorSystemTypeParam = ["ActorSystem"]
+    } else {
+      actorSystemTypeParam = []
+    }
 
     // Prepend the actor system type parameter, as we want it to be the first one
     primaryTypeParams = actorSystemTypeParam + primaryTypeParams
@@ -215,20 +215,20 @@ extension DistributedResolvableMacro {
       }
     }
 
-    let stubActorBody: String =
-      if isGenericOverActorSystem {
-        // there may be no `where` clause specifying an actor system,
-        // but perhaps there is a typealias (or extension with a typealias),
-        // specifying a concrete actor system so we let this synthesize
-        // an empty `$Greeter` -- this may fail, or succeed depending on
-        // surrounding code using a default distributed actor system,
-        // or extensions providing it.
-        ""
-      } else if let specificActorSystemRequirement {
-        "\(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement))"
-      } else {
-        ""
-      }
+    let stubActorBody: String
+    if isGenericOverActorSystem {
+      // there may be no `where` clause specifying an actor system,
+      // but perhaps there is a typealias (or extension with a typealias),
+      // specifying a concrete actor system so we let this synthesize
+      // an empty `$Greeter` -- this may fail, or succeed depending on
+      // surrounding code using a default distributed actor system,
+      // or extensions providing it.
+      stubActorBody = ""
+    } else if let specificActorSystemRequirement {
+      stubActorBody = "\(typealiasActorSystem(access: accessModifiers, proto, specificActorSystemRequirement))"
+    } else {
+      stubActorBody = ""
+    }
 
     return [
       """

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -152,8 +152,9 @@ _searchForFunctionRecord(AccessibleFunctionsState &S, llvm::StringRef name) {
     for (auto &record : section) {
       auto recordName =
           swift::Demangle::makeSymbolicMangledNameStringRef(record.Name.get());
-      if (recordName == name)
+      if (recordName == name) {
         return traceState.end(&record);
+      }
     }
   }
   return nullptr;

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -20,7 +20,9 @@
 #include "swift/Demangling/Demangler.h"
 #include "swift/Runtime/AccessibleFunction.h"
 #include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Threading/Once.h"
 #include "Tracing.h"
 
 #include <cstdint>
@@ -98,6 +100,29 @@ static Lazy<AccessibleFunctionsState> Functions;
 
 } // end anonymous namespace
 
+LLVM_ATTRIBUTE_UNUSED
+static void _dumpAccessibleFunctionRecords(void *context) {
+  auto &S = Functions.get();
+
+  fprintf(stderr, "==== Accessible Function Records ====\n");
+  int count = 0;
+  for (const auto &section : S.SectionsToScan.snapshot()) {
+    for (auto &record : section) {
+      auto recordName =
+          swift::Demangle::makeSymbolicMangledNameStringRef(record.Name.get());
+      auto demangledRecordName =
+          swift::Demangle::demangleSymbolAsString(recordName);
+      fprintf(stderr, "Record name: %s\n", recordName.data());
+      fprintf(stderr, "    Demangled: %s\n", demangledRecordName.c_str());
+      fprintf(stderr, "    Function Ptr: %p\n", record.Function.get());
+      fprintf(stderr, "    Flags.IsDistributed: %d\n", record.Flags.isDistributed());
+      ++count;
+    }
+  }
+  fprintf(stderr, "Record count: %d\n", count);
+  fprintf(stderr, "==== End of Accessible Function Records ====\n");
+}
+
 static void _registerAccessibleFunctions(AccessibleFunctionsState &C,
                                          AccessibleFunctionsSection section) {
   C.SectionsToScan.push_back(section);
@@ -117,27 +142,6 @@ void swift::addImageAccessibleFunctionsBlockCallback(
   const void *baseAddress, const void *functions, uintptr_t size) {
   Functions.get();
   addImageAccessibleFunctionsBlockCallbackUnsafe(baseAddress, functions, size);
-}
-
-// TODO(distributed): expose dumping records via a flag
-LLVM_ATTRIBUTE_UNUSED
-static void _dumpAccessibleFunctionRecords() {
-  auto &S = Functions.get();
-
-  fprintf(stderr, "==== Accessible Function Records ====\n");
-  int count = 0;
-  for (const auto &section : S.SectionsToScan.snapshot()) {
-    for (auto &record : section) {
-      auto recordName =
-          swift::Demangle::makeSymbolicMangledNameStringRef(record.Name.get());
-      fprintf(stderr, "Record name: %s\n", recordName.data());
-      fprintf(stderr, "    Function Ptr: %p\n", record.Function.get());
-      fprintf(stderr, "    Flags.IsDistributed: %d\n", record.Flags.isDistributed());
-      ++count;
-    }
-  }
-  fprintf(stderr, "Record count: %d\n", count);
-  fprintf(stderr, "==== End of Accessible Function Records ====\n");
 }
 
 static const AccessibleFunctionRecord *
@@ -160,13 +164,19 @@ const AccessibleFunctionRecord *
 swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
                                              size_t targetNameLength) {
   auto &S = Functions.get();
-
   llvm::StringRef name{targetNameStart, targetNameLength};
+
+  if (swift::runtime::environment::SWIFT_DUMP_ACCESSIBLE_FUNCTIONS()) {
+    static swift::once_t dumpAccessibleFunctionsToken;
+    swift::once(dumpAccessibleFunctionsToken, _dumpAccessibleFunctionRecords, nullptr);
+  }
+
   // Look for an existing entry.
   {
     auto snapshot = S.Cache.snapshot();
-    if (auto E = snapshot.find(name))
+    if (auto E = snapshot.find(name)) {
       return E->getRecord();
+    }
   }
 
   // If entry doesn't exist (either record doesn't exist, hasn't been loaded, or

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -128,4 +128,10 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'legacy' (Legacy behavior), "
          " 'swift6' (Swift 6.0+ behavior)")
 
+VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, string, "",
+         "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "
+         "These are used to obtain function pointers from accessible function "
+         "record names, e.g. by the Distributed runtime to invoke distributed "
+         "functions.")
+
 #undef VARIABLE

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_primary_associatedtype.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_primary_associatedtype.swift
@@ -1,0 +1,89 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s 2>&1 | %FileCheck %s
+
+import Distributed
+
+typealias System = LocalTestingDistributedActorSystem
+
+@Resolvable
+protocol Base<Fruit>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  distributed func get() -> Fruit
+}
+// CHECK: distributed actor $Base<ActorSystem, Fruit>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable
+// CHECK-NEXT: {
+// CHECK: }
+
+@Resolvable
+protocol Base2<Fruit, Animal>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base2<ActorSystem, Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable
+// CHECK-NEXT: {
+// CHECK: }
+
+@Resolvable
+protocol Base3<Fruit, Animal>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable & Hashable
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base3<ActorSystem, Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable & Hashable
+// CHECK-NEXT: {
+// CHECK: }
+
+/// This type is not generic over the actor system because of the == constraint:
+@Resolvable
+protocol Base4<Fruit, Animal>: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  associatedtype Fruit: Codable
+  associatedtype Animal: Codable & Hashable
+
+  distributed func get(animal: Animal) -> Fruit
+}
+// CHECK: distributed actor $Base4<Fruit, Animal>: Base
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   Fruit: Codable,
+// CHECK-NEXT:   Animal: Codable & Hashable
+// CHECK-NEXT: {
+// CHECK-NEXT:   typealias ActorSystem = LocalTestingDistributedActorSystem
+// CHECK-NEXT: }
+
+@Resolvable
+public protocol DistributedWorker<WorkItem, WorkResult>: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  distributed func dist_sync(work: WorkItem) -> WorkResult
+  distributed func dist_async(work: WorkItem) async -> WorkResult
+  distributed func dist_syncThrows(work: WorkItem) throws -> WorkResult
+  distributed func dist_asyncThrows(work: WorkItem) async throws -> WorkResult
+}
+
+// CHECK: public distributed actor $DistributedWorker<WorkItem, WorkResult>: DistributedWorker
+// CHECK-NEXT:   Distributed._DistributedActorStub
+// CHECK-NEXT:   WorkItem: Sendable & Codable,
+// CHECK-NEXT:   WorkResult: Sendable & Codable
+// CHECK-NEXT: {
+// CHECK:        public typealias ActorSystem = LocalTestingDistributedActorSystem
+// CHECK-NEXT: }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -22,7 +22,7 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 // CHECK-NEXT: Distributed._DistributedActorStub
 // CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK-NEXT: {
-// CHECK-NEXT: }
+// CHECK: }
 
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK-NEXT:   distributed func greet(name: String) -> String {

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_array_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_array_param.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -plugin-path %swift-plugin-dir -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -plugin-path %swift-plugin-dir -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+@Resolvable
+@available(SwiftStdlib 6.0, *)
+protocol Service: DistributedActor where ActorSystem == FakeRoundtripActorSystem {
+  distributed func getArray(a1: [Int], a2: String?) async throws -> [Int]
+
+  // Make sure method-level generics also work fine
+  distributed func getArrayGeneric<Gen: Codable & Sendable>(a1: [Int], a2: String?, gen: Gen) async throws -> [Int]
+}
+
+@available(SwiftStdlib 6.0, *)
+distributed actor ServiceImpl: Service {
+  distributed func getArray(a1: [Int], a2: String?) async throws -> [Int] {
+    return a1 + [4, 5]
+  }
+
+  distributed func getArrayGeneric<Gen: Codable & Sendable>(a1: [Int], a2: String?, gen: Gen) async throws -> [Int] {
+    return a1 + [4, 5]
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let local = ServiceImpl(actorSystem: system)
+
+  let implRef = try ServiceImpl.resolve(id: local.id, using: system)
+  let r1 = try await implRef.getArray(a1: [1, 2, 3], a2: "second")
+  // CHECK: >> remoteCall: on:main.ServiceImpl, target:main.ServiceImpl.getArray(a1:a2:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [[[ARGS:.*]]], returnType: Optional(Swift.Array<Swift.Int>), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.Array<Swift.Int>
+  // CHECK: > execute distributed target: main.ServiceImpl.getArray(a1:a2:), identifier: $s4main11ServiceImplC8getArray2a12a2SaySiGAG_SSSgtYaKFTE
+  print("reply 1: \(r1)")
+  // CHECK: reply 1: [1, 2, 3, 4, 5]
+
+  let ref = try $Service.resolve(id: local.id, using: system)
+  let r2 = try await ref.getArray(a1: [1, 2, 3], a2: "second")
+  // CHECK: >> remoteCall: on:main.$Service, target:main.$Service.getArray(a1:a2:), invocation:FakeInvocationEncoder(genericSubs: [main.$Service], arguments: [[[ARGS:.*]]], returnType: Optional(Swift.Array<Swift.Int>), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.Array<Swift.Int>
+  // CHECK: > execute distributed target: main.$Service.getArray(a1:a2:), identifier: $s4main8$ServiceC8getArray2a12a2SaySiGAG_SSSgtYaKFTE
+  // CHECK: > decode generic subs: [main.$Service]
+  // CHECK: > decode return type: Swift.Array<Swift.Int>
+  // CHECK: > decode argument: [1, 2, 3]
+  // CHECK: > decode argument: Optional("second")
+  print("reply 2: \(r2)")
+  // CHECK: reply 2: [1, 2, 3, 4, 5]
+
+  _ = try await ref.getArrayGeneric(a1: [1, 2, 3], a2: "third", gen: 12)
+  // CHECK: remoteCall: on:main.$Service, target:main.$Service.getArrayGeneric(a1:a2:gen:), invocation:FakeInvocationEncoder(genericSubs: [main.$Service, Swift.Int], arguments: [[[ARGS:.*]]], returnType: Optional(Swift.Array<Swift.Int>), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.Array<Swift.Int>
+  // CHECK: > execute distributed target: main.$Service.getArrayGeneric(a1:a2:gen:), identifier: $s4main8$ServiceC15getArrayGeneric2a12a23genSaySiGAH_SSSgqd__tYaKSeRd__SERd__lFTE
+  // CHECK: > decode generic subs: [main.$Service, Swift.Int]
+  // CHECK: > decode return type: Swift.Array<Swift.Int>
+  // CHECK: > decode argument: [1, 2, 3]
+  // CHECK: > decode argument: Optional("third")
+  // CHECK: > decode argument: 12
+}
+
+@available(SwiftStdlib 6.0, *)
+@main struct Main {
+  static func main() async {
+    try! await test()
+
+    print("Done")
+    // CHECK: Done
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension.swift
@@ -40,7 +40,9 @@ func test() async throws {
   let ref = try KappaProtocolImpl.resolve(id: local.id, using: system)
 
   let reply = try await ref.echo(name: "Caplin")
-  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:main.$KappaProtocol.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [main.KappaProtocolImpl], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:echo(name:), invocation:FakeInvocationEncoder(genericSubs: [main.KappaProtocolImpl], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: > execute distributed target: echo(name:), identifier: $s4main13KappaProtocolPAAE4echo4nameS2S_tYaKFTE
+  // CHECK: > decode generic subs: [main.KappaProtocolImpl]
 
   // CHECK: << remoteCall return: Echo: Caplin
   print("reply: \(reply)")

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_not_codable.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_not_codable.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -20,6 +20,7 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
+@available(SwiftStdlib 6.0, *)
 protocol PlainWorker {
   associatedtype WorkItem: Sendable & Codable
   associatedtype WorkResult: Sendable & Codable
@@ -28,7 +29,9 @@ protocol PlainWorker {
   func asyncThrows(work: WorkItem) async throws -> WorkResult
 }
 
-protocol DistributedWorker: DistributedActor where ActorSystem == DefaultDistributedActorSystem {
+@Resolvable
+@available(SwiftStdlib 6.0, *)
+protocol DistributedWorker<WorkItem, WorkResult>: DistributedActor where ActorSystem == DefaultDistributedActorSystem {
   associatedtype WorkItem: Sendable & Codable
   associatedtype WorkResult: Sendable & Codable
 
@@ -49,6 +52,7 @@ protocol DistributedWorker: DistributedActor where ActorSystem == DefaultDistrib
   func asyncThrowsReq_witnessDistributed_asyncThrows(work: WorkItem) async throws -> WorkResult
 }
 
+@available(SwiftStdlib 6.0, *)
 distributed actor ThePlainWorker: PlainWorker {
   typealias ActorSystem = DefaultDistributedActorSystem
   typealias WorkItem = String
@@ -59,6 +63,7 @@ distributed actor ThePlainWorker: PlainWorker {
   }
 }
 
+@available(SwiftStdlib 6.0, *)
 distributed actor TheWorker: DistributedWorker {
   typealias ActorSystem = DefaultDistributedActorSystem
   typealias WorkItem = String
@@ -105,6 +110,7 @@ distributed actor TheWorker: DistributedWorker {
 
 }
 
+@available(SwiftStdlib 6.0, *)
 func test_generic(system: DefaultDistributedActorSystem) async throws {
   let localW = TheWorker(actorSystem: system)
   let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
@@ -218,6 +224,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   // distributedness of those witnesses never actually is used remotely, but at
   // least check we invoke the right methods.
 
+  @available(SwiftStdlib 6.0, *)
   func call_requirement_witnessedByDistributed_sync<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
     try await w.whenLocal { __secretlyKnownToBeLocal in
       try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_sync(work: "Hello")
@@ -231,6 +238,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   }
   print("==== ----------------------------------------------------------------")
 
+  @available(SwiftStdlib 6.0, *)
   func call_requirement_witnessedByDistributed_async<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
     try await w.whenLocal { __secretlyKnownToBeLocal in
       try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_async(work: "Hello")
@@ -244,6 +252,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   }
   print("==== ----------------------------------------------------------------")
 
+  @available(SwiftStdlib 6.0, *)
   func call_requirement_witnessedByDistributed_syncThrows<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
     try await w.whenLocal { __secretlyKnownToBeLocal in
       try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_syncThrows(work: "Hello")
@@ -257,6 +266,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   }
   print("==== ----------------------------------------------------------------")
 
+  @available(SwiftStdlib 6.0, *)
   func call_requirement_witnessedByDistributed_asyncThrows<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
     try await w.whenLocal { __secretlyKnownToBeLocal in
       try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_asyncThrows(work: "Hello")
@@ -271,6 +281,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   print("==== ----------------------------------------------------------------")
 }
 
+@available(SwiftStdlib 6.0, *)
 func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
   let localW = TheWorker(actorSystem: system)
   let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
@@ -341,6 +352,7 @@ func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
   }
 }
 
+@available(SwiftStdlib 6.0, *)
 func test_generic_plain(system: DefaultDistributedActorSystem) async throws {
   let localW = ThePlainWorker(actorSystem: system)
   let remoteW = try! ThePlainWorker.resolve(id: localW.id, using: system)
@@ -355,6 +367,7 @@ func test_generic_plain(system: DefaultDistributedActorSystem) async throws {
   }
   print("==== ----------------------------------------------------------------")
 
+  @available(SwiftStdlib 6.0, *)
   func call_plainWorker<W: PlainWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
     try await w.asyncThrows(work: "Hello")
   }
@@ -372,6 +385,7 @@ func test_generic_plain(system: DefaultDistributedActorSystem) async throws {
   }
 }
 
+@available(SwiftStdlib 6.0, *)
 @main struct Main {
   static func main() async {
     let system = DefaultDistributedActorSystem()

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -plugin-path %swift-plugin-dir -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -64,7 +64,7 @@ func test_distributedVariable<DA: WorkerProtocol>(actor: DA) async throws -> Str
     let v1 = try await test_distributedVariable(actor: actor)
     print("v1 = \(v1)") // CHECK: v1 = implemented variable
 
-    let v = try await actor.distributedVariable
-    print("v = \(v)") // CHECK: v = implemented variable
+    let v2 = try await actor.distributedVariable
+    print("v2 = \(v2)") // CHECK: v2 = implemented variable
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s -plugin-path %swift-plugin-dir -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// rdar://90373022
+// UNSUPPORTED: OS=watchos
+
+// rdar://125628060
+// UNSUPPORTED: CPU=arm64e
+ 
+import Distributed
+
+@Resolvable
+@available(SwiftStdlib 6.0, *)
+protocol WorkerProtocol: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  distributed var distributedVariable: String { get }
+}
+
+@available(SwiftStdlib 6.0, *)
+distributed actor Worker: WorkerProtocol {
+  distributed var distributedVariable: String {
+    "implemented variable"
+  }
+}
+
+// ==== Execute ----------------------------------------------------------------
+
+
+@available(SwiftStdlib 6.0, *)
+func test_distributedVariable<DA: WorkerProtocol>(actor: DA) async throws -> String {
+  try await actor.distributedVariable
+}
+
+@available(SwiftStdlib 6.0, *)
+@main struct Main {
+  static func main() async throws {
+    let system = LocalTestingDistributedActorSystem()
+
+    let actor: any WorkerProtocol = Worker(actorSystem: system)
+
+    // force a call through witness table
+    let v1 = try await test_distributedVariable(actor: actor)
+    print("v1 = \(v1)") // CHECK: v1 = implemented variable
+  }
+}


### PR DESCRIPTION
The commits are now properly staged, please check their descriptions for details.

This solves:
- rdar://139332556 - so now we're handling primary associated types in protocols with @resolvable -- and this would have then crashed during mangling (!), which is why the follow up commits
- rdar://139781083 - which is solved in [`2a3ac44` (#77584)](https://github.com/swiftlang/swift/pull/77584/commits/2a3ac4458fcca51906ffd53a40129347ed8d81d7) which was about how sometimes with generics involved or more complex type signatures of a `distributed func` we'd wrongly mangle and crash during thunk mangling.

Both changes go hand in hand and allow correct handling of more situations with generics and complex types in `distributed func`s