### PR TITLE
[BarrierAccessScopes] Handle end_access instructions' barrierness introduced during run.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
+++ b/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
@@ -259,8 +259,9 @@ private:
       }
     }
     // If any of this block's predecessors haven't already been visited, it
-    // means that they aren't in the region and consequently this block is a
-    // barrier block.
+    // means EITHER that those predecessors aren't in the region OR that a
+    // barrier was encountered when visiting some (iterative) successor of that
+    // predecessor.  Either way, this block is a barrier block as a result.
     if (llvm::any_of(block->getSuccessorBlocks(), [&](SILBasicBlock *block) {
           return !visited.contains(block);
         })) {

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -296,8 +296,8 @@ Dataflow::Effect Dataflow::effectForPhi(SILBasicBlock *block) {
 }
 
 /// Finds end_access instructions which are barriers to hoisting because the
-/// access scopes they contain barriers to hoisting.  Hoisting end_borrows into
-/// such access scopes could introduce exclusivity violations.
+/// access scopes they end contain barriers to hoisting.  Hoisting end_borrows
+/// into such access scopes could introduce exclusivity violations.
 ///
 /// Implements BarrierAccessScopeFinder::Visitor
 class BarrierAccessScopeFinder final {

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -501,14 +501,11 @@ bool swift::shrinkBorrowScope(
 namespace swift::test {
 // Arguments:
 // - BeginBorrowInst - the introducer for the scope to shrink
-// - bool - the expected return value of shrinkBorrowScope
-// - variadic list of values consisting of the copies expected to be rewritten
 // Dumps:
 // - DELETED:  <<instruction deleted>>
 static FunctionTest ShrinkBorrowScopeTest(
-    "shrink-borrow-scope", [](auto &function, auto &arguments, auto &test) {
+    "shrink_borrow_scope", [](auto &function, auto &arguments, auto &test) {
       auto instruction = arguments.takeValue();
-      auto expected = arguments.takeBool();
       auto *bbi = cast<BeginBorrowInst>(instruction);
       auto *analysis = test.template getAnalysis<BasicCalleeAnalysis>();
       SmallVector<CopyValueInst *, 4> modifiedCopyValueInsts;
@@ -516,20 +513,16 @@ static FunctionTest ShrinkBorrowScopeTest(
           InstModCallbacks().onDelete([&](auto *instruction) {
             llvm::outs() << "DELETED:\n";
             instruction->print(llvm::outs());
+            instruction->eraseFromParent();
+
           }));
       auto shrunk =
           shrinkBorrowScope(*bbi, deleter, analysis, modifiedCopyValueInsts);
-      unsigned index = 0;
+      auto *shrunkString = shrunk ? "shrunk" : "did not shrink";
+      llvm::outs() << "Result: " << shrunkString << "\n";
+      llvm::outs() << "Rewrote the following copies:\n";
       for (auto *cvi : modifiedCopyValueInsts) {
-        auto expectedCopy = arguments.takeValue();
-        llvm::outs() << "rewritten copy " << index << ":\n";
-        llvm::outs() << "expected:\n";
-        expectedCopy->print(llvm::outs());
-        llvm::outs() << "got:\n";
         cvi->print(llvm::outs());
-        assert(cvi == expectedCopy);
-        ++index;
       }
-      assert(expected == shrunk && "didn't shrink expectedly!?");
     });
 } // namespace swift::test

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1174,7 +1174,7 @@ entry(%addr : $*X):
   return %retval : $()
 }
 
-// Even though the apply of %empty is not a deinit barrier (c.f.
+// Even though the apply of %empty is not a deinit barrier (cf.
 // hoist_over_apply_of_non_barrier_fn), verify that the destroy_addr is not
 // hoisted, because MoS is move-only.
 // CHECK-LABEL: sil [ossa] @dont_move_destroy_addr_of_moveonly_struct : {{.*}} {

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -5,8 +5,12 @@ import Swift
 
 class C {}
 
+struct X {}
+
 sil [ossa] @get_owned_c : $@convention(thin) () -> (@owned C)
 sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @barrier : $@convention(thin) () -> ()
+
 
 // CHECK-LABEL: begin running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 // CHECK-NOT: DELETED:
@@ -29,3 +33,37 @@ entry:
   return %retval : $(C, C)
 }
 
+// CHECK-LABEL: begin running test {{.*}} on nohoist_over_access_scope_barrier_1
+// CHECK:       Result: did not shrink
+// CHECK-LABEL: end running test {{.*}} on nohoist_over_access_scope_barrier_1
+sil [ossa] @nohoist_over_access_scope_barrier_1 : $@convention(thin) (@guaranteed C, @inout X) -> () {
+entry(%c : @guaranteed $C, %addr : $*X):
+  %borrow = begin_borrow %c : $C
+  specify_test "shrink_borrow_scope %borrow"
+  %access = begin_access [modify] [dynamic] %addr : $*X
+  cond_br undef, kill_introducer, newly_local_gen
+
+kill_introducer:
+  cond_br undef, left, right
+
+left:
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+right:
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+newly_local_gen:
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -11,10 +11,11 @@ sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
 // CHECK-LABEL: begin running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 // CHECK-NOT: DELETED:
 // CHECK-NOT: end_borrow
+// CHECK: Result: did not shrink
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 sil [ossa] @nohoist_over_rewritten_copy : $@convention(thin) () -> (@owned C, @owned C) {
 entry:
-  specify_test "shrink-borrow-scope @trace true @trace[1]"
+  specify_test "shrink_borrow_scope %lifetime"
   %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
   %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C

--- a/validation-test/SILOptimizer/gh77693.swift
+++ b/validation-test/SILOptimizer/gh77693.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -c -O %s
+
+protocol P {}
+enum E {
+  case c(any P)
+  var d: [String:String] { [:] }
+}
+
+final class C {
+  var o: [String:String]?
+}
+
+func f(_ e: E?) {
+  if let e {
+    C().o?.merge(e.d) { c, _ in c }
+  }
+}


### PR DESCRIPTION
As the utility runs, new gens may become local: as access scopes are determined to contain deinit barriers, their `end_access` instructions become kills; if such an `end_access` occurs in the same block above an initially-non-local gen, that gen is now local.

Previously, it was asserted that kills would not be encountered when visiting a block backwards from an initially-non-local gen.  As described above, the assertion was incorrect.

Iteration would also _stop_ at the discovered kill, if any.  That too was incorrect. To continue walking the block after finding such a newly discovered kill is needed by the book-keeping the utility does for which access scopes contain barriers: there may be more `end_access` instructions.  Concretely, there are two cases: (1) The block may contain another `end_access` and above it a deinit barrier which must result in that second scope becoming a deinit barrier. (2) Some of the block's predecessors may be in the region, all the access scope which are open at the begin of this block must be unioned into the set of scopes open at each predecessors' end, and more such access scopes may be discovered above the just-visited `end_access`.

Here, both the assertion failure and the early bailout are fixed by walking from the indicated initially-non-local gen backwards over the entire block, regardless of whether a kill was encountered.  If a kill is encountered, it is asserted that the kill is an `end_access` to account for the case described above.

rdar://139840307
