### PR TITLE
SimplifyLoad: fix removal of load operand instructions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -295,7 +295,9 @@ private func transitivelyErase(load: LoadInst, _ context: SimplifyContext) {
       context.erase(instruction: inst)
       return
     }
-    let operandInst = inst.operands[0].value as! SingleValueInstruction
+    guard let operandInst = inst.operands[0].value as? SingleValueInstruction else {
+      return
+    }
     context.erase(instruction: inst)
     inst = operandInst
   }

--- a/test/SILOptimizer/simplify_load.sil
+++ b/test/SILOptimizer/simplify_load.sil
@@ -530,3 +530,16 @@ bb0:
   return %2
 }
 
+// CHECK-LABEL: sil @load_from_begin_cow_mutation :
+// CHECK:         [[I:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:         return [[I]]
+// CHECK:       } // end sil function 'load_from_begin_cow_mutation'
+sil @load_from_begin_cow_mutation : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = global_value @gc : $D
+  (%1, %2) = begin_cow_mutation %0
+  %3 = ref_element_addr %2, #D.d
+  %4 = load %3
+  return %4
+}
+


### PR DESCRIPTION
Also consider that the (transitive) operand of a load can be a multi-value instruction, like begin_cow_mutation

rdar://140778782
