### PR TITLE
[DebugInfo][[test] Fix incorrect CHECK lines on 32-bit architectures

### DIFF
--- a/test/DebugInfo/async-let.swift
+++ b/test/DebugInfo/async-let.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: concurrency
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 public actor Alice {
   let bob = Bob()


### PR DESCRIPTION
A previous commit added a check for a store of `i32`, which would not work for 32-bit targets. In order to avoid having multiple test, this commit addresses the issue by requiring a 64-bit architecture for the target. This follows the example of other async debug info tests.