### PR TITLE
test: adjust quoting of arguments

### DIFF
--- a/test/Driver/driver_mode.swift
+++ b/test/Driver/driver_mode.swift
@@ -1,5 +1,5 @@
-// RUN: %swift_driver_plain --driver-mode=swiftc -sdk "" -driver-print-actions %s 2>&1 | %FileCheck -check-prefix=CHECK-SWIFTC-%target-object-format %s
-// RUN: %swift_driver_plain -sdk "" -driver-print-actions %s --driver-mode=swiftc 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT %s
+// RUN: %swift_driver_plain --driver-mode=swiftc -sdk '""' -driver-print-actions %s 2>&1 | %FileCheck -check-prefix=CHECK-SWIFTC-%target-object-format %s
+// RUN: %swift_driver_plain -sdk '""' -driver-print-actions %s --driver-mode=swiftc 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT %s
 
 // CHECK-SWIFTC-macho: 0: input, "{{.*}}driver_mode.swift", swift
 // CHECK-SWIFTC-macho: 1: compile, {0}, object

--- a/test/Driver/infer-simulator.swift
+++ b/test/Driver/infer-simulator.swift
@@ -1,13 +1,13 @@
 // Test the inference of the "simulator" environment within the driver.
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-ios11.0 %s > %t.simple.txt 2>&1
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -target x86_64-apple-ios11.0 %s > %t.simple.txt 2>&1
 // RUN: %FileCheck -check-prefix WARN_IOS_SIMULATOR %s < %t.simple.txt
 // WARN_IOS_SIMULATOR:  warning: inferring simulator environment for target 'x86_64-apple-ios11.0'; use '-target x86_64-apple-ios11.0-simulator' instead
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-tvos10.0 %s > %t.simple.txt 2>&1
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -target x86_64-apple-tvos10.0 %s > %t.simple.txt 2>&1
 // RUN: %FileCheck -check-prefix WARN_TVOS_SIMULATOR %s < %t.simple.txt
 // WARN_TVOS_SIMULATOR: inferring simulator environment for target 'x86_64-apple-tvos10.0'; use '-target x86_64-apple-tvos10.0-simulator' instead
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target i386-apple-watchos4.0 %s > %t.simple.txt 2>&1
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -target i386-apple-watchos4.0 %s > %t.simple.txt 2>&1
 // RUN: %FileCheck -check-prefix WARN_WATCHOS_SIMULATOR %s < %t.simple.txt
 // WARN_WATCHOS_SIMULATOR: warning: inferring simulator environment for target 'i386-apple-watchos4.0'; use '-target i386-apple-watchos4.0-simulator' instead

--- a/test/Driver/linker-library-with-space.swift
+++ b/test/Driver/linker-library-with-space.swift
@@ -1,4 +1,4 @@
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-lib-flag-space %s < %t.linux.txt
 
 // LINUX-lib-flag-space: swift

--- a/test/Driver/os-deployment.swift
+++ b/test/Driver/os-deployment.swift
@@ -1,16 +1,16 @@
-// RUN: not %swiftc_driver -sdk "" -target x86_64-apple-macosx10.8 %s 2>&1 | %FileCheck --check-prefix=CHECK-OSX %s
-// RUN: not %swiftc_driver -sdk "" -target x86_64-apple-ios6.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-IOS %s
-// RUN: not %swiftc_driver -sdk "" -target x86_64-apple-tvos8.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-tvOS %s
-// RUN: not %swiftc_driver -sdk "" -target x86_64-apple-watchos1.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-watchOS %s
+// RUN: not %swiftc_driver -sdk '""' -target x86_64-apple-macosx10.8 %s 2>&1 | %FileCheck --check-prefix=CHECK-OSX %s
+// RUN: not %swiftc_driver -sdk '""' -target x86_64-apple-ios6.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-IOS %s
+// RUN: not %swiftc_driver -sdk '""' -target x86_64-apple-tvos8.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-tvOS %s
+// RUN: not %swiftc_driver -sdk '""' -target x86_64-apple-watchos1.0 %s 2>&1 | %FileCheck --check-prefix=CHECK-watchOS %s
 
