### PR TITLE
utils: remove `DEVTOOLS_ROOT` property for MSIs

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2692,7 +2692,6 @@ function Build-Installer($Arch) {
 
   $Properties = @{
     BundleFlavor = "offline";
-    DEVTOOLS_ROOT = "$($Arch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($Arch.ToolchainInstallRoot)\";
     INCLUDE_SWIFT_INSPECT = $INCLUDE_SWIFT_INSPECT;
     SWIFT_INSPECT_BUILD = "$($Arch.BinaryCache)\swift-inspect\release";


### PR DESCRIPTION
This property was unused and has been removed from the WiX rules as of swiftlang/swift-installer-scripts#347. Simplify the invocation.