### PR TITLE
[cxx-interop] Workaround a deserialization error for CxxStdlib on Linux

### DIFF
--- a/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
@@ -4,12 +4,21 @@
 
 /// Used for std::string conformance to Swift.Hashable
 typedef std::hash<std::string> __swift_interopHashOfString;
+inline std::size_t __swift_interopComputeHashOfString(std::string str) {
+  return __swift_interopHashOfString()(str);
+}
 
 /// Used for std::u16string conformance to Swift.Hashable
 typedef std::hash<std::u16string> __swift_interopHashOfU16String;
+inline std::size_t __swift_interopComputeHashOfU16String(std::u16string str) {
+  return __swift_interopHashOfU16String()(str);
+}
 
 /// Used for std::u32string conformance to Swift.Hashable
 typedef std::hash<std::u32string> __swift_interopHashOfU32String;
+inline std::size_t __swift_interopComputeHashOfU32String(std::u32string str) {
+  return __swift_interopHashOfU32String()(str);
+}
 
 inline std::chrono::seconds __swift_interopMakeChronoSeconds(int64_t seconds) {
   return std::chrono::seconds(seconds);

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -198,7 +198,7 @@ extension std.string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::string>::operator()
-    let cxxHash = __swift_interopHashOfString().callAsFunction(self)
+    let cxxHash = __swift_interopComputeHashOfString(self)
     hasher.combine(cxxHash)
   }
 }
@@ -207,7 +207,7 @@ extension std.u16string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u16string>::operator()
-    let cxxHash = __swift_interopHashOfU16String().callAsFunction(self)
+    let cxxHash = __swift_interopComputeHashOfU16String(self)
     hasher.combine(cxxHash)
   }
 }
@@ -216,7 +216,7 @@ extension std.u32string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u32string>::operator()
-    let cxxHash = __swift_interopHashOfU32String().callAsFunction(self)
+    let cxxHash = __swift_interopComputeHashOfU32String(self)
     hasher.combine(cxxHash)
   }
 }


### PR DESCRIPTION
In certain versions of libstdc++, `std::hash<std::string>` defines `operator()` in a base class. It looks like Swift is not correctly deserializing an inherited `operator()` for inlinable functions. This change sidesteps the issue by moving the call to `callAsFunction`/`operator()` to the C++ shim layer.

rdar://140358388

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
