### PR TITLE
[build-script] Adding buildbot_linux,bootstrap

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -927,6 +927,15 @@ mixin-preset=
 
 skip-test-swiftdocc
 
+[preset: buildbot_linux,bootstrapped]
+mixin-preset=
+  buildbot_linux
+
+skip-early-swiftsyntax
+skip-early-swift-driver
+
+bootstrapping=bootstrapping
+
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
 


### PR DESCRIPTION
Adding a preset for running a bootstrapped buildbot linux configuration to verify that bootstrapping on environments that do not have a compiler will still work.

Swift Syntax and the Swift Driver must be disabled since build-script cannot schedule them at the appropriate times during the compiler build. Since we do not start with an existing Swift compiler, they can't be pre-built.

>  Note: This currently fails with the following error message:
> `ninja: error: 'stdlib/public/core/SwiftMacros', needed by 'bootstrapping0/stdlib/public/core/LINUX/x86_64/Swift.o', missing and no known rule to make it`