### PR TITLE
[xcodegen] Update help text for `--stdlib-swift`

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -76,8 +76,13 @@ PROJECT CONFIGURATION:
                           Generate a target for C/C++ files in the standard library (default: --stdlib)
   --stdlib-swift/--no-stdlib-swift
                           Generate targets for Swift files in the standard library. This requires
-                          using Xcode with a main development snapshot (and as such is disabled
-                          by default). (default: --no-stdlib-swift)
+                          using Xcode with a main development Swift snapshot, and as such is
+                          disabled by default.
+
+                          A development snapshot is necessary to avoid spurious build/live issues
+                          due to fact that the the stdlib is built using the just-built Swift
+                          compiler, which may support features not yet supported by the Swift
+                          compiler in Xcode's toolchain. (default: --no-stdlib-swift)
   --test-folders/--no-test-folders
                           Add folder references for test files (default: --test-folders)
   --unittests/--no-unittests

--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -80,7 +80,7 @@ PROJECT CONFIGURATION:
                           disabled by default.
 
                           A development snapshot is necessary to avoid spurious build/live issues
-                          due to fact that the the stdlib is built using the just-built Swift
+                          due to the fact that the the stdlib is built using the just-built Swift
                           compiler, which may support features not yet supported by the Swift
                           compiler in Xcode's toolchain. (default: --no-stdlib-swift)
   --test-folders/--no-test-folders

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -168,7 +168,7 @@ struct ProjectOptions: ParsableArguments {
       disabled by default. 
       
       A development snapshot is necessary to avoid spurious build/live issues
-      due to fact that the the stdlib is built using the just-built Swift
+      due to the fact that the the stdlib is built using the just-built Swift
       compiler, which may support features not yet supported by the Swift
       compiler in Xcode's toolchain.
       """

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -164,8 +164,13 @@ struct ProjectOptions: ParsableArguments {
     name: .customLong("stdlib-swift"), inversion: .prefixedNo,
     help: """
       Generate targets for Swift files in the standard library. This requires
-      using Xcode with a main development snapshot (and as such is disabled
-      by default).
+      using Xcode with a main development Swift snapshot, and as such is
+      disabled by default. 
+      
+      A development snapshot is necessary to avoid spurious build/live issues
+      due to fact that the the stdlib is built using the just-built Swift
+      compiler, which may support features not yet supported by the Swift
+      compiler in Xcode's toolchain.
       """
   )
   var addStdlibSwift: Bool = false


### PR DESCRIPTION
Clarify why a development snapshot is needed for stdlib Swift targets.