### PR TITLE
Make isolated deinit non-experiment and add version checks & fix pointer auth

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1704,6 +1704,9 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t RelativeProtocolWitnessTable = 0xb830; // = 47152
 
   const uint16_t TypeLayoutString = 0x8b65; // = 35685
+
+  /// Isolated deinit body function pointer
+  const uint16_t DeinitWorkFunction = 0x8438; // = 33848
 }
 
 /// The number of arguments that will be passed directly to a generic

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -790,6 +790,11 @@ NOTE(box_to_stack_cannot_promote_box_to_stack_due_to_escape_location, none,
 
 WARNING(semantic_function_improper_nesting, none, "'@_semantics' function calls non-'@_semantics' function with nested '@_semantics' calls", ())
 
+// SDK mismatch diagnostics
+ERROR(missing_deinit_on_executor_function, none,
+      "Missing 'swift_task_deinitOnExecutor' function! "
+      "This is likely due to an outdated/incompatible SDK.", ())
+
 // Capture promotion diagnostics
 WARNING(capturepromotion_concurrentcapture_mutation, none,
         "'%0' mutated after capture by sendable closure", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5969,9 +5969,6 @@ ERROR(isolated_deinit_no_isolation,none,
 ERROR(isolated_deinit_on_value_type,none,
       "only classes and actors can have isolated deinit",
       ())
-ERROR(isolated_deinit_experimental,none,
-      "'isolated' deinit requires frontend flag -enable-experimental-feature IsolatedDeinit "
-      "to enable the usage of this language feature", ())
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5969,6 +5969,9 @@ ERROR(isolated_deinit_no_isolation,none,
 ERROR(isolated_deinit_on_value_type,none,
       "only classes and actors can have isolated deinit",
       ())
+ERROR(isolated_deinit_unavailable,none,
+      "isolated deinit is only available in %0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -76,6 +76,7 @@ FEATURE(InitRawStructMetadata,                          (6, 0))
 
 FEATURE(LayoutStringValueWitnesses,                     (6, 1))
 FEATURE(CreateTaskWithConsumedFunction,                 (6, 1))
+FEATURE(IsolatedDeinit,                                 (6, 1))
 
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -414,7 +414,7 @@ EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 
 // Isolated deinit
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedDeinit, true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")
 
 // Enable values in generic signatures, e.g. <let N: Int>
 EXPERIMENTAL_FEATURE(ValueGenerics, true)

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -324,6 +324,9 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_type_layout_string                                     \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             SpecialPointerAuthDiscriminators::TypeLayoutString)
+#define __ptrauth_swift_deinit_work_function                                   \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::DeinitWorkFunction)
 
 #if __has_attribute(ptrauth_struct)
 #define swift_ptrauth_struct(key, discriminator)                               \
@@ -364,6 +367,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define swift_ptrauth_sign_opaque_read_resume_function(__fn, __buffer) (__fn)
 #define swift_ptrauth_sign_opaque_modify_resume_function(__fn, __buffer) (__fn)
 #define __ptrauth_swift_type_layout_string
+#define __ptrauth_swift_deinit_work_function
 #define swift_ptrauth_struct(key, discriminator)
 #define swift_ptrauth_struct_derived(from)
 #endif
@@ -537,6 +541,17 @@ swift_auth_code(T value, unsigned extra) {
 #if SWIFT_PTRAUTH
   return (T)ptrauth_auth_function((void *)value,
                                   ptrauth_key_process_independent_code, extra);
+#else
+  return value;
+#endif
+}
+
+template <typename T>
+SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static inline T
+swift_auth_code_function(T value, unsigned extra) {
+#if SWIFT_PTRAUTH
+  return (T)ptrauth_auth_function((void *)value,
+                                  ptrauth_key_function_pointer, extra);
 #else
   return value;
 #endif

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -373,8 +373,11 @@ void SILGenFunction::emitIsolatingDestructor(DestructorDecl *dd) {
 
     // Get deinitOnExecutor
     FuncDecl *swiftDeinitOnExecutorDecl = SGM.getDeinitOnExecutor();
-    assert(swiftDeinitOnExecutorDecl &&
-           "Failed to find swift_task_deinitOnExecutor function decl");
+    if (!swiftDeinitOnExecutorDecl) {
+      llvm::report_fatal_error(
+          "Failed to find swift_task_deinitOnExecutor function decl! "
+          "This is likely due to an outdated/incompatible SDK.");
+    }
     SILFunction *swiftDeinitOnExecutorSILFunc = SGM.getFunction(
         SILDeclRef(swiftDeinitOnExecutorDecl, SILDeclRef::Kind::Func),
         NotForDefinition);

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -17,6 +17,7 @@
 #include "SwitchEnumBuilder.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Assertions.h"
@@ -374,9 +375,8 @@ void SILGenFunction::emitIsolatingDestructor(DestructorDecl *dd) {
     // Get deinitOnExecutor
     FuncDecl *swiftDeinitOnExecutorDecl = SGM.getDeinitOnExecutor();
     if (!swiftDeinitOnExecutorDecl) {
-      llvm::report_fatal_error(
-          "Failed to find swift_task_deinitOnExecutor function decl! "
-          "This is likely due to an outdated/incompatible SDK.");
+      dd->diagnose(diag::missing_deinit_on_executor_function);
+      return;
     }
     SILFunction *swiftDeinitOnExecutorSILFunc = SGM.getFunction(
         SILDeclRef(swiftDeinitOnExecutorDecl, SILDeclRef::Kind::Func),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -112,6 +112,8 @@ public:
   }
 
   void diagnoseIsolatedDeinitInValueTypes(DeclAttribute *attr) {
+    auto &C = D->getASTContext();
+
     if (isa<DestructorDecl>(D)) {
       if (auto nominal = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
         if (!isa<ClassDecl>(nominal)) {
@@ -120,6 +122,13 @@ public:
           return;
         }
       }
+
+      TypeChecker::checkAvailability(
+        attr->getRange(), C.getIsolatedDeinitAvailability(),
+        D->getDeclContext(),
+        [&](StringRef platformName, llvm::VersionTuple version) {
+          return diagnoseAndRemoveAttr(attr, diag::isolated_deinit_unavailable, platformName, version);
+        });
     }
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -112,14 +112,7 @@ public:
   }
 
   void diagnoseIsolatedDeinitInValueTypes(DeclAttribute *attr) {
-    auto &C = D->getASTContext();
-
     if (isa<DestructorDecl>(D)) {
-      if (!C.LangOpts.hasFeature(Feature::IsolatedDeinit)) {
-        diagnoseAndRemoveAttr(attr, diag::isolated_deinit_experimental);
-        return;
-      }
-
       if (auto nominal = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
         if (!isa<ClassDecl>(nominal)) {
           // only classes and actors can have isolated deinit.

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2323,11 +2323,11 @@ namespace {
 class IsolatedDeinitJob : public Job {
 private:
   void *Object;
-  DeinitWorkFunction *Work;
+  DeinitWorkFunction *__ptrauth_swift_deinit_work_function Work;
 
 public:
   IsolatedDeinitJob(JobPriority priority, void *object,
-                    DeinitWorkFunction *work)
+                    DeinitWorkFunction * work)
       : Job({JobKind::IsolatedDeinit, priority}, &process), Object(object),
         Work(work) {}
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -18,6 +18,7 @@
 #include "swift/Runtime/Concurrency.h"
 #include <atomic>
 #include <new>
+#include <ptrauth.h>
 
 #include "../CompatibilityOverride/CompatibilityOverride.h"
 #include "swift/ABI/Actor.h"
@@ -2351,6 +2352,9 @@ static void swift_task_deinitOnExecutorImpl(void *object,
                                             DeinitWorkFunction *work,
                                             SerialExecutorRef newExecutor,
                                             size_t rawFlags) {
+  // Sign the function pointer
+  work = swift_auth_code_function(
+      work, SpecialPointerAuthDiscriminators::DeinitWorkFunction);
   // If the current executor is compatible with running the new executor,
   // we can just immediately continue running with the resume function
   // we were passed in.

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -541,7 +541,7 @@ internal final class DispatchQueueShim: @unchecked Sendable, SerialExecutor {
 #endif // SWIFT_CONCURRENCY_USES_DISPATCH
 
 
-@available(SwiftStdlib 5.6, *) // TODO: Clarify version
+@available(SwiftStdlib 6.1, *)
 @_silgen_name("swift_task_deinitOnExecutor")
 @usableFromInline
 internal func _deinitOnExecutor(_ object: __owned AnyObject,

--- a/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
+++ b/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
@@ -1,10 +1,9 @@
-// RUN: %target-run-simple-swift( -enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple %import-libdispatch -parse-as-library)
 
 // REQUIRES: executable_test
 // REQUIRES: libdispatch
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 // UNSUPPORTED: back_deployment_runtime
 
 import _Concurrency

--- a/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
+++ b/test/Concurrency/Runtime/actor_deinit_escaping_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift( -target %target-future-triple %import-libdispatch -parse-as-library)
 
 // REQUIRES: executable_test
 // REQUIRES: libdispatch

--- a/test/Concurrency/Runtime/actor_recursive_deinit.swift
+++ b/test/Concurrency/Runtime/actor_recursive_deinit.swift
@@ -1,10 +1,9 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple -parse-stdlib -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -parse-stdlib -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 // UNSUPPORTED: back_deployment_runtime
 
 // Compiler crashes because builtin "ifdef_SWIFT_STDLIB_PRINT_DISABLED"() gets lowered as "i32 0",

--- a/test/Concurrency/Runtime/actor_recursive_deinit.swift
+++ b/test/Concurrency/Runtime/actor_recursive_deinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -parse-stdlib -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-future-triple -parse-stdlib -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
+++ b/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -plugin-path %swift-plugin-dir -target %target-swift-5.1-abi-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
+// RUN: %target-build-swift -plugin-path %swift-plugin-dir -target %target-future-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
 

--- a/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
+++ b/test/Concurrency/Runtime/async_task_locals_isolated_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -enable-experimental-feature IsolatedDeinit -plugin-path %swift-plugin-dir -enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
+// RUN: %target-build-swift -plugin-path %swift-plugin-dir -target %target-swift-5.1-abi-triple -parse-stdlib %import-libdispatch %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
 
@@ -8,7 +8,6 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 
 import Swift
 import _Concurrency

--- a/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
+++ b/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature IsolatedDeinit -target %target-swift-5.1-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedDeinit
 
 var isDead: Bool = false
 

--- a/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
+++ b/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-future-triple) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/deinit_isolation.swift
+++ b/test/Concurrency/deinit_isolation.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -verify %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -enable-experimental-feature IsolatedDeinit -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // Fixtures
 

--- a/test/Concurrency/deinit_isolation.swift
+++ b/test/Concurrency/deinit_isolation.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -3,20 +3,19 @@
 // RUN: cp -R $INPUT_DIR/Alpha.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule)
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Headers/)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -parse-as-library -module-name Alpha \
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -parse-as-library -module-name Alpha \
 // RUN:  -emit-module -o %t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule/%module-target-triple.swiftmodule \
 // RUN:  -enable-objc-interop -disable-objc-attr-requires-foundation-module \
 // RUN:  -emit-objc-header -emit-objc-header-path %t/Frameworks/Alpha.framework/Headers/Alpha-Swift.h $INPUT_DIR/Alpha.swift
 // RUN: cp -R $INPUT_DIR/Beta.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/Beta.framework/Headers/)
 // RUN: cp $INPUT_DIR/Beta.h %t/Frameworks/Beta.framework/Headers/Beta.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -typecheck -verify %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -typecheck -verify %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -disable-availability-checking -parse-as-library -emit-silgen -DSILGEN %s -F %t/Frameworks -F %clang-importer-sdk-path/frameworks | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // Note: intentionally importing Alpha implicitly
 import Beta

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -3,7 +3,7 @@
 // RUN: cp -R $INPUT_DIR/Alpha.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule)
 // RUN: %empty-directory(%t/Frameworks/Alpha.framework/Headers/)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -parse-as-library -module-name Alpha \
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -parse-as-library -disable-availability-checking -module-name Alpha \
 // RUN:  -emit-module -o %t/Frameworks/Alpha.framework/Modules/Alpha.swiftmodule/%module-target-triple.swiftmodule \
 // RUN:  -enable-objc-interop -disable-objc-attr-requires-foundation-module \
 // RUN:  -emit-objc-header -emit-objc-header-path %t/Frameworks/Alpha.framework/Headers/Alpha-Swift.h $INPUT_DIR/Alpha.swift

--- a/test/Concurrency/deinit_isolation_in_value_types.swift
+++ b/test/Concurrency/deinit_isolation_in_value_types.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -enable-experimental-feature IsolatedDeinit -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 @globalActor final actor FirstActor {
   static let shared = FirstActor()

--- a/test/Concurrency/deinit_isolation_in_value_types.swift
+++ b/test/Concurrency/deinit_isolation_in_value_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen -verify %s
 
 
 @globalActor final actor FirstActor {

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -1,10 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_IsolatedDeinit
 
 import Foundation
 

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -verify %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-swift-5.1-abi-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-silgen -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/deinit_isolation_tbd.swift
+++ b/test/Concurrency/deinit_isolation_tbd.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature IsolatedDeinit -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 public class Foo {
   @MainActor

--- a/test/Concurrency/deinit_isolation_tbd.swift
+++ b/test/Concurrency/deinit_isolation_tbd.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-availability-checking -emit-ir %s | %FileCheck %s
 
 
 public class Foo {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: swift_feature_RegionBasedIsolation
-// REQUIRES: swift_feature_IsolatedDeinit
 
 func randomBool() -> Bool { return false }
 func logTransaction(_ i: Int) {}

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -127,7 +127,7 @@ actor Demons {
     self.ns = x
   }
 
-  nonisolated deinit {
+  deinit {
     let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
@@ -158,7 +158,7 @@ actor ExampleFromProposal {
   }
 
 
-  nonisolated deinit {
+  deinit {
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // ok
     _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
@@ -198,7 +198,7 @@ class CheckGAIT1 {
     silly += 2 // expected-warning {{cannot access property 'silly' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated deinit {
+  deinit {
     _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
     f()     // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
     _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode}}
@@ -622,7 +622,7 @@ actor Ahmad {
     prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated deinit {
+  deinit {
     // expected-warning@+2 {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     // expected-note@+1 {{after accessing property 'computedProp', only nonisolated properties of 'self' can be accessed from a deinit}}
     let x = computedProp
@@ -678,7 +678,7 @@ actor NonIsolatedDeinitExceptionForSwift5 {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 6.1, *)
 actor IsolatedDeinitExceptionForSwift5 {
   var x: Int = 0
 

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -enable-experimental-feature IsolatedDeinit -o %t/voucher_propagation
+// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -o %t/voucher_propagation
 // RUN: %target-codesign %t/voucher_propagation
 // RUN: MallocStackLogging=1 %target-run %t/voucher_propagation
 
@@ -13,7 +13,6 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // REQUIRES: OS=macosx
-// REQUIRES: swift_feature_IsolatedDeinit
 
 import Darwin
 import Dispatch // expected-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'Dispatch'}}

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-future-triple -o %t/voucher_propagation
+// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -o %t/voucher_propagation
 // RUN: %target-codesign %t/voucher_propagation
 // RUN: MallocStackLogging=1 %target-run %t/voucher_propagation
 
@@ -75,6 +75,7 @@ actor Counter {
   func get() -> Int { n }
 }
 
+@available(SwiftStdlib 6.1, *)
 actor ActorWithSelfIsolatedDeinit {
   let expectedVoucher: voucher_t?
   let group: DispatchGroup
@@ -101,6 +102,7 @@ actor ActorWithSelfIsolatedDeinit {
   }
 }
 
+@available(SwiftStdlib 6.1, *)
 actor ActorWithDeinitIsolatedOnAnother {
   let expectedVoucher: voucher_t?
   let group: DispatchGroup
@@ -120,6 +122,7 @@ actor ActorWithDeinitIsolatedOnAnother {
   }
 }
 
+@available(SwiftStdlib 6.1, *)
 class ClassWithIsolatedDeinit {
   let expectedVoucher: voucher_t?
   let group: DispatchGroup
@@ -426,47 +429,49 @@ if #available(SwiftStdlib 5.1, *) {
      group.wait()
    }
   }
-  
-  tests.test("voucher propagation in isolated deinit [fast path]") {
-    withVouchers { v1, v2, v3 in
-      let group = DispatchGroup()
-      group.enter()
-      group.enter()
-      group.enter()
-      Task {
-        await AnotherActor.shared.performTesting {
-          adopt(voucher: v1)
-          _ = ClassWithIsolatedDeinit(expectedVoucher: v1, group: group)
+
+  if #available(SwiftStdlib 6.1, *) {
+    tests.test("voucher propagation in isolated deinit [fast path]") {
+      withVouchers { v1, v2, v3 in
+        let group = DispatchGroup()
+        group.enter()
+        group.enter()
+        group.enter()
+        Task {
+          await AnotherActor.shared.performTesting {
+            adopt(voucher: v1)
+            _ = ClassWithIsolatedDeinit(expectedVoucher: v1, group: group)
+          }
+          await AnotherActor.shared.performTesting {
+            adopt(voucher: v2)
+            _ = ActorWithSelfIsolatedDeinit(expectedVoucher: v2, group: group)
+          }
+          await AnotherActor.shared.performTesting {
+            adopt(voucher: v3)
+            _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v3, group: group)
+          }
         }
-        await AnotherActor.shared.performTesting {
-          adopt(voucher: v2)
-          _ = ActorWithSelfIsolatedDeinit(expectedVoucher: v2, group: group)
-        }
-        await AnotherActor.shared.performTesting {
-          adopt(voucher: v3)
-          _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v3, group: group)
-        }
+        group.wait()
       }
-      group.wait()
     }
-  }
-  
-  tests.test("voucher propagation in isolated deinit [slow path]") {
-    withVouchers { v1, v2, v3 in
-      let group = DispatchGroup()
-      group.enter()
-      group.enter()
-      Task {
-        do {
-          adopt(voucher: v1)
-          _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v1, group: group)
+
+    tests.test("voucher propagation in isolated deinit [slow path]") {
+      withVouchers { v1, v2, v3 in
+        let group = DispatchGroup()
+        group.enter()
+        group.enter()
+        Task {
+          do {
+            adopt(voucher: v1)
+            _ = ActorWithDeinitIsolatedOnAnother(expectedVoucher: v1, group: group)
+          }
+          do {
+            adopt(voucher: v2)
+            _ = ClassWithIsolatedDeinit(expectedVoucher: v2, group: group)
+          }
         }
-        do {
-          adopt(voucher: v2)
-          _ = ClassWithIsolatedDeinit(expectedVoucher: v2, group: group)
-        }
+        group.wait()
       }
-      group.wait()
     }
   }
 }

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -target %target-swift-5.1-abi-triple -o %t/voucher_propagation
+// RUN: %target-build-swift %s -target %target-future-triple -o %t/voucher_propagation
 // RUN: %target-codesign %t/voucher_propagation
 // RUN: MallocStackLogging=1 %target-run %t/voucher_propagation
 

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-swift-5.7-abi-triple %import-libdispatch -enable-experimental-feature IsolatedDeinit -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
+// RUN: %target-build-swift -target %target-swift-5.7-abi-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
 
@@ -7,7 +7,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-swift-5.7-abi-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
+// RUN: %target-build-swift -target %target-future-triple %import-libdispatch -parse-stdlib -parse-as-library -module-name=main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out | %FileCheck %s
 

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -28,7 +28,7 @@ distributed actor SomeSpecificDistributedActor {
     self.age = 42
   }
 
-  nonisolated deinit {
+  deinit {
     print("deinit \(self.id)")
   }
 

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -1,13 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -enable-experimental-feature IsolatedDeinit -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -enable-experimental-feature IsolatedDeinit -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
@@ -11,7 +11,7 @@
 import Distributed
 
 distributed actor SomeSpecificDistributedActor {
-  nonisolated deinit {
+  deinit {
     print("deinit \(self.id)")
   }
 }
@@ -40,7 +40,7 @@ final class FakeActorSystem: DistributedActorSystem {
   typealias SerializationRequirement = Codable
   typealias ResultHandler = FakeResultHandler
 
-  nonisolated deinit {
+  deinit {
     print("deinit \(self)")
   }
 

--- a/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift( -enable-experimental-feature IsolatedDeinit -target %target-swift-5.7-abi-triple -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift( -target %target-swift-5.7-abi-triple -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/ModuleInterface/isolated-deinit-compatibility.swift
+++ b/test/ModuleInterface/isolated-deinit-compatibility.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -emit-silgen -verify %s
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-experimental-feature IsolatedDeinit -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -emit-silgen -verify %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // MARK: Sync deinit in class
 

--- a/test/ModuleInterface/isolated-deinit-compatibility.swift
+++ b/test/ModuleInterface/isolated-deinit-compatibility.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -emit-silgen -verify %s
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -target %target-swift-5.5-abi-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-frontend -target %target-future-triple -emit-silgen -verify %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -DEMIT_IFACE %s -target %target-future-triple -module-name IsolatedDeinitCompatibility
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -target %target-future-triple -module-name IsolatedDeinitCompatibility
 // RUN: %FileCheck %s < %t.swiftinterface
 
 

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-future-triple %s | %FileCheck %s
 
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -67,8 +67,8 @@ public actor MyAct {
 
 @available(SwiftStdlib 6.1, *)
 public actor MyActIsolatedDeinit {
-  // CHECK: sil [serialized] [[AVAILABILITY:\[available.*\]]] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
-  // CHECK: sil [serialized] [[AVAILABILITY:\[available.*\]]] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK: sil [serialized] [[AVAILABILITY:.*]][ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK: sil [serialized] [[AVAILABILITY:.*]][ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
   @inlinable isolated deinit {}
 }
 

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature IsolatedDeinit -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedDeinit
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
 @inlinable public func fragileFunction() {

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-future-triple %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -target %target-swift-5.1-abi-triple %s | %FileCheck %s
 
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
@@ -65,9 +65,10 @@ public actor MyAct {
   }
 }
 
+@available(SwiftStdlib 6.1, *)
 public actor MyActIsolatedDeinit {
-  // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
-  // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK-LABEL: sil [serialized] [available 9999] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK-LABEL: sil [serialized] [available 9999] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
   @inlinable isolated deinit {}
 }
 

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -67,8 +67,8 @@ public actor MyAct {
 
 @available(SwiftStdlib 6.1, *)
 public actor MyActIsolatedDeinit {
-  // CHECK-LABEL: sil [serialized] [available 9999] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
-  // CHECK-LABEL: sil [serialized] [available 9999] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK: sil [serialized] [[AVAILABILITY:\[available.*\]]] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfZ : $@convention(thin) (@owned MyActIsolatedDeinit) -> ()
+  // CHECK: sil [serialized] [[AVAILABILITY:\[available.*\]]] [ossa] @$s19inlinable_attribute19MyActIsolatedDeinitCfD : $@convention(method) (@owned MyActIsolatedDeinit) -> ()
   @inlinable isolated deinit {}
 }
 

--- a/test/SILOptimizer/stack_promotion_isolated_deinit.swift
+++ b/test/SILOptimizer/stack_promotion_isolated_deinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -Xllvm -sil-print-types -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -target %target-future-triple -O -module-name=test %s -Xllvm -sil-print-types -emit-sil | %FileCheck %s
 // REQUIRES: swift_in_compiler
 
 @globalActor actor AnotherActor: GlobalActor {

--- a/test/SILOptimizer/stack_promotion_isolated_deinit.swift
+++ b/test/SILOptimizer/stack_promotion_isolated_deinit.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -Xllvm -sil-print-types -emit-sil -enable-experimental-feature IsolatedDeinit | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -Xllvm -sil-print-types -emit-sil | %FileCheck %s
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_IsolatedDeinit
 
 @globalActor actor AnotherActor: GlobalActor {
   static let shared = AnotherActor()

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify %s  -disable-availability-checking -package-name myPkg -enable-experimental-feature IsolatedDeinit
+// RUN: %target-swift-frontend -typecheck -verify %s  -disable-availability-checking -package-name myPkg
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedDeinit
 
 actor SomeActor { }
 


### PR DESCRIPTION
Using 6.1 for the feature per [this comment](https://forums.swift.org/t/versioning-back-deployment-of-isolated-deinit/76089/10), but using %target-future-triple as a workaround for the clang importer assertion.