### PR TITLE
[ScanDependency] Fix a regression caused by rewrite in #76700

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -451,6 +451,11 @@ private:
   }
 
   void pruneUnusedVFSOverlay() {
+    // Pruning of unused VFS overlay options for Clang dependencies is performed
+    // by the Clang dependency scanner.
+    if (moduleID.Kind == ModuleDependencyKind::Clang)
+      return;
+
     std::vector<std::string> resolvedCommandLine;
     size_t skip = 0;
     for (auto it = commandline.begin(), end = commandline.end();

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -65,3 +65,10 @@ import F
 
 /// --------Clang module F
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
+// CHECK: "commandLine": [
+// CHECK: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: ],


### PR DESCRIPTION
In the refactoring change #76700, it accidentally introduced a behavior change that causes the generated PCM command-line to have useful VFSOverlay files getting dropped. Clang module command-line and its unused VFS pruning should be done by the clang dependency scanner already so there is no need to touch that in the swift scanner. Since the original logics is not used to handle clang module commands, it will actually dropped the useful vfs overlay that is needed when none of the dependencies uses it. Fix the regression by restoring the old behavior and ignoring clang modules when pruning VFS overlay.

rdar://139233781

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
