### PR TITLE
[6.1] Treat swift_willThrow(Typed) as not locking or performing allocation

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -40,6 +40,7 @@ import SwiftShims
 #if os(iOS) && !os(visionOS)
 @_effects(readnone)
 @_transparent
+@_noLocks
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -51,6 +52,7 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+@_noLocks
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -63,6 +65,7 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_alwaysEmitIntoClient
+@_noLocks
 public func _stdlib_isOSVersionAtLeast_AEIC(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -107,6 +110,7 @@ public func _stdlib_isOSVersionAtLeast_AEIC(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @available(macOS 10.15, iOS 13.0, *)
+@_noLocks
 public func _stdlib_isVariantOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -149,6 +153,7 @@ public func _stdlib_isVariantOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+@_noLocks
 public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -181,6 +181,7 @@ public func _bridgeErrorToNSError(_ error: __owned Error) -> AnyObject
 @_silgen_name("swift_willThrowTypedImpl")
 @available(SwiftStdlib 6.0, *)
 @usableFromInline
+@_noLocks
 func _willThrowTypedImpl<E: Error>(_ error: E)
 
 #if !$Embedded

--- a/test/SILOptimizer/constant_propagation_availability.swift
+++ b/test/SILOptimizer/constant_propagation_availability.swift
@@ -62,7 +62,7 @@ public func testInlinable() -> Int {
 // CHECK-macosx10_14:  apply [[F]]
 // CHECK-macosx10_14: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
 
-// CHECK-macosx10_14: sil [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK-macosx10_14: sil [no_locks] [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
 
 // CHECK-inlinable-LABEL: sil {{.*}} @$s4Test13testInlinableSiyF  : $@convention(thin) () -> Int {
 // CHECK-inlinable:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -125,6 +125,37 @@ func testCatch(_ b: Bool) throws -> Int? {
   }
 }
 
+enum ErrorEnum: Error {
+  case failed
+  case tryAgain
+}
+
+@_noLocks
+func concreteError(_ b: Bool) throws(ErrorEnum) -> Int {
+  if b {
+    return 28
+  }
+
+  throw .tryAgain
+}
+
+func concreteErrorOther(_ b: Bool) throws(ErrorEnum) -> Int {
+  if b {
+    return 28
+  }
+
+  throw .tryAgain
+}
+
+@_noLocks
+func testCatchConcrete(_ b: Bool) -> Int {
+  do {
+    return try concreteError(b) + concreteErrorOther(b)
+  } catch {
+    return 17
+  }
+}
+
 @_noLocks
 func testRecursion(_ i: Int) -> Int {
   if i > 0 {


### PR DESCRIPTION
* Description: The `@_noLocks`/`@_noAllocation` checking considers throwing a typed error to always use generic metadata, even though it is designed not to unless specifically hooked (by a debugger). Teach the checker to allow typed errors in `@_noLocks/`@_noAllocation` mode.
* Origination: With the introduction of typed throws, we failed to account for this checking pass.
* Risk: Low.
* Tested: New tests.
* Main pull request: https://github.com/swiftlang/swift/pull/77780
* Radar: rdar://140230684
* Reviewed by: Erik Eckstein
