### PR TITLE
[IRGen] Check if type is empty instead of void in CallEmission::emitT…

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4564,7 +4564,7 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
   }
 
   // If the regular result type is void, there is nothing to explode
-  if (!resultType.isVoid()) {
+  if (!nativeSchema.empty()) {
     Explosion resultExplosion;
     if (auto *structTy =
             dyn_cast<llvm::StructType>(nativeSchema.getExpandedType(IGF.IGM))) {

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -252,3 +252,16 @@ public func reabstractAsyncVoidThrowsNever() async {
 struct LoadableGeneric<E>: Error {}
 
 func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {}
+
+@inline(never)
+func throwError() throws(SmallError) -> Never {
+  throw SmallError(x: 1)
+}
+
+func conditionallyCallsThrowError(b: Bool) throws(SmallError) -> Int {
+  if b {
+    try throwError()
+  } else {
+    return 0
+  }
+}


### PR DESCRIPTION
…oUnmappedExplosionWithDirectTypedError

rdar://140573912

This caused assertions to fail when using other empty types, like `Never` as the result type on typed throwing functions.
