### PR TITLE
Revert "[NFC][CMake] Disable use of in-process 'libSwiftScan' queries when building the Standard Library"

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -300,11 +300,6 @@ elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WINDOWS")
   list(APPEND swift_core_private_link_libraries shell32;DbgHelp;Synchronization)
 endif()
 
-# There is a race condition with building the 'tools' CMake build of the compiler,
-# which produces libSwiftScan that the compiler building the standard library may attempt to use. 
-# Since the current build system makes establishing this dependency relationship exceedingly difficult,
-# we attempt to work around it by disabling use of 'libSwiftScan' here.
-list(APPEND swift_stdlib_compile_flags "-nonlib-dependency-scanner")
 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
@@ -457,7 +452,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
         ${swift_stdlib_compile_flags} -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
-        -Xfrontend -enable-ossa-modules -nonlib-dependency-scanner
+        -Xfrontend -enable-ossa-modules
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"


### PR DESCRIPTION
Reverts swiftlang/swift#77601

https://github.com/swiftlang/swift/pull/77606 is the more-principled solution to the problem we were seeing. 