### PR TITLE
[CMake] Enable unicode data support

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -88,6 +88,7 @@ defaulted_option(SwiftCore_ENABLE_STATIC_PRINT "Disable full print")
 defaulted_option(SwiftCore_ENABLE_UNICODE_DATA "Embed Unicode info in Swift Core")
 defaulted_option(SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS "Resolve absolute function pointer as identity")
 defaulted_option(SwiftCore_ENABLE_BACKDEPLOYMENT_SUPPORT "Add symbols for runtime backdeployment")
+option(SwiftCore_ENABLE_UNICODE_DATA "Include unicode data in Swift runtimes" ON)
 
 defaulted_option(SwiftCore_ENABLE_BACKTRACING "Enable backtracing runtime support")
 defaulted_set(SwiftCore_BACKTRACER_PATH STRING "Set a fixed path to the Swift backtracer")

--- a/Runtimes/Core/stubs/CMakeLists.txt
+++ b/Runtimes/Core/stubs/CMakeLists.txt
@@ -26,7 +26,9 @@ if(SwiftCore_ENABLE_OBJC_INTEROP)
 endif()
 
 
-target_compile_definitions(swiftStdlibStubs PRIVATE swiftCore_EXPORTS)
+target_compile_definitions(swiftStdlibStubs PRIVATE
+  swiftCore_EXPORTS
+  $<$<BOOL:${SwiftCore_ENABLE_UNICODE_DATA}>:-DSWIFT_STDLIB_ENABLE_UNICODE_DATA>)
 target_link_libraries(swiftStdlibStubs PRIVATE swiftShims)
 target_include_directories(swiftStdlibStubs PRIVATE
   "${PROJECT_BINARY_DIR}/include"


### PR DESCRIPTION
Stubs has a macro define for enabling or disabling the embedded unicode data tables, which are required for doing things like counting characters in strings. Add that option and default it to 'on' for full unicode support.