### PR TITLE
IRGen: Adjust hacks for keypaths to protocol extension members

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -343,8 +343,10 @@ std::string ASTMangler::mangleKeyPathGetterThunkHelper(
       // FIXME: This seems wrong. We used to just mangle opened archetypes as
       // their interface type. Let's make that explicit now.
       sub = sub.transformRec([](Type t) -> std::optional<Type> {
-        if (auto *openedExistential = t->getAs<OpenedArchetypeType>())
-          return openedExistential->getInterfaceType();
+        if (auto *openedExistential = t->getAs<OpenedArchetypeType>()) {
+          auto &ctx = openedExistential->getASTContext();
+          return GenericTypeParamType::getType(0, 0, ctx);
+        }
         return std::nullopt;
       });
 
@@ -377,8 +379,10 @@ std::string ASTMangler::mangleKeyPathSetterThunkHelper(
       // FIXME: This seems wrong. We used to just mangle opened archetypes as
       // their interface type. Let's make that explicit now.
       sub = sub.transformRec([](Type t) -> std::optional<Type> {
-        if (auto *openedExistential = t->getAs<OpenedArchetypeType>())
-          return openedExistential->getInterfaceType();
+        if (auto *openedExistential = t->getAs<OpenedArchetypeType>()) {
+          auto &ctx = openedExistential->getASTContext();
+          return GenericTypeParamType::getType(0, 0, ctx);
+        }
         return std::nullopt;
       });
 

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1573,8 +1573,10 @@ public:
       astType =
           astType
               .transformRec([](Type t) -> std::optional<Type> {
-                if (auto *openedExistential = t->getAs<OpenedArchetypeType>())
-                  return openedExistential->getInterfaceType();
+                if (auto *openedExistential = t->getAs<OpenedArchetypeType>()) {
+                  auto &ctx = openedExistential->getASTContext();
+                  return GenericTypeParamType::getType(0, 0, ctx);
+                }
                 return std::nullopt;
               })
               ->getCanonicalType();

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -784,8 +784,10 @@ emitKeyPathComponent(IRGenModule &IGM,
               substType = substType
                               .transformRec([](Type t) -> std::optional<Type> {
                                 if (auto *openedExistential =
-                                        t->getAs<OpenedArchetypeType>())
-                                  return openedExistential->getInterfaceType();
+                                        t->getAs<OpenedArchetypeType>()) {
+                                  auto &ctx = openedExistential->getASTContext();
+                                  return GenericTypeParamType::getType(0, 0, ctx);
+                                }
                                 return std::nullopt;
                               })
                               ->getCanonicalType();

--- a/test/IRGen/Inputs/keypath_protocol_extension_other.swift
+++ b/test/IRGen/Inputs/keypath_protocol_extension_other.swift
@@ -1,0 +1,7 @@
+public protocol P<A> {
+  associatedtype A
+}
+
+extension P {
+  public var value: Bool { true }
+}

--- a/test/IRGen/keypath_protocol_extension.swift
+++ b/test/IRGen/keypath_protocol_extension.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/keypath_protocol_extension_other.swift -emit-module-path %t/keypath_protocol_extension_other.swiftmodule
+// RUN: %target-swift-frontend -emit-ir %s -I %t
+
+import keypath_protocol_extension_other
+
+public func foo(array: [any P<String>]) {
+  _ = array.filter(\.value)
+}


### PR DESCRIPTION
This was never implemented properly, but it works sometimes.

When the protocol is parameterized, it started crashing in a new way, because the interface type of an existential is now derived from the generalization signature, which will have nothing to do with the signature that IRGen is passing in here.

Tweak the workaround to keep things limping along.

Fixes rdar://problem/139745699