### PR TITLE
[CS] Correctly set compound bit for UnresolvedMemberExprs

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1898,18 +1898,7 @@ public:
                        bool implicit)
     : Expr(ExprKind::UnresolvedMember, implicit), DotLoc(dotLoc),
       NameLoc(nameLoc), Name(name) {
-    // FIXME(FunctionRefInfo): Really, we should be passing `nameLoc` directly,
-    // allowing the FunctionRefInfo to be treated as compound. This would
-    // require us to enable IUOs for compound names, e.g:
-    // ```
-    // struct S {
-    //   static func makeS(_: Int) -> S! { S() }
-    // }
-    //
-    // let s: S = .makeS(_:)(0)
-    // ```
-    setFunctionRefInfo(
-        FunctionRefInfo::unapplied(DeclNameLoc(nameLoc.getBaseNameLoc())));
+    setFunctionRefInfo(FunctionRefInfo::unapplied(nameLoc));
   }
 
   DeclNameRef getName() const { return Name; }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1955,11 +1955,6 @@ OverloadChoice::getIUOReferenceKind(ConstraintSystem &cs,
   auto refKind = getFunctionRefInfo();
   assert(!forSecondApplication || refKind.isDoubleApply());
 
-  // Compound references currently never produce IUOs.
-  // FIXME(FunctionRefInfo): They should.
-  if (refKind.isCompoundName())
-    return std::nullopt;
-
   switch (refKind.getApplyLevel()) {
   case FunctionRefInfo::ApplyLevel::Unapplied:
     // Such references never produce IUOs.

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -260,3 +260,26 @@ let _: Int? = returnsIUOFn()()
 let _: Int = returnsIUOFn()() // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
 // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
 // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+
+// Make sure it works for compound function references.
+func testCompoundRefs() {
+  func hasArgLabel(x: Int) -> Int! { x }
+  struct S {
+    func hasArgLabel(x: Int) -> Int! { x }
+  }
+  let _ = hasArgLabel(x:)(0)
+  let _: Int? = hasArgLabel(x:)(0)
+  let _: Int = hasArgLabel(x:)(0)
+
+  let _ = S.hasArgLabel(x:)(S())(0)
+  let _: Int? = S.hasArgLabel(x:)(S())(0)
+  let _: Int = S.hasArgLabel(x:)(S())(0)
+
+  let _ = S().hasArgLabel(x:)(0)
+  let _: Int? = S().hasArgLabel(x:)(0)
+  let _: Int = S().hasArgLabel(x:)(0)
+
+  // We still don't allow IUOs for the function itself.
+  let _: (Int) -> Int = hasArgLabel(x:) // expected-error {{cannot convert value of type '(Int) -> Int?' to specified type '(Int) -> Int}}
+  let _: (Int) -> Int? = hasArgLabel(x:)
+}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -837,3 +837,13 @@ do {
     // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
   }
 }
+
+func testCompoundLeadingDot() {
+  struct S {
+    static func foo(x: Int) -> Self { .init() }
+  }
+
+  // Make sure we correctly strip the argument label.
+  let _: S = .foo(x:)(0)
+  let _: S = .foo(x:)(x: 0) // expected-error {{extraneous argument label 'x:' in call}}
+}

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -46,7 +46,7 @@ struct S0 {
 }
 
 // Determine context from type.
-let s0_static: S0 = .f3(_:y:z:)(0, y: 0, z: 0)
+let s0_static: S0 = .f3(_:y:z:)(0, 0, 0)
 
 class C0 {
   init(x: Int, y: Int, z: Int) { }


### PR DESCRIPTION
Allow IUOs to be used with functions referenced using a compound name, and correctly set the compound bit for UnresolvedMemberExprs.

This is a source breaking change since this used to be legal:

```swift
struct S {
  static func foo(x: Int) -> Self { .init() }
}
let _: S = .foo(x:)(x: 0)
```

However I somewhat doubt anyone is intentionally writing code like that.