### PR TITLE
[PreCheckTarget] Consider UnresolvedSpecializeExpr a chain expression

### DIFF
--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -333,6 +333,8 @@ static Expr *getMemberChainSubExpr(Expr *expr) {
     return SE->getBase();
   } else if (auto *DSE = dyn_cast<DotSelfExpr>(expr)) {
     return DSE->getSubExpr();
+  } else if (auto *USE = dyn_cast<UnresolvedSpecializeExpr>(expr)) {
+    return USE->getSubExpr();
   } else if (auto *CCE = dyn_cast<CodeCompletionExpr>(expr)) {
     return CCE->getBase();
   } else {

--- a/test/Sema/generic_specialization.swift
+++ b/test/Sema/generic_specialization.swift
@@ -2,7 +2,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
 
 extension Int {
-  func foo() -> Int {} // expected-note 2 {{'foo()' declared here}}
+  func foo() -> Int {} // expected-note 3 {{'foo()' declared here}}
   var bar: Int {
     get {}
   }
@@ -38,6 +38,12 @@ func test(i: Int) {
   let _ = 0.bar<Int>
   // expected-swift5-error@-1 {{cannot specialize non-generic type 'Int'}}
   // expected-swift6-error@-2 {{cannot specialize non-generic type 'Int'}}
+}
+
+func testOptionalChain(i: Int?) {
+  let _ = i?.foo<Int>()
+  // expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'foo()'}}
+  // expected-swift6-error@-2 {{cannot explicitly specialize instance method 'foo()'}}
 }
 
 extension Bool {

--- a/test/expr/delayed-ident/specialize.swift
+++ b/test/expr/delayed-ident/specialize.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+
+struct Outer {
+  struct Inner {
+    struct Foo<T> {
+      static func id(_ v: T) -> T { v }
+    }
+  }
+}
+
+let _: Outer = .Inner.Foo<Outer>.id(.init())
+


### PR DESCRIPTION
Optional chain and unresolved member chain should consider a generic specialization as a chain expression.

rdar://140378864
