### PR TITLE
[SILGen] Disable swift_willThrow(Typed) call in functions that cannot allocate

### DIFF
--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -27,6 +27,15 @@ func throwsConcrete() throws(MyError) {
   throw .fail
 }
 
+// CHECK-LABEL: sil hidden [no_locks] [ossa] @$s12typed_throws0B25ConcreteWithoutAllocatingyyAA7MyErrorOYKF : $@convention(thin) () -> @error MyError
+@_noLocks
+func throwsConcreteWithoutAllocating() throws(MyError) {
+  // CHECK-NOT: swift_willThrowTyped
+  // CHECK: throw [[ERROR:%.*]] : $MyError
+  // CHECK: return
+  throw .fail
+}
+
 class ClassError: Error { }
 
 // CHECK-LABEL: sil hidden [ossa] @$s12typed_throws0B10ClassErroryyAA0cD0CYKF : $@convention(thin) () -> @error ClassError

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -125,6 +125,29 @@ func testCatch(_ b: Bool) throws -> Int? {
   }
 }
 
+enum ErrorEnum: Error {
+  case failed
+  case tryAgain
+}
+
+@_noLocks
+func concreteError(_ b: Bool) throws(ErrorEnum) -> Int {
+  if b {
+    return 28
+  }
+
+  throw .tryAgain
+}
+
+@_noLocks
+func testCatchConcrete(_ b: Bool) -> Int {
+  do {
+    return try concreteError(b)
+  } catch {
+    return 17
+  }
+}
+
 @_noLocks
 func testRecursion(_ i: Int) -> Int {
   if i > 0 {


### PR DESCRIPTION
Prior to throwing, Swift emits a call to `swift_willThrow(Typed)`, which allows various diagnostic tools (such as debuggers and testing libraries) to intercept errors at the point where they are initially thrown.

Since `swift_willThrow(Typed)` can be hooked by arbitrary code at runtime, there is no way for it to meet performance constraints like @_noLocks or @_noAllocation. Therefore, in a function that has those performance constraints specified, disable emission of the call to `swift_willThrow(Typed)`.

Fixes rdar://140230684.
