### PR TITLE
[Observation] include ThreadingError.cpp in build

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   Observable.swift
   ObservationRegistrar.swift
   ObservationTracking.swift
+  ThreadingError.cpp
   ThreadLocal.cpp
   ThreadLocal.swift
 

--- a/stdlib/public/Observation/Sources/Observation/ThreadingError.cpp
+++ b/stdlib/public/Observation/Sources/Observation/ThreadingError.cpp
@@ -1,0 +1,26 @@
+//===--- ThreadingError.cpp - Error handling support code -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Threading/Errors.h"
+#include <cstdio>
+
+#include "Error.h"
+
+// Handle fatal errors from the threading library
+SWIFT_ATTRIBUTE_NORETURN
+SWIFT_FORMAT(1, 2)
+void swift::threading::fatal(const char *format, ...) {
+  va_list val;
+
+  va_start(val, format);
+  swift_Concurrency_fatalErrorv(0, format, val);
+}


### PR DESCRIPTION
On Linux at least, using observation can lead to an undefined reference to swift::threading::fatal(char const*, ...) at link time. That this is not an error on Darwin may be due to different symbol export or lazy binding policies.

Mirroring libswift_Concurrency, ensure that ThreadingError.cpp is present as a local symbol in libswiftObservation.

Resolves: #75670