### PR TITLE
AST: Store `AvailableAttr`'s rename decl in split request evaluator storage

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -147,12 +147,16 @@ protected:
       Value : 32
     );
 
-    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 8+8+1+1,
+    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 8+8+1+1+1+1,
       /// A `PlatformKind` value.
       Platform : 8,
 
       /// A `PlatformAgnosticAvailabilityKind` value.
       PlatformAgnostic : 8,
+
+      /// State storage for `RenamedDeclRequest`.
+      HasComputedRenamedDecl : 1,
+      HasRenamedDecl : 1,
 
       /// Whether this attribute was spelled `@_spi_available`.
       IsSPI : 1,
@@ -861,6 +865,22 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Available;
+  }
+
+  bool hasCachedRenamedDecl() const {
+    return Bits.AvailableAttr.HasRenamedDecl;
+  }
+
+private:
+  friend class RenamedDeclRequest;
+
+  bool hasComputedRenamedDecl() const {
+    return Bits.AvailableAttr.HasComputedRenamedDecl;
+  }
+
+  void setComputedRenamedDecl(bool hasRenamedDecl) {
+    Bits.AvailableAttr.HasComputedRenamedDecl = true;
+    Bits.AvailableAttr.HasRenamedDecl = hasRenamedDecl;
   }
 };
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -851,8 +851,8 @@ public:
 
   /// Create an AvailableAttr that indicates the given \p AsyncFunc should be
   /// preferentially used in async contexts
