### PR TITLE
AST: Remove `Decl::getSemanticAvailableRangeAttr()`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1433,15 +1433,6 @@ public:
   const AvailableAttr *
   getUnavailableAttr(bool ignoreAppExtensions = false) const;
 
-  /// Retrieve the @available attribute that provides the OS version range that
-  /// this declaration is available in.
-  ///
-  /// This attribute may come from an enclosing decl since availability is
-  /// inherited. The second member of the returned pair is the decl that owns
-  /// the attribute.
-  std::optional<std::pair<const AvailableAttr *, const Decl *>>
-  getSemanticAvailableRangeAttr() const;
-
   /// Returns true if the decl is effectively always unavailable in the current
   /// compilation context. This query differs from \c isUnavailable() because it
   /// takes the availability of parent declarations into account.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4103,25 +4103,6 @@ public:
   void cacheResult(ValueDecl *value) const;
 };
 
-using AvailableAttrDeclPair = std::pair<const AvailableAttr *, const Decl *>;
-
-class SemanticAvailableRangeAttrRequest
-    : public SimpleRequest<SemanticAvailableRangeAttrRequest,
-                           std::optional<AvailableAttrDeclPair>(const Decl *),
-                           RequestFlags::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  std::optional<AvailableAttrDeclPair> evaluate(Evaluator &evaluator,
-                                                const Decl *decl) const;
-
-public:
-  bool isCached() const { return true; }
-};
-
 enum class SemanticDeclAvailability : uint8_t {
   /// The decl is potentially available in some contexts and/or under certain
   /// deployment conditions.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -469,9 +469,6 @@ SWIFT_REQUEST(TypeChecker, ImplicitKnownProtocolConformanceRequest,
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
               ValueDecl *(const ValueDecl *, const AvailableAttr *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SemanticAvailableRangeAttrRequest,
-              Optional<AvailableAttrDeclPair>(const Decl *),
-              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SemanticDeclAvailabilityRequest,
               SemanticDeclAvailability(const Decl *),
               Cached, NoLocationInfo)

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -453,26 +453,6 @@ AvailabilityInference::attrForAnnotatedAvailableRange(const Decl *D) {
   return bestAvailAttr;
 }
 
-std::optional<AvailableAttrDeclPair>
-SemanticAvailableRangeAttrRequest::evaluate(Evaluator &evaluator,
-                                            const Decl *decl) const {
-  if (auto attr = AvailabilityInference::attrForAnnotatedAvailableRange(decl))
-    return std::make_pair(attr, decl);
-
-  if (auto *parent =
-          AvailabilityInference::parentDeclForInferredAvailability(decl))
-    return parent->getSemanticAvailableRangeAttr();
-
-  return std::nullopt;
-}
-
-std::optional<AvailableAttrDeclPair>
-Decl::getSemanticAvailableRangeAttr() const {
-  auto &eval = getASTContext().evaluator;
-  return evaluateOrDefault(eval, SemanticAvailableRangeAttrRequest{this},
-                           std::nullopt);
-}
-
 std::optional<AvailabilityRange>
 AvailabilityInference::annotatedAvailableRange(const Decl *D) {
   auto bestAvailAttr = attrForAnnotatedAvailableRange(D);


### PR DESCRIPTION
This query's functionality was not useful enough to be exposed on `Decl` and cached in the request evaluator. Instead, just share a local implementation of it in `TypeCheckAttr.cpp`.
