### PR TITLE
[xcodegen] Enable buildable folders by default

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -89,7 +89,7 @@ PROJECT CONFIGURATION:
                           edit (e.g sourcekitdAPI-InProc.cpp). (default: --infer-args)
   --prefer-folder-refs/--no-prefer-folder-refs
                           Whether to prefer folder references for groups containing non-source
-                          files (default: --no-prefer-folder-refs)
+                          files (default: --prefer-folder-refs)
   --buildable-folders/--no-buildable-folders
                           Requires Xcode 16: Enables the use of "buildable folders", allowing
                           folder references to be used for compatible targets. This allows new
@@ -98,7 +98,7 @@ PROJECT CONFIGURATION:
 
                           Only supported for targets that have no per-file build settings. This
                           unfortunately means some Clang targes such as 'lib/Basic' and 'stdlib'
-                          cannot currently use buildable folders. (default: --no-buildable-folders)
+                          cannot currently use buildable folders. (default: --buildable-folders)
 
 MISC:
   --project-root-dir <project-root-dir>

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -200,7 +200,7 @@ struct ProjectOptions: ParsableArguments {
       files
       """
   )
-  var preferFolderRefs: Bool = false
+  var preferFolderRefs: Bool = true
 
   @Flag(
     name: .customLong("buildable-folders"), inversion: .prefixedNo,
@@ -215,7 +215,7 @@ struct ProjectOptions: ParsableArguments {
       cannot currently use buildable folders.
       """
   )
-  var useBuildableFolders: Bool = false
+  var useBuildableFolders: Bool = true
 
   @Option(help: .hidden)
   var blueFolders: String = ""

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -292,6 +292,14 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
     let buildDirPath = buildDir.absoluteInWorkingDir.resolvingSymlinks
     log.info("Generating project for '\(buildDirPath)'...")
 
+    if projectOpts.useBuildableFolders {
+      log.note("""
+        Buildable folders are enabled by default, which requires Xcode 16. You \
+        can pass '--no-buildable-folders' to disable this. See the '--help' entry \
+        for more info.
+        """)
+    }
+
     let projectRootDir = self.projectRootDir?.absoluteInWorkingDir
     let buildDir = try NinjaBuildDir(at: buildDirPath, projectRootDir: projectRootDir)
     let outputDir = miscOptions.outputDir?.absoluteInWorkingDir ?? buildDir.projectRootDir


### PR DESCRIPTION
I've been living on this for a bit without issue, enable by default. Filed #77790 to track splitting up "umbrella" targets such that they can benefit.

Resolves #77418