-  static AvailableAttr *createForAlternative(ASTContext &C,
-                                             AbstractFunctionDecl *AsyncFunc);
+  static AvailableAttr *
+  createForAsyncAlternative(ASTContext &C, AbstractFunctionDecl *AsyncFunc);
 
   AvailableAttr *clone(ASTContext &C, bool implicit) const;
   AvailableAttr *clone(ASTContext &C) const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -734,7 +734,7 @@ enum class PlatformAgnosticAvailabilityKind : uint8_t {
 class AvailableAttr : public DeclAttribute {
 public:
   AvailableAttr(SourceLoc AtLoc, SourceRange Range, PlatformKind Platform,
-                StringRef Message, StringRef Rename, ValueDecl *RenameDecl,
+                StringRef Message, StringRef Rename,
                 const llvm::VersionTuple &Introduced,
                 SourceRange IntroducedRange,
                 const llvm::VersionTuple &Deprecated,
@@ -752,13 +752,12 @@ public:
   /// This should take the form of an operator, identifier, or full function
   /// name, optionally with a prefixed type, similar to the syntax used for
   /// the `NS_SWIFT_NAME` annotation in Objective-C.
+  ///
+  /// \c ValueDecl::getRenamedDecl() can be used to look up the declaration
+  /// referred to by this string. Note that this attribute can have a rename
+  /// target that was provided directly when synthesized and therefore can have
+  /// a rename decl even when this string is empty.
   const StringRef Rename;
-
-  /// The declaration referred to by \c Rename. Note that this is only set for
-  /// deserialized attributes or inferred attributes from ObjectiveC code.
-  /// \c ValueDecl::getRenamedDecl should be used to find the declaration
-  /// corresponding to \c Rename.
-  ValueDecl *RenameDecl;
 
   /// Indicates when the symbol was introduced.
   const std::optional<llvm::VersionTuple> Introduced;
@@ -852,11 +851,6 @@ public:
                          = PlatformAgnosticAvailabilityKind::Unavailable,
                          llvm::VersionTuple Obsoleted
                          = llvm::VersionTuple());
-
-  /// Create an AvailableAttr that indicates the given \p AsyncFunc should be
-  /// preferentially used in async contexts
-  static AvailableAttr *
-  createForAsyncAlternative(ASTContext &C, AbstractFunctionDecl *AsyncFunc);
 
   AvailableAttr *clone(ASTContext &C, bool implicit) const;
   AvailableAttr *clone(ASTContext &C) const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3266,6 +3266,11 @@ public:
   /// Performs a request to look up the decl that this decl has been renamed to
   /// if `attr` indicates that it has been renamed.
   ValueDecl *getRenamedDecl(const AvailableAttr *attr) const;
+
+  /// Directly sets the renamed decl corresponding to `attr`. This should only
+  /// be used when synthesizing an `AvailableAttr`, before calling
+  /// `getRenamedDecl()`.
+  void setRenamedDecl(const AvailableAttr *attr, ValueDecl *renameDecl) const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3262,6 +3262,10 @@ public:
   /// @_dynamicReplacement(for: ...), compute the original declaration
   /// that this declaration dynamically replaces.
   ValueDecl *getDynamicallyReplacedDecl() const;
+
+  /// Performs a request to look up the decl that this decl has been renamed to
+  /// if `attr` indicates that it has been renamed.
+  ValueDecl *getRenamedDecl(const AvailableAttr *attr) const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4085,8 +4085,9 @@ public:
 
 class RenamedDeclRequest
     : public SimpleRequest<RenamedDeclRequest,
-                           ValueDecl *(const ValueDecl *, const AvailableAttr *),
-                           RequestFlags::Cached> {
+                           ValueDecl *(const ValueDecl *,
+                                       const AvailableAttr *),
+                           RequestFlags::Cached | RequestFlags::SplitCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -4098,6 +4099,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  std::optional<ValueDecl *> getCachedResult() const;
+  void cacheResult(ValueDecl *value) const;
 };
 
 using AvailableAttrDeclPair = std::pair<const AvailableAttr *, const Decl *>;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2236,6 +2236,8 @@ AvailableAttr::AvailableAttr(
       INIT_VER_TUPLE(Obsoleted), ObsoletedRange(ObsoletedRange) {
   Bits.AvailableAttr.Platform = static_cast<uint8_t>(Platform);
   Bits.AvailableAttr.PlatformAgnostic = static_cast<uint8_t>(PlatformAgnostic);
+  Bits.AvailableAttr.HasComputedRenamedDecl = false;
+  Bits.AvailableAttr.HasRenamedDecl = false;
   Bits.AvailableAttr.IsSPI = IsSPI;
 
   if (IsForEmbedded) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2226,14 +2226,14 @@ Type RawLayoutAttr::getResolvedCountType(StructDecl *sd) const {
 
 AvailableAttr::AvailableAttr(
     SourceLoc AtLoc, SourceRange Range, PlatformKind Platform,
-    StringRef Message, StringRef Rename, ValueDecl *RenameDecl,
+    StringRef Message, StringRef Rename,
     const llvm::VersionTuple &Introduced, SourceRange IntroducedRange,
     const llvm::VersionTuple &Deprecated, SourceRange DeprecatedRange,
     const llvm::VersionTuple &Obsoleted, SourceRange ObsoletedRange,
     PlatformAgnosticAvailabilityKind PlatformAgnostic, bool Implicit,
     bool IsSPI, bool IsForEmbedded)
     : DeclAttribute(DeclAttrKind::Available, AtLoc, Range, Implicit),
-      Message(Message), Rename(Rename), RenameDecl(RenameDecl),
+      Message(Message), Rename(Rename),
       INIT_VER_TUPLE(Introduced), IntroducedRange(IntroducedRange),
       INIT_VER_TUPLE(Deprecated), DeprecatedRange(DeprecatedRange),
       INIT_VER_TUPLE(Obsoleted), ObsoletedRange(ObsoletedRange) {
@@ -2265,23 +2265,10 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
     assert(!Obsoleted.empty());
   }
   return new (C) AvailableAttr(
-    SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename, nullptr,
-    NoVersion, SourceRange(),
-    NoVersion, SourceRange(),
-    Obsoleted, SourceRange(),
-    Kind, /* isImplicit */ false, /*SPI*/false);
-}
-
-AvailableAttr *
-AvailableAttr::createForAsyncAlternative(ASTContext &C,
-                                         AbstractFunctionDecl *AsyncFunc) {
-  llvm::VersionTuple NoVersion;
-  return new (C) AvailableAttr(
-    SourceLoc(), SourceRange(), PlatformKind::none, "", "", AsyncFunc,
-    NoVersion, SourceRange(),
-    NoVersion, SourceRange(),
-    NoVersion, SourceRange(),
-    PlatformAgnosticAvailabilityKind::None, /*Implicit=*/true, /*SPI*/false);
+      SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
+      /*Introduced=*/NoVersion, SourceRange(), /*Deprecated=*/NoVersion,
+      SourceRange(), Obsoleted, SourceRange(), Kind, /*Implicit=*/false,
+      /*SPI=*/false);
 }
 
 bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
@@ -2294,19 +2281,16 @@ bool BackDeployedAttr::isActivePlatform(const ASTContext &ctx,
 }
 
 AvailableAttr *AvailableAttr::clone(ASTContext &C, bool implicit) const {
-  return new (C) AvailableAttr(implicit ? SourceLoc() : AtLoc,
-                               implicit ? SourceRange() : getRange(),
-                               getPlatform(), Message, Rename, RenameDecl,
-                               Introduced ? *Introduced : llvm::VersionTuple(),
-                               implicit ? SourceRange() : IntroducedRange,
-                               Deprecated ? *Deprecated : llvm::VersionTuple(),
-                               implicit ? SourceRange() : DeprecatedRange,
-                               Obsoleted ? *Obsoleted : llvm::VersionTuple(),
-                               implicit ? SourceRange() : ObsoletedRange,
-                               getPlatformAgnosticAvailability(),
-                               implicit,
-                               isSPI(),
-                               isForEmbedded());
+  return new (C) AvailableAttr(
+      implicit ? SourceLoc() : AtLoc, implicit ? SourceRange() : getRange(),
+      getPlatform(), Message, Rename,
+      Introduced ? *Introduced : llvm::VersionTuple(),
+      implicit ? SourceRange() : IntroducedRange,
+      Deprecated ? *Deprecated : llvm::VersionTuple(),
+      implicit ? SourceRange() : DeprecatedRange,
+      Obsoleted ? *Obsoleted : llvm::VersionTuple(),
+      implicit ? SourceRange() : ObsoletedRange,
+      getPlatformAgnosticAvailability(), implicit, isSPI(), isForEmbedded());
 }
 
 std::optional<OriginallyDefinedInAttr::ActiveVersion>

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2267,8 +2267,9 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
     Kind, /* isImplicit */ false, /*SPI*/false);
 }
 
-AvailableAttr *AvailableAttr::createForAlternative(
-    ASTContext &C, AbstractFunctionDecl *AsyncFunc) {
+AvailableAttr *
+AvailableAttr::createForAsyncAlternative(ASTContext &C,
+                                         AbstractFunctionDecl *AsyncFunc) {
   llvm::VersionTuple NoVersion;
   return new (C) AvailableAttr(
     SourceLoc(), SourceRange(), PlatformKind::none, "", "", AsyncFunc,

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -235,7 +235,9 @@ void AvailabilityInference::applyInferredAvailableAttrs(
 
         if (Rename.empty() && !AvAttr->Rename.empty()) {
           Rename = AvAttr->Rename;
-          RenameDecl = AvAttr->RenameDecl;
+          if (auto *VD = dyn_cast<ValueDecl>(D)) {
+            RenameDecl = VD->getRenamedDecl(AvAttr);
+          }
         }
       }
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -233,12 +233,8 @@ void AvailabilityInference::applyInferredAvailableAttrs(
         if (Message.empty() && !AvAttr->Message.empty())
           Message = AvAttr->Message;
 
-        if (Rename.empty() && !AvAttr->Rename.empty()) {
+        if (Rename.empty() && !AvAttr->Rename.empty())
           Rename = AvAttr->Rename;
-          if (auto *VD = dyn_cast<ValueDecl>(D)) {
-            RenameDecl = VD->getRenamedDecl(AvAttr);
-          }
-        }
       }
 
       MergedAttrs.append(PendingAttrs);

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -183,13 +183,10 @@ static AvailableAttr *createAvailableAttr(PlatformKind Platform,
       Inferred.Obsoleted.value_or(llvm::VersionTuple());
 
   return new (Context)
-      AvailableAttr(SourceLoc(), SourceRange(), Platform,
-                    Message, Rename, RenameDecl,
-                    Introduced, /*IntroducedRange=*/SourceRange(),
-                    Deprecated, /*DeprecatedRange=*/SourceRange(),
-                    Obsoleted, /*ObsoletedRange=*/SourceRange(),
-                    Inferred.PlatformAgnostic, /*Implicit=*/true,
-                    Inferred.IsSPI);
+      AvailableAttr(SourceLoc(), SourceRange(), Platform, Message, Rename,
+                    Introduced, SourceRange(), Deprecated, SourceRange(),
+                    Obsoleted, SourceRange(), Inferred.PlatformAgnostic,
+                    /*Implicit=*/true, Inferred.IsSPI);
 }
 
 void AvailabilityInference::applyInferredAvailableAttrs(
@@ -246,6 +243,7 @@ void AvailabilityInference::applyInferredAvailableAttrs(
   }
 
   DeclAttributes &Attrs = ToDecl->getAttrs();
+  auto *ToValueDecl = dyn_cast<ValueDecl>(ToDecl);
 
   // Create an availability attribute for each observed platform and add
   // to ToDecl.
@@ -253,8 +251,12 @@ void AvailabilityInference::applyInferredAvailableAttrs(
     auto *Attr = createAvailableAttr(Pair.first, Pair.second, Message,
                                      Rename, RenameDecl, Context);
 
-    if (Attr)
+    if (Attr) {
+      if (RenameDecl && ToValueDecl)
+        ToValueDecl->setRenamedDecl(Attr, RenameDecl);
+
       Attrs.add(Attr);
+    }
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4236,6 +4236,14 @@ ValueDecl *ValueDecl::getRenamedDecl(const AvailableAttr *attr) const {
                            RenamedDeclRequest{this, attr}, nullptr);
 }
 
+void ValueDecl::setRenamedDecl(const AvailableAttr *attr,
+                               ValueDecl *renameDecl) const {
+  // This is only designed to be used with decls synthesized by ClangImporter.
+  assert(hasClangNode());
+  getASTContext().evaluator.cacheNonEmptyOutput(RenamedDeclRequest{this, attr},
+                                                std::move(renameDecl));
+}
+
 SourceLoc Decl::getAttributeInsertionLoc(bool forModifier) const {
   // Some decls have a parent/child split where the introducer keyword is on the
   // parent, but the attributes are on the children. If this is a child in such

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9245,29 +9245,26 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
   if (hasAsync())
     return nullptr;
 
-  const AvailableAttr *avAttr = nullptr;
+  // Prefer the first availability attribute with no platform and a valid
+  // rename target, falling back to the first with a rename. Note that
+  // `getAttrs` is in reverse source order, so the last attribute is the
+  // first in source.
+  AbstractFunctionDecl *alternative = nullptr;
   for (const auto *attr : getAttrs().getAttributes<AvailableAttr>()) {
-    // If there's an attribute with an already-resolved rename decl, use it
-    if (attr->RenameDecl) {
-      avAttr = attr;
-      break;
-    }
+    if (attr->isNoAsync())
+      continue;
 
-    // Otherwise prefer the first availability attribute with no platform and
-    // rename parameter, falling back to the first with a rename. Note that
-    // `getAttrs` is in reverse source order, so the last attribute is the
-    // first in source
-    if (!attr->Rename.empty() &&
-        (attr->getPlatform() == PlatformKind::none || !avAttr) &&
-        !attr->isNoAsync()) {
-      avAttr = attr;
+    if (attr->getPlatform() != PlatformKind::none && alternative != nullptr)
+      continue;
+
+    if (auto *renamedDecl = getRenamedDecl(attr)) {
+      if (auto *afd = dyn_cast<AbstractFunctionDecl>(renamedDecl)) {
+        if (afd->hasAsync())
+          alternative = afd;
+      }
     }
   }
 
-  auto *renamedDecl = getRenamedDecl(avAttr);
-  auto *alternative = dyn_cast_or_null<AbstractFunctionDecl>(renamedDecl);
-  if (!alternative || !alternative->hasAsync())
-    return nullptr;
   return alternative;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4231,6 +4231,11 @@ bool ValueDecl::canInferObjCFromRequirement(ValueDecl *requirement) {
   return false;
 }
 
+ValueDecl *ValueDecl::getRenamedDecl(const AvailableAttr *attr) const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           RenamedDeclRequest{this, attr}, nullptr);
+}
+
 SourceLoc Decl::getAttributeInsertionLoc(bool forModifier) const {
   // Some decls have a parent/child split where the introducer keyword is on the
   // parent, but the attributes are on the children. If this is a child in such
@@ -9259,8 +9264,7 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
     }
   }
 
-  auto *renamedDecl = evaluateOrDefault(
-      getASTContext().evaluator, RenamedDeclRequest{this, avAttr}, nullptr);
+  auto *renamedDecl = getRenamedDecl(avAttr);
   auto *alternative = dyn_cast_or_null<AbstractFunctionDecl>(renamedDecl);
   if (!alternative || !alternative->hasAsync())
     return nullptr;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1623,6 +1623,34 @@ void ResolveRawLayoutTypeRequest::cacheResult(Type value) const {
 }
 
 //----------------------------------------------------------------------------//
+// RenamedDeclRequest computation.
+//----------------------------------------------------------------------------//
+
+std::optional<ValueDecl *> RenamedDeclRequest::getCachedResult() const {
+  auto decl = std::get<0>(getStorage());
+  auto attr = std::get<1>(getStorage());
+
+  if (attr->hasComputedRenamedDecl()) {
+    if (attr->hasCachedRenamedDecl())
+      return decl->getASTContext().evaluator.getCachedNonEmptyOutput(*this);
+
+    return nullptr;
+  }
+
+  return std::nullopt;
+}
+
+void RenamedDeclRequest::cacheResult(ValueDecl *value) const {
+  auto decl = std::get<0>(getStorage());
+  auto attr = const_cast<AvailableAttr *>(std::get<1>(getStorage()));
+
+  attr->setComputedRenamedDecl(value != nullptr);
+  if (value)
+    decl->getASTContext().evaluator.cacheNonEmptyOutput(*this,
+                                                        std::move(value));
+}
+
+//----------------------------------------------------------------------------//
 // TypeCheckSourceFileRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7887,7 +7887,7 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
     if (member != asyncImport && isa<AbstractFunctionDecl>(member) &&
         !member->getAttrs().hasAttribute<AvailableAttr>()) {
       member->getAttrs().add(
-          AvailableAttr::createForAlternative(SwiftContext, asyncFunc));
+          AvailableAttr::createForAsyncAlternative(SwiftContext, asyncFunc));
     }
   }
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -536,20 +536,17 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityRange &info,
     return;
 
   llvm::VersionTuple noVersion;
-  auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
-                                      targetPlatform(C.LangOpts),
-                                      /*Message=*/StringRef(),
-                                      /*Rename=*/StringRef(),
-                                      /*RenameDecl=*/nullptr,
-                                      info.getRawMinimumVersion(),
-                                      /*IntroducedRange*/SourceRange(),
-                                      /*Deprecated=*/noVersion,
-                                      /*DeprecatedRange*/SourceRange(),
-                                      /*Obsoleted=*/noVersion,
-                                      /*ObsoletedRange*/SourceRange(),
-                                      PlatformAgnosticAvailabilityKind::None,
-                                      /*Implicit=*/false,
-                                      /*SPI*/false);
+  auto AvAttr = new (C) AvailableAttr(
+      SourceLoc(), SourceRange(), targetPlatform(C.LangOpts),
+      /*Message=*/StringRef(),
+      /*Rename=*/StringRef(), info.getRawMinimumVersion(),
+      /*IntroducedRange=*/SourceRange(),
+      /*Deprecated=*/noVersion,
+      /*DeprecatedRange=*/SourceRange(),
+      /*Obsoleted=*/noVersion,
+      /*ObsoletedRange=*/SourceRange(), PlatformAgnosticAvailabilityKind::None,
+      /*Implicit=*/false,
+      /*SPI=*/false);
 
   decl->getAttrs().add(AvAttr);
 }
