### PR TITLE
test: fix the broken test

### DIFF
--- a/test/Interpreter/shebang-env.swift
+++ b/test/Interpreter/shebang-env.swift
@@ -4,8 +4,8 @@
 // RUN: cat %s >> %t.shebang.swift
 // RUN: chmod u+x %t.shebang.swift
 
-// RUN: env PATH=$(dirname %swift_driver_plain) %t.shebang.swift | %FileCheck -check-prefix=NONE %s
-// RUN: env PATH=$(dirname %swift_driver_plain) %t.shebang.swift a b c | %FileCheck -check-prefix=THREE-ARGS %s
+// RUN: env PATH=$(dirname %swift_driver_plain) %t.shebang.swift | %raw-FileCheck -check-prefix=NONE %s
+// RUN: env PATH=$(dirname %swift_driver_plain) %t.shebang.swift a b c | %raw-FileCheck -check-prefix=THREE-ARGS %s
 
 // REQUIRES: swift_interpreter
 


### PR DESCRIPTION
swiftlang/swift-driver#1741 fixed a bug in the swift-driver which exposed a bug in this test. The use of `%FileCheck` is a problem as that sanitises the output substituting `BUILD_DIR` for the build directory that is now properly computed. Because `PATH` is being configured to an invalid path the actual driver is not found and the test fails.