### PR TITLE
[ASTGen] Add a convenient method to process attribute arguments

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -130,3 +130,21 @@ extension ASTGenDiagnostic {
     )
   }
 }
+
+/// DeclAttributes diagnostics
+extension ASTGenDiagnostic {
+  static func expectedArgumentsInAttribute(_ attribute: AttributeSyntax) -> Self {
+    // FIXME: The diagnostic position should be at the and of the attribute name.
+    Self(
+      node: attribute,
+      message: "expected arguments for '\(attribute.attributeName.trimmedDescription)' attribute"
+    )
+  }
+
+  static func extraneousArgumentsInAttribute(_ attribute: AttributeSyntax, _ extra: some SyntaxProtocol) -> Self {
+    Self(
+      node: extra,
+      message: "unexpected arguments in '\(attribute.attributeName.trimmedDescription)' attribute"
+    )
+  }
+}

--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -31,3 +31,9 @@ func testEditorPlaceholder() -> Int {
 _ = [(Int) -> async throws Int]()
 // expected-error@-1{{'async throws' must precede '->'}}
 // expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}
+
+@freestanding // expected-error {{expected arguments for 'freestanding' attribute}}
+func dummy() {}
+
+@_silgen_name("whatever", extra)  // expected-error@:27 {{unexpected arguments in '_silgen_name' attribute}}
+func _whatever()


### PR DESCRIPTION
`generateWithLabeledExprListArguments(attribute:_:)` ensures all the `LabeledExprListSyntax` arguments are processed in the generator function.

It simplifies:
```swift
    guard var args = node.arguments?.as(LabeledExprListSyntax.self)?[...] else {
      self.diagnose(.expectedArgumentsForAttribtue(node))
      return nil
    }
    
    ...consume arguments...   

    if !args.isEmpty {
      self.diagnose(.extraneousArgumentsInAttribute(node, args.first!))
    }
```
into:
```swift
    self.generateWithLabeledExprListArguments(attribute: node) { args in
      ...consume arguments...
    }
```