@@ -1316,14 +1313,13 @@ namespace {
                 : llvm::VersionTuple(majorVersion);
           attr = new (ctx) AvailableAttr(
               SourceLoc(), SourceRange(), PlatformKind::none,
-              /*Message*/StringRef(), ctx.AllocateCopy(renamed.str()),
-              /*RenameDecl=*/nullptr,
-              /*Introduced*/introducedVersion, SourceRange(),
-              /*Deprecated*/llvm::VersionTuple(), SourceRange(),
-              /*Obsoleted*/llvm::VersionTuple(), SourceRange(),
+              /*Message=*/StringRef(), ctx.AllocateCopy(renamed.str()),
+              /*Introduced=*/introducedVersion, SourceRange(),
+              /*Deprecated=*/llvm::VersionTuple(), SourceRange(),
+              /*Obsoleted=*/llvm::VersionTuple(), SourceRange(),
               PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
-              /*Implicit*/false,
-              /*SPI*/false);
+              /*Implicit=*/false,
+              /*SPI=*/false);
         }
       }
 
@@ -2880,15 +2876,16 @@ namespace {
         auto availability = Impl.SwiftContext.getSwift58Availability();
         if (!availability.isAlwaysAvailable()) {
           assert(availability.hasMinimumVersion());
-          auto AvAttr = new (Impl.SwiftContext) AvailableAttr(
-              SourceLoc(), SourceRange(),
-              targetPlatform(Impl.SwiftContext.LangOpts), "", "",
-              /*RenameDecl=*/nullptr, availability.getRawMinimumVersion(),
-              /*IntroducedRange=*/SourceRange(), {},
-              /*DeprecatedRange=*/SourceRange(), {},
-              /*ObsoletedRange=*/SourceRange(),
-              PlatformAgnosticAvailabilityKind::None, /*Implicit=*/false,
-              false);
+          auto AvAttr = new (Impl.SwiftContext)
+              AvailableAttr(SourceLoc(), SourceRange(),
+                            targetPlatform(Impl.SwiftContext.LangOpts),
+                            /*Message=*/"", /*Rename=*/"",
+                            availability.getRawMinimumVersion(),
+                            /*IntroducedRange=*/SourceRange(), {},
+                            /*DeprecatedRange=*/SourceRange(), {},
+                            /*ObsoletedRange=*/SourceRange(),
+                            PlatformAgnosticAvailabilityKind::None,
+                            /*Implicit=*/false, false);
           classDecl->getAttrs().add(AvAttr);
         }
       }
