### PR TITLE
Frontend: re-serialise static library status

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -279,6 +279,7 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
   // optimization pipeline.
   SerializationOptions SerializationOpts;
   std::string OutPathStr = OutputPath.str();
+  SerializationOpts.StaticLibrary = FEOpts.Static;
   SerializationOpts.OutputPath = OutPathStr.c_str();
   SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
   SerializationOpts.AutolinkForceLoad =

--- a/test/ModuleInterface/Inputs/SR77756/dynamic.swiftinterface
+++ b/test/ModuleInterface/Inputs/SR77756/dynamic.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name dynamic
+
+import Swift
+
+public func f() {}
+

--- a/test/ModuleInterface/Inputs/SR77756/static.swiftinterface
+++ b/test/ModuleInterface/Inputs/SR77756/static.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -static -module-name static
+
+import Swift
+
+public func f() {}

--- a/test/ModuleInterface/swift-interface-compile.swift
+++ b/test/ModuleInterface/swift-interface-compile.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t/mcp -I %S/Inputs/SR77756 -c %s -o /dev/null -D STATIC
+// RUN: llvm-bcanalyzer -dump %t/mcp/static-*.swiftmodule | %FileCheck %s -check-prefix CHECK-STATIC
+// RUN: %target-swift-frontend -module-cache-path %t/mcp -I %S/Inputs/SR77756 -c %s -o /dev/null
+// RUN: llvm-bcanalyzer -dump %t/mcp/dynamic-*.swiftmodule | %FileCheck %s -check-prefix CHECK-DYNAMIC
+
+#if STATIC
+import `static`
+#else
+import `dynamic`
+#endif
+
+// CHECK-STATIC: IS_STATIC
+// CHECK-DYNAMIC-NOT: IS_STATIC


### PR DESCRIPTION
When compiling the swiftmodule from the textual swift interface, ensure that we re-serialise the static or dynamic nature of the module. This is required for proper code generation where the static and dynamic linking is material to symbolic references. This also opens the possibility of optimizations on other platforms via internalisation of the symbols.

Fixes: #77756