### PR TITLE
[NFC] mark_dependence handling for coroutines and accessors.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -976,6 +976,10 @@ class MarkDependenceInst : SingleValueInstruction {
   public func resolveToNonEscaping() {
     bridged.MarkDependenceInst_resolveToNonEscaping()
   }
+
+  public func settleToEscaping() {
+    bridged.MarkDependenceInst_settleToEscaping()
+  }
 }
 
 final public class RefToBridgeObjectInst : SingleValueInstruction {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1344,7 +1344,7 @@ final public class AbortApplyInst : Instruction, UnaryInstruction {
 
 extension BeginApplyInst : ScopedInstruction {
   public var endOperands: LazyFilterSequence<UseList> {
-    return token.uses.lazy.filter { $0.endsLifetime }
+    return token.uses.lazy.filter { $0.isScopeEndingUse }
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -192,6 +192,19 @@ extension Operand {
   }
 }
 
+extension Operand {
+  /// A scope ending use is a consuming use for normal borrow scopes, but it also applies to intructions that end the
+  /// scope of an address (end_access) or a token (end_apply, abort_apply),
+  public var isScopeEndingUse: Bool {
+    switch instruction {
+    case is EndBorrowInst, is EndAccessInst, is EndApplyInst, is AbortApplyInst:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
 extension OptionalBridgedOperand {
   init(bridged: BridgedOperand?) {
     self = OptionalBridgedOperand(op: bridged?.op)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5699,6 +5699,8 @@ mark_dependence
 
   %2 = mark_dependence %value : $*T on %base : $Builtin.NativeObject
 
+``%base`` must not be identical to ``%value``.
+
 Indicates that the validity of ``%value`` depends on the value of
 ``%base``. Operations that would destroy ``%base`` must not be moved
 before any instructions which depend on the result of this
@@ -5715,7 +5717,7 @@ the dependency is on the current value stored in the address.
 The optional ``nonescaping`` attribute indicates that no value derived
 from ``%value`` escapes the lifetime of ``%base``. As with escaping
 ``mark_dependence``, all values transitively forwarded from ``%value``
-must be destroyed within the lifetime of ` `%base``. Unlike escaping
+must be destroyed within the lifetime of ``%base``. Unlike escaping
 ``mark_dependence``, this must be statically verifiable. Additionally,
 unlike escaping ``mark_dependence``, derived values include copies of
 ``%value`` and values transitively forwarded from those copies. If

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -788,6 +788,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt AssignInst_getAssignOwnership() const;
   BRIDGED_INLINE MarkDependenceKind MarkDependenceInst_dependenceKind() const;
   BRIDGED_INLINE void MarkDependenceInst_resolveToNonEscaping() const;
+  BRIDGED_INLINE void MarkDependenceInst_settleToEscaping() const;
   BRIDGED_INLINE SwiftInt BeginAccessInst_getAccessKind() const;
   BRIDGED_INLINE bool BeginAccessInst_isStatic() const;
   BRIDGED_INLINE bool BeginAccessInst_isUnsafe() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1387,6 +1387,10 @@ void BridgedInstruction::MarkDependenceInst_resolveToNonEscaping() const {
   getAs<swift::MarkDependenceInst>()->resolveToNonEscaping();
 }
 
+void BridgedInstruction::MarkDependenceInst_settleToEscaping() const {
+  getAs<swift::MarkDependenceInst>()->settleToEscaping();
+}
+
 SwiftInt BridgedInstruction::BeginAccessInst_getAccessKind() const {
   return (SwiftInt)getAs<swift::BeginAccessInst>()->getAccessKind();
 }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -433,8 +433,7 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromDependsOn(
     auto kind = descriptor.getParsedLifetimeDependenceKind();
 
     if (kind == ParsedLifetimeDependenceKind::Scope &&
-        (!isGuaranteedParameterInCallee(paramConvention) &&
-         !isMutatingParameter(paramConvention))) {
+        isConsumedParameterInCallee(paramConvention)) {
       diags.diagnose(loc, diag::lifetime_dependence_cannot_use_kind, "_scope",
                      getStringForParameterConvention(paramConvention));
       return true;


### PR DESCRIPTION
Preparation for lifetime dependent coroutines and accessors.

Includes a minor fix to BeginApply that I missed in the previous PR.

Add flexibility to mark_dependence diagnostics. This allows SILGen to emit mark_dependence [unresolved] in more places.

These changes are covered by unit tests on the branch that they were pulled from.