### PR TITLE
AliasAnalysis: fix the memory behavior of `end_borrow`

### DIFF
--- a/test/SILOptimizer/load-copy-to-borrow.sil
+++ b/test/SILOptimizer/load-copy-to-borrow.sil
@@ -52,6 +52,17 @@ final class Klass {
 
 class C {}
 
+class Base {
+  @_hasStorage var c: C
+}
+
+class Derived : Base {
+}
+
+class Container {
+  @_hasStorage var b: Base
+}
+
 struct OptionalAndClass {
   var o: FakeOptional<C>
   var c: C
@@ -78,6 +89,9 @@ sil @use_inguaranteed : $@convention(thin) (@in_guaranteed Klass) -> ()
 sil @guaranteed_fakeoptional_klass_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 sil @guaranteed_fakeoptional_classlet_user : $@convention(thin) (@guaranteed FakeOptional<ClassLet>) -> ()
 sil @closure : $@convention(thin) (@inout_aliasable Klass) -> ()
+sil @useC : $@convention(thin) (@guaranteed C) -> () {
+[global:]
+}
 
 struct MyInt {
   var value: Builtin.Int32
@@ -2006,5 +2020,23 @@ bb5:
   destroy_value %1 : $Klass
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @blocked_by_end_borrow :
+// CHECK:         %7 = load [copy] %6
+// CHECK:       } // end sil function 'blocked_by_end_borrow'
+sil [ossa] @blocked_by_end_borrow : $@convention(thin) (@guaranteed Container) -> () {
+bb0(%0 : @guaranteed $Container):
+  %1 = function_ref @useC : $@convention(thin) (@guaranteed C) -> ()
+  %2 = ref_element_addr [immutable] %0 : $Container, #Container.b
+  %3 = load_borrow %2 : $*Base
+  %4 = unconditional_checked_cast %3 : $Base to Derived
+  %5 = upcast %4 : $Derived to $Base
+  %6 = ref_element_addr [immutable] %5 : $Base, #Base.c
+  %7 = load [copy] %6 : $*C
+  end_borrow %3 : $Base
+  %9 = apply %1(%7) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %7 : $C
+  return %9 : $()
 }
 

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1462,6 +1462,101 @@ bb0(%0 : @guaranteed $X):
   return %5 : $Int32
 }
 
+// CHECK-LABEL: @test_end_borrow3
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     end_borrow %6 : $X
+// CHECK-NEXT:     %3 = ref_element_addr %2 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     end_borrow %6 : $X
+// CHECK-NEXT:     %4 = ref_element_addr %0 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #5.
+// CHECK-NEXT:     end_borrow %6 : $X
+// CHECK-NEXT:     %7 = ref_element_addr %6 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #6.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %3 = ref_element_addr %2 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #7.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %4 = ref_element_addr %0 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #8.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %7 = ref_element_addr %6 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+sil [ossa] @test_end_borrow3 : $@convention(thin) (@guaranteed X, @owned X) -> @owned (X, X) {
+bb0(%0 : @guaranteed $X, %1 : @owned $X):
+  %2 = begin_borrow %1 : $X
+  %3 = ref_element_addr %2 : $X, #X.x
+  %4 = ref_element_addr %0 : $X, #X.x
+  %5 = copy_value %2 : $X
+  %6 = begin_borrow %5 : $X
+  %7 = ref_element_addr %6 : $X, #X.x
+  end_borrow %6 : $X
+  end_borrow %2 : $X
+  %r = tuple (%5 : $X, %1 : $X)
+  return %r : $(X, X)
+}
+
+// CHECK-LABEL: @test_end_borrow4
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     end_borrow %3 : $X
+// CHECK-NEXT:     %4 = ref_element_addr %3 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #5.
+// CHECK-NEXT:     end_borrow %3 : $X
+// CHECK-NEXT:     %8 = ref_element_addr %7 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #10.
+// CHECK-NEXT:     end_borrow %7 : $X
+// CHECK-NEXT:     %4 = ref_element_addr %3 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #11.
+// CHECK-NEXT:     end_borrow %7 : $X
+// CHECK-NEXT:     %8 = ref_element_addr %7 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #13.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %4 = ref_element_addr %3 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #14.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %8 = ref_element_addr %7 : $X, #X.x
+// CHECK-NEXT:   r=0,w=0
+sil [ossa] @test_end_borrow4 : $@convention(thin) (@guaranteed X, @in_guaranteed X) -> @owned X {
+bb0(%0 : @guaranteed $X, %1 : $*X):
+  %2 = begin_borrow %0 : $X
+  %3 = load_borrow %1 : $*X
+  %4 = ref_element_addr %3 : $X, #X.x
+  end_borrow %3 : $X
+  %6 = load [copy] %1 : $*X
+  %7 = begin_borrow %6 : $X
+  %8 = ref_element_addr %7 : $X, #X.x
+  end_borrow %7 : $X
+  end_borrow %2 : $X
+  return %6 : $X
+}
+
+// CHECK-LABEL: @test_end_borrow5
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     end_borrow %2 : $X
+// CHECK-NEXT:     %5 = ref_element_addr [immutable] %4 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @test_end_borrow5 : $@convention(thin) (@guaranteed X) -> () {
+bb0(%0 : @guaranteed $X):
+  %1 = ref_element_addr [immutable] %0 : $X, #X.x
+  %2 = load_borrow %1 : $*X
+  %3 = unconditional_checked_cast %2 : $X to Derived
+  %4 = upcast %3 : $Derived to $X
+  %5 = ref_element_addr [immutable] %4 : $X, #X.x
+  end_borrow %2 : $X
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: @test_load_borrow
 // CHECK:      PAIR #0.
 // CHECK-NEXT:     %1 = load_borrow %0 : $*X


### PR DESCRIPTION
Checking if an access base is derived from a begin-borrow was too optimistic. We have to bail for instructions which are not handled by the walker utilities.

Fixes a verifier crash.
rdar://139788357
