### PR TITLE
[cxx-interop] Declare CxxStdlib dependency on _Builtin_float

### DIFF
--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -28,6 +28,11 @@ if(SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
   set(swift_cxxstdlib_darwin_dependencies Darwin)
 endif()
 
+set(swift_cxxstdlib_dependencies)
+if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT)
+  set(swift_cxxstdlib_dependencies _Builtin_float)
+endif()
+
 #
 # C++ Standard Library Overlay.
 #
@@ -38,7 +43,7 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     Chrono.swift
     String.swift
 
-    SWIFT_MODULE_DEPENDS Cxx
+    SWIFT_MODULE_DEPENDS Cxx ${swift_cxxstdlib_dependencies}
     SWIFT_MODULE_DEPENDS_IOS ${swift_cxxstdlib_darwin_dependencies}
     SWIFT_MODULE_DEPENDS_OSX ${swift_cxxstdlib_darwin_dependencies}
     SWIFT_MODULE_DEPENDS_TVOS ${swift_cxxstdlib_darwin_dependencies}


### PR DESCRIPTION
This fixes incremental builds of the overlay.

The CxxStdlib overlay re-exports the entire C++ standard library, which has headers that transitively include Clang builtin headers, bringing in the _Builtin_float module.

rdar://140036608

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
