### PR TITLE
[🍒6.1] cherry-pick fine-grained tracing changes

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -73,7 +73,7 @@ TYPE("tbd",                 TBD,                       "tbd",             "")
 // engineers can see more details on the "Swift module traces" page in the
 // Swift section of the internal wiki.
 TYPE("module-trace",        ModuleTrace,               "trace.json",      "")
-TYPE("module-objc-trace",   ModuleObjCTrace,           "",                "")
+TYPE("fine-module-trace",   FineModuleTrace,           "",                "")
 
 // Complete dependency information for the given Swift files as JSON.
 TYPE("json-dependencies",   JSONDependencies,          "dependencies.json",      "")

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -73,6 +73,7 @@ TYPE("tbd",                 TBD,                       "tbd",             "")
 // engineers can see more details on the "Swift module traces" page in the
 // Swift section of the internal wiki.
 TYPE("module-trace",        ModuleTrace,               "trace.json",      "")
+TYPE("module-objc-trace",   ModuleObjCTrace,           "",                "")
 
 // Complete dependency information for the given Swift files as JSON.
 TYPE("json-dependencies",   JSONDependencies,          "dependencies.json",      "")

--- a/include/swift/Basic/SupplementaryOutputPaths.def
+++ b/include/swift/Basic/SupplementaryOutputPaths.def
@@ -106,7 +106,7 @@ OUTPUT(FixItsOutputPath, TY_SwiftFixIt)
 /// to each .swiftmodule that was loaded while building module NAME for target
 /// TARGET. This format is subject to arbitrary change, however.
 OUTPUT(LoadedModuleTracePath, TY_ModuleTrace)
-OUTPUT(ModuleObjCTracePath,   TY_ModuleObjCTrace)
+OUTPUT(FineModuleTracePath,   TY_FineModuleTrace)
 
 /// The path to which we should output a TBD file.
 ///

--- a/include/swift/Basic/SupplementaryOutputPaths.def
+++ b/include/swift/Basic/SupplementaryOutputPaths.def
@@ -106,6 +106,7 @@ OUTPUT(FixItsOutputPath, TY_SwiftFixIt)
 /// to each .swiftmodule that was loaded while building module NAME for target
 /// TARGET. This format is subject to arbitrary change, however.
 OUTPUT(LoadedModuleTracePath, TY_ModuleTrace)
+OUTPUT(ModuleObjCTracePath,   TY_ModuleObjCTrace)
 
 /// The path to which we should output a TBD file.
 ///

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -133,8 +133,8 @@ public:
   StringRef getLoadedModuleTracePath() const {
     return getPrimarySpecificPaths().SupplementaryOutputs.LoadedModuleTracePath;
   }
