### PR TITLE
[CSTrail] NFC: Make `dumpActiveScopeChanges` friendlier to humans

### DIFF
--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -260,6 +260,10 @@ public:
 
   void undo(unsigned toIndex);
 
+  SWIFT_DEBUG_DUMP;
+  void dump(raw_ostream &OS, unsigned fromIndex = 0,
+            unsigned indent = 0) const LLVM_ATTRIBUTE_USED;
+
 private:
   ConstraintSystem &CS;
 

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -743,11 +743,139 @@ void SolverTrail::undo(unsigned toIndex) {
 void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,
                                          unsigned fromIndex,
                                          unsigned indent) const {
-  out.indent(indent);
-  out << "(changes:\n";
+  if (Changes.empty())
+    return;
 
-  for (unsigned i = fromIndex; i < Changes.size(); ++i)
-    Changes[i].dump(out, CS, indent + 2);
+  // Collect Changes for printing.
+  std::vector<TypeVariableType *> addedTypeVars;
+  std::set<TypeVariableType *> updatedTypeVars;
+  std::set<Constraint *> addedConstraints;
+  std::set<Constraint *> removedConstraints;
+  for (unsigned int i = fromIndex; i < Changes.size(); i++) {
+    auto change = Changes[i];
+    switch (change.Kind) {
+    case ChangeKind::AddedTypeVariable:
+      addedTypeVars.push_back(change.TypeVar);
+      break;
+    case ChangeKind::UpdatedTypeVariable:
+      updatedTypeVars.insert(change.Update.TypeVar);
+      break;
+    case ChangeKind::AddedConstraint:
+      addedConstraints.insert(change.TheConstraint.Constraint);
+      break;
+    case ChangeKind::RemovedConstraint:
+      removedConstraints.insert(change.TheConstraint.Constraint);
+      break;
+    default:
+      // Don't consider changes that don't affect the graph.
+      break;
+    }
+  }
+
+  // If there are any constraints that were both added and removed in this set
+  // of Changes, remove them from both.
+  std::set<Constraint *> intersects;
+  set_intersection(addedConstraints.begin(), addedConstraints.end(),
+                   removedConstraints.begin(), removedConstraints.end(),
+                   std::inserter(intersects, intersects.begin()));
+  llvm::set_subtract(addedConstraints, intersects);
+  llvm::set_subtract(removedConstraints, intersects);
+
+  // Print out Changes.
+  PrintOptions PO;
+  PO.PrintTypesForDebugging = true;
+  out.indent(indent);
+  out << "(Changes:\n";
+  if (!addedTypeVars.empty()) {
+    out.indent(indent + 2);
+    auto heading = (addedTypeVars.size() > 1) ? "(New Type Variables: \n"
+                                              : "(New Type Variable: \n";
+    out << heading;
+    for (const auto &typeVar : addedTypeVars) {
+      out.indent(indent + 4);
+      out << "> $T" << typeVar->getImpl().getID();
+      out << '\n';
+    }
+    out.indent(indent + 2);
+    out << ")\n";
+  }
+  if (!updatedTypeVars.empty()) {
+    std::vector<TypeVariableType *> assignments;
+    std::vector<std::pair<TypeVariableType *, TypeVariableType *>> equivalences;
+
+    for (auto *typeVar : updatedTypeVars) {
+      if (auto *parentVar =
+              typeVar->getImpl().getRepresentative(/*trail=*/nullptr)) {
+        if (parentVar != typeVar) {
+          equivalences.push_back(std::make_pair(parentVar, typeVar));
+          continue;
+        }
+      }
+
+      if (typeVar->getImpl().ParentOrFixed.is<TypeBase *>())
+        assignments.push_back(typeVar);
+    }
+
+    if (!assignments.empty()) {
+      out.indent(indent + 2);
+      auto heading = (assignments.size() > 1) ? "(Bound Type Variables: \n"
+                                              : "(Bound Type Variable: \n";
+      out << heading;
+
+      for (auto *typeVar : assignments) {
+        out.indent(indent + 4);
+        out << "> $T" << typeVar->getImpl().getID() << " := ";
+        typeVar->getImpl().ParentOrFixed.get<TypeBase *>()->print(out, PO);
+        out << '\n';
+      }
+      out.indent(indent + 2);
+      out << ")\n";
+    }
+
+    if (!equivalences.empty()) {
+      out.indent(indent + 2);
+      auto heading = (equivalences.size() > 1) ? "(New Equivalences: \n"
+                                               : "(New Equivalence: \n";
+      out << heading;
+      for (const auto &eq : equivalences) {
+        out.indent(indent + 4);
+        out << "> $T" << eq.first->getImpl().getID();
+        out << " == ";
+        out << "$T" << eq.second->getImpl().getID();
+        out << '\n';
+      }
+      out.indent(indent + 2);
+      out << ")\n";
+    }
+  }
+  if (!addedConstraints.empty()) {
+    out.indent(indent + 2);
+    auto heading = (addedConstraints.size() > 1) ? "(Added Constraints: \n"
+                                                 : "(Added Constraint: \n";
+    out << heading;
+    for (const auto &constraint : addedConstraints) {
+      out.indent(indent + 4);
+      out << "> ";
+      constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
+      out << '\n';
+    }
+    out.indent(indent + 2);
+    out << ")\n";
+  }
+  if (!removedConstraints.empty()) {
+    out.indent(indent + 2);
+    auto heading = (removedConstraints.size() > 1) ? "(Removed Constraints: \n"
+                                                   : "(Removed Constraint: \n";
+    out << heading;
+    for (const auto &constraint : removedConstraints) {
+      out.indent(indent + 4);
+      out << "> ";
+      constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
+      out << '\n';
+    }
+    out.indent(indent + 2);
+    out << ")\n";
+  }
 
   out.indent(indent);
   out << ")\n";

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -880,3 +880,11 @@ void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,
   out.indent(indent);
   out << ")\n";
 }
+
+void SolverTrail::dump() const { dump(llvm::errs()); }
+
+void SolverTrail::dump(raw_ostream &OS, unsigned fromIndex,
+                       unsigned indent) const {
+  for (unsigned i = fromIndex; i < Changes.size(); ++i)
+    Changes[i].dump(OS, CS, indent);
+}


### PR DESCRIPTION
`dumpActiveScopeChanges` is used as part of `-debug-constraints`
and could be overwhelming if there are a lot of changes in the scope
because it prints every change including binding inference from
every applicable constraint.

These changes make `dumpActiveScopeChanges` more of summary of
what happened with type variables and constraints so far which
is much easier to navigate while debugging.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
