### PR TITLE
[cxx-interop] Support conditional escapability

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -308,5 +308,10 @@ NOTE(forward_declared_protocol_clashes_with_imported_objc_Swift_protocol, none,
 WARNING(return_escapable_with_lifetimebound, none, "the returned type '%0' is annotated as escapable; it cannot have lifetime dependencies", (StringRef))
 WARNING(return_nonescapable_without_lifetimebound, none, "the returned type '%0' is annotated as non-escapable; its lifetime dependencies must be annotated", (StringRef))
 
+ERROR(unknown_template_parameter,none,
+  "template parameter '%0' does not exist", (StringRef))
+ERROR(type_template_parameter_expected,none,
+  "template parameter '%0' expected to be a type parameter", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -22,6 +22,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "clang/AST/Type.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -504,6 +505,8 @@ enum class CxxEscapability { Escapable, NonEscapable, Unknown };
 
 struct EscapabilityLookupDescriptor final {
   const clang::Type *type;
+  ClangImporter::Implementation &impl;
+  bool annotationOnly = true;
 
   friend llvm::hash_code hash_value(const EscapabilityLookupDescriptor &desc) {
     return llvm::hash_combine(desc.type);
@@ -511,7 +514,7 @@ struct EscapabilityLookupDescriptor final {
 
   friend bool operator==(const EscapabilityLookupDescriptor &lhs,
                          const EscapabilityLookupDescriptor &rhs) {
-    return lhs.type == rhs.type;
+    return lhs.type == rhs.type && lhs.annotationOnly == rhs.annotationOnly;
   }
 
   friend bool operator!=(const EscapabilityLookupDescriptor &lhs,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2042,6 +2042,9 @@ bool hasNonEscapableAttr(const clang::RecordDecl *decl);
 
 bool hasEscapableAttr(const clang::RecordDecl *decl);
 
+std::set<StringRef>
+getConditionalEscapableAttrParams(const clang::RecordDecl *decl);
+
 bool isViewType(const clang::CXXRecordDecl *decl);
 
 } // end namespace importer

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -39,6 +39,12 @@
 
 #define _CXX_INTEROP_STRINGIFY(_x) #_x
 
+#define _CXX_INTEROP_CONCAT_(a,b,c,d,e,f,g,i,j,k,l,m,n,o,p,...)         \
+  #a "," #b "," #c "," #d "," #e "," #f "," #g "," #i "," #j "," #k "," \
+  #l "," #m "," #n "," #o "," #p
+#define _CXX_INTEROP_CONCAT(...) \
+  _CXX_INTEROP_CONCAT_(__VA_ARGS__,,,,,,,,,,,,,,,,,)
+
 /// Specifies that a C++ `class` or `struct` is reference-counted using
 /// the given `retain` and `release` functions. This annotation lets Swift import
 /// such a type as reference counted type in Swift, taking advantage of Swift's
@@ -172,6 +178,11 @@
 #define SWIFT_ESCAPABLE \
   __attribute__((swift_attr("Escapable")))
 
+/// Specifies that a C++ `class` or `struct` should be imported as a escapable
+/// Swift value if all of the specified template arguments are escapable.
+#define SWIFT_ESCAPABLE_IF(...) \
+  __attribute__((swift_attr("escapable_if:" _CXX_INTEROP_CONCAT(__VA_ARGS__))))
+
 /// Specifies that the return value is passed as owned for C++ functions and
 /// methods returning types annotated as `SWIFT_SHARED_REFERENCE`
 #define SWIFT_RETURNS_RETAINED __attribute__((swift_attr("returns_retained")))
@@ -196,6 +207,7 @@
 #define SWIFT_NONCOPYABLE
 #define SWIFT_NONESCAPABLE
 #define SWIFT_ESCAPABLE
+#define SWIFT_ESCAPABLE_IF(...)
 #define SWIFT_RETURNS_RETAINED
 #define SWIFT_RETURNS_UNRETAINED
 

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -37,6 +37,30 @@ View g(int* x) {
     return View(x);
 }
 
+template<typename F, typename S>
+struct SWIFT_ESCAPABLE_IF(F, S) MyPair {
+    F first;
+    S second;
+};
+
+MyPair<View, Owner> h1(int* x);
+MyPair<Owner, View> h2(int* x);
+MyPair<Owner, Owner> h3(int* x);
+
+template<typename F, typename S>
+struct SWIFT_ESCAPABLE_IF(F, Missing) MyPair2 {
+    F first;
+    S second;
+};
+
+template<typename F, int S>
+struct SWIFT_ESCAPABLE_IF(F, S) MyType {
+    F field;
+};
+
+MyPair2<Owner, Owner> i1();
+MyType<Owner, 0> i2();
+
 //--- test.swift
 
 import Test
@@ -50,7 +74,18 @@ public func noAnnotations() -> View {
     // CHECK-NOT: nonescapable.h:19
     f2(nil, nil)
     // CHECK: nonescapable.h:23:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
-    // CHECKL nonescapable.h:23:6: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    // CHECK: nonescapable.h:23:6: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
     g(nil)
+    h1(nil)
+    // CHECK: nonescapable.h:33:21: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    h2(nil)
+    // CHECK: nonescapable.h:34:21: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    h3(nil)
+    i1()
+    // CHECK: nonescapable.h:38:39: error: template parameter 'Missing' does not exist
+    i2()
+    // CHECK: nonescapable.h:44:33: error: template parameter 'S' expected to be a type parameter
+    // CHECK-NOT: error
+    // CHECK-NOT: warning
     return View()
 }


### PR DESCRIPTION
This PR adds a variadic macro that builds a SwiftAttr string containing the names of the template type parameters that need to be escapable for the type to be considered escapable. It also adds logic to interpret this annotation.

rdar://139065437
