### PR TITLE
IRGen: Omit property descriptors from #_hasSymbol checks for static properties

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -359,14 +359,14 @@ class LinkEntity {
     BaseConformanceDescriptor,
 
     /// A global function pointer for dynamically replaceable functions.
-    /// The pointer is a AbstractStorageDecl*.
+    /// The pointer is a AbstractFunctionDecl*.
     DynamicallyReplaceableFunctionVariableAST,
 
-    /// The pointer is a AbstractStorageDecl*.
+    /// The pointer is a AbstractFunctionDecl*.
     DynamicallyReplaceableFunctionKeyAST,
 
     /// The original implementation of a dynamically replaceable function.
-    /// The pointer is a AbstractStorageDecl*.
+    /// The pointer is a AbstractFunctionDecl*.
     DynamicallyReplaceableFunctionImpl,
 
     /// The once token used by cacheCanonicalSpecializedMetadata, by way of
@@ -1473,6 +1473,11 @@ public:
     return reinterpret_cast<ExtensionDecl*>(Pointer);
   }
 
+  const AbstractStorageDecl *getAbstractStorageDecl() const {
+    assert(getKind() == Kind::PropertyDescriptor);
+    return reinterpret_cast<AbstractStorageDecl *>(Pointer);
+  }
+
   const PointerUnion<DeclContext *, VarDecl *> getAnonymousDeclContext() const {
     assert(getKind() == Kind::AnonymousDescriptor);
     return PointerUnion<DeclContext *, VarDecl *>
@@ -1631,6 +1636,9 @@ public:
            getKind() == Kind::DispatchThunkInitializer ||
            getKind() == Kind::DispatchThunkAllocator ||
            getKind() == Kind::DispatchThunkDerivative;
+  }
+  bool isPropertyDescriptor() const {
+    return getKind() == Kind::PropertyDescriptor;
   }
   bool isNominalTypeDescriptor() const {
     return getKind() == Kind::NominalTypeDescriptor;

--- a/lib/IRGen/GenHasSymbol.cpp
+++ b/lib/IRGen/GenHasSymbol.cpp
@@ -109,6 +109,13 @@ public:
   }
 
   void addLinkEntity(LinkEntity entity) override {
+    // Skip property descriptors for static properties, which were only
+    // introduced with SE-0438 and are therefore not present in all libraries.
+    if (entity.isPropertyDescriptor()) {
+      if (entity.getAbstractStorageDecl()->isStatic())
+        return;
+    }
+
     if (entity.hasSILFunction()) {
       addFunction(entity.getSILFunction());
       return;

--- a/test/IRGen/Inputs/has_symbol/has_symbol_helper.swift
+++ b/test/IRGen/Inputs/has_symbol/has_symbol_helper.swift
@@ -37,6 +37,7 @@ extension P {
 
 public struct S {
   public var member: Int
+  public static var staticMember: Int = 0
 
   public init(member: Int) {
     self.member = member

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -159,6 +159,9 @@ public func testStruct(_ s: S) {
   // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1SV6memberSivpTwS"()
   if #_hasSymbol(s.member) {}
 
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1SV12staticMemberSivpZTwS"()
+  if #_hasSymbol(S.staticMember) {}
+
   // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1SV6method4withySi_tFTwS"()
   if #_hasSymbol(s.method(with:)) {}
 }
@@ -172,6 +175,15 @@ public func testStruct(_ s: S) {
 // CHECK:   [[V4:%.*]] = and i1 [[V2]], [[V3]]
 // CHECK:   [[V5:%.*]] = icmp ne ptr @"$s17has_symbol_helper1SV6memberSivM", null
 // CHECK:   [[RES:%.*]] = and i1 [[V4]], [[V5]]
+// CHECK:   ret i1 [[RES]]
+
+// --- S.staticMember ---
+// CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper1SV12staticMemberSivpZTwS"()
+// CHECK:   [[V0:%.*]] = icmp ne ptr @"$s17has_symbol_helper1SV12staticMemberSivgZ", null
+// CHECK:   [[V1:%.*]] = icmp ne ptr @"$s17has_symbol_helper1SV12staticMemberSivsZ", null
+// CHECK:   [[V2:%.*]] = and i1 [[V0]], [[V1]]
+// CHECK:   [[V3:%.*]] = icmp ne ptr @"$s17has_symbol_helper1SV12staticMemberSivMZ", null
+// CHECK:   [[RES:%.*]] = and i1 [[V2]], [[V3]]
 // CHECK:   ret i1 [[RES]]
 
 // --- S.method(with:) ---


### PR DESCRIPTION
Property descriptors for static properties were only recently introduced with SE-438. Since these symbols are not present in Swift libraries that were compiled with earlier versions of the compiler, it is not safe for `#_hasSymbol` to check for the property descriptor symbols, since they can be absent at either link time or runtime.

Resolves rdar://139749275.