### PR TITLE
SwiftShims: memcmp should accept optional pointers on Darwin

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -60,8 +60,11 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
+#if defined(__APPLE__)
+  // Darwin defines memcmp with optional pointers, preserve the same type here.
+  extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
 // FIXME: Is there a way to identify Glibc specifically?
-#if (defined(__gnu_linux__) || defined(__ANDROID__)) && !defined(__musl__)
+#elif (defined(__gnu_linux__) || defined(__ANDROID__)) && !defined(__musl__)
   extern int memcmp(const void * _Nonnull, const void * _Nonnull, __swift_size_t);
 #else
   extern int memcmp(const void * _Null_unspecified, const void * _Null_unspecified, __swift_size_t);

--- a/validation-test/ClangImporter/memcmp-definitions.swift
+++ b/validation-test/ClangImporter/memcmp-definitions.swift
@@ -1,4 +1,5 @@
-/// rdar://69876253
+/// Darwin's memcmp accepts nullable pointers, make sure the SwiftShims one
+/// preserves the same type.
 // REQUIRES: VENDOR=apple
 // RUN: %target-build-swift %s -o %t.out
 
@@ -9,4 +10,6 @@ func foo () {
   let a = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)
   let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)
   memcmp(a, b, 4)
+
+  memcmp(nil, nil, 0)
 }


### PR DESCRIPTION
Darwin defines `memcmp` with optional pointers. Update SwiftShims to define it to the same type to avoid deserialization failures where we get one over the other and the types don't match.

This basically brings back #36666 which changes were lost a little while back apparently.

rdar://140596571