### PR TITLE
[AST] Remove `ModuleDecl::addFile`

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -486,9 +486,11 @@ void simple_display(llvm::raw_ostream &out, const FileUnit *file);
 inline FileUnit &ModuleDecl::getMainFile(FileUnitKind expectedKind) const {
   assert(expectedKind != FileUnitKind::Source &&
          "must use specific source kind; see getMainSourceFile");
-  assert(!Files.empty() && "No files added yet");
-  assert(Files.front()->getKind() == expectedKind);
-  return *Files.front();
+
+  auto files = getFiles();
+  assert(!files.empty() && "No files in module");
+  assert(files.front()->getKind() == expectedKind);
+  return *files.front();
 }
 
 } // end namespace swift

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -823,8 +823,8 @@ inline SourceFile::ParsingOptions operator|(SourceFile::ParsingFlags lhs,
 }
 
 inline SourceFile &ModuleDecl::getMainSourceFile() const {
-  assert(!Files.empty() && "No files added yet");
-  return *cast<SourceFile>(Files.front());
+  assert(!getFiles().empty() && "No files in module");
+  return *cast<SourceFile>(getFiles().front());
 }
 
 inline FileUnit *ModuleDecl::EntryPointInfoTy::getEntryPointFile() const {

--- a/include/swift/IDETool/SyntacticMacroExpansion.h
+++ b/include/swift/IDETool/SyntacticMacroExpansion.h
@@ -45,35 +45,32 @@ class SyntacticMacroExpansionInstance {
   DiagnosticEngine Diags{SourceMgr};
   std::unique_ptr<ASTContext> Ctx;
   ModuleDecl *TheModule = nullptr;
+  SourceFile *SF = nullptr;
   llvm::StringMap<MacroDecl *> MacroDecls;
-
-  /// Create 'SourceFile' using the buffer.
-  swift::SourceFile *getSourceFile(llvm::MemoryBuffer *inputBuf);
 
   /// Synthesize 'MacroDecl' AST object to use the expansion.
   swift::MacroDecl *
   getSynthesizedMacroDecl(swift::Identifier name,
                           const MacroExpansionSpecifier &expansion);
 
-  /// Expand single 'expansion' in SF.
-  void expand(swift::SourceFile *SF,
-                    const MacroExpansionSpecifier &expansion,
-                    SourceEditConsumer &consumer);
+  /// Expand single 'expansion'.
+  void expand(const MacroExpansionSpecifier &expansion,
+              SourceEditConsumer &consumer);
 
 public:
   SyntacticMacroExpansionInstance() {}
 
-  /// Setup the instance with \p args .
+  /// Setup the instance with \p args and a given \p inputBuf.
   bool setup(StringRef SwiftExecutablePath, ArrayRef<const char *> args,
+             llvm::MemoryBuffer *inputBuf,
              std::shared_ptr<PluginRegistry> plugins, std::string &error);
 
   ASTContext &getASTContext() { return *Ctx; }
 
-  /// Expand all macros in \p inputBuf and send the edit results to \p consumer.
-  /// Expansions are specified by \p expansions .
-  void expandAll(llvm::MemoryBuffer *inputBuf,
-                     ArrayRef<MacroExpansionSpecifier> expansions,
-                     SourceEditConsumer &consumer);
+  /// Expand all macros and send the edit results to \p consumer. Expansions are
+  /// specified by \p expansions .
+  void expandAll(ArrayRef<MacroExpansionSpecifier> expansions,
+                 SourceEditConsumer &consumer);
 };
 
 /// Manager object to vend 'SyntacticMacroExpansionInstance'.
@@ -86,9 +83,11 @@ public:
                           std::shared_ptr<PluginRegistry> Plugins)
       : SwiftExecutablePath(SwiftExecutablePath), Plugins(Plugins) {}
 