-// RUN: not %swiftc_driver -sdk "" -target i386-apple-ios11.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-11 %s
-// RUN: not %swiftc_driver -sdk "" -target armv7-apple-ios11.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-11 %s
-// RUN: not %swiftc_driver -sdk "" -target i386-apple-ios12.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-12 %s
-// RUN: not %swiftc_driver -sdk "" -target armv7-apple-ios12.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-12 %s
-// RUN: %swiftc_driver -sdk "" -target i386-apple-ios10.3 %s -### >/dev/null
-// RUN: %swiftc_driver -sdk "" -target armv7-apple-ios10.3 %s -### >/dev/null
-// RUN: %swiftc_driver -sdk "" -target x86_64-apple-ios11.0 %s -### >/dev/null
-// RUN: %swiftc_driver -sdk "" -target arm64-apple-ios11.0 %s -### >/dev/null
+// RUN: not %swiftc_driver -sdk '""' -target i386-apple-ios11.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-11 %s
+// RUN: not %swiftc_driver -sdk '""' -target armv7-apple-ios11.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-11 %s
+// RUN: not %swiftc_driver -sdk '""' -target i386-apple-ios12.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-12 %s
+// RUN: not %swiftc_driver -sdk '""' -target armv7-apple-ios12.0 %s -### 2>&1 | %FileCheck --check-prefix=CHECK-IOS-12 %s
+// RUN: %swiftc_driver -sdk '""' -target i386-apple-ios10.3 %s -### >/dev/null
+// RUN: %swiftc_driver -sdk '""' -target armv7-apple-ios10.3 %s -### >/dev/null
+// RUN: %swiftc_driver -sdk '""' -target x86_64-apple-ios11.0 %s -### >/dev/null
+// RUN: %swiftc_driver -sdk '""' -target arm64-apple-ios11.0 %s -### >/dev/null
 
 
 // CHECK-OSX: Swift requires a minimum deployment target of OS X 10.9

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -1,26 +1,26 @@
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK -check-prefix=OSX %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK -check-prefix=OSX %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOSSIM %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-apple-ios7.1-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOSSIM %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target arm64-apple-ios7.1 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=IOS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-apple-tvos9.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target arm64-apple-tvos9.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=tvOS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir-old/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target i386-apple-watchos2.0-simulator -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target armv7k-apple-watchos2.0 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=CHECK -check-prefix=watchOS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK -check-prefix=LINUX %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target x86_64-unknown-windows-msvc %s | %FileCheck -check-prefix=CHECK -check-prefix=WINDOWS %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK -check-prefix=LINUX %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target x86_64-unknown-windows-msvc %s | %FileCheck -check-prefix=CHECK -check-prefix=WINDOWS %s
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -target wasm32-unknown-wasi -resource-dir %S/Inputs/fake-resource-dir/lib/swift_static %s | %FileCheck -check-prefix CHECK -check-prefix WASI %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -target wasm32-unknown-wasi -resource-dir %S/Inputs/fake-resource-dir/lib/swift_static %s | %FileCheck -check-prefix CHECK -check-prefix WASI %s
 
 // CHECK: swift
 // CHECK: -profile-generate
@@ -58,12 +58,12 @@
 // WASI: lib{{(\\\\|/)}}{{swift|swift_static}}{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}wasi{{(\\\\|/)}}libclang_rt.profile-wasm32.a
 // WASI: -u__llvm_profile_runtime
 
-// RUN: not %swiftc_driver -sdk "" -driver-print-jobs -profile-generate -profile-use=/dev/null %s 2>&1 | %FileCheck -check-prefix=MIX_GEN_USE %s
+// RUN: not %swiftc_driver -sdk '""' -driver-print-jobs -profile-generate -profile-use=/dev/null %s 2>&1 | %FileCheck -check-prefix=MIX_GEN_USE %s
 // MIX_GEN_USE: conflicting options '-profile-generate' and '-profile-use'
 
