### PR TITLE
[build-script] Stop installing the llbuildSwift library that is no longer used

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2984,7 +2984,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_LLBUILD}" ]] ; then
                     continue
                 fi
-                INSTALL_TARGETS="install-swift-build-tool install-libllbuildSwift"
+                INSTALL_TARGETS="install-swift-build-tool"
                 ;;
             # Products from this here install themselves; they don't fall-through.
             lldb)


### PR DESCRIPTION
I'm cross-compiling the trunk Swift 6.1 toolchain for Android and was surprised to find that this library hasn't been used by the linux toolchain in years, as the following shows no other binary links to it:
```
> ag --search-binary libllbuildSwift swift-5.* swift-6.0.2-RELEASE-fedora39/ swift-DEVELOPMENT-SNAPSHOT-2024-11-09-a-ubi9/
Binary file swift-5.10.1-RELEASE-fedora39/usr/lib/swift/pm/llbuild/libllbuildSwift.so matches.
Binary file swift-5.8.1-RELEASE-ubi9/usr/lib/swift/pm/llbuild/libllbuildSwift.so matches.
Binary file swift-5.9.2-RELEASE-ubi9/usr/lib/swift/pm/llbuild/libllbuildSwift.so matches.
Binary file swift-6.0.2-RELEASE-fedora39/usr/lib/swift/pm/llbuild/libllbuildSwift.so matches.
Binary file swift-DEVELOPMENT-SNAPSHOT-2024-11-09-a-ubi9/usr/lib/swift/pm/llbuild/libllbuildSwift.so matches.
```
I tried building SwiftPM natively on Android as part of the toolchain with this change and had no problem. The CMake-built `swift-bootstrap` uses this library but directly from the build directory, not from the install directory, so this pull has no effect on that.

The Windows trunk build uses the new `swift-toolchain-sqlite` package from @jakepetroules and doesn't appear to install this library already.

I don't know if macOS still needs this library installed, as I don't use that OS, but I can limit this change to non-Darwin if needed.

Jake and @ahoppen, let me know what you think.