-  StringRef getModuleObjCTracePath() const {
-    return getPrimarySpecificPaths().SupplementaryOutputs.ModuleObjCTracePath;
+  StringRef getFineModuleTracePath() const {
+    return getPrimarySpecificPaths().SupplementaryOutputs.FineModuleTracePath;
   }
   StringRef getSerializedDiagnosticsPath() const {
     return getPrimarySpecificPaths().SupplementaryOutputs

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -133,6 +133,9 @@ public:
   StringRef getLoadedModuleTracePath() const {
     return getPrimarySpecificPaths().SupplementaryOutputs.LoadedModuleTracePath;
   }
+  StringRef getModuleObjCTracePath() const {
+    return getPrimarySpecificPaths().SupplementaryOutputs.ModuleObjCTracePath;
+  }
   StringRef getSerializedDiagnosticsPath() const {
     return getPrimarySpecificPaths().SupplementaryOutputs
         .SerializedDiagnosticsPath;

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -105,7 +105,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_ImportedModules:
   case file_types::TY_TBD:
   case file_types::TY_ModuleTrace:
-  case file_types::TY_ModuleObjCTrace:
+  case file_types::TY_FineModuleTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_SwiftModuleInterfaceFile:
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
@@ -187,7 +187,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
-  case file_types::TY_ModuleObjCTrace:
+  case file_types::TY_FineModuleTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_SwiftModuleInterfaceFile:
@@ -251,7 +251,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
-  case file_types::TY_ModuleObjCTrace:
+  case file_types::TY_FineModuleTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
@@ -314,7 +314,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
-  case file_types::TY_ModuleObjCTrace:
+  case file_types::TY_FineModuleTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -105,6 +105,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_ImportedModules:
   case file_types::TY_TBD:
   case file_types::TY_ModuleTrace:
+  case file_types::TY_ModuleObjCTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_SwiftModuleInterfaceFile:
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
@@ -186,6 +187,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
+  case file_types::TY_ModuleObjCTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_SwiftModuleInterfaceFile:
@@ -249,6 +251,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
+  case file_types::TY_ModuleObjCTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
@@ -311,6 +314,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
+  case file_types::TY_ModuleObjCTrace:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1691,7 +1691,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_PCH:
       case file_types::TY_ImportedModules:
       case file_types::TY_ModuleTrace:
-      case file_types::TY_ModuleObjCTrace:
+      case file_types::TY_FineModuleTrace:
       case file_types::TY_YAMLOptRecord:
       case file_types::TY_BitstreamOptRecord:
       case file_types::TY_SwiftModuleInterfaceFile:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1691,6 +1691,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_PCH:
       case file_types::TY_ImportedModules:
       case file_types::TY_ModuleTrace:
+      case file_types::TY_ModuleObjCTrace:
       case file_types::TY_YAMLOptRecord:
       case file_types::TY_BitstreamOptRecord:
       case file_types::TY_SwiftModuleInterfaceFile:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -761,7 +761,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftDeps:
   case file_types::TY_ExternalSwiftDeps:
   case file_types::TY_ModuleTrace:
-  case file_types::TY_ModuleObjCTrace:
+  case file_types::TY_FineModuleTrace:
   case file_types::TY_TBD:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
@@ -1037,7 +1037,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ExternalSwiftDeps:
     case file_types::TY_Remapping:
     case file_types::TY_ModuleTrace:
-    case file_types::TY_ModuleObjCTrace:
+    case file_types::TY_FineModuleTrace:
     case file_types::TY_YAMLOptRecord:
     case file_types::TY_BitstreamOptRecord:
     case file_types::TY_SwiftModuleInterfaceFile:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -761,6 +761,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftDeps:
   case file_types::TY_ExternalSwiftDeps:
   case file_types::TY_ModuleTrace:
+  case file_types::TY_ModuleObjCTrace:
   case file_types::TY_TBD:
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
@@ -1036,6 +1037,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ExternalSwiftDeps:
     case file_types::TY_Remapping:
     case file_types::TY_ModuleTrace:
+    case file_types::TY_ModuleObjCTrace:
     case file_types::TY_YAMLOptRecord:
     case file_types::TY_BitstreamOptRecord:
     case file_types::TY_SwiftModuleInterfaceFile:

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -458,11 +458,11 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   // We piggy-back on the loadedModuleTracePath to decide (1) whether
   // to emit the fine module Trace file, and (2) where to emit the fine module
   // trace file if the path isn't explicitly given by
-  // SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH.
+  // SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH.
   // FIXME: we probably need to move this to a frontend argument.
   llvm::SmallString<128> FineModuleTracePath;
   if (!loadedModuleTracePath.empty()) {
-    if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH")) {
+    if (const char *P = ::getenv("SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH")) {
       StringRef FilePath = P;
       llvm::sys::path::append(FineModuleTracePath, FilePath);
     } else {

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -455,6 +455,23 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       file_types::TY_ModuleTrace, "",
       defaultSupplementaryOutputPathExcludingExtension);
 
+  // We piggy-back on the loadedModuleTracePath to decide (1) whether
+  // to emit the ObjC Trace file, and (2) where to emit the objc trace file if
+  // the path isn't explicitly given by SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH.
+  // FIXME: we probably need to move this to a frontend argument.
+  llvm::SmallString<128> ModuleObjCTracePath;
+  if (!loadedModuleTracePath.empty()) {
+    if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH")) {
+      StringRef FilePath = P;
+      llvm::sys::path::append(ModuleObjCTracePath, FilePath);
+    } else {
+      llvm::sys::path::append(ModuleObjCTracePath, loadedModuleTracePath);
+      llvm::sys::path::remove_filename(ModuleObjCTracePath);
+      llvm::sys::path::append(ModuleObjCTracePath,
+                              ".SWIFT_FINE_DEPENDENCY_TRACE.json");
+    }
+  }
+
   auto tbdPath = determineSupplementaryOutputFilename(
       OPT_emit_tbd, pathsFromArguments.TBDPath, file_types::TY_TBD, "",
       defaultSupplementaryOutputPathExcludingExtension);
@@ -520,6 +537,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.SerializedDiagnosticsPath = serializedDiagnosticsPath;
   sop.FixItsOutputPath = fixItsOutputPath;
   sop.LoadedModuleTracePath = loadedModuleTracePath;
+  sop.ModuleObjCTracePath = ModuleObjCTracePath.str().str();
   sop.TBDPath = tbdPath;
   sop.ModuleInterfaceOutputPath = ModuleInterfaceOutputPath;
   sop.PrivateModuleInterfaceOutputPath = PrivateModuleInterfaceOutputPath;

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -456,18 +456,19 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       defaultSupplementaryOutputPathExcludingExtension);
 
   // We piggy-back on the loadedModuleTracePath to decide (1) whether
-  // to emit the ObjC Trace file, and (2) where to emit the objc trace file if
-  // the path isn't explicitly given by SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH.
+  // to emit the fine module Trace file, and (2) where to emit the fine module
+  // trace file if the path isn't explicitly given by
+  // SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH.
   // FIXME: we probably need to move this to a frontend argument.
-  llvm::SmallString<128> ModuleObjCTracePath;
+  llvm::SmallString<128> FineModuleTracePath;
   if (!loadedModuleTracePath.empty()) {
     if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH")) {
       StringRef FilePath = P;
-      llvm::sys::path::append(ModuleObjCTracePath, FilePath);
+      llvm::sys::path::append(FineModuleTracePath, FilePath);
     } else {
-      llvm::sys::path::append(ModuleObjCTracePath, loadedModuleTracePath);
-      llvm::sys::path::remove_filename(ModuleObjCTracePath);
-      llvm::sys::path::append(ModuleObjCTracePath,
+      llvm::sys::path::append(FineModuleTracePath, loadedModuleTracePath);
+      llvm::sys::path::remove_filename(FineModuleTracePath);
+      llvm::sys::path::append(FineModuleTracePath,
                               ".SWIFT_FINE_DEPENDENCY_TRACE.json");
     }
   }
@@ -537,7 +538,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.SerializedDiagnosticsPath = serializedDiagnosticsPath;
   sop.FixItsOutputPath = fixItsOutputPath;
   sop.LoadedModuleTracePath = loadedModuleTracePath;
-  sop.ModuleObjCTracePath = ModuleObjCTracePath.str().str();
+  sop.FineModuleTracePath = FineModuleTracePath.str().str();
   sop.TBDPath = tbdPath;
   sop.ModuleInterfaceOutputPath = ModuleInterfaceOutputPath;
   sop.PrivateModuleInterfaceOutputPath = PrivateModuleInterfaceOutputPath;

--- a/lib/FrontendTool/Dependencies.h
+++ b/lib/FrontendTool/Dependencies.h
@@ -32,8 +32,8 @@ bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
                                    const FrontendOptions &opts,
                                    const InputFile &input);
 
-bool emitObjCMessageSendTraceIfNeeded(ModuleDecl *mainModule,
-                                      const FrontendOptions &opts);
+bool emitFineModuleTraceIfNeeded(ModuleDecl *mainModule,
+                                 const FrontendOptions &opts);
 
 } // end namespace swift
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1001,7 +1001,7 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
         Instance.getMainModule(), Instance.getDependencyTracker(), opts);
 
     dumpAPIIfNeeded(Instance);
