### PR TITLE
embedded: Don't emit SILProperties in embedded swift

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1224,10 +1224,12 @@ void IRGenerator::emitGlobalTopLevel(
     }
   }
   
-  // Emit property descriptors.
-  for (auto &prop : PrimaryIGM->getSILModule().getPropertyList()) {
-    CurrentIGMPtr IGM = getGenModule(prop.getDecl()->getInnermostDeclContext());
-    IGM->emitSILProperty(&prop);
+  if (!SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    // Emit property descriptors.
+    for (auto &prop : PrimaryIGM->getSILModule().getPropertyList()) {
+      CurrentIGMPtr IGM = getGenModule(prop.getDecl()->getInnermostDeclContext());
+      IGM->emitSILProperty(&prop);
+    }
   }
 
   // Emit differentiability witnesses.

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -42,4 +42,14 @@ public struct State<Wrapped> {
   }
 }
 
+public struct S<T> {
+  public private(set) subscript(x: Int) -> Int {
+     get {
+       return 27
+     }
+     mutating set {
+     }
+   }
+}
+
 // CHECK: define {{.*}}@main(


### PR DESCRIPTION
SILProperties are only needed for resilient builds.

Fixes a crash in IRGen
https://github.com/swiftlang/swift/issues/77682
