### PR TITLE
swift-inspect: remove obsolete workaround

### DIFF
--- a/tools/swift-inspect/Package.swift
+++ b/tools/swift-inspect/Package.swift
@@ -21,10 +21,7 @@ let package = Package(
                 .target(name: "SwiftInspectClientInterface", condition: .when(platforms: [.windows])),
             ],
             swiftSettings: [.unsafeFlags(["-parse-as-library"])]),
-        .target(
-            name: "SwiftInspectClient",
-            // Workaround https://github.com/llvm/llvm-project/issues/40056
-            cxxSettings: [.unsafeFlags(["-Xclang", "-fno-split-cold-code"])]),
+        .target(name: "SwiftInspectClient"),
         .systemLibrary(
             name: "SwiftInspectClientInterface"),
         .testTarget(


### PR DESCRIPTION
`-fno-split-cold-code` should no longer be needed after llvm/llvm-project#99759. Remove the use of unsafe flags.