### PR TITLE
ArrayElementValuePropagation: require that the initialization and element-get are in the same block for non-trivial values.

### DIFF
--- a/test/SILOptimizer/array_element_propagation_crash.swift
+++ b/test/SILOptimizer/array_element_propagation_crash.swift
@@ -15,7 +15,24 @@ func testit(_ arr: inout [Int]) {
 var a = [27]
 testit(&a)
 
+// Second test case:
+var gg = ""
+
+@inline(never)
+func use(_ s: String) {
+  gg = s
+}
+
+func testLoop() {
+  let a = [""]
+
+  for _ in 0..<1000 {
+    use(a[0])
+  }
+}
+
 // As a bonus, also check if the code works as expected.
 // CHECK: [27, 28]
 print(a)
 
+testLoop()


### PR DESCRIPTION
In OSSA we only insert a copy_value of the element at the array initialization point. This would result in an over-consume if the getElement is in a loop. Therefore require that both semantic calls are in the same block.

Fixes an ownership verifier crash when OSSA modules are enabled.
