### PR TITLE
SILPrinter: don't print operand types in static initializers of globals

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -809,6 +809,10 @@ public:
             /*needPrintType=*/true};
   }
 
+  void markBlockAsPrinted(const SILBasicBlock *block) {
+    printedBlocks.insert(block);
+  }
+
   //===--------------------------------------------------------------------===//
   // Big entrypoints.
   void print(const SILFunction *F) {
@@ -932,7 +936,7 @@ public:
 #endif
 
   void print(const SILBasicBlock *BB) {
-    printedBlocks.insert(BB);
+    markBlockAsPrinted(BB);
 
     // Output uses for BB arguments. These are put into place as comments before
     // the block header.
@@ -3677,6 +3681,7 @@ void SILGlobalVariable::print(llvm::raw_ostream &OS, bool Verbose) const {
     {
       SILPrintContext Ctx(OS);
       SILPrinter Printer(Ctx);
+      Printer.markBlockAsPrinted(&StaticInitializerBlock);
       for (const SILInstruction &I : StaticInitializerBlock) {
         Printer.print(&I);
       }

--- a/test/Concurrency/global_function_pointer.swift
+++ b/test/Concurrency/global_function_pointer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -emit-sil -target %target-swift-5.1-abi-triple -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -Xllvm -sil-print-types -emit-sil -target %target-swift-5.1-abi-triple -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-SIL
 // RUN: %target-build-swift -enable-experimental-feature SymbolLinkageMarkers -target %target-swift-5.1-abi-triple -Xfrontend -parse-as-library %s -o %t_binary
 // RUN: %target-codesign %t_binary
 // RUN: %target-run %t_binary | %FileCheck %s --check-prefix=CHECK-EXEC

--- a/test/SIL/Parser/pure_mode.sil
+++ b/test/SIL/Parser/pure_mode.sil
@@ -8,6 +8,20 @@ import SwiftShims
 
 sil_global hidden @$s3nix2ggSSvp : $String
 
+class C {
+  @_hasStorage var a: Builtin.Int64
+  @_hasStorage var b: Builtin.Int64
+}
+
+sil_global [let] @gc : $C = {
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = integer_literal $Builtin.Int64, 2
+  %3 = integer_literal $Builtin.Int64, 3
+  // CHECK: %initval = object $C (%0, %1, [tail_elems] %2, %3)
+  %initval = object $C (%0, %1, [tail_elems] %2, %3)
+}
+
 sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 [%1: noescape **]
 [global: read,write,copy,deinit_barrier]

--- a/test/SIL/Parser/static_initializer.sil
+++ b/test/SIL/Parser/static_initializer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types %s | %FileCheck %s
 
 // Generated from
 // var x : Int32 = 2

--- a/test/SIL/Serialization/globals.sil
+++ b/test/SIL/Serialization/globals.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -Xllvm -sil-disable-pass=simplification -emit-module -o %t/tmp.swiftmodule
-// RUN: %target-sil-opt %t/tmp.swiftmodule | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types %t/tmp.swiftmodule | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/global-functionptr.swift
+++ b/test/SILOptimizer/global-functionptr.swift
@@ -12,7 +12,7 @@
 
 // Second test (bonus): check if the optimization is done: statically initialize the array of function pointers.
 
-// RUN: %target-build-swift -O -wmo -parse-as-library -module-name=Test %s -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-build-swift -O -wmo -parse-as-library -module-name=Test %s -Xllvm -sil-print-types -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
 
 // REQUIRES: executable_test
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib

--- a/test/SILOptimizer/globalopt_resilience_testing.swift
+++ b/test/SILOptimizer/globalopt_resilience_testing.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -O -enable-library-evolution -primary-file %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -O -enable-library-evolution -enable-testing -primary-file %s | %FileCheck %s --check-prefix=CHECK-TESTING
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -O -enable-library-evolution -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -O -enable-library-evolution -enable-testing -primary-file %s | %FileCheck %s --check-prefix=CHECK-TESTING
 
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | grep -v debug_value | %FileCheck %s
-// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | grep -v debug_value | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -Xllvm -sil-print-types -emit-sil | grep -v debug_value | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -Xllvm -sil-print-types -emit-sil | grep -v debug_value | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
This was missing from https://github.com/swiftlang/swift/pull/77763
