### PR TITLE
[Performance diagnostics] Enable checking of throw instructions

### DIFF
--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -69,20 +69,6 @@ public:
   }
 };
 
-/// Computes the set of blocks which are not used for error handling, i.e. not
-/// (exclusively) reachable from the error-block of a try_apply.
-class NonErrorHandlingBlocks {
-    BasicBlockWorklist worklist;
-
-public:
-  NonErrorHandlingBlocks(SILFunction *function);
-
-  /// Returns true if there exists a path from \p block to the return-block.
-  bool isNonErrorHandling(SILBasicBlock *block) const {
-    return worklist.isVisited(block);
-  }
-};
-
 /// Remove all unreachable blocks in a function.
 bool removeUnreachableBlocks(SILFunction &f);
 

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -290,21 +290,6 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
     if (isa<UnreachableInst>(block.getTerminator()))
       continue;
 
-    // TODO: it's not yet clear how to deal with error existentials.
-    // Ignore them for now. If we have typed throws we could ban error existentials
-    // because typed throws would provide and alternative.
-    if (isa<ThrowInst>(block.getTerminator()))
-      continue;
-
-    // If a function has multiple throws, all throw-path branch to the single throw-block.
-    if (SILBasicBlock *succ = block.getSingleSuccessorBlock()) {
-      if (isa<ThrowInst>(succ->getTerminator()))
-        continue;
-    }
-
-    if (!neBlocks.isNonErrorHandling(&block))
-      continue;
-
     for (SILInstruction &inst : block) {
       if (visitInst(&inst, perfConstr, parentLoc)) {
         if (inst.getLoc().getSourceLoc().isInvalid()) {

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -213,8 +213,6 @@ bool PerformanceDiagnostics::visitFunctionEmbeddedSwift(
     return false;
   visitedFuncs[function] = PerformanceConstraints::None;
 
-  NonErrorHandlingBlocks neBlocks(function);
-
   for (SILBasicBlock &block : *function) {
     for (SILInstruction &inst : block) {
       if (visitInst(&inst, PerformanceConstraints::None, parentLoc)) {
@@ -282,8 +280,6 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
                                               LocWithParent *parentLoc) {
   if (!function->isDefinition())
     return false;
-
-  NonErrorHandlingBlocks neBlocks(function);
 
   for (SILBasicBlock &block : *function) {
     // Exclude fatal-error blocks.

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -55,19 +55,6 @@ ReachingReturnBlocks::ReachingReturnBlocks(SILFunction *function)
   }
 }
 
-NonErrorHandlingBlocks::NonErrorHandlingBlocks(SILFunction *function)
-    : worklist(function->getEntryBlock()) {
-  while (SILBasicBlock *block = worklist.pop()) {
-    if (auto ta = dyn_cast<TryApplyInst>(block->getTerminator())) {
-      worklist.pushIfNotVisited(ta->getNormalBB());
-    } else {
-      for (SILBasicBlock *succ : block->getSuccessorBlocks()) {
-        worklist.pushIfNotVisited(succ);
-      }
-    }
-  }
-}
-
 bool swift::removeUnreachableBlocks(SILFunction &f) {
   ReachableBlocks reachable(&f);
   // Visit all the blocks without doing any extra work.

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -40,6 +40,7 @@ import SwiftShims
 #if os(iOS) && !os(visionOS)
 @_effects(readnone)
 @_transparent
+@_noLocks
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -51,6 +52,7 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+@_noLocks
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -63,6 +65,7 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_alwaysEmitIntoClient
+@_noLocks
 public func _stdlib_isOSVersionAtLeast_AEIC(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -107,6 +110,7 @@ public func _stdlib_isOSVersionAtLeast_AEIC(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @available(macOS 10.15, iOS 13.0, *)
+@_noLocks
 public func _stdlib_isVariantOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -149,6 +153,7 @@ public func _stdlib_isVariantOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+@_noLocks
 public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -181,6 +181,7 @@ public func _bridgeErrorToNSError(_ error: __owned Error) -> AnyObject
 @_silgen_name("swift_willThrowTypedImpl")
 @available(SwiftStdlib 6.0, *)
 @usableFromInline
+@_noLocks
 func _willThrowTypedImpl<E: Error>(_ error: E)
 
 #if !$Embedded

--- a/test/SILOptimizer/constant_propagation_availability.swift
+++ b/test/SILOptimizer/constant_propagation_availability.swift
@@ -62,7 +62,7 @@ public func testInlinable() -> Int {
 // CHECK-macosx10_14:  apply [[F]]
 // CHECK-macosx10_14: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
 
-// CHECK-macosx10_14: sil [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK-macosx10_14: sil [no_locks] [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 
 // CHECK-inlinable-LABEL: sil {{.*}} @$s4Test13testInlinableSiyF  : $@convention(thin) () -> Int {
 // CHECK-inlinable:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -101,13 +101,22 @@ func errorExistential(_ b: Bool) throws -> Int {
   if b {
     return 28
   }
-  throw MyError()
+  throw MyError() // expected-error{{Using type 'MyError' can cause metadata allocation or locks}}
+}
+
+@_noLocks
+func concreteThrowsExistential(_ b: Bool) throws -> Int {
+  if b {
+    return 28
+  }
+
+  throw ErrorEnum.tryAgain // expected-error{{Using type 'any Error' can cause metadata allocation or locks}}
 }
 
 @_noLocks
 func multipleThrows(_ b1: Bool, _ b2: Bool) throws -> Int {
   if b1 {
-    throw MyError()
+    throw MyError() // expected-error{{Using type 'MyError' can cause metadata allocation or locks}}
   }
   if b2 {
     throw MyError2()
@@ -119,7 +128,7 @@ func multipleThrows(_ b1: Bool, _ b2: Bool) throws -> Int {
 func testCatch(_ b: Bool) throws -> Int? {
   do {
     return try errorExistential(true)
-  } catch let e as MyError {
+  } catch let e as MyError { // expected-error{{this code performs reference counting operations which can cause locking}}
     print(e)
     return nil
   }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -125,6 +125,37 @@ func testCatch(_ b: Bool) throws -> Int? {
   }
 }
 
+enum ErrorEnum: Error {
+  case failed
+  case tryAgain
+}
+
+@_noLocks
+func concreteError(_ b: Bool) throws(ErrorEnum) -> Int {
+  if b {
+    return 28
+  }
+
+  throw .tryAgain
+}
+
+func concreteErrorOther(_ b: Bool) throws(ErrorEnum) -> Int {
+  if b {
+    return 28
+  }
+
+  throw .tryAgain
+}
+
+@_noLocks
+func testCatchConcrete(_ b: Bool) -> Int {
+  do {
+    return try concreteError(b) + concreteErrorOther(b)
+  } catch {
+    return 17
+  }
+}
+
 @_noLocks
 func testRecursion(_ i: Int) -> Int {
   if i > 0 {


### PR DESCRIPTION
When performance diagnostics were introduced, typed throws didn't exist
so it was not generally possible to have throws anywhere without
triggering performance diagnostics. As a short term hack, we disabled
checking of `throw` instructions and the basic blocks that terminate
in a `throw`.

Now that typed throws is available and can be used to eliminate
allocations with error handling, remove all of the hacks. We'll now
diagnose attempts to throw or catch existential values (e.g., the `any
Error` used for untyped throws), but typed throws are fine.