### PR TITLE
🍒[6.1][cxx-interop] Use the new lifetime dependence language feature flag

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2184,8 +2184,7 @@ namespace {
                                    MoveOnlyAttr(/*Implicit=*/true));
       }
 
-      if (Impl.SwiftContext.LangOpts.hasFeature(Feature::NonescapableTypes) &&
-          evaluateOrDefault(
+      if (evaluateOrDefault(
               Impl.SwiftContext.evaluator,
               ClangTypeEscapability({decl->getTypeForDecl(), Impl}),
               CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
@@ -3866,6 +3865,10 @@ namespace {
     void addLifetimeDependencies(const clang::FunctionDecl *decl,
                                  AbstractFunctionDecl *result) {
       if (decl->getTemplatedKind() == clang::FunctionDecl::TK_FunctionTemplate)
+        return;
+
+      if (!result->getASTContext().LangOpts.hasFeature(
+              Feature::LifetimeDependence))
         return;
 
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: not %target-swift-frontend -typecheck -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs  %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs  %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-NO-LIFETIMES
 
 // REQUIRES: swift_feature_LifetimeDependence
 
@@ -62,10 +63,10 @@ MyPair2<Owner, Owner> i1();
 MyType<Owner, 0> i2();
 
 //--- test.swift
-
 import Test
 
 // CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+// CHECK-NO-LIFETIMES: test.swift:5:32: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
 public func noAnnotations() -> View {
     // CHECK: nonescapable.h:15:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
     f(nil)
@@ -75,17 +76,25 @@ public func noAnnotations() -> View {
     f2(nil, nil)
     // CHECK: nonescapable.h:23:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
     // CHECK: nonescapable.h:23:6: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    // CHECK-NO-LIFETIMES: nonescapable.h:23:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     g(nil)
     h1(nil)
     // CHECK: nonescapable.h:33:21: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    // CHECK-NO-LIFETIMES: nonescapable.h:33:21: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     h2(nil)
     // CHECK: nonescapable.h:34:21: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    // CHECK-NO-LIFETIMES: nonescapable.h:34:21: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     h3(nil)
     i1()
     // CHECK: nonescapable.h:38:39: error: template parameter 'Missing' does not exist
+    // CHECK-NO-LIFETIMES: nonescapable.h:38:39: error: template parameter 'Missing' does not exist
     i2()
     // CHECK: nonescapable.h:44:33: error: template parameter 'S' expected to be a type parameter
     // CHECK-NOT: error
     // CHECK-NOT: warning
     return View()
+    // CHECK-NO-LIFETIMES: nonescapable.h:4:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:5:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES-NOT: error
+    // CHECK-NO-LIFETIMES-NOT: warning
 }

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift  -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-NO-LIFETIMES
 
 
 //--- Inputs/module.modulemap
@@ -91,6 +92,19 @@ View returnsImmortal() SWIFT_RETURNS_INDEPENDENT_VALUE {
 // CHECK: sil [clang View.init] {{.*}} : $@convention(c) () -> @lifetime(immortal) @out View
 // CHECK: sil [clang OtherView.init] {{.*}} : $@convention(c) (@guaranteed View) -> @lifetime(copy 0) @out OtherView
 // CHECK: sil [clang returnsImmortal] {{.*}} : $@convention(c) () -> @lifetime(immortal) @autoreleased View
+
+// CHECK-NO-LIFETIMES: nonescapable.h:36:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:40:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:46:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:53:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:23:10: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:27:10: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:4:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:5:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:13:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:14:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: nonescapable.h:68:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES-NOT: error
 
 //--- test.swift
 


### PR DESCRIPTION
Non-escapable types are now enabled by default. Use the new lifetime dependence feature flag to gate interpreting lifetime annotations on the C++ side and add tests to make sure we get the expected diagnostics when the feature flag is off.
