### PR TITLE
[6.1][Diagnostics] Support "swift" style diagnostics at EOF

### DIFF
--- a/test/NameLookup/nonempty-brace-in-brace.swift
+++ b/test/NameLookup/nonempty-brace-in-brace.swift
@@ -1,6 +1,8 @@
 // RUN: not %target-swift-frontend -typecheck %s  2>&1 |  %FileCheck %s --check-prefix=CHECK-NO-ASSERTION
 
+// CHECK-NO-ASSERTION-NOT: Assertion
 // Used to trip an assertion
+
 
 public struct Foo {
     func bar() {
@@ -14,5 +16,4 @@ private extension String {}
 
 
 
-
-// CHECK-NO-ASSERTION-NOT: Assertion
+// EOF

--- a/test/diagnostics/pretty-printed-diagnostics-eof.swift
+++ b/test/diagnostics/pretty-printed-diagnostics-eof.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -diagnostic-style=swift -typecheck %/s 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_swift_parser
+
+// CHECK:      {{SOURCE_DIR[/\]test[/\]diagnostics[/\]pretty-printed-diagnostics-eof\.swift}}:[[#LINE:]]:1: error: expected '}' in struct
+// CHECK:      [[#LINE-2]] | struct MyStruct {
+// CHECK-NEXT:             |                 `- note: to match this opening '{'
+// CHECK-NEXT: [[#LINE-1]] |   func foo() {}
+// CHECK-NEXT: [[#LINE]]   |
+// CHECK-NEXT:             | `- error: expected '}' in struct
+
+struct MyStruct {
+  func foo() {}


### PR DESCRIPTION
Cherry-pick #77755 into `release/6.1`

**Explanation**: In the new diagnostic printing style, diagnostics at EOF were mistakenly ignored. This change fix that by adjusting the position checking logic, and also make sure it emits the diagnostics at the correct position.
**Scope**: Diagnostics
**Risk**: Low. The change is simple enough
**Testing**: Added a regression test case
**Issues**: rdar://129883075 rdar://138426038
**Reviewers**: Doug Gregor (@DougGregor), Hamish Knight (@hamishknight), and Alex Hoppen (@ahoppen)