### PR TITLE
Frontend: Introduce `-disable-upcoming-feature` and `-disable-experimental-feature`

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -925,9 +925,19 @@ def enable_experimental_feature :
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable an experimental feature">;
 
+def disable_experimental_feature :
+  Separate<["-"], "disable-experimental-feature">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Disable an experimental feature">;
+
 def enable_upcoming_feature : Separate<["-"], "enable-upcoming-feature">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable a feature that will be introduced in an upcoming language "
+           "version">;
+
+def disable_upcoming_feature : Separate<["-"], "disable-upcoming-feature">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Disable a feature that will be introduced in an upcoming language "
            "version">;
 
 def Rpass_EQ : Joined<["-"], "Rpass=">,

--- a/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature StrictConcurrency=targeted %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -enable-experimental-feature StrictConcurrency
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -enable-experimental-feature StrictConcurrency=targeted -enable-experimental-feature StrictConcurrency=complete
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency

--- a/test/Frontend/upcoming_feature.swift
+++ b/test/Frontend/upcoming_feature.swift
@@ -5,20 +5,36 @@
 // Make sure that hasFeature(ConciseMagicFile) evaluates true in Swift 6.
 // RUN: %target-typecheck-verify-swift -swift-version 6
 
-// Make sure that hasFeature(ConciseMagicFile) is off prior to Swift 6
+// Make sure that hasFeature(ConciseMagicFile) is off prior to Swift 6.
 // RUN: %target-typecheck-verify-swift -verify-additional-prefix swift5-
 
-// It's fine to provide a feature that we don't know about
+// It's fine to provide a feature that we don't know about.
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature UnknownFeature
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature UnknownFeature -enable-upcoming-feature ConciseMagicFile
+
+// When -disable-upcoming-feature is specified, leave the feature disabled.
+// RUN: %target-typecheck-verify-swift -disable-upcoming-feature ConciseMagicFile -verify-additional-prefix swift5-
+
+// When both -enable-upcoming-feature and -disable-upcoming-feature are
+// specified, the result depends on the order.
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ConciseMagicFile -disable-upcoming-feature ConciseMagicFile -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -disable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ConciseMagicFile
 
 // For compatibility when a feature graduates, it's fine to refer to an
 // upcoming feature as an experimental feature.
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature ConciseMagicFile
 
+// A feature that has graduated can also be disabled as an experimental feature.
+// RUN: %target-typecheck-verify-swift -disable-experimental-feature ConciseMagicFile -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ConciseMagicFile -disable-experimental-feature ConciseMagicFile -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -disable-experimental-feature ConciseMagicFile -enable-experimental-feature ConciseMagicFile
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ConciseMagicFile -disable-experimental-feature ConciseMagicFile -verify-additional-prefix swift5-
+
 // It's not fine to provide a feature that's in the specified language version.
 // RUN: not %target-swift-frontend -typecheck -enable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: %target-swift-frontend -typecheck -disable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
 // RUN: %target-swift-frontend -typecheck -enable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
+// RUN: %target-swift-frontend -typecheck -disable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
 
 // REQUIRES: swift_feature_ConciseMagicFile
 // REQUIRES: !swift_feature_UnknownFeature


### PR DESCRIPTION
To allow feature build settings to be composed more flexibly, allow an `-enable-upcoming-feature` flag to be overridden by a `-disable-upcoming-feature` flag. Whichever comes last on the command line takes effect. Provide the same functionality for `-enable-experimental-feature` as well.

Resolves rdar://126283879.
