### PR TITLE
[6.1] embedded: Don't emit SILProperties in embedded swift

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1224,10 +1224,12 @@ void IRGenerator::emitGlobalTopLevel(
     }
   }
   
-  // Emit property descriptors.
-  for (auto &prop : PrimaryIGM->getSILModule().getPropertyList()) {
-    CurrentIGMPtr IGM = getGenModule(prop.getDecl()->getInnermostDeclContext());
-    IGM->emitSILProperty(&prop);
+  if (!SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    // Emit property descriptors.
+    for (auto &prop : PrimaryIGM->getSILModule().getPropertyList()) {
+      CurrentIGMPtr IGM = getGenModule(prop.getDecl()->getInnermostDeclContext());
+      IGM->emitSILProperty(&prop);
+    }
   }
 
   // Emit differentiability witnesses.

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -42,4 +42,14 @@ public struct State<Wrapped> {
   }
 }
 
+public struct S<T> {
+  public private(set) subscript(x: Int) -> Int {
+     get {
+       return 27
+     }
+     mutating set {
+     }
+   }
+}
+
 // CHECK: define {{.*}}@main(


### PR DESCRIPTION
* **Explanation**: Fixes an IRGen crash when using keypaths in embedded swift. For resilient keypaths IRGen creates property descriptors, which are needed for resilient builds. Property descriptors are not needed and do not work in embedded swift.
* **Scope**: Only affects embedded swift when using keypaths.
* **Risk**: Low. The change just disables IR-generating SILProperties.
* **Testing**: Tested by a test case.
* **Issue**: https://github.com/swiftlang/swift/issues/77682
* **Reviewer**:  @kubamracek
* **Main branch PR**: https://github.com/swiftlang/swift/pull/77697
