### PR TITLE
[Clang importer] Use ParseSourceFileRequest for parsing swift_attr attributes

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -694,11 +694,6 @@ BridgedInlineAttr BridgedInlineAttr_createParsed(BridgedASTContext cContext,
                                                  BridgedSourceRange cRange,
                                                  BridgedInlineKind cKind);
 
-SWIFT_NAME("BridgedMainTypeAttr.createParsed(_:atLoc:nameLoc:)")
-BridgedMainTypeAttr BridgedMainTypeAttr_createParsed(BridgedASTContext cContext,
-                                                     BridgedSourceLoc cAtLoc,
-                                                     BridgedSourceLoc cNameLoc);
-
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedMacroSyntax {
   BridgedMacroSyntaxFreestanding,
   BridgedMacroSyntaxAttached,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1164,7 +1164,7 @@ public:
     return DA->getKind() == DeclAttrKind::TypeEraser;
   }
 
-  UNIMPLEMENTED_CLONE(DynamicReplacementAttr)
+  UNIMPLEMENTED_CLONE(TypeEraserAttr)
 };
 
 /// Represents any sort of access control modifier.
@@ -2814,7 +2814,7 @@ public:
     return DA->getKind() == DeclAttrKind::RawLayout;
   }
 
-  UNIMPLEMENTED_CLONE(MacroRoleAttr)
+  UNIMPLEMENTED_CLONE(RawLayoutAttr)
 };
 
 class LifetimeAttr final : public DeclAttribute {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1904,7 +1904,7 @@ public:
 
   /// Create a copy of this attribute.
   CustomAttr *clone(ASTContext &ctx) const {
-    return create(ctx, AtLoc, getTypeExpr(), isImplicit());
+    return create(ctx, AtLoc, getTypeExpr(), initContext, argList, isImplicit());
   }
 
 private:

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -495,7 +495,16 @@ public:
   static DeclAttribute *createSimple(const ASTContext &context,
                                      DeclAttrKind kind, SourceLoc atLoc,
                                      SourceLoc attrLoc);
+
+  /// Create a copy of this attribute.
+  DeclAttribute *clone(ASTContext &ctx) const;
 };
+
+#define UNIMPLEMENTED_CLONE(AttrType)    \
+AttrType *clone(ASTContext &ctx) const { \
+    llvm_unreachable("unimplemented");   \
+    return nullptr;                      \
+  }
 
 /// Describes a "simple" declaration attribute that carries no data.
 template<DeclAttrKind Kind>
@@ -504,16 +513,22 @@ public:
   SimpleDeclAttr(bool IsImplicit)
     : DeclAttribute(Kind, SourceLoc(), SourceLoc(), IsImplicit) {}
 
-  SimpleDeclAttr(SourceLoc AtLoc, SourceLoc NameLoc)
+  SimpleDeclAttr(SourceLoc AtLoc, SourceLoc NameLoc, bool Implicit = false)
     : DeclAttribute(Kind, AtLoc,
                     SourceRange(AtLoc.isValid() ? AtLoc : NameLoc, NameLoc),
-                    /*Implicit=*/false) { }
+                    Implicit) { }
   SimpleDeclAttr(SourceLoc NameLoc)
     : DeclAttribute(Kind, SourceLoc(), SourceRange(NameLoc, NameLoc),
                     /*Implicit=*/false) { }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == Kind;
+  }
+
+  /// Create a copy of this attribute.
+  SimpleDeclAttr<Kind> *clone(ASTContext &ctx) const {
+    return new (ctx) SimpleDeclAttr<Kind>(
+        AtLoc, Range.Start, isImplicit());
   }
 };
 
@@ -542,6 +557,11 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::SILGenName;
   }
+
+  /// Create a copy of this attribute.
+  SILGenNameAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SILGenNameAttr(Name, Raw, AtLoc, Range, isImplicit());
+  }
 };
 
 /// Defines the @_section attribute.
@@ -560,6 +580,10 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Section;
   }
+
+  SectionAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SectionAttr(Name, AtLoc, Range, isImplicit());
+  }
 };
 
 /// Defines the @_cdecl attribute.
@@ -577,6 +601,10 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::CDecl;
+  }
+
+  CDeclAttr *clone(ASTContext &ctx) const {
+    return new (ctx) CDeclAttr(Name, AtLoc, Range, isImplicit());
   }
 };
 
@@ -597,6 +625,10 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Semantics;
   }
+
+  SemanticsAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SemanticsAttr(Value, AtLoc, Range, isImplicit());
+  }
 };
 
 /// Defines the @_alignment attribute.
@@ -612,6 +644,10 @@ public:
   
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Alignment;
+  }
+
+  AlignmentAttr *clone(ASTContext &ctx) const {
+    return new (ctx) AlignmentAttr(getValue(), AtLoc, Range, isImplicit());
   }
 };
 
