### PR TITLE
[Test][IRGen] Disable noncopyable tests for arm64e.

### DIFF
--- a/test/IRGen/empty-noncopyable-with-deinit.swift
+++ b/test/IRGen/empty-noncopyable-with-deinit.swift
@@ -5,6 +5,10 @@
 // CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9.]+]],
 // CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9.]+]],
 
+// We don't really need to test arm64e, and doing so would mean tweaking the
+// test to cope with ptrauth.
+// UNSUPPORTED: CPU=arm64e
+
 @_silgen_name("mystery_destroy")
 func mystery_destroy() {}
 

--- a/test/IRGen/fixed-noncopyable-with-deinit.swift
+++ b/test/IRGen/fixed-noncopyable-with-deinit.swift
@@ -5,6 +5,10 @@
 // CHECK: [[BOX_3:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_3:@[A-Za-z0-9.]+]],
 // CHECK: [[BOX_4:@[A-Za-z0-9.]+]] = private constant %swift.full_boxmetadata { ptr [[DESTROY_BOX_4:@[A-Za-z0-9.]+]],
 
+// We don't really need to test arm64e, and doing so would mean tweaking the
+// test to cope with ptrauth.
+// UNSUPPORTED: CPU=arm64e
+
 @_silgen_name("mystery_destroy")
 func mystery_destroy() {}
 


### PR DESCRIPTION
There's nothing particularly interesting about testing these for arm64e, and doing so would require changing the test to cope with ptrauth.  Disable for arm64e instead.

rdar://140369127
