### PR TITLE
[cxx-interop] Remove redundant condition for invoking move ctor

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -568,10 +568,7 @@ namespace {
         return nullptr;
       for (auto ctor : cxxRecordDecl->ctors()) {
         if (ctor->isCopyConstructor() &&
-            ctor->getAccess() == clang::AS_public &&
-            // rdar://106964356
-            // ctor->doesThisDeclarationHaveABody() &&
-            !ctor->isDeleted())
+            ctor->getAccess() == clang::AS_public && !ctor->isDeleted())
           return ctor;
       }
       return nullptr;
@@ -583,8 +580,7 @@ namespace {
         return nullptr;
       for (auto ctor : cxxRecordDecl->ctors()) {
         if (ctor->isMoveConstructor() &&
-            ctor->getAccess() == clang::AS_public &&
-            ctor->doesThisDeclarationHaveABody() && !ctor->isDeleted())
+            ctor->getAccess() == clang::AS_public && !ctor->isDeleted())
           return ctor;
       }
       return nullptr;

--- a/test/Interop/CxxToSwiftToCxx/consuming-cxx-struct-parameter-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/consuming-cxx-struct-parameter-back-to-cxx-execution.cpp
@@ -151,12 +151,12 @@ int main() {
 // CHECK-NEXT: create NonTrivialTemplate
 // CHECK-NEXT: call
 // CHECK-NEXT: copy NonTrivialTemplate
-// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: DoneCall
 // CHECK-NEXT: copy NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
-// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate


### PR DESCRIPTION
There is no reason to require a body for move/copy ctors to use them.