### PR TITLE
[cxx-interop] allow shared ref retain function to return self

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -231,10 +231,14 @@ ERROR(foreign_reference_types_invalid_retain_release, none,
       "type '%2'",
       (bool, StringRef, StringRef))
 
-ERROR(foreign_reference_types_retain_release_non_void_return_type, none,
-      "specified %select{retain|release}0 function '%1' is invalid; "
-      "%select{retain|release}0 function must have 'void' return type",
-      (bool, StringRef))
+ERROR(foreign_reference_types_retain_non_void_or_self_return_type, none,
+      "specified retain function '%0' is invalid; "
+      "retain function must have 'void' or parameter return type",
+      (StringRef))
+ERROR(foreign_reference_types_release_non_void_return_type, none,
+      "specified release function '%0' is invalid; "
+      "release function must have 'void' return type",
+      (StringRef))
 ERROR(foreign_reference_types_retain_release_not_a_function_decl, none,
       "specified %select{retain|release}0 function '%1' is not a function",
       (bool, StringRef))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2530,7 +2530,7 @@ namespace {
     void validateForeignReferenceType(const clang::CXXRecordDecl *decl,
                                       ClassDecl *classDecl) {
 
-      enum class RetainReleaseOperatonKind {
+      enum class RetainReleaseOperationKind {
         notAfunction,
         doesntReturnVoid,
         invalidParameters,
@@ -2538,16 +2538,16 @@ namespace {
       };
 
       auto getOperationValidity =
-          [&](ValueDecl *operation) -> RetainReleaseOperatonKind {
+          [&](ValueDecl *operation) -> RetainReleaseOperationKind {
         auto operationFn = dyn_cast<FuncDecl>(operation);
         if (!operationFn)
-          return RetainReleaseOperatonKind::notAfunction;
+          return RetainReleaseOperationKind::notAfunction;
 
         if (!operationFn->getResultInterfaceType()->isVoid())
-          return RetainReleaseOperatonKind::doesntReturnVoid;
+          return RetainReleaseOperationKind::doesntReturnVoid;
 
         if (operationFn->getParameters()->size() != 1)
-          return RetainReleaseOperatonKind::invalidParameters;
+          return RetainReleaseOperationKind::invalidParameters;
 
         Type paramType =
             operationFn->getParameters()->get(0)->getInterfaceType();
@@ -2564,13 +2564,13 @@ namespace {
             if (const auto *paramTypeDecl =
                     dyn_cast<clang::CXXRecordDecl>(paramClangDecl)) {
               if (decl->isDerivedFrom(paramTypeDecl)) {
-                return RetainReleaseOperatonKind::valid;
+                return RetainReleaseOperationKind::valid;
               }
             }
           }
-          return RetainReleaseOperatonKind::invalidParameters;
+          return RetainReleaseOperationKind::invalidParameters;
         }
-        return RetainReleaseOperatonKind::valid;
+        return RetainReleaseOperationKind::valid;
       };
 
       auto retainOperation = evaluateOrDefault(
@@ -2607,28 +2607,28 @@ namespace {
                       false, retainOperation.name, decl->getNameAsString());
       } else if (retainOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
-        RetainReleaseOperatonKind operationKind =
+        RetainReleaseOperationKind operationKind =
             getOperationValidity(retainOperation.operation);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
-        case RetainReleaseOperatonKind::notAfunction:
+        case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               false, retainOperation.name);
           break;
-        case RetainReleaseOperatonKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoid:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_non_void_return_type,
               false, retainOperation.name);
           break;
-        case RetainReleaseOperatonKind::invalidParameters:
+        case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,
                         diag::foreign_reference_types_invalid_retain_release,
                         false, retainOperation.name, classDecl->getNameStr());
           break;
-        case RetainReleaseOperatonKind::valid:
+        case RetainReleaseOperationKind::valid:
           break;
         }
       } else {
@@ -2671,28 +2671,28 @@ namespace {
                       true, releaseOperation.name, decl->getNameAsString());
       } else if (releaseOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
-        RetainReleaseOperatonKind operationKind =
+        RetainReleaseOperationKind operationKind =
             getOperationValidity(releaseOperation.operation);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
-        case RetainReleaseOperatonKind::notAfunction:
+        case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               true, releaseOperation.name);
           break;
-        case RetainReleaseOperatonKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoid:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_non_void_return_type,
               true, releaseOperation.name);
           break;
-        case RetainReleaseOperatonKind::invalidParameters:
+        case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,
                         diag::foreign_reference_types_invalid_retain_release,
                         true, releaseOperation.name, classDecl->getNameStr());
           break;
-        case RetainReleaseOperatonKind::valid:
+        case RetainReleaseOperationKind::valid:
           break;
         }
       } else {

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -48,6 +48,15 @@ void goodRelease(GoodRetainRelease *v);
 
 struct
     __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:goodRetainWithRetainReturningSelf")))
+    __attribute__((swift_attr("release:goodReleaseWithRetainReturningSelf")))
+GoodRetainReleaseWithRetainReturningSelf {};
+
+GoodRetainReleaseWithRetainReturningSelf *goodRetainWithRetainReturningSelf(GoodRetainReleaseWithRetainReturningSelf *v);
+void goodReleaseWithRetainReturningSelf(GoodRetainReleaseWithRetainReturningSelf *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:goodRetainWithNullabilityAnnotations")))
     __attribute__((swift_attr("release:goodReleaseWithNullabilityAnnotations")))
 GoodRetainReleaseWithNullabilityAnnotations {};
@@ -226,7 +235,7 @@ public func test(x: NonExistent) { }
 @available(macOS 13.3, *)
 public func test(x: NoRetainRelease) { }
 
-// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have 'void' return type
+// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have 'void' or parameter return type
 // CHECK: error: specified release function 'badRelease' is invalid; release function must have exactly one argument of type 'BadRetainRelease'
 @available(macOS 13.3, *)
 public func test(x: BadRetainRelease) { }
@@ -238,6 +247,9 @@ public func test(x: BadRetainReleaseWithNullabilityAnnotations) { }
 
 @available(macOS 13.3, *)
 public func test(x: GoodRetainRelease) { }
+
+@available(macOS 13.3, *)
+public func test(x: GoodRetainReleaseRetainReturningSelf) { }
 
 @available(macOS 13.3, *)
 public func test(x: GoodRetainReleaseWithNullabilityAnnotations) { }


### PR DESCRIPTION
Many existing C APIs for retaining references, including Apple's own, return the reference. Support this pattern, along with the existing `void` return signature, with when importing reference types from C++.

More: https://forums.swift.org/t/swift-shared-reference-signature-error/76194/7