### PR TITLE
[ASTDumper] Don't try to print opaque type decl substitutions

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1171,10 +1171,6 @@ namespace {
 
       }, "opaque_interface", TypeColor);
 
-      if (auto underlyingSubs = OTD->getUniqueUnderlyingTypeSubstitutions()) {
-        printRec(*underlyingSubs);
-      }
-
       printFoot();
     }
 


### PR DESCRIPTION
Attempting to dump opaque decl while type-checking a body of the declaration it's associated with results in a request cycle because underlying substitutions request would trigger type-checking if the body isn't type-checked yet.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
