### PR TITLE
Add support for creating a task with a self-consuming task function

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2654,6 +2654,13 @@ public:
     Task_EnqueueJob                               = 12,
     Task_AddPendingGroupTaskUnconditionally       = 13,
     Task_IsDiscardingTask                         = 14,
+
+    /// The task function is consumed by calling it (@callee_owned).
+    /// The context pointer should be treated as opaque and non-copyable;
+    /// in particular, it should not be retained or released.
+    ///
+    /// Supported starting in Swift 6.1.
+    Task_IsTaskFunctionConsumed                       = 15,
   };
 
   explicit constexpr TaskCreateFlags(size_t bits) : FlagSet(bits) {}
@@ -2683,6 +2690,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsDiscardingTask,
                                 isDiscardingTask,
                                 setIsDiscardingTask)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsTaskFunctionConsumed,
+                                isTaskFunctionConsumed,
+                                setIsTaskFunctionConsumed)
 };
 
 /// Flags for schedulable jobs.

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -75,6 +75,7 @@ FEATURE(NoncopyableGenerics,                            (6, 0))
 FEATURE(InitRawStructMetadata,                          (6, 0))
 
 FEATURE(LayoutStringValueWitnesses,                     (6, 1))
+FEATURE(CreateTaskWithConsumedFunction,                 (6, 1))
 
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)


### PR DESCRIPTION
Not used yet.  Apparently difficult to unit-test because we don't reliably actually build the runtime unit tests anymore.