### PR TITLE
[6.1] AST: Workaround for rdar://139469939

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -233,9 +233,7 @@ Type SubstitutionMap::lookupSubstitution(GenericTypeParamType *genericParam) con
 
 ProtocolConformanceRef
 SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
-  ASSERT(type->isTypeParameter());
-
-  if (empty())
+  if (!type->isTypeParameter() || empty())
     return ProtocolConformanceRef::forInvalid();
 
   auto genericSig = getGenericSignature();


### PR DESCRIPTION
6.1 cherry-pick of https://github.com/swiftlang/swift/pull/77786.

* **Description:** Fixes a spurious assertion failure due to invariant violations with opaque return types in the SILCloner.
* **Origination:** The assertion was introduced in https://github.com/swiftlang/swift/pull/76263.
* **Tested:** Existing tests pass.
* **Risk:** None.
* **Radar:** rdar://139469939
* **Reviewed by:** @hborla