### PR TITLE
[Observation] Do not create initAccessor if an initializer exists

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -303,13 +303,19 @@ public struct ObservationTrackedMacro: AccessorMacro {
       return []
     }
 
-    let initAccessor: AccessorDeclSyntax =
+    var accessors: [AccessorDeclSyntax] = []
+
+    if property.initializer == nil || !property.willSetAccessors.isEmpty || !property.didSetAccessors.isEmpty {
+      let initAccessor: AccessorDeclSyntax =
       """
       @storageRestrictions(initializes: _\(identifier))
       init(initialValue) {
       _\(identifier) = initialValue
       }
       """
+
+      accessors.append(initAccessor)
+    }
 
     let getAccessor: AccessorDeclSyntax =
       """
@@ -337,8 +343,10 @@ public struct ObservationTrackedMacro: AccessorMacro {
       yield &_\(identifier)
       }
       """
+    
+    accessors.append(contentsOf: [getAccessor, setAccessor, modifyAccessor])
 
-    return [initAccessor, getAccessor, setAccessor, modifyAccessor]
+    return accessors
   }
 }
 


### PR DESCRIPTION
The ObservationTracked macro (generated by the Observable macro) creates an init accessor by default. For example:

```swift
@Observable
class FooObject {
    var name = "Hello"
}
```

Generates the following accessors:

```swift
{
    @storageRestrictions(initializes: _name)
    init(initialValue) {
        _name = initialValue
    }
    get {
        access(keyPath: \.name)
        return _name
    }
    set {
        withMutation(keyPath: \.name) {
            _name = newValue
        }
    }
    _modify {
        access(keyPath: \.name)
        _$observationRegistrar.willSet(self, keyPath: \.name)
        defer {
            _$observationRegistrar.didSet(self, keyPath: \.name)
        }
        yield &_name
    }
}
```

When a property has a default value (initializer), the init accessor is unnecessary.
This change modifies the behavior to skip generating the init accessor if a property already has a default value.