@@ -7883,12 +7880,28 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
     return;
 
   for (auto *member : members) {
+    if (member == asyncImport)
+      continue;
+
+    auto afd = dyn_cast<AbstractFunctionDecl>(member);
+    if (!afd)
+      continue;
+
     // Only add the attribute to functions that don't already have availability
-    if (member != asyncImport && isa<AbstractFunctionDecl>(member) &&
-        !member->getAttrs().hasAttribute<AvailableAttr>()) {
-      member->getAttrs().add(
-          AvailableAttr::createForAsyncAlternative(SwiftContext, asyncFunc));
-    }
+    if (afd->getAttrs().hasAttribute<AvailableAttr>())
+      continue;
+
+    llvm::VersionTuple NoVersion;
+    auto *attr = new (SwiftContext)
+        AvailableAttr(SourceLoc(), SourceRange(), PlatformKind::none,
+                      /*Message=*/"", /*Rename=*/"", /*Introduced=*/NoVersion,
+                      SourceRange(), /*Deprecated=*/NoVersion, SourceRange(),
+                      /*Obsoleted=*/NoVersion, SourceRange(),
+                      PlatformAgnosticAvailabilityKind::None, /*Implicit=*/true,
+                      /*SPI=*/false);
+
+    afd->setRenamedDecl(attr, asyncFunc);
+    afd->getAttrs().add(attr);
   }
 }
 
