### PR TITLE
Delete lifetime dependence inference on mutating self

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -513,16 +513,6 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
     if (accessor->getAccessorKind() == AccessorKind::Set) {
       return inferSetter(accessor);
     }
-  } else if (auto *fd = dyn_cast<FuncDecl>(afd)) {
-    // Infer self dependence for a mutating function with no result.
-    //
-    // FIXME: temporary hack until we have dependsOn(self: param) syntax.
-    // Do not apply this to accessors (_modify). _modify is handled below like
-    // a mutating method.
-    if (fd->isMutating() && fd->getResultInterfaceType()->isVoid() &&
-        !dc->getSelfTypeInContext()->isEscapable()) {
-      return inferMutatingSelf(afd);
-    }
   }
 
   if (hasEscapableResultOrYield(afd)) {

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -196,9 +196,8 @@ public struct OuterNE: ~Escapable {
     self.inner1 = InnerNE(owner: owner)
   }
 
-  // Infer a dependence from 'self' on 'value'. We might revoke this rule once we have syntax.
-  //
   // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method) (@guaranteed OuterNE.InnerNE, @lifetime(copy 0) @inout OuterNE) -> () {
+  @lifetime(self: value)
   mutating func setInner(value: InnerNE) {
     self.inner1 = value
   }


### PR DESCRIPTION
We don't need this anymore since we have @lifetime(target: sources) syntax

