### PR TITLE
Give ~Escapable _read accessors with borrow scope borrowed ownership

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -869,6 +869,18 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     return OpaqueReadOwnership::Borrowed;
   };
 
+  if (auto *accessorDecl = storage->getAccessor(AccessorKind::Read)) {
+    auto lifetimeDependencies = accessorDecl->getLifetimeDependencies();
+    if (lifetimeDependencies.has_value() && !lifetimeDependencies->empty()) {
+      for (auto &lifetimeDependenceInfo : *lifetimeDependencies) {
+        if (lifetimeDependenceInfo.hasScopeLifetimeParamIndices()) {
+          // A scoped lifetime dependence borrows its source.
+          return OpaqueReadOwnership::Borrowed;
+        }
+      }
+    }
+  }
+
   if (storage->getAccessor(AccessorKind::Read2))
     return OpaqueReadOwnership::Borrowed;
 

--- a/test/SILGen/accessor_borrow.swift
+++ b/test/SILGen/accessor_borrow.swift
@@ -1,12 +1,22 @@
-// RUN: %target-swift-emit-silgen -module-name accessor_borrow -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name accessor_borrow \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: %s | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
 
 struct NE: ~Escapable {}
 
 struct NEContainer: ~Copyable {
   // This accessor borrows self. Do not synthesize a getter.
+  //
+  // Check NEContainer.ne_coroutine.read
+  // CHECK-LABEL: sil hidden [ossa] @$s15accessor_borrow11NEContainerV12ne_coroutineAA2NEVvr : $@yield_once @convention(method) (@guaranteed NEContainer) -> @lifetime(borrow 0) @yields @guaranteed NE {
+  //
+  // Do not synthesize NEContainer.ne_coroutine.getter
+  // CHECK-NOT: $s15accessor_borrow11NEContainerV12ne_coroutineAA2NEVvg
   var ne_coroutine: NE {
     _read {
-      NE()
+      yield NE()
     }
   }
 }

--- a/test/SILGen/accessor_borrow.swift
+++ b/test/SILGen/accessor_borrow.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-silgen -module-name accessor_borrow -Xllvm -sil-full-demangle %s | %FileCheck %s
+
+struct NE: ~Escapable {}
+
+struct NEContainer: ~Copyable {
+  // This accessor borrows self. Do not synthesize a getter.
+  var ne_coroutine: NE {
+    _read {
+      NE()
+    }
+  }
+}


### PR DESCRIPTION
This applies to all _read accessors whose result depends on a borrow of self. In this case, the coroutine defines the borrow scope, and the ~Escapable property value can only be used within that scope. This makes it impossible to synthesize a getter. Returning the ~Escpable value from the getter would always escape the coroutine.