@@ -8696,18 +8709,11 @@ void ClangImporter::Implementation::importAttributes(
       if (!replacement.empty())
         swiftReplacement = getSwiftNameFromClangName(replacement);
 
-      auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
-                                          platformK.value(),
-                                          message, swiftReplacement,
-                                          /*RenameDecl=*/nullptr,
-                                          introduced,
-                                          /*IntroducedRange=*/SourceRange(),
-                                          deprecated,
-                                          /*DeprecatedRange=*/SourceRange(),
-                                          obsoleted,
-                                          /*ObsoletedRange=*/SourceRange(),
-                                          PlatformAgnostic, /*Implicit=*/false,
-                                          EnableClangSPI && IsSPI);
+      auto AvAttr = new (C) AvailableAttr(
+          SourceLoc(), SourceRange(), platformK.value(), message,
+          swiftReplacement, introduced, SourceRange(), deprecated,
+          SourceRange(), obsoleted, SourceRange(), PlatformAgnostic,
+          /*Implicit=*/false, EnableClangSPI && IsSPI);
 
       MappedDecl->getAttrs().add(AvAttr);
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -632,16 +632,11 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
             canonicalizePlatformVersion(*PlatformKind, Obsoleted.Version);
   }
 
-  auto Attr = new (Context)
-  AvailableAttr(AtLoc, SourceRange(AttrLoc, Tok.getLoc()),
-                PlatformKind.value(),
-                Message, Renamed, /*RenameDecl=*/nullptr,
-                Introduced.Version, Introduced.Range,
-                Deprecated.Version, Deprecated.Range,
-                Obsoleted.Version, Obsoleted.Range,
-                PlatformAgnostic,
-                /*Implicit=*/false,
-                AttrName == SPI_AVAILABLE_ATTRNAME);
+  auto Attr = new (Context) AvailableAttr(
+      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), PlatformKind.value(), Message,
+      Renamed, Introduced.Version, Introduced.Range, Deprecated.Version,
+      Deprecated.Range, Obsoleted.Version, Obsoleted.Range, PlatformAgnostic,
+      /*Implicit=*/false, AttrName == SPI_AVAILABLE_ATTRNAME);
   return makeParserResult(Attr);
 
 }
