### PR TITLE
AST: `AvailableAttr` cleanup

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -768,12 +768,14 @@ public:
   /// Indicates where the Obsoleted version was specified.
   const SourceRange ObsoletedRange;
 
+private:
   /// Indicates if the declaration has platform-agnostic availability.
   const PlatformAgnosticAvailabilityKind PlatformAgnostic;
 
-  /// The platform of the availability.
+  /// The platform that the attribute applies to (may be `none`).
   const PlatformKind Platform;
 
+public:
   /// Whether this is a language-version-specific entity.
   bool isLanguageVersionSpecific() const;
 
@@ -794,6 +796,9 @@ public:
 
   /// Whether this attribute was spelled `@_unavailableInEmbedded`.
   bool isForEmbedded() const { return Bits.AvailableAttr.IsForEmbedded; }
+
+  /// Returns the platform that the attribute applies to (may be `none`).
+  PlatformKind getPlatform() const { return Platform; }
 
   /// Returns the platform-agnostic availability.
   PlatformAgnosticAvailabilityKind getPlatformAgnosticAvailability() const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -147,7 +147,13 @@ protected:
       Value : 32
     );
 
-    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 1+1,
+    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 8+8+1+1,
+      /// A `PlatformKind` value.
+      Platform : 8,
+
+      /// A `PlatformAgnosticAvailabilityKind` value.
+      PlatformAgnostic : 8,
+
       /// Whether this attribute was spelled `@_spi_available`.
       IsSPI : 1,
 
@@ -700,7 +706,7 @@ enum class AvailableVersionComparison {
 };
 
 /// Describes the platform-agnostic availability of a declaration.
