### PR TITLE
[OSSACanonicalizeOwned] Record traversed defs and don't traverse copies of guaranteed values.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -342,8 +342,8 @@ private:
   };
   friend llvm::DenseMapInfo<Def>;
 
-  /// Visited set for general def-use traversal that prevents revisiting values.
-  SmallVector<Def, 8> defUseWorklist;
+  /// The defs derived from currentDef whose uses are added to liveness.
+  SmallVector<Def, 8> discoveredDefs;
 
   /// The blocks that were discovered by PrunedLiveness.
   SmallVector<SILBasicBlock *, 32> discoveredBlocks;

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -98,6 +98,7 @@
 
 #include "swift/Basic/GraphNodeWorklist.h"
 #include "swift/Basic/SmallPtrSetVector.h"
+#include "swift/Basic/TaggedUnion.h"
 #include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
@@ -279,8 +280,74 @@ private:
   /// outside the pruned liveness at the time it is discovered.
   llvm::SmallPtrSet<DebugValueInst *, 8> debugValues;
 
+  class Def {
+    struct Root {
+      SILValue value;
+    };
+    struct Copy {
+      CopyValueInst *cvi;
+    };
+    struct BorrowedFrom {
+      BorrowedFromInst *bfi;
+    };
+    struct Reborrow {
+      SILArgument *argument;
+    };
+    using Payload = TaggedUnion<Root, Copy, BorrowedFrom, Reborrow>;
+    Payload payload;
+    Def(Payload payload) : payload(payload) {}
+
+  public:
+    enum class Kind {
+      Root,
+      Copy,
+      BorrowedFrom,
+      Reborrow,
+    };
+    Kind getKind() const {
+      if (payload.isa<Root>()) {
+        return Kind::Root;
+      }
+      if (payload.isa<Copy>()) {
+        return Kind::Copy;
+      }
+      if (payload.isa<BorrowedFrom>()) {
+        return Kind::BorrowedFrom;
+      }
+      assert(payload.isa<Reborrow>());
+      return Kind::Reborrow;
+    }
+    operator Kind() const { return getKind(); }
+    bool operator==(Def rhs) const {
+      return getKind() == rhs.getKind() && getValue() == rhs.getValue();
+    }
+    static Def root(SILValue value) { return {Root{value}}; }
+    static Def copy(CopyValueInst *cvi) { return {Copy{cvi}}; }
+    static Def borrowedFrom(BorrowedFromInst *bfi) {
+      return {BorrowedFrom{bfi}};
+    }
+    static Def reborrow(SILArgument *argument) { return {Reborrow{argument}}; }
+    SILValue getValue() const {
+      switch (*this) {
+      case Kind::Root:
+        return payload.get<Root>().value;
+      case Kind::Copy:
+        return payload.get<Copy>().cvi;
+      case Kind::BorrowedFrom:
+        return payload.get<BorrowedFrom>().bfi;
+      case Kind::Reborrow:
+        return payload.get<Reborrow>().argument;
+      }
+      llvm_unreachable("covered switch");
+    }
+  };
+  friend llvm::DenseMapInfo<Def>;
+  friend llvm::PointerLikeTypeTraits<Def>;
+  friend llvm::PointerLikeTypeTraits<
+      std::optional<swift::CanonicalizeOSSALifetime::Def>>;
+
   /// Visited set for general def-use traversal that prevents revisiting values.
-  GraphNodeWorklist<SILValue, 8> defUseWorklist;
+  GraphNodeWorklist<std::optional<Def>, 8> defUseWorklist;
 
   /// The blocks that were discovered by PrunedLiveness.
   SmallVector<SILBasicBlock *, 32> discoveredBlocks;
@@ -495,5 +562,95 @@ private:
 };
 
 } // end namespace swift
