### PR TITLE
[Dependency Scan] Remove newly-introduced error failure on missing header dependency of a binary module dependency

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -552,15 +552,8 @@ bool ClangImporter::getHeaderDependencies(
     auto swiftBinaryDeps = targetModuleInfo.getAsSwiftBinaryModule();
     if (!swiftBinaryDeps->headerImport.empty()) {
       auto clangModuleDependencies = scanHeaderDependencies(swiftBinaryDeps->headerImport);
-      if (!clangModuleDependencies) {
-        // FIXME: Route this to a normal diagnostic.
-        llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
-                                    llvm::errs());
-        Impl.SwiftContext.Diags.diagnose(
-            SourceLoc(), diag::clang_dependency_scan_error,
-            "failed to scan header dependencies");
+      if (!clangModuleDependencies)
         return true;
-      }
     }
   }
 


### PR DESCRIPTION
Previous behavior had the scanner simply proceed if the header input of a binary Swift module dependency could not be resolved on the filesystem

Resolves rdar://139736789