### PR TITLE
[CoroutineAccessors] Default implementations are transparent.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8454,6 +8454,11 @@ public:
   /// even when it does not have one _yet_.
   bool doesAccessorHaveBody() const;
 
+  /// Whether this accessor is a protocol requirement for which a default
+  /// implementation must be provided for back-deployment.  For example, read2
+  /// and modify2 requirements with early enough availability.
+  bool isRequirementWithSynthesizedDefaultImplementation() const;
+
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Accessor;
   }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3889,7 +3889,7 @@ static bool isCurrentFunctionAccessor(SILGenFunction &SGF,
          contextAccessorDecl->getAccessorKind() == accessorKind;
 }
 
-static bool isSynthesizedDefaultImplementionatThunk(SILGenFunction &SGF) {
+static bool isSynthesizedDefaultImplementionThunk(SILGenFunction &SGF) {
   if (!SGF.FunctionDC)
     return false;
 
@@ -3932,7 +3932,7 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   AccessStrategy strategy = var->getAccessStrategy(
       accessSemantics, getFormalAccessKind(accessKind),
       SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
-      /*useOldABI=*/isSynthesizedDefaultImplementionatThunk(SGF));
+      /*useOldABI=*/isSynthesizedDefaultImplementionThunk(SGF));
 
   bool isOnSelfParameter = isCallToSelfOfCurrentFunction(SGF, e);
 
@@ -4141,7 +4141,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   auto strategy = decl->getAccessStrategy(
       accessSemantics, getFormalAccessKind(accessKind),
       SGF.SGM.M.getSwiftModule(), SGF.F.getResilienceExpansion(),
-      /*useOldABI=*/isSynthesizedDefaultImplementionatThunk(SGF));
+      /*useOldABI=*/isSynthesizedDefaultImplementionThunk(SGF));
 
   bool isOnSelfParameter = isCallToSelfOfCurrentFunction(SGF, e);
   bool isContextRead = isCurrentFunctionAccessor(SGF, AccessorKind::Read);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2828,6 +2828,11 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
   if (accessor->getAttrs().hasAttribute<TransparentAttr>())
     return true;
 
+  // Default implementations of read2 and modify2 provided for back-deployment
+  // are transparent.
+  if (accessor->isRequirementWithSynthesizedDefaultImplementation())
+    return true;
+
   if (!accessor->isImplicit())
     return false;
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -938,34 +938,6 @@ buildIndexForwardingParamList(AbstractStorageDecl *storage,
   return ParameterList::create(context, elements);
 }
 
-bool AccessorDecl::doesAccessorHaveBody() const {
-  auto *accessor = this;
-  auto *storage = accessor->getStorage();
-
-  if (isa<ProtocolDecl>(accessor->getDeclContext())) {
-    if (!accessor->getASTContext().LangOpts.hasFeature(
-            Feature::CoroutineAccessors)) {
-      return false;
-    }
-    if (!requiresFeatureCoroutineAccessors(accessor->getAccessorKind())) {
-      return false;
-    }
-    if (storage->getOverrideLoc()) {
-      return false;
-    }
-    return accessor->getStorage()
-        ->requiresCorrespondingUnderscoredCoroutineAccessor(
-            accessor->getAccessorKind(), accessor);
-  }
-
-  // NSManaged getters and setters don't have bodies.
-  if (storage->getAttrs().hasAttribute<NSManagedAttr>(/*AllowInvalid=*/true))
-    if (accessor->isGetterOrSetter())
-      return false;
-
-  return true;
-}
-
 /// Build an argument list referencing the subscript parameters for this
 /// subscript accessor.
 static ArgumentList *buildSubscriptArgumentList(ASTContext &ctx,

--- a/test/SILGen/coroutine_accessors_skip.swift
+++ b/test/SILGen/coroutine_accessors_skip.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-silgen                            \
+// RUN:     %s                                               \
+// RUN:     -experimental-skip-non-inlinable-function-bodies \
+// RUN:     -enable-library-evolution                        \
+// RUN:     -enable-experimental-feature CoroutineAccessors  \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+
+// RUN: %target-swift-emit-silgen                                              \
+// RUN:     %s                                                                 \
+// RUN:     -experimental-skip-non-inlinable-function-bodies                   \
+// RUN:     -enable-library-evolution                                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors                    \
+// RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError
+
+// CHECK-LABEL: sil_default_witness_table MutatableAssociatedField {
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    method #MutatableAssociatedField.field!read2
+// CHECK-SAME:        : @$s24coroutine_accessors_skip24MutatableAssociatedFieldP5field5AssocQzvy
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    no_default
+// CHECK-NEXT:    method #MutatableAssociatedField.field!modify2
+// CHECK-SAME:        : @$s24coroutine_accessors_skip24MutatableAssociatedFieldP5field5AssocQzvx
+// CHECK-NEXT:  }
+public protocol MutatableAssociatedField {
+  associatedtype Assoc
+
+  var field: Assoc { read set }
+}

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -55,7 +55,7 @@ public protocol P1 : ~Copyable {
 // CHECK:        unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements2P1P4ubgsAA1UVvy'
 
-// CHECK-LABEL: sil [ossa] @$s17read_requirements2P1P4ubgsAA1UVvx : {{.*}} {
+// CHECK-LABEL: sil{{.*}} [ossa] @$s17read_requirements2P1P4ubgsAA1UVvx : {{.*}} {
 // CHECK:       bb0(
 // CHECK-SAME:      [[SELF_UNCHECKED:%[^:]+]]
 // CHECK-SAME:  ):


### PR DESCRIPTION
Like every other method entry in the default witness table, the default implementations of the `read2` and `modify2` accessors that just call `read` and `modify` respectively should be transparent.