@@ -638,6 +674,11 @@ public:
   
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::SwiftNativeObjCRuntimeBase;
+  }
+
+  SwiftNativeObjCRuntimeBaseAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SwiftNativeObjCRuntimeBaseAttr(
+        BaseClassName, AtLoc, Range, isImplicit());
   }
 };
 
@@ -810,6 +851,9 @@ public:
                                              AbstractFunctionDecl *AsyncFunc);
 
   AvailableAttr *clone(ASTContext &C, bool implicit) const;
+  AvailableAttr *clone(ASTContext &C) const {
+    return clone(C, isImplicit());
+  }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Available;
@@ -960,33 +1004,13 @@ public:
   }
 };
 
-class MainTypeAttr final : public DeclAttribute {
-public:
-  MainTypeAttr(bool isImplicit)
-      : DeclAttribute(DeclAttrKind::MainType, SourceLoc(), SourceLoc(),
-                      isImplicit) {}
-
-  MainTypeAttr(SourceLoc AtLoc, SourceLoc NameLoc)
-      : DeclAttribute(DeclAttrKind::MainType, AtLoc,
-                      SourceRange(AtLoc.isValid() ? AtLoc : NameLoc, NameLoc),
-                      /*Implicit=*/false) {}
-
-  MainTypeAttr(SourceLoc NameLoc)
-      : DeclAttribute(DeclAttrKind::MainType, SourceLoc(),
-                      SourceRange(NameLoc, NameLoc),
-                      /*Implicit=*/false) {}
-
-  static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DeclAttrKind::MainType;
-  }
-};
-
 class PrivateImportAttr final
 : public DeclAttribute {
   StringRef SourceFile;
 
   PrivateImportAttr(SourceLoc atLoc, SourceRange baseRange,
-                    StringRef sourceFile, SourceRange parentRange);
+                    StringRef sourceFile, SourceRange parentRange,
+                    bool implicit = false);
 
 public:
   static PrivateImportAttr *create(ASTContext &Ctxt, SourceLoc AtLoc,
@@ -998,6 +1022,12 @@ public:
   }
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::PrivateImport;
+  }
+
+  /// Create a copy of this attribute.
+  PrivateImportAttr *clone(ASTContext &ctx) const {
+    return new (ctx) PrivateImportAttr(
+        AtLoc, Range, SourceFile, SourceRange(), isImplicit());
   }
 };
 
@@ -1076,6 +1106,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::DynamicReplacement;
   }
+
+  UNIMPLEMENTED_CLONE(DynamicReplacementAttr)
 };
 
 /// The \c @_typeEraser(TypeEraserType) attribute.
@@ -1131,6 +1163,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::TypeEraser;
   }
+
+  UNIMPLEMENTED_CLONE(DynamicReplacementAttr)
 };
 
 /// Represents any sort of access control modifier.
@@ -1165,6 +1199,11 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::AccessControl;
   }
+
+  /// Create a copy of this attribute.
+  AccessControlAttr *clone(ASTContext &ctx) const {
+    return new (ctx) AccessControlAttr(AtLoc, Range, getAccess(), isImplicit());
+  }
 };
 
 /// Represents a 'private', 'internal', or 'public' marker for a setter on a
@@ -1178,6 +1217,11 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::SetterAccess;
+  }
+
+  /// Create a copy of this attribute.
+  SetterAccessAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SetterAccessAttr(AtLoc, Range, getAccess(), isImplicit());
   }
 };
 
@@ -1199,6 +1243,10 @@ public:
 
   SPIAccessControlAttr *clone(ASTContext &C, bool implicit) const;
 
+  SPIAccessControlAttr *clone(ASTContext &ctx) const {
+    return clone(ctx, isImplicit());
+  }
+
   /// Name of SPIs declared by the attribute.
   ///
   /// Note: A single SPI name per attribute is currently supported but this