-    swift::emitObjCMessageSendTraceIfNeeded(Instance.getMainModule(), opts);
+    swift::emitFineModuleTraceIfNeeded(Instance.getMainModule(), opts);
   }
 
   // Contains the hadError checks internally, we still want to output the

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -853,8 +853,8 @@ public:
   }
 };
 
-static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
-  StringRef tracePath = input.getModuleObjCTracePath();
+static void createFineModuleTraceFile(const InputFile &input, ModuleDecl *MD) {
+  StringRef tracePath = input.getFineModuleTracePath();
   if (tracePath.empty()) {
     // we basically rely on the passing down of module trace file path
     // as an indicator that this job needs to emit an ObjC message trace file.
@@ -893,7 +893,7 @@ static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
     return;
   }
   ObjcMethodReferenceCollector collector(MD);
-  for (auto *SF : filesToWalk) {
+  for (auto *SF: filesToWalk) {
     collector.setFileBeforeVisiting(SF);
     collector.walk(*SF);
   }
@@ -915,14 +915,14 @@ static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
   }
 }
 
-bool swift::emitObjCMessageSendTraceIfNeeded(ModuleDecl *mainModule,
-                                             const FrontendOptions &opts) {
+bool swift::emitFineModuleTraceIfNeeded(ModuleDecl *mainModule,
+                                        const FrontendOptions &opts) {
   ASTContext &ctxt = mainModule->getASTContext();
   assert(!ctxt.hadError() &&
          "We should've already exited earlier if there was an error.");
 
   opts.InputsAndOutputs.forEachInput([&](const InputFile &input) {
-    createObjCMessageTraceFile(input, mainModule);
+    createFineModuleTraceFile(input, mainModule);
     return true;
   });
   return false;

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -854,7 +854,8 @@ public:
 };
 
 static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
-  if (input.getLoadedModuleTracePath().empty()) {
+  StringRef tracePath = input.getModuleObjCTracePath();
+  if (tracePath.empty()) {
     // we basically rely on the passing down of module trace file path
     // as an indicator that this job needs to emit an ObjC message trace file.
     // FIXME: add a separate swift-frontend flag for ObjC message trace path
@@ -881,15 +882,6 @@ static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
   // No source files to walk, abort.
   if (filesToWalk.empty()) {
     return;
-  }
-  llvm::SmallString<128> tracePath;
-  if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH")) {
-    StringRef FilePath = P;
-    llvm::sys::path::append(tracePath, FilePath);
-  } else {
-    llvm::sys::path::append(tracePath, input.getLoadedModuleTracePath());
-    llvm::sys::path::remove_filename(tracePath);
-    llvm::sys::path::append(tracePath, ".SWIFT_FINE_DEPENDENCY_TRACE.json");
   }
   // Write output via atomic append.
   llvm::vfs::OutputConfig config;

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -853,16 +853,16 @@ public:
   }
 };
 
