### PR TITLE
[embedded] Enable integer parsing in Embedded Swift

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -93,7 +93,7 @@ split_embedded_sources(
   EMBEDDED Identifiable.swift
   EMBEDDED Indices.swift
   EMBEDDED InputStream.swift
-    NORMAL IntegerParsing.swift
+  EMBEDDED IntegerParsing.swift
   EMBEDDED Integers.swift
     NORMAL Join.swift
   EMBEDDED KeyPath.swift

--- a/test/embedded/stdlib-parsing.swift
+++ b/test/embedded/stdlib-parsing.swift
@@ -1,0 +1,19 @@
+// RUN: %target-run-simple-swift(-Osize -swift-version 5 -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+@main
+struct Main {
+  static func main() {
+    print(Int("42")!)
+    // CHECK: 42
+    print(Int("-123")!)
+    // CHECK: -123
+    print(Int("1000", radix: 16)!)
+    // CHECK: 4096
+  }
+}


### PR DESCRIPTION
Straightforward addition of `stdlib/public/core/IntegerParsing.swift` into the embedded stdlib.

rdar://139729135
