### PR TITLE
[ClangImporter] Correctly set parent type when importing ObjC pointers

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1059,6 +1059,16 @@ namespace {
         // If the objc type has any generic args, convert them and bind them to
         // the imported class type.
         if (imported->getGenericParams()) {
+          auto *dc = imported->getDeclContext();
+          Type parentTy;
+          // Check if this is a nested type and if so,
+          // fetch the parent type.
+          if (dc->isTypeContext()) {
+            parentTy = dc->getDeclaredInterfaceType();
+            if (parentTy->is<ErrorType>())
+              return Type();
+          }
+
           unsigned typeParamCount = imported->getGenericParams()->size();
           auto typeArgs = type->getObjectType()->getTypeArgs();
           assert(typeArgs.empty() || typeArgs.size() == typeParamCount);
@@ -1084,7 +1094,7 @@ namespace {
           }
           assert(importedTypeArgs.size() == typeParamCount);
           importedType = BoundGenericClassType::get(
-            imported, nullptr, importedTypeArgs);
+            imported, parentTy, importedTypeArgs);
         } else {
           importedType = imported->getDeclaredInterfaceType();
         }

--- a/test/ClangImporter/rdar102564592.swift
+++ b/test/ClangImporter/rdar102564592.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module -import-objc-header %t/src/ObjC.h -O %t/src/main.swift
+
+// REQUIRES: objc_interop
+
+//--- ObjC.h
+
+@interface MyUnit
+@end
+
+__attribute__((swift_name("Metrics.SomeMetric")))
+@interface SomeMetric <T: MyUnit *>
+@end
+
+@interface Metrics
+@property (readonly, strong) SomeMetric<MyUnit *> *metric;
+@end
+
+//--- main.swift
+func test(metrics: Metrics) -> Metrics.SomeMetric<MyUnit> {
+  metrics.metric
+}
+


### PR DESCRIPTION
Fixes an issue where parent type wasn't set for qualified ObjC pointers which leads to crashes during Sema because non-pointer uses are imported correctly.

Resolves: rdar://102564592

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
