### PR TITLE
[doc] Fix typo in shell command from Getting Started guide

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -455,7 +455,7 @@ Now check if the version string has been updated (assumes you have `platform` sh
 defined as specified in the previous subsection:
 
 ```sh
-../build/Ninja-RelWithDebInfoAssert/swift-$(platform)-$(uname -m)/bin/swift-frontend --version
+../build/Ninja-RelWithDebInfoAssert/swift-${platform}-$(uname -m)/bin/swift-frontend --version
 ```
 
 This should print your updated version string.


### PR DESCRIPTION
In these instructions, `platform` is a shell variable, not a command (or function or alias).
