### PR TITLE
[6.1] [Completion] Fix invertible type completion

### DIFF
--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -204,6 +204,7 @@ enum class CompletionKind : uint8_t {
   TypeSimpleBeginning,
   TypeSimpleWithDot,
   TypeSimpleWithoutDot,
+  TypeSimpleInverted,
   CaseStmtKeyword,
   CaseStmtBeginning,
   NominalMemberBeginning,
@@ -231,9 +232,6 @@ enum class CompletionKind : uint8_t {
   TypeAttrBeginning,
   TypeAttrInheritanceBeginning,
   OptionalBinding,
-
-  /// Completion after `~` in an inheritance clause.
-  WithoutConstraintType
 };
 
 enum class CodeCompletionDiagnosticSeverity : uint8_t {

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -593,6 +593,9 @@ public:
 
   void getTypeCompletions(Type BaseType);
 
+  /// Add completions for types that can appear after a \c ~ prefix.
+  void getInvertedTypeCompletions();
+
   void getGenericRequirementCompletions(DeclContext *DC,
                                         SourceLoc CodeCompletionLoc);
 
@@ -631,8 +634,6 @@ public:
   void getStmtLabelCompletions(SourceLoc Loc, bool isContinue);
 
   void getOptionalBindingCompletions(SourceLoc Loc);
-
-  void addWithoutConstraintTypes();
 };
 
 } // end namespace ide

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -204,6 +204,9 @@ public:
   /// Complete a given \c type-simple when there is no trailing dot.
   virtual void completeTypeSimpleWithoutDot(TypeRepr *TR){};
 
+  /// Complete a given \c type-simple following a \c ~ prefix.
+  virtual void completeTypeSimpleInverted() {};
+
   /// Complete the beginning of a case statement at the top of switch stmt.
   virtual void completeCaseStmtKeyword() {};
 
@@ -291,8 +294,6 @@ public:
   virtual void completeTypeAttrInheritanceBeginning() {};
 
   virtual void completeOptionalBinding(){};
-
-  virtual void completeWithoutConstraintType(){};
 };
 
 class DoneParsingCallback {

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2965,6 +2965,22 @@ void CompletionLookup::getTypeCompletions(Type BaseType) {
   }
 }
 
+void CompletionLookup::getInvertedTypeCompletions() {
+  Kind = LookupKind::Type;
+
+  auto addCompletion = [&](InvertibleProtocolKind invertableKind) {
+    auto *P = Ctx.getProtocol(getKnownProtocolKind(invertableKind));
+    if (!P)
+      return;
+
+    addNominalTypeRef(P, DeclVisibilityKind::VisibleAtTopLevel,
+                      DynamicLookupInfo());
+  };
+#define INVERTIBLE_PROTOCOL(Name, Bit)         \
+  addCompletion(InvertibleProtocolKind::Name);
+#include "swift/ABI/InvertibleProtocols.def"
+}
+
 void CompletionLookup::getGenericRequirementCompletions(
     DeclContext *DC, SourceLoc CodeCompletionLoc) {
   auto genericSig = DC->getGenericSignatureOfContext();
@@ -3490,10 +3506,4 @@ void CompletionLookup::getOptionalBindingCompletions(SourceLoc Loc) {
 
   lookupVisibleDecls(FilteringConsumer, Loc, CurrDeclContext,
                      /*IncludeTopLevel=*/false);
-}
-
-void CompletionLookup::addWithoutConstraintTypes() {
-  auto *CopyableDecl = Ctx.getProtocol(KnownProtocolKind::Copyable);
-  addNominalTypeRef(CopyableDecl, DeclVisibilityKind::VisibleAtTopLevel,
-                    DynamicLookupInfo());
 }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -227,7 +227,11 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     break;
   case tok::code_complete:
     if (CodeCompletionCallbacks) {
-      CodeCompletionCallbacks->completeTypeSimpleBeginning();
+      if (tildeLoc.isValid()) {
+        CodeCompletionCallbacks->completeTypeSimpleInverted();
+      } else {
+        CodeCompletionCallbacks->completeTypeSimpleBeginning();
+      }
     }
     return makeParserCodeCompletionResult<TypeRepr>(
         ErrorTypeRepr::create(Context, consumeToken(tok::code_complete)));

--- a/test/IDE/complete_without_constraint_type.swift
+++ b/test/IDE/complete_without_constraint_type.swift
@@ -1,4 +1,7 @@
 // RUN: %batch-code-completion
 
+// rdar://139212286 - We should only suggest invertible types here.
 struct FileDescriptor: ~#^COMPLETE^# {}
-// COMPLETE: Decl[Protocol]/OtherModule[Swift]/IsSystem: Copyable[#Copyable#]; name=Copyable
+// COMPLETE:     Begin completions, 2 items
+// COMPLETE-DAG: Decl[Protocol]/OtherModule[Swift]/IsSystem: Copyable[#Copyable#]; name=Copyable
+// COMPLETE-DAG: Decl[Protocol]/OtherModule[Swift]/IsSystem: Escapable[#Escapable#]; name=Escapable


### PR DESCRIPTION
*6.1 cherry-pick of #77698*

- Explanation: Ensures that type completion after `~` only shows invertible types
- Scope: Affects type completion
- Issue: rdar://139212286
- Risk: Low, the fix is fairly straightforward, only affects completion
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen