### PR TITLE
[Debug] Remove unnecessary DebugDescriptionMacro feature references (NFC)

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -284,7 +284,6 @@ target_compile_options(swiftCore PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature FreestandingMacros>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BitwiseCopyable>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature DebugDescriptionMacro>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -group-info-path -Xfrontend ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-experimental-concise-pound-file>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-autolinking-runtime-compatibility-concurrency>"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -331,8 +331,8 @@ else()
   set(swift_lib_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib")
 endif()
 
+# For `@DebugDescription`.
 list(APPEND swift_stdlib_compile_flags "-plugin-path" "${swift_lib_dir}/swift/host/plugins")
-list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "DebugDescriptionMacro")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntime)

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -13,7 +13,7 @@
 import SwiftShims
 
 // Macros are disabled when Swift is built without swift-syntax.
-#if $Macros && $DebugDescriptionMacro && hasAttribute(attached)
+#if $Macros && hasAttribute(attached)
 
 /// Converts description definitions to a debugger Type Summary.
 ///

--- a/test/Macros/DebugDescription/dollar_handling.swift
+++ b/test/Macros/DebugDescription/dollar_handling.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/explicit_self_property.swift
+++ b/test/Macros/DebugDescription/explicit_self_property.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/extension.swift
+++ b/test/Macros/DebugDescription/extension.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 struct MyStruct {}

--- a/test/Macros/DebugDescription/implicit_self_property.swift
+++ b/test/Macros/DebugDescription/implicit_self_property.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/linkage.swift
+++ b/test/Macros/DebugDescription/linkage.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/long_string.swift
+++ b/test/Macros/DebugDescription/long_string.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/property_chain.swift
+++ b/test/Macros/DebugDescription/property_chain.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/static_string.swift
+++ b/test/Macros/DebugDescription/static_string.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription

--- a/test/Macros/DebugDescription/supported_description.swift
+++ b/test/Macros/DebugDescription/supported_description.swift
@@ -1,8 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_DebugDescriptionMacro
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 @DebugDescription


### PR DESCRIPTION
The `DebugDescription` macro has been accepted. Additionally, the `DebugDescriptionMacro` feature was not providing conditional declaration as I originally intended. References to the feature are not needed and can be removed.

(cherry-picked from #77738)