### PR TITLE
AliasAnalysis: fix memory-behavior of closures with inout arguments

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -741,6 +741,12 @@ private struct FullApplyEffectsVisitor : EscapeVisitorWithResult {
       return .ignore
     }
     if user == apply {
+      if apply.isCallee(operand: operand) {
+        // If the address "escapes" to the callee of the apply it means that the address was captured
+        // by an inout_aliasable operand of an partial_apply.
+        // Therefore assume that the called function will both, read and write, to the address.
+        return .abort
+      }
       let e = calleeAnalysis.getSideEffects(of: apply, operand: operand, path: path.projectionPath)
       result.merge(with: e)
     }

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1692,3 +1692,21 @@ bb0(%0 : $Int, %1 : $Builtin.Int64, %2 : $Builtin.RawPointer):
   return %r : $()
 }
 
+sil @closure_with_inout : $@convention(thin) (@inout_aliasable Int) -> ()
+
+// CHECK-LABEL: sil @closure_with_inout_reads_argument :
+// CHECK:         store %0
+// CHECK:       end sil function 'closure_with_inout_reads_argument'
+sil @closure_with_inout_reads_argument : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int
+  store %0 to %1
+  %3 = function_ref @closure_with_inout : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%1) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %50 = apply %4() : $@noescape @callee_guaranteed () -> ()
+  dealloc_stack %4 : $@noescape @callee_guaranteed () -> ()
+  dealloc_stack %1 : $*Int
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1656,6 +1656,78 @@ bb0(%0 :  $*X):
   return %3 : $()
 }
 
+sil @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+sil @closure2 : $@convention(thin) (Int, @inout_aliasable Int) -> ()
+
+// CHECK-LABEL: @closure_with_inout
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = partial_apply [callee_guaranteed] [on_stack] %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %3 = apply %2() : $@noescape @callee_guaranteed () -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=1,w=1
+sil @closure_with_inout : $@convention(thin) (@inout Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = partial_apply [callee_guaranteed] [on_stack] %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %3 = apply %2() : $@noescape @callee_guaranteed () -> ()
+  dealloc_stack %2
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: @two_closures_with_inout
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %3 = partial_apply [callee_guaranteed] [on_stack] %2(%0) : $@convention(thin) (Int, @inout_aliasable Int) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %4 = partial_apply [callee_guaranteed] [on_stack] %3(%1) : $@noescape @callee_guaranteed (Int) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #2.
+// CHECK-NEXT:      %5 = apply %4() : $@noescape @callee_guaranteed () -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=1,w=1
+sil @two_closures_with_inout : $@convention(thin) (@inout Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @closure2 : $@convention(thin) (Int, @inout_aliasable Int) -> ()
+  %3 = partial_apply [callee_guaranteed] [on_stack] %2(%0) : $@convention(thin) (Int, @inout_aliasable Int) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%1) : $@noescape @callee_guaranteed (Int) -> ()
+  %5 = apply %4() : $@noescape @callee_guaranteed () -> ()
+  dealloc_stack %4
+  dealloc_stack %3
+  %r = tuple ()
+  return %r
+}
+
+sil @call_closure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> () {
+[%0: read v**.c*.v**, write v**.c*.v**]
+[global: read,write]
+}
+
+// CHECK-LABEL: @pass_closure_to_function
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = partial_apply [callee_guaranteed] [on_stack] %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %4 = apply %3(%2) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:    r=1,w=1
+sil @pass_closure_to_function : $@convention(thin) (@inout Int) -> () {
+bb0(%0 : $*Int):
+  %4 = function_ref @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+  %5 = partial_apply [callee_guaranteed] [on_stack] %4(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %6 = function_ref @call_closure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %7 = apply %6(%5) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %5
+  %r = tuple ()
+  return %r
+}
+
 // CHECK-LABEL: @test_is_unique
 // CHECK:      PAIR #0.
 // CHECK-NEXT:     %2 = is_unique %0 : $*X

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1656,6 +1656,25 @@ bb0(%0 :  $*X):
   return %3 : $()
 }
 
+// CHECK-LABEL: @test_non_escaping_applied
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = partial_apply [on_stack] %1(%0) : $@convention(thin) (@in_guaranteed X) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*X
+// CHECK-NEXT:    r=1,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %3 = apply %2() : $@noescape @callee_owned () -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*X
+// CHECK-NEXT:    r=0,w=0
+sil [ossa] @test_non_escaping_applied : $@convention(thin) (@in X) -> () {
+bb0(%0 :  $*X):
+  %1 = function_ref @indirect_X : $@convention(thin) (@in_guaranteed X) -> ()
+  %2 = partial_apply [on_stack] %1(%0) : $@convention(thin) (@in_guaranteed X) -> ()
+  %3 = apply %2() : $@noescape @callee_owned () -> ()
+  destroy_addr %0
+  %6 = tuple ()
+  return %6 : $()
+}
+
 sil @closure : $@convention(thin) (@inout_aliasable Int) -> ()
 sil @closure2 : $@convention(thin) (Int, @inout_aliasable Int) -> ()
 


### PR DESCRIPTION
Calls of such closures were not considered to read or modify the inout argument.

Fixes a miscompile.
rdar://140338313