-  /// Get instance configured with the specified compiler arguments.
+  /// Get instance configured with the specified compiler arguments and
+  /// input buffer.
   std::shared_ptr<SyntacticMacroExpansionInstance>
-  getInstance(ArrayRef<const char *> args, std::string &error);
+  getInstance(ArrayRef<const char *> args, llvm::MemoryBuffer *inputBuf,
+              std::string &error);
 };
 
 } // namespace ide

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -117,6 +117,9 @@ namespace swift {
                               bool TokenizeInterpolatedString = true,
                               ArrayRef<Token> SplitTokens = ArrayRef<Token>());
 
+  /// Perform import resolution for the module.
+  void performImportResolution(ModuleDecl *M);
+
   /// This walks the AST to resolve imports.
   void performImportResolution(SourceFile &SF);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -734,8 +734,10 @@ ConstraintCheckerArenaRAII::~ConstraintCheckerArenaRAII() {
 }
 
 static ModuleDecl *createBuiltinModule(ASTContext &ctx) {
-  auto M = ModuleDecl::create(ctx.getIdentifier(BUILTIN_NAME), ctx);
-  M->addFile(*new (ctx) BuiltinUnit(*M));
+  auto *M = ModuleDecl::create(ctx.getIdentifier(BUILTIN_NAME), ctx,
+                               [&](ModuleDecl *M, auto addFile) {
+    addFile(new (ctx) BuiltinUnit(*M));
+  });
   M->setHasResolvedImports();
   return M;
 }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1135,7 +1135,7 @@ ASTBuilder::getAcceptableTypeDeclCandidate(ValueDecl *decl,
 
 DeclContext *ASTBuilder::getNotionalDC() {
   if (!NotionalDC) {
-    NotionalDC = ModuleDecl::create(Ctx.getIdentifier(".RemoteAST"), Ctx);
+    NotionalDC = ModuleDecl::createEmpty(Ctx.getIdentifier(".RemoteAST"), Ctx);
     NotionalDC = new (Ctx) TopLevelCodeDecl(NotionalDC);
   }
   return NotionalDC;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1581,11 +1581,14 @@ ClangImporter::create(ASTContext &ctx,
     = clangContext.Selectors.getSelector(2, setObjectForKeyedSubscriptIdents);
 
   // Set up the imported header module.
-  auto *importedHeaderModule =
-      ModuleDecl::create(ctx.getIdentifier(CLANG_HEADER_MODULE_NAME), ctx);
-  importer->Impl.ImportedHeaderUnit =
-    new (ctx) ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);
-  importedHeaderModule->addFile(*importer->Impl.ImportedHeaderUnit);
+  auto *importedHeaderModule = ModuleDecl::create(
+      ctx.getIdentifier(CLANG_HEADER_MODULE_NAME), ctx,
+      [&](ModuleDecl *importedHeaderModule, auto addFile) {
+        importer->Impl.ImportedHeaderUnit = new (ctx)
+            ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);
+        addFile(importer->Impl.ImportedHeaderUnit);
+      });
+
   importedHeaderModule->setHasResolvedImports();
   importedHeaderModule->setIsNonSwiftModule(true);
 
@@ -2805,7 +2808,12 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   if (auto mainModule = SwiftContext.MainModule) {
     implicitImportInfo = mainModule->getImplicitImportInfo();
   }
-  auto wrapper = ModuleDecl::create(name, SwiftContext, implicitImportInfo);
+  ClangModuleUnit *file = nullptr;
+  auto wrapper = ModuleDecl::create(name, SwiftContext, implicitImportInfo,
+                                    [&](ModuleDecl *wrapper, auto addFile) {
+    file = new (SwiftContext) ClangModuleUnit(*wrapper, *this, underlying);
+    addFile(file);
+  });
   wrapper->setIsSystemModule(underlying->IsSystem);
   wrapper->setIsNonSwiftModule();
   wrapper->setHasResolvedImports();
@@ -2813,9 +2821,6 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     wrapper->setExportAsName(
         SwiftContext.getIdentifier(underlying->ExportAsModule));
 
-  auto file = new (SwiftContext) ClangModuleUnit(*wrapper, *this,
-                                                 underlying);
-  wrapper->addFile(*file);
   SwiftContext.getClangModuleLoader()->findOverlayFiles(diagLoc, wrapper, file);
   cacheEntry.setPointer(file);
 

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -202,7 +202,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
                                                nullptr, nullptr,
                                                true),
                          true);
