### PR TITLE
[CSSimplify] CGFloat-Double: Fix ambiguity when assigning CGFloat to …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14664,13 +14664,26 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   case ConversionRestrictionKind::CGFloatToDouble: {
     // Prefer CGFloat -> Double over other way araund.
     auto impact =
-        restriction == ConversionRestrictionKind::CGFloatToDouble ? 1 : 10;
+        restriction == ConversionRestrictionKind::CGFloatToDouble ? 2 : 10;
 
     if (restriction == ConversionRestrictionKind::DoubleToCGFloat) {
       if (auto *anchor = locator.trySimplifyToExpr()) {
         if (auto depth = getExprDepth(anchor))
           impact = (*depth + 1) * impact;
       }
+    } else if (locator.directlyAt<AssignExpr>() ||
+               locator.endsWith<LocatorPathElt::ContextualType>()) {
+      // Situations like:
+      //
+      //  let _: Double = <<CGFloat>>
+      //  <var/property of type Double> = <<CGFloat>>
+      //
+      // Used to be supported due to an incorrect fix added in
+      // diagnostic mode. Lower impact here means that right-hand
+      // side of the assignment is allowed to maintain CGFloat
+      // until the very end which minimizes the number of conversions
+      // used and keeps literals as Double when possible.
+      impact = 1;
     }
 
     increaseScore(SK_ImplicitValueConversion, locator, impact);

--- a/validation-test/Sema/implicit_cgfloat_double_conversion_correctness.swift
+++ b/validation-test/Sema/implicit_cgfloat_double_conversion_correctness.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: objc_interop
+
+// Note this cannot use a fake Foundation because it lacks required operator overloads
+
+import Foundation
+import CoreGraphics
+
+do {
+  func test(a: CGFloat, b: CGFloat) {
+    let _: Double = a + b + 1 // Ok
+    let _: Double = a + b + 1.0 // Ok
+
+    var test: Double
+
+    test = a + b + 1 // Ok
+    test = a + b + 1.0 // Ok
+
+    _ = test
+
+    let _ = a + b + 1 // Ok
+    let _ = a + b + 1.0 // Ok
+
+    let _: Double = 1 + 2 + 3 // Ok
+
+    test = 1 + 2 + 3 // Ok
+  }
+}
+
+func test(cond: Bool, a: CGFloat, b: CGFloat) {
+  var test: Double
+
+  let width = a - b // CGFloat
+
+  if cond {
+    test = (width - 10) / 2 // Ok
+  } else {
+    test = (width - 20.0) / 3 // Ok
+  }
+
+  _ = test
+}
+
+func test_atan_ambiguity(points: (CGPoint, CGPoint)) {
+  var test = 0.0
+  test = atan((points.1.y - points.0.y) / (points.1.x - points.0.x)) // Ok
+  _ = test
+}


### PR DESCRIPTION
…double property/variable

Situations like:
```
  let _: Double = <<CGFloat>>
  <var/property of type Double> = <<CGFloat>>
```

Used to be supported due to an incorrect fix added in
diagnostic mode. Lower impact here means that right-hand
side of the assignment is allowed to maintain CGFloat
until the very end which minimizes the number of conversions
used and keeps literals as Double when possible.

Resolves: rdar://139675914

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
