### PR TITLE
AST: Workaround for rdar://139469939

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -233,9 +233,7 @@ Type SubstitutionMap::lookupSubstitution(GenericTypeParamType *genericParam) con
 
 ProtocolConformanceRef
 SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
-  ASSERT(type->isTypeParameter());
-
-  if (empty())
+  if (!type->isTypeParameter() || empty())
     return ProtocolConformanceRef::forInvalid();
 
   auto genericSig = getGenericSignature();


### PR DESCRIPTION
This unconditional assert was added recently so it started failing in noassert toolchains. I'll have a proper fix soon.
