### PR TITLE
[Basic] Limit `version::getCompilerversion` to major + minor only

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -343,11 +343,10 @@ std::string getCompilerVersion() {
   std::string buf;
   llvm::raw_string_ostream OS(buf);
 
-#if defined(SWIFT_COMPILER_VERSION)
-  OS << SWIFT_COMPILER_VERSION;
-#else
-  OS << SWIFT_VERSION_STRING;
-#endif
+ // TODO: This should print SWIFT_COMPILER_VERSION when
+ // available, but to do that we need to switch from
+ // llvm::VersionTuple to swift::Version.
+ OS << SWIFT_VERSION_STRING;
 
   return OS.str();
 }


### PR DESCRIPTION
At the moment the only user of this method is `-interface-compiler-version` and it's checked against major + minor only, so this is not going to affect functionality.

In the future we should switch from `llvm::VersionTuple` to `swift::Version` because swift tags have five components.

Resolves: rdar://140006577

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
