### PR TITLE
[ClangImporter] Do not import DynamicRangePointerType and ValueTerminatedType

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -410,33 +410,6 @@ namespace {
       return Type();
     }
 
-    ImportResult VisitCountAttributedType(
-        const clang::CountAttributedType *type) {
-      // CountAttributedType is a clang type representing a pointer with
-      // a "counted_by" type attribute. For now, we don't import these
-      // into Swift.
-      // In the future we could do something more clever (such as trying to
-      // import as an Array where possible) or less clever (such as importing
-      // as the desugared, underlying pointer type).
-      return Type();
-    }
-
-    ImportResult VisitDynamicRangePointerType(
-        const clang::DynamicRangePointerType *type) {
-      // DynamicRangePointerType is a clang type representing a pointer with
-      // an "ended_by" type attribute for -fbounds-safety. For now, we don't
-      // import these into Swift.
-      return Type();
-    }
-
-    ImportResult VisitValueTerminatedType(
-        const clang::ValueTerminatedType *type) {
-      // ValueTerminatedType is a clang type representing a pointer with
-      // a "terminated_by" type attribute for -fbounds-safety. For now, we don't
-      // import these into Swift.
-      return Type();
-    }
-
     ImportResult VisitMemberPointerType(const clang::MemberPointerType *type) {
       return Type();
     }
@@ -956,6 +929,12 @@ namespace {
     SUGAR_TYPE(Elaborated)
     SUGAR_TYPE(Using)
     SUGAR_TYPE(BTFTagAttributed)
+
+    // Clang types representing a pointer with a bounds annotation such as
+    // "counted_by", "ended_by" and "terminated_by". For now, we ignore them.
+    SUGAR_TYPE(CountAttributed)
+    SUGAR_TYPE(DynamicRangePointer)
+    SUGAR_TYPE(ValueTerminated)
 
     ImportResult VisitDecayedType(const clang::DecayedType *type) {
       clang::ASTContext &clangCtx = Impl.getClangASTContext();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -421,6 +421,22 @@ namespace {
       return Type();
     }
 
+    ImportResult VisitDynamicRangePointerType(
+        const clang::DynamicRangePointerType *type) {
+      // DynamicRangePointerType is a clang type representing a pointer with
+      // an "ended_by" type attribute for -fbounds-safety. For now, we don't
+      // import these into Swift.
+      return Type();
+    }
+
+    ImportResult VisitValueTerminatedType(
+        const clang::ValueTerminatedType *type) {
+      // ValueTerminatedType is a clang type representing a pointer with
+      // a "terminated_by" type attribute for -fbounds-safety. For now, we don't
+      // import these into Swift.
+      return Type();
+    }
+
     ImportResult VisitMemberPointerType(const clang::MemberPointerType *type) {
       return Type();
     }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -417,6 +417,33 @@ namespace {
       return Type();
     }
 
+    ImportResult VisitCountAttributedType(
+        const clang::CountAttributedType *type) {
+      // CountAttributedType is a clang type representing a pointer with
+      // a "counted_by" type attribute. For now, we don't import these
+      // into Swift.
+      // In the future we could do something more clever (such as trying to
+      // import as an Array where possible) or less clever (such as importing
+      // as the desugared, underlying pointer type).
+      return Type();
+    }
+
+    ImportResult VisitDynamicRangePointerType(
+        const clang::DynamicRangePointerType *type) {
+      // DynamicRangePointerType is a clang type representing a pointer with
+      // an "ended_by" type attribute for -fbounds-safety. For now, we don't
+      // import these into Swift.
+      return Type();
+    }
+
+    ImportResult VisitValueTerminatedType(
+        const clang::ValueTerminatedType *type) {
+      // ValueTerminatedType is a clang type representing a pointer with
+      // a "terminated_by" type attribute for -fbounds-safety. For now, we don't
+      // import these into Swift.
+      return Type();
+    }
+
     ImportResult VisitMemberPointerType(const clang::MemberPointerType *type) {
       return Type();
     }
@@ -936,12 +963,6 @@ namespace {
     SUGAR_TYPE(Elaborated)
     SUGAR_TYPE(Using)
     SUGAR_TYPE(BTFTagAttributed)
-
-    // Clang types representing a pointer with a bounds annotation such as
-    // "counted_by", "ended_by" and "terminated_by". For now, we ignore them.
-    SUGAR_TYPE(CountAttributed)
-    SUGAR_TYPE(DynamicRangePointer)
-    SUGAR_TYPE(ValueTerminated)
 
     ImportResult VisitDecayedType(const clang::DecayedType *type) {
       clang::ASTContext &clangCtx = Impl.getClangASTContext();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -55,6 +55,13 @@
 using namespace swift;
 using namespace importer;
 
+// XXX: This is to resolve the build dependency with Clang. Remove it once these
+// types actually land in Clang.
+namespace clang {
+class DynamicRangePointerType;
+class ValueTerminatedType;
+}
+
 /// Given that a type is the result of a special typedef import, was
 /// it originally a CF pointer?
 static bool isImportedCFPointer(clang::QualType clangType, Type type) {


### PR DESCRIPTION
- **Explanation**: DynamicRangePointerType and ValueTerminatedType are new Clang types for -fbounds-safety, annotated with the 'ended_by' and the 'terminated_by' attributes. This adds visitors for these types in ClangImporter so Swift continues to build with the upcoming Clang change that will introduce these new types. This should unblock https://github.com/swiftlang/llvm-project/pull/9665

  - **Scope**: This cannot affect the existing code because it adds visitors for new clang types that do not exist. Until Clang introduces these types those visitors are not reachable. 

  - **Issues**: N/A

  - **Original PRs**: https://github.com/swiftlang/swift/pull/77910

  - **Risk**: The risk is very low because it doesn't affect any existing code. Without this patch, this repo will stop building once Clang lands the change to introduce these new types.

  - **Testing**: Typical swift-ci tests will be sufficient

  - **Reviewers**: @DougGregor