### PR TITLE
[windows][toolchain] Enable sccache for Clang and add version checks

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1043,11 +1043,6 @@ function Build-CMakeProject {
       }
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
 
-      if (-not (Test-CMakeAtLeast -Major 3 -Minor 26 -Patch 3) -and $Platform -eq "Windows") {
-        # Workaround for https://github.com/ninja-build/ninja/issues/2280
-        TryAdd-KeyValue $Defines CMAKE_CL_SHOWINCLUDES_PREFIX "Note: including file: "
-      }
-
       if ($DebugInfo -and $CDebugFormat -eq "dwarf") {
         Append-FlagsDefine $Defines CMAKE_C_FLAGS "-gdwarf"
       }
@@ -1061,11 +1056,6 @@ function Build-CMakeProject {
         TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
       }
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
-
-      if (-not (Test-CMakeAtLeast -Major 3 -Minor 26 -Patch 3) -and $Platform -eq "Windows") {
-        # Workaround for https://github.com/ninja-build/ninja/issues/2280
-        TryAdd-KeyValue $Defines CMAKE_CL_SHOWINCLUDES_PREFIX "Note: including file: "
-      }
 
       if ($DebugInfo -and $CDebugFormat -eq "dwarf") {
         Append-FlagsDefine $Defines CMAKE_CXX_FLAGS "-gdwarf"

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -996,12 +996,8 @@ function Build-CMakeProject {
     }
 
     if ($EnableCaching) {
-      if ($UseMSVCCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("C")) {
-        TryAdd-KeyValue $Defines CMAKE_C_COMPILER_LAUNCHER sccache
-      }
-      if ($UseMSVCCompilers.Contains("CXX") -Or $UsePinnedCompilers.Contains("CXX")) {
-        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
-      }
+      TryAdd-KeyValue $Defines CMAKE_C_COMPILER_LAUNCHER sccache
+      TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
     }
 
     if ($UseMSVCCompilers.Contains("C")) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -995,18 +995,21 @@ function Build-CMakeProject {
       }
     }
 
-    if ($UseMSVCCompilers.Contains("C")) {
-      TryAdd-KeyValue $Defines CMAKE_C_COMPILER cl
-      if ($EnableCaching) {
+    if ($EnableCaching) {
+      if ($UseMSVCCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("C")) {
         TryAdd-KeyValue $Defines CMAKE_C_COMPILER_LAUNCHER sccache
       }
+      if ($UseMSVCCompilers.Contains("CXX") -Or $UsePinnedCompilers.Contains("CXX")) {
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
+      }
+    }
+
+    if ($UseMSVCCompilers.Contains("C")) {
+      TryAdd-KeyValue $Defines CMAKE_C_COMPILER cl
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
     if ($UseMSVCCompilers.Contains("CXX")) {
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER cl
-      if ($EnableCaching) {
-        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
-      }
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
     if ($UsePinnedCompilers.Contains("ASM") -Or $UseBuiltCompilers.Contains("ASM")) {


### PR DESCRIPTION
We need sccache 0.7.4 (Nov. 2023) or newer for clang support: https://github.com/mozilla/sccache/pull/1983