### PR TITLE
Add access level import diagnostic for named pattern.

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -376,33 +376,27 @@ static void highlightOffendingType(InFlightDiagnostic &diag,
 
 /// Emit a note on \p limitImport when it restricted the access level
 /// of a type.
-static void noteLimitingImport(const Decl *userDecl,
-                               ASTContext &ctx,
+static void noteLimitingImport(const Decl *userDecl, ASTContext &ctx,
                                const ImportAccessLevel limitImport,
-                               const TypeRepr *complainRepr) {
+                               const Decl *complainDecl) {
   if (!limitImport.has_value())
     return;
 
   assert(limitImport->accessLevel != AccessLevel::Public &&
          "a public import shouldn't limit the access level of a decl");
 
-  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(complainRepr)) {
-    ValueDecl *VD = declRefTR->getBoundDecl();
-
+  if (complainDecl) {
     // When using an IDE in a large file the decl_import_via_here note
     // may be easy to miss on the import. Duplicate the information on the
     // error line as well so it can't be missed.
     if (userDecl)
-      userDecl->diagnose(diag::decl_import_via_local,
-                     VD,
-                     limitImport->accessLevel,
-                     limitImport->module.importedModule);
+      userDecl->diagnose(diag::decl_import_via_local, complainDecl,
+                         limitImport->accessLevel,
+                         limitImport->module.importedModule);
 
     if (limitImport->importLoc.isValid())
-      ctx.Diags.diagnose(limitImport->importLoc,
-                         diag::decl_import_via_here,
-                         VD,
-                         limitImport->accessLevel,
+      ctx.Diags.diagnose(limitImport->importLoc, diag::decl_import_via_here,
+                         complainDecl, limitImport->accessLevel,
                          limitImport->module.importedModule);
   } else if (limitImport->importLoc.isValid()) {
     ctx.Diags.diagnose(limitImport->importLoc, diag::module_imported_here,
@@ -411,14 +405,21 @@ static void noteLimitingImport(const Decl *userDecl,
   }
 }
 
+static void noteLimitingImport(const Decl *userDecl, ASTContext &ctx,
+                               const ImportAccessLevel limitImport,
+                               const TypeRepr *complainRepr) {
+  const Decl *complainDecl = nullptr;
+  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(complainRepr))
+    complainDecl = declRefTR->getBoundDecl();
+
+  noteLimitingImport(userDecl, ctx, limitImport, complainDecl);
+}
+
 static void noteLimitingImport(const Decl *userDecl,
                                const ImportAccessLevel limitImport,
                                const TypeRepr *complainRepr) {
-  if (!limitImport.has_value())
-    return;
-
-  ASTContext &ctx = userDecl->getASTContext();
-  noteLimitingImport(userDecl, ctx, limitImport, complainRepr);
+  noteLimitingImport(userDecl, userDecl->getASTContext(), limitImport,
+                     complainRepr);
 }
 
 void AccessControlCheckerBase::checkGenericParamAccess(
@@ -625,7 +626,8 @@ public:
     if (seenVars.count(theVar) || theVar->isInvalid())
       return;
 
-    checkTypeAccess(theVar->getInterfaceType(), nullptr, theVar,
+    Type interfaceType = theVar->getInterfaceType();
+    checkTypeAccess(interfaceType, nullptr, theVar,
                     /*mayBeInferred*/false,
                     [&](AccessScope typeAccessScope,
                         const TypeRepr *complainRepr,
@@ -644,8 +646,24 @@ public:
       DE.diagnose(NP->getLoc(), diagID, theVar->isLet(),
                   isTypeContext, isExplicit, theVarAccess,
                   isa<FileUnit>(theVar->getDeclContext()),
-                  typeAccess, theVar->getInterfaceType());
-      noteLimitingImport(theVar, importLimit, complainRepr);
+                  typeAccess, interfaceType);
+
+      // As we pass in a null typeRepr the complainRepr will always be null.
+      // Extract the module import from the interface type instead.
+      const Decl *complainDecl = nullptr;
+      ImportAccessLevel complainImport = std::nullopt;
+      interfaceType.walk(SimpleTypeDeclFinder([&](const ValueDecl *VD) {
+        ImportAccessLevel import = VD->getImportAccessFrom(theVar->getDeclContext());
+        if (import.has_value() && import->accessLevel < VD->getFormalAccess()) {
+          complainDecl = VD;
+          complainImport = import;
+          return TypeWalker::Action::Stop;
+        }
+        return TypeWalker::Action::Continue;
+      }));
+
+      noteLimitingImport(theVar, theVar->getASTContext(), complainImport,
+                         complainDecl);
     });
   }
 

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -760,9 +760,13 @@ public struct PublicVars {
 
     public var k = PublicImportType()
     public var l = PackageImportType() // expected-error {{property cannot be declared public because its type 'PackageImportType' uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     public var m = InternalImportType() // expected-error {{property cannot be declared public because its type 'InternalImportType' uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     public var n = FileprivateImportType() // expected-error {{property cannot be declared public because its type 'FileprivateImportType' uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     public var o = PrivateImportType() // expected-error {{property cannot be declared public because its type 'PrivateImportType' uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 package struct PackageVars {
@@ -792,8 +796,11 @@ package struct PackageVars {
     package var k = PublicImportType()
     package var l = PackageImportType()
     package var m = InternalImportType() // expected-error {{property cannot be declared package because its type 'InternalImportType' uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     package var n = FileprivateImportType() // expected-error {{property cannot be declared package because its type 'FileprivateImportType' uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     package var o = PrivateImportType() // expected-error {{property cannot be declared package because its type 'PrivateImportType' uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 internal struct InternalVars {
@@ -822,7 +829,9 @@ internal struct InternalVars {
     internal var l = PackageImportType()
     internal var m = InternalImportType()
     internal var n = FileprivateImportType() // expected-error {{property cannot be declared internal because its type 'FileprivateImportType' uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     internal var o = PrivateImportType() // expected-error {{property cannot be declared internal because its type 'PrivateImportType' uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 fileprivate struct FileprivateVars {


### PR DESCRIPTION
This PR adds a missing access level diagnostic when type checking named patterns by extracting the TypeRepr from the pattern's initializer.
