### PR TITLE
AST: Clean up future availability a bit

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -689,6 +689,9 @@ AvailabilityRange ASTContext::getSwiftFutureAvailability() const {
   } else if (target.isWatchOS()) {
     return AvailabilityRange(
         VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
+  } else if (target.isXROS()) {
+    return AvailabilityRange(
+        VersionRange::allGTE(llvm::VersionTuple(99, 0, 0)));
   } else {
     return AvailabilityRange::alwaysAvailable();
   }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -680,18 +680,19 @@ AvailabilityRange AvailabilityInference::inferForType(Type t) {
 AvailabilityRange ASTContext::getSwiftFutureAvailability() const {
   auto target = LangOpts.Target;
 
-  if (target.isMacOSX() ) {
+  auto getFutureAvailabilityRange = []() -> AvailabilityRange {
     return AvailabilityRange(
         VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
+  };
+
+  if (target.isMacOSX()) {
+    return getFutureAvailabilityRange();
   } else if (target.isiOS()) {
-    return AvailabilityRange(
-        VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
+    return getFutureAvailabilityRange();
   } else if (target.isWatchOS()) {
-    return AvailabilityRange(
-        VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
+    return getFutureAvailabilityRange();
   } else if (target.isXROS()) {
-    return AvailabilityRange(
-        VersionRange::allGTE(llvm::VersionTuple(99, 0, 0)));
+    return getFutureAvailabilityRange();
   } else {
     return AvailabilityRange::alwaysAvailable();
   }

--- a/test/IRGen/async_let_back_deploy_workaround.swift
+++ b/test/IRGen/async_let_back_deploy_workaround.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-sans-workaround %s
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos12.3 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-with-workaround %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.7-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-sans-workaround %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.6-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-with-workaround %s
 
 // REQUIRES: OS=macosx
 // UNSUPPORTED: CPU=arm64e

--- a/test/IRGen/conditional_conformances_gettypemetdatabyname.swift
+++ b/test/IRGen/conditional_conformances_gettypemetdatabyname.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -target %target-cpu-apple-macosx10.15.4 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %target-cpu-apple-macosx99.99 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME_PRESPECIALIZED
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15.4 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=CHECK --check-prefix=CHECK-STABLE-ABI-TRUE
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -target %target-swift-5.2-abi-triple -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %target-future-triple -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME_PRESPECIALIZED
+// RUN: %target-swift-frontend -target %target-swift-5.2-abi-triple -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=CHECK --check-prefix=CHECK-STABLE-ABI-TRUE
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/reflection_metadata_isolated_any.swift
+++ b/test/IRGen/reflection_metadata_isolated_any.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos14.4 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-6.0-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.10-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
 
 // REQUIRES: OS=macosx
 // UNSUPPORTED: CPU=arm64e

--- a/test/IRGen/reflection_metadata_typed_throws.swift
+++ b/test/IRGen/reflection_metadata_typed_throws.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
-// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos14.4 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-6.0-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-5.10-abi-triple %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
 
 // REQUIRES: OS=macosx
 // UNSUPPORTED: CPU=arm64e

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -37,8 +37,6 @@ SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
-# TODO: Also update ASTContext::getSwift510Availability when needed
-# TODO: Also update ASTContext::getSwift60Availability when needed
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
- Use a consistent definition of the "future" availability triple and add support for visionOS.
- Remove some out of date TODOs.
- Update IRGen tests to avoid direct use of `99.99` triples and use relevant Swift release target triple substitutions where possible.