### PR TITLE
utils: unlock building swift-inspect

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2852,7 +2852,7 @@ if (-not $SkipBuild -and $Allocator -eq "mimalloc") {
   Invoke-BuildStep Build-Mimalloc $HostArch
 }
 
-if (-not $SkipBuild -and -not $IsCrossCompiling) {
+if (-not $SkipBuild) {
   Invoke-BuildStep Build-Inspect $HostArch
   Invoke-BuildStep Build-DocC $HostArch
 }


### PR DESCRIPTION
When building for ARM64, we can now build swift-inspect as we use CMake for the cross-compilation.