@@ -927,7 +922,6 @@ bool Parser::parseAvailability(
           AtLoc, attrRange, Platform,
           /*Message=*/StringRef(),
           /*Rename=*/StringRef(),
-          /*RenameDecl=*/nullptr,
           /*Introduced=*/Version,
           /*IntroducedRange=*/VersionRange,
           /*Deprecated=*/llvm::VersionTuple(),
@@ -4384,9 +4378,9 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
       StringRef Message = "unavailable in embedded Swift", Renamed;
       auto attr = new (Context) AvailableAttr(
           AtLoc, SourceRange(AtLoc, attrLoc), PlatformKind::none, Message,
-          Renamed, /*RenameDecl=*/nullptr, llvm::VersionTuple(), SourceRange(),
-          llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
-          SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
+          Renamed, llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
+          SourceRange(), llvm::VersionTuple(), SourceRange(),
+          PlatformAgnosticAvailabilityKind::Unavailable,
           /*Implicit=*/false, /*IsSPI=*/false, /*IsForEmbedded=*/true);
       Attributes.add(attr);
     }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1835,8 +1835,7 @@ private:
                           const ValueDecl *D, bool includeQuotes) {
     assert(!AvAttr->Rename.empty());
 
-    auto *renamedDecl = evaluateOrDefault(
-        getASTContext().evaluator, RenamedDeclRequest{D, AvAttr}, nullptr);
+    auto *renamedDecl = D->getRenamedDecl(AvAttr);
     if (renamedDecl) {
       assert(shouldInclude(renamedDecl) &&
              "ObjC printer logic mismatch with renamed decl");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7871,9 +7871,6 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
   if (!attached || !attr)
     return nullptr;
 
-  if (attr->RenameDecl)
-    return attr->RenameDecl;
-
   if (attr->Rename.empty())
     return nullptr;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6637,16 +6637,13 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
         continue;
 
       auto attr = new (ctx) AvailableAttr(
-          SourceLoc(), SourceRange(),
-          available->getPlatform(),
+          SourceLoc(), SourceRange(), available->getPlatform(),
           available->Message,
-          "", nullptr,
-          available->Introduced.value_or(noVersion), SourceRange(),
-          available->Deprecated.value_or(noVersion), SourceRange(),
-          available->Obsoleted.value_or(noVersion), SourceRange(),
-          PlatformAgnosticAvailabilityKind::Unavailable,
-          /*implicit=*/true,
-          available->isSPI());
+          /*Rename=*/"", available->Introduced.value_or(noVersion),
+          SourceRange(), available->Deprecated.value_or(noVersion),
+          SourceRange(), available->Obsoleted.value_or(noVersion),
+          SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
+          /*Implicit=*/true, available->isSPI());
       ext->getAttrs().add(attr);
       anyPlatformSpecificAttrs = true;
     }