@@ -1216,8 +1264,9 @@ public:
 /// Represents an inline attribute.
 class InlineAttr : public DeclAttribute {
 public:
-  InlineAttr(SourceLoc atLoc, SourceRange range, InlineKind kind)
-      : DeclAttribute(DeclAttrKind::Inline, atLoc, range, /*Implicit=*/false) {
+  InlineAttr(SourceLoc atLoc, SourceRange range, InlineKind kind,
+             bool implicit = false)
+      : DeclAttribute(DeclAttrKind::Inline, atLoc, range, implicit) {
     Bits.InlineAttr.kind = unsigned(kind);
   }
 
@@ -1228,14 +1277,18 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Inline;
   }
+
+  InlineAttr *clone(ASTContext &ctx) const {
+    return new (ctx) InlineAttr(AtLoc, Range, getKind(), isImplicit());
+  }
 };
 
 /// Represents the optimize attribute.
 class OptimizeAttr : public DeclAttribute {
 public:
-  OptimizeAttr(SourceLoc atLoc, SourceRange range, OptimizationMode mode)
-      : DeclAttribute(DeclAttrKind::Optimize, atLoc, range,
-                      /*Implicit=*/false) {
+  OptimizeAttr(SourceLoc atLoc, SourceRange range, OptimizationMode mode,
+               bool implicit = false)
+      : DeclAttribute(DeclAttrKind::Optimize, atLoc, range, implicit) {
     Bits.OptimizeAttr.mode = unsigned(mode);
   }
 
@@ -1247,6 +1300,10 @@ public:
   }
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Optimize;
+  }
+
+  OptimizeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) OptimizeAttr(AtLoc, Range, getMode(), isImplicit());
   }
 };
 
@@ -1262,9 +1319,9 @@ private:
   Mode mode;
 
 public:
-  ExclusivityAttr(SourceLoc atLoc, SourceRange range, Mode mode)
-      : DeclAttribute(DeclAttrKind::Exclusivity, atLoc, range,
-                      /*Implicit=*/false),
+  ExclusivityAttr(SourceLoc atLoc, SourceRange range, Mode mode,
+                  bool implicit = false)
+      : DeclAttribute(DeclAttrKind::Exclusivity, atLoc, range, implicit),
         mode(mode) {}
 
   ExclusivityAttr(Mode mode)
@@ -1274,6 +1331,10 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Exclusivity;
+  }
+
+  ExclusivityAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ExclusivityAttr(AtLoc, Range, getMode(), isImplicit());
   }
 };
 
@@ -1358,15 +1419,19 @@ class RawDocCommentAttr : public DeclAttribute {
   CharSourceRange CommentRange;
 
 public:
-  RawDocCommentAttr(CharSourceRange CommentRange)
+  RawDocCommentAttr(CharSourceRange CommentRange, bool Implicit = false)
       : DeclAttribute(DeclAttrKind::RawDocComment, SourceLoc(), SourceRange(),
-                      /*Implicit=*/false),
+                      Implicit),
         CommentRange(CommentRange) {}
 
   CharSourceRange getCommentRange() const { return CommentRange; }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::RawDocComment;
+  }
+
+  RawDocCommentAttr *clone(ASTContext &ctx) const {
+    return new (ctx) RawDocCommentAttr(CommentRange, isImplicit());
   }
 };
 
@@ -1390,6 +1455,10 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::ObjCBridged;
+  }
+
+  ObjCBridgedAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ObjCBridgedAttr(ObjCClass);
   }
 };
 
@@ -1429,6 +1498,11 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::SynthesizedProtocol;
+  }
+
+  SynthesizedProtocolAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SynthesizedProtocolAttr(
+        protocol, getLazyLoader(), isUnchecked());
   }
 };
 
@@ -1562,6 +1636,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Specialize;
   }
+
+  UNIMPLEMENTED_CLONE(SpecializeAttr)
 };
 
 class StorageRestrictionsAttr final
@@ -1604,6 +1680,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::StorageRestrictions;
   }
+
+  UNIMPLEMENTED_CLONE(StorageRestrictionsAttr)
 };
 
 /// The @_implements attribute, which treats a decl as the implementation for
@@ -1638,6 +1716,12 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Implements;
   }
+
+  /// Create a copy of this attribute.
+  ImplementsAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ImplementsAttr(
+        AtLoc, Range, TyR, getMemberName(), getMemberNameLoc());
+  }
 };
 
 /// A limited variant of \c \@objc that's used for classes with generic ancestry.
@@ -1661,6 +1745,11 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::ObjCRuntimeName;
   }
+
+  /// Create a copy of this attribute.
+  ObjCRuntimeNameAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ObjCRuntimeNameAttr(Name, AtLoc, Range, isImplicit());
+  }
 };
 
 /// Attribute that specifies a protocol conformance that has been restated
@@ -1678,6 +1767,11 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::RestatedObjCConformance;
+  }
+
+  /// Create a copy of this attribute.
+  RestatedObjCConformanceAttr *clone(ASTContext &ctx) const {
+    return new (ctx) RestatedObjCConformanceAttr(Proto);
   }
 };
 
@@ -1739,6 +1833,12 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::ClangImporterSynthesizedType;
+  }
+
+  /// Create a copy of this attribute.
+  ClangImporterSynthesizedTypeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ClangImporterSynthesizedTypeAttr(
+        originalTypeName, getKind());
   }
 };
 
@@ -1802,6 +1902,11 @@ public:
     return DA->getKind() == DeclAttrKind::Custom;
   }
 
