### PR TITLE
[test] Quote `%original_path_env` in `swift-xcodegen.test`

### DIFF
--- a/validation-test/BuildSystem/swift-xcodegen.test
+++ b/validation-test/BuildSystem/swift-xcodegen.test
@@ -1,7 +1,7 @@
 # RUN: %empty-directory(%t)
 # RUN: %empty-directory(%t/src/swift/utils)
 # RUN: %empty-directory(%t/out)
-# RUN: export PATH=%original_path_env
+# RUN: export PATH="%original_path_env"
 # RUN: export SWIFTCI_USE_LOCAL_DEPS=1
 
 # REQUIRES: OS=macosx


### PR DESCRIPTION
Ensure we can handle a `PATH` with spaces.