### PR TITLE
[cxx-interop] Import rvalue references as consuming parameters

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1445,6 +1445,8 @@ public:
     swift::Type swiftTy;
     /// If the parameter is or not inout.
     bool isInOut;
+    /// If the parameter should be imported as consuming.
+    bool isConsuming;
     /// If the parameter is implicitly unwrapped or not.
     bool isParamTypeImplicitlyUnwrapped;
   };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3347,6 +3347,9 @@ void MoveOnlyAddressCheckerPImpl::rewriteUses(
     bool isFinalConsume = consumes.claimConsume(destroyPair.first, bits);
 
     // Remove destroys that are not the final consuming use.
+    // TODO: for C++ types we do not want to remove destroys as the caller is
+    //       still responsible for invoking the dtor for the moved-from object.
+    //       See GH Issue #77894.
     if (!isFinalConsume) {
       destroyPair.first->eraseFromParent();
       continue;

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -21,6 +21,7 @@
 // CHECK-NEXT: }
 
 // CHECK: struct UsingBaseConstructorWithParam {
+// CHECK-NEXT:   init(consuming _: consuming IntBox)
 // CHECK-NEXT:   init(_: IntBox)
 // CHECK-NEXT:   init(_: UInt32)
 // CHECK-NEXT:   init(_: Int32)
@@ -29,6 +30,7 @@
 
 // CHECK: struct UsingBaseConstructorEmpty {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   init(consuming _: consuming Empty)
 // CHECK-NEXT:   init(_: Empty)
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -34,13 +34,13 @@ writeOnlyIntArray[2] = 654
 let writeOnlyValue = writeOnlyIntArray[2]
 
 var readOnlyRvalueParam = ReadOnlyRvalueParam()
-let readOnlyRvalueVal = readOnlyRvalueParam[1] // expected-error {{value of type 'ReadOnlyRvalueParam' has no subscripts}}
+let readOnlyRvalueVal = readOnlyRvalueParam[consuming: 1]
 
 var readWriteRvalueParam = ReadWriteRvalueParam()
-let readWriteRvalueVal = readWriteRvalueParam[1] // expected-error {{value of type 'ReadWriteRvalueParam' has no subscripts}}
+let readWriteRvalueVal = readWriteRvalueParam[consuming: 1]
 
 var readWriteRvalueGetterParam = ReadWriteRvalueGetterParam()
-let readWriteRvalueGetterVal = readWriteRvalueGetterParam[1]
+let readWriteRvalueGetterVal = readWriteRvalueGetterParam[consuming: 1]
 
 var diffTypesArray = DifferentTypesArray()
 let diffTypesResultInt: Int32 = diffTypesArray[0]

--- a/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
+++ b/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
@@ -22,9 +22,7 @@ import Test
 
 public func test() {
   var x: CInt = 2
-  acceptRValueRef(x) // expected-error {{cannot find 'acceptRValueRef' in scope}}
-  // CHECK: note: function 'acceptRValueRef' unavailable (cannot import)
-  // CHECK: note: C++ functions with rvalue reference parameters are unavailable in Swift
+  acceptRValueRef(consuming: x)
 
   notStdMove(x) // expected-error {{cannot find 'notStdMove' in scope}}
   // CHECK: note: function 'notStdMove' unavailable (cannot import)


### PR DESCRIPTION
Unfortunately, importing them as is results in ambiguous call sites. E.g., std::vector::push_back has overloads for lvalue reference and rvalue reference and we have no way to distinguish them at the call site in Swift. To overcome this issue, functions with rvalue reference parameters are imported with 'consuming:' argument labels.

Note that, in general, move only types and consuming is not properly supported in Swift yet. We do not invoke the dtor for the moved-from objects. This is a preexisting problem that can be observed with move only types before this PR, so the fix will be done in a separate PR. Fortunately, for most types, the moved-from objects do not require additional cleanups.

rdar://125816354
