### PR TITLE
[build-script] Add buildbot_linux,lld preset

### DIFF
--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -1,12 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -g %S/Inputs/fib.c -o %t/fib
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -g %S/Inputs/fib.c -o %t/fib-no-uuid
-// RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib-gnu -g %S/Inputs/fib.c -o %t/fib-compress-gnu
+// RUN: if %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib-gnu -g %S/Inputs/fib.c -o %t/fib-compress-gnu; then ( %target-run %t/ElfReader %t/fib-compress-gnu | %FileCheck %s --check-prefix CMPGNU ); else echo "warning: skipping zlib-gnu test as linker does not support zlib-gnu compression"; fi
 // RUN: %target-clang -x c -Wno-unused-command-line-argument -Wl,--build-id -Wl,--compress-debug-sections=zlib -g %S/Inputs/fib.c -o %t/fib-compress-zlib
 // RUN: %target-build-swift %s -parse-as-library -g -o %t/ElfReader
 // RUN: %target-run %t/ElfReader %t/fib | %FileCheck %s
 // RUN: %target-run %t/ElfReader %t/fib-no-uuid | %FileCheck %s --check-prefix NOUUID
-// RUN: %target-run %t/ElfReader %t/fib-compress-gnu | %FileCheck %s --check-prefix CMPGNU
 // RUN: %target-run %t/ElfReader %t/fib-compress-zlib | %FileCheck %s --check-prefix CMPZLIB
 // RUN: if %S/Inputs/make-minidebug %t/fib %t/fib-minidebug; then ( %target-run %t/ElfReader %t/fib-minidebug | %FileCheck %s --check-prefix MINIDEBUG ); else echo "warning: skipping minidebug test as we couldn't generate minidebug data"; fi
 // RUN: libc=$(ldd %t/fib | awk '/libc\.so\.6/ { print $3 }'); if %S/Inputs/has-uuid-syms "$libc" >/dev/null; then %target-run %t/ElfReader "$libc" | %FileCheck %s --check-prefix LIBC; else echo "warning: skipping /usr/lib/debug test as libc symbols are not installed"; fi

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1029,6 +1029,30 @@ mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
 
 android-arch=x86_64
 
+[preset: mixin_lld]
+
+use-linker=lld
+
+[preset: buildbot_linux,lld]
+mixin-preset=
+  buildbot_linux
+  mixin_lld
+
+[preset: buildbot_linux,lld,no_assertions]
+mixin-preset=
+  buildbot_linux,no_assertions
+  mixin_lld
+
+[preset: buildbot_linux,lld,no_test]
+mixin-preset=
+  buildbot_linux,no_test
+  mixin_lld
+
+[preset: buildbot_linux,lld,no_assertions,no_test]
+mixin-preset=
+  buildbot_linux,no_assertions,no_test
+  mixin_lld
+
 # Ubuntu 18.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -922,11 +922,12 @@ install-libdispatch
 install-swiftformat
 reconfigure
 
+use-linker=gold
+
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
 llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
-  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux]
 mixin-preset=
@@ -1119,11 +1120,12 @@ reconfigure
 test-optimized
 skip-test-swiftdocc
 
+use-linker=gold
+
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
 llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
-  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux_1404_no_lldb]
 mixin-preset=buildbot_incremental_linux
@@ -1203,8 +1205,7 @@ reconfigure
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 build-embedded-stdlib-cross-compiling
 
@@ -1833,7 +1834,7 @@ skip-test-osx
 
 [preset: pr_apple_llvm_project_linux]
 
-llvm-cmake-options=-DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 foundation
 libdispatch
@@ -1898,8 +1899,7 @@ skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 # SwiftPM package base
 [preset: mixin_swiftpm_package_macos_platform]
@@ -1935,8 +1935,7 @@ skip-test-xctest
 skip-test-llbuild
 skip-test-swiftpm
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 #===------------------------------------------------------------------------===#
 # Test swiftPM on macOS builder
@@ -2207,8 +2206,7 @@ skip-test-swift
 skip-test-libdispatch
 skip-test-foundation
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 #===------------------------------------------------------------------------===#
 # Remote Mirror Library
@@ -3043,8 +3041,7 @@ install-libdispatch
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 [preset: source_compat_suite_macos_DA]
 mixin-preset=source_compat_suite_macos_base
@@ -3131,8 +3128,7 @@ skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
 
-llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+use-linker=gold
 
 #===------------------------------------------------------------------------===#
 # Toolchain Bootstrapping Stages


### PR DESCRIPTION
This patch adds a preset that defaults the toolchain to use lld instead of gold on Linux.

Added presets are
  - `buildbot_linux,lld`
  - `buildbot_linux,lld,no_assertions`
  - `buildbot_linux,lld,no_test`
  - `buildbot_linux,lld,no_assertions,no_test`