### PR TITLE
[cxx-interop]: Enhance CxxDictionary with Merging, Initializer, and Unsafe Erasure

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -4,12 +4,14 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 using Map = std::map<int, int>;
 using MapStrings = std::map<std::string, std::string>;
 using NestedMap = std::map<int, Map>;
+using MapGroup = std::map<int, std::vector<int>>;
 using UnorderedMap = std::unordered_map<int, int>;
-
+using UnorderedMapGroup = std::unordered_map<int, std::vector<int>>;
 inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }
 inline UnorderedMap initUnorderedMap() { return {{1, 3}, {3, 3}, {2, 2}}; }
 inline Map initEmptyMap() { return {}; }


### PR DESCRIPTION
This pull request introduces key enhancements to CxxDictionary:
- Merging Methods:
    - Adds `mutating merge` and `merging` methods for sequences and dictionaries.
- Grouping Initializer:
    - Adds `init(grouping:by:)` initializer.
- Defaulted Subscript:
    - Adds subscript with default value support.
- Value Removal:
    - Introduces `removeValue(forKey:)` method.