-// RUN: not %swiftc_driver -sdk "" -driver-print-jobs -profile-use=%t.does_not_exist %s 2>&1 | %FileCheck -check-prefix=USE_MISSING_FILE %s
+// RUN: not %swiftc_driver -sdk '""' -driver-print-jobs -profile-use=%t.does_not_exist %s 2>&1 | %FileCheck -check-prefix=USE_MISSING_FILE %s
 // USE_MISSING_FILE: no profdata file exists at '{{[^']+}}.does_not_exist'
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -profile-use=/dev/null %s | %FileCheck -check-prefix=USE_DEVNULL %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -profile-use=/dev/null %s | %FileCheck -check-prefix=USE_DEVNULL %s
 // USE_DEVNULL: swift
 // USE_DEVNULL: -profile-use={{/dev/null|(.*profiling-[^ ]*.o)}}

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -1,63 +1,63 @@
 /*
  * Address Sanitizer Tests  (asan)
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_OSX %s
-// RUN: not %swiftc_driver -sdk "" -driver-print-jobs -sanitize=fuzzer -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NONEXISTENT %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOSSIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=ASAN_LINUX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=ASAN_WINDOWS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_OSX %s
+// RUN: not %swiftc_driver -sdk '""' -driver-print-jobs -sanitize=fuzzer -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NONEXISTENT %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOSSIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_watchOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=ASAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=ASAN_WINDOWS %s
 
 /*
  * Thread Sanitizer Tests  (tsan)
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=TSAN -check-prefix=TSAN_OSX %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=TSAN_OSX_32 %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-ios7.1-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_IOSSIM %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=TSAN_IOS %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-tvos9.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS_SIM %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target i386-apple-watchos2.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_watchOS_SIM %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target armv7k-apple-watchos2.0 %s 2>&1  | %FileCheck -check-prefix=TSAN_watchOS %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=TSAN_WINDOWS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=TSAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=TSAN -check-prefix=TSAN_OSX %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=TSAN_OSX_32 %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-ios7.1-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_IOSSIM %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=TSAN_IOS %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-apple-tvos9.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS_SIM %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=TSAN_tvOS %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target i386-apple-watchos2.0-simulator %s 2>&1 | %FileCheck -check-prefix=TSAN_watchOS_SIM %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target armv7k-apple-watchos2.0 %s 2>&1  | %FileCheck -check-prefix=TSAN_watchOS %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=TSAN_WINDOWS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=TSAN_LINUX %s
 
 /*
  * Undefined Behavior Sanitizer Tests  (ubsan)
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_OSX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOSSIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS_SIM %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=UBSAN_LINUX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=UBSAN_WINDOWS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_OSX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOSSIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_IOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target arm64-apple-tvos9.0 %s  | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_tvOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target i386-apple-watchos2.0-simulator %s   | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS_SIM %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target armv7k-apple-watchos2.0 %s | %FileCheck -check-prefix=UBSAN -check-prefix=UBSAN_watchOS %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=UBSAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=undefined -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=UBSAN_WINDOWS %s
 
 /*
  * Multiple Sanitizers At Once
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,undefined,fuzzer -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,undefined,fuzzer -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
 
 /*
  * Bad Argument Tests
  */
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address,unknown %s 2>&1 | %FileCheck -check-prefix=BADARG %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address -sanitize=unknown %s 2>&1 | %FileCheck -check-prefix=BADARG %s
-// RUN: not %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address,thread %s 2>&1 | %FileCheck -check-prefix=INCOMPATIBLESANITIZERS %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address,unknown %s 2>&1 | %FileCheck -check-prefix=BADARG %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address -sanitize=unknown %s 2>&1 | %FileCheck -check-prefix=BADARG %s
+// RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -target x86_64-apple-macosx10.9 -sanitize=address,thread %s 2>&1 | %FileCheck -check-prefix=INCOMPATIBLESANITIZERS %s
 
 /*
  * Make sure we don't accidentally add the sanitizer library path when building libraries or modules
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-library -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=ASAN_LINUX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-module -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=ASAN_LINUX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-library -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=TSAN_LINUX %s
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-module -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=TSAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-library -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=ASAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-module -sanitize=address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=ASAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-library -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=TSAN_LINUX %s
+// RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-module -sanitize=thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck --implicit-check-not=TSAN_LINUX %s
 
 // ASAN: swift
 // ASAN: -sanitize=address


### PR DESCRIPTION
When running the tests with a toolchain built with the "early swift driver", we would incorrectly process the command line, losing the empty string argument to `-sdk` which would then incorrectly process the remainder of the command line. This allows most of the remaining tests to pass with the early swift driver on Windows (assuming that the paths are adjusted properly).