### PR TITLE
AST: Refactor semantic unavailability queries

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1455,9 +1455,15 @@ public:
   std::optional<std::pair<const AvailableAttr *, const Decl *>>
   getSemanticUnavailableAttr(bool ignoreAppExtensions = false) const;
 
+  /// Returns true if the decl is effectively always unavailable in the current
+  /// compilation context. This query differs from \c isUnavailable() because it
+  /// takes the availability of parent declarations into account.
+  bool isSemanticallyUnavailable() const;
+
   /// Returns true if code associated with this declaration should be considerd
   /// unreachable at runtime because the declaration is unavailable in all
-  /// execution contexts in which the code may run.
+  /// execution contexts in which the code may run. This result takes the
+  /// availability of parent declarations into account.
   bool isUnreachableAtRuntime() const;
 
   /// Returns true if this declaration should be considered available during

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1442,19 +1442,6 @@ public:
   std::optional<std::pair<const AvailableAttr *, const Decl *>>
   getSemanticAvailableRangeAttr() const;
 
-  /// Retrieve the @available attribute that makes this declaration unavailable,
-  /// if any. If \p ignoreAppExtensions is true then attributes for app
-  /// extension platforms are ignored.
-  ///
-  /// This attribute may come from an enclosing decl since availability is
-  /// inherited. The second member of the returned pair is the decl that owns
-  /// the attribute.
-  ///
-  /// Note that this notion of unavailability is broader than that which is
-  /// checked by \c isUnavailable().
-  std::optional<std::pair<const AvailableAttr *, const Decl *>>
-  getSemanticUnavailableAttr(bool ignoreAppExtensions = false) const;
-
   /// Returns true if the decl is effectively always unavailable in the current
   /// compilation context. This query differs from \c isUnavailable() because it
   /// takes the availability of parent declarations into account.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4141,6 +4141,40 @@ public:
   bool isCached() const { return true; }
 };
 
+enum class SemanticDeclAvailability : uint8_t {
+  /// The decl is potentially available in some contexts and/or under certain
+  /// deployment conditions.
+  PotentiallyAvailable,
+
+  /// The decl is always unavailable in the current compilation context.
+  /// However, it may still be used at runtime by other modules with different
+  /// settings. For example a decl that is obsolete in Swift 5 is still
+  /// available to other modules compiled for an earlier language mode.
+  ConditionallyUnavailable,
+
+  /// The decl is universally unavailable. For example, when compiling for macOS
+  /// a decl with `@available(macOS, unavailable)` can never be used (except in
+  /// contexts that are also completely unavailable on macOS).
+  CompletelyUnavailable,
+};
+
+class SemanticDeclAvailabilityRequest
+    : public SimpleRequest<SemanticDeclAvailabilityRequest,
+                           SemanticDeclAvailability(const Decl *decl),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  SemanticDeclAvailability evaluate(Evaluator &evaluator,
+                                    const Decl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 class ClosureEffectsRequest
     : public SimpleRequest<ClosureEffectsRequest,
                            FunctionType::ExtInfo(ClosureExpr *),

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4122,25 +4122,6 @@ public:
   bool isCached() const { return true; }
 };
 
