### PR TITLE
[cxx-interop] Mark all CxxStdlib APIs as `@inlinable`

### DIFF
--- a/stdlib/public/Cxx/std/Chrono.swift
+++ b/stdlib/public/Cxx/std/Chrono.swift
@@ -14,6 +14,7 @@ import CxxStdlibShim
 
 extension std.chrono.seconds {
   @available(SwiftStdlib 5.7, *)
+  @inlinable
   public init(_ duration: Duration) {
     let (seconds, _) = duration.components
     self = __swift_interopMakeChronoSeconds(seconds)
@@ -22,6 +23,7 @@ extension std.chrono.seconds {
 
 extension std.chrono.milliseconds {
   @available(SwiftStdlib 5.7, *)
+  @inlinable
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoMilliseconds(
@@ -32,6 +34,7 @@ extension std.chrono.milliseconds {
 
 extension std.chrono.microseconds {
   @available(SwiftStdlib 5.7, *)
+  @inlinable
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoMicroseconds(
@@ -42,6 +45,7 @@ extension std.chrono.microseconds {
 
 extension std.chrono.nanoseconds {
   @available(SwiftStdlib 5.7, *)
+  @inlinable
   public init(_ duration: Duration) {
     let (seconds, attoseconds) = duration.components
     self = __swift_interopMakeChronoNanoseconds(
@@ -52,18 +56,22 @@ extension std.chrono.nanoseconds {
 
 @available(SwiftStdlib 5.7, *)
 extension Duration {
+  @inlinable
   public init(_ seconds: std.chrono.seconds) {
     self = Duration.seconds(seconds.count())
   }
 
+  @inlinable
   public init(_ milliseconds: std.chrono.milliseconds) {
     self = Duration.milliseconds(milliseconds.count())
   }
 
+  @inlinable
   public init(_ microseconds: std.chrono.microseconds) {
     self = Duration.microseconds(microseconds.count())
   }
 
+  @inlinable
   public init(_ nanoseconds: std.chrono.nanoseconds) {
     self = Duration.nanoseconds(nanoseconds.count())
   }

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -19,6 +19,7 @@ extension std.string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-8 code units in the
   ///   Swift string.
+  @inlinable
   public init(_ string: String) {
     self = string.withCString(encodedAs: UTF8.self) { buffer in
 #if os(Windows)
@@ -32,6 +33,7 @@ extension std.string {
     }
   }
 
+  @inlinable
   public init(_ string: UnsafePointer<CChar>?) {
     if let str = string {
 #if os(Windows)
@@ -54,6 +56,7 @@ extension std.u16string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-16 code units in the
   ///   Swift string.
+  @inlinable
   public init(_ string: String) {
     self.init()
     for char in string.utf16 {
@@ -68,6 +71,7 @@ extension std.u32string {
   ///
   /// - Complexity: O(*n*), where *n* is the number of UTF-32 code units in the
   ///   Swift string.
+  @inlinable
   public init(_ string: String) {
     self.init()
     for char in string.unicodeScalars {
@@ -79,18 +83,21 @@ extension std.u32string {
 // MARK: Initializing C++ string from a Swift String literal
 
 extension std.string: ExpressibleByStringLiteral {
+  @inlinable
   public init(stringLiteral value: String) {
     self.init(value)
   }
 }
 
 extension std.u16string: ExpressibleByStringLiteral {
+  @inlinable
   public init(stringLiteral value: String) {
     self.init(value)
   }
 }
 
 extension std.u32string: ExpressibleByStringLiteral {
+  @inlinable
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -99,14 +106,17 @@ extension std.u32string: ExpressibleByStringLiteral {
 // MARK: Concatenating and comparing C++ strings
 
 extension std.string: Equatable, Comparable {
+  @inlinable
   public static func ==(lhs: std.string, rhs: std.string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
+  @inlinable
   public static func <(lhs: std.string, rhs: std.string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
+  @inlinable
   public static func +=(lhs: inout std.string, rhs: std.string) {
     lhs.append(rhs)
   }
@@ -116,6 +126,7 @@ extension std.string: Equatable, Comparable {
     __appendUnsafe(other) // ignore the returned pointer
   }
 
+  @inlinable
   public static func +(lhs: std.string, rhs: std.string) -> std.string {
     var copy = lhs
     copy += rhs
@@ -124,14 +135,17 @@ extension std.string: Equatable, Comparable {
 }
 
 extension std.u16string: Equatable, Comparable {
+  @inlinable
   public static func ==(lhs: std.u16string, rhs: std.u16string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
+  @inlinable
   public static func <(lhs: std.u16string, rhs: std.u16string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
+  @inlinable
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
     lhs.append(rhs)
   }
@@ -141,6 +155,7 @@ extension std.u16string: Equatable, Comparable {
     __appendUnsafe(other) // ignore the returned pointer
   }
 
+  @inlinable
   public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {
     var copy = lhs
     copy += rhs
@@ -149,14 +164,17 @@ extension std.u16string: Equatable, Comparable {
 }
 
 extension std.u32string: Equatable, Comparable {
+  @inlinable
   public static func ==(lhs: std.u32string, rhs: std.u32string) -> Bool {
     return lhs.compare(rhs) == 0
   }
 
+  @inlinable
   public static func <(lhs: std.u32string, rhs: std.u32string) -> Bool {
     return lhs.compare(rhs) < 0
   }
 
+  @inlinable
   public static func +=(lhs: inout std.u32string, rhs: std.u32string) {
     lhs.append(rhs)
   }
@@ -166,6 +184,7 @@ extension std.u32string: Equatable, Comparable {
     __appendUnsafe(other) // ignore the returned pointer
   }
 
+  @inlinable
   public static func +(lhs: std.u32string, rhs: std.u32string) -> std.u32string {
     var copy = lhs
     copy += rhs
@@ -176,6 +195,7 @@ extension std.u32string: Equatable, Comparable {
 // MARK: Hashing C++ strings
 
 extension std.string: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::string>::operator()
     let cxxHash = __swift_interopHashOfString().callAsFunction(self)
@@ -184,6 +204,7 @@ extension std.string: Hashable {
 }
 
 extension std.u16string: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u16string>::operator()
     let cxxHash = __swift_interopHashOfU16String().callAsFunction(self)
@@ -192,6 +213,7 @@ extension std.u16string: Hashable {
 }
 
 extension std.u32string: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u32string>::operator()
     let cxxHash = __swift_interopHashOfU32String().callAsFunction(self)
@@ -202,36 +224,42 @@ extension std.u32string: Hashable {
 // MARK: Getting a Swift description of a C++ string
 
 extension std.string: CustomDebugStringConvertible {
+  @inlinable
   public var debugDescription: String {
     return "std.string(\(String(self)))"
   }
 }
 
 extension std.u16string: CustomDebugStringConvertible {
+  @inlinable
   public var debugDescription: String {
     return "std.u16string(\(String(self)))"
   }
 }
 
 extension std.u32string: CustomDebugStringConvertible {
+  @inlinable
   public var debugDescription: String {
     return "std.u32string(\(String(self)))"
   }
 }
 
 extension std.string: CustomStringConvertible {
+  @inlinable
   public var description: String {
     return String(self)
   }
 }
 
 extension std.u16string: CustomStringConvertible {
+  @inlinable
   public var description: String {
     return String(self)
   }
 }
 
 extension std.u32string: CustomStringConvertible {
+  @inlinable
   public var description: String {
     return String(self)
   }
@@ -247,6 +275,7 @@ extension String {
   /// (`"\u{FFFD}"`).
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ string.
+  @inlinable
   public init(_ cxxString: std.string) {
     let buffer = UnsafeBufferPointer<CChar>(
       start: cxxString.__c_strUnsafe(),
@@ -265,6 +294,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
   ///   string.
+  @inlinable
   public init(_ cxxU16String: std.u16string) {
     let buffer = UnsafeBufferPointer<UInt16>(
       start: cxxU16String.__dataUnsafe(),
@@ -281,6 +311,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-32
   ///   string.
+  @inlinable
   public init(_ cxxU32String: std.u32string) {
     let buffer = UnsafeBufferPointer<Unicode.Scalar>(
       start: cxxU32String.__dataUnsafe(),
@@ -303,6 +334,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ string
   ///   view.
+  @inlinable
   public init(_ cxxStringView: std.string_view) {
     let buffer = UnsafeBufferPointer<CChar>(
       start: cxxStringView.__dataUnsafe(),
@@ -322,6 +354,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
   ///   string view.
+  @inlinable
   public init(_ cxxU16StringView: std.u16string_view) {
     let buffer = UnsafeBufferPointer<UInt16>(
       start: cxxU16StringView.__dataUnsafe(),
@@ -339,6 +372,7 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-32
   ///   string view.
+  @inlinable
   public init(_ cxxU32StringView: std.u32string_view) {
     let buffer = UnsafeBufferPointer<Unicode.Scalar>(
       start: cxxU32StringView.__dataUnsafe(),


### PR DESCRIPTION
This is a requirement for being able to use the CxxStdlib overlay with a C++ standard library which is not the platform default, specifically libc++ on Linux.

The module would get rebuilt from its textual interface (`CxxStdlib.swiftinterface`) by the compiler whenever a custom C++ stdlib is used. Since the mangled names of C++ stdlib symbols differ across implementations (libc++ vs libstdc++), a Swift program that uses these overlay functions would fail to link, unless the definitions of these functions are available.

rdar://138838506

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
