### PR TITLE
Build without swift host tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -943,6 +943,13 @@ if (NOT BOOTSTRAPPING_MODE)
   message(FATAL_ERROR "turning off bootstrapping is not supported anymore")
 endif()
 
+endif()
+
+# Disable bootstrapping when we aren't building SwiftSyntax
+if(NOT SWIFT_BUILD_SWIFT_SYNTAX)
+  set(BOOTSTRAPPING_MODE "OFF")
+endif()
+
 set(SWIFT_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -148,6 +148,7 @@ void ASTScope::unqualifiedLookup(
   if (auto *s = SF->getASTContext().Stats)
     ++s->getFrontendCounters().NumASTScopeLookups;
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
   // Perform validation of SwiftLexicalLookup if option
   // Feature::UnqualifiedLookupValidation is enabled and lookup was not
   // performed in a macro.
@@ -171,6 +172,9 @@ void ASTScope::unqualifiedLookup(
   } else {
     ASTScopeImpl::unqualifiedLookup(SF, loc, consumer);
   }
+#else
+    ASTScopeImpl::unqualifiedLookup(SF, loc, consumer);
+#endif
 }
 
 llvm::SmallVector<LabeledStmt *, 4> ASTScope::lookupLabeledStmts(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3471,6 +3471,20 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
   if (!macroNameRef)
     return status;
 
+#if !SWIFT_BUILD_SWIFT_SYNTAX
+  // If we don't have swift-syntax and therefore have no support for macros,
+  // recognize #isolation as special and route it through
+  // CurrentContextIsolationExpr.
+  if (macroNameRef.getBaseName().userFacingName() == "isolation" &&
+      genericArgs.empty() &&
+      (!argList || argList->empty())) {
+    return makeParserResult(
+      status,
+      new (Context) CurrentContextIsolationExpr(
+          macroNameLoc.getStartLoc(), Type()));
+  }
+#endif
+
   return makeParserResult(
       status,
       MacroExpansionExpr::create(

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -755,6 +755,7 @@ std::pair<bool, bool> EvaluateIfConditionRequest::evaluate(
     Evaluator &evaluator, SourceFile *sourceFile, SourceRange conditionRange,
     bool shouldEvaluate
 ) const {
+#if SWIFT_BUILD_SWIFT_SYNTAX
   // FIXME: When we migrate to SwiftParser, use the parsed syntax tree.
   ASTContext &ctx = sourceFile->getASTContext();
   auto &sourceMgr = ctx.SourceMgr;
@@ -775,4 +776,7 @@ std::pair<bool, bool> EvaluateIfConditionRequest::evaluate(
   bool isActive = (evalResult & 0x01) != 0;
   bool allowSyntaxErrors = (evalResult & 0x02) != 0;
   return std::pair(isActive, allowSyntaxErrors);
+#else
+  llvm_unreachable("Must not be used in C++-only build");
+#endif
 }

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -886,8 +886,11 @@ function(_compile_swift_files
     # cross-compiling the compiler.
     list(APPEND swift_compiler_tool_dep "swift-frontend${target_suffix}")
 
-    # If we aren't cross compiling, also depend on SwiftMacros.
-    list(APPEND swift_compiler_tool_dep SwiftMacros)
+    # If we aren't cross compiling and have swift-syntax, also depend on
+    # SwiftMacros.
+    if(SWIFT_BUILD_SWIFT_SYNTAX)
+      list(APPEND swift_compiler_tool_dep SwiftMacros)
+    endif()
   endif()
 
   # If there are more than one output files, we assume that they are specified

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -52,7 +52,9 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -65,7 +67,9 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_alwaysEmitIntoClient
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeast_AEIC(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -110,7 +114,9 @@ public func _stdlib_isOSVersionAtLeast_AEIC(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @available(macOS 10.15, iOS 13.0, *)
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isVariantOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -153,7 +159,9 @@ public func _stdlib_isVariantOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,

--- a/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
+++ b/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded
+#if !$Embedded && hasFeature(Macros)
 @DebugDescription
 extension ObjectIdentifier {
   var lldbDescription: String {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -751,6 +751,7 @@ extension StringProtocol {
 
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
+#if hasFeature(Macros)
     if Self.self == String.self {
       let s = unsafeBitCast(self, to: String.self)
       return s.utf16._indexRange(for: range, from: s.startIndex)
@@ -759,6 +760,7 @@ extension StringProtocol {
       let s = unsafeBitCast(self, to: Substring.self)
       return s._slice._base.utf16._indexRange(for: range, from: s.startIndex)
     }
+#endif
     let lowerbound = _toUTF16Index(range.lowerBound)
     let upperbound = _toUTF16Index(range.upperBound)
     return Range(uncheckedBounds: (lower: lowerbound, upper: upperbound))

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -58,6 +58,8 @@ public enum _SwiftifyInfo {
 ///
 /// Parameter paramInfo: information about how the function uses the pointer passed to it. The
 /// safety of the generated wrapper function depends on this info being extensive and accurate.
+#if hasFeature(Macros)
 @attached(peer, names: overloaded)
 public macro _SwiftifyImport(_ paramInfo: _SwiftifyInfo..., typeMappings: [String: String] = [:]) =
     #externalMacro(module: "SwiftMacros", type: "SwiftifyImportMacro")
+#endif

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -941,6 +941,7 @@ mixin-preset=
 
 skip-early-swiftsyntax
 skip-early-swift-driver
+skip-test
 
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -937,11 +937,10 @@ skip-test-swiftdocc
 
 [preset: buildbot_linux,without_host_swift]
 mixin-preset=
-  buildbot_linux
+  buildbot_linux,no_test
 
 skip-early-swiftsyntax
 skip-early-swift-driver
-skip-test
 
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -935,6 +935,13 @@ mixin-preset=
 
 skip-test-swiftdocc
 
+[preset: buildbot_linux,without_host_swift]
+mixin-preset=
+  buildbot_linux
+
+skip-early-swiftsyntax
+skip-early-swift-driver
+
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
 


### PR DESCRIPTION
Introduce various fixes to the build system, compiler, and standard library to enable building *without* Swift host tools, to make it possible to bootstrap a Swift compiler on a host that does not have Swift yet (without cross-compiling). The compiler built from only C++ doesn't need to have full functionality (and it doesn't---at least macros and embedded won't work), but it needs to have enough functionality to act as host tools for a full build of the toolchain.