+  /// Create a copy of this attribute.
+  CustomAttr *clone(ASTContext &ctx) const {
+    return create(ctx, AtLoc, getTypeExpr(), isImplicit());
+  }
+
 private:
   friend class CustomAttrNominalRequest;
   void resetTypeInformation(TypeExpr *repr);
@@ -1833,6 +1938,12 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::ProjectedValueProperty;
+  }
+
+  /// Create a copy of this attribute.
+  ProjectedValuePropertyAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ProjectedValuePropertyAttr(
+        ProjectionPropertyName, AtLoc, Range, isImplicit());
   }
 };
 
@@ -1878,6 +1989,12 @@ public:
   std::optional<ActiveVersion> isActivePlatform(const ASTContext &ctx) const;
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::OriginallyDefinedIn;
+  }
+
+  /// Create a copy of this attribute.
+  OriginallyDefinedInAttr *clone(ASTContext &ctx) const {
+    return new (ctx) OriginallyDefinedInAttr(
+        AtLoc, Range, OriginalModuleName, Platform, MovedVersion, isImplicit());
   }
 };
 
@@ -2026,6 +2143,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Differentiable;
   }
+
+  UNIMPLEMENTED_CLONE(DifferentiableAttr)
 };
 
 /// A declaration name with location.
@@ -2165,6 +2284,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Derivative;
   }
+
+  UNIMPLEMENTED_CLONE(DerivativeAttr)
 };
 
 /// The `@transpose(of:)` attribute registers a function as a transpose of
@@ -2249,6 +2370,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Transpose;
   }
+
+  UNIMPLEMENTED_CLONE(TransposeAttr)
 };
 
 enum class NonSendableKind : uint8_t {
@@ -2279,6 +2402,11 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::NonSendable;
   }
+
+  /// Create a copy of this attribute.
+  NonSendableAttr *clone(ASTContext &ctx) const {
+    return new (ctx) NonSendableAttr(AtLoc, Range, Specificity, isImplicit());
+  }
 };
 
 /// The @_unavailableFromAsync attribute, used to make function declarations
@@ -2300,6 +2428,12 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::UnavailableFromAsync;
   }
+
+  /// Create a copy of this attribute.
+  UnavailableFromAsyncAttr *clone(ASTContext &ctx) const {
+    return new (ctx) UnavailableFromAsyncAttr(
+        Message, AtLoc, Range, isImplicit());
+  }
 };
 
 /// The `@backDeployed(...)` attribute, used to make function declarations
@@ -2308,7 +2442,7 @@ public:
 class BackDeployedAttr : public DeclAttribute {
 public:
   BackDeployedAttr(SourceLoc AtLoc, SourceRange Range, PlatformKind Platform,
-                   const llvm::VersionTuple Version, bool Implicit)
+                   const llvm::VersionTuple &Version, bool Implicit)
       : DeclAttribute(DeclAttrKind::BackDeployed, AtLoc, Range, Implicit),
         Platform(Platform), Version(Version) {}
 
@@ -2323,6 +2457,12 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::BackDeployed;
+  }
+
+  /// Create a copy of this attribute.
+  BackDeployedAttr *clone(ASTContext &ctx) const {
+    return new (ctx) BackDeployedAttr(
+        AtLoc, Range, Platform, Version, isImplicit());
   }
 };
 
@@ -2350,6 +2490,12 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Expose;
+  }
+
+  /// Create a copy of this attribute.
+  ExposeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ExposeAttr(
+        Name, AtLoc, Range, getExposureKind(), isImplicit());
   }
 };
 
@@ -2399,6 +2545,13 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Extern;
   }
+
+  /// Create a copy of this attribute.
+  ExternAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ExternAttr(
+        ModuleName, Name, AtLoc, getLParenLoc(), getRParenLoc(), Range,
+        getExternKind(), isImplicit());
+  }
 };
 
 /// The `@_documentation(...)` attribute, used to override a symbol's visibility
@@ -2420,6 +2573,12 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Documentation;
+  }
+
+  /// Create a copy of this attribute.
+  DocumentationAttr *clone(ASTContext &ctx) const {
+    return new (ctx) DocumentationAttr(
+        AtLoc, Range, Metadata, Visibility, isImplicit());
   }
 };
 
@@ -2468,6 +2627,13 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::ObjCImplementation;
   }
+
+  /// Create a copy of this attribute.
+  ObjCImplementationAttr *clone(ASTContext &ctx) const {
+    return new (ctx) ObjCImplementationAttr(
+        CategoryName, AtLoc, Range, isEarlyAdopter(), isImplicit(),
+        isCategoryNameInvalid());
+  }
 };
 
 /// Represents nonisolated modifier.
@@ -2487,6 +2653,11 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Nonisolated;
+  }
+
+  /// Create a copy of this attribute.
+  NonisolatedAttr *clone(ASTContext &ctx) const {
+    return new (ctx) NonisolatedAttr(AtLoc, Range, isUnsafe(), isImplicit());
   }
 };
 
