### PR TITLE
Clarify what "schoolbook" rounding means

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -938,8 +938,8 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///
   /// For more information about the available rounding rules, see the
   /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `rounded()`
-  /// method instead.
+  /// default "schoolbook rounding" of `.toNearestOrAwayFromZero`, you can use
+  /// the shorter `rounded()` method instead.
   ///
   ///     print(x.rounded())
   ///     // Prints "7.0"
@@ -974,8 +974,8 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///
   /// For more information about the available rounding rules, see the
   /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `round()` method
-  /// instead.
+  /// default "schoolbook rounding" of `.toNearestOrAwayFromZero`, you can use
+  /// the shorter `round()` method instead.
   ///
   ///     var w1 = 6.5
   ///     w1.round()


### PR DESCRIPTION
The docs for `FloatingPointRoundingRule.toNearestOrAwayFromZero` note that this default behavior is also known as "schoolbook rounding", but it's hard to look up what that means if you don't know the enum name.

Fixes: rdar://140725655