### PR TITLE
[cxx-interop] Bring back `AssumeResilientCxxTypes` flag for CxxStdlib overlay

### DIFF
--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -56,6 +56,10 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     -cxx-interoperability-mode=default
     -Xfrontend -module-interface-preserve-types-as-written
 
+    # This flag is unnecessary when building with newer compilers that allow
+    # using C++ symbols in resilient overlays (see f4204568).
+    -enable-experimental-feature AssumeResilientCxxTypes
+
     # The varying modularization of the C++ standard library on different
     # platforms makes it difficult to enable MemberImportVisibility for this
     # module


### PR DESCRIPTION
This fixes a CI job that is building the Swift stdlib with a recent nightly compiler.

rdar://140850172

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
