### PR TITLE
Sema: Subscript called with opened existential cannot produce lvalue if result is type-erased

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1005,8 +1005,14 @@ namespace {
       auto *env = record.Archetype->getGenericEnvironment();
 
       if (resultTy->hasLocalArchetypeFromEnvironment(env)) {
-        Type erasedTy = typeEraseOpenedArchetypesFromEnvironment(
-            resultTy, env);
+        Type erasedTy = typeEraseOpenedArchetypesFromEnvironment(resultTy, env);
+        ASSERT(erasedTy.getPointer() != resultTy.getPointer());
+
+        // We currently cannot keep lvalueness if the object type changed.
+        if (auto *lvalueTy = dyn_cast<LValueType>(erasedTy.getPointer())) {
+          erasedTy = lvalueTy->getObjectType();
+        }
+
         auto range = result->getSourceRange();
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13270,9 +13270,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
     Type result2 = func2->getResult();
     if (result2->hasTypeVariable() && !openedExistentials.empty()) {
       for (const auto &opened : openedExistentials) {
-        result2 = typeEraseOpenedExistentialReference(
-            result2, opened.second->getExistentialType(), opened.first,
+        auto originalTy = result2;
+        if (auto *lvalueTy = dyn_cast<LValueType>(originalTy.getPointer())) {
+          originalTy = lvalueTy->getObjectType();
+        }
+
+        const auto erasedTy = typeEraseOpenedExistentialReference(
+            originalTy, opened.second->getExistentialType(), opened.first,
             TypePosition::Covariant);
+
+        if (originalTy.getPointer() != erasedTy.getPointer()) {
+          // We currently cannot keep lvalueness if the object type changed.
+          result2 = erasedTy;
+        }
       }
     }
 

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -800,20 +800,6 @@ static Type typeEraseExistentialSelfReferences(
               return parameterized->getBaseType();
           }
         }
-        /*
-        if (auto lvalue = dyn_cast<LValueType>(t)) {
-          auto objTy = lvalue->getObjectType();
-          auto erasedTy =
-            typeEraseExistentialSelfReferences(
-              objTy, currPos,
-              containsFn, predicateFn, eraseFn);
-
-          if (erasedTy.getPointer() == objTy.getPointer())
-            return Type(lvalue);
-
-          return erasedTy;
-        }
-        */
 
         if (!predicateFn(t)) {
           // Recurse.

--- a/test/Sema/open_existential_lvalue.swift
+++ b/test/Sema/open_existential_lvalue.swift
@@ -1,24 +1,22 @@
 // RUN: %target-typecheck-verify-swift
 
-// rdar://121214563
 // https://github.com/swiftlang/swift/issues/60619
-// REQUIRES: rdar121214563
-
-protocol Q {}
-
-func takesAny(x: any Q) {}
-func takesRValue(x: any Q) {}
-func takesInOut(x: inout any Q) {}
-
-struct S {
-  subscript<T: Q>(_ ct: T.Type) -> T {
-    get { fatalError() }
-    set { fatalError() }
+do {
+  protocol P {
+    associatedtype A
   }
-}
+  struct S {
+    subscript<T: P>(_: T) -> T {
+      get {} set {}
+    }
+  }
 
-func f(s: inout S, t: any Q.Type) -> (any Q) {
-  takesAny(x: s[t])
-  takesRValue(x: s[t])
-  takesInOut(x: &s[t]) // expected-error {{cannot pass immutable value as inout argument: 's' is immutable}}
+  func takesInOut(_: inout any P) {}
+
+  var s: S
+  let p: any P
+
+  let _ = s[p]
+  s[p] = p // expected-error {{cannot assign through subscript: 's' is immutable}}
+  takesInOut(&s[p]) // expected-error {{cannot pass immutable value as inout argument: 's' is immutable}}
 }

--- a/test/decl/protocol/existential_member_access/storage.swift
+++ b/test/decl/protocol/existential_member_access/storage.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
 
+// rdar://121214563
 // https://github.com/apple/swift/issues/62219
 
 // nonmutating get mutating set


### PR DESCRIPTION
Fixes #60619, rdar://125520325.