### PR TITLE
[release/6.0][android] pick fixes for building Android stdlib and swift-foundation to swift 6

### DIFF
--- a/cmake/caches/Runtime-Android-i686.cmake
+++ b/cmake/caches/Runtime-Android-i686.cmake
@@ -1,0 +1,24 @@
+
+set(SWIFT_HOST_VARIANT_SDK ANDROID CACHE STRING "")
+set(SWIFT_HOST_VARIANT_ARCH i686 CACHE STRING "")
+
+# NOTE(compnerd) disable the tools, we are trying to build just the standard
+# library.
+set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build tests since the tests require the toolchain
+set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build docs since that requires perl
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+
+# NOTE(compnerd) these are part of the toolchain, not the runtime.
+set(SWIFT_BUILD_SOURCEKIT NO CACHE BOOL "")
+
+# NOTE(compnerd) build with the compiler specified, not a just built compiler.
+set(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER YES CACHE BOOL "")
+
+set(SWIFT_SDK_ANDROID_ARCHITECTURES i686 CACHE STRING "")
+
+# NOTE(compnerd) this is lollipop, which seems to still have decent usage.
+set(SWIFT_ANDROID_API_LEVEL 21 CACHE STRING "")

--- a/cmake/caches/Runtime-Android-x86_64.cmake
+++ b/cmake/caches/Runtime-Android-x86_64.cmake
@@ -1,0 +1,24 @@
+
+set(SWIFT_HOST_VARIANT_SDK ANDROID CACHE STRING "")
+set(SWIFT_HOST_VARIANT_ARCH x86_64 CACHE STRING "")
+
+# NOTE(compnerd) disable the tools, we are trying to build just the standard
+# library.
+set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build tests since the tests require the toolchain
+set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build docs since that requires perl
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+
+# NOTE(compnerd) these are part of the toolchain, not the runtime.
+set(SWIFT_BUILD_SOURCEKIT NO CACHE BOOL "")
+
+# NOTE(compnerd) build with the compiler specified, not a just built compiler.
+set(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER YES CACHE BOOL "")
+
+set(SWIFT_SDK_ANDROID_ARCHITECTURES x86_64 CACHE STRING "")
+
+# NOTE(compnerd) this is lollipop, which seems to still have decent usage.
+set(SWIFT_ANDROID_API_LEVEL 21 CACHE STRING "")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -553,13 +553,16 @@ function(_add_target_variant_link_flags)
     list(APPEND link_libraries "dl" "log")
     # We need to add the math library, which is linked implicitly by libc++
     list(APPEND result "-lm")
