### PR TITLE
[Frontend] Switch `-interface-compiler-version` to `Version`

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -347,7 +347,7 @@ public:
 
   /// Returns the version of the Swift compiler used to create generate
   /// .swiftinterface file if this file is produced from one.
-  virtual llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+  virtual version::Version getSwiftInterfaceCompilerVersion() const {
     return {};
   }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -257,7 +257,7 @@ class ModuleDecl
 
   /// Indicates a version of the Swift compiler used to generate 
   /// .swiftinterface file that this module was produced from (if any).
-  mutable llvm::VersionTuple InterfaceCompilerVersion;
+  mutable version::Version InterfaceCompilerVersion;
 
 public:
   /// Produces the components of a given module's full name in reverse order.
@@ -524,11 +524,11 @@ public:
   }
 
   /// See \c InterfaceCompilerVersion
-  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+  version::Version getSwiftInterfaceCompilerVersion() const {
     return InterfaceCompilerVersion;
   }
 
-  void setSwiftInterfaceCompilerVersion(llvm::VersionTuple version) {
+  void setSwiftInterfaceCompilerVersion(version::Version version) {
     InterfaceCompilerVersion = version;
   }
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -112,7 +112,7 @@ public:
 
   /// The Swift compiler version number that would be used to synthesize
   /// swiftinterface files and subsequently their swiftmodules.
-  llvm::VersionTuple SwiftInterfaceCompilerVersion;
+  version::Version SwiftInterfaceCompilerVersion;
 
   /// A set of modules allowed to import this module.
   std::set<std::string> AllowableClients;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -539,7 +539,7 @@ public:
 
   virtual StringRef getPublicModuleName() const override;
 
-  virtual llvm::VersionTuple getSwiftInterfaceCompilerVersion() const override;
+  virtual version::Version getSwiftInterfaceCompilerVersion() const override;
 
   ValueDecl *getMainDecl() const override;
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -16,7 +16,9 @@
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/Version.h"
+#include "swift/Parse/ParseVersion.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -131,7 +133,7 @@ class ExtendedValidationInfo {
   StringRef ExportAsName;
   StringRef PublicModuleName;
   CXXStdlibKind CXXStdlib;
-  llvm::VersionTuple SwiftInterfaceCompilerVersion;
+  version::Version SwiftInterfaceCompilerVersion;
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -252,14 +254,13 @@ public:
   CXXStdlibKind getCXXStdlibKind() const { return CXXStdlib; }
   void setCXXStdlibKind(CXXStdlibKind kind) { CXXStdlib = kind; }
 
-  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+  version::Version getSwiftInterfaceCompilerVersion() const {
     return SwiftInterfaceCompilerVersion;
   }
   void setSwiftInterfaceCompilerVersion(StringRef version) {
-    llvm::VersionTuple compilerVersion;
-    if (compilerVersion.tryParse(version))
-      return;
-    SwiftInterfaceCompilerVersion = compilerVersion;
+    if (auto genericVersion = VersionParser::parseVersionString(
+            version, SourceLoc(), /*Diags=*/nullptr))
+      SwiftInterfaceCompilerVersion = genericVersion.value();
   }
 };
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -343,10 +343,11 @@ std::string getCompilerVersion() {
   std::string buf;
   llvm::raw_string_ostream OS(buf);
 
- // TODO: This should print SWIFT_COMPILER_VERSION when
- // available, but to do that we need to switch from
- // llvm::VersionTuple to swift::Version.
- OS << SWIFT_VERSION_STRING;
+#if defined(SWIFT_COMPILER_VERSION)
+  OS << SWIFT_COMPILER_VERSION;
+#else
+  OS << SWIFT_VERSION_STRING;
+#endif
 
   return OS.str();
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -22,6 +22,7 @@
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Parse/ParseVersion.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/TargetParser/Triple.h"
@@ -302,10 +303,15 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.PublicModuleName = A->getValue();
 
   if (auto A = Args.getLastArg(OPT_swiftinterface_compiler_version)) {
-    if (Opts.SwiftInterfaceCompilerVersion.tryParse(A->getValue())) {
+    if (auto version = VersionParser::parseVersionString(
+            A->getValue(), SourceLoc(), /*Diags=*/nullptr)) {
+      Opts.SwiftInterfaceCompilerVersion = version.value();
+    }
+
+    if (Opts.SwiftInterfaceCompilerVersion.empty() ||
+        Opts.SwiftInterfaceCompilerVersion.size() > 5)
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
-    }
   }
 
   // This must be called after computing module name, module abi name,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1493,8 +1493,10 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getSILOptions().EnableSerializePackage)
       MainModule->setSerializePackageEnabled();
 
-    if (auto compilerVersion =
-            Invocation.getFrontendOptions().SwiftInterfaceCompilerVersion) {
+    if (!Invocation.getFrontendOptions()
+             .SwiftInterfaceCompilerVersion.empty()) {
+      auto compilerVersion =
+          Invocation.getFrontendOptions().SwiftInterfaceCompilerVersion;
       MainModule->setSwiftInterfaceCompilerVersion(compilerVersion);
     }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/RequirementSignature.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Basic/Version.h"
 #include "swift/Sema/ConstraintLocator.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/CSFix.h"
@@ -1300,11 +1301,11 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, Type baseType,
     // are built with 6.1+ compilers, libraries produced by earlier
     // compilers don't have required symbols.
     if (auto *module = member->getDeclContext()->getParentModule()) {
-      if (module->isBuiltFromInterface() &&
-          module->getSwiftInterfaceCompilerVersion() <
-              llvm::VersionTuple(6, 1)) {
-        return AllowInvalidRefInKeyPath::create(
-            cs, baseType, RefKind::UnsupportedStaticMember, member, locator);
+      if (module->isBuiltFromInterface()) {
+        auto compilerVersion = module->getSwiftInterfaceCompilerVersion();
+        if (!compilerVersion.isVersionAtLeast(6, 1))
+          return AllowInvalidRefInKeyPath::create(
+              cs, baseType, RefKind::UnsupportedStaticMember, member, locator);
       }
     }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1416,6 +1416,6 @@ StringRef SerializedASTFile::getPublicModuleName() const {
   return File.getPublicModuleName();
 }
 
-llvm::VersionTuple SerializedASTFile::getSwiftInterfaceCompilerVersion() const {
+version::Version SerializedASTFile::getSwiftInterfaceCompilerVersion() const {
   return File.getSwiftInterfaceCompilerVersion();
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -603,7 +603,7 @@ public:
     return Core->UserModuleVersion;
   }
 
-  llvm::VersionTuple getSwiftInterfaceCompilerVersion() const {
+  version::Version getSwiftInterfaceCompilerVersion() const {
     return Core->SwiftInterfaceCompilerVersion;
   }
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -106,7 +106,7 @@ class ModuleFileSharedCore {
   /// The version of the Swift compiler used to produce swiftinterface
   /// this module is based on. This is the most precise version possible
   /// - a compiler tag or version if this is a development compiler.
-  llvm::VersionTuple SwiftInterfaceCompilerVersion;
+  version::Version SwiftInterfaceCompilerVersion;
 
   /// \c true if this module has incremental dependency information.
   bool HasIncrementalInfo = false;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1142,11 +1142,16 @@ void Serializer::writeHeader() {
         PublicModuleName.emit(ScratchRecord, publicModuleName.str());
       }
 
-      llvm::VersionTuple compilerVersion =
-          M->getSwiftInterfaceCompilerVersion();
-      if (compilerVersion) {
+      version::Version compilerVersion = M->getSwiftInterfaceCompilerVersion();
+      if (!compilerVersion.empty()) {
         options_block::SwiftInterfaceCompilerVersionLayout Version(Out);
-        Version.emit(ScratchRecord, compilerVersion.getAsString());
+
+        SmallString<32> versionBuf;
+        llvm::raw_svector_ostream OS(versionBuf);
+
+        OS << compilerVersion;
+
+        Version.emit(ScratchRecord, OS.str());
       }
 
       if (M->isConcurrencyChecked()) {

--- a/test/ModuleInterface/swiftinterface-compiler-version-option.swift
+++ b/test/ModuleInterface/swiftinterface-compiler-version-option.swift
@@ -1,5 +1,17 @@
 // RUN: %empty-directory(%t)
 
+// Test some invalid uses
+// RUN: not %target-swift-frontend -typecheck %s -interface-compiler-version A 2>&1 | %FileCheck %s --check-prefix=INVALID
+// RUN: not %target-swift-frontend -typecheck %s -interface-compiler-version 6.0.0.0.1.6 2>&1 |  %FileCheck %s --check-prefix=INVALID
+// RUN: not %target-swift-frontend -typecheck %s -interface-compiler-version 6.xx 2>&1 | %FileCheck %s --check-prefix=INVALID
+
+// INVALID: <unknown>:0: error: invalid value '{{.*}}' in '-interface-compiler-version {{.*}}'
+
+// RUN: %target-typecheck-verify-swift %s -interface-compiler-version 6
+// RUN: %target-typecheck-verify-swift %s -interface-compiler-version 6.1
+// RUN: %target-typecheck-verify-swift %s -interface-compiler-version 6.1.0.0
+// RUN: %target-typecheck-verify-swift %s -interface-compiler-version 6.1.0.0.0
+
 /// Build the libraries.
 // RUN: %target-swift-frontend %s \
 // RUN:   -module-name Lib \


### PR DESCRIPTION
`SWIFT_COMPILER_VERSION` has more than 4 components and it's
easier to use `Version` API over `VersionTuple` as well.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