@@ -2539,6 +2710,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::MacroRole;
   }
+
+  UNIMPLEMENTED_CLONE(MacroRoleAttr)
 };
 
 /// Specifies the raw storage used by a type.
@@ -2640,6 +2813,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::RawLayout;
   }
+
+  UNIMPLEMENTED_CLONE(MacroRoleAttr)
 };
 
 class LifetimeAttr final : public DeclAttribute {
@@ -2659,6 +2834,11 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Lifetime;
+  }
+
+  /// Create a copy of this attribute.
+  LifetimeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) LifetimeAttr(AtLoc, Range, isImplicit(), entry);
   }
 };
 
@@ -2700,6 +2880,8 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::AllowFeatureSuppression;
   }
+
+  UNIMPLEMENTED_CLONE(AllowFeatureSuppressionAttr)
 };
 
 /// Attributes that may be applied to declarations.
@@ -3319,5 +3501,7 @@ struct EnumTraits<TypeAttrKind> {
 };
 
 } // end namespace swift
+
+#undef UNIMPLEMENTED_CLONE
 
 #endif

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -59,7 +59,7 @@ DECL_ATTR(objc, ObjC,
 SIMPLE_DECL_ATTR(dynamicCallable, DynamicCallable,
   OnNominalType | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   6)
-DECL_ATTR(main, MainType,
+SIMPLE_DECL_ATTR(main, MainType,
   OnClass | OnStruct | OnEnum | OnExtension | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   7)
 SIMPLE_DECL_ATTR(_exported, Exported,

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -67,7 +67,7 @@ public:
     DefaultArgument,
 
     /// A Swift attribute expressed in C headers.
-    Attribute,
+    AttributeFromClang,
   } kind;
 
   static StringRef kindToString(GeneratedSourceInfo::Kind kind) {
@@ -83,8 +83,8 @@ public:
       return "PrettyPrinted";
     case DefaultArgument:
       return "DefaultArgument";
-    case Attribute:
-      return "Attribute";
+    case AttributeFromClang:
+      return "AttributeFromClang";
     }
     llvm_unreachable("Invalid kind");
   }

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1322,7 +1322,11 @@ public:
   ///
   /// Parsing a floating attribute list will produce a `MissingDecl` with
   /// the attribute list attached.
-  void parseExpandedAttributeList(SmallVectorImpl<ASTNode> &items);
+  ///
+  /// If isFromClangAttribute, we also parse modifiers and suppress any
+  /// diagnostics about bad modifiers.
+  void parseExpandedAttributeList(SmallVectorImpl<ASTNode> &items,
+                                  bool isFromClangAttribute);
 
   /// Parse the result of member macro expansion, which is a floating
   /// member list.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4535,7 +4535,7 @@ void ASTMangler::appendMacroExpansionContext(
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return appendMacroExpansionLoc();
   }
   
@@ -4587,7 +4587,7 @@ void ASTMangler::appendMacroExpansionContext(
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     llvm_unreachable("Exited above");
   }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -353,7 +353,16 @@ bool DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind DAK, DeclKind DK) 
   llvm_unreachable("bad DeclKind");
 }
 
