### PR TITLE
[Clang importer] Don't cache swift_attr source files that have CustomAttrs with arguments

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -508,13 +508,17 @@ public:
 
   /// Create a copy of this attribute.
   DeclAttribute *clone(ASTContext &ctx) const;
+
+  /// Determine whether we can clone this attribute.
+  bool canClone() const;
 };
 
 #define UNIMPLEMENTED_CLONE(AttrType)    \
 AttrType *clone(ASTContext &ctx) const { \
     llvm_unreachable("unimplemented");   \
     return nullptr;                      \
-  }
+  }                                      \
+bool canClone() const { return false; }
 
 /// Describes a "simple" declaration attribute that carries no data.
 template<DeclAttrKind Kind>
@@ -1916,8 +1920,12 @@ public:
 
   /// Create a copy of this attribute.
   CustomAttr *clone(ASTContext &ctx) const {
+    assert(argList == nullptr &&
+           "Cannot clone custom attribute with an argument list");
     return create(ctx, AtLoc, getTypeExpr(), initContext, argList, isImplicit());
   }
+
+  bool canClone() const { return argList == nullptr; }
 
 private:
   friend class CustomAttrNominalRequest;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -370,6 +370,17 @@ DeclAttribute *DeclAttribute::clone(ASTContext &ctx) const {
   }
 }
 
+bool DeclAttribute::canClone() const {
+  switch (getKind()) {
+#define DECL_ATTR(_,CLASS, ...)                                \
+  case DeclAttrKind::CLASS:                                    \
+    if (&CLASS##Attr::canClone == &DeclAttribute::canClone)    \
+      return true;                                             \
+    return static_cast<const CLASS##Attr *>(this)->canClone();
+#include "swift/AST/DeclAttr.def"
+  }
+}
+
 const BackDeployedAttr *
 DeclAttributes::getBackDeployed(const ASTContext &ctx,
                                 bool forTargetVariant) const {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1057,7 +1057,8 @@ public:
 
   /// Retrieve the placeholder source file for use in parsing Swift attributes
   /// in the given module.
-  SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module, StringRef attributeText);
+  SourceFile &getClangSwiftAttrSourceFile(
+      ModuleDecl &module, StringRef attributeText, bool cached);
 
   /// Utility function to import Clang attributes from a source Swift decl to
   /// synthesized Swift decl.

--- a/test/Inputs/clang-importer-sdk/usr/include/completion_handler_globals.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/completion_handler_globals.h
@@ -1,9 +1,11 @@
 #if __SWIFT_ATTR_SUPPORTS_MACROS
 #define ADD_ASYNC __attribute__((swift_attr("@macro_library.AddAsync")))
 #define ADD_ASYNC_FINAL __attribute__((swift_attr("@macro_library.AddAsyncFinal")))
+#define DO_SOMETHING_DOTTED __attribute__((swift_attr("@AcceptDotted(.something)")))
 #else
 #define ADD_ASYNC
 #define ADD_ASYNC_FINAL
+#define DO_SOMETHING_DOTTED
 #endif
 
 void async_divide(double x, double y, void (^ _Nonnull completionHandler)(double x)) ADD_ASYNC;
@@ -15,6 +17,9 @@ void computer_divide(const SlowComputer *computer, double x, double y, void (^ _
   ADD_ASYNC
   __attribute__((swift_name("SlowComputer.divide(self:_:_:completionHandler:)")));
 
+void f1(double x) DO_SOMETHING_DOTTED;
+void f2(double x) DO_SOMETHING_DOTTED;
+void f3(double x) DO_SOMETHING_DOTTED;
 
 #if __OBJC__
 @import Foundation;

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -59,3 +59,10 @@ public macro AddAsync() = #externalMacro(module: "MacroDefinition", type: "AddAs
 
 @attached(peer, names: overloaded)
 public macro AddAsyncFinal() = #externalMacro(module: "MacroDefinition", type: "AddAsyncMacro")
+
+public enum Something {
+case something
+}
+
+@attached(peer, names: overloaded)
+public macro AcceptedDotted(_: Something) = #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")

--- a/test/Macros/expand_on_imported.swift
+++ b/test/Macros/expand_on_imported.swift
@@ -20,6 +20,10 @@ import macro_library
 func testAll(x: Double, y: Double, computer: SlowComputer) async {
   let _: Double = await async_divide(1.0, 2.0)
   let _: Double = await computer.divide(x, y)
+
+  f1(3.14159)
+  f2(3.14159)
+  f3(3.14159)
 }
 
 // CHECK: define{{.*}}@"$sSC12async_divideyS2d_SdtYaF"


### PR DESCRIPTION
Since we can't do a proper "deep" clone of expression nodes, cloning such a CustomAttr is necessarily shallow. In such cases, don't cache the swift_attr source files at all, so we get fresh attribute nodes for each such usage.
