### PR TITLE
[ASTGen] Handle '#sourceLocation' directives

### DIFF
--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -450,6 +450,18 @@ enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedGeneratedSourceFileKind {
   BridgedGeneratedSourceFileKindNone,
 };
 
+//===----------------------------------------------------------------------===//
+// MARK: VirtualFile
+//===----------------------------------------------------------------------===//
+
+struct BridgedVirtualFile {
+  size_t StartPosition;
+  size_t EndPosition;
+  BridgedStringRef Name;
+  ptrdiff_t LineOffset;
+  size_t NamePosition;
+};
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #ifndef PURE_BRIDGING_MODE

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -94,6 +94,12 @@ intptr_t swift_ASTGen_configuredRegions(
 void swift_ASTGen_freeConfiguredRegions(
     BridgedIfConfigClauseRangeInfo *_Nullable regions, intptr_t numRegions);
 
+size_t
+swift_ASTGen_virtualFiles(void *_Nonnull sourceFile,
+                          BridgedVirtualFile *_Nullable *_Nonnull virtualFiles);
+void swift_ASTGen_freeBridgedVirtualFiles(
+    BridgedVirtualFile *_Nullable virtualFiles, size_t numFiles);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/ASTGen/sourcelocation.swift
+++ b/test/ASTGen/sourcelocation.swift
@@ -1,0 +1,40 @@
+func test(arg: Int) -> Int { 1 }
+
+func foo() {
+  #sourceLocation(file: "first/foo.swift", line: 100)
+  test(arg: 1)
+}
+
+func bar() {
+  #sourceLocation(file: "second/foo.swift", line: 100)
+}
+
+test(arg: 2)
+
+// RUN: %target-swift-frontend -emit-silgen -module-name MyMod %s -enable-experimental-feature ParserASTGen -diagnostic-style llvm \
+// RUN:  2>&1 >/dev/null | %FileCheck --enable-windows-compatibility --strict-whitespace %s
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_ParserASTGen
+
+// CHECK:      {{^}}second/foo.swift:102:1: warning: result of call to 'test(arg:)' is unused
+// CHECK-NEXT: {{^}}test(arg: 2)
+// CHECK-NEXT: {{^}}^   ~~~~~~~~
+
+// CHECK:      {{^}}first/foo.swift:100:3: warning: result of call to 'test(arg:)' is unused
+// CHECK-NEXT: {{^}}  test(arg: 1)
+// CHECK-NEXT: {{^}}  ^   ~~~~~~~~
+
+// CHECK:      {{^SOURCE_DIR[\//]test[/\\]ASTGen[\//]sourcelocation\.swift}}:4:25: warning: '#sourceLocation' directive produces '#fileID' string of 'MyMod/foo.swift', which conflicts with '#fileID' strings produced by other paths in the module
+// CHECK-NEXT: {{^}}  #sourceLocation(file: "first/foo.swift", line: 100)
+// CHECK-NEXT: {{^}}                        ^
+
+// CHECK:      {{^SOURCE_DIR[\//]test[/\\]ASTGen[\//]sourcelocation\.swift}}:9:25: warning: '#sourceLocation' directive produces '#fileID' string of 'MyMod/foo.swift', which conflicts with '#fileID' strings produced by other paths in the module
+// CHECK-NEXT: {{^}}  #sourceLocation(file: "second/foo.swift", line: 100)
+// CHECK-NEXT: {{^}}                        ^
+
+// CHECK:      {{^SOURCE_DIR[\//]test[/\\]ASTGen[\//]sourcelocation\.swift}}:9:25: note: change file in '#sourceLocation' to 'first/foo.swift'
+// CHECK-NEXT: {{^}}  #sourceLocation(file: "second/foo.swift", line: 100)
+// CHECK-NEXT: {{^}}                        ^~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: {{^}}                        "first/foo.swift"
+


### PR DESCRIPTION
Use `ExportedSourceFile.sourceLocationConverter.lineTable.virtualFiles` to populate the information in `swift::SourceManger` and `swift::SourceFile` when "parsing" with ASTGen
