### PR TITLE
[6.1] Fix existential specializer for unowned ownership

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -221,6 +221,10 @@ void ExistentialSpecializerCloner::cloneArguments(
             NewFBuilder.emitLoadValueOperation(InsertLoc, NewArg, qual);
       }
 
+      if (NewFBuilder.hasOwnership() &&
+          NewArg->getOwnershipKind() == OwnershipKind::Unowned) {
+        NewArgValue = NewFBuilder.emitCopyValueOperation(InsertLoc, NewArg);
+      }
       ///  Simple case: Create an init_existential.
       /// %5 = init_existential_ref %0 : $T : $T, $P
       SILValue InitRef = NewFBuilder.createInitExistentialRef(
@@ -228,6 +232,10 @@ void ExistentialSpecializerCloner::cloneArguments(
           NewArg->getType().getASTType(),
           NewArgValue, Conformances);
 
+      if (NewFBuilder.hasOwnership() &&
+          NewArg->getOwnershipKind() == OwnershipKind::Unowned) {
+        CleanupValues.push_back(InitRef);
+      }
       // If we don't have an object and we are in ossa, the store will consume
       // the InitRef.
       if (!NewArg->getType().isObject()) {

--- a/test/SILOptimizer/existential_transform_extras_ossa.sil
+++ b/test/SILOptimizer/existential_transform_extras_ossa.sil
@@ -313,3 +313,29 @@ sil_witness_table hidden Klass4: P module devirtualize_protocol_composition {
   method #P.foo: <Self where Self : P> (Self) -> () -> Int32 : @Klass4foo
 }
 
+// CHECK-LABEL: sil shared [ossa] @$s32testExistentialSpecializeUnownedTf4e_n : 
+// CHECK:  [[VAL0:%.*]] = copy_value %0
+// CHECK:  [[VAL1:%.*]] = init_existential_ref [[VAL0]]
+// CHECK:  destroy_value [[VAL1]]
+// CHECK-LABEL: } // end sil function '$s32testExistentialSpecializeUnownedTf4e_n'
+sil hidden [ossa] @testExistentialSpecializeUnowned : $@convention(thin) (any Klass3 & P) -> Int32 {
+bb0(%0 : @unowned $Klass3 & P):
+  %1 = copy_value %0 : $Klass3 & P 
+  %2 = open_existential_ref %1 : $Klass3 & P to $@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  %3 = alloc_stack $@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  %4 = store_borrow %2 to %3 : $*@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  %5 = witness_method $@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %2 : $@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
+  %6 = apply %5<@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
+  end_borrow %4 : $*@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  dealloc_stack %3 : $*@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  destroy_value %2 : $@opened("77949BFA-77BC-11EB-BC0E-F2189810406F", Klass3 & P) Self
+  return %6 : $Int32
+}
+
+sil hidden [ossa] @entrypoint_unowned : $@convention(thin) (@guaranteed Klass4) -> Int32 {
+bb0(%0 : @guaranteed $Klass4):
+  %1 = init_existential_ref %0 : $Klass4 : $Klass4, $any Klass3 & P
+  %func = function_ref @testExistentialSpecializeUnowned : $@convention(thin) (any Klass3 & P) -> Int32
+  %res = apply %func(%1) : $@convention(thin) (any Klass3 & P) -> Int32
+  return %res : $Int32
+}


### PR DESCRIPTION
Explanation: `init_existential_ref` cannot forward operands of `unowned` ownership. Create an `owned` value when we have such args in ExistentialSpecializer.
Scope: Fixes verification error in ExistentialSpecializer
Risk: Low. 
Reviewer: @eeckstein 
Main branch PR: https://github.com/swiftlang/swift/pull/77933