-enum class PlatformAgnosticAvailabilityKind {
+enum class PlatformAgnosticAvailabilityKind : uint8_t {
   /// The associated availability attribute is not platform-agnostic.
   None,
   /// The declaration is deprecated, but can still be used.
@@ -768,14 +774,6 @@ public:
   /// Indicates where the Obsoleted version was specified.
   const SourceRange ObsoletedRange;
 
-private:
-  /// Indicates if the declaration has platform-agnostic availability.
-  const PlatformAgnosticAvailabilityKind PlatformAgnostic;
-
-  /// The platform that the attribute applies to (may be `none`).
-  const PlatformKind Platform;
-
-public:
   /// Whether this is a language-version-specific entity.
   bool isLanguageVersionSpecific() const;
 
@@ -798,11 +796,14 @@ public:
   bool isForEmbedded() const { return Bits.AvailableAttr.IsForEmbedded; }
 
   /// Returns the platform that the attribute applies to (may be `none`).
-  PlatformKind getPlatform() const { return Platform; }
+  PlatformKind getPlatform() const {
+    return static_cast<PlatformKind>(Bits.AvailableAttr.Platform);
+  }
 
   /// Returns the platform-agnostic availability.
   PlatformAgnosticAvailabilityKind getPlatformAgnosticAvailability() const {
-    return PlatformAgnostic;
+    return static_cast<PlatformAgnosticAvailabilityKind>(
+        Bits.AvailableAttr.PlatformAgnostic);
   }
 
   /// Determine if a given declaration should be considered unavailable given
@@ -813,18 +814,16 @@ public:
 
   /// Returns true if the availability applies to a specific
   /// platform.
-  bool hasPlatform() const {
-    return Platform != PlatformKind::none;
-  }
+  bool hasPlatform() const { return getPlatform() != PlatformKind::none; }
 
   /// Returns the string for the platform of the attribute.
   StringRef platformString() const {
-    return swift::platformString(Platform);
+    return swift::platformString(getPlatform());
   }
 
   /// Returns the human-readable string for the platform of the attribute.
   StringRef prettyPlatformString() const {
-    return swift::prettyPlatformString(Platform);
+    return swift::prettyPlatformString(getPlatform());
   }
 
   /// Returns true if this attribute is active given the current platform.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2042,7 +2042,7 @@ public:
   };
 
   /// Parse a comma-separated list of availability specifications. Try to
-  /// expand availability macros when /p Source is not a command line macro.
+  /// expand availability macros when \p Source is not a command line macro.
   ParserStatus
   parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs,
                             AvailabilitySpecSource Source);

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1341,9 +1341,9 @@ static bool isABIPlaceHolder(Decl *D) {
   llvm::SmallSet<PlatformKind, 4> Platforms;
   for (auto *ATT: D->getAttrs()) {
     if (auto *AVA = dyn_cast<AvailableAttr>(ATT)) {
-      if (AVA->Platform != PlatformKind::none && AVA->Introduced &&
+      if (AVA->getPlatform() != PlatformKind::none && AVA->Introduced &&
           AVA->Introduced->getMajor() == 9999) {
-        Platforms.insert(AVA->Platform);
+        Platforms.insert(AVA->getPlatform());
       }
     }
   }
@@ -1363,7 +1363,7 @@ StringRef SDKContext::getPlatformIntroVersion(Decl *D, PlatformKind Kind) {
     return StringRef();
   for (auto *ATT: D->getAttrs()) {
     if (auto *AVA = dyn_cast<AvailableAttr>(ATT)) {
-      if (AVA->Platform == Kind && AVA->Introduced) {
+      if (AVA->getPlatform() == Kind && AVA->Introduced) {
         return buffer(AVA->Introduced->getAsString());
       }
     }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -379,8 +379,7 @@ DeclAttributes::isUnavailableInSwiftVersion(
       if (available->isInvalid())
         continue;
 
-      if (available->getPlatformAgnosticAvailability() ==
-          PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
+      if (available->isLanguageVersionSpecific()) {
         if (available->Introduced.has_value() &&
             available->Introduced.value() > vers)
           return true;

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -58,7 +58,7 @@ bool AvailabilityContext::PlatformInfo::constrainWith(const Decl *decl) {
     isConstrained |= constrainRange(Range, *range);
 
   if (auto *attr = decl->getAttrs().getUnavailable(ctx)) {
-    isConstrained |= constrainUnavailability(attr->Platform);
+    isConstrained |= constrainUnavailability(attr->getPlatform());
     isConstrained |=
         CONSTRAIN_BOOL(IsUnavailableInEmbedded, attr->isForEmbedded());
   }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -301,7 +301,7 @@ getAvailabilityConditionVersionSourceRange(const DeclAttributes &DeclAttrs,
   for (auto *Attr : DeclAttrs) {
     if (auto *AA = dyn_cast<AvailableAttr>(Attr)) {
       if (AA->Introduced.has_value() && AA->Introduced.value() == Version &&
-          AA->Platform == Platform) {
+          AA->getPlatform() == Platform) {
 
         // More than one: return invalid range.
         if (Range.isValid())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -557,7 +557,7 @@ std::optional<llvm::VersionTuple>
 Decl::getIntroducedOSVersion(PlatformKind Kind) const {
   for (auto *attr: getAttrs()) {
     if (auto *ava = dyn_cast<AvailableAttr>(attr)) {
-      if (ava->Platform == Kind && ava->Introduced) {
+      if (ava->getPlatform() == Kind && ava->Introduced) {
         return ava->Introduced;
       }
     }
@@ -9253,7 +9253,8 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
     // `getAttrs` is in reverse source order, so the last attribute is the
     // first in source
     if (!attr->Rename.empty() &&
-        (attr->Platform == PlatformKind::none || !avAttr) && !attr->isNoAsync()) {
+        (attr->getPlatform() == PlatformKind::none || !avAttr) &&
+        !attr->isNoAsync()) {
       avAttr = attr;
     }
   }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -456,8 +456,8 @@ class InheritedProtocolCollector {
         // attributes for the same platform; formally they'd need to be merged.
         bool alreadyHasMoreSpecificAttrForThisPlatform =
             llvm::any_of(*cache, [nextAttr](const AvailableAttr *existingAttr) {
-          return existingAttr->Platform == nextAttr->Platform;
-        });
+              return existingAttr->getPlatform() == nextAttr->getPlatform();
+            });
         if (alreadyHasMoreSpecificAttrForThisPlatform)
           continue;
         cache->push_back(nextAttr);

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -773,11 +773,11 @@ private:
     auto platform = targetPlatform(module->getASTContext().LangOpts);
     for (auto *attr : decl->getAttrs()) {
       if (auto *ava = dyn_cast<AvailableAttr>(attr)) {
-        if (ava->Platform == PlatformKind::none) {
+        if (ava->getPlatform() == PlatformKind::none) {
           hasFallbackUnavailability = ava->isUnconditionallyUnavailable();
           continue;
         }
-        if (ava->Platform != platform)
+        if (ava->getPlatform() != platform)
           continue;
         unavailable = ava->isUnconditionallyUnavailable();
         if (ava->Introduced)

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1686,8 +1686,8 @@ public:
     };
 
     for (auto AvAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
-      if (AvAttr->Platform == PlatformKind::none) {
-        if (AvAttr->PlatformAgnostic ==
+      if (AvAttr->getPlatform() == PlatformKind::none) {
+        if (AvAttr->getPlatformAgnosticAvailability() ==
             PlatformAgnosticAvailabilityKind::Unavailable) {
           // Availability for *
           if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
@@ -1741,7 +1741,7 @@ public:
       }
 
       const char *plat;
-      switch (AvAttr->Platform) {
+      switch (AvAttr->getPlatform()) {
       case PlatformKind::macOS:
         plat = "macos";
         break;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2164,14 +2164,14 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   // Make sure there isn't a more specific attribute we should be using instead.
   // findMostSpecificActivePlatform() is O(N), so only do this if we're checking
   // an iOS attribute while building for macCatalyst.
-  if (attr->Platform == PlatformKind::iOS &&
+  if (attr->getPlatform() == PlatformKind::iOS &&
       isPlatformActive(PlatformKind::macCatalyst, Ctx.LangOpts)) {
     if (attr != D->getAttrs().findMostSpecificActivePlatform(Ctx)) {
       return;
     }
   }
 
-  if (attr->Platform == PlatformKind::iOS &&
+  if (attr->getPlatform() == PlatformKind::iOS &&
       isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
     if (attr != D->getAttrs().findMostSpecificActivePlatform(Ctx)) {
       return;
@@ -4798,7 +4798,7 @@ void AttributeChecker::checkBackDeployedAttrs(
     // Unavailable decls cannot be back deployed.
     if (auto unavailableAttrPair = VD->getSemanticUnavailableAttr()) {
       auto unavailableAttr = unavailableAttrPair.value().first;
-      if (!inheritsAvailabilityFromPlatform(unavailableAttr->Platform,
+      if (!inheritsAvailabilityFromPlatform(unavailableAttr->getPlatform(),
                                             Attr->Platform)) {
         auto platformString = prettyPlatformString(Attr->Platform);
         llvm::VersionTuple ignoredVersion;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -354,7 +354,7 @@ static bool isInsideCompatibleUnavailableDeclaration(
 
   // Refuse calling universally unavailable functions from unavailable code,
   // but allow the use of types.
-  PlatformKind platform = attr->Platform;
+  PlatformKind platform = attr->getPlatform();
   if (platform == PlatformKind::none && !attr->isForEmbedded() &&
       !isa<TypeDecl>(D) && !isa<ExtensionDecl>(D))
     return false;
@@ -3004,7 +3004,7 @@ getExplicitUnavailabilityDiagnosticInfo(const Decl *decl,
 
   case PlatformAgnosticAvailabilityKind::None:
   case PlatformAgnosticAvailabilityKind::Unavailable:
-    if (attr->Platform != PlatformKind::none) {
+    if (attr->getPlatform() != PlatformKind::none) {
       platform = attr->prettyPlatformString();
       versionedPlatform = platform;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6627,12 +6627,12 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
            : nullptr) {
     bool anyPlatformSpecificAttrs = false;
     for (auto available: enclosing->getAttrs().getAttributes<AvailableAttr>()) {
-      if (available->Platform == PlatformKind::none)
+      if (available->getPlatform() == PlatformKind::none)
         continue;
 
       auto attr = new (ctx) AvailableAttr(
           SourceLoc(), SourceRange(),
-          available->Platform,
+          available->getPlatform(),
           available->Message,
           "", nullptr,
           available->Introduced.value_or(noVersion), SourceRange(),

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -916,8 +916,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
           static AvailabilityRange from(const ValueDecl *VD) {
             AvailabilityRange result;
             for (auto *attr : VD->getAttrs().getAttributes<AvailableAttr>()) {
-              if (attr->getPlatformAgnosticAvailability() ==
-                  PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
+              if (attr->isLanguageVersionSpecific()) {
                 if (attr->Introduced)
                   result.introduced = attr->Introduced;
                 if (attr->Obsoleted)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -916,8 +916,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
           static AvailabilityRange from(const ValueDecl *VD) {
             AvailabilityRange result;
             for (auto *attr : VD->getAttrs().getAttributes<AvailableAttr>()) {
-              if (attr->PlatformAgnostic ==
-                    PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
+              if (attr->getPlatformAgnosticAvailability() ==
+                  PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
                 if (attr->Introduced)
                   result.introduced = attr->Introduced;
                 if (attr->Obsoleted)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3055,7 +3055,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           LIST_VER_TUPLE_PIECES(Introduced),
           LIST_VER_TUPLE_PIECES(Deprecated),
           LIST_VER_TUPLE_PIECES(Obsoleted),
-          static_cast<unsigned>(theAttr->Platform),
+          static_cast<unsigned>(theAttr->getPlatform()),
           renameDeclID,
           theAttr->Message.size(),
           theAttr->Rename.size(),

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -37,7 +37,7 @@ StringRef getDomain(const AvailableAttr &AvAttr) {
   }
 
   // Platform-specific availability.
-  switch (AvAttr.Platform) {
+  switch (AvAttr.getPlatform()) {
     case swift::PlatformKind::iOS:
       return { "iOS" };
     case swift::PlatformKind::macCatalyst:

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -114,7 +114,7 @@ namespace {
 bool isUnavailableOrObsoleted(const Decl *D) {
   if (const auto *Avail =
         D->getAttrs().getUnavailable(D->getASTContext())) {
-    if (Avail->Platform != PlatformKind::none) {
+    if (Avail->getPlatform() != PlatformKind::none) {
       switch (Avail->getVersionAvailability(D->getASTContext())) {
         case AvailableVersionComparison::Unavailable:
         case AvailableVersionComparison::Obsoleted:

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -693,7 +693,7 @@ static void reportAttributes(ASTContext &Ctx,
   for (auto Attr : getDeclAttributes(D, Scratch)) {
     if (auto Av = dyn_cast<AvailableAttr>(Attr)) {
       UIdent PlatformUID;
-      switch (Av->Platform) {
+      switch (Av->getPlatform()) {
       case PlatformKind::none:
         PlatformUID = UIdent(); break;
       case PlatformKind::iOS:


### PR DESCRIPTION
- Expose getters for `Platform` and `PlatformAgnostic` and adopt throughout the compiler.
- Move `Platform` and `PlatformAgnostic` into `DeclAttribute` bit storage.
- Prefer boolean convenience getters over calling `getPlatformAgnosticAvailability()`. 