### PR TITLE
[android] Use emulated thread-local storage for API 28 and earlier

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -143,6 +143,11 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // Set UseInitArray appropriately.
   TargetOpts.UseInitArray = Clang->getCodeGenOpts().UseInitArray;
 
+  // Set emulated TLS in inlined C/C++ functions based on what clang is doing,
+  // ie either setting the default based on the OS or -Xcc -f{no-,}emulated-tls
+  // command-line flags.
+  TargetOpts.EmulatedTLS = Clang->getCodeGenOpts().EmulatedTLS;
+
   // WebAssembly doesn't support atomics yet, see
   // https://github.com/apple/swift/issues/54533 for more details.
   if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm())

--- a/test/IRGen/Inputs/tls.h
+++ b/test/IRGen/Inputs/tls.h
@@ -1,0 +1,7 @@
+#include "shims/SwiftStdint.h"
+
+static inline __swift_uint32_t _swift_stdlib_gettid() {
+  static __thread __swift_uint32_t tid = 0;
+
+  return tid;
+}

--- a/test/IRGen/emulated-tls.swift
+++ b/test/IRGen/emulated-tls.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -Xcc -femulated-tls %s -S -import-objc-header %S/Inputs/tls.h | %FileCheck %s --check-prefix=EMUTLS --check-prefix=EMUTLS-%target-os
+// RUN: %target-swift-frontend -Xcc -fno-emulated-tls %s -S -import-objc-header %S/Inputs/tls.h | %FileCheck %s --check-prefix=NOEMUTLS
+
+_swift_stdlib_gettid()
+
+// EMUTLS: __emutls_v._swift_stdlib_gettid.tid
+// EMUTLS-linux-android: __emutls_get_address
+// EMUTLS-linux-gnu: __emutls_get_address
+// EMUTLS-macosx: __emutls_get_address
+// EMUTLS-openbsd: __emutls_get_address
+// EMUTLS-windows-msvc: __emutls_get_address
+// EMUTLS-wasi-NOT: __emutls_get_address
+
+// NOEMUTLS-NOT: __emutls_v._swift_stdlib_gettid.tid
+// NOEMUTLS-NOT: __emutls_get_address


### PR DESCRIPTION
[Android before API 29](https://android.googlesource.com/platform/bionic/+/HEAD/android-changes-for-ndk-developers.md#elf-tls-available-for-api-level-29) and [a few other platforms don't support native TLS](https://github.com/llvm/llvm-project/blob/7672216ed7f480c8d461a2d046a74453307f6298/llvm/include/llvm/TargetParser/Triple.h#L1094), so fall back to LLVM's emulated TLS there, [just like clang does](https://github.com/llvm/llvm-project/blob/93caee17add0c7bc6770365b1d3cae93f258d866/clang/lib/Driver/ToolChains/Clang.cpp#L6745). Also, make sure `-Xcc -f{no-,}emulated-tls` flags passed in are applied to control what the Swift compiler does.

Swift 6 [added a thread-local variable to the stdlib for all linux-based platforms](https://github.com/swiftlang/swift/pull/71383/files#diff-4a4beab0106e7043768f49f30baf61eb45116edabc020f16d39259ec2f9b6c6aR26) for the first time, ie outside [linux threading](https://github.com/swiftlang/swift/blob/ee5efff5b17fddfb0e3535acf71ab3d2b80393e9/include/swift/Threading/Impl/Linux/ulock.h#L49) (Android uses pthreads instead), which then generated code in Foundation with native TLS even for Android API 24, breaking my Android CI that runs cross-compiled tests in the Android emulator at API 24.

I assumed the LLVM codegen backend automatically handled this, but it turns out it has to be explicitly enabled by the clang frontend, so I'm doing the same with the Swift frontend now. I just ran the compiler validation suite and toolchain tests on the Nov. 20 trunk snapshot built natively on Android 13 AArch64: this patch fixed running the Foundation tests and looks like it didn't cause any test regressions.

Considering Swift doesn't appear to have a way to choose native TLS for Swift variables, this pull appears to only really be useful for inline functions from C/C++ headers that are inserted into Swift's IR and codegened together.

@azoy, who added this TLS variable in the C/C++ header earlier this year, and @al45tair, let me know what you think.

@compnerd and @hyp, I don't know if you test your Android SDK on API 28 or earlier, let me know if you've seen this regression.

@3405691582, OpenBSD is listed as one of the platforms using emulated TLS in that second link, let us know if that's correct.