### PR TITLE
[6.1] Devirtualization: make sure to de-serialize the body of shared deinit functions.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -227,6 +227,14 @@ extension MutatingContext {
     }
   }
 
+  func loadFunction(function: Function, loadCalleesRecursively: Bool) -> Bool {
+    if function.isDefinition {
+      return true
+    }
+    _bridged.loadFunction(function.bridged, loadCalleesRecursively)
+    return function.isDefinition
+  }
+
   private func notifyNewInstructions(from: Instruction, to: Instruction) {
     var inst = from
     while inst != to {
@@ -303,14 +311,6 @@ struct FunctionPassContext : MutatingContext {
       let nameStr = BridgedStringRef(data: nameBuffer.baseAddress, count: nameBuffer.count)
       return _bridged.loadFunction(nameStr, loadCalleesRecursively).function
     }
-  }
-
-  func loadFunction(function: Function, loadCalleesRecursively: Bool) -> Bool {
-    if function.isDefinition {
-      return true
-    }
-    _bridged.loadFunction(function.bridged, loadCalleesRecursively)
-    return function.isDefinition
   }
 
   /// Looks up a function in the `Swift` module.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -43,6 +43,10 @@ private func devirtualize(destroy: some DevirtualizableDestroy, _ context: some 
     guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
       return false
     }
+    if deinitFunc.linkage == .shared && !deinitFunc.isDefinition {
+      // Make sure to not have an external shared function, which is illegal in SIL.
+      _ = context.loadFunction(function: deinitFunc, loadCalleesRecursively: false)
+    }
     destroy.createDeinitCall(to: deinitFunc, context)
     context.erase(instruction: destroy)
     return true

--- a/test/SILOptimizer/stdlib/Atomics.swift
+++ b/test/SILOptimizer/stdlib/Atomics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -enable-ossa-modules -O -emit-sil -disable-availability-checking %s | %IRGenFileCheck %s
 
 // REQUIRES: synchronization
 


### PR DESCRIPTION
* **Explanation**: Fixes a verification error caused by the deinit-devirtualizer pass. Sometimes it can happen that a deinit function, which is imported from another module, has shared linkage. In this case it is important to de-serialize the function body. Otherwise it would be illegal SIL.
* **Scope**: Can affect code which uses a non-copyable type, which has a deinit, from another module.
* **Risk**: Low. It's a small change which exactly catches the crashing scenario
* **Testing**: Tested by a test case.
* **Issue**: rdar://140112207
* **Reviewer**:  @meg-gupta
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/77858 (I only cherry-picked the relevant commit 9279a2c0d62a1557813c997d2b0b73c4f25db541)
