### PR TITLE
[AutoDiff][test] Use true and false literals instead of `1 == 1` and `1 == 0`

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/58660-conflicting-debug-info-inlining.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/58660-conflicting-debug-info-inlining.swift
@@ -55,8 +55,7 @@ struct MyModel: Differentiable {
     property2 = localVar
 
     // `false` may instead be any expression that returns a `Bool`.
-    // TODO: cannot use literal `false` because it crashes
-    if 1 == 0 {
+    if false {
       localVar = member3
     }
   }

--- a/test/AutoDiff/compiler_crashers_fixed/issue-58123-mutating-functions-with-control-flow.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-58123-mutating-functions-with-control-flow.swift
@@ -62,8 +62,7 @@ struct BatchNorm<Scalar>: Layer { // Crash requires conformance to `Layer`
   @differentiable(reverse)
   func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     var offset = self.offset
-    // TODO: cannot use literal `true` because it crashes
-    if 1 == 1 { // Crash requires `if true`
+    if true { // Crash requires `if true`
       offset += offset // Using `offset = offset + offset` stops the crash
     }
     return offset

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -43,8 +43,7 @@ AddressOnlyTangentVectorTests.test("LoadableClassAddressOnlyTangentVector") {
   @differentiable(reverse)
   func conditional<T: Differentiable>(_ s: LoadableClass<T>) -> T {
     var tuple = (s, (s, s))
-    // TODO: cannot use literal `false` because it crashes
-    if 1 == 0 {}
+    if false {}
     return tuple.1.0.stored
   }
   expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), of: conditional))

--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -66,12 +66,10 @@ ControlFlowTests.test("Conditionals") {
 
   func cond4_var(_ x: Float) -> Float {
     var outer = x
-    // TODO: cannot use literal `true` because it crashes
-    outerIf: if 1 == 1 {
+    outerIf: if true {
       var inner = outer
       inner = inner * x
-      // TODO: cannot use literal `false` because it crashes
-      if 1 == 0 {
+      if false {
         break outerIf
       }
       outer = inner
@@ -388,9 +386,8 @@ ControlFlowTests.test("NestedConditionals") {
       @differentiable(reverse, wrt: self) // wrt only self is important
       func callAsFunction(_ input: Float) -> Float {
         var x = input
-        // TODO: cannot use literal `true` because it crashes
-        if 1 == 1 {
-          if 1 == 1 {
+        if true {
+          if true {
             // Function application below should make `self` have non-zero
             // derivative.
             x = x * w
@@ -408,9 +405,8 @@ ControlFlowTests.test("NestedConditionals") {
     @differentiable(reverse, wrt: x)
     func TF_781(_ x: Float, _ y: Float) -> Float {
       var result = y
-      // TODO: cannot use literal `true` because it crashes
-      if 1 == 1 {
-        if 1 == 1 {
+      if true {
+        if true {
           result = result * x
         }
       }
@@ -795,8 +791,7 @@ ControlFlowTests.test("ThrowingCalls") {
   func testComplexControlFlow(_ x: Float) -> Float {
     rethrowing({})
     for _ in 0..<Int(x) {
-      // TODO: cannot use literal `true` because it crashes
-      if 1 == 1 {
+      if true {
         rethrowing({})
       }
       rethrowing({}) // non-active `try_apply`
@@ -810,8 +805,7 @@ ControlFlowTests.test("ThrowingCalls") {
   func testComplexControlFlowGeneric<T: Differentiable>(_ x: T) -> T {
     rethrowing({})
     for _ in 0..<10 {
-      // TODO: cannot use literal `true` because it crashes
-      if 1 == 1 {
+      if true {
         rethrowing({})
       }
       rethrowing({}) // non-active `try_apply`


### PR DESCRIPTION
After introducing BooleanLiteralFolding mandatory pass in c89df9ec985244ff5109b0a7852c086e39d8e5eb, true and false literals in some tests were changed to `1 == 1` and `1 == 0` with a comment that literals caused crash. At this point, using literals no longer causes crashes, so switch back to using true and false in such cases.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
