### PR TITLE
[embedded] Add back lazy collection operations, collection diffing and StaticBigInt to Embedded Stdlib

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -71,16 +71,16 @@ split_embedded_sources(
   EMBEDDED DictionaryCasting.swift
   EMBEDDED DictionaryStorage.swift
   EMBEDDED DictionaryVariant.swift
-    NORMAL DiscontiguousSlice.swift
-    NORMAL DropWhile.swift
+  EMBEDDED DiscontiguousSlice.swift
+  EMBEDDED DropWhile.swift
     NORMAL Dump.swift
   EMBEDDED EmptyCollection.swift
   EMBEDDED Equatable.swift
   EMBEDDED ErrorType.swift
   EMBEDDED ExistentialCollection.swift
-    NORMAL Filter.swift
-    NORMAL FlatMap.swift
-    NORMAL Flatten.swift
+  EMBEDDED Filter.swift
+  EMBEDDED FlatMap.swift
+  EMBEDDED Flatten.swift
   EMBEDDED FloatingPoint.swift
   EMBEDDED Hashable.swift
   # WORKAROUND: This file name is not sorted alphabetically in the list because
@@ -95,7 +95,7 @@ split_embedded_sources(
   EMBEDDED InputStream.swift
   EMBEDDED IntegerParsing.swift
   EMBEDDED Integers.swift
-    NORMAL Join.swift
+  EMBEDDED Join.swift
   EMBEDDED KeyPath.swift
   EMBEDDED KeyValuePairs.swift
   EMBEDDED LazyCollection.swift
@@ -104,7 +104,7 @@ split_embedded_sources(
   EMBEDDED LifetimeManager.swift
     NORMAL Macros.swift
   EMBEDDED ManagedBuffer.swift
-    NORMAL Map.swift
+  EMBEDDED Map.swift
   EMBEDDED MemoryLayout.swift
   EMBEDDED UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
     NORMAL Mirrors.swift
@@ -121,7 +121,7 @@ split_embedded_sources(
   EMBEDDED OutputStream.swift
   EMBEDDED Pointer.swift
   EMBEDDED Policy.swift
-    NORMAL PrefixWhile.swift
+  EMBEDDED PrefixWhile.swift
     NORMAL Prespecialize.swift
     NORMAL Print.swift
   EMBEDDED PtrAuth.swift
@@ -220,9 +220,9 @@ split_embedded_sources(
     ### "NON-ESSENTIAL" SOURCES, LAYERED ON TOP OF THE "ESSENTIAL" ONES
     ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
   EMBEDDED Availability.swift
-    NORMAL CollectionDifference.swift
+  EMBEDDED CollectionDifference.swift
   EMBEDDED CollectionOfOne.swift
-    NORMAL Diffing.swift
+  EMBEDDED Diffing.swift
   EMBEDDED Duration.swift
   EMBEDDED DurationProtocol.swift
   EMBEDDED FloatingPointRandom.swift
@@ -232,9 +232,9 @@ split_embedded_sources(
     NORMAL PlaygroundDisplay.swift
     NORMAL CommandLine.swift
   EMBEDDED SliceBuffer.swift
-    NORMAL StaticBigInt.swift
+  EMBEDDED StaticBigInt.swift
   EMBEDDED UInt128.swift
-    NORMAL UnfoldSequence.swift
+  EMBEDDED UnfoldSequence.swift
   EMBEDDED UnsafeBufferPointerSlice.swift
     NORMAL VarArgs.swift
   EMBEDDED Zip.swift

--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -386,6 +386,7 @@ extension CollectionDifference where ChangeElement: Hashable {
   }
 }
 
+#if !$Embedded
 @available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Change: Codable where ChangeElement: Codable {
   private enum _CodingKeys: String, CodingKey {
@@ -449,6 +450,7 @@ extension CollectionDifference: Codable where ChangeElement: Codable {
     try container.encode(removals, forKey: .removals)
   }
 }
+#endif
 
 @available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Sendable where ChangeElement: Sendable { }

--- a/stdlib/public/core/DiscontiguousSlice.swift
+++ b/stdlib/public/core/DiscontiguousSlice.swift
@@ -53,6 +53,7 @@ extension DiscontiguousSlice: Hashable where Base.Element: Hashable {
 }
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension DiscontiguousSlice: CustomStringConvertible {
   public var description: String {
     _makeCollectionDescription()
@@ -98,6 +99,7 @@ extension DiscontiguousSlice.Index: Comparable {
 }
 
 @available(SwiftStdlib 6.0, *)
+@_unavailableInEmbedded
 extension DiscontiguousSlice.Index: CustomStringConvertible {
   public var description: String {
     "<base: \(String(reflecting: base)), rangeOffset: \(_rangeOffset)>"

--- a/test/embedded/collection-difference.swift
+++ b/test/embedded/collection-difference.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+@main
+struct Main {
+  static func main() {
+    let a = [1, 2, 3, 4, 5]
+    let b = [   2, 3, 4,    6]
+    let diff = b.difference(from: a)
+    for entry in diff {
+        switch entry {
+        case .remove(let offset, let element, _): print(".remove(\(offset), \(element))")
+        case .insert(let offset, let element, _): print(".insert(\(offset), \(element))")
+        }
+    }
+    // CHECK: .remove(4, 5)
+    // CHECK: .remove(0, 1)
+    // CHECK: .insert(3, 6)
+  }
+}

--- a/test/embedded/collection-difference.swift
+++ b/test/embedded/collection-difference.swift
@@ -3,7 +3,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 
 @main

--- a/test/embedded/lazy-collections.swift
+++ b/test/embedded/lazy-collections.swift
@@ -16,5 +16,13 @@ struct Main {
     [1, 2, 3].lazy.map { $0 * 2 }.forEach { print($0, terminator: " ") }
     print("")
     // CHECK: 2 4 6
+
+    [1, 2, 3].lazy.drop(while: { $0 < 2 }).forEach { print($0, terminator: " ") }
+    print("")
+    // CHECK: 2 3
+
+    [[1, 2, 3], [4, 5, 6]].lazy.joined().forEach { print($0, terminator: " ") }
+    print("")
+    // CHECK: 1 2 3 4 5 6
   }
 }


### PR DESCRIPTION
Straightforward enablement of a bunch of files to the Embedded stdlib, which seem to be excluded for no reason:

- DiscontiguousSlice.swift
- DropWhile.swift
- Filter.swift
- FlatMap.swift
- Flatten.swift
- Join.swift
- Map.swift
- PrefixWhile.swift
- CollectionDifference.swift
- Diffing.swift
- StaticBigInt.swift
- UnfoldSequence.swift

rdar://139729059
rdar://139729075
rdar://139729137