+// Ensure that every DeclAttribute subclass implements its own CloneAttr.
+static void checkDeclAttributeClones() {
+#define DECL_ATTR(_,CLASS,...) \
+  CLASS##Attr *(CLASS##Attr::*ptr##CLASS)(ASTContext &) const = &CLASS##Attr::clone; \
+  (void)ptr##CLASS;
+#include "swift/AST/DeclAttr.def"
+}
+
 DeclAttribute *DeclAttribute::clone(ASTContext &ctx) const {
+  (void)checkDeclAttributeClones;
   switch (getKind()) {
 #define DECL_ATTR(_,CLASS, ...) \
   case DeclAttrKind::CLASS: return static_cast<const CLASS##Attr *>(this)->clone(ctx);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -353,6 +353,14 @@ bool DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind DAK, DeclKind DK) 
   llvm_unreachable("bad DeclKind");
 }
 
+DeclAttribute *DeclAttribute::clone(ASTContext &ctx) const {
+  switch (getKind()) {
+#define DECL_ATTR(_,CLASS, ...) \
+  case DeclAttrKind::CLASS: return static_cast<const CLASS##Attr *>(this)->clone(ctx);
+#include "swift/AST/DeclAttr.def"
+  }
+}
+
 bool
 DeclAttributes::isUnavailableInSwiftVersion(
   const version::Version &effectiveVersion) const {
@@ -1289,18 +1297,13 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       // Use @_functionBuilder in Swift interfaces to maintain backward
       // compatibility.
       Printer.printSimpleAttr("_functionBuilder", /*needAt=*/true);
+    } else if (getKind() == DeclAttrKind::MainType && Options.PrintForSIL) {
+      // Don't print into SIL. Necessary bits have already been generated.
+      return false;
     } else {
       Printer.printSimpleAttr(getAttrName(), /*needAt=*/true);
     }
     return true;
-
-  case DeclAttrKind::MainType: {
-    // Don't print into SIL. Necessary bits have already been generated.
-    if (Options.PrintForSIL)
-      return false;
-    Printer.printSimpleAttr(getAttrName(), /*needAt=*/true);
-    return true;
-  }
 
   case DeclAttrKind::SetterAccess:
     Printer.printKeyword(getAttrName(), Options, "(set)");
@@ -1889,8 +1892,6 @@ StringRef DeclAttribute::getAttrName() const {
     if (cast<ObjCImplementationAttr>(this)->isEarlyAdopter())
       return "_objcImplementation";
     return "implementation";
-  case DeclAttrKind::MainType:
-    return "main";
   case DeclAttrKind::DynamicReplacement:
     return "_dynamicReplacement";
   case DeclAttrKind::TypeEraser:
@@ -2133,9 +2134,9 @@ ObjCAttr *ObjCAttr::clone(ASTContext &context) const {
 
 PrivateImportAttr::PrivateImportAttr(SourceLoc atLoc, SourceRange baseRange,
                                      StringRef sourceFile,
-                                     SourceRange parenRange)
-    : DeclAttribute(DeclAttrKind::PrivateImport, atLoc, baseRange,
-                    /*Implicit=*/false),
+                                     SourceRange parenRange,
+                                     bool implicit)
+    : DeclAttribute(DeclAttrKind::PrivateImport, atLoc, baseRange, implicit),
       SourceFile(sourceFile) {}
 
 PrivateImportAttr *PrivateImportAttr::create(ASTContext &Ctxt, SourceLoc AtLoc,

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -315,14 +315,6 @@ BridgedMacroRoleAttr BridgedMacroRoleAttr_createParsed(
       conformances, cRParenLoc.unbridged(), /*implicit=*/false);
 }
 
-BridgedMainTypeAttr
-BridgedMainTypeAttr_createParsed(BridgedASTContext cContext,
-                                 BridgedSourceLoc cAtLoc,
-                                 BridgedSourceLoc cNameLoc) {
-  return new (cContext.unbridged())
-      MainTypeAttr(cAtLoc.unbridged(), cNameLoc.unbridged());
-}
-
 BridgedSwiftNativeObjCRuntimeBaseAttr
 BridgedSwiftNativeObjCRuntimeBaseAttr_createParsed(BridgedASTContext cContext,
                                                    BridgedSourceLoc cAtLoc,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12075,7 +12075,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return origDC;
   }
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1336,7 +1336,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
 #include "swift/Basic/MacroRoles.def"
       case GeneratedSourceInfo::PrettyPrinted:
       case GeneratedSourceInfo::DefaultArgument:
-      case GeneratedSourceInfo::Attribute:
+      case GeneratedSourceInfo::AttributeFromClang:
         fixIts = {};
         break;
       case GeneratedSourceInfo::ReplacedFunctionBody:
@@ -1382,7 +1382,7 @@ getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info) {
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return DeclName();
   }
 }
@@ -1444,7 +1444,7 @@ DiagnosticEngine::getGeneratedSourceBufferNotes(SourceLoc loc) {
 
     case GeneratedSourceInfo::DefaultArgument:
     case GeneratedSourceInfo::ReplacedFunctionBody:
-    case GeneratedSourceInfo::Attribute:
+    case GeneratedSourceInfo::AttributeFromClang:
       return childNotes;
     }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -862,7 +862,7 @@ ModuleDecl::getOriginalLocation(SourceLoc loc) const {
       // replaced function bodies. The body is actually different code to the
       // original file.
     case GeneratedSourceInfo::PrettyPrinted:
-    case GeneratedSourceInfo::Attribute:
+    case GeneratedSourceInfo::AttributeFromClang:
       // No original location, return the original buffer/location
       return {startBufferID, startLoc};
     }
