### PR TITLE
Flush out incorrectly-constructed substitution maps

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -213,8 +213,9 @@ public:
   /// interface types.
   SubstitutionMap mapReplacementTypesOutOfContext() const;
 
-  /// Verify that this substitution map is valid.
-  void verify() const;
+  /// Verify that the conformances stored in this substitution map match the
+  /// replacement types provided.
+  void verify(bool allowInvalid=true) const;
 
   /// Whether to dump the full substitution map, or just a minimal useful subset
   /// (on a single line).

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -976,8 +976,7 @@ ProtocolConformance::subst(InFlightSubstitution &IFS) const {
   switch (getKind()) {
   case ProtocolConformanceKind::Normal: {
     auto origType = getType();
-    if (!origType->hasTypeParameter() &&
-        !origType->hasArchetype())
+    if (IFS.isInvariant(origType))
       return ProtocolConformanceRef(mutableThis);
 
     auto substType = origType.subst(IFS);
@@ -998,8 +997,7 @@ ProtocolConformance::subst(InFlightSubstitution &IFS) const {
 
   case ProtocolConformanceKind::Builtin: {
     auto origType = getType();
-    if (!origType->hasTypeParameter() &&
-        !origType->hasArchetype())
+    if (IFS.isInvariant(origType))
       return ProtocolConformanceRef(mutableThis);
 
     auto substType = origType.subst(IFS);
@@ -1022,18 +1020,14 @@ ProtocolConformance::subst(InFlightSubstitution &IFS) const {
 
   case ProtocolConformanceKind::Inherited: {
     // Substitute the base.
+    auto origType = getType();
+    if (IFS.isInvariant(origType))
+      return ProtocolConformanceRef(mutableThis);
+
     auto inheritedConformance
       = cast<InheritedProtocolConformance>(this)->getInheritedConformance();
 
-    auto origType = getType();
-    if (!origType->hasTypeParameter() &&
-        !origType->hasArchetype()) {
-      return ProtocolConformanceRef(mutableThis);
-    }
-
-    auto origBaseType = inheritedConformance->getType();
-    if (origBaseType->hasTypeParameter() ||
-        origBaseType->hasArchetype()) {
+    if (!IFS.isInvariant(inheritedConformance->getType())) {
       // Substitute into the superclass.
       auto substConformance = inheritedConformance->subst(IFS);
       if (!substConformance.isConcrete())

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -152,7 +152,7 @@ RequirementEnvironment::RequirementEnvironment(
 
       // All other generic parameters come from the requirement itself
       // and conform abstractly.
-      return ProtocolConformanceRef(proto);
+      return MakeAbstractConformanceForGenericType()(type, replacement, proto);
     });
 
   // If the requirement itself is non-generic, the witness thunk signature

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -118,23 +118,36 @@ RequirementEnvironment::RequirementEnvironment(
       }
       return substGenericParam;
     },
-    [selfType, substConcreteType, conformance, conformanceDC, &ctx](
+    [selfType, substConcreteType, conformance, conformanceDC, covariantSelf, &ctx](
         CanType type, Type replacement, ProtocolDecl *proto)
           -> ProtocolConformanceRef {
       // The protocol 'Self' conforms concretely to the conforming type.
       if (type->isEqual(selfType)) {
-        ProtocolConformance *specialized = conformance;
-        if (conformance && conformance->getGenericSignature()) {
-          auto concreteSubs =
-            substConcreteType->getContextSubstitutionMap(conformanceDC);
-          specialized =
-            ctx.getSpecializedConformance(substConcreteType,
-                                          cast<NormalProtocolConformance>(conformance),
-                                          concreteSubs);
-        }
+        ASSERT(covariantSelf || replacement->isEqual(substConcreteType));
 
-        if (specialized)
+        if (conformance) {
+          ProtocolConformance *specialized = conformance;
+
+          if (conformance->getGenericSignature()) {
+            auto concreteSubs =
+              substConcreteType->getContextSubstitutionMap(conformanceDC);
+            specialized =
+              ctx.getSpecializedConformance(substConcreteType,
+                                            cast<NormalProtocolConformance>(conformance),
+                                            concreteSubs);
+          }
+
+          // findWitnessedObjCRequirements() does a weird thing by passing in a
+          // DC that is not the conformance DC. Work around it here.
+          if (!specialized->getType()->isEqual(replacement)) {
+            ASSERT(specialized->getType()->isExactSuperclassOf(substConcreteType));
+            ASSERT(covariantSelf ? replacement->is<GenericTypeParamType>()
+                                 : replacement->isEqual(substConcreteType));
+            specialized = ctx.getInheritedConformance(replacement, specialized);
+          }
+
           return ProtocolConformanceRef(specialized);
+        }
       }
 
       // All other generic parameters come from the requirement itself

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -772,6 +772,9 @@ public:
       auto createIntrinsic =
           throws ? SGF.SGM.getCreateCheckedThrowingContinuation()
                  : SGF.SGM.getCreateCheckedContinuation();
+    auto conformances =
+        collectExistentialConformances(calleeTypeInfo.substResultType,
+                                       ctx.TheAnyType);
       auto subs =
           SubstitutionMap::get(createIntrinsic->getGenericSignature(),
                                {calleeTypeInfo.substResultType}, conformances);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -7230,8 +7230,7 @@ void SILGenFunction::emitProtocolWitness(
     auto deallocCleanup = std::get<3>(tokenAndCleanups);
 
     YieldInfo witnessYieldInfo(SGM, witness, witnessFTy, witnessSubs);
-    YieldInfo reqtYieldInfo(SGM, requirement, thunkTy,
-                            reqtSubs.subst(getForwardingSubstitutionMap()));
+    YieldInfo reqtYieldInfo(SGM, requirement, thunkTy, reqtSubs);
 
     translateYields(*this, loc, witnessYields, witnessYieldInfo, reqtYieldInfo);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5438,7 +5438,10 @@ CanSILFunctionType SILGenFunction::buildThunkType(
     SubstitutionMap &interfaceSubs,
     CanType &dynamicSelfType,
     bool withoutActuallyEscaping) {
-  return buildSILFunctionThunkType(&F, sourceType, expectedType, inputSubstType, outputSubstType, genericEnv, interfaceSubs, dynamicSelfType, withoutActuallyEscaping);
+  return buildSILFunctionThunkType(
+      &F, sourceType, expectedType, inputSubstType, outputSubstType,
+      genericEnv, interfaceSubs, dynamicSelfType,
+      withoutActuallyEscaping);
 }
 
 static ManagedValue createPartialApplyOfThunk(SILGenFunction &SGF,

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -3137,7 +3137,7 @@ static bool usePrespecialized(
 
       auto newSubstMap = SubstitutionMap::get(
           apply.getSubstitutionMap().getGenericSignature(), newSubs,
-          apply.getSubstitutionMap().getConformances());
+          LookUpConformanceInModule());
 
       ReabstractionInfo layoutReInfo = ReabstractionInfo(
           funcBuilder.getModule().getSwiftModule(),

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -38,6 +38,7 @@
 
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -2860,12 +2861,18 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   // Check any same-type requirements in the protocol's requirement signature.
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
 
-  auto typeInContext = dc->mapTypeIntoContext(adoptee);
+  auto typeInContext = adoptee;
+  ProtocolConformanceRef conformanceInContext(conformance);
+  if (auto *genericEnv = conformance->getGenericEnvironment()) {
+    typeInContext = genericEnv->mapTypeIntoContext(typeInContext);
+    conformanceInContext =
+      conformanceInContext.subst(conformance->getType(),
+                                 genericEnv->getForwardingSubstitutionMap());
+  }
 
   auto substitutions =
     SubstitutionMap::getProtocolSubstitutions(
-                                    proto, typeInContext,
-                                    ProtocolConformanceRef(conformance));
+      proto, typeInContext, conformanceInContext);
 
   SmallVector<Requirement, 4> sanitizedRequirements;
   auto requirements = proto->getRequirementSignature().getRequirements();

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -538,7 +538,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     // clause, check those requirements now.
     if (!TypeChecker::checkContextualRequirements(
             genericDecl, dc->getSelfInterfaceType(), SourceLoc(),
-            dc->getParentModule(), dc->getGenericSignatureOfContext())) {
+            dc->getGenericSignatureOfContext())) {
       continue;
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4943,7 +4943,7 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
         // Substitute into the global actor type.
         auto conformance = std::get<0>(isolated);
         auto requirementSubs = SubstitutionMap::getProtocolSubstitutions(
-            conformance->getProtocol(), dc->getSelfTypeInContext(),
+            conformance->getProtocol(), dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
         Type globalActor = isolation.getGlobalActor().subst(requirementSubs);
         if (!globalActorTypes.insert(globalActor->getCanonicalType()).second)

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -914,7 +914,7 @@ void TypeChecker::diagnoseRequirementFailure(
     const CheckGenericArgumentsResult::RequirementFailureInfo &reqFailureInfo,
     SourceLoc errorLoc, SourceLoc noteLoc, Type targetTy,
     ArrayRef<GenericTypeParamType *> genericParams,
-    TypeSubstitutionFn substitutions, ModuleDecl *module) {
+    TypeSubstitutionFn substitutions) {
   assert(errorLoc.isValid() && noteLoc.isValid());
 
   const auto &req = reqFailureInfo.Req;
@@ -939,7 +939,7 @@ void TypeChecker::diagnoseRequirementFailure(
 
   case RequirementKind::Conformance: {
     diagnoseConformanceFailure(substReq.getFirstType(),
-                               substReq.getProtocolDecl(), module, errorLoc);
+                               substReq.getProtocolDecl(), nullptr, errorLoc);
 
     if (reqFailureInfo.ReqPath.empty())
       return;
@@ -965,7 +965,7 @@ void TypeChecker::diagnoseRequirementFailure(
     break;
   }
 
-  ASTContext &ctx = module->getASTContext();
+  ASTContext &ctx = targetTy->getASTContext();
   // FIXME: Poor source-location information.
   ctx.Diags.diagnose(errorLoc, diagnostic, targetTy, substReq.getFirstType(),
                      substSecondTy);
@@ -981,7 +981,7 @@ void TypeChecker::diagnoseRequirementFailure(
 }
 
 CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
-    ModuleDecl *module, ArrayRef<Requirement> requirements,
+    ArrayRef<Requirement> requirements,
     TypeSubstitutionFn substitutions) {
   using ParentConditionalConformances =
       SmallVector<ParentConditionalConformance, 2>;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4911,7 +4911,7 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
   }
 
   const auto result = TypeChecker::checkGenericArgumentsForDiagnostics(
-      module, reqSig, QuerySubstitutionMap{substitutions});
+      reqSig, QuerySubstitutionMap{substitutions});
   switch (result.getKind()) {
   case CheckRequirementsResult::Success:
     // Go on to check exportability.
@@ -4924,13 +4924,13 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
     if (!conformance->isInvalid()) {
       if (result.getKind() == CheckRequirementsResult::RequirementFailure) {
         ctx.addDelayedConformanceDiag(conformance, /*isError=*/true,
-          [result, proto, substitutions, module](NormalProtocolConformance *conformance) {
+          [result, proto, substitutions](NormalProtocolConformance *conformance) {
             TypeChecker::diagnoseRequirementFailure(
               result.getRequirementFailureInfo(),
               conformance->getLoc(), conformance->getLoc(),
               proto->getDeclaredInterfaceType(),
               {proto->getSelfInterfaceType()->castTo<GenericTypeParamType>()},
-              QuerySubstitutionMap{substitutions}, module);
+              QuerySubstitutionMap{substitutions});
           });
       }
 
@@ -5335,7 +5335,7 @@ void swift::diagnoseConformanceFailure(Type T,
   if (T->hasError())
     return;
 
-  ASTContext &ctx = DC->getASTContext();
+  ASTContext &ctx = Proto->getASTContext();
   auto &diags = ctx.Diags;
 
   // If we're checking conformance of an existential type to a protocol,
@@ -5443,7 +5443,7 @@ void swift::diagnoseConformanceFailure(Type T,
                          T);
 
       // Try to suggest inheriting from NSObject instead.
-      auto classDecl = dyn_cast<ClassDecl>(DC);
+      auto classDecl = dyn_cast_or_null<ClassDecl>(DC);
       if (!classDecl)
         return;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -524,14 +524,13 @@ void diagnoseRequirementFailure(
     const CheckGenericArgumentsResult::RequirementFailureInfo &reqFailureInfo,
     SourceLoc errorLoc, SourceLoc noteLoc, Type targetTy,
     ArrayRef<GenericTypeParamType *> genericParams,
-    TypeSubstitutionFn substitutions, ModuleDecl *module);
+    TypeSubstitutionFn substitutions);
 
 /// Check the given generic parameter substitutions against the given
 /// requirements and report on any requirement failures in detail for
 /// diagnostic needs.
 CheckGenericArgumentsResult
-checkGenericArgumentsForDiagnostics(ModuleDecl *module,
-                                    ArrayRef<Requirement> requirements,
+checkGenericArgumentsForDiagnostics(ArrayRef<Requirement> requirements,
                                     TypeSubstitutionFn substitutions);
 
 /// Checks whether the generic requirements imposed on the nested type
@@ -575,8 +574,7 @@ checkGenericArgumentsForDiagnostics(ModuleDecl *module,
 ///
 /// \returns \c true on success.
 bool checkContextualRequirements(GenericTypeDecl *decl, Type parentTy,
-                                 SourceLoc loc, ModuleDecl *module,
-                                 GenericSignature contextSig);
+                                 SourceLoc loc, GenericSignature contextSig);
 
 /// Add any implicitly-defined constructors required for the given
 /// struct, class or actor.


### PR DESCRIPTION
A common mistake that can lead to subtle bugs is calling `SubstitutionMap::get()` with a list of conformances that don't match the replacement types. Such substitution maps can be silently introduced in the AST or SIL and only cause problems later.

This PR dusts off the old `SubstitutionMap::verify()` and fixes a few of the problems revealed. So far there's nothing serious here. Note that verification is off by default.