### PR TITLE
[cxx-interop] Do not emit C++ interop flag in textual interfaces

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -794,12 +794,12 @@ def enable_experimental_concise_pound_file : Flag<["-"],
 
 def enable_experimental_cxx_interop :
   Flag<["-"], "enable-experimental-cxx-interop">,
-  Flags<[NoDriverOption, FrontendOption, HelpHidden, ModuleInterfaceOption]>,
+  Flags<[NoDriverOption, FrontendOption, HelpHidden]>,
   HelpText<"Enable experimental C++ interop code generation and config directives">;
 
 def cxx_interoperability_mode :
   Joined<["-"], "cxx-interoperability-mode=">,
-  Flags<[FrontendOption, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
+  Flags<[FrontendOption, SwiftSymbolGraphExtractOption,
          SwiftSynthesizeInterfaceOption]>,
   HelpText<"Enables C++ interoperability; pass 'default' to enable or 'off' to disable">;
 

--- a/test/Interop/Cxx/modules/emit-module-interface.swift
+++ b/test/Interop/Cxx/modules/emit-module-interface.swift
@@ -3,15 +3,18 @@
 // Check if fragile Swift interface with struct
 // extensions can be reparsed:
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -emit-module-interface-path %t/UsesCxxStruct.swiftinterface %s -I %S/Inputs -swift-version 5 -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift
-// RUN: %target-swift-frontend -swift-version 5 -typecheck-module-from-interface  %t/UsesCxxStruct.swiftinterface -I %S/Inputs
+// RUN: %target-swift-frontend -swift-version 5 -typecheck-module-from-interface  %t/UsesCxxStruct.swiftinterface -I %S/Inputs -enable-experimental-cxx-interop
 // RUN: %FileCheck --input-file=%t/UsesCxxStruct.swiftinterface %s
-// CHECK: -enable-experimental-cxx-interop
+
+// The textual module interface should not contain the C++ interop flag.
+// CHECK-NOT: -enable-experimental-cxx-interop
+// CHECK-NOT: -cxx-interoperability-mode
 
 
 // Check if resilient Swift interface with builtin
 // type extensions can be reparsed:
 // RUN: %target-swift-emit-module-interface(%t/ResilientStruct.swiftinterface) %s -I %S/Inputs -enable-library-evolution -swift-version 5 -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift -DRESILIENT
-// RUN: %target-swift-typecheck-module-from-interface(%t/ResilientStruct.swiftinterface) -I %S/Inputs -DRESILIENT
+// RUN: %target-swift-typecheck-module-from-interface(%t/ResilientStruct.swiftinterface) -I %S/Inputs -DRESILIENT -enable-experimental-cxx-interop
 // RUN: %FileCheck --input-file=%t/ResilientStruct.swiftinterface %s
 
 import Namespaces

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -46,15 +46,10 @@ for filename in os.listdir(sdk_overlay_dir):
         "DifferentiationUnittest",
         "Swift",
         "SwiftLang",
-        "std",  # swiftstd uses `-module-interface-preserve-types-as-written`
+        # swiftCxxStdlib uses `-module-interface-preserve-types-as-written`
+        "CxxStdlib",
     ]:
         continue
-
-    # Cxx and CxxStdlib are built without library evolution and don't have a
-    # .swiftinterface file
-    if module_name in ["Cxx", "CxxStdlib"]:
-        if not os.path.exists(interface_file):
-            continue
 
     # swift -build-module-from-parseable-interface
     output_path = os.path.join(output_dir, module_name + ".swiftmodule")


### PR DESCRIPTION
This makes sure that the compiler does not emit `-enable-experimental-cxx-interop`/`-cxx-interoperability-mode` flags in `.swiftinterface` files. Those flags were breaking explicit module builds. The module can still be rebuilt from its textual interface if C++ interop was enabled in the current compilation.

rdar://140203932

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
