### PR TITLE
[CSSimplify] Handle invalid type specializations

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13936,6 +13936,13 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
   } else {
     // If the overload hasn't been resolved, we can't simplify this constraint.
     auto overloadLocator = getCalleeLocator(getConstraintLocator(locator));
+
+    // If there was a problem resolving specialization expression
+    // it would be diagnosted as invalid AST node.
+    if (overloadLocator->directlyAt<ErrorExpr>()) {
+      return shouldAttemptFixes() ? SolutionKind::Error : SolutionKind::Solved;
+    }
+
     auto selectedOverload = findSelectedOverloadFor(overloadLocator);
     if (!selectedOverload)
       return formUnsolved();

--- a/test/Constraints/rdar139913219.swift
+++ b/test/Constraints/rdar139913219.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift
 
 // rdar://139913219 - Make sure we don't crash.
 
@@ -6,9 +6,6 @@ func bar(_ x: Int.Type, _: Int) {}
 func bar<T>(_ x: T.Type, _: Int) {}
 
 func foo() {
-  // FIXME: We shouldn't be failing to produce a diagnostic.
-  // Once resolved, remove '-verify-ignore-unknown'
   bar(X<Int?>.self, .zero)
   // expected-error@-1 {{cannot find 'X' in scope}}
-  // expected-error@-2 {{failed to produce diagnostic for expression}}
 }


### PR DESCRIPTION
If the base type of the specialization is invalid, the AST node is going to be replaced with `ErrorExpr`.

We need to handle that gracefully when attempting
to apply specialization in such situations.

Resolves: https://github.com/swiftlang/swift/issues/77644

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
