### PR TITLE
tools: use `LibXml2::LibXml2` to link against

### DIFF
--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -17,12 +17,8 @@ target_link_libraries(swift-ide-test
 
 # If libxml2 is available, make it available for swift-ide-test.
 if(LLVM_ENABLE_LIBXML2)
-  include_directories(SYSTEM ${LIBXML2_INCLUDE_DIR})
-  target_link_libraries(swift-ide-test PRIVATE ${LIBXML2_LIBRARIES})
+  target_link_libraries(swift-ide-test PRIVATE LibXml2::LibXml2)
   target_compile_definitions(swift-ide-test PRIVATE SWIFT_HAVE_LIBXML=1)
-  if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "OpenBSD" AND NOT CMAKE_CROSSCOMPILING)
-    include_directories(SYSTEM "/usr/local/include")
-  endif()
 endif()
 
 # Create a symlink for swift-api-dump.py in the bin directory


### PR DESCRIPTION
Adjust the build rules to use the `LibXml2::LibXml2` target rather than use the explicit include paths and link flags. This allows us to track additional dependencies (implicit linked libraries) as well as properly propagate the include paths and library search paths.