### PR TITLE
[region-isolation] Fix two small usage issues around diagnosing closure captures

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -434,17 +434,21 @@ public:
     return {};
   }
 
+  static bool isNonSendableType(SILType type, SILFunction *fn) {
+    return isNonSendableType(type.getASTType(), fn);
+  }
+
+  static bool isNonSendableType(SILValue value) {
+    return isNonSendableType(value->getType(), value->getFunction());
+  }
+
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.
   ///
   /// E.x.: Builtin.RawPointer and Builtin.NativeObject
   ///
   /// TODO: Fix the type checker.
-  static bool isNonSendableType(SILType type, SILFunction *fn);
-
-  static bool isNonSendableType(SILValue value) {
-    return isNonSendableType(value->getType(), value->getFunction());
-  }
+  static bool isNonSendableType(CanType type, SILFunction *fn);
 
   bool hasSameIsolation(ActorIsolation actorIsolation) const;
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1667,6 +1667,7 @@ bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
   for (auto capture : ce->getCaptureInfo().getCaptures()) {
     auto *decl = capture.getDecl();
     auto type = decl->getInterfaceType()->getCanonicalType();
+    type = pai->getFunction()->mapTypeIntoContext(type)->getCanonicalType();
     auto silType = SILType::getPrimitiveObjectType(type);
     if (!SILIsolationInfo::isNonSendableType(silType, pai->getFunction()))
       continue;

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1668,12 +1668,11 @@ bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
     auto *decl = capture.getDecl();
     auto type = decl->getInterfaceType()->getCanonicalType();
     type = pai->getFunction()->mapTypeIntoContext(type)->getCanonicalType();
-    auto silType = SILType::getPrimitiveObjectType(type);
-    if (!SILIsolationInfo::isNonSendableType(silType, pai->getFunction()))
+    if (!SILIsolationInfo::isNonSendableType(type, pai->getFunction()))
       continue;
 
     auto *fromDC = decl->getInnermostDeclContext();
-    auto *nom = silType.getNominalOrBoundGenericNominal();
+    auto *nom = type.getNominalOrBoundGenericNominal();
     if (nom && fromDC) {
       if (auto diagnosticBehavior =
               getConcurrencyDiagnosticBehaviorLimit(nom, fromDC)) {

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1907,7 +1907,7 @@ func offByOneWithImplicitPartialApply() {
   }
 }
 
-protocol Progress {
+protocol Progress { // expected-note {{}}
   associatedtype AssocType
   var x: AssocType { get }
   func checkCancellation() throws
@@ -1920,6 +1920,20 @@ func testCaptureDiagnosticMapsTypeIntoContext<T : Progress>(_ x: NonSendableKlas
   await withTaskGroup(of: Void.self) { group in
     group.addTask { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
       print(z) // expected-tns-note {{closure captures 'z' which is accessible to code in the current task}}
+    }
+  }
+}
+
+// We used to crash here since we were using an API that wanted a SIL Type and
+// we were creating a SILType from a CanType that needed to be lowered.
+func testUseCanTypeNonSendableCheckAPI(y: any Progress) async {
+  @Sendable func test() {
+    print(y) // expected-warning {{capture of 'y' with non-sendable type 'any Progress' in a `@Sendable` local function}}
+  }
+  await withTaskGroup(of: Void.self) { group in
+    group.addTask { // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+      // expected-tns-note @-1 {{Passing task-isolated value of non-Sendable type '() async -> ()' as a 'sending' parameter to instance method 'addTask(priority:operation:)' risks causing races inbetween task-isolated uses and uses reachable from 'addTask(priority:operation:)'}}
+      test()
     }
   }
 }


### PR DESCRIPTION
Specifically:

1. We were not mapping a type into the SILFunction's context and in the second case.
2. We were wrapping CanTypes into a SILType and calling an API to check for non-Send ability. The second ignores that the type since it is from the AST may not be a lowered type... so I changed the underlying API to use CanTypes instead of SILTypes (since we did not need that in the first place) and changed the SILType API to just call that.

rdar://138667211