### PR TITLE
SE-0362: Only warn about features that are enabled by the language mode

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -36,7 +36,7 @@ ERROR(error_unsupported_target_os, none,
 ERROR(error_unsupported_target_arch, none,
       "unsupported target architecture: '%0'", (StringRef))
 
-ERROR(error_upcoming_feature_on_by_default, none,
+WARNING(warning_upcoming_feature_on_by_default, none,
       "upcoming feature '%0' is already enabled as of Swift version %1",
       (StringRef, unsigned))
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -795,13 +795,9 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
     // diagnose and skip it.
     if (auto firstVersion = getFeatureLanguageVersion(*feature)) {
       if (Opts.isSwiftVersionAtLeast(*firstVersion)) {
-        Diags
-            .diagnose(SourceLoc(), diag::error_upcoming_feature_on_by_default,
-                      getFeatureName(*feature), *firstVersion)
-            .limitBehaviorIf(!enableUpcoming, DiagnosticBehavior::Warning);
-        if (enableUpcoming)
-          HadError = true;
-
+        Diags.diagnose(SourceLoc(),
+                       diag::warning_upcoming_feature_on_by_default,
+                       getFeatureName(*feature), *firstVersion);
         continue;
       }
     }

--- a/test/Frontend/upcoming_feature.swift
+++ b/test/Frontend/upcoming_feature.swift
@@ -30,17 +30,16 @@
 // RUN: %target-typecheck-verify-swift -disable-experimental-feature ConciseMagicFile -enable-experimental-feature ConciseMagicFile
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature ConciseMagicFile -disable-experimental-feature ConciseMagicFile -verify-additional-prefix swift5-
 
-// It's not fine to provide a feature that's in the specified language version.
-// RUN: not %target-swift-frontend -typecheck -enable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: %target-swift-frontend -typecheck -disable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
-// RUN: %target-swift-frontend -typecheck -enable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
-// RUN: %target-swift-frontend -typecheck -disable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
+// Warn about enabled features that are implied by the specified language version.
+// RUN: %target-swift-frontend -typecheck -enable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -disable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -disable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_ConciseMagicFile
 // REQUIRES: !swift_feature_UnknownFeature
 
-// CHECK-ERROR: error: upcoming feature 'ConciseMagicFile' is already enabled as of Swift version 6
-// CHECK-WARN: warning: upcoming feature 'ConciseMagicFile' is already enabled as of Swift version 6
+// CHECK: warning: upcoming feature 'ConciseMagicFile' is already enabled as of Swift version 6
 
 #if hasFeature(ConciseMagicFile)
 let x = 0

--- a/test/ModuleInterface/redundant-experimental-features.swiftinterface
+++ b/test/ModuleInterface/redundant-experimental-features.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -swift-version 6 -enable-experimental-feature IsolatedAny -enable-experimental-feature ImplicitOpenExistentials -enable-experimental-feature InferSendableFromCaptures -module-name Test
+
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/Test.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name Test -o /dev/null %t/Test.swiftinterface
+// RUN: echo "import Test" | %target-swift-frontend -typecheck - -I %t/
+
+import Swift

--- a/test/ModuleInterface/redundant-upcoming-features.swiftinterface
+++ b/test/ModuleInterface/redundant-upcoming-features.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -swift-version 6 -enable-upcoming-feature IsolatedAny -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature InferSendableFromCaptures -module-name Test
+
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/Test.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name Test -o /dev/null %t/Test.swiftinterface
+// RUN: echo "import Test" | %target-swift-frontend -typecheck - -I %t/
+
+import Swift


### PR DESCRIPTION
As proposed in the amendment described on the [forums](https://forums.swift.org/t/downgrade-upcoming-feature-is-already-enabled-error-to-a-warning/75762), only warn about explicitly enabled features that are already enabled by the language mode.