### PR TITLE
[CS] Remove hack for rdar://139234188

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6434,10 +6434,9 @@ Type getPatternTypeOfSingleUnlabeledPackExpansionTuple(Type type);
 /// methods prefixed with `build*` i.e. `buildBlock`, `buildExpression` etc.
 bool isResultBuilderMethodReference(ASTContext &, UnresolvedDotExpr *);
 
-/// Determine the number of applications applied to the given overload.
-unsigned getNumApplications(ValueDecl *decl, bool hasAppliedSelf,
-                            FunctionRefInfo functionRefInfo,
-                            ConstraintLocatorBuilder locator);
+/// Determine the number of applications applied for a given FunctionRefInfo.
+unsigned getNumApplications(bool hasAppliedSelf,
+                            FunctionRefInfo functionRefInfo);
 
 } // end namespace constraints
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2255,6 +2255,11 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
   if (kind != ConstraintKind::UnresolvedValueMember)
     return nullptr;
 
+  // Only diagnose for UnresolvedMemberExprs.
+  // TODO: We ought to support diagnosing EnumElementPatterns too.
+  if (!isExpr<UnresolvedMemberExpr>(locator->getAnchor()))
+    return nullptr;
+
   // None or only one viable candidate, there is no ambiguity.
   if (result.ViableCandidates.size() <= 1)
     return nullptr;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10163,8 +10163,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
         auto hasAppliedSelf = decl->hasCurriedSelf() &&
                               doesMemberRefApplyCurriedSelf(baseObjTy, decl);
-        return getNumApplications(decl, hasAppliedSelf, functionRefInfo,
-                                  memberLocator) < decl->getNumCurryLevels();
+        auto numApplies = getNumApplications(hasAppliedSelf, functionRefInfo);
+        return numApplies < decl->getNumCurryLevels();
       });
     };
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -663,26 +663,8 @@ static unsigned getNumRemovedArgumentLabels(ValueDecl *decl,
   llvm_unreachable("Unhandled FunctionRefInfo in switch.");
 }
 
-/// Determine the number of applications
-unsigned constraints::getNumApplications(ValueDecl *decl, bool hasAppliedSelf,
-                                         FunctionRefInfo functionRefInfo,
-                                         ConstraintLocatorBuilder locator) {
-  // FIXME: Narrow hack for rdar://139234188 - Currently we set
-  // FunctionRefInfo::Compound for enum element patterns with tuple
-  // sub-patterns to ensure the member has argument labels stripped. As such,
-  // we need to account for the correct application level here. We ought to be
-  // setting the correct FunctionRefInfo and properly handling the label
-  // matching in the solver though.
-  if (auto lastElt = locator.last()) {
-    if (auto matchElt = lastElt->getAs<LocatorPathElt::PatternMatch>()) {
-      if (auto *EP = dyn_cast<EnumElementPattern>(matchElt->getPattern()))
-        return (EP->hasSubPattern() ? 1 : 0) + hasAppliedSelf;
-    }
-  }
-  // FIXME(FunctionRefInfo): This matches the old behavior, but is wrong.
-  if (functionRefInfo.isCompoundName())
-    return 0 + hasAppliedSelf;
-
+unsigned constraints::getNumApplications(bool hasAppliedSelf,
+                                         FunctionRefInfo functionRefInfo) {
   switch (functionRefInfo.getApplyLevel()) {
   case FunctionRefInfo::ApplyLevel::Unapplied:
     return 0 + hasAppliedSelf;
@@ -908,8 +890,8 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     auto origOpenedType = openedType;
     if (!isRequirementOrWitness(locator)) {
-      unsigned numApplies = getNumApplications(value, false, functionRefInfo,
-                                               locator);
+      unsigned numApplies = getNumApplications(/*hasAppliedSelf*/ false,
+                                               functionRefInfo);
       openedType = adjustFunctionTypeForConcurrency(
           origOpenedType, /*baseType=*/Type(), func, useDC, numApplies, false,
           replacements, locator);
@@ -937,8 +919,8 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     auto origOpenedType = openedType;
     if (!isRequirementOrWitness(locator)) {
-      unsigned numApplies = getNumApplications(
-          funcDecl, false, functionRefInfo, locator);
+      unsigned numApplies = getNumApplications(/*hasAppliedSelf*/ false,
+                                               functionRefInfo);
       openedType = adjustFunctionTypeForConcurrency(
           origOpenedType->castTo<FunctionType>(), /*baseType=*/Type(), funcDecl,
           useDC, numApplies, false, replacements, locator);
@@ -1680,8 +1662,7 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   if (isRequirementOrWitness(locator)) {
     // Don't adjust when doing witness matching, because that can cause cycles.
   } else if (isa<AbstractFunctionDecl>(value) || isa<EnumElementDecl>(value)) {
-    unsigned numApplies = getNumApplications(
-        value, hasAppliedSelf, functionRefInfo, locator);
+    unsigned numApplies = getNumApplications(hasAppliedSelf, functionRefInfo);
     openedType = adjustFunctionTypeForConcurrency(
         origOpenedType->castTo<FunctionType>(), resolvedBaseTy, value, useDC,
         numApplies, isMainDispatchQueueMember(locator), replacements, locator);
@@ -1864,8 +1845,8 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
 
       auto hasAppliedSelf =
           doesMemberRefApplyCurriedSelf(overload.getBaseType(), decl);
-      unsigned numApplies = getNumApplications(
-          decl, hasAppliedSelf, overload.getFunctionRefInfo(), locator);
+      unsigned numApplies = getNumApplications(hasAppliedSelf,
+                                               overload.getFunctionRefInfo());
 
       type = adjustFunctionTypeForConcurrency(
                  type->castTo<FunctionType>(), overload.getBaseType(), decl,


### PR DESCRIPTION
Now that "is compound" is a separate bit in FunctionRefInfo (#77896), we can correctly track the application level for an EnumElementPattern.