### PR TITLE
[6.1] [Completion] Fix crash in `getTypeOfMember`

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -716,8 +716,8 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
         return T;
 
       // If we are doing implicit member lookup on a protocol and we have found
-      // a declaration in an extension, use the extension's `Self` type for the
-      // generic substitution.
+      // a declaration in a constrained extension, use the extension's `Self`
+      // type for the generic substitution.
       // Eg in the following, the `Self` type returned by `qux` is
       // `MyGeneric<Int>`, not `MyProto` because of the `Self` type restriction.
       // ```
@@ -733,9 +733,11 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
       // ```
       if (MaybeNominalType->isExistentialType()) {
         Type SelfType;
-        if (auto ED = dyn_cast<ExtensionDecl>(VD->getDeclContext())) {
-          SelfType = ED->getGenericSignature()->getConcreteType(
-              ED->getSelfInterfaceType());
+        if (auto *ED = dyn_cast<ExtensionDecl>(VD->getDeclContext())) {
+          if (ED->getSelfProtocolDecl() && ED->isConstrainedExtension()) {
+            auto Sig = ED->getGenericSignature();
+            SelfType = Sig->getConcreteType(ED->getSelfInterfaceType());
+          }
         }
         if (SelfType) {
           MaybeNominalType = SelfType;

--- a/test/IDE/complete_rdar138774888.swift
+++ b/test/IDE/complete_rdar138774888.swift
@@ -1,0 +1,29 @@
+// RUN: %batch-code-completion
+
+// rdar://138774888 - Make sure we don't crash
+
+class C1 {}
+extension C1 {
+  func foo() {}
+}
+protocol P1 where Self: C1 {}
+
+func bar(_ x: P1) {
+  x.#^COMPLETE1^#
+  // COMPLETE1: Decl[InstanceMethod]/CurrNominal:   foo()[#Void#]; name=foo()
+}
+
+class C2<T> {}
+extension C2 where T == String {
+  func foo() {}
+}
+extension C2 where T == Int {
+  func bar() {}
+}
+
+protocol P2 where Self: C2<Int> {}
+
+func bar(_ x: P2) {
+  x.#^COMPLETE2^#
+  // COMPLETE2: Decl[InstanceMethod]/CurrNominal:   bar()[#Void#]; name=bar()
+}

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -748,3 +748,39 @@ func testNestedExprPatternCompletion(_ x: SomeEnum1) {
   // UNRESOLVED_NESTED4: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#]; name=North
   // UNRESOLVED_NESTED4: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 }
+
+protocol P1 {}
+protocol P2 {}
+struct S1: P1, P2 {}
+
+extension P1 where Self == S1 {
+  static func foo() -> Self { fatalError() }
+}
+extension P2 where Self == S1 {
+  static func bar() -> Self { fatalError() }
+}
+
+func testComposition() {
+  func foo(_ x: any P1 & P2) {}
+  foo(.#^EXISTENTIAL_COMPOSITION^#)
+  // EXISTENTIAL_COMPOSITION-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: foo()[#S1#]; name=foo()
+  // EXISTENTIAL_COMPOSITION-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: bar()[#S1#]; name=bar()
+}
+
+protocol P3 {
+  associatedtype X
+}
+struct S3<T> {}
+extension S3: P3 {
+  typealias X = Int
+}
+
+extension P3 where Self == S3<X> {
+  static func foo() -> Self {}
+}
+
+func testGenericSelfClause() {
+  func foo(_ x: any P3) {}
+  foo(.#^GENERIC_SELF_CLAUSE^#)
+  // GENERIC_SELF_CLAUSE: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: foo()[#S3<Int>#]; name=foo()
+}


### PR DESCRIPTION
*6.1 cherry-pick of #77711*

- Explanation: Fixes a crash that could occur when attempting to do code completion on an existential with a superclass
- Scope: Affects completion
- Issue: rdar://138774888
- Risk: Low, adds a new check, only affects completion
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen