### PR TITLE
[cxx-interop] Explicit conversions between Swift and C++ spans

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -21,6 +21,8 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -cxx-interoperability-mode=default
+    -enable-experimental-feature Span
+    -enable-experimental-feature BuiltinModule
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).
     -Xcc -nostdinc++

--- a/stdlib/public/Cxx/std/std.apinotes
+++ b/stdlib/public/Cxx/std/std.apinotes
@@ -13,3 +13,7 @@ Namespaces:
     SwiftImportAs: owned
   - Name: vector
     SwiftImportAs: owned
+  - Name: span
+    Methods:
+    - Name: data
+      SwiftName: __dataUnsafe()

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -5,53 +5,51 @@
 #include <string>
 #include <span>
 
-using ConstSpan = std::span<const int>;
-using Span = std::span<int>;
+using ConstSpanOfInt = std::span<const int>;
+using SpanOfInt = std::span<int>;
 using ConstSpanOfString = std::span<const std::string>;
 using SpanOfString = std::span<std::string>;
 
 static int iarray[]{1, 2, 3};
 static std::string sarray[]{"", "ab", "abc"};
-static ConstSpan icspan = {iarray};
-static Span ispan = {iarray};
+static ConstSpanOfInt icspan = {iarray};
+static SpanOfInt ispan = {iarray};
 static ConstSpanOfString scspan = {sarray};
 static SpanOfString sspan = {sarray};
 
 struct SpanBox {
-  ConstSpan icspan;
-  Span ispan;
+  ConstSpanOfInt icspan;
+  SpanOfInt ispan;
   ConstSpanOfString scspan;
   SpanOfString sspan;
 };
 
 class CppApi {
 public:
-  ConstSpan getConstSpan();
-  Span getSpan();
+  ConstSpanOfInt getConstSpan();
+  SpanOfInt getSpan();
 };
 
-ConstSpan CppApi::getConstSpan() {
-  ConstSpan sp{new int[2], 2};
+ConstSpanOfInt CppApi::getConstSpan() {
+  ConstSpanOfInt sp{new int[2], 2};
   return sp;
 }
 
-Span CppApi::getSpan() {
-  Span sp{new int[2], 2};
+SpanOfInt CppApi::getSpan() {
+  SpanOfInt sp{new int[2], 2};
   return sp;
 }
 
-inline ConstSpan initConstSpan() {
-  const int a[]{1, 2, 3};
-  return ConstSpan(a);
+inline ConstSpanOfInt initConstSpan() {
+  return ConstSpanOfInt(iarray);
 }
 
-inline Span initSpan() {
-  int a[]{1, 2, 3};
-  return Span(a);
+inline SpanOfInt initSpan() {
+  return SpanOfInt(iarray);
 }
 
-inline Span initSpan(int arr[], size_t size) {
-  return Span(arr, size);
+inline SpanOfInt initSpan(int arr[], size_t size) {
+  return SpanOfInt(arr, size);
 }
 
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -7,7 +7,7 @@ import StdSpan
 
 let arr: [Int32] = [1, 2, 3]
 arr.withUnsafeBufferPointer { ubpointer in
-    let _ = ConstSpan(ubpointer) // okay
-    let _ = ConstSpan(ubpointer.baseAddress!, ubpointer.count) 
+    let _ = ConstSpanOfInt(ubpointer) // okay
+    let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
     // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }


### PR DESCRIPTION
A first step towards creating safe overloads for C++ APIs using span (rdar://139074571).

Note that we need to mark span as owned because it the libc++
implementation was mistakenly recognized as owned and might now rely on
span methods like `data` being renamed as `__dataUnsafe`. We will change
it under a new interop version. But for the time being, we want
consistent behavior across stdlib versions. 