@@ -1149,7 +1149,7 @@ std::optional<MacroRole> SourceFile::getFulfilledMacroRole() const {
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return std::nullopt;
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -135,8 +135,6 @@ extension ASTGenVisitor {
         return self.generateImplementsAttr(attribute: node)?.asDeclAttribute
       case .inline:
         return self.generateInlineAttr(attribute: node)?.asDeclAttribute
-      case .mainType:
-        return self.generateMainTypeAttr(attribute: node)?.asDeclAttribute
       case .macroRole:
         return self.generateMacroRoleAttr(attribute: node, attrName: attrName)?.asDeclAttribute
       case .noExistentials:
@@ -229,6 +227,7 @@ extension ASTGenVisitor {
         .isolated,
         .lexicalLifetimes,
         .lldbDebuggerFunction,
+        .mainType,
         .marker,
         .moveOnly,
         .noAllocation,
@@ -665,15 +664,6 @@ extension ASTGenVisitor {
       atLoc: self.generateSourceLoc(node.atSign),
       range: self.generateSourceRange(node),
       kind: kind
-    )
-  }
-
-  func generateMainTypeAttr(attribute node: AttributeSyntax) -> BridgedMainTypeAttr? {
-    // TODO: Diagnose extraneous arguments.
-    return BridgedMainTypeAttr.createParsed(
-      self.ctx,
-      atLoc: self.generateSourceLoc(node.atSign),
-      nameLoc: self.generateSourceLoc(node.attributeName)
     )
   }
 

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -307,7 +307,7 @@ StringRef SourceManager::getIdentifierForBuffer(
       if (generatedInfo->kind == GeneratedSourceInfo::ReplacedFunctionBody ||
           generatedInfo->kind == GeneratedSourceInfo::PrettyPrinted ||
           generatedInfo->kind == GeneratedSourceInfo::DefaultArgument ||
-          generatedInfo->kind == GeneratedSourceInfo::Attribute)
+          generatedInfo->kind == GeneratedSourceInfo::AttributeFromClang)
         return buffer->getBufferIdentifier();
 
       if (generatedInfo->onDiskBufferCopyFileName.empty()) {
@@ -401,7 +401,7 @@ void SourceManager::setGeneratedSourceInfo(
 #include "swift/Basic/MacroRoles.def"
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     break;
 
   case GeneratedSourceInfo::ReplacedFunctionBody:

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8214,7 +8214,7 @@ SourceFile &ClangImporter::Implementation::getClangSwiftAttrSourceFile(
   sourceMgr.setGeneratedSourceInfo(
       bufferID,
       {
-        GeneratedSourceInfo::Attribute,
+        GeneratedSourceInfo::AttributeFromClang,
         CharSourceRange(),
         sourceMgr.getRangeForBuffer(bufferID),
         &module

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -52,7 +52,6 @@
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Lexer.h"
-#include "swift/Parse/Parser.h"
 #include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -8281,7 +8280,6 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
 
   std::optional<const clang::SwiftAttrAttr *> seenMainActorAttr;
   const clang::SwiftAttrAttr *seenMutabilityAttr = nullptr;
-  PatternBindingInitializer *initContext = nullptr;
 
   auto importAttrsFromDecl = [&](const clang::NamedDecl *ClangDecl) {
     //
@@ -8406,37 +8404,12 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
           *MappedDecl->getDeclContext()->getParentModule(),
           swiftAttr->getAttribute());
 
-      // Spin up a parser.
-      swift::Parser parser(
-          sourceFile.getBufferID(), sourceFile, &SwiftContext.Diags,
-          nullptr, nullptr);
-      // Prime the lexer.
-      parser.consumeTokenWithoutFeedingReceiver();
-
-      bool hadError = false;
-      if (parser.Tok.is(tok::at_sign)) {
-        SourceLoc atEndLoc = parser.Tok.getRange().getEnd();
-        SourceLoc atLoc = parser.consumeToken(tok::at_sign);
-        hadError = parser
-                       .parseDeclAttribute(MappedDecl->getAttrs(), atLoc,
-                                           atEndLoc, initContext,
-                                           /*isFromClangAttribute=*/true)
-                       .isError();
-      } else {
-        SourceLoc staticLoc;
-        StaticSpellingKind staticSpelling;
-        hadError = parser
-                       .parseDeclModifierList(MappedDecl->getAttrs(), staticLoc,
-                                              staticSpelling,
-                                              /*isFromClangAttribute=*/true)
-                       .isError();
-      }
-
-      if (hadError) {
-        // Complain about the unhandled attribute or modifier.
-        HeaderLoc attrLoc(swiftAttr->getLocation());
-        diagnose(attrLoc, diag::clang_swift_attr_unhandled,
-                 swiftAttr->getAttribute());
+      // Collect the attributes from the synthesized top-level declaration in
+      // the source file.
+      auto topLevelDecls = sourceFile.getTopLevelDecls();
+      for (auto decl : topLevelDecls) {
+        for (auto attr : decl->getAttrs())
+          MappedDecl->getAttrs().add(attr->clone(SwiftContext));
       }
     }
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -661,7 +661,7 @@ adjustMacroExpansionWhitespace(GeneratedSourceInfo::Kind kind,
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return expandedCode;
   }
 }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -301,7 +301,7 @@ public:
         if (generatedInfo->kind != GeneratedSourceInfo::ReplacedFunctionBody &&
             generatedInfo->kind != GeneratedSourceInfo::PrettyPrinted &&
             generatedInfo->kind != GeneratedSourceInfo::DefaultArgument &&
-            generatedInfo->kind != GeneratedSourceInfo::Attribute)
+            generatedInfo->kind != GeneratedSourceInfo::AttributeFromClang)
           if (auto *MemBuf = SM.getLLVMSourceMgr().getMemoryBuffer(BufferID)) {
             Source = MemBuf->getBuffer();
             // This is copying the buffer twice, but Xcode depends on this

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2856,11 +2856,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       Attributes.add(DeclAttribute::createSimple(Context, DK, AtLoc, Loc));
     break;
 
-  case DeclAttrKind::MainType:
-    if (!DiscardAttribute)
-      Attributes.add(new (Context) MainTypeAttr(AtLoc, Loc));
-    break;
-
   case DeclAttrKind::Effects: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -162,7 +162,7 @@ getBridgedGeneratedSourceFileKind(const GeneratedSourceInfo *genInfo) {
     return BridgedGeneratedSourceFileKindPrettyPrinted;
   case GeneratedSourceInfo::Kind::DefaultArgument:
     return BridgedGeneratedSourceFileKindDefaultArgument;
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     return BridgedGeneratedSourceFileKindAttribute;
   }
 }
@@ -382,7 +382,7 @@ SourceFileParsingResult parseSourceFile(SourceFile &SF) {
       parser.parseExpandedAttributeList(items, /*isFromClangAttribute=*/false);
       break;
 
-    case GeneratedSourceInfo::Attribute:
+    case GeneratedSourceInfo::AttributeFromClang:
       parser.parseExpandedAttributeList(items, /*isFromClangAttribute=*/true);
       break;
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -379,10 +379,12 @@ SourceFileParsingResult parseSourceFile(SourceFile &SF) {
     }
 
     case GeneratedSourceInfo::MemberAttributeMacroExpansion:
-    case GeneratedSourceInfo::Attribute: {
-      parser.parseExpandedAttributeList(items);
+      parser.parseExpandedAttributeList(items, /*isFromClangAttribute=*/false);
       break;
-    }
+
+    case GeneratedSourceInfo::Attribute:
+      parser.parseExpandedAttributeList(items, /*isFromClangAttribute=*/true);
+      break;
 
     case GeneratedSourceInfo::PeerMacroExpansion: {
       if (parser.CurDeclContext->isTypeContext()) {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -348,7 +348,7 @@ static MacroInfo getMacroInfo(const GeneratedSourceInfo &Info,
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::DefaultArgument:
-  case GeneratedSourceInfo::Attribute:
+  case GeneratedSourceInfo::AttributeFromClang:
     break;
   }
   return Result;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5932,14 +5932,6 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
-      case decls_block::MainType_DECL_ATTR: {
-        bool isImplicit;
-        serialization::decls_block::MainTypeDeclAttrLayout::readRecord(
-            scratch, isImplicit);
-        Attr = new (ctx) MainTypeAttr(isImplicit);
-        break;
-      }
-
       case decls_block::Specialize_DECL_ATTR: {
         unsigned exported;
         SpecializeAttr::SpecializationKind specializationKind;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 902; // merge_isolation_region
+const uint16_t SWIFTMODULE_VERSION_MINOR = 903; // @main attribute moved
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3099,13 +3099,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DeclAttrKind::MainType: {
-      auto abbrCode = S.DeclTypeAbbrCodes[MainTypeDeclAttrLayout::Code];
-      MainTypeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                         DA->isImplicit());
-      return;
-    }
-
     case DeclAttrKind::Specialize: {
       auto abbrCode = S.DeclTypeAbbrCodes[SpecializeDeclAttrLayout::Code];
       auto attr = cast<SpecializeAttr>(DA);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -972,7 +972,7 @@ public:
       case GeneratedSourceInfo::DefaultArgument:
       case GeneratedSourceInfo::ReplacedFunctionBody:
       case GeneratedSourceInfo::PrettyPrinted:
-      case GeneratedSourceInfo::Attribute:
+      case GeneratedSourceInfo::AttributeFromClang:
         break;
       }
     }


### PR DESCRIPTION
The Clang importer was directly calling into the parser to parse the
attribute (or modifier) within swift_attr. Aside from being gross, this
isn't possible with ASTGen.

Instead, teach ParseSourceFileRequest to deal with modifiers in the
same way that the Clang importer was hardcoding, and have the Clang
importer pull the attributes/modifiers off of the "missing"
declaration introduced by the request.

One benefit of this approach is that we're only parsing each
swift_attr source buffer once, then cloning the attributes each time
it's used, so we should be doing less work overall.

Fixes rdar://139119159.