### PR TITLE
Span: Remove ownership modifiers and explicit copies from pointers.

### DIFF
--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -70,10 +70,10 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @inline(__always)
   @lifetime(borrow pointer)
   internal init(
-    _unchecked pointer: borrowing UnsafeRawPointer?,
+    _unchecked pointer: UnsafeRawPointer?,
     byteCount: Int
   ) {
-    _pointer = copy pointer
+    _pointer = pointer
     _count = byteCount
   }
 }
@@ -95,7 +95,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
+    _unsafeBytes buffer: UnsafeRawBufferPointer
   ) {
     self.init(
       _unchecked: buffer.baseAddress, byteCount: buffer.count
@@ -129,7 +129,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -155,11 +155,11 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
   public init(
-    _unsafeStart pointer: borrowing UnsafeRawPointer,
+    _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
   ) {
     _precondition(byteCount >= 0, "Count must not be negative")
-    self.init(_unchecked: copy pointer, byteCount: byteCount)
+    self.init(_unchecked: pointer, byteCount: byteCount)
   }
 
   /// Unsafely create a `RawSpan` over initialized memory.
@@ -173,7 +173,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
-    _unsafeElements buffer: borrowing UnsafeBufferPointer<T>
+    _unsafeElements buffer: UnsafeBufferPointer<T>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -207,7 +207,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
-    _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<T>
+    _unsafeElements buffer: UnsafeMutableBufferPointer<T>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
@@ -243,12 +243,12 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
   public init<T: BitwiseCopyable>(
-    _unsafeStart pointer: borrowing UnsafePointer<T>,
+    _unsafeStart pointer: UnsafePointer<T>,
     count: Int
   ) {
     _precondition(count >= 0, "Count must not be negative")
     self.init(
-      _unchecked: copy pointer, byteCount: count * MemoryLayout<T>.stride
+      _unchecked: pointer, byteCount: count * MemoryLayout<T>.stride
     )
   }
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -72,10 +72,10 @@ public struct Span<Element: ~Copyable & ~Escapable>
   @inline(__always)
   @lifetime(borrow pointer)
   internal init(
-    _unchecked pointer: borrowing UnsafeRawPointer?,
+    _unchecked pointer: UnsafeRawPointer?,
     count: Int
   ) {
-    _pointer = copy pointer
+    _pointer = pointer
     _count = count
   }
 }
@@ -97,7 +97,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeElements buffer: borrowing UnsafeBufferPointer<Element>
+    _unsafeElements buffer: UnsafeBufferPointer<Element>
   ) {
     //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = buffer.baseAddress
@@ -120,7 +120,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeElements buffer: borrowing UnsafeMutableBufferPointer<Element>
+    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
@@ -138,11 +138,11 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
   public init(
-    _unsafeStart pointer: borrowing UnsafePointer<Element>,
+    _unsafeStart pointer: UnsafePointer<Element>,
     count: Int
   ) {
     _precondition(count >= 0, "Count must not be negative")
-    self.init(_unsafeElements: .init(start: copy pointer, count: count))
+    self.init(_unsafeElements: .init(start: pointer, count: count))
   }
 }
 
@@ -200,7 +200,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
+    _unsafeBytes buffer: UnsafeRawBufferPointer
   ) {
     //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = buffer.baseAddress
@@ -232,7 +232,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: borrowing UnsafeMutableRawBufferPointer
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
@@ -254,11 +254,11 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
   public init(
-    _unsafeStart pointer: borrowing UnsafeRawPointer,
+    _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
   ) {
     _precondition(byteCount >= 0, "Count must not be negative")
-    self.init(_unsafeBytes: .init(start: copy pointer, count: byteCount))
+    self.init(_unsafeBytes: .init(start: pointer, count: byteCount))
   }
 
   /// Unsafely create a `Span` over initialized memory.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -110,6 +110,10 @@ public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable>: Copyable {
 % end
 }
 
+// FIXME: The ASTPrinter should print this synthesized conformance.
+// rdar://140291657
+extension Unsafe${Mutable}BufferPointer: BitwiseCopyable where Element: ~Copyable {}
+
 @available(*, unavailable)
 extension Unsafe${Mutable}BufferPointer: Sendable where Element: ~Copyable {}
 


### PR DESCRIPTION
Without this fix, the standard library source will break with shortly upcoming compiler toolchain.

Never explicitly copy a pointer before passing it to an argument that is the source of a lifetime dependency on the function's return value. That will always raise a diagnostic error: depending on a temporary value is not the same as depending on a variable. A temporary value's scope is only the current expression.

Also avoid using ownership modifiers for UnsafePointer. We don't want to treat them like noncopyable types. They are simply values. Treating them like noncopyable types creates a lot of overhead in the representation, which is likely to interfere with diagnostics and optimization.