-  ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
+  ModuleDecl *M =
+      ModuleDecl::createEmpty(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
   std::unique_ptr<Lowering::TypeConverter> TC(
       new Lowering::TypeConverter(*M, ASTCtx.SILOpts.EnableSILOpaqueValues));
   std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, *TC, SILOpts);

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -94,7 +94,7 @@ struct LibParseExecutor {
     if (!opts.contains(ExecuteOptionFlag::SkipBodies))
       parseOpts |= SourceFile::ParsingFlags::DisableDelayedBodies;
 
-    ModuleDecl *M = ModuleDecl::create(Identifier(), *ctx);
+    ModuleDecl *M = ModuleDecl::createEmpty(Identifier(), *ctx);
     SourceFile *SF =
         new (*ctx) SourceFile(*M, SourceFileKind::Library, bufferID, parseOpts);
 
@@ -170,7 +170,7 @@ struct ASTGenExecutor {
     if (!opts.contains(ExecuteOptionFlag::SkipBodies))
       parseOpts |= SourceFile::ParsingFlags::DisableDelayedBodies;
 
-    ModuleDecl *M = ModuleDecl::create(Identifier(), *ctx);
+    ModuleDecl *M = ModuleDecl::createEmpty(Identifier(), *ctx);
     SourceFile *SF =
         new (*ctx) SourceFile(*M, SourceFileKind::Library, bufferID, parseOpts);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1552,19 +1552,8 @@ bool CompilerInstance::performParseAndResolveImportsOnly() {
     }
   }
 
-  // Resolve imports for all the source files.
-  for (auto *file : mainModule->getFiles()) {
-    if (auto *SF = dyn_cast<SourceFile>(file))
-      performImportResolution(*SF);
-  }
-
-  assert(llvm::all_of(mainModule->getFiles(), [](const FileUnit *File) -> bool {
-    auto *SF = dyn_cast<SourceFile>(File);
-    if (!SF)
-      return true;
-    return SF->ASTStage >= SourceFile::ImportsResolved;
-  }) && "some files have not yet had their imports resolved");
-  mainModule->setHasResolvedImports();
+  // Resolve imports for all the source files in the module.
+  performImportResolution(mainModule);
 
   bindExtensions(*mainModule);
   return Context->hadError();

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -292,8 +292,7 @@ void CompletionLookup::addSubModuleNames(
   for (auto &Pair : SubModuleNameVisibilityPairs) {
     CodeCompletionResultBuilder Builder = makeResultBuilder(
         CodeCompletionResultKind::Declaration, SemanticContextKind::None);
-    auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
-    MD->setFailedToLoad();
+    auto *MD = ModuleDecl::createEmpty(Ctx.getIdentifier(Pair.first), Ctx);
     Builder.setAssociatedDecl(MD);
     Builder.addBaseName(MD->getNameStr());
     Builder.addTypeAnnotation("Module");
@@ -367,8 +366,7 @@ void CompletionLookup::addImportModuleNames() {
     if (ModuleName == mainModuleName || isHiddenModuleName(ModuleName))
       continue;
 
-    auto MD = ModuleDecl::create(ModuleName, Ctx);
-    MD->setFailedToLoad();
+    auto *MD = ModuleDecl::createEmpty(ModuleName, Ctx);
 
     std::optional<ContextualNotRecommendedReason> Reason = std::nullopt;
 

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -249,11 +249,12 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   // Create a new module and file for the code completion buffer, similar to how
   // we handle new lines of REPL input.
   auto *newModule = ModuleDecl::create(
-      Ctx.getIdentifier("REPL_Code_Completion"), Ctx, implicitImports);
-  auto &newSF =
-      *new (Ctx) SourceFile(*newModule, SourceFileKind::Main, *BufferID);
-  newModule->addFile(newSF);
+      Ctx.getIdentifier("REPL_Code_Completion"), Ctx, implicitImports,
+      [&](ModuleDecl *newModule, auto addFile) {
+    addFile(new (Ctx) SourceFile(*newModule, SourceFileKind::Main, *BufferID));
+  });
 
+  auto &newSF = newModule->getMainSourceFile();
   performImportResolution(newSF);
   bindExtensions(*newModule);
 

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -137,7 +137,7 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   registerParseRequestFunctions(tmpCtx.evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx.evaluator);
 
-  ModuleDecl *tmpM = ModuleDecl::create(Identifier(), tmpCtx);
+  ModuleDecl *tmpM = ModuleDecl::createEmpty(Identifier(), tmpCtx);
   auto tmpBufferID = tmpSM.addNewSourceBuffer(std::move(*tmpBuffer));
   SourceFile *tmpSF = new (tmpCtx)
       SourceFile(*tmpM, SF.Kind, tmpBufferID, SF.getParsingOptions());

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -26,11 +26,13 @@ using namespace ide;
 
 std::shared_ptr<SyntacticMacroExpansionInstance>
 SyntacticMacroExpansion::getInstance(ArrayRef<const char *> args,
+                                     llvm::MemoryBuffer *inputBuf,
                                      std::string &error) {
   // Create and configure a new instance.
   auto instance = std::make_shared<SyntacticMacroExpansionInstance>();
 
-  bool failed = instance->setup(SwiftExecutablePath, args, Plugins, error);
+  bool failed =
+      instance->setup(SwiftExecutablePath, args, inputBuf, Plugins, error);
   if (failed)
     return nullptr;
 
@@ -39,7 +41,8 @@ SyntacticMacroExpansion::getInstance(ArrayRef<const char *> args,
 
 bool SyntacticMacroExpansionInstance::setup(
     StringRef SwiftExecutablePath, ArrayRef<const char *> args,
-    std::shared_ptr<PluginRegistry> plugins, std::string &error) {
+    llvm::MemoryBuffer *inputBuf, std::shared_ptr<PluginRegistry> plugins,
+    std::string &error) {
   SmallString<256> driverPath(SwiftExecutablePath);
   llvm::sys::path::remove_filename(driverPath);
   llvm::sys::path::append(driverPath, "swiftc");
@@ -73,37 +76,16 @@ bool SyntacticMacroExpansionInstance::setup(
   pluginLoader->setRegistry(plugins.get());
   Ctx->setPluginLoader(std::move(pluginLoader));
 
-  // Create a module where SourceFiles reside.
+  // Create the ModuleDecl and SourceFile.
   Identifier ID = Ctx->getIdentifier(invocation.getModuleName());
   TheModule = ModuleDecl::create(ID, *Ctx);
 
-  return false;
-}
-
-SourceFile *
-SyntacticMacroExpansionInstance::getSourceFile(llvm::MemoryBuffer *inputBuf) {
-
-  // If there is a SourceFile with the same name and the content, use it.
-  // Note that this finds the generated source file that was created in the
-  // previous expansion requests.
-  if (auto bufID =
-          SourceMgr.getIDForBufferIdentifier(inputBuf->getBufferIdentifier())) {
-    if (inputBuf->getBuffer() == SourceMgr.getEntireTextForBuffer(*bufID)) {
-      SourceLoc bufLoc = SourceMgr.getLocForBufferStart(*bufID);
-      if (SourceFile *existing =
-              TheModule->getSourceFileContainingLocation(bufLoc)) {
-        return existing;
-      }
-    }
-  }
-
-  // Otherwise, create a new SourceFile.
-  SourceFile *SF = new (getASTContext()) SourceFile(
-      *TheModule, SourceFileKind::Main, SourceMgr.addMemBufferCopy(inputBuf));
+  SF = new (*Ctx) SourceFile(*TheModule, SourceFileKind::Main,
+                             SourceMgr.addMemBufferCopy(inputBuf));
   SF->setImports({});
   TheModule->addFile(*SF);
 
-  return SF;
+  return false;
 }
 
 MacroDecl *SyntacticMacroExpansionInstance::getSynthesizedMacroDecl(
@@ -425,8 +407,7 @@ public:
 } // namespace
 
 void SyntacticMacroExpansionInstance::expand(
-    SourceFile *SF, const MacroExpansionSpecifier &expansion,
-    SourceEditConsumer &consumer) {
+    const MacroExpansionSpecifier &expansion, SourceEditConsumer &consumer) {
 
   // Find the expansion at 'expansion.offset'.
   MacroExpansionFinder expansionFinder(
@@ -475,13 +456,9 @@ void SyntacticMacroExpansionInstance::expand(
 }
 
 void SyntacticMacroExpansionInstance::expandAll(
-    llvm::MemoryBuffer *inputBuf, ArrayRef<MacroExpansionSpecifier> expansions,
+    ArrayRef<MacroExpansionSpecifier> expansions,
     SourceEditConsumer &consumer) {
-
-  // Create a source file.
-  SourceFile *SF = getSourceFile(inputBuf);
-
   for (const auto &expansion : expansions) {
-    expand(SF, expansion, consumer);
+    expand(expansion, consumer);
   }
 }

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -78,12 +78,13 @@ bool SyntacticMacroExpansionInstance::setup(
 
   // Create the ModuleDecl and SourceFile.
   Identifier ID = Ctx->getIdentifier(invocation.getModuleName());
-  TheModule = ModuleDecl::create(ID, *Ctx);
-
-  SF = new (*Ctx) SourceFile(*TheModule, SourceFileKind::Main,
-                             SourceMgr.addMemBufferCopy(inputBuf));
-  SF->setImports({});
-  TheModule->addFile(*SF);
+  TheModule = ModuleDecl::create(ID, *Ctx,
+                                 [&](ModuleDecl *TheModule, auto addFile) {
+    SF = new (*Ctx) SourceFile(*TheModule, SourceFileKind::Main,
+                               SourceMgr.addMemBufferCopy(inputBuf));
+    SF->setImports({});
+    addFile(SF);
+  });
 
   return false;
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2959,18 +2959,16 @@ IRGenModule::getAddrOfModuleContextDescriptor(ModuleDecl *D,
 llvm::Constant *
 IRGenModule::getAddrOfObjCModuleContextDescriptor() {
   if (!ObjCModule)
-    ObjCModule = ModuleDecl::create(
-      Context.getIdentifier(MANGLING_MODULE_OBJC),
-      Context);
+    ObjCModule = ModuleDecl::createEmpty(
+        Context.getIdentifier(MANGLING_MODULE_OBJC), Context);
   return getAddrOfModuleContextDescriptor(ObjCModule);
 }
 
 llvm::Constant *
 IRGenModule::getAddrOfClangImporterModuleContextDescriptor() {
   if (!ClangImporterModule)
-    ClangImporterModule = ModuleDecl::create(
-      Context.getIdentifier(MANGLING_MODULE_CLANG_IMPORTER),
-      Context);
+    ClangImporterModule = ModuleDecl::createEmpty(
+        Context.getIdentifier(MANGLING_MODULE_CLANG_IMPORTER), Context);
   return getAddrOfModuleContextDescriptor(ClangImporterModule);
 }
 
@@ -2993,9 +2991,9 @@ IRGenModule::getAddrOfAnonymousContextDescriptor(
 
 llvm::Constant *
 IRGenModule::getAddrOfOriginalModuleContextDescriptor(StringRef Name) {
-  return getAddrOfModuleContextDescriptor(OriginalModules.insert({Name,
-    ModuleDecl::create(Context.getIdentifier(Name), Context)})
-                                          .first->getValue());
+  auto *M = ModuleDecl::createEmpty(Context.getIdentifier(Name), Context);
+  return getAddrOfModuleContextDescriptor(
+      OriginalModules.insert({Name, M}).first->getValue());
 }
 
 void IRGenFunction::

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1146,7 +1146,7 @@ struct ParserUnit::Implementation {
     parsingOpts |= ParsingFlags::DisableDelayedBodies;
     parsingOpts |= ParsingFlags::DisablePoundIfEvaluation;
 
-    auto *M = ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx);
+    auto *M = ModuleDecl::createEmpty(Ctx.getIdentifier(ModuleName), Ctx);
     SF = new (Ctx) SourceFile(*M, SFKind, BufferID, parsingOpts);
   }
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -266,6 +266,19 @@ private:
 // MARK: performImportResolution
 //===----------------------------------------------------------------------===//
 
+void swift::performImportResolution(ModuleDecl *M) {
+  for (auto *file : M->getFiles()) {
+    auto *SF = dyn_cast<SourceFile>(file);
+    if (!SF)
+      continue;
+
+    performImportResolution(*SF);
+    assert(SF->ASTStage >= SourceFile::ImportsResolved &&
+           "file has not had its imports resolved");
+  }
+  M->setHasResolvedImports();
+}
+
 /// performImportResolution - This walks the AST to resolve imports.
 ///
 /// Before we can type-check a source file, we need to make declarations

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -133,15 +133,16 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   importInfo.StdlibKind = Ctx.getStdlibModule() ? ImplicitStdlibKind::Stdlib
                                                 : ImplicitStdlibKind::None;
 
-  auto *importMod = ModuleDecl::create(moduleID.Item, Ctx, importInfo);
+  auto *importMod = ModuleDecl::create(
+      moduleID.Item, Ctx, importInfo, [&](ModuleDecl *importMod, auto addFile) {
+    auto opts = SourceFile::getDefaultParsingOptions(Ctx.LangOpts);
+    addFile(new (Ctx) SourceFile(*importMod, SourceFileKind::Library, bufferID,
+                                 opts));
+  });
   if (EnableLibraryEvolution)
     importMod->setResilienceStrategy(ResilienceStrategy::Resilient);
   Ctx.addLoadedModule(importMod);
 
-  auto *importFile =
-      new (Ctx) SourceFile(*importMod, SourceFileKind::Library, bufferID,
-                           SourceFile::getDefaultParsingOptions(Ctx.LangOpts));
-  importMod->addFile(*importFile);
   performImportResolution(importMod);
   bindExtensions(*importMod);
   return importMod;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -142,8 +142,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
       new (Ctx) SourceFile(*importMod, SourceFileKind::Library, bufferID,
                            SourceFile::getDefaultParsingOptions(Ctx.LangOpts));
   importMod->addFile(*importFile);
-  performImportResolution(*importFile);
-  importMod->setHasResolvedImports();
+  performImportResolution(importMod);
   bindExtensions(*importMod);
   return importMod;
 }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -221,7 +221,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
         // Create a source file.
         unsigned bufferID =
             Ctx.SourceMgr.addNewSourceBuffer(std::move(interfaceBuf.get()));
-        auto moduleDecl = ModuleDecl::create(realModuleName, Ctx);
+        auto moduleDecl = ModuleDecl::createEmpty(realModuleName, Ctx);
 
         SourceFile::ParsingOptions parsingOpts;
         auto sourceFile = new (Ctx) SourceFile(

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1635,22 +1635,25 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
   assert(moduleInputBuffer);
 
-  auto M = ModuleDecl::create(moduleID.Item, Ctx);
-  M->setIsSystemModule(isSystemModule);
-  if (AllowMemoryCache)
-    Ctx.addLoadedModule(M);
-  SWIFT_DEFER { M->setHasResolvedImports(); };
+  LoadedFile *file = nullptr;
+  auto *M = ModuleDecl::create(moduleID.Item, Ctx,
+                               [&](ModuleDecl *M, auto addFile) {
+    M->setIsSystemModule(isSystemModule);
+    if (AllowMemoryCache)
+      Ctx.addLoadedModule(M);
 
-  llvm::sys::path::native(moduleInterfacePath);
-  auto *file =
-      loadAST(*M, moduleID.Loc, moduleInterfacePath, moduleInterfaceSourcePath,
-              std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
-              std::move(moduleSourceInfoInputBuffer), isFramework);
-  if (file) {
-    M->addFile(*file);
-  } else {
-    M->setFailedToLoad();
-  }
+    llvm::sys::path::native(moduleInterfacePath);
+    file = loadAST(*M, moduleID.Loc, moduleInterfacePath,
+                   moduleInterfaceSourcePath, std::move(moduleInputBuffer),
+                   std::move(moduleDocInputBuffer),
+                   std::move(moduleSourceInfoInputBuffer), isFramework);
+    if (file) {
+      addFile(file);
+    } else {
+      M->setFailedToLoad();
+    }
+    M->setHasResolvedImports();
+  });
 
   if (dependencyTracker && file) {
     auto DepPath = file->getFilename();
@@ -1692,25 +1695,32 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
   MemoryBuffers.erase(bufIter);
   assert(moduleInputBuffer);
 
-  auto *M = ModuleDecl::create(moduleID.Item, Ctx);
-  SWIFT_DEFER { M->setHasResolvedImports(); };
-  if (AllowMemoryCache)
-    Ctx.addLoadedModule(M);
+  auto *M = ModuleDecl::create(moduleID.Item, Ctx,
+                               [&](ModuleDecl *M, auto addFile) {
+    if (AllowMemoryCache)
+      Ctx.addLoadedModule(M);
 
-  auto *file = loadAST(*M, moduleID.Loc, /*moduleInterfacePath=*/"",
-                       /*moduleInterfaceSourcePath=*/"",
-                       std::move(moduleInputBuffer), {}, {}, isFramework);
-  if (!file) {
+    auto *file = loadAST(*M, moduleID.Loc, /*moduleInterfacePath=*/"",
+                         /*moduleInterfaceSourcePath=*/"",
+                         std::move(moduleInputBuffer), {}, {}, isFramework);
+    if (!file) {
+      M->setFailedToLoad();
+      return;
+    }
+
+    addFile(file);
+    M->setHasResolvedImports();
+  });
+  if (M->failedToLoad()) {
     Ctx.removeLoadedModule(moduleID.Item);
     return nullptr;
   }
-
   // The MemoryBuffer loader is used by LLDB during debugging. Modules imported
   // from .swift_ast sections are never produced from textual interfaces. By
   // disabling resilience the debugger can directly access private members.
   if (BypassResilience)
     M->setBypassResilience();
-  M->addFile(*file);
+
   return M;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
@@ -30,7 +30,7 @@ void SwiftLangSupport::expandMacroSyntactically(
     CategorizedEditsReceiver receiver) {
 
   std::string error;
-  auto instance = SyntacticMacroExpansions->getInstance(args, error);
+  auto instance = SyntacticMacroExpansions->getInstance(args, inputBuf, error);
   if (!instance) {
     return receiver(
         RequestResult<ArrayRef<CategorizedEdits>>::fromError(error));
@@ -85,6 +85,6 @@ void SwiftLangSupport::expandMacroSyntactically(
   }
 
   RequestRefactoringEditConsumer consumer(receiver);
-  instance->expandAll(inputBuf, expansions, consumer);
+  instance->expandAll(expansions, consumer);
   // consumer automatically send the results on destruction.
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1762,12 +1762,15 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
   // implicit stdlib import.
   ImplicitImportInfo importInfo;
   importInfo.StdlibKind = ImplicitStdlibKind::Stdlib;
-  auto *M = ModuleDecl::create(ctx.getIdentifier(Invocation.getModuleName()),
-                               ctx, importInfo);
-  auto bufferID = ctx.SourceMgr.addMemBufferCopy("// nothing\n");
-  auto *SF =
-      new (ctx) SourceFile(*M, SourceFileKind::Main, bufferID);
-  M->addFile(*SF);
+
+  auto *M = ModuleDecl::create(
+      ctx.getIdentifier(Invocation.getModuleName()), ctx, importInfo,
+      [&](ModuleDecl *M, auto addFile) {
+    auto bufferID = ctx.SourceMgr.addMemBufferCopy("// nothing\n");
+    addFile(new (ctx) SourceFile(*M, SourceFileKind::Main, bufferID));
+  });
+
+  auto *SF = &M->getMainSourceFile();
   performImportResolution(*SF);
 
   REPLCompletions REPLCompl;

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -41,13 +41,13 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);
   auto stdlibID = Ctx.getIdentifier(STDLIB_NAME);
-  auto *module = ModuleDecl::create(stdlibID, Ctx);
-  Ctx.addLoadedModule(module);
-
-  auto bufferID = Ctx.SourceMgr.addMemBufferCopy("// nothing\n");
-  FileForLookups = new (Ctx) SourceFile(*module, SourceFileKind::Library,
-                                        bufferID);
-  module->addFile(*FileForLookups);
+  auto *M = ModuleDecl::create(stdlibID, Ctx, [&](ModuleDecl *M, auto addFile) {
+    auto bufferID = Ctx.SourceMgr.addMemBufferCopy("// nothing\n");
+    FileForLookups =
+        new (Ctx) SourceFile(*M, SourceFileKind::Library, bufferID);
+    addFile(FileForLookups);
+  });
+  Ctx.addLoadedModule(M);
 
   if (optionals == DeclareOptionalTypes) {
     SmallVector<ASTNode, 2> optionalTypes;

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -44,20 +44,18 @@ SemaTest::SemaTest()
   auto *stdlib = Context.getStdlibModule(/*loadIfAbsent=*/true);
   assert(stdlib && "Failed to load standard library");
 
-  auto *module =
-      ModuleDecl::create(Context.getIdentifier("SemaTests"), Context);
+  DC = ModuleDecl::create(Context.getIdentifier("SemaTests"), Context,
+                          [&](ModuleDecl *M, auto addFile) {
+    auto bufferID = Context.SourceMgr.addMemBufferCopy("// nothing\n");
+    MainFile = new (Context) SourceFile(*M, SourceFileKind::Main, bufferID);
 
-  auto bufferID = Context.SourceMgr.addMemBufferCopy("// nothing\n");
-  MainFile = new (Context) SourceFile(*module, SourceFileKind::Main,
-                                      bufferID);
+    AttributedImport<ImportedModule> stdlibImport{
+        {ImportPath::Access(), stdlib},
+        /*options=*/{}};
 
-  AttributedImport<ImportedModule> stdlibImport{{ImportPath::Access(), stdlib},
-                                                /*options=*/{}};
-
-  MainFile->setImports(stdlibImport);
-  module->addFile(*MainFile);
-
-  DC = module;
+    MainFile->setImports(stdlibImport);
+    addFile(MainFile);
+  });
 }
 
 Type SemaTest::getStdlibType(StringRef name) const {


### PR DESCRIPTION
Rather than exposing an `addFile` member on ModuleDecl, have the `create` members take a lambda that populates the files for the module. Once module construction has finished, the files are immutable.