### PR TITLE
[AST] Split out "is compound" bit on FunctionRefKind 

### DIFF
--- a/include/swift/AST/FunctionRefInfo.h
+++ b/include/swift/AST/FunctionRefInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,43 +10,150 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the FunctionRefInfo enum, which is used to describe how
+// This file defines the FunctionRefInfo class, which describes how a function
+// is referenced in an expression.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_AST_FUNCTION_REF_INFO_H
 #define SWIFT_AST_FUNCTION_REF_INFO_H
 
-#include "llvm/ADT/StringRef.h"
+#include "swift/Basic/Debug.h"
+#include "swift/Basic/LLVM.h"
 
 namespace swift {
 
-/// Describes how a function is referenced within an expression node,
-/// which dictates whether argument labels are part of the resulting
-/// function type or not.
+class DeclNameLoc;
+class DeclNameRef;
+
+/// Describes how a function is referenced within an expression node.
+///
+/// This dictates things like:
+/// - Whether argument labels are part of the resulting function type or not.
+/// - Whether the result can produce an implicitly unwrapped optional.
+/// - Whether the function type needs adjustment for concurrency.
 ///
 /// How a function is referenced comes down to how it was spelled in
 /// the source code, e.g., was it called in the source code and was it
 /// spelled as a compound name.
-enum class FunctionRefInfo : unsigned {
-  /// The function was referenced using a bare function name (e.g.,
-  /// 'f') and not directly called.
-  Unapplied,
-  /// The function was referenced using a bare function name and was
-  /// directly applied once, e.g., "f(a: 1, b: 2)".
-  SingleApply,
-  /// The function was referenced using a bare function name and was
-  /// directly applied two or more times, e.g., "g(x)(y)".
-  DoubleApply,
-  /// The function was referenced using a compound function name,
+class FunctionRefInfo final {
+public:
+  /// Whether the function reference is part of a call, and if so how many
+  /// applications were used.
+  enum class ApplyLevel : uint8_t {
+    /// The function is not directly called.
+    Unapplied,
+    /// The function is directly applied once, e.g., "f(a: 1, b: 2)".
+    SingleApply,
+    /// The function is directly applied two or more times, e.g., "g(x)(y)".
+    DoubleApply,
+  };
+
+private:
+  /// The application level of the function reference.
+  ApplyLevel ApplyLevelKind;
+
+  /// Whether the function was referenced using a compound function name,
   /// e.g., "f(a:b:)".
-  Compound,
+  bool IsCompoundName;
+
+  FunctionRefInfo(ApplyLevel applyLevel, bool isCompoundName)
+      : ApplyLevelKind(applyLevel), IsCompoundName(isCompoundName) {}
+
+public:
+  /// An unapplied function reference for a given DeclNameLoc.
+  static FunctionRefInfo unapplied(DeclNameLoc nameLoc);
+
+  /// An unapplied function reference for a given DeclNameRef.
+  static FunctionRefInfo unapplied(DeclNameRef nameRef);
+
+  /// An unapplied function reference using a base name, e.g `let x = fn`.
+  static FunctionRefInfo unappliedBaseName() {
+    return FunctionRefInfo(ApplyLevel::Unapplied, /*isCompoundName*/ false);
+  }
+
+  /// An unapplied function reference using a compound name,
+  /// e.g `let x = fn(x:)`.
+  static FunctionRefInfo unappliedCompoundName() {
+    return FunctionRefInfo(ApplyLevel::Unapplied, /*isCompoundName*/ true);
+  }
+
+  /// A single application using a base name, e.g `fn(x: 0)`.
+  static FunctionRefInfo singleBaseNameApply() {
+    return FunctionRefInfo(ApplyLevel::SingleApply, /*isCompoundName*/ false);
+  }
+
+  /// A single application using a compound name, e.g `fn(x:)(0)`.
+  static FunctionRefInfo singleCompoundNameApply() {
+    return FunctionRefInfo(ApplyLevel::SingleApply, /*isCompoundName*/ true);
+  }
+
+  /// A double application using a base name, e.g `S.fn(S())(x: 0)`.
+  static FunctionRefInfo doubleBaseNameApply() {
+    return FunctionRefInfo(ApplyLevel::DoubleApply, /*isCompoundName*/ false);
+  }
+
+  /// A double application using a compound name, e.g `S.fn(x:)(S())(0)`.
+  static FunctionRefInfo doubleCompoundNameApply() {
+    return FunctionRefInfo(ApplyLevel::DoubleApply, /*isCompoundName*/ true);
+  }
+
+  /// Reconstructs a FunctionRefInfo from its \c getOpaqueValue().
+  static FunctionRefInfo fromOpaque(uint8_t bits) {
+    return FunctionRefInfo(static_cast<ApplyLevel>(bits >> 1), bits & 0x1);
+  }
+
+  /// Retrieves an opaque value that can be stored in e.g a bitfield.
+  uint8_t getOpaqueValue() const {
+    return (static_cast<uint8_t>(ApplyLevelKind) << 1) | !!IsCompoundName;
+  }
+
+  /// Whether the function reference is part of a call, and if so how many
+  /// applications were used.
+  ApplyLevel getApplyLevel() const { return ApplyLevelKind; }
+
+  /// Whether the function was referenced using a compound name,
+  /// e.g `fn(x:)(0)`.
+  bool isCompoundName() const { return IsCompoundName; }
+
+  /// Whether the function reference is not part of a call.
+  bool isUnapplied() const {
+    return getApplyLevel() == ApplyLevel::Unapplied;
+  }
+
+  /// Whether the function reference is both not part of a call, and is
+  /// not using a compound name.
+  bool isUnappliedBaseName() const {
+    return getApplyLevel() == ApplyLevel::Unapplied && !isCompoundName();
+  }
+
+  /// Whether the function reference has been applied a single time.
+  bool isSingleApply() const {
+    return getApplyLevel() == ApplyLevel::SingleApply;
+  }
+
+  /// Whether the function reference has been applied twice.
+  bool isDoubleApply() const {
+    return getApplyLevel() == ApplyLevel::DoubleApply;
+  }
+
+  /// Returns the FunctionRefInfo with an additional level of function
+  /// application added.
+  FunctionRefInfo addingApplicationLevel() const;
+
+  friend bool operator==(const FunctionRefInfo &lhs,
+                         const FunctionRefInfo &rhs) {
+    return lhs.getApplyLevel() == rhs.getApplyLevel() &&
+           lhs.isCompoundName() == rhs.isCompoundName();
+  }
+  friend bool operator!=(const FunctionRefInfo &lhs,
+                         const FunctionRefInfo &rhs) {
+    return !(lhs == rhs);
+  }
+
+  void dump(raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP;
 };
-
-/// Produce a string describing a function reference kind, for
-/// debugging purposes.
-llvm::StringRef getFunctionRefInfoStr(FunctionRefInfo refKind);
-
 }
 
 #endif // SWIFT_AST_FUNCTION_REF_INFO_H

--- a/include/swift/AST/FunctionRefInfo.h
+++ b/include/swift/AST/FunctionRefInfo.h
@@ -1,4 +1,4 @@
-//===--- FunctionRefKind.h - Function reference kind ------------*- C++ -*-===//
+//===--- FunctionRefInfo.h - Function reference info ------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the FunctionRefKind enum, which is used to describe how
+// This file defines the FunctionRefInfo enum, which is used to describe how
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_AST_FUNCTION_REF_KIND_H
-#define SWIFT_AST_FUNCTION_REF_KIND_H
+#ifndef SWIFT_AST_FUNCTION_REF_INFO_H
+#define SWIFT_AST_FUNCTION_REF_INFO_H
 
 #include "llvm/ADT/StringRef.h"
 
@@ -28,7 +28,7 @@ namespace swift {
 /// How a function is referenced comes down to how it was spelled in
 /// the source code, e.g., was it called in the source code and was it
 /// spelled as a compound name.
-enum class FunctionRefKind : unsigned {
+enum class FunctionRefInfo : unsigned {
   /// The function was referenced using a bare function name (e.g.,
   /// 'f') and not directly called.
   Unapplied,
@@ -45,8 +45,8 @@ enum class FunctionRefKind : unsigned {
 
 /// Produce a string describing a function reference kind, for
 /// debugging purposes.
-llvm::StringRef getFunctionRefKindStr(FunctionRefKind refKind);
+llvm::StringRef getFunctionRefInfoStr(FunctionRefInfo refKind);
 
 }
 
-#endif // SWIFT_AST_FUNCTION_REF_KIND_H
+#endif // SWIFT_AST_FUNCTION_REF_INFO_H

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -3244,7 +3244,7 @@ public:
 
   static SpecifyBaseTypeForOptionalUnresolvedMember *
   attempt(ConstraintSystem &cs, ConstraintKind kind, Type baseTy,
-          DeclNameRef memberName, FunctionRefKind functionRefKind,
+          DeclNameRef memberName, FunctionRefInfo functionRefInfo,
           MemberLookupResult result, ConstraintLocator *locator);
 
   static bool classof(const ConstraintFix *fix) {

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -19,7 +19,7 @@
 #define SWIFT_SEMA_CONSTRAINT_H
 
 #include "swift/AST/ASTNode.h"
-#include "swift/AST/FunctionRefKind.h"
+#include "swift/AST/FunctionRefInfo.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeLoc.h"
@@ -384,7 +384,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
   unsigned NumTypeVariables : 11;
 
   /// The kind of function reference, for member references.
-  unsigned TheFunctionRefKind : 2;
+  unsigned TheFunctionRefInfo : 2;
 
   /// The trailing closure matching for an applicable function constraint,
   /// if any. 0 = None, 1 = Forward, 2 = Backward.
@@ -471,14 +471,14 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
   /// Construct a new member constraint.
   Constraint(ConstraintKind kind, Type first, Type second, DeclNameRef member,
-             DeclContext *useDC, FunctionRefKind functionRefKind,
+             DeclContext *useDC, FunctionRefInfo functionRefInfo,
              ConstraintLocator *locator,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
   /// Construct a new value witness constraint.
   Constraint(ConstraintKind kind, Type first, Type second,
              ValueDecl *requirement, DeclContext *useDC,
-             FunctionRefKind functionRefKind, ConstraintLocator *locator,
+             FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
   /// Construct a new overload-binding constraint, which might have a fix.
@@ -534,21 +534,21 @@ public:
   /// alternatives.
   static Constraint *createMemberOrOuterDisjunction(
       ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-      DeclNameRef member, DeclContext *useDC, FunctionRefKind functionRefKind,
+      DeclNameRef member, DeclContext *useDC, FunctionRefInfo functionRefInfo,
       ArrayRef<OverloadChoice> outerAlternatives, ConstraintLocator *locator);
 
   /// Create a new member constraint.
   static Constraint *createMember(ConstraintSystem &cs, ConstraintKind kind,
                                   Type first, Type second, DeclNameRef member,
                                   DeclContext *useDC,
-                                  FunctionRefKind functionRefKind,
+                                  FunctionRefInfo functionRefInfo,
                                   ConstraintLocator *locator);
 
   /// Create a new value witness constraint.
   static Constraint *createValueWitness(
       ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
       ValueDecl *requirement, DeclContext *useDC,
-      FunctionRefKind functionRefKind, ConstraintLocator *locator);
+      FunctionRefInfo functionRefInfo, ConstraintLocator *locator);
 
   /// Create an overload-binding constraint, possibly with a fix.
   static Constraint *createBindOverload(ConstraintSystem &cs, Type type, 
@@ -798,14 +798,14 @@ public:
   }
 
   /// Determine the kind of function reference we have for a member reference.
-  FunctionRefKind getFunctionRefKind() const {
+  FunctionRefInfo getFunctionRefInfo() const {
     if (Kind == ConstraintKind::ValueMember ||
         Kind == ConstraintKind::UnresolvedValueMember ||
         Kind == ConstraintKind::ValueWitness)
-      return static_cast<FunctionRefKind>(TheFunctionRefKind);
+      return static_cast<FunctionRefInfo>(TheFunctionRefInfo);
 
     // Conservative answer: drop all of the labels.
-    return FunctionRefKind::Compound;
+    return FunctionRefInfo::Compound;
   }
 
   /// Retrieve the set of constraints in a disjunction.

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -384,7 +384,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
   unsigned NumTypeVariables : 11;
 
   /// The kind of function reference, for member references.
-  unsigned TheFunctionRefInfo : 2;
+  unsigned TheFunctionRefInfo : 3;
 
   /// The trailing closure matching for an applicable function constraint,
   /// if any. 0 = None, 1 = Forward, 2 = Backward.
@@ -799,13 +799,11 @@ public:
 
   /// Determine the kind of function reference we have for a member reference.
   FunctionRefInfo getFunctionRefInfo() const {
-    if (Kind == ConstraintKind::ValueMember ||
-        Kind == ConstraintKind::UnresolvedValueMember ||
-        Kind == ConstraintKind::ValueWitness)
-      return static_cast<FunctionRefInfo>(TheFunctionRefInfo);
+    ASSERT(Kind == ConstraintKind::ValueMember ||
+           Kind == ConstraintKind::UnresolvedValueMember ||
+           Kind == ConstraintKind::ValueWitness);
 
-    // Conservative answer: drop all of the labels.
-    return FunctionRefInfo::Compound;
+    return FunctionRefInfo::fromOpaque(TheFunctionRefInfo);
   }
 
   /// Retrieve the set of constraints in a disjunction.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3717,7 +3717,7 @@ public:
   /// Add a value member constraint to the constraint system.
   void addValueMemberConstraint(Type baseTy, DeclNameRef name, Type memberTy,
                                 DeclContext *useDC,
-                                FunctionRefKind functionRefKind,
+                                FunctionRefInfo functionRefInfo,
                                 ArrayRef<OverloadChoice> outerAlternatives,
                                 ConstraintLocatorBuilder locator) {
     assert(baseTy);
@@ -3726,7 +3726,7 @@ public:
     assert(useDC);
     switch (simplifyMemberConstraint(
         ConstraintKind::ValueMember, baseTy, name, memberTy, useDC,
-        functionRefKind, outerAlternatives, TMF_GenerateConstraints, locator)) {
+        functionRefInfo, outerAlternatives, TMF_GenerateConstraints, locator)) {
     case SolutionKind::Unsolved:
       llvm_unreachable("Unsolved result when generating constraints!");
 
@@ -3737,7 +3737,7 @@ public:
       if (shouldRecordFailedConstraint()) {
         recordFailedConstraint(Constraint::createMemberOrOuterDisjunction(
             *this, ConstraintKind::ValueMember, baseTy, memberTy, name, useDC,
-            functionRefKind, outerAlternatives, getConstraintLocator(locator)));
+            functionRefInfo, outerAlternatives, getConstraintLocator(locator)));
       }
       break;
     }
@@ -3747,7 +3747,7 @@ public:
   /// to the constraint system.
   void addUnresolvedValueMemberConstraint(Type baseTy, DeclNameRef name,
                                           Type memberTy, DeclContext *useDC,
-                                          FunctionRefKind functionRefKind,
+                                          FunctionRefInfo functionRefInfo,
                                           ConstraintLocatorBuilder locator) {
     assert(baseTy);
     assert(memberTy);
@@ -3755,7 +3755,7 @@ public:
     assert(useDC);
     switch (simplifyMemberConstraint(ConstraintKind::UnresolvedValueMember,
                                      baseTy, name, memberTy,
-                                     useDC, functionRefKind,
+                                     useDC, functionRefInfo,
                                      /*outerAlternatives=*/{},
                                      TMF_GenerateConstraints, locator)) {
     case SolutionKind::Unsolved:
@@ -3769,7 +3769,7 @@ public:
         recordFailedConstraint(
           Constraint::createMember(*this, ConstraintKind::UnresolvedValueMember,
                                    baseTy, memberTy, name,
-                                   useDC, functionRefKind,
+                                   useDC, functionRefInfo,
                                    getConstraintLocator(locator)));
       }
       break;
@@ -3779,14 +3779,14 @@ public:
   /// Add a value witness constraint to the constraint system.
   void addValueWitnessConstraint(
       Type baseTy, ValueDecl *requirement, Type memberTy, DeclContext *useDC,
-      FunctionRefKind functionRefKind, ConstraintLocatorBuilder locator) {
+      FunctionRefInfo functionRefInfo, ConstraintLocatorBuilder locator) {
     assert(baseTy);
     assert(memberTy);
     assert(requirement);
     assert(useDC);
     switch (simplifyValueWitnessConstraint(
         ConstraintKind::ValueWitness, baseTy, requirement, memberTy, useDC,
-        functionRefKind, TMF_GenerateConstraints, locator)) {
+        functionRefInfo, TMF_GenerateConstraints, locator)) {
     case SolutionKind::Unsolved:
       llvm_unreachable("Unsolved result when generating constraints!");
 
@@ -4333,7 +4333,7 @@ public:
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfReference(
                           ValueDecl *decl,
-                          FunctionRefKind functionRefKind,
+                          FunctionRefInfo functionRefInfo,
                           ConstraintLocatorBuilder locator,
                           DeclContext *useDC);
 
@@ -4375,7 +4375,7 @@ public:
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfMemberReference(
       Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
-      FunctionRefKind functionRefKind, ConstraintLocator *locator,
+      FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
       SmallVectorImpl<OpenedType> *replacements = nullptr);
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
@@ -4829,7 +4829,7 @@ public:
   /// referenced.
   MemberLookupResult performMemberLookup(ConstraintKind constraintKind,
                                          DeclNameRef memberName, Type baseTy,
-                                         FunctionRefKind functionRefKind,
+                                         FunctionRefInfo functionRefInfo,
                                          ConstraintLocator *memberLocator,
                                          bool includeInaccessibleMembers);
 
@@ -4903,7 +4903,7 @@ private:
                                               FunctionType *fnType,
                                               TypeMatchOptions flags,
                                               DeclContext *DC,
-                                              FunctionRefKind functionRefKind,
+                                              FunctionRefInfo functionRefInfo,
                                               ConstraintLocator *locator);
 
   /// Attempt to simplify the given superclass constraint.
@@ -4959,14 +4959,14 @@ private:
   /// Attempt to simplify the given member constraint.
   SolutionKind simplifyMemberConstraint(
       ConstraintKind kind, Type baseType, DeclNameRef member, Type memberType,
-      DeclContext *useDC, FunctionRefKind functionRefKind,
+      DeclContext *useDC, FunctionRefInfo functionRefInfo,
       ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the given value witness constraint.
   SolutionKind simplifyValueWitnessConstraint(
       ConstraintKind kind, Type baseType, ValueDecl *member, Type memberType,
-      DeclContext *useDC, FunctionRefKind functionRefKind,
+      DeclContext *useDC, FunctionRefInfo functionRefInfo,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the optional object constraint.
@@ -6434,7 +6434,7 @@ bool isResultBuilderMethodReference(ASTContext &, UnresolvedDotExpr *);
 
 /// Determine the number of applications applied to the given overload.
 unsigned getNumApplications(ValueDecl *decl, bool hasAppliedSelf,
-                            FunctionRefKind functionRefKind,
+                            FunctionRefInfo functionRefInfo,
                             ConstraintLocatorBuilder locator);
 
 } // end namespace constraints

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -407,8 +407,8 @@ static StringRef getDumpString(MagicIdentifierLiteralExpr::Kind kind) {
 static StringRef getDumpString(ObjectLiteralExpr::LiteralKind kind) {
   return ObjectLiteralExpr::getLiteralKindPlainName(kind);
 }
-static StringRef getDumpString(FunctionRefKind kind) {
-  return getFunctionRefKindStr(kind);
+static StringRef getDumpString(FunctionRefInfo kind) {
+  return getFunctionRefInfoStr(kind);
 }
 static StringRef getDumpString(ParamSpecifier specifier) {
   return ParamDecl::getSpecifierSpelling(specifier);
@@ -2306,7 +2306,7 @@ public:
     printDeclRefField(E->getDeclRef(), "decl");
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)
       printFlag(getDumpString(E->getAccessSemantics()), AccessLevelColor);
-    printField(E->getFunctionRefKind(), "function_ref",
+    printField(E->getFunctionRefInfo(), "function_ref",
                ExprModifierColor);
 
     printFoot();
@@ -2338,7 +2338,7 @@ public:
 
     printFieldQuoted(E->getDecls()[0]->getBaseName(), "name", IdentifierColor);
     printField(E->getDecls().size(), "number_of_decls", ExprModifierColor);
-    printField(E->getFunctionRefKind(), "function_ref", ExprModifierColor);
+    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
 
     if (!E->isForOperator()) {
       for (auto D : E->getDecls()) {
@@ -2356,7 +2356,7 @@ public:
     printCommon(E, "unresolved_decl_ref_expr", label);
 
     printFieldQuoted(E->getName(), "name", IdentifierColor);
-    printField(E->getFunctionRefKind(), "function_ref", ExprModifierColor);
+    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
 
     printFoot();
   }
@@ -2397,7 +2397,7 @@ public:
     printCommon(E, "unresolved_member_expr", label);
 
     printFieldQuoted(E->getName(), "name", ExprModifierColor);
-    printField(E->getFunctionRefKind(), "function_ref", ExprModifierColor);
+    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
     printFoot();
   }
   void visitDotSelfExpr(DotSelfExpr *E, StringRef label) {
@@ -2520,7 +2520,7 @@ public:
     printCommon(E, "unresolved_dot_expr", label);
 
     printFieldQuoted(E->getName(), "field");
-    printField(E->getFunctionRefKind(), "function_ref", ExprModifierColor);
+    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
 
     if (E->getBase()) {
       printRec(E->getBase());

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -407,9 +407,6 @@ static StringRef getDumpString(MagicIdentifierLiteralExpr::Kind kind) {
 static StringRef getDumpString(ObjectLiteralExpr::LiteralKind kind) {
   return ObjectLiteralExpr::getLiteralKindPlainName(kind);
 }
-static StringRef getDumpString(FunctionRefInfo kind) {
-  return getFunctionRefInfoStr(kind);
-}
 static StringRef getDumpString(ParamSpecifier specifier) {
   return ParamDecl::getSpecifierSpelling(specifier);
 }
@@ -2306,8 +2303,8 @@ public:
     printDeclRefField(E->getDeclRef(), "decl");
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)
       printFlag(getDumpString(E->getAccessSemantics()), AccessLevelColor);
-    printField(E->getFunctionRefInfo(), "function_ref",
-               ExprModifierColor);
+    printFieldRaw([&](auto &os) { E->getFunctionRefInfo().dump(os); },
+                  "function_ref", ExprModifierColor);
 
     printFoot();
   }
@@ -2338,7 +2335,8 @@ public:
 
     printFieldQuoted(E->getDecls()[0]->getBaseName(), "name", IdentifierColor);
     printField(E->getDecls().size(), "number_of_decls", ExprModifierColor);
-    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
+    printFieldRaw([&](auto &os) { E->getFunctionRefInfo().dump(os); },
+                  "function_ref", ExprModifierColor);
 
     if (!E->isForOperator()) {
       for (auto D : E->getDecls()) {
@@ -2356,7 +2354,8 @@ public:
     printCommon(E, "unresolved_decl_ref_expr", label);
 
     printFieldQuoted(E->getName(), "name", IdentifierColor);
-    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
+    printFieldRaw([&](auto &os) { E->getFunctionRefInfo().dump(os); },
+                  "function_ref", ExprModifierColor);
 
     printFoot();
   }
@@ -2397,7 +2396,8 @@ public:
     printCommon(E, "unresolved_member_expr", label);
 
     printFieldQuoted(E->getName(), "name", ExprModifierColor);
-    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
+    printFieldRaw([&](auto &os) { E->getFunctionRefInfo().dump(os); },
+                  "function_ref", ExprModifierColor);
     printFoot();
   }
   void visitDotSelfExpr(DotSelfExpr *E, StringRef label) {
@@ -2520,7 +2520,8 @@ public:
     printCommon(E, "unresolved_dot_expr", label);
 
     printFieldQuoted(E->getName(), "field");
-    printField(E->getFunctionRefInfo(), "function_ref", ExprModifierColor);
+    printFieldRaw([&](auto &os) { E->getFunctionRefInfo().dump(os); },
+                  "function_ref", ExprModifierColor);
 
     if (E->getBase()) {
       printRec(E->getBase());

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -58,6 +58,7 @@ add_swift_host_library(swiftAST STATIC
   FineGrainedDependencyFormat.cpp
   FreestandingMacroExpansion.cpp
   FrontendSourceFileDepGraphFactory.cpp
+  FunctionRefInfo.cpp
   GenericEnvironment.cpp
   GenericParamList.cpp
   GenericSignature.cpp

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -41,21 +41,6 @@ using namespace swift;
                 "Exprs are BumpPtrAllocated; the destructor is never called");
 #include "swift/AST/ExprNodes.def"
 
-StringRef swift::getFunctionRefInfoStr(FunctionRefInfo refKind) {
-  switch (refKind) {
-  case FunctionRefInfo::Unapplied:
-    return "unapplied";
-  case FunctionRefInfo::SingleApply:
-    return "single";
-  case FunctionRefInfo::DoubleApply:
-    return "double";
-  case FunctionRefInfo::Compound:
-    return "compound";
-  }
-
-  llvm_unreachable("Unhandled FunctionRefInfo in switch.");
-}
-
 //===----------------------------------------------------------------------===//
 // Expr methods.
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -41,19 +41,19 @@ using namespace swift;
                 "Exprs are BumpPtrAllocated; the destructor is never called");
 #include "swift/AST/ExprNodes.def"
 
-StringRef swift::getFunctionRefKindStr(FunctionRefKind refKind) {
+StringRef swift::getFunctionRefInfoStr(FunctionRefInfo refKind) {
   switch (refKind) {
-  case FunctionRefKind::Unapplied:
+  case FunctionRefInfo::Unapplied:
     return "unapplied";
-  case FunctionRefKind::SingleApply:
+  case FunctionRefInfo::SingleApply:
     return "single";
-  case FunctionRefKind::DoubleApply:
+  case FunctionRefInfo::DoubleApply:
     return "double";
-  case FunctionRefKind::Compound:
+  case FunctionRefInfo::Compound:
     return "compound";
   }
 
-  llvm_unreachable("Unhandled FunctionRefKind in switch.");
+  llvm_unreachable("Unhandled FunctionRefInfo in switch.");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/FunctionRefInfo.cpp
+++ b/lib/AST/FunctionRefInfo.cpp
@@ -1,0 +1,63 @@
+//===--- FunctionRefInfo.cpp - Function reference info --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the FunctionRefInfo class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/FunctionRefInfo.h"
+#include "swift/AST/DeclNameLoc.h"
+#include "swift/AST/Identifier.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+FunctionRefInfo FunctionRefInfo::unapplied(DeclNameLoc nameLoc) {
+  return FunctionRefInfo(ApplyLevel::Unapplied, nameLoc.isCompound());
+}
+
+FunctionRefInfo FunctionRefInfo::unapplied(DeclNameRef nameRef) {
+  return FunctionRefInfo(ApplyLevel::Unapplied, nameRef.isCompoundName());
+}
+
+FunctionRefInfo FunctionRefInfo::addingApplicationLevel() const {
+  auto withApply = [&]() {
+    switch (getApplyLevel()) {
+    case ApplyLevel::Unapplied:
+      return ApplyLevel::SingleApply;
+    case ApplyLevel::SingleApply:
+    case ApplyLevel::DoubleApply:
+      return ApplyLevel::DoubleApply;
+    }
+  };
+  return FunctionRefInfo(withApply(), isCompoundName());
+}
+
+void FunctionRefInfo::dump(raw_ostream &os) const {
+  switch (getApplyLevel()) {
+  case ApplyLevel::Unapplied:
+    os << "unapplied";
+    break;
+  case ApplyLevel::SingleApply:
+    os << "single apply";
+    break;
+  case ApplyLevel::DoubleApply:
+    os << "double apply";
+    break;
+  }
+  if (isCompoundName())
+    os << " (compound)";
+}
+
+void FunctionRefInfo::dump() const {
+  dump(llvm::errs());
+}

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2505,7 +2505,7 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
   auto declRefExpr = new (ctx)
       DeclRefExpr(ConcreteDeclRef(funcDecl), DeclNameLoc(), /*Implicit*/ true);
   declRefExpr->setType(funcDecl->getInterfaceType());
-  declRefExpr->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+  declRefExpr->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
   auto callExpr = CallExpr::createImplicit(
       ctx, declRefExpr, ArgumentList::forImplicitUnlabeled(ctx, {}));

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2505,7 +2505,7 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
   auto declRefExpr = new (ctx)
       DeclRefExpr(ConcreteDeclRef(funcDecl), DeclNameLoc(), /*Implicit*/ true);
   declRefExpr->setType(funcDecl->getInterfaceType());
-  declRefExpr->setFunctionRefKind(FunctionRefKind::SingleApply);
+  declRefExpr->setFunctionRefInfo(FunctionRefInfo::SingleApply);
 
   auto callExpr = CallExpr::createImplicit(
       ctx, declRefExpr, ArgumentList::forImplicitUnlabeled(ctx, {}));

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -128,21 +128,19 @@ static bool isUnappliedFunctionRef(const OverloadChoice &Choice) {
   if (!Choice.isDecl()) {
     return false;
   }
-  switch (Choice.getFunctionRefInfo()) {
-  case FunctionRefInfo::Unapplied:
+  auto fnRefKind = Choice.getFunctionRefInfo();
+
+  if (fnRefKind.isUnapplied())
     return true;
-  case FunctionRefInfo::SingleApply:
-    if (auto BaseTy = Choice.getBaseType()) {
-      // We consider curried member calls as unapplied. E.g.
-      //   MyStruct.someInstanceFunc(theInstance)#^COMPLETE^#
-      // is unapplied.
+
+  // We consider curried member calls as unapplied. E.g.
+  //   MyStruct.someInstanceFunc(theInstance)#^COMPLETE^#
+  // is unapplied.
+  if (fnRefKind.isSingleApply()) {
+    if (auto BaseTy = Choice.getBaseType())
       return BaseTy->is<MetatypeType>() && !Choice.getDeclOrNull()->isStatic();
-    } else {
-      return false;
-    }
-  default:
-    return false;
   }
+  return false;
 }
 
 void PostfixCompletionCallback::sawSolutionImpl(

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -128,10 +128,10 @@ static bool isUnappliedFunctionRef(const OverloadChoice &Choice) {
   if (!Choice.isDecl()) {
     return false;
   }
-  switch (Choice.getFunctionRefKind()) {
-  case FunctionRefKind::Unapplied:
+  switch (Choice.getFunctionRefInfo()) {
+  case FunctionRefInfo::Unapplied:
     return true;
-  case FunctionRefKind::SingleApply:
+  case FunctionRefInfo::SingleApply:
     if (auto BaseTy = Choice.getBaseType()) {
       // We consider curried member calls as unapplied. E.g.
       //   MyStruct.someInstanceFunc(theInstance)#^COMPLETE^#

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -184,7 +184,7 @@ class ValidateIfConfigCondition :
     if (!UDE)
       return getDeclRefStr(E, DeclRefKind::Ordinary).has_value();
 
-    return UDE->getFunctionRefKind() == FunctionRefKind::Unapplied &&
+    return UDE->getFunctionRefInfo() == FunctionRefInfo::Unapplied &&
            isModulePath(UDE->getBase());
   }
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -184,7 +184,7 @@ class ValidateIfConfigCondition :
     if (!UDE)
       return getDeclRefStr(E, DeclRefKind::Ordinary).has_value();
 
-    return UDE->getFunctionRefInfo() == FunctionRefInfo::Unapplied &&
+    return UDE->getFunctionRefInfo().isUnappliedBaseName() &&
            isModulePath(UDE->getBase());
   }
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -712,7 +712,8 @@ protected:
         auto arrayAppendRef = new (ctx) UnresolvedDotExpr(
             arrayVarRef, endLoc, DeclNameRef(ctx.getIdentifier("append")),
             DeclNameLoc(endLoc), /*implicit=*/true);
-        arrayAppendRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+        arrayAppendRef->setFunctionRefInfo(
+            FunctionRefInfo::singleBaseNameApply());
 
         auto *argList = ArgumentList::createImplicit(
             ctx, endLoc, {Argument::unlabeled(bodyVarRef.get())}, endLoc);
@@ -1578,7 +1579,7 @@ Expr *ResultBuilder::buildCall(SourceLoc loc, Identifier fnName,
   auto memberRef = new (ctx)
       UnresolvedDotExpr(baseExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
                         /*implicit=*/true);
-  memberRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+  memberRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
   auto openLoc = args.empty() ? loc : argExprs.front()->getStartLoc();
   auto closeLoc = args.empty() ? loc : argExprs.back()->getEndLoc();

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -712,7 +712,7 @@ protected:
         auto arrayAppendRef = new (ctx) UnresolvedDotExpr(
             arrayVarRef, endLoc, DeclNameRef(ctx.getIdentifier("append")),
             DeclNameLoc(endLoc), /*implicit=*/true);
-        arrayAppendRef->setFunctionRefKind(FunctionRefKind::SingleApply);
+        arrayAppendRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
 
         auto *argList = ArgumentList::createImplicit(
             ctx, endLoc, {Argument::unlabeled(bodyVarRef.get())}, endLoc);
@@ -1578,7 +1578,7 @@ Expr *ResultBuilder::buildCall(SourceLoc loc, Identifier fnName,
   auto memberRef = new (ctx)
       UnresolvedDotExpr(baseExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
                         /*implicit=*/true);
-  memberRef->setFunctionRefKind(FunctionRefKind::SingleApply);
+  memberRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
 
   auto openLoc = args.empty() ? loc : argExprs.front()->getStartLoc();
   auto closeLoc = args.empty() ? loc : argExprs.back()->getEndLoc();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -685,7 +685,7 @@ namespace {
                   ConcreteDeclRef witnessRef(witness, *subMap);
                   auto declRefExpr =  new (ctx) DeclRefExpr(witnessRef, loc,
                                                             /*Implicit=*/false);
-                  declRefExpr->setFunctionRefKind(choice.getFunctionRefKind());
+                  declRefExpr->setFunctionRefInfo(choice.getFunctionRefInfo());
                   cs.setType(declRefExpr, refType);
 
                   Expr *refExpr;
@@ -758,14 +758,14 @@ namespace {
       auto declRefExpr =
           new (ctx) DeclRefExpr(ref, loc, implicit, semantics, fullType);
       cs.cacheType(declRefExpr);
-      declRefExpr->setFunctionRefKind(choice.getFunctionRefKind());
+      declRefExpr->setFunctionRefInfo(choice.getFunctionRefInfo());
 
       Expr *result = forceUnwrapIfExpected(declRefExpr, locator);
 
       if (auto *fnDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
         if (AnyFunctionRef(fnDecl).hasExternalPropertyWrapperParameters() &&
-            (declRefExpr->getFunctionRefKind() == FunctionRefKind::Compound ||
-             declRefExpr->getFunctionRefKind() == FunctionRefKind::Unapplied)) {
+            (declRefExpr->getFunctionRefInfo() == FunctionRefInfo::Compound ||
+             declRefExpr->getFunctionRefInfo() == FunctionRefInfo::Unapplied)) {
           // We don't need to do any further adjustment once we've built the
           // curry thunk.
           return buildSingleCurryThunk(result, fnDecl,
@@ -875,7 +875,7 @@ namespace {
       // FIXME: Walking over the ExprStack to figure out the number of argument
       // lists being applied is brittle. We should instead be checking
       // hasAppliedSelf to figure out if the self param is applied, and looking
-      // at the FunctionRefKind to see if the parameter list is applied.
+      // at the FunctionRefInfo to see if the parameter list is applied.
       unsigned e = ExprStack.size();
       unsigned argCount;
 
@@ -1642,7 +1642,7 @@ namespace {
                "Direct property access doesn't make sense for this");
         auto *dre = new (context) DeclRefExpr(memberRef, memberLoc, Implicit);
         cs.setType(dre, refTy);
-        dre->setFunctionRefKind(choice.getFunctionRefKind());
+        dre->setFunctionRefInfo(choice.getFunctionRefInfo());
         Expr *ref = cs.cacheType(new (context) DotSyntaxBaseIgnoredExpr(
             base, dotLoc, dre, refTy));
 
@@ -1752,7 +1752,7 @@ namespace {
         Expr *ref = new (context) DynamicMemberRefExpr(base, dotLoc, memberRef,
                                                        memberLoc);
         ref->setImplicit(Implicit);
-        // FIXME: FunctionRefKind
+        // FIXME: FunctionRefInfo
 
         // Compute the type of the reference.
         auto computeRefType = [&](Type refType) {
@@ -1866,7 +1866,7 @@ namespace {
       // Handle all other references.
       auto declRefExpr = new (context) DeclRefExpr(memberRef, memberLoc,
                                                    Implicit, semantics);
-      declRefExpr->setFunctionRefKind(choice.getFunctionRefKind());
+      declRefExpr->setFunctionRefInfo(choice.getFunctionRefInfo());
       declRefExpr->setType(refTy);
       cs.setType(declRefExpr, refTy);
       Expr *ref = declRefExpr;
@@ -4799,7 +4799,7 @@ namespace {
       }
       DeclRefExpr *fnRef = new (ctx) DeclRefExpr(undefinedDecl, DeclNameLoc(),
                                                  /*Implicit=*/true);
-      fnRef->setFunctionRefKind(FunctionRefKind::SingleApply);
+      fnRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
 
       StringRef msg = "attempt to evaluate editor placeholder";
       Expr *argExpr = new (ctx) StringLiteralExpr(msg, E->getLoc(),

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -764,8 +764,10 @@ namespace {
 
       if (auto *fnDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
         if (AnyFunctionRef(fnDecl).hasExternalPropertyWrapperParameters() &&
-            (declRefExpr->getFunctionRefInfo() == FunctionRefInfo::Compound ||
-             declRefExpr->getFunctionRefInfo() == FunctionRefInfo::Unapplied)) {
+            // FIXME(FunctionRefInfo): This should just be `isUnapplied()`, see
+            // the FIXME in `unwrapPropertyWrapperParameterTypes`.
+            (declRefExpr->getFunctionRefInfo().isCompoundName() ||
+             declRefExpr->getFunctionRefInfo().isUnappliedBaseName())) {
           // We don't need to do any further adjustment once we've built the
           // curry thunk.
           return buildSingleCurryThunk(result, fnDecl,
@@ -4799,7 +4801,7 @@ namespace {
       }
       DeclRefExpr *fnRef = new (ctx) DeclRefExpr(undefinedDecl, DeclNameLoc(),
                                                  /*Implicit=*/true);
-      fnRef->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+      fnRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
       StringRef msg = "attempt to evaluate editor placeholder";
       Expr *argExpr = new (ctx) StringLiteralExpr(msg, E->getLoc(),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2349,7 +2349,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
               dyn_cast_or_null<SubscriptDecl>(declRef.getDecl())) {
         if (isImmutable(subscript))
           return {expr, OverloadChoice(getType(SE->getBase()), subscript,
-                                       FunctionRefInfo::DoubleApply)};
+                                       FunctionRefInfo::doubleBaseNameApply())};
       }
     }
 
@@ -2405,7 +2405,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     if (auto member = dyn_cast<AbstractStorageDecl>(MRE->getMember().getDecl()))
       if (isImmutable(member))
         return {expr, OverloadChoice(getType(MRE->getBase()), member,
-                                     FunctionRefInfo::SingleApply)};
+                                     FunctionRefInfo::singleBaseNameApply())};
 
     // If we weren't able to resolve a member or if it is mutable, then the
     // problem must be with the base, recurse.
@@ -2425,8 +2425,8 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
   }
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(expr))
-    return {expr,
-            OverloadChoice(Type(), DRE->getDecl(), FunctionRefInfo::Unapplied)};
+    return {expr, OverloadChoice(Type(), DRE->getDecl(),
+                                 FunctionRefInfo::unappliedBaseName())};
 
   // Look through x!
   if (auto *FVE = dyn_cast<ForceValueExpr>(expr))
@@ -4387,7 +4387,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 
       auto result = cs.performMemberLookup(
           ConstraintKind::ValueMember, getName().withoutArgumentLabels(),
-          metatypeTy, FunctionRefInfo::DoubleApply, getLocator(),
+          metatypeTy, FunctionRefInfo::doubleBaseNameApply(), getLocator(),
           /*includeInaccessibleMembers=*/true);
 
       // If there are no `init` members at all produce a tailored

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2349,7 +2349,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
               dyn_cast_or_null<SubscriptDecl>(declRef.getDecl())) {
         if (isImmutable(subscript))
           return {expr, OverloadChoice(getType(SE->getBase()), subscript,
-                                       FunctionRefKind::DoubleApply)};
+                                       FunctionRefInfo::DoubleApply)};
       }
     }
 
@@ -2405,7 +2405,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
     if (auto member = dyn_cast<AbstractStorageDecl>(MRE->getMember().getDecl()))
       if (isImmutable(member))
         return {expr, OverloadChoice(getType(MRE->getBase()), member,
-                                     FunctionRefKind::SingleApply)};
+                                     FunctionRefInfo::SingleApply)};
 
     // If we weren't able to resolve a member or if it is mutable, then the
     // problem must be with the base, recurse.
@@ -2426,7 +2426,7 @@ AssignmentFailure::resolveImmutableBase(Expr *expr) const {
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(expr))
     return {expr,
-            OverloadChoice(Type(), DRE->getDecl(), FunctionRefKind::Unapplied)};
+            OverloadChoice(Type(), DRE->getDecl(), FunctionRefInfo::Unapplied)};
 
   // Look through x!
   if (auto *FVE = dyn_cast<ForceValueExpr>(expr))
@@ -4387,7 +4387,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 
       auto result = cs.performMemberLookup(
           ConstraintKind::ValueMember, getName().withoutArgumentLabels(),
-          metatypeTy, FunctionRefKind::DoubleApply, getLocator(),
+          metatypeTy, FunctionRefInfo::DoubleApply, getLocator(),
           /*includeInaccessibleMembers=*/true);
 
       // If there are no `init` members at all produce a tailored

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2249,7 +2249,7 @@ bool SpecifyBaseTypeForOptionalUnresolvedMember::diagnose(
 SpecifyBaseTypeForOptionalUnresolvedMember *
 SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
     ConstraintSystem &cs, ConstraintKind kind, Type baseTy,
-    DeclNameRef memberName, FunctionRefKind functionRefKind,
+    DeclNameRef memberName, FunctionRefInfo functionRefInfo,
     MemberLookupResult result, ConstraintLocator *locator) {
 
   if (kind != ConstraintKind::UnresolvedValueMember)
@@ -2264,7 +2264,7 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
     return nullptr;
 
   // Don't diagnose for function members e.g. Foo? = .none(0).
-  if (functionRefKind != FunctionRefKind::Unapplied)
+  if (functionRefInfo != FunctionRefInfo::Unapplied)
     return nullptr;
 
   Type underlyingBaseType = baseTy->getMetatypeInstanceType();
@@ -2344,7 +2344,7 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
 
   MemberLookupResult unwrappedResult =
       cs.performMemberLookup(kind, memberName, MetatypeType::get(unwrappedType),
-                             functionRefKind, locator,
+                             functionRefInfo, locator,
                              /*includeInaccessibleMembers*/ false);
   SmallVector<OverloadChoice, 4> unwrappedViableCandidates;
   filterViableCandidates(unwrappedResult.ViableCandidates,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2264,7 +2264,7 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
     return nullptr;
 
   // Don't diagnose for function members e.g. Foo? = .none(0).
-  if (functionRefInfo != FunctionRefInfo::Unapplied)
+  if (!functionRefInfo.isUnappliedBaseName())
     return nullptr;
 
   Type underlyingBaseType = baseTy->getMetatypeInstanceType();

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -192,7 +192,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
 
 Constraint::Constraint(ConstraintKind kind, Type first, Type second,
                        DeclNameRef member, DeclContext *useDC,
-                       FunctionRefKind functionRefKind,
+                       FunctionRefInfo functionRefInfo,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
     : Kind(kind), HasFix(false), HasRestriction(false), IsActive(false),
@@ -202,8 +202,8 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
       Locator(locator) {
   assert(kind == ConstraintKind::ValueMember ||
          kind == ConstraintKind::UnresolvedValueMember);
-  TheFunctionRefKind = static_cast<unsigned>(functionRefKind);
-  assert(getFunctionRefKind() == functionRefKind);
+  TheFunctionRefInfo = static_cast<unsigned>(functionRefInfo);
+  assert(getFunctionRefInfo() == functionRefInfo);
   assert(member && "Member constraint has no member");
   assert(useDC && "Member constraint has no use DC");
 
@@ -212,7 +212,7 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
 
 Constraint::Constraint(ConstraintKind kind, Type first, Type second,
                        ValueDecl *requirement, DeclContext *useDC,
-                       FunctionRefKind functionRefKind,
+                       FunctionRefInfo functionRefInfo,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
     : Kind(kind), HasFix(false), HasRestriction(false), IsActive(false),
@@ -223,10 +223,10 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
   Member.Second = second;
   Member.Member.Ref = requirement;
   Member.UseDC = useDC;
-  TheFunctionRefKind = static_cast<unsigned>(functionRefKind);
+  TheFunctionRefInfo = static_cast<unsigned>(functionRefInfo);
 
   assert(kind == ConstraintKind::ValueWitness);
-  assert(getFunctionRefKind() == functionRefKind);
+  assert(getFunctionRefInfo() == functionRefInfo);
   assert(requirement && "Value witness constraint has no requirement");
   assert(useDC && "Member constraint has no use DC");
 
@@ -786,10 +786,10 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
 
 Constraint *Constraint::createMemberOrOuterDisjunction(
     ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-    DeclNameRef member, DeclContext *useDC, FunctionRefKind functionRefKind,
+    DeclNameRef member, DeclContext *useDC, FunctionRefInfo functionRefInfo,
     ArrayRef<OverloadChoice> outerAlternatives, ConstraintLocator *locator) {
   auto memberConstraint = createMember(cs, kind, first, second, member,
-                             useDC, functionRefKind, locator);
+                             useDC, functionRefInfo, locator);
 
   if (outerAlternatives.empty())
     return memberConstraint;
@@ -808,7 +808,7 @@ Constraint *Constraint::createMemberOrOuterDisjunction(
 Constraint *Constraint::createMember(ConstraintSystem &cs, ConstraintKind kind, 
                                      Type first, Type second,
                                      DeclNameRef member, DeclContext *useDC,
-                                     FunctionRefKind functionRefKind,
+                                     FunctionRefInfo functionRefInfo,
                                      ConstraintLocator *locator) {
   // Collect type variables.
   SmallPtrSet<TypeVariableType *, 4> typeVars;
@@ -823,13 +823,13 @@ Constraint *Constraint::createMember(ConstraintSystem &cs, ConstraintKind kind,
       typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, member, useDC,
-                              functionRefKind, locator, typeVars);
+                              functionRefInfo, locator, typeVars);
 }
 
 Constraint *Constraint::createValueWitness(
     ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
     ValueDecl *requirement, DeclContext *useDC,
-    FunctionRefKind functionRefKind, ConstraintLocator *locator) {
+    FunctionRefInfo functionRefInfo, ConstraintLocator *locator) {
   assert(kind == ConstraintKind::ValueWitness);
 
   // Collect type variables.
@@ -845,7 +845,7 @@ Constraint *Constraint::createValueWitness(
       typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, requirement, useDC,
-                              functionRefKind, locator, typeVars);
+                              functionRefInfo, locator, typeVars);
 }
 
 Constraint *Constraint::createBindOverload(ConstraintSystem &cs, Type type, 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -202,7 +202,7 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
       Locator(locator) {
   assert(kind == ConstraintKind::ValueMember ||
          kind == ConstraintKind::UnresolvedValueMember);
-  TheFunctionRefInfo = static_cast<unsigned>(functionRefInfo);
+  TheFunctionRefInfo = functionRefInfo.getOpaqueValue();
   assert(getFunctionRefInfo() == functionRefInfo);
   assert(member && "Member constraint has no member");
   assert(useDC && "Member constraint has no use DC");
@@ -223,7 +223,7 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
   Member.Second = second;
   Member.Member.Ref = requirement;
   Member.UseDC = useDC;
-  TheFunctionRefInfo = static_cast<unsigned>(functionRefInfo);
+  TheFunctionRefInfo = functionRefInfo.getOpaqueValue();
 
   assert(kind == ConstraintKind::ValueWitness);
   assert(getFunctionRefInfo() == functionRefInfo);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1952,16 +1952,16 @@ OverloadChoice::getIUOReferenceKind(ConstraintSystem &cs,
   if (!decl->getInterfaceType()->is<AnyFunctionType>())
     return IUOReferenceKind::Value;
 
-  auto refKind = getFunctionRefKind();
-  assert(!forSecondApplication || refKind == FunctionRefKind::DoubleApply);
+  auto refKind = getFunctionRefInfo();
+  assert(!forSecondApplication || refKind == FunctionRefInfo::DoubleApply);
 
   switch (refKind) {
-  case FunctionRefKind::Unapplied:
-  case FunctionRefKind::Compound:
+  case FunctionRefInfo::Unapplied:
+  case FunctionRefInfo::Compound:
     // Such references never produce IUOs.
     return std::nullopt;
-  case FunctionRefKind::SingleApply:
-  case FunctionRefKind::DoubleApply: {
+  case FunctionRefInfo::SingleApply:
+  case FunctionRefInfo::DoubleApply: {
     // Check whether this is a curried function reference e.g
     // (Self) -> (Args...) -> Ret. Such a function reference can only produce
     // an IUO on the second application.

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -94,7 +94,7 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
   assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
-  initDRE->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+  initDRE->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
   auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
       DeclNameLoc(), nominal, funcDecl,
       funcDecl->mapTypeIntoContext(nominal->getInterfaceType()));
@@ -223,7 +223,7 @@ deriveBodyPropertyGetter(AbstractFunctionDecl *funcDecl, ProtocolDecl *proto,
   assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
-  initDRE->setFunctionRefInfo(FunctionRefInfo::SingleApply);
+  initDRE->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
   auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
       DeclNameLoc(), nominal, funcDecl,

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -94,7 +94,7 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
   assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
-  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+  initDRE->setFunctionRefInfo(FunctionRefInfo::SingleApply);
   auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
       DeclNameLoc(), nominal, funcDecl,
       funcDecl->mapTypeIntoContext(nominal->getInterfaceType()));
@@ -223,7 +223,7 @@ deriveBodyPropertyGetter(AbstractFunctionDecl *funcDecl, ProtocolDecl *proto,
   assert(memberwiseInitDecl && "Memberwise initializer must exist");
   auto *initDRE =
       new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
-  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+  initDRE->setFunctionRefInfo(FunctionRefInfo::SingleApply);
 
   auto *nominalTypeExpr = TypeExpr::createImplicitForDecl(
       DeclNameLoc(), nominal, funcDecl,

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -979,29 +979,12 @@ TypeChecker::getSelfForInitDelegationInConstructor(DeclContext *DC,
 }
 
 namespace {
-/// Update the function reference kind based on adding a direct call to a
-/// callee with this kind.
-FunctionRefInfo addingDirectCall(FunctionRefInfo kind) {
-  switch (kind) {
-  case FunctionRefInfo::Unapplied:
-    return FunctionRefInfo::SingleApply;
-
-  case FunctionRefInfo::SingleApply:
-  case FunctionRefInfo::DoubleApply:
-    return FunctionRefInfo::DoubleApply;
-
-  case FunctionRefInfo::Compound:
-    return FunctionRefInfo::Compound;
-  }
-
-  llvm_unreachable("Unhandled FunctionRefInfo in switch.");
-}
-
 /// Update a direct callee expression node that has a function reference kind
 /// based on seeing a call to this callee.
 template <typename E, typename = decltype(((E *)nullptr)->getFunctionRefInfo())>
 void tryUpdateDirectCalleeImpl(E *callee, int) {
-  callee->setFunctionRefInfo(addingDirectCall(callee->getFunctionRefInfo()));
+  callee->setFunctionRefInfo(
+      callee->getFunctionRefInfo().addingApplicationLevel());
 }
 
 /// Version of tryUpdateDirectCalleeImpl for when the callee

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -864,7 +864,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
     }
 
     return buildRefExpr(ResultValues, DC, UDRE->getNameLoc(),
-                        UDRE->isImplicit(), UDRE->getFunctionRefKind());
+                        UDRE->isImplicit(), UDRE->getFunctionRefInfo());
   }
 
   ResultValues.clear();
@@ -981,27 +981,27 @@ TypeChecker::getSelfForInitDelegationInConstructor(DeclContext *DC,
 namespace {
 /// Update the function reference kind based on adding a direct call to a
 /// callee with this kind.
-FunctionRefKind addingDirectCall(FunctionRefKind kind) {
+FunctionRefInfo addingDirectCall(FunctionRefInfo kind) {
   switch (kind) {
-  case FunctionRefKind::Unapplied:
-    return FunctionRefKind::SingleApply;
+  case FunctionRefInfo::Unapplied:
+    return FunctionRefInfo::SingleApply;
 
-  case FunctionRefKind::SingleApply:
-  case FunctionRefKind::DoubleApply:
-    return FunctionRefKind::DoubleApply;
+  case FunctionRefInfo::SingleApply:
+  case FunctionRefInfo::DoubleApply:
+    return FunctionRefInfo::DoubleApply;
 
-  case FunctionRefKind::Compound:
-    return FunctionRefKind::Compound;
+  case FunctionRefInfo::Compound:
+    return FunctionRefInfo::Compound;
   }
 
-  llvm_unreachable("Unhandled FunctionRefKind in switch.");
+  llvm_unreachable("Unhandled FunctionRefInfo in switch.");
 }
 
 /// Update a direct callee expression node that has a function reference kind
 /// based on seeing a call to this callee.
-template <typename E, typename = decltype(((E *)nullptr)->getFunctionRefKind())>
+template <typename E, typename = decltype(((E *)nullptr)->getFunctionRefInfo())>
 void tryUpdateDirectCalleeImpl(E *callee, int) {
-  callee->setFunctionRefKind(addingDirectCall(callee->getFunctionRefKind()));
+  callee->setFunctionRefInfo(addingDirectCall(callee->getFunctionRefInfo()));
 }
 
 /// Version of tryUpdateDirectCalleeImpl for when the callee

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3036,7 +3036,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
     CS.addDisjunctionConstraint(typeEqualityConstraints, locator);
     CS.addValueMemberConstraint(
         nominal->getInterfaceType(), DeclNameRef(context.Id_main),
-        Type(mainType), declContext, FunctionRefKind::SingleApply, {}, locator);
+        Type(mainType), declContext, FunctionRefInfo::SingleApply, {}, locator);
   }
 
   FuncDecl *mainFunction = nullptr;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3036,7 +3036,8 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
     CS.addDisjunctionConstraint(typeEqualityConstraints, locator);
     CS.addValueMemberConstraint(
         nominal->getInterfaceType(), DeclNameRef(context.Id_main),
-        Type(mainType), declContext, FunctionRefInfo::SingleApply, {}, locator);
+        Type(mainType), declContext, FunctionRefInfo::singleBaseNameApply(), {},
+        locator);
   }
 
   FuncDecl *mainFunction = nullptr;

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -513,7 +513,7 @@ bool TypeChecker::requireArrayLiteralIntrinsics(ASTContext &ctx,
 
 Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
                                 DeclContext *UseDC, DeclNameLoc NameLoc,
-                                bool Implicit, FunctionRefKind functionRefKind) {
+                                bool Implicit, FunctionRefInfo functionRefInfo) {
   assert(!Decls.empty() && "Must have at least one declaration");
 
   auto &Context = UseDC->getASTContext();
@@ -525,7 +525,7 @@ Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
 
   Decls = Context.AllocateCopy(Decls);
   auto result = new (Context) OverloadedDeclRefExpr(Decls, NameLoc, 
-                                                    functionRefKind,
+                                                    functionRefInfo,
                                                     Implicit);
   return result;
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1198,12 +1198,12 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     reqLocator =
         cs->getConstraintLocator(req, ConstraintLocator::ProtocolRequirement);
     SmallVector<OpenedType, 4> reqReplacements;
-    reqType = cs->getTypeOfMemberReference(selfTy, req, dc,
-                                           /*isDynamicResult=*/false,
-                                           FunctionRefInfo::DoubleApply,
-                                           reqLocator,
-                                           &reqReplacements)
-        .adjustedReferenceType;
+    reqType =
+        cs->getTypeOfMemberReference(selfTy, req, dc,
+                                     /*isDynamicResult=*/false,
+                                     FunctionRefInfo::doubleBaseNameApply(),
+                                     reqLocator, &reqReplacements)
+            .adjustedReferenceType;
     reqType = reqType->getRValueType();
 
     // For any type parameters we replaced in the witness, map them
@@ -1234,15 +1234,17 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     witnessLocator =
         cs->getConstraintLocator(req, LocatorPathElt::Witness(witness));
     if (witness->getDeclContext()->isTypeContext()) {
-      openWitnessType = cs->getTypeOfMemberReference(
-          selfTy, witness, dc, /*isDynamicResult=*/false,
-          FunctionRefInfo::DoubleApply, witnessLocator)
-        .adjustedReferenceType;
+      openWitnessType =
+          cs->getTypeOfMemberReference(
+                selfTy, witness, dc, /*isDynamicResult=*/false,
+                FunctionRefInfo::doubleBaseNameApply(), witnessLocator)
+              .adjustedReferenceType;
     } else {
-      openWitnessType = cs->getTypeOfReference(
-          witness, FunctionRefInfo::DoubleApply, witnessLocator,
-          /*useDC=*/nullptr)
-        .adjustedReferenceType;
+      openWitnessType =
+          cs->getTypeOfReference(
+                witness, FunctionRefInfo::doubleBaseNameApply(), witnessLocator,
+                /*useDC=*/nullptr)
+              .adjustedReferenceType;
     }
     openWitnessType = openWitnessType->getRValueType();
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1200,7 +1200,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     SmallVector<OpenedType, 4> reqReplacements;
     reqType = cs->getTypeOfMemberReference(selfTy, req, dc,
                                            /*isDynamicResult=*/false,
-                                           FunctionRefKind::DoubleApply,
+                                           FunctionRefInfo::DoubleApply,
                                            reqLocator,
                                            &reqReplacements)
         .adjustedReferenceType;
@@ -1236,11 +1236,11 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     if (witness->getDeclContext()->isTypeContext()) {
       openWitnessType = cs->getTypeOfMemberReference(
           selfTy, witness, dc, /*isDynamicResult=*/false,
-          FunctionRefKind::DoubleApply, witnessLocator)
+          FunctionRefInfo::DoubleApply, witnessLocator)
         .adjustedReferenceType;
     } else {
       openWitnessType = cs->getTypeOfReference(
-          witness, FunctionRefKind::DoubleApply, witnessLocator,
+          witness, FunctionRefInfo::DoubleApply, witnessLocator,
           /*useDC=*/nullptr)
         .adjustedReferenceType;
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -932,7 +932,7 @@ bool isDeclRefinementOf(ValueDecl *declA, ValueDecl *declB);
 /// the given set of declarations.
 Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
                    DeclNameLoc NameLoc, bool Implicit,
-                   FunctionRefKind functionRefKind);
+                   FunctionRefInfo functionRefInfo);
 /// @}
 
 /// Retrieve a specific, known protocol.

--- a/unittests/Sema/KeypathFunctionConversionTests.cpp
+++ b/unittests/Sema/KeypathFunctionConversionTests.cpp
@@ -101,7 +101,7 @@ TEST_F(SemaTest, TestKeypathFunctionConversionPrefersNarrowConversion) {
                                        SourceLoc(), std::nullopt, false);
   llvm::SmallVector<ValueDecl *, 2> fDecls = {genericFnDecl, concreteFnDecl};
   auto *fDRE = new (Context) OverloadedDeclRefExpr(
-      fDecls, DeclNameLoc(), FunctionRefInfo::SingleApply, false);
+      fDecls, DeclNameLoc(), FunctionRefInfo::singleBaseNameApply(), false);
   auto *callExpr = CallExpr::create(Context, fDRE, argList, false);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());

--- a/unittests/Sema/KeypathFunctionConversionTests.cpp
+++ b/unittests/Sema/KeypathFunctionConversionTests.cpp
@@ -101,7 +101,7 @@ TEST_F(SemaTest, TestKeypathFunctionConversionPrefersNarrowConversion) {
                                        SourceLoc(), std::nullopt, false);
   llvm::SmallVector<ValueDecl *, 2> fDecls = {genericFnDecl, concreteFnDecl};
   auto *fDRE = new (Context) OverloadedDeclRefExpr(
-      fDecls, DeclNameLoc(), FunctionRefKind::SingleApply, false);
+      fDecls, DeclNameLoc(), FunctionRefInfo::SingleApply, false);
   auto *callExpr = CallExpr::create(Context, fDRE, argList, false);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());


### PR DESCRIPTION
FunctionRefKind was originally designed to represent the handling needed for argument labels on function references, in which the unapplied and compound cases are effectively the same. However it has since been adopted in a bunch of other places where the spelling of the function reference is entirely orthogonal to the application level.

Split out the application level from the "is compound" bit, and rename to FunctionRefInfo. Should be NFC. I've left some FIXMEs for non-NFC changes that I'll address in a follow-up.

Resolves #77804
rdar://140415962