### PR TITLE
[6.0][IRGen+Runtime] Fix tag bit mask handling for objc, unknown objects a…

### DIFF
--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -661,6 +661,17 @@ public enum OneExtraTagValue {
     case z
 }
 
+public enum ErrorWrapper {
+    case x(Error)
+    case y(Error)
+}
+
+public enum MultiPayloadAnyObject {
+    case x(AnyObject)
+    case y(AnyObject)
+    case z(AnyObject)
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_objc.swift
+++ b/test/Interpreter/layout_string_witnesses_objc.swift
@@ -90,3 +90,101 @@ func testMultiPayloadObjCExistentialWrapper() {
 }
 
 testMultiPayloadObjCExistentialWrapper()
+
+@objc
+class SwiftObjC: NSObject {
+    deinit {
+        print("SwiftObjC deinitialized!")
+    }
+}
+
+enum MultiPayloadNativeSwiftObjC {
+    case x(SwiftObjC)
+    case y(SwiftObjC)
+    case z(SwiftObjC)
+}
+
+func testMultiPayloadNativeSwiftObjC() {
+    let ptr = allocateInternalGenericPtr(of: MultiPayloadNativeSwiftObjC.self)
+
+    do {
+        let x = MultiPayloadNativeSwiftObjC.y(SwiftObjC())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = MultiPayloadNativeSwiftObjC.z(SwiftObjC())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SwiftObjC deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SwiftObjC deinitialized!
+    testGenericDestroy(ptr, of: MultiPayloadNativeSwiftObjC.self)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadNativeSwiftObjC()
+
+public enum MultiPayloadBlock {
+#if _pointerBitWidth(_32)
+    public typealias PaddingPayload = (Int16, Int8, Bool)
+#else
+    public typealias PaddingPayload = (Int32, Int16, Int8, Bool)
+#endif
+
+    case x(PaddingPayload)
+    case y(@convention(block) () -> Void)
+}
+
+func testMultiPayloadBlock() {
+    let ptr = UnsafeMutablePointer<MultiPayloadBlock>.allocate(capacity: 1)
+
+    // initWithCopy
+    do {
+        let instance = SimpleClass(x: 0)
+        let x = MultiPayloadBlock.y({ print(instance) })
+        testInit(ptr, to: x)
+    }
+
+    // assignWithTake
+    do {
+        let instance = SimpleClass(x: 1)
+        let y = MultiPayloadBlock.y({ print(instance) })
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        let instance = SimpleClass(x: 2)
+        var z = MultiPayloadBlock.y({ print(instance) })
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadBlock()

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1348,6 +1348,49 @@ func testMultiPayloadOneExtraTagValue() {
 
 testMultiPayloadOneExtraTagValue()
 
+func testMultiPayloadAnyObject() {
+    let ptr = UnsafeMutablePointer<MultiPayloadAnyObject>.allocate(capacity: 1)
+
+    // initWithCopy
+    do {
+        let x = MultiPayloadAnyObject.y(SimpleClass(x: 0))
+        testInit(ptr, to: x)
+    }
+
+    // assignWithTake
+    do {
+        let y = MultiPayloadAnyObject.z(SimpleClass(x: 1))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        var z = MultiPayloadAnyObject.z(SimpleClass(x: 2))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadAnyObject()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
…nd blocks

- Explanation: On platforms that don't have reserved bits in objc (including unknown) pointers, we use the spare bits for Swift enums, so they have to be masked out. Blocks don't have reserved bits on any platform.
- Scope: Compact value witnesses runtime.
- Issues: rdar://138487964, rdar://139830282
- Original PRs: https://github.com/swiftlang/swift/pull/77431
- Risk: Low. Only touches cases that are already broken today and only on the affected platforms.
- Testing: Added regression tests.
- Reviewers: @mikeash 