### PR TITLE
Revert "[cxx-interop] Check the presence of copy constructor correctly"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7652,26 +7652,18 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
   if (decl->isInStdNamespace() && decl->getIdentifier() &&
       decl->getName() == "_Optional_construct_base")
     return true;
-  // Hack for std::vector::const_iterator from libstdc++, which uses an extra
-  // parameter on its copy constructor, which has a defaulted enable_if value.
-  auto namespaceContext = dyn_cast_or_null<clang::NamespaceDecl>(
-      decl->getEnclosingNamespaceContext());
-  if (namespaceContext && namespaceContext->getIdentifier() &&
-      namespaceContext->getName() == "__gnu_cxx" && decl->getIdentifier() &&
-      decl->getName() == "__normal_iterator")
-    return true;
-  // Hack for certain build configurations of SwiftCompilerSources
-  // (rdar://138924133).
-  if (decl->getIdentifier() && decl->getName() == "BridgedSwiftObject")
-    return true;
 
   // If we have no way of copying the type we can't import the class
   // at all because we cannot express the correct semantics as a swift
   // struct.
-  return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-    return ctor->isCopyConstructor() && !ctor->isDeleted() &&
-           ctor->getAccess() == clang::AccessSpecifier::AS_public;
-  });
+  if (llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
+        return ctor->isCopyConstructor() &&
+               (ctor->isDeleted() || ctor->getAccess() != clang::AS_public);
+      }))
+    return false;
+
+  // TODO: this should probably check to make sure we actually have a copy ctor.
+  return true;
 }
 
 static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -71,25 +71,6 @@ struct TemplatedConstructorWithExtraArg {
   TemplatedConstructorWithExtraArg(T value, U other) { }
 };
 
-struct TemplatedCopyConstructor {
-  int x = 0;
-
-  TemplatedCopyConstructor(int x) : x(x) {}
-
-  template <class T>
-  TemplatedCopyConstructor(const T &value) : x(value.x) {}
-};
-
-struct TemplatedCopyConstructorWithExtraArg {
-  int x = 0;
-
-  TemplatedCopyConstructorWithExtraArg(int x) : x(x) {}
-
-  template <class T>
-  TemplatedCopyConstructorWithExtraArg(const T &value, int add = 0)
-      : x(value.x + add) {}
-};
-
 struct __attribute__((swift_attr("import_unsafe")))
 HasUserProvidedCopyConstructor {
   int numCopies;

--- a/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-copy-module-interface.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: struct TemplatedCopyConstructor
-// CHECK: struct TemplatedCopyConstructorWithExtraArg
-
 // Make sure we don't import non-copyable types because we will have no way to
 // represent and copy/move these in swift with correct semantics.
 // CHECK-NOT: DeletedCopyConstructor

--- a/test/Interop/Cxx/class/constructors-typechecker.swift
+++ b/test/Interop/Cxx/class/constructors-typechecker.swift
@@ -2,8 +2,6 @@
 
 import Constructors
 
-func takesCopyable<T: Copyable>(_ x: T.Type) {}
-
 let explicit = ExplicitDefaultConstructor()
 
 let implicit = ImplicitDefaultConstructor()
@@ -14,8 +12,3 @@ let onlyCopyAndMove = CopyAndMoveConstructor() // expected-warning {{'init()' is
 let deletedExplicitly = DefaultConstructorDeleted() // expected-error {{missing argument for parameter 'a' in call}}
 
 let withArg = ConstructorWithParam(42)
-
-let _ = TemplatedCopyConstructor(123)
-let _ = TemplatedCopyConstructorWithExtraArg(123)
-takesCopyable(TemplatedCopyConstructor.self)
-takesCopyable(TemplatedCopyConstructorWithExtraArg.self)


### PR DESCRIPTION
This reverts commit fbbec48c

The change was causing regressions in certain build configs that need to be investigated.

rdar://139723218

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
