### PR TITLE
[CSGen] Fix compiler crash when property wrapper applied to a param lacks wrappedValue initializer

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65500.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65500.swift
@@ -1,0 +1,16 @@
+//  RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/65500
+
+@propertyWrapper
+struct Wrapper { 
+  var wrappedValue: Bool { true }
+  init(wrappedValue: Bool, er: Void) {}
+
+  var projectedValue: Bool { true }
+  init(projectedValue: Bool) {}
+}
+
+func test(@Wrapper x: Bool) {} 
+test(x: false) 
+// expected-error@-1 {{cannot convert value 'x' of type 'Bool' to expected type 'Wrapper', use wrapper instead}}{{9-9=$}}


### PR DESCRIPTION

This commit fixes a compiler crash that occurred when dealing with external property wrappers that had a missing wrappedValue init when they were applied onto parameters.

Resolves: #65500 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
