### PR TITLE
[6.1] CI: Include stdlib build for WASI in the Linux buildbot

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -870,6 +870,9 @@ build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 build-embedded-stdlib-cross-compiling
 
+wasmkit
+build-wasm-stdlib
+
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
 


### PR DESCRIPTION
* **Explanation**: "Swift Test Linux Platform" jobs on ci.swift.org required as PR checks should cross-compile and run tests for WebAssembly. Effectively, what was previously an optional `@swift-ci test webassembly` trigger should become an implicit and required part of PR testing to prevent occasional regressions in Wasm and WASI support.
* **Scope**: Only affects the WASI platform
* **Risk**: Low. It increases job run time by ~10% and this platform has active maintainers.
* **Testing**: stdlib test suite is now enabled.
* **Issue**: N/A
* **Reviewer**:  @shahmishal 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/77872