### PR TITLE
[cxx-interop] Workaround a compiler crash for CxxStdlib on Windows

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -198,7 +198,11 @@ extension std.string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::string>::operator()
+#if os(Windows) // FIXME: https://github.com/swiftlang/swift/issues/77856
+    let cxxHash = __swift_interopHashOfString().callAsFunction(self)
+#else
     let cxxHash = __swift_interopComputeHashOfString(self)
+#endif
     hasher.combine(cxxHash)
   }
 }
@@ -207,7 +211,11 @@ extension std.u16string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u16string>::operator()
+#if os(Windows) // FIXME: https://github.com/swiftlang/swift/issues/77856
+    let cxxHash = __swift_interopHashOfU16String().callAsFunction(self)
+#else
     let cxxHash = __swift_interopComputeHashOfU16String(self)
+#endif
     hasher.combine(cxxHash)
   }
 }
@@ -216,7 +224,11 @@ extension std.u32string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u32string>::operator()
+#if os(Windows) // FIXME: https://github.com/swiftlang/swift/issues/77856
+    let cxxHash = __swift_interopHashOfU32String().callAsFunction(self)
+#else
     let cxxHash = __swift_interopComputeHashOfU32String(self)
+#endif
     hasher.combine(cxxHash)
   }
 }


### PR DESCRIPTION
This is a workaround for https://github.com/swiftlang/swift/issues/77856.

rdar://140358388

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