-static std::optional<int> createObjCMessageTraceFile(const InputFile &input,
-                                                     ModuleDecl *MD,
-                                        std::vector<SourceFile*> &filesToWalk) {
+static void createObjCMessageTraceFile(const InputFile &input, ModuleDecl *MD) {
   if (input.getLoadedModuleTracePath().empty()) {
     // we basically rely on the passing down of module trace file path
     // as an indicator that this job needs to emit an ObjC message trace file.
     // FIXME: add a separate swift-frontend flag for ObjC message trace path
     // specifically.
-    return {};
+    return;
   }
+  auto &ctx = MD->getASTContext();
+  std::vector<SourceFile*> filesToWalk;
   for (auto *FU : MD->getFiles()) {
     if (auto *SF = dyn_cast<SourceFile>(FU)) {
       switch (SF->Kind) {
@@ -880,29 +880,47 @@ static std::optional<int> createObjCMessageTraceFile(const InputFile &input,
   }
   // No source files to walk, abort.
   if (filesToWalk.empty()) {
-    return {};
+    return;
   }
   llvm::SmallString<128> tracePath;
-  if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_DIRECTORY")) {
-    StringRef DirPath = P;
-    llvm::sys::path::append(tracePath, DirPath);
+  if (const char *P = ::getenv("SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH")) {
+    StringRef FilePath = P;
+    llvm::sys::path::append(tracePath, FilePath);
   } else {
     llvm::sys::path::append(tracePath, input.getLoadedModuleTracePath());
     llvm::sys::path::remove_filename(tracePath);
-    llvm::sys::path::append(tracePath, ".SWIFT_FINE_DEPENDENCY_TRACE");
+    llvm::sys::path::append(tracePath, ".SWIFT_FINE_DEPENDENCY_TRACE.json");
   }
-  if (!llvm::sys::fs::exists(tracePath)) {
-    if (llvm::sys::fs::create_directory(tracePath))
-      return {};
+  // Write output via atomic append.
+  llvm::vfs::OutputConfig config;
+  config.setAppend().setAtomicWrite();
+  auto outputFile = ctx.getOutputBackend().createFile(tracePath, config);
+  if (!outputFile) {
+    ctx.Diags.diagnose(SourceLoc(), diag::error_opening_output, tracePath,
+                       toString(outputFile.takeError()));
+    return;
   }
-  SmallString<32> fileName(MD->getNameStr());
-  fileName.append("-%%%%-%%%%-%%%%.json");
-  llvm::sys::path::append(tracePath, fileName);
-  int tmpFD;
-  if (llvm::sys::fs::createUniqueFile(tracePath.str(), tmpFD, tracePath)) {
-    return {};
+  ObjcMethodReferenceCollector collector(MD);
+  for (auto *SF : filesToWalk) {
+    collector.setFileBeforeVisiting(SF);
+    collector.walk(*SF);
   }
-  return tmpFD;
+
+  // print this json line.
+  std::string stringBuffer;
+  {
+    llvm::raw_string_ostream memoryBuffer(stringBuffer);
+    collector.serializeAsJson(memoryBuffer);
+  }
+  stringBuffer += "\n";
+
+  // Write output via atomic append.
+  *outputFile << stringBuffer;
+  if (auto err = outputFile->keep()) {
+    ctx.Diags.diagnose(SourceLoc(), diag::error_opening_output,
+                       tracePath, toString(std::move(err)));
+    return;
+  }
 }
 
 bool swift::emitObjCMessageSendTraceIfNeeded(ModuleDecl *mainModule,
@@ -912,18 +930,7 @@ bool swift::emitObjCMessageSendTraceIfNeeded(ModuleDecl *mainModule,
          "We should've already exited earlier if there was an error.");
 
   opts.InputsAndOutputs.forEachInput([&](const InputFile &input) {
-    std::vector<SourceFile*> filesToWalk;
-    auto tmpFD = createObjCMessageTraceFile(input, mainModule, filesToWalk);
-    if (!tmpFD)
-      return false;
-    // Write the contents of the buffer.
-    llvm::raw_fd_ostream out(*tmpFD, /*shouldClose=*/true);
-    ObjcMethodReferenceCollector collector(mainModule);
-    for (auto *SF : filesToWalk) {
-      collector.setFileBeforeVisiting(SF);
-      collector.walk(*SF);
-    }
-    collector.serializeAsJson(out);
+    createObjCMessageTraceFile(input, mainModule);
     return true;
   });
   return false;

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
 // RUN: cat %t/.SWIFT_FINE_DEPENDENCY_TRACE.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s
 
-// RUN: SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t/given_trace.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
+// RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
 // RUN: cat %t/given_trace.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -2,10 +2,10 @@
 // RUN: %empty-directory(%t/CUSTOM_DIR)
 
 // RUN: %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
-// RUN: cat %t/.SWIFT_FINE_DEPENDENCY_TRACE/* | %FileCheck %s
+// RUN: cat %t/.SWIFT_FINE_DEPENDENCY_TRACE.json | %FileCheck %s
 
-// RUN: SWIFT_COMPILER_OBJC_MESSAGE_TRACE_DIRECTORY=%t/CUSTOM_DIR %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
-// RUN: cat %t/CUSTOM_DIR/* | %FileCheck %s
+// RUN: SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t/given_trace.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
+// RUN: cat %t/given_trace.json | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -2,10 +2,10 @@
 // RUN: %empty-directory(%t/CUSTOM_DIR)
 
 // RUN: %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
-// RUN: cat %t/.SWIFT_FINE_DEPENDENCY_TRACE.json | %FileCheck %s
+// RUN: cat %t/.SWIFT_FINE_DEPENDENCY_TRACE.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s
 
 // RUN: SWIFT_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t/given_trace.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
-// RUN: cat %t/given_trace.json | %FileCheck %s
+// RUN: cat %t/given_trace.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Cherry-pick of PR against main: https://github.com/swiftlang/swift/pull/77710

- Description: these changes are integral to the feature of emitting fine-grained module trace files, therefore we need to cherry-pick to the 6.1 branch where most of the feature is already in.
- Origination: new compiler feature of emitting the fine-grained module trace file.
- Risk: Low.
- Tested: Existing tests pass.
- Radar: rdar://138776708
- Reviewed by: Doug Gregor