-class SemanticUnavailableAttrRequest
-    : public SimpleRequest<SemanticUnavailableAttrRequest,
-                           std::optional<AvailableAttrDeclPair>(
-                               const Decl *decl, bool ignoreAppExtensions),
-                           RequestFlags::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  std::optional<AvailableAttrDeclPair>
-  evaluate(Evaluator &evaluator, const Decl *decl,
-           bool ignoreAppExtensions) const;
-
-public:
-  bool isCached() const { return true; }
-};
-
 enum class SemanticDeclAvailability : uint8_t {
   /// The decl is potentially available in some contexts and/or under certain
   /// deployment conditions.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -475,6 +475,9 @@ SWIFT_REQUEST(TypeChecker, SemanticAvailableRangeAttrRequest,
 SWIFT_REQUEST(TypeChecker, SemanticUnavailableAttrRequest,
               Optional<AvailableAttrDeclPair>(const Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SemanticDeclAvailabilityRequest,
+              SemanticDeclAvailability(const Decl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -472,9 +472,6 @@ SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
 SWIFT_REQUEST(TypeChecker, SemanticAvailableRangeAttrRequest,
               Optional<AvailableAttrDeclPair>(const Decl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SemanticUnavailableAttrRequest,
-              Optional<AvailableAttrDeclPair>(const Decl *),
-              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SemanticDeclAvailabilityRequest,
               SemanticDeclAvailability(const Decl *),
               Cached, NoLocationInfo)

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -711,18 +711,13 @@ Decl::getSemanticUnavailableAttr(bool ignoreAppExtensions) const {
       std::nullopt);
 }
 
-bool Decl::isUnreachableAtRuntime() const {
+static bool isDeclCompletelyUnavailable(const Decl *decl) {
   // Don't trust unavailability on declarations from clang modules.
-  if (isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext()))
+  if (isa<ClangModuleUnit>(decl->getDeclContext()->getModuleScopeContext()))
     return false;
 
-  if (auto *parent =
-          AvailabilityInference::parentDeclForInferredAvailability(this)) {
-    if (parent->isUnreachableAtRuntime())
-      return true;
-  }
-
-  auto *unavailableAttr = getUnavailableAttr(/*ignoreAppExtensions=*/true);
+  auto *unavailableAttr =
+      decl->getUnavailableAttr(/*ignoreAppExtensions=*/true);
   if (!unavailableAttr)
     return false;
 
@@ -733,14 +728,7 @@ bool Decl::isUnreachableAtRuntime() const {
   if (!unavailableAttr->isUnconditionallyUnavailable())
     return false;
 
-  // getUnavailableAttr() can return an @available attribute that makes its
-  // declaration unavailable conditionally due to deployment target. Only
-  // stub or skip a declaration that is unavailable regardless of deployment
-  // target.
-  if (!unavailableAttr->isUnconditionallyUnavailable())
-    return false;
-
-  // Universally unavailable declarations are always unreachable.
+  // Universally unavailable declarations are always completely unavailable.
   if (unavailableAttr->getPlatform() == PlatformKind::none)
     return true;
 
@@ -748,10 +736,38 @@ bool Decl::isUnreachableAtRuntime() const {
   // If we have a target variant (e.g. we're building a zippered macOS
   // framework) then the decl is only unreachable if it is unavailable for both
   // the primary target and the target variant.
-  if (getASTContext().LangOpts.TargetVariant.has_value())
+  if (decl->getASTContext().LangOpts.TargetVariant.has_value())
     return false;
 
   return true;
+}
+
+SemanticDeclAvailability
+SemanticDeclAvailabilityRequest::evaluate(Evaluator &evaluator,
+                                          const Decl *decl) const {
+  auto inherited = SemanticDeclAvailability::PotentiallyAvailable;
+  if (auto *parent =
+          AvailabilityInference::parentDeclForInferredAvailability(decl)) {
+    inherited = evaluateOrDefault(
+        evaluator, SemanticDeclAvailabilityRequest{parent}, inherited);
+  }
+
+  if (inherited == SemanticDeclAvailability::CompletelyUnavailable ||
+      isDeclCompletelyUnavailable(decl))
+    return SemanticDeclAvailability::CompletelyUnavailable;
+
+  if (inherited == SemanticDeclAvailability::ConditionallyUnavailable ||
+      decl->isUnavailable())
+    return SemanticDeclAvailability::ConditionallyUnavailable;
+
+  return SemanticDeclAvailability::PotentiallyAvailable;
+}
+
+bool Decl::isUnreachableAtRuntime() const {
+  auto availability = evaluateOrDefault(
+      getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},
+      SemanticDeclAvailability::PotentiallyAvailable);
+  return availability == SemanticDeclAvailability::CompletelyUnavailable;
 }
 
 static UnavailableDeclOptimization

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -763,6 +763,13 @@ SemanticDeclAvailabilityRequest::evaluate(Evaluator &evaluator,
   return SemanticDeclAvailability::PotentiallyAvailable;
 }
 
+bool Decl::isSemanticallyUnavailable() const {
+  auto availability = evaluateOrDefault(
+      getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},
+      SemanticDeclAvailability::PotentiallyAvailable);
+  return availability != SemanticDeclAvailability::PotentiallyAvailable;
+}
+
 bool Decl::isUnreachableAtRuntime() const {
   auto availability = evaluateOrDefault(
       getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -689,28 +689,6 @@ const AvailableAttr *Decl::getUnavailableAttr(bool ignoreAppExtensions) const {
   return nullptr;
 }
 
-std::optional<AvailableAttrDeclPair>
-SemanticUnavailableAttrRequest::evaluate(Evaluator &evaluator, const Decl *decl,
-                                         bool ignoreAppExtensions) const {
-  // Directly marked unavailable.
-  if (auto attr = decl->getUnavailableAttr(ignoreAppExtensions))
-    return std::make_pair(attr, decl);
-
-  if (auto *parent =
-          AvailabilityInference::parentDeclForInferredAvailability(decl))
-    return parent->getSemanticUnavailableAttr(ignoreAppExtensions);
-
-  return std::nullopt;
-}
-
-std::optional<AvailableAttrDeclPair>
-Decl::getSemanticUnavailableAttr(bool ignoreAppExtensions) const {
-  auto &eval = getASTContext().evaluator;
-  return evaluateOrDefault(
-      eval, SemanticUnavailableAttrRequest{this, ignoreAppExtensions},
-      std::nullopt);
-}
-
 static bool isDeclCompletelyUnavailable(const Decl *decl) {
   // Don't trust unavailability on declarations from clang modules.
   if (isa<ClangModuleUnit>(decl->getDeclContext()->getModuleScopeContext()))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1299,8 +1299,7 @@ bool Decl::isAlwaysWeakImported() const {
 
   // FIXME: Weak linking on Windows is not yet supported
   // https://github.com/apple/swift/issues/53303
-  if (getSemanticUnavailableAttr() &&
-      !getASTContext().LangOpts.Target.isOSWindows())
+  if (isUnavailable() && !getASTContext().LangOpts.Target.isOSWindows())
     return true;
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -117,7 +117,7 @@ static bool shouldProfile(SILDeclRef Constant) {
 
   if (auto *D = DC->getInnermostDeclarationDeclContext()) {
     // Do not profile AST nodes in unavailable contexts.
-    if (D->getSemanticUnavailableAttr()) {
+    if (D->isSemanticallyUnavailable()) {
       LLVM_DEBUG(llvm::dbgs() << "Skipping ASTNode: unavailable context\n");
       return false;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5007,7 +5007,7 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D) {
   auto parentIsUnavailable = [](const Decl *D) -> bool {
     if (auto *parent =
             AvailabilityInference::parentDeclForInferredAvailability(D)) {
-      return parent->getSemanticUnavailableAttr() != std::nullopt;
+      return parent->isSemanticallyUnavailable();
     }
     return false;
   };

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4795,10 +4795,12 @@ void AttributeChecker::checkBackDeployedAttrs(
     if (Attr != ActiveAttr)
       continue;
 
+    auto availability =
+        TypeChecker::availabilityAtLocation(D->getLoc(), D->getDeclContext());
+
     // Unavailable decls cannot be back deployed.
-    if (auto unavailableAttrPair = VD->getSemanticUnavailableAttr()) {
-      auto unavailableAttr = unavailableAttrPair.value().first;
-      if (!inheritsAvailabilityFromPlatform(unavailableAttr->getPlatform(),
+    if (auto unavailablePlatform = availability.getUnavailablePlatformKind()) {
+      if (!inheritsAvailabilityFromPlatform(*unavailablePlatform,
                                             Attr->Platform)) {
         auto platformString = prettyPlatformString(Attr->Platform);
         llvm::VersionTuple ignoredVersion;
@@ -4808,9 +4810,21 @@ void AttributeChecker::checkBackDeployedAttrs(
 
         diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr, VD,
                  platformString);
-        diagnose(unavailableAttr->AtLoc, diag::availability_marked_unavailable,
-                 VD)
-            .highlight(unavailableAttr->getRange());
+
+        // Find the attribute that makes the declaration unavailable.
+        const Decl *attrDecl = D;
+        do {
+          if (auto *unavailableAttr = attrDecl->getUnavailableAttr()) {
+            diagnose(unavailableAttr->AtLoc,
+                     diag::availability_marked_unavailable, VD)
+                .highlight(unavailableAttr->getRange());
+            break;
+          }
+
+          attrDecl = AvailabilityInference::parentDeclForInferredAvailability(
+              attrDecl);
+        } while (attrDecl);
+
         continue;
       }
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -814,11 +814,17 @@ private:
     if (D->getDeclContext()->isLocalContext())
       return false;
 
-    // As a convenience, SPI decls and explicitly unavailable decls are
-    // constrained to the deployment target. There's not much benefit to
-    // checking these declarations at a lower availability version floor since
-    // neither can be used by API clients.
-    if (D->isSPI() || D->getSemanticUnavailableAttr())
+    // As a convenience, explicitly unavailable decls are constrained to the
+    // deployment target. There's not much benefit to checking these decls at a
+    // lower availability version floor since they can't be invoked by clients.
+    if (getCurrentScope()->getAvailabilityContext().isUnavailable() ||
+        D->isUnavailable())
+      return true;
+
+    // To remain compatible with a lot of existing SPIs that are declared
+    // without availability attributes, constrain them to the deployment target
+    // too.
+    if (D->isSPI())
       return true;
 
     return !::isExported(D);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1924,7 +1924,7 @@ checkOverrideUnavailability(ValueDecl *override, ValueDecl *base) {
   if (auto *overrideParent = override->getDeclContext()->getAsDecl()) {
     // If the parent of the override is unavailable, then the unavailability of
     // the override decl is irrelevant.
-    if (overrideParent->getSemanticUnavailableAttr())
+    if (overrideParent->isSemanticallyUnavailable())
       return {OverrideUnavailabilityStatus::Ignored, nullptr};
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1881,7 +1881,7 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
       }
 
       if (auto adoptingNominal = DC->getSelfNominalTypeDecl()) {
-        if (adoptingNominal->getSemanticUnavailableAttr())
+        if (adoptingNominal->isSemanticallyUnavailable())
           return true;
       }
 

--- a/test/IRGen/unavailable_decl_optimization_complete_nested_type.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_nested_type.swift
@@ -1,35 +1,38 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=none %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=none %s -emit-ir | %FileCheck %s --check-prefixes=CHECK-NO-STRIP
 
-// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --implicit-check-not=unavailableFuncWithNestedObsoleteType --implicit-check-not=unavailableFuncWithNestedType --implicit-check-not=NestedInExtension
 
-// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF
-// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF
+// CHECK-NO-STRIP-DAG: s4Test29unavailableFuncWithNestedType
+// CHECK-NO-STRIP-DAG: s4Test29unavailableFuncWithNestedTypeyyF0E10InFunction
+
 @available(*, unavailable)
 public func unavailableFuncWithNestedType() {
   struct NestedInFunction {
-    // s4Test29unavailableFuncWithNestedTypeyyF0E10InFunctionL_VADycfC
     init() {}
   }
 
   _ = NestedInFunction()
 }
 
-// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF0E10InFunctionL_VADycfC
-// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF0E10InFunctionL_VADycfC
+// CHECK-NO-STRIP-DAG: s4Test37unavailableFuncWithNestedObsoleteType
+// CHECK-NO-STRIP-DAG: s4Test37unavailableFuncWithNestedObsoleteTypeyyF0E10InFunction
+
+@available(*, unavailable)
+public func unavailableFuncWithNestedObsoleteType() {
+  @available(swift, obsoleted: 4)
+  struct NestedInFunction {
+    init() {}
+  }
+}
 
 public struct S {}
+
+// CHECK-NO-STRIP-DAG: s4Test1SV17NestedInExtension
 
 extension S {
   @available(*, unavailable)
   public struct NestedInExtension {
-    // CHECK-NO-STRIP: s4Test1SV17NestedInExtensionV6methodyyF
-    // CHECK-STRIP-NOT: s4Test1SV17NestedInExtensionV6methodyyF
     public func method() {}
   }
 }
 
-// CHECK-NO-STRIP: s4Test1SV17NestedInExtensionVMa
-// CHECK-STRIP-NOT: s4Test1SV17NestedInExtensionVMa
-
-// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF0E10InFunctionL_VMa
-// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF0E10InFunctionL_VMa

--- a/test/SILGen/unavailable_decl_optimization_stub.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub.swift
@@ -12,6 +12,37 @@ public func unavailableFunc() -> S {
   return S()
 }
 
+// CHECK-LABEL: sil{{.*}}@$s4Test025unavailableFuncWithNestedC0yyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:         function_ref @$s4Test025unavailableFuncWithNestedC0yyF6nestedL_SiyF
+// CHECK:       } // end sil function '$s4Test025unavailableFuncWithNestedC0yyF'
+@available(*, unavailable)
+public func unavailableFuncWithNestedFunc() {
+  func nested() -> Int { 1 }
+  _ = nested()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test025unavailableFuncWithNestedC0yyF6nestedL_SiyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:       } // end sil function '$s4Test025unavailableFuncWithNestedC0yyF6nestedL_SiyF'
+
+// CHECK-LABEL: sil{{.*}}@$s4Test033unavailableFuncWithObsoleteNestedC0yyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:       } // end sil function '$s4Test033unavailableFuncWithObsoleteNestedC0yyF'
+@available(*, unavailable)
+public func unavailableFuncWithObsoleteNestedFunc() {
+  @available(swift, obsoleted: 1)
+  func nested() -> Int { 1 }
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test033unavailableFuncWithObsoleteNestedC0yyF6nestedL_SiyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:       } // end sil function '$s4Test033unavailableFuncWithObsoleteNestedC0yyF6nestedL_SiyF'
+
 enum SomeError: Error { case generic }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test23unavailableThrowingFuncyyKF


### PR DESCRIPTION
Improve the efficiency and correctness of queries related to semantic availability of decls. Previously, `Decl::getSemanticUnavailableAttr()` was the designated query for semantic unavailability, but it cached much richer information than most callers needed and bloated the storage requirements of the request evaluator. Additionally, its results were not actually accurate for `Decl::isUnreachableAtRuntime()`, since that query has a stricter notion of unavailability. The new request implementation computes a semantic decl availability classification that is suitable for all callers and also can be stored much more efficiently.