### PR TITLE
Revert "Revert "CI: Include stdlib build for Wasm in the Linux buildbot""

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -870,6 +870,9 @@ build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 build-embedded-stdlib-cross-compiling
 
+wasmkit
+build-wasm-stdlib
+
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
 


### PR DESCRIPTION
Reverts swiftlang/swift#76597

After performance improvements landed in WasmKit, this no longer introduces a 1hr regression, but only 10-20 minutes slowdown to Ubuntu jobs.

Additional solutions are investigated to shave time off SwiftPM build jobs, which could potentially reduce total build time by 5-10 minutes in https://github.com/swiftlang/swift-package-manager/pull/8145.