### PR TITLE
tests: run SIL/Parser/pure_mode.sil only on 64 bit targets

### DIFF
--- a/test/SIL/Parser/pure_mode.sil
+++ b/test/SIL/Parser/pure_mode.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt %s | %target-sil-opt -sil-print-no-uses | %FileCheck %s
 
+// REQUIRES: PTRSIZE=64
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
It depends on internals of String which is target dependent

rdar://140907938