+
+namespace llvm {
+template <>
+struct DenseMapInfo<swift::CanonicalizeOSSALifetime::Def> {
+  static swift::CanonicalizeOSSALifetime::Def getEmptyKey() {
+    return swift::CanonicalizeOSSALifetime::Def::root(
+        DenseMapInfo<swift::SILValue>::getEmptyKey());
+  }
+  static swift::CanonicalizeOSSALifetime::Def getTombstoneKey() {
+    return swift::CanonicalizeOSSALifetime::Def::root(
+        DenseMapInfo<swift::SILValue>::getTombstoneKey());
+  }
+  static unsigned getHashValue(swift::CanonicalizeOSSALifetime::Def def) {
+    return detail::combineHashValue(
+        DenseMapInfo<swift::CanonicalizeOSSALifetime::Def::Kind>::getHashValue(
+            def.getKind()),
+        DenseMapInfo<swift::SILValue>::getHashValue(def.getValue()));
+  }
+  static bool isEqual(swift::CanonicalizeOSSALifetime::Def LHS,
+                      swift::CanonicalizeOSSALifetime::Def RHS) {
+    return LHS == RHS;
+  }
+};
+template <>
+struct PointerLikeTypeTraits<swift::CanonicalizeOSSALifetime::Def> {
+private:
+  using Def = swift::CanonicalizeOSSALifetime::Def;
+
+public:
+  static void *getAsVoidPointer(Def def) {
+    return reinterpret_cast<void *>(
+        reinterpret_cast<uintptr_t>(def.getValue().getOpaqueValue()) |
+        ((uintptr_t)def.getKind()) << NumLowBitsAvailable);
+  }
+  static Def getFromVoidPointer(void *p) {
+    auto kind = (Def::Kind)((reinterpret_cast<uintptr_t>(p) & 0b110) >>
+                            NumLowBitsAvailable);
+    auto opaque =
+        reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(p) & ~0b111);
+    auto value = swift::SILValue::getFromOpaqueValue(opaque);
+    switch (kind) {
+    case Def::Kind::Root:
+      return Def::root(value);
+    case Def::Kind::Copy:
+      return Def::copy(cast<swift::CopyValueInst>(value));
+    case Def::Kind::Reborrow:
+      return Def::reborrow(cast<swift::SILArgument>(value));
+    case Def::Kind::BorrowedFrom:
+      return Def::borrowedFrom(cast<swift::BorrowedFromInst>(value));
+    }
+  }
+
+  enum {
+    NumLowBitsAvailable =
+        llvm::PointerLikeTypeTraits<swift::SILValue>::NumLowBitsAvailable - 2
+  };
+};
+template <>
+struct PointerLikeTypeTraits<
+    std::optional<swift::CanonicalizeOSSALifetime::Def>> {
+private:
+  using Def = swift::CanonicalizeOSSALifetime::Def;
+  using Payload = std::optional<Def>;
+
+public:
+  static void *getAsVoidPointer(Payload payload) {
+    if (!payload)
+      return 0x0;
+    return reinterpret_cast<void *>(
+        reinterpret_cast<uintptr_t>(
+            PointerLikeTypeTraits<swift::CanonicalizeOSSALifetime::Def>::
+                getAsVoidPointer(*payload)) |
+        0b1);
+  }
+  static Payload getFromVoidPointer(void *p) {
+    auto none = reinterpret_cast<uintptr_t>(p) & 0b1;
+    if (none)
+      return std::nullopt;
+    auto opaque =
+        reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(p) & ~0b1);
+    return {PointerLikeTypeTraits<
+        swift::CanonicalizeOSSALifetime::Def>::getFromVoidPointer(opaque)};
+  }
+
+  enum {
+    NumLowBitsAvailable =
+        llvm::PointerLikeTypeTraits<Def>::NumLowBitsAvailable - 1
+  };
+};
+} // end namespace llvm
 
 #endif

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -454,6 +454,7 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(SILValue value,
 namespace swift::test {
 // Arguments:
 // - SILValue: value
+// - string: either "liveness" or "availability"
 // Dumps:
 // - function
 static FunctionTest OSSALifetimeCompletionTest(

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/GraphNodeWorklist.h"
 #include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/DebugUtils.h"

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1149,6 +1149,9 @@ void CanonicalizeOSSALifetime::rewriteCopies(
     SmallVectorImpl<DestroyValueInst *> const &newDestroys) {
   assert(getCurrentDef()->getOwnershipKind() == OwnershipKind::Owned);
 
+  // Shadow defUseWorklist in order to constrain its uses.
+  auto &defUseWorklist = this->defUseWorklist;
+
   InstructionSetVector instsToDelete(getCurrentDef()->getFunction());
 
   // Visit each operand in the def-use chain.

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -789,3 +789,71 @@ entry(%c : @owned $C):
   specify_test "canonicalize_ossa_lifetime true false true %c"
   unreachable
 }
+
+// CHECK-LABEL: begin running test {{.*}} on consume_copy_of_borrowed_from
+// CHECK-LABEL: sil [ossa] @consume_copy_of_borrowed_from : {{.*}} {
+// The copy can't be eliminated because it's a copy of a borrowed-from.  Such
+// copies are not rewritten.
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'consume_copy_of_borrowed_from'
+// CHECK-LABEL: end running test {{.*}} on consume_copy_of_borrowed_from
+sil [ossa] @consume_copy_of_borrowed_from : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %borrow = begin_borrow %instance : $C
+  br bb1(%instance : $C, %borrow : $C)
+
+bb1(%instance2 : @owned $C, %reborrowed : @reborrow $C):
+  specify_test "canonicalize_ossa_lifetime true false true %instance2"
+  %reborrow = borrowed %reborrowed : $C from (%instance2 : $C)
+  cond_br undef, bb2, bb3
+
+bb2:
+  end_borrow %reborrow : $C
+  destroy_value %instance2 : $C
+  %retval = tuple ()
+  return %retval : $()
+
+bb3:
+  %copy = copy_value %reborrow : $C
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  apply %takeC(%copy) : $@convention(thin) (@owned C) -> ()
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on consume_copy_of_borrowed_from_2
+// CHECK-LABEL: sil [ossa] @consume_copy_of_borrowed_from_2 : {{.*}} {
+// The copy can't be eliminated because it's a copy of a borrowed-from.  Such
+// copies are not rewritten.
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'consume_copy_of_borrowed_from_2'
+// CHECK-LABEL: end running test {{.*}} on consume_copy_of_borrowed_from_2
+sil [ossa] @consume_copy_of_borrowed_from_2 : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %borrow = begin_borrow %instance : $C
+  br bb1(%instance : $C, %borrow : $C)
+
+bb1(%instance2 : @owned $C, %reborrowed : @reborrow $C):
+  specify_test "canonicalize_ossa_lifetime true false true %instance2"
+  %reborrow = borrowed %reborrowed : $C from (%instance2 : $C)
+  cond_br undef, bb2, bb3
+
+bb2:
+  end_borrow %reborrow : $C
+  destroy_value %instance2 : $C
+  br exit
+
+bb3:
+  %copy = copy_value %reborrow : $C
+  end_borrow %reborrow : $C
+  destroy_value %instance2 : $C
+  br bb4
+
+bb4:
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  apply %takeC(%copy) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -242,7 +242,7 @@ bb(%0 : @owned $T):
 // CHECK-ONONE-NEXT:  [[CP:%.*]] = copy_value [[INSTANCE]] : $T
 // CHECK-NEXT:  // function_ref takeMultipleOwned
 // CHECK-NEXT:  function_ref @takeMultipleOwned : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
-// CHECK-NEXT:  apply %{{.*}}<T>([[INSTANCE]], [[CP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
+// CHECK-NEXT:  apply %{{.*}}<T>([[CP]], [[INSTANCE]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
 // CHECK-ONONE-NEXT:  destroy_value
 // CHECK-NEXT:  tuple ()
 // CHECK-NEXT:  return


### PR DESCRIPTION
The utility performs two def-use traversals.  The first determines liveness from uses.  The second rewrites copies.

Previously, the defs whose uses are analyzed were discovered twice, once during each traversal.  The non-triviality of the discovery logic (i.e. the logic determining when to walk into the values produced by the instructions which were the users of visited uses) opened the possibility for a divergence between the two discoveries.  This possibility had indeed been realized--the two discoveries didn't find exactly the same defs, the two traversals didn't visit exactly the same uses, and issues ensued.

Here, the defs whose uses are analyzed are discovered only once during the first traversal.  The second "traversal" now reuses the defs discovered in the first traversal, eliminating the possibility of a def discovery difference.

Extra care is taken to preserve the traversal order of the first traversal (as compared to the order before this change).  Evidently diagnostics depend on it.  The second traversal's order is changed, which results in slight SIL perturbations in certain cases (e.g. an instruction which consumes a value and its copy may see the order of those operands reversed).

Because discovery of defs walks into reborrows and borrowed-from instructions, copies are processed whose underlying value is a reborrow or borrowed-from.  Such copies cannot generally be sunk to consuming uses because the lifetime of their underlying value (the reborrow or borrowed-from) may not extend to the consuming use.   Eliminating such copies is outside the scope of OSSACanonicalizeOwned--it's the responsibility of a separate OSSACanonicalizeGuaranteed utility.  For this reason, when visiting copies during the first traversal, the copies are only walked into (and added to the list of defs) if their operand is not a reborrow or borrowed-from.

rdar://139842132
