### PR TITLE
[6.1] Sema: Cache Solution::getTotalMemory()

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1482,6 +1482,9 @@ class Solution {
   /// The fixed score for this solution.
   Score FixedScore;
 
+  /// The total memory used by this solution.
+  std::optional<size_t> TotalMemory;
+
 public:
   /// Create a solution for the given constraint system.
   Solution(ConstraintSystem &cs, const Score &score)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1863,7 +1863,11 @@ static inline size_t size_in_bytes(const T &x) {
 }
 
 size_t Solution::getTotalMemory() const {
-  return sizeof(*this) + typeBindings.getMemorySize() +
+  if (TotalMemory)
+    return *TotalMemory;
+
+  const_cast<Solution *>(this)->TotalMemory
+       = sizeof(*this) + typeBindings.getMemorySize() +
          overloadChoices.getMemorySize() +
          ConstraintRestrictions.getMemorySize() +
          (Fixes.size() * sizeof(void *)) + DisjunctionChoices.getMemorySize() +
@@ -1887,6 +1891,8 @@ size_t Solution::getTotalMemory() const {
          size_in_bytes(argumentLists) +
          size_in_bytes(ImplicitCallAsFunctionRoots) +
          size_in_bytes(SynthesizedConformances);
+
+  return *TotalMemory;
 }
 
 DeclContext *Solution::getDC() const { return constraintSystem->DC; }


### PR DESCRIPTION
6.1 cherry-pick of https://github.com/swiftlang/swift/pull/77716.

- **Description:** Every time we perform the 'too complex' check we compute the sum total memory usage of all valid solutions found so far. This was showing up in performance profiles. Cache the size in the solution, since it doesn't change after construction.
- **Origination:** This has always been that way.
- **Risk:** Low.
- **Tested:** Existing tests pass.
- **Radar:** rdar://136106973.
- **Reviewed by:** @hborla and @xedin 