### PR TITLE
[CS] Add a narrow hack for rdar://139234188

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6434,7 +6434,8 @@ bool isResultBuilderMethodReference(ASTContext &, UnresolvedDotExpr *);
 
 /// Determine the number of applications applied to the given overload.
 unsigned getNumApplications(ValueDecl *decl, bool hasAppliedSelf,
-                            FunctionRefKind functionRefKind);
+                            FunctionRefKind functionRefKind,
+                            ConstraintLocatorBuilder locator);
 
 } // end namespace constraints
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10153,8 +10153,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
         auto hasAppliedSelf = decl->hasCurriedSelf() &&
                               doesMemberRefApplyCurriedSelf(baseObjTy, decl);
-        return getNumApplications(decl, hasAppliedSelf, functionRefKind) <
-               decl->getNumCurryLevels();
+        return getNumApplications(decl, hasAppliedSelf, functionRefKind,
+                                  memberLocator) < decl->getNumCurryLevels();
       });
     };
 

--- a/test/Constraints/rdar139234188.swift
+++ b/test/Constraints/rdar139234188.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen %s -verify -swift-version 6
+
+struct S: Equatable {
+  static func foo() -> Self { fatalError() }
+  static func bar(_ x: Int) -> Self { fatalError() }
+  static func baz(x: Int, y: Int) -> Self { fatalError() }
+  public static func == (_: Self, _: Self) -> Bool { false }
+}
+
+// rdar://139234188 - Make sure we don't consider these members to be partially
+// applied for concurrency adjustment.
+func foo(_ x: S) {
+  _ = {
+    switch x {
+    case .foo():
+      break
+    case .bar(0):
+      break
+    case .baz(x: 1, y: 2):
+      break
+    default:
+      break
+    }
+  }
+}


### PR DESCRIPTION
Currently we set `FunctionRefKind::Compound` for enum element patterns with tuple sub-patterns to ensure the member has argument labels stripped. As such, we need to account for the correct application level in `getNumApplications`. We ought to be setting the correct FunctionRefKind and properly handling the label matching in the solver though. We also ought to consider changing FunctionRefKind such that "is compound" is a separate bit from the application level.

Filed #77803 & #77804 to track properly fixing things here.

rdar://139234188