### PR TITLE
Revert changes related to `Void` binding favoring

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -486,10 +486,6 @@ public:
   /// Determine whether this type variable represents a subscript result type.
   bool isSubscriptResultType() const;
 
-  /// Determine whether this type variable represents a result type of an
-  /// application i.e. a call, an operator, or a subscript.
-  bool isApplicationResultType() const;
-
   /// Determine whether this type variable represents an opened
   /// type parameter pack.
   bool isParameterPack() const;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1281,16 +1281,9 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
 
         return !hasConversions(binding.BindingType);
       })) {
-    bool isApplicationResultType = TypeVar->getImpl().isApplicationResultType();
-    if (llvm::none_of(Info.DelayedBy, [&isApplicationResultType](
-                                          const Constraint *constraint) {
-          // Let's not attempt to bind result type before application
-          // happens. For example because it could be discardable or
-          // l-value (subscript applications).
-          if (isApplicationResultType &&
-              constraint->getKind() == ConstraintKind::ApplicableFunction)
-            return true;
-
+    // Result type of subscript could be l-value so we can't bind it early.
+    if (!TypeVar->getImpl().isSubscriptResultType() &&
+        llvm::none_of(Info.DelayedBy, [](const Constraint *constraint) {
           return constraint->getKind() == ConstraintKind::Disjunction ||
                  constraint->getKind() == ConstraintKind::ValueMember;
         }))

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1264,8 +1264,7 @@ static bool hasConversions(Type type) {
   }
 
   return !(type->is<StructType>() || type->is<EnumType>() ||
-           type->is<BuiltinType>() || type->is<ArchetypeType>() ||
-           type->isVoid());
+           type->is<BuiltinType>() || type->is<ArchetypeType>());
 }
 
 bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -175,16 +175,6 @@ bool TypeVariableType::Implementation::isSubscriptResultType() const {
              KeyPathExpr::Component::Kind::UnresolvedSubscript;
 }
 
-bool TypeVariableType::Implementation::isApplicationResultType() const {
-  if (!(locator && locator->getAnchor()))
-    return false;
-
-  if (!locator->isLastElement<LocatorPathElt::FunctionResult>())
-    return false;
-
-  return isExpr<ApplyExpr>(locator->getAnchor()) || isSubscriptResultType();
-}
-
 bool TypeVariableType::Implementation::isParameterPack() const {
   return locator
       && locator->isForGenericParameter()

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -180,3 +180,20 @@ struct OverloadInImplicitAsyncClosure {
 
   init(int: Int) throws { }
 }
+
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) async throws {}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) -> String { "" }
+
+@available(SwiftStdlib 5.5, *)
+func compute(_: @escaping () -> Void) {}
+
+@available(SwiftStdlib 5.5, *)
+func test_sync_in_closure_context() {
+  compute {
+    test(42) // Ok (select sync overloads and discards the result)
+  }
+}

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -180,20 +180,3 @@ struct OverloadInImplicitAsyncClosure {
 
   init(int: Int) throws { }
 }
-
-@available(SwiftStdlib 5.5, *)
-func test(_: Int) async throws {}
-
-@discardableResult
-@available(SwiftStdlib 5.5, *)
-func test(_: Int) -> String { "" }
-
-@available(SwiftStdlib 5.5, *)
-func compute(_: @escaping () -> Void) {}
-
-@available(SwiftStdlib 5.5, *)
-func test_sync_in_closure_context() {
-  compute {
-    test(42) // Ok (select sync overloads and discards the result)
-  }
-}


### PR DESCRIPTION
- [CSBindings] Adjust `hasConversions` to handle `Void` has having not conversions
- [CSBindings] Don't favor application result types before application happens

Although the changes are correct they have a negative impact on performance in
some situations (especially the second part) because the result type would no longer
be eagerly bound.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