@@ -6658,14 +6655,12 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
 
   // Add the blanket "unavailable".
 
-  auto attr = new (ctx) AvailableAttr(SourceLoc(), SourceRange(),
-                                      PlatformKind::none, "", "", nullptr,
-                                      noVersion, SourceRange(),
-                                      noVersion, SourceRange(),
-                                      noVersion, SourceRange(),
-                                      PlatformAgnosticAvailabilityKind::Unavailable,
-                                      false,
-                                      false);
+  auto attr = new (ctx) AvailableAttr(
+      SourceLoc(), SourceRange(), PlatformKind::none, /*Message*/ "",
+      /*Rename=*/"", /*Introduced=*/noVersion, SourceRange(),
+      /*Deprecated=*/noVersion, SourceRange(), /*Obsoleted=*/noVersion,
+      SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
+      /*Implicit=*/false, /*SPI=*/false);
   ext->getAttrs().add(attr);
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5615,7 +5615,6 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   DEF_VER_TUPLE_PIECES(Introduced);
   DEF_VER_TUPLE_PIECES(Deprecated);
   DEF_VER_TUPLE_PIECES(Obsoleted);
-  DeclID renameDeclID;
   unsigned rawPlatform, messageSize, renameSize;
 
   // Decode the record, pulling the version tuple information.
@@ -5623,7 +5622,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
       scratch, isImplicit, isUnavailable, isDeprecated, isNoAsync,
       isPackageDescriptionVersionSpecific, isSPI, isForEmbedded,
       LIST_VER_TUPLE_PIECES(Introduced), LIST_VER_TUPLE_PIECES(Deprecated),
