### PR TITLE
Fix python arch on the windows arm64 CI

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -351,7 +351,7 @@ function Get-BisonExecutable {
 }
 
 function Get-PythonExecutable {
-  return Join-Path -Path $BinaryCache -ChildPath "Python$($HostArch.CMakeName)-$PythonVersion\tools\python.exe"
+  return Join-Path -Path $BinaryCache -ChildPath "Python$($BuildArch.CMakeName)-$PythonVersion\tools\python.exe"
 }
 
 function Get-InstallDir($Arch) {


### PR DESCRIPTION
https://ci-external.swift.org/job/swift-main-windows-toolchain-arm64/777/consoleText
```
Error: Program 'python.exe' failed to run: The specified executable is not a valid application for this OS platform.At C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift\utils\build.ps1:545 char:7
+       & $Executable @Args | Out-Null
+       ~~~~~~~~~~~~~~~~~~~.
```