### PR TITLE
Re-land "[cxx-interop] Check the presence of copy constructor correctly"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7653,17 +7653,16 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
       decl->getName() == "_Optional_construct_base")
     return true;
 
+  if (decl->hasSimpleCopyConstructor())
+    return true;
+
   // If we have no way of copying the type we can't import the class
   // at all because we cannot express the correct semantics as a swift
   // struct.
-  if (llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-        return ctor->isCopyConstructor() &&
-               (ctor->isDeleted() || ctor->getAccess() != clang::AS_public);
-      }))
-    return false;
-
-  // TODO: this should probably check to make sure we actually have a copy ctor.
-  return true;
+  return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
+    return ctor->isCopyConstructor() && !ctor->isDeleted() &&
+           ctor->getAccess() == clang::AccessSpecifier::AS_public;
+  });
 }
 
 static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -71,6 +71,25 @@ struct TemplatedConstructorWithExtraArg {
   TemplatedConstructorWithExtraArg(T value, U other) { }
 };
 
+struct TemplatedCopyConstructor {
+  int x = 0;
+
+  TemplatedCopyConstructor(int x) : x(x) {}
+
+  template <class T>
+  TemplatedCopyConstructor(const T &value) : x(value.x) {}
+};
+
+struct TemplatedCopyConstructorWithExtraArg {
+  int x = 0;
+
+  TemplatedCopyConstructorWithExtraArg(int x) : x(x) {}
+
+  template <class T>
+  TemplatedCopyConstructorWithExtraArg(const T &value, int add = 0)
+      : x(value.x + add) {}
+};
+
 struct __attribute__((swift_attr("import_unsafe")))
 HasUserProvidedCopyConstructor {
   int numCopies;

--- a/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-copy-module-interface.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
+// CHECK: struct TemplatedCopyConstructor
+// CHECK: struct TemplatedCopyConstructorWithExtraArg
+
 // Make sure we don't import non-copyable types because we will have no way to
 // represent and copy/move these in swift with correct semantics.
 // CHECK-NOT: DeletedCopyConstructor

--- a/test/Interop/Cxx/class/constructors-typechecker.swift
+++ b/test/Interop/Cxx/class/constructors-typechecker.swift
@@ -2,6 +2,8 @@
 
 import Constructors
 
+func takesCopyable<T: Copyable>(_ x: T.Type) {}
+
 let explicit = ExplicitDefaultConstructor()
 
 let implicit = ImplicitDefaultConstructor()
@@ -12,3 +14,8 @@ let onlyCopyAndMove = CopyAndMoveConstructor() // expected-warning {{'init()' is
 let deletedExplicitly = DefaultConstructorDeleted() // expected-error {{missing argument for parameter 'a' in call}}
 
 let withArg = ConstructorWithParam(42)
+
+let _ = TemplatedCopyConstructor(123)
+let _ = TemplatedCopyConstructorWithExtraArg(123)
+takesCopyable(TemplatedCopyConstructor.self)
+takesCopyable(TemplatedCopyConstructorWithExtraArg.self)


### PR DESCRIPTION
This reverts commit 3066bd6919b4b44524ca48a2241511353f44adb3.

This re-lands a change after it got reverted because of a regression in the build of SwiftCompilerSources.

rdar://136838485

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
