### PR TITLE
Refactor the remaining parts of replacing starts_with("_") with hasUnderscoredNaming()

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -553,7 +553,8 @@ unsigned TypeChecker::getCallEditDistance(DeclNameRef writtenName,
 
   // Don't typo-correct to a name with a leading underscore unless the typed
   // name also begins with an underscore.
-  if (correctedBase.starts_with("_") && !writtenBase.starts_with("_")) {
+  if (correctedName.getBaseIdentifier().hasUnderscoredNaming() &&
+      !writtenName.getBaseIdentifier().hasUnderscoredNaming()) {
     return UnreasonableCallEditDistance;
   }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -548,15 +548,15 @@ unsigned TypeChecker::getCallEditDistance(DeclNameRef writtenName,
     return 0;
   }
 
-  StringRef writtenBase = writtenName.getBaseName().userFacingName();
-  StringRef correctedBase = correctedName.getBaseName().userFacingName();
-
   // Don't typo-correct to a name with a leading underscore unless the typed
   // name also begins with an underscore.
   if (correctedName.getBaseIdentifier().hasUnderscoredNaming() &&
       !writtenName.getBaseIdentifier().hasUnderscoredNaming()) {
     return UnreasonableCallEditDistance;
   }
+
+  StringRef writtenBase = writtenName.getBaseName().userFacingName();
+  StringRef correctedBase = correctedName.getBaseName().userFacingName();
 
   unsigned distance = writtenBase.edit_distance(correctedBase, maxEditDistance);
 


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift/issues/56350

## Description
Regarding Issue https://github.com/swiftlang/swift/issues/56350, it seems that most of the work was addressed in PR https://github.com/swiftlang/swift/pull/72048. 
However, as mentioned in https://github.com/swiftlang/swift/issues/56350#issuecomment-2307508005, there are still parts that can be replaced with `hasUnderscoredNaming()`. 
This PR addresses those remaining parts.

I don't have permission to run the CI bot, so if necessary, I would appreciate it if you could invoke the CI bot.