### PR TITLE
Devirtualization: make sure to de-serialize the body of shared deinit functions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -227,6 +227,14 @@ extension MutatingContext {
     }
   }
 
+  func loadFunction(function: Function, loadCalleesRecursively: Bool) -> Bool {
+    if function.isDefinition {
+      return true
+    }
+    _bridged.loadFunction(function.bridged, loadCalleesRecursively)
+    return function.isDefinition
+  }
+
   private func notifyNewInstructions(from: Instruction, to: Instruction) {
     var inst = from
     while inst != to {
@@ -303,14 +311,6 @@ struct FunctionPassContext : MutatingContext {
       let nameStr = BridgedStringRef(data: nameBuffer.baseAddress, count: nameBuffer.count)
       return _bridged.loadFunction(nameStr, loadCalleesRecursively).function
     }
-  }
-
-  func loadFunction(function: Function, loadCalleesRecursively: Bool) -> Bool {
-    if function.isDefinition {
-      return true
-    }
-    _bridged.loadFunction(function.bridged, loadCalleesRecursively)
-    return function.isDefinition
   }
 
   /// Looks up a function in the `Swift` module.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -43,6 +43,10 @@ private func devirtualize(destroy: some DevirtualizableDestroy, _ context: some 
     guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
       return false
     }
+    if deinitFunc.linkage == .shared && !deinitFunc.isDefinition {
+      // Make sure to not have an external shared function, which is illegal in SIL.
+      _ = context.loadFunction(function: deinitFunc, loadCalleesRecursively: false)
+    }
     destroy.createDeinitCall(to: deinitFunc, context)
     context.erase(instruction: destroy)
     return true

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1095,7 +1095,9 @@ public:
 
   /// Get the source location of the function.
   SILLocation getLocation() const {
-    assert(DebugScope && "no scope/location");
+    if (!DebugScope) {
+      return SILLocation::invalid();
+    }
     return getDebugScope()->Loc;
   }
 


### PR DESCRIPTION
Sometimes it can happen that a deinit function, which is imported from another module, has shared linkage.
In this case it is important to de-serialize the function body. Otherwise it would be illegal SIL.

Also change an assert to a bail-out condition in `SILFunction::getLocation` to avoid a crash if a function doesn't have a debug location (for whatever reason).

Unfortunately I don't have a test case for this.

rdar://140112207