### PR TITLE
AST: Introduce ProtocolConformanceRef::forAbstract()

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -59,12 +59,14 @@ class ProtocolConformanceRef {
 
   explicit ProtocolConformanceRef(UnionType value) : Union(value) {}
 
-public:
   /// Create an abstract protocol conformance reference.
   explicit ProtocolConformanceRef(ProtocolDecl *proto) : Union(proto) {
     assert(proto != nullptr &&
            "cannot construct ProtocolConformanceRef with null");
   }
+
+public:
+  ProtocolConformanceRef() : Union() {}
 
   /// Create a concrete protocol conformance reference.
   explicit ProtocolConformanceRef(ProtocolConformance *conf) : Union(conf) {
@@ -77,9 +79,6 @@ public:
     assert(conf != nullptr &&
            "cannot construct ProtocolConformanceRef with null");
   }
-
-  ProtocolConformanceRef(std::nullptr_t = nullptr)
-      : Union((ProtocolDecl *)nullptr) {}
 
   static ProtocolConformanceRef forInvalid() {
     return ProtocolConformanceRef();
@@ -94,10 +93,9 @@ public:
 
   explicit operator bool() const { return !isInvalid(); }
 
-  /// Create either a concrete or an abstract protocol conformance reference,
-  /// depending on whether ProtocolConformance is null.
-  explicit ProtocolConformanceRef(ProtocolDecl *protocol,
-                                  ProtocolConformance *conf);
+  /// Create an abstract conformance for a type parameter or archetype.
+  static ProtocolConformanceRef forAbstract(Type subjectType,
+                                            ProtocolDecl *protocol);
 
   bool isConcrete() const {
     return !isInvalid() && Union.is<ProtocolConformance*>();

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -93,7 +93,7 @@ struct SubstitutionMapWithLocalArchetypes {
     if (SubsMap)
       return SubsMap->lookupConformance(origType, proto);
 
-    return ProtocolConformanceRef(proto);
+    return ProtocolConformanceRef::forAbstract(substType, proto);
   }
 
   void dump(llvm::raw_ostream &out) const {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1625,7 +1625,7 @@ public:
 
   /// The set of conformances synthesized during solving (i.e. for
   /// ad-hoc distributed `SerializationRequirement` conformances).
-  llvm::DenseMap<ConstraintLocator *, ProtocolConformanceRef>
+  llvm::DenseMap<ConstraintLocator *, ProtocolDecl *>
       SynthesizedConformances;
 
   /// Record a new argument matching choice for given locator that maps a
@@ -2426,7 +2426,7 @@ public:
 
   /// The set of conformances synthesized during solving (i.e. for
   /// ad-hoc distributed `SerializationRequirement` conformances).
-  llvm::DenseMap<ConstraintLocator *, ProtocolConformanceRef>
+  llvm::DenseMap<ConstraintLocator *, ProtocolDecl *>
       SynthesizedConformances;
 
 private:
@@ -4948,7 +4948,7 @@ private:
                                             TypeMatchOptions flags);
 
   void recordSynthesizedConformance(ConstraintLocator *locator,
-                                    ProtocolConformanceRef conformance);
+                                    ProtocolDecl *conformance);
 
   /// Attempt to simplify the given conformance constraint.
   ///

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1976,7 +1976,8 @@ SwiftDeclCollector::addConformancesToTypeDecl(SDKNodeDeclType *Root,
   if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
     for (auto *inherited : PD->getAllInheritedProtocols()) {
       if (!Ctx.shouldIgnore(inherited)) {
-        ProtocolConformanceRef Conf(inherited);
+        auto Conf = ProtocolConformanceRef::forAbstract(
+          PD->getSelfInterfaceType(), inherited);
         auto ConfNode = SDKNodeInitInfo(Ctx, Conf)
             .createSDKNode(SDKNodeKind::Conformance);
         Root->addConformance(ConfNode);

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -509,7 +509,7 @@ LookupConformanceInModuleRequest::evaluate(
 
     for (auto ap : archetype->getConformsTo()) {
       if (ap == protocol || ap->inheritsFrom(protocol))
-        return ProtocolConformanceRef(protocol);
+        return ProtocolConformanceRef::forAbstract(archetype, protocol);
     }
 
     return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
@@ -527,17 +527,17 @@ LookupConformanceInModuleRequest::evaluate(
 
   // Type parameters have trivial conformances.
   if (type->isTypeParameter())
-    return ProtocolConformanceRef(protocol);
+    return ProtocolConformanceRef::forAbstract(type, protocol);
 
   // Type variables have trivial conformances.
   if (type->isTypeVariableOrMember())
-    return ProtocolConformanceRef(protocol);
+    return ProtocolConformanceRef::forAbstract(type, protocol);
 
   // UnresolvedType is a placeholder for an unknown type used when generating
   // diagnostics.  We consider it to conform to all protocols, since the
   // intended type might have. Same goes for PlaceholderType.
   if (type->is<UnresolvedType>() || type->is<PlaceholderType>())
-    return ProtocolConformanceRef(protocol);
+    return ProtocolConformanceRef::forAbstract(type, protocol);
 
   // Pack types can conform to protocols.
   if (auto packType = type->getAs<PackType>()) {

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -130,8 +130,7 @@ swift::getDistributedActorAsActorConformanceRef(ASTContext &C) {
   auto distributedActorAsActorConformance =
       getDistributedActorAsActorConformance(C);
 
-  auto actorProto = C.getProtocol(KnownProtocolKind::Actor);
-  return ProtocolConformanceRef(actorProto, distributedActorAsActorConformance);
+  return ProtocolConformanceRef(distributedActorAsActorConformance);
 }
 NormalProtocolConformance *
 swift::getDistributedActorAsActorConformance(ASTContext &C) {

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -265,7 +265,7 @@ swift::buildSubstitutionMapWithCapturedEnvironments(
     [&](CanType origType, Type substType,
         ProtocolDecl *proto) -> ProtocolConformanceRef {
       if (origType->getRootGenericParam()->getDepth() >= baseDepth)
-        return ProtocolConformanceRef(proto);
+        return ProtocolConformanceRef::forAbstract(substType, proto);
       return baseSubMap.lookupConformance(origType, proto);
     });
 }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -33,16 +33,10 @@
 
 using namespace swift;
 
-ProtocolConformanceRef::ProtocolConformanceRef(ProtocolDecl *protocol,
-                                               ProtocolConformance *conf) {
-  assert(protocol != nullptr &&
-         "cannot construct ProtocolConformanceRef with null protocol");
-  if (conf) {
-    assert(protocol == conf->getProtocol() && "protocol conformance mismatch");
-    Union = conf;
-  } else {
-    Union = protocol;
-  }
+ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
+    Type subjectType, ProtocolDecl *proto) {
+  // Temporary implementation:
+  return ProtocolConformanceRef(proto);
 }
 
 bool ProtocolConformanceRef::isInvalid() const {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -491,7 +491,7 @@ LookUpConformanceInOverrideSubs::operator()(CanType type,
                                             Type substType,
                                             ProtocolDecl *proto) const {
   if (type->getRootGenericParam()->getDepth() >= info.BaseDepth)
-    return ProtocolConformanceRef(proto);
+    return ProtocolConformanceRef::forAbstract(substType, proto);
 
   if (auto conformance = info.BaseSubMap.lookupConformance(type, proto))
     return conformance;
@@ -696,7 +696,8 @@ ProtocolConformanceRef OuterSubstitutions::operator()(
                                         Type conformingReplacementType,
                                         ProtocolDecl *conformedProtocol) const {
   if (isUnsubstitutedTypeParameter(dependentType))
-    return ProtocolConformanceRef(conformedProtocol);
+    return ProtocolConformanceRef::forAbstract(
+      conformingReplacementType, conformedProtocol);
 
   return LookUpConformanceInSubstitutionMap(subs)(
       dependentType, conformingReplacementType, conformedProtocol);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2306,15 +2306,11 @@ public:
           QueryTypeSubstitutionMap{newParamsMap},
           LookUpConformanceInModule());
         
-        if (newSubstTy->isTypeParameter()) {
-          newConformances.push_back(ProtocolConformanceRef(proto));
-        } else {
-          auto newConformance
-            = lookupConformance(newSubstTy, proto, /*allowMissing=*/true);
-          if (!newConformance)
-            return CanType();
-          newConformances.push_back(newConformance);
-        }
+        auto newConformance
+          = lookupConformance(newSubstTy, proto, /*allowMissing=*/true);
+        if (!newConformance)
+          return CanType();
+        newConformances.push_back(newConformance);
       }
     }
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -166,7 +166,8 @@ operator()(CanType dependentType, Type conformingReplacementType,
       return lookupConformance(archetypeType, conformedProtocol);
     }
   }
-  return ProtocolConformanceRef(conformedProtocol);
+  return ProtocolConformanceRef::forAbstract(
+    conformingReplacementType, conformedProtocol);
 }
 
 static Type substGenericFunctionType(GenericFunctionType *genericFnType,
@@ -1197,7 +1198,7 @@ ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
 ProtocolConformanceRef ReplaceOpaqueTypesWithUnderlyingTypes::
 operator()(CanType maybeOpaqueType, Type replacementType,
            ProtocolDecl *protocol) const {
-  auto abstractRef = ProtocolConformanceRef(protocol);
+  auto abstractRef = ProtocolConformanceRef::forAbstract(maybeOpaqueType, protocol);
   
   auto archetype = dyn_cast<OpaqueTypeArchetypeType>(maybeOpaqueType);
   if (!archetype) {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -306,8 +306,10 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
     assert(rootWTable && "root witness table not bound in local context!");
   }
 
+  auto conformance = ProtocolConformanceRef::forAbstract(
+      rootArchetype, rootProtocol);
   wtable = path.followFromWitnessTable(IGF, rootArchetype,
-                                       ProtocolConformanceRef(rootProtocol),
+                                       conformance,
                                        MetadataResponse::forComplete(rootWTable),
                                        /*request*/ MetadataState::Complete,
                                        nullptr).getMetadata();

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -354,10 +354,12 @@ static void bindElementSignatureRequirementsAtIndex(
                       patternPackArchetype)
                   ->getCanonicalType();
           llvm::Value *_metadata = nullptr;
-          auto packConformance = ProtocolConformanceRef(proto);
+          auto packConformance = ProtocolConformanceRef::forAbstract(
+              patternPackArchetype, proto);
           auto *wtablePack = emitWitnessTableRef(IGF, patternPackArchetype,
                                                  &_metadata, packConformance);
-          auto elementConformance = ProtocolConformanceRef(proto);
+          auto elementConformance = ProtocolConformanceRef::forAbstract(
+              elementArchetype, proto);
           auto *wtable = bindWitnessTableAtIndex(
               IGF, elementArchetype, elementConformance, wtablePack, index);
           assert(wtable);

--- a/lib/IRGen/LocalTypeDataKind.h
+++ b/lib/IRGen/LocalTypeDataKind.h
@@ -186,7 +186,10 @@ public:
   ProtocolConformanceRef getProtocolConformance() const {
     assert(!isSingletonKind());
     if ((Value & KindMask) == Kind_Decl) {
-      return ProtocolConformanceRef(getAbstractProtocolConformance());
+      // FIXME: Passing an empty Type() here temporarily while staging in
+      // new representation for abstract conformances
+      return ProtocolConformanceRef::forAbstract(
+          Type(), getAbstractProtocolConformance());
     } else if ((Value & KindMask) == Kind_PackConformance) {
       return ProtocolConformanceRef(getPackProtocolConformance());
     } else {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3940,7 +3940,8 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
 
     if (silRep == SILFunctionTypeRepresentation::WitnessMethod) {
       auto proto = constant.getDecl()->getDeclContext()->getSelfProtocolDecl();
-      witnessMethodConformance = ProtocolConformanceRef(proto);
+      witnessMethodConformance = ProtocolConformanceRef::forAbstract(
+          proto->getSelfInterfaceType()->getCanonicalType(), proto);
     }
 
     // Does this constant have a preferred abstraction pattern set?

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -75,7 +75,8 @@ public:
              Type conformingReplacementType,
              ProtocolDecl *conformedProtocol) -> ProtocolConformanceRef {
         return substOpaqueTypesWithUnderlyingTypes(
-               ProtocolConformanceRef(conformedProtocol),
+               ProtocolConformanceRef::forAbstract(conformingReplacementType,
+                                                   conformedProtocol),
                conformingReplacementType->getCanonicalType(),
                typeExpansionContext);
       },

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1875,7 +1875,8 @@ SubstitutionMap getApplySubstitutionsFromParsed(
                       proto->getDeclaredInterfaceType());
         failed = true;
 
-        return ProtocolConformanceRef(proto);
+        // FIXME: Passing an empty Type() here temporarily.
+        return ProtocolConformanceRef::forAbstract(Type(), proto);
       });
 
   return failed ? SubstitutionMap() : subMap;
@@ -8162,7 +8163,8 @@ static bool parseSILWitnessTableEntry(
         P.parseToken(tok::colon, diag::expected_sil_witness_colon))
       return true;
 
-    ProtocolConformanceRef conformance(proto);
+    // FIXME: Passing an empty Type() here temporarily.
+    auto conformance = ProtocolConformanceRef::forAbstract(Type(), proto);
     if (P.Tok.getText() != "dependent") {
       auto concrete =
         witnessState.parseProtocolConformance();

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -819,8 +819,7 @@ SILGenFunction::emitDistributedActorAsAnyActor(SILLocation loc,
       getDistributedActorAsActorConformance(ctx);
   auto actorProto = ctx.getProtocol(KnownProtocolKind::Actor);
   auto distributedActorType = distributedActorSubs.getReplacementTypes()[0];
-  auto ref = ProtocolConformanceRef(
-      actorProto, ctx.getSpecializedConformance(
+  auto ref = ProtocolConformanceRef(ctx.getSpecializedConformance(
                       distributedActorType, distributedActorAsActorConformance,
                       distributedActorSubs));
   ProtocolConformanceRef conformances[1] = {ref};

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1088,7 +1088,8 @@ namespace {
 
       SmallVector<ProtocolConformanceRef, 2> conformances;
       for (auto proto : OpenedArchetype->getConformsTo())
-        conformances.push_back(ProtocolConformanceRef(proto));
+        conformances.push_back(ProtocolConformanceRef::forAbstract(
+          OpenedArchetype, proto));
 
       SILValue ref;
       if (base.getType().is<ExistentialMetatypeType>()) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -915,11 +915,12 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
   // Open the protocol type.
   auto openedType = OpenedArchetypeType::get(
       protocol->getDeclaredExistentialType()->getCanonicalType());
+  auto openedConf = ProtocolConformanceRef::forAbstract(openedType, protocol);
 
   // Form the substitutions for calling the witness.
   auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,
                                           openedType,
-                                          ProtocolConformanceRef(protocol));
+                                          openedConf);
 
   // Substitute to get the formal substituted type of the thunk.
   auto reqtSubstTy =
@@ -1073,8 +1074,11 @@ public:
       addMissingDefault();
       return;
     }
+
+    auto Conf = ProtocolConformanceRef::forAbstract(
+        Proto->getSelfInterfaceType()->getCanonicalType(), Proto);
     SILFunction *witnessFn = SGM.emitProtocolWitness(
-        ProtocolConformanceRef(Proto), SILLinkage::Private, IsNotSerialized,
+        Conf, SILLinkage::Private, IsNotSerialized,
         requirementRef, witnessRef, isFree, witness);
     auto entry = SILWitnessTable::MethodWitness{requirementRef, witnessFn};
     DefaultWitnesses.push_back(entry);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1181,7 +1181,7 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
                 // base type of the existential's requirements.
                 return CEI.lookupExistentialConformance(proto);
               }
-              return ProtocolConformanceRef(proto);
+              return ProtocolConformanceRef::forAbstract(substTy, proto);
             }, SubstFlags::SubstituteLocalArchetypes);
         continue;
       }
@@ -1219,7 +1219,7 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
             // base type of the existential's requirements.
             return CEI.lookupExistentialConformance(proto);
           }
-          return ProtocolConformanceRef(proto);
+          return ProtocolConformanceRef::forAbstract(substTy, proto);
         }, SubstFlags::SubstituteLocalArchetypes);
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8349,8 +8349,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
 void ConstraintSystem::recordSynthesizedConformance(
                                            ConstraintLocator *locator,
-                                           ProtocolConformanceRef conformance) {
-  bool inserted = SynthesizedConformances.insert({locator, conformance}).second;
+                                           ProtocolDecl *proto) {
+  bool inserted = SynthesizedConformances.insert({locator, proto}).second;
   ASSERT(inserted);
 
   if (solverState)
@@ -8512,13 +8512,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       // dynamically during IRGen.
       if (auto *witness = dyn_cast<FuncDecl>(witnessInfo->first)) {
         auto synthesizeConformance = [&]() {
-          ProtocolConformanceRef synthesized(protocol);
           auto witnessLoc = getConstraintLocator(
               locator.getAnchor(), LocatorPathElt::Witness(witness));
           // FIXME: Why are we recording the same locator more than once here?
           if (SynthesizedConformances.count(witnessLoc) == 0)
-            recordSynthesizedConformance(witnessLoc, synthesized);
-          return recordConformance(synthesized);
+            recordSynthesizedConformance(witnessLoc, protocol);
+          return SolutionKind::Solved;
         };
 
         if (witness->isGeneric()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5517,12 +5517,16 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto,
     for (auto *PD : layout.getProtocols()) {
       // If we found the protocol we're looking for, return an abstract
       // conformance to it.
-      if (PD == Proto)
-        return ProtocolConformanceRef(Proto);
+      if (PD == Proto) {
+        // FIXME: Passing an empty Type() here temporarily.
+        return ProtocolConformanceRef::forAbstract(Type(), Proto);
+      }
 
       // Now check refined protocols.
-      if (PD->inheritsFrom(Proto))
-        return ProtocolConformanceRef(Proto);
+      if (PD->inheritsFrom(Proto)) {
+        // FIXME: Passing an empty Type() here temporarily.
+        return ProtocolConformanceRef::forAbstract(Type(), Proto);
+      }
     }
 
     return allowMissing ? ProtocolConformanceRef::forMissingOrInvalid(T, Proto)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1133,7 +1133,8 @@ ModuleFile::getConformanceChecked(ProtocolConformanceID conformanceID) {
     if (!maybeProtocol)
       return maybeProtocol.takeError();
     auto proto = cast<ProtocolDecl>(maybeProtocol.get());
-    return ProtocolConformanceRef(proto);
+    // FIXME: Passing an empty Type() here temporarily.
+    return ProtocolConformanceRef::forAbstract(Type(), proto);
   }
 
   case SerializedProtocolConformanceKind::Concrete: {
@@ -8583,7 +8584,10 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
         // conformance to an Objective-C protocol for anything important.
         // There are no associated types and we don't emit a Swift conformance
         // record.
-        reqConformances.push_back(ProtocolConformanceRef(proto));
+        //
+        // FIXME: Passing an empty Type() here temporarily.
+        reqConformances.push_back(ProtocolConformanceRef::forAbstract(
+            Type(), proto));
       }
     }
   } else {


### PR DESCRIPTION
I've wanted to change the representation of abstract conformances for a while, so that they store a conforming type, just like concrete conformances do. This will fix some edge cases involving opaque type substitution.

For now, land a change that introduces the new `forAbstract()` factory method, that just ignores the conforming type. I've had this change locally for a while, and I'm tired of rebasing it, so I'm just landing this now.