-      LIST_VER_TUPLE_PIECES(Obsoleted), rawPlatform, renameDeclID, messageSize,
+      LIST_VER_TUPLE_PIECES(Obsoleted), rawPlatform, messageSize,
       renameSize);
 
   auto maybePlatform = platformFromUnsigned(rawPlatform);
@@ -5631,11 +5630,6 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
     return llvm::make_error<InvalidEnumValueError>(rawPlatform, "PlatformKind");
 
   PlatformKind platform = maybePlatform.value();
-
-  ValueDecl *renameDecl = nullptr;
-  if (renameDeclID) {
-    renameDecl = cast<ValueDecl>(MF.getDecl(renameDeclID));
-  }
 
   StringRef message = blobData.substr(0, messageSize);
   blobData = blobData.substr(messageSize);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5657,9 +5657,9 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
     platformAgnostic = PlatformAgnosticAvailabilityKind::None;
 
   auto attr = new (ctx) AvailableAttr(
-      SourceLoc(), SourceRange(), platform, message, rename, renameDecl,
-      Introduced, SourceRange(), Deprecated, SourceRange(), Obsoleted,
-      SourceRange(), platformAgnostic, isImplicit, isSPI, isForEmbedded);
+      SourceLoc(), SourceRange(), platform, message, rename, Introduced,
+      SourceRange(), Deprecated, SourceRange(), Obsoleted, SourceRange(),
+      platformAgnostic, isImplicit, isSPI, isForEmbedded);
   return attr;
 }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 903; // @main attribute moved
+const uint16_t SWIFTMODULE_VERSION_MINOR = 904; // @available renamed decl ID removed
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2352,7 +2352,6 @@ namespace decls_block {
     BC_AVAIL_TUPLE, // Deprecated
     BC_AVAIL_TUPLE, // Obsoleted
     BCVBR<5>,    // platform
-    DeclIDField, // rename declaration (if any)
     BCVBR<5>,    // number of bytes in message string
     BCVBR<5>,    // number of bytes in rename string
     BCBlob       // message, followed by rename

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3038,7 +3038,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       ENCODE_VER_TUPLE(Deprecated, theAttr->Deprecated)
       ENCODE_VER_TUPLE(Obsoleted, theAttr->Obsoleted)
 
-      auto renameDeclID = S.addDeclRef(theAttr->RenameDecl);
+      assert(theAttr->Rename.empty() || !theAttr->hasCachedRenamedDecl());
+
       llvm::SmallString<32> blob;
       blob.append(theAttr->Message);
       blob.append(theAttr->Rename);
@@ -3056,7 +3057,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           LIST_VER_TUPLE_PIECES(Deprecated),
           LIST_VER_TUPLE_PIECES(Obsoleted),
           static_cast<unsigned>(theAttr->getPlatform()),
-          renameDeclID,
           theAttr->Message.size(),
           theAttr->Rename.size(),
           blob);

--- a/test/Serialization/renamed-cycle.swift
+++ b/test/Serialization/renamed-cycle.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Library.swift -o %t/Library.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Renamed.swift -o %t/Renamed.swiftmodule -I %t/
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t/
+
+//--- Library.swift
+
+public struct HasRename {
+  public init(new: Int) { }
+}
+
+//--- Renamed.swift
+
+import Library
+
+extension HasRename {
+  @available(*, renamed: "init(new:)")
+  public init(old: Int) {
+    self.init(new: old)
+  }
+}
+
+//--- Client.swift
+
+import Library
+import Renamed
+
+_ = HasRename(old: 0)

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -89,9 +89,13 @@ func defaultedParamsEnd4(newArg: Int, arg: Int = 0) async { }
 @available(macOS, deprecated: 12, renamed: "manyAttrsOld()")
 @available(*, deprecated)
 func manyAttrs(completionHandler: @escaping () -> Void) { }
+
 // expected-note@+2 {{'manyAttrsNew()' declared here}}
 @available(SwiftStdlib 5.5, *)
 func manyAttrsNew() async { }
+
+@available(SwiftStdlib 5.5, *)
+func manyAttrsNewOther() async { }
 
 @available(macOS, introduced: 12, renamed: "platformOnlyNew()")
 func platformOnly(completionHandler: @escaping () -> Void) { }


### PR DESCRIPTION
Make the memory footprint of `AvailableAttr` smaller by optimizing for the common case of no `rename:` decl being associated with the attribute.