-    if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
-      if("${SWIFT_ANDROID_NDK_PATH}" MATCHES "r26")
-        file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib/clang/*)
-      else()
-        file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+    if(NOT CMAKE_HOST_SYSTEM MATCHES Windows)
+      # The Android resource dir is specified from build.ps1 on windows.
+      if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
+        if("${SWIFT_ANDROID_NDK_PATH}" MATCHES "r26")
+          file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib/clang/*)
+        else()
+          file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+        endif()
+        list(APPEND result "-resource-dir=${RESOURCE_DIR}")
       endif()
-      list(APPEND result "-resource-dir=${RESOURCE_DIR}")
     endif()
 
     # link against the custom C++ library
@@ -3233,9 +3236,14 @@ function(add_swift_target_executable name)
       # it tries to build swift-backtrace it fails because *the compiler*
       # refers to a libswiftCore.so that can't be found.
 
+      if(SWIFTEXE_TARGET_NOSWIFTRT)
+        set(NOSWIFTRT_KEYWORD "NOSWIFTRT")
+      else()
+        set(NOSWIFTRT_KEYWORD "")
+      endif()
       _add_swift_target_executable_single(
           ${VARIANT_NAME}
-          ${SWIFTEXE_TARGET_NOSWIFTRT_keyword}
+          ${NOSWIFTRT_KEYWORD}
           ${SWIFTEXE_TARGET_SOURCES}
           DEPENDS
             ${SWIFTEXE_TARGET_DEPENDS_with_suffix}

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -1,25 +1,28 @@
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(BUILTIN_FLOAT_SWIFT_FLAGS -Xfrontend -module-abi-name -Xfrontend Darwin)
-else()
-  set(BUILTIN_FLOAT_SWIFT_FLAGS)
+if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(BUILTIN_FLOAT_SWIFT_FLAGS -Xfrontend -module-abi-name -Xfrontend Darwin)
+  else()
+    set(BUILTIN_FLOAT_SWIFT_FLAGS)
+  endif()
+
+  add_swift_target_library(swift_Builtin_float
+      ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
+      IS_SDK_OVERLAY
+
+      linker-support/magic-symbols-for-install-name.c
+
+      GYB_SOURCES
+        float.swift.gyb
+
+      SWIFT_COMPILE_FLAGS
+        ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
+        ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+        ${BUILTIN_FLOAT_SWIFT_FLAGS}
+
+      LINK_FLAGS
+        ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}
+
+      INSTALL_IN_COMPONENT stdlib
+      MACCATALYST_BUILD_FLAVOR zippered)
 endif()
-
-add_swift_target_library(swift_Builtin_float
-    ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
-    IS_SDK_OVERLAY
-
-    linker-support/magic-symbols-for-install-name.c
-
-    GYB_SOURCES
-      float.swift.gyb
-
-    SWIFT_COMPILE_FLAGS
-      ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
-      ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-      ${BUILTIN_FLOAT_SWIFT_FLAGS}
-
-    LINK_FLAGS
-      ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}
-
-    INSTALL_IN_COMPONENT stdlib
-    MACCATALYST_BUILD_FLAVOR zippered)

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -47,6 +47,9 @@ struct MinimalDispatchObjectHeader {
   int Opaque1;
   void *Linkage;
 };
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-offsetof-extensions"
 static_assert(
     offsetof(Job, metadata) == offsetof(MinimalDispatchObjectHeader, VTable),
     "Job Metadata field must match location of Dispatch VTable field.");
@@ -54,6 +57,7 @@ static_assert(offsetof(Job, SchedulerPrivate[Job::DispatchLinkageIndex]) ==
                   offsetof(MinimalDispatchObjectHeader, Linkage),
               "Dispatch Linkage field must match Job "
               "SchedulerPrivate[DispatchLinkageIndex].");
+#pragma clang diagnostic pop
 
 /// The function passed to dispatch_async_f to execute a job.
 static void __swift_run_job(void *_job) {

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -473,10 +473,23 @@ if("ANDROID" IN_LIST SWIFT_SDKS)
     endif()
   endforeach()
 
+  set(android_posix_filesystem_apinotes_source "posix_filesystem.apinotes")
+  set(apinotes_subdir "${SWIFTLIB_DIR}/apinotes")
+  add_custom_command_target(
+    copy_android_posix_filesystem_apinotes_resource
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "make_directory" ${apinotes_subdir}
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${android_posix_filesystem_apinotes_source}" ${apinotes_subdir}
+    OUTPUT ${apinotes_subdir}/${android_posix_filesystem_apinotes_source}
+    COMMENT "Copying Android posix_filesystem API notes to resource directories")
+  add_dependencies(sdk-overlay ${copy_android_posix_filesystem_apinotes_resource})
+  list(APPEND android_modulemap_target_list ${copy_android_posix_filesystem_apinotes_resource})
   swift_install_in_component(FILES
-      posix_filesystem.apinotes
-    DESTINATION "share"
-    COMPONENT sdk-overlay)
+                              "${android_posix_filesystem_apinotes_source}"
+                             DESTINATION "lib/swift/apinotes"
+                             COMPONENT sdk-overlay)
 endif()
 add_custom_target(android_modulemap DEPENDS ${android_modulemap_target_list})
 set_property(TARGET android_modulemap PROPERTY FOLDER "Miscellaneous")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -472,6 +472,11 @@ if("ANDROID" IN_LIST SWIFT_SDKS)
                                  COMPONENT sdk-overlay)
     endif()
   endforeach()
+
+  swift_install_in_component(FILES
+      posix_filesystem.apinotes
+    DESTINATION "share"
+    COMPONENT sdk-overlay)
 endif()
 add_custom_target(android_modulemap DEPENDS ${android_modulemap_target_list})
 set_property(TARGET android_modulemap PROPERTY FOLDER "Miscellaneous")

--- a/stdlib/public/Platform/posix_filesystem.apinotes
+++ b/stdlib/public/Platform/posix_filesystem.apinotes
@@ -1,0 +1,7 @@
+---
+Name: bionic
+Functions:
+- Name: fts_open
+  Parameters:
+  - Position: 0
+    Type: "char * const _Nullable * _Nonnull"

--- a/stdlib/tools/swift-reflection-test/CMakeLists.txt
+++ b/stdlib/tools/swift-reflection-test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_target_executable(swift-reflection-test BUILD_WITH_STDLIB
+  NOSWIFTRT
   swift-reflection-test.c
   overrides.c
   LINK_LIBRARIES


### PR DESCRIPTION
  - **Explanation**:
   This change adds missing cherry-picks for building Android stdlib and swift-foundation to swift 6.
  
    These changes add missing cache files for x86_64 and x86 stdlib, ensures that builtin float isn't built for Android, fixes two minor stdlib build issues, adds `"-Wgnu-offsetof-extensions"` pragma to avoid a compile error, and introduces the posix_filesystem.apinotes file that is needed to build swift-foundation.

  - **Scope**:
   Cmake Stdlib build.

  - **Issues**:
    N/A
  - **Original PRs**:
  PRs:
  #72014 
   #75494 
  #74829

  picks:
  - 7a5a0aad22f1cb13b820681e48a50fbc34caca98
  - 7815f843a34888d7492fa58c2b14d4ee296ae58c
  - 5905dc9ef3b5e4b0df4669c983a006cace483f04
  - 47f9d789900a4c3c74b34863915830bd2558747e
  - c03627014e25e357f1d554e3d4c4d6d34bf39ce6
  - **Risk**:
    Relatively low. Impacts mostly on Android bits, and introduces a cmake flag for hiding the build of builtin float overlay. Also fixes `NOSWIFTRT` flag used when building the stdlib's swift-reflection-test.
  - **Testing**:
    Local android build testing, and thebrowsercompany/swift-build build testing.
    Validated when building the windows stdlib as well.
  - **Reviewers**:
    @compnerd 
