### PR TITLE
Swift on OpenBSD supports arm64.

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -429,14 +429,14 @@ macro(configure_sdk_unix name architectures)
 
         set(SWIFT_SDK_FREEBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-freebsd${freebsd_system_version}")
       elseif("${prefix}" STREQUAL "OPENBSD")
-        if(NOT arch STREQUAL "amd64")
+        if(NOT arch STREQUAL "x86_64" AND NOT arch STREQUAL "aarch64")
           message(FATAL_ERROR "unsupported arch for OpenBSD: ${arch}")
         endif()
 
         set(openbsd_system_version ${CMAKE_SYSTEM_VERSION})
         message(STATUS "OpenBSD Version: ${openbsd_system_version}")
 
-        set(SWIFT_SDK_OPENBSD_ARCH_amd64_TRIPLE "amd64-unknown-openbsd${openbsd_system_version}")
+        set(SWIFT_SDK_OPENBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-openbsd${openbsd_system_version}")
 
         if(CMAKE_SYSROOT)
           set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -529,6 +529,7 @@ function(_add_target_variant_link_flags)
     list(APPEND link_libraries "pthread")
   elseif("${LFLAGS_SDK}" STREQUAL "OPENBSD")
     list(APPEND link_libraries "pthread")
+    list(APPEND result "-Wl,-Bsymbolic")
   elseif("${LFLAGS_SDK}" STREQUAL "CYGWIN")
     # No extra libraries required.
   elseif("${LFLAGS_SDK}" STREQUAL "WINDOWS")

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -108,6 +108,8 @@ public typealias CLongDouble = Double
 #elseif os(OpenBSD)
 #if arch(x86_64)
 public typealias CLongDouble = Float80
+#elseif arch(arm64)
+public typealias CLongDouble = Double
 #else
 #error("CLongDouble needs to be defined for this OpenBSD architecture")
 #endif

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -459,7 +459,8 @@ function verify_host_is_supported() {
     case ${host} in
       freebsd-arm64             \
       | freebsd-x86_64          \
-      | openbsd-amd64           \
+      | openbsd-x86_64          \
+      | openbsd-aarch64         \
       | cygwin-x86_64           \
       | haiku-x86_64            \
       | linux-x86_64            \

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -296,7 +296,7 @@ class StdlibDeploymentTarget(object):
         'x86_64',
         'aarch64'])
 
-    OpenBSD = OpenBSDPlatform("openbsd", archs=["amd64"])
+    OpenBSD = OpenBSDPlatform("openbsd", archs=["x86_64", "aarch64"])
 
     Cygwin = Platform("cygwin", archs=["x86_64"])
 
@@ -403,7 +403,9 @@ class StdlibDeploymentTarget(object):
 
         elif system == 'OpenBSD':
             if machine == 'amd64':
-                return StdlibDeploymentTarget.OpenBSD.amd64
+                return StdlibDeploymentTarget.OpenBSD.x86_64
+            elif machine == 'arm64':
+                return StdlibDeploymentTarget.OpenBSD.aarch64
 
         elif system == 'CYGWIN_NT-10.0':
             if machine == 'x86_64':


### PR DESCRIPTION
However, to do this, we end up changing how amd64 is supported too. Previously, I had tried to keep some meaningful separation between platform spelling and LLVM spelling, but this is becoming more difficult
to meaningfully maintain.

See the commit comment for more specifics, but it suffices to say that it's far simpler to give up and rename to LLVM spellings right at the beginning. This does mean that this commit is less constrained to just adding the necessary parts to enable arm64, but it should mean less headaches overall from differing architecture spellings.

Other than that, the only real change of note is that `-Wl,-Bsymbolic` seems necessary to squash some relocation errors; I have not verified whether this is only necessary on arm64.
