### PR TITLE
wasm: Enable filesystem APIs in libcxx

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -203,7 +203,7 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         self.cmake_options.define('LIBCXX_ENABLE_SHARED:BOOL', 'FALSE')
         self.cmake_options.define('LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY:BOOL', 'FALSE')
         self.cmake_options.define('LIBCXX_ENABLE_EXCEPTIONS:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_ENABLE_FILESYSTEM:BOOL', 'FALSE')
+        self.cmake_options.define('LIBCXX_ENABLE_FILESYSTEM:BOOL', 'TRUE')
         self.cmake_options.define('LIBCXX_CXX_ABI', 'libcxxabi')
         self.cmake_options.define('LIBCXX_HAS_MUSL_LIBC:BOOL', 'TRUE')
 


### PR DESCRIPTION
As of a recent fix included in LLVM 17 [^1] and wasi-libc fix [^2], we can enable `LIBCXX_ENABLE_FILESYSTEM` in libcxx build for WebAssembly/WASI. This allows us to use `<filesystem>`, `<fstream>`, etc in C++ code.

[^1]: https://github.com/llvm/llvm-project/commit/66a562d22e708ba40b8443b58e504ac3f983ba59
[^2]: https://github.com/WebAssembly/wasi-libc/pull/463

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
