### PR TITLE
[6.1] [AST] Remove assert from `ModuleDecl::getFiles`

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -399,7 +399,6 @@ public:
   void setBypassResilience() { BypassResilience = true; }
 
   ArrayRef<FileUnit *> getFiles() {
-    ASSERT(!Files.empty() || failedToLoad());
     return Files;
   }
   ArrayRef<const FileUnit *> getFiles() const {


### PR DESCRIPTION
- Explanation: This can be hit for `IsNonUserModuleRequest`. On main this is properly fixed by enforcing that a ModuleDecl's files are immutable after construction (#77666).
- Scope: N/A
- Issue: rdar://137769081
- Risk: None, this is just removing an assert
- Testing: None, this is just removing an assert
- Reviewer: Ben Barham