### PR TITLE
[Frontend] Re-enable ASAN builds support in `load-pass-plugin` test (NFC)

### DIFF
--- a/test/Frontend/load-pass-plugin.swift
+++ b/test/Frontend/load-pass-plugin.swift
@@ -1,17 +1,12 @@
 // REQUIRES: OS=macosx
 
-// This test fails under ASAN because of an ODR violation (which is strictly
-// speaking a bug: https://github.com/swiftlang/swift/issues/77771).  Disable
-// for ASAN until it's fixed.
-// UNSUPPORTED: asan
-
 // RUN: %target-swift-frontend -load-pass-plugin=nonexistent.dylib %s -emit-ir -o /dev/null 2>&1 | %FileCheck -check-prefix=CHECK-UNABLE-LOAD %s
 // CHECK-UNABLE-LOAD: error: unable to load plugin 'nonexistent.dylib': 'Could not load library{{.*}}'
 
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx %S/Inputs/TestPlugin.cpp -std=c++17 -stdlib=libc++ \
-// RUN:     -isysroot %sdk -I %llvm_src_root/include -I %llvm_obj_root/include -L %llvm_obj_root/lib -lLLVMSupport \
-// RUN:     -Wl,-undefined -Wl,suppress -Wl,-flat_namespace \
+// RUN:     -isysroot %sdk -I %llvm_src_root/include -I %llvm_obj_root/include -L %llvm_obj_root/lib \
+// RUN:     -Wl,-hidden-lLLVMSupport -Wl,-undefined -Wl,dynamic_lookup -Wl,-flat_namespace \
 // RUN:     -dynamiclib -o %t/libTestPlugin.dylib
 
 // RUN: %target-swift-frontend -load-pass-plugin=%t/libTestPlugin.dylib %s -emit-ir -o /dev/null 2>&1 | %swift-demangle | %FileCheck %s


### PR DESCRIPTION
`libTestPlugin.dylib` dynamic library was previously linking against `libLLVMSupport.a`, whose library is already linked in the Swift compiler binary, hence leading to multiple conflicting definitions of `libLLVMSupport` symbols. This issue has been addressed by telling the linker to resolve undefined symbols from the Swift frontend at runtime.

Fixes: https://github.com/swiftlang/swift/issues/77771.