### PR TITLE
6.1: [BarrierAccessScopes] Handle end_access instructions' barrierness introduced during run.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
+++ b/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
@@ -259,8 +259,9 @@ private:
       }
     }
     // If any of this block's predecessors haven't already been visited, it
-    // means that they aren't in the region and consequently this block is a
-    // barrier block.
+    // means EITHER that those predecessors aren't in the region OR that a
+    // barrier was encountered when visiting some (iterative) successor of that
+    // predecessor.  Either way, this block is a barrier block as a result.
     if (llvm::any_of(block->getSuccessorBlocks(), [&](SILBasicBlock *block) {
           return !visited.contains(block);
         })) {

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -296,8 +296,8 @@ Dataflow::Effect Dataflow::effectForPhi(SILBasicBlock *block) {
 }
 
 /// Finds end_access instructions which are barriers to hoisting because the
-/// access scopes they contain barriers to hoisting.  Hoisting end_borrows into
-/// such access scopes could introduce exclusivity violations.
+/// access scopes they end contain barriers to hoisting.  Hoisting end_borrows
+/// into such access scopes could introduce exclusivity violations.
 ///
 /// Implements BarrierAccessScopeFinder::Visitor
 class BarrierAccessScopeFinder final {

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -501,14 +501,11 @@ bool swift::shrinkBorrowScope(
 namespace swift::test {
 // Arguments:
 // - BeginBorrowInst - the introducer for the scope to shrink
-// - bool - the expected return value of shrinkBorrowScope
-// - variadic list of values consisting of the copies expected to be rewritten
 // Dumps:
 // - DELETED:  <<instruction deleted>>
 static FunctionTest ShrinkBorrowScopeTest(
-    "shrink-borrow-scope", [](auto &function, auto &arguments, auto &test) {
+    "shrink_borrow_scope", [](auto &function, auto &arguments, auto &test) {
       auto instruction = arguments.takeValue();
-      auto expected = arguments.takeBool();
       auto *bbi = cast<BeginBorrowInst>(instruction);
       auto *analysis = test.template getAnalysis<BasicCalleeAnalysis>();
       SmallVector<CopyValueInst *, 4> modifiedCopyValueInsts;
@@ -516,20 +513,16 @@ static FunctionTest ShrinkBorrowScopeTest(
           InstModCallbacks().onDelete([&](auto *instruction) {
             llvm::outs() << "DELETED:\n";
             instruction->print(llvm::outs());
+            instruction->eraseFromParent();
+
           }));
       auto shrunk =
           shrinkBorrowScope(*bbi, deleter, analysis, modifiedCopyValueInsts);
-      unsigned index = 0;
+      auto *shrunkString = shrunk ? "shrunk" : "did not shrink";
+      llvm::outs() << "Result: " << shrunkString << "\n";
+      llvm::outs() << "Rewrote the following copies:\n";
       for (auto *cvi : modifiedCopyValueInsts) {
-        auto expectedCopy = arguments.takeValue();
-        llvm::outs() << "rewritten copy " << index << ":\n";
-        llvm::outs() << "expected:\n";
-        expectedCopy->print(llvm::outs());
-        llvm::outs() << "got:\n";
         cvi->print(llvm::outs());
-        assert(cvi == expectedCopy);
-        ++index;
       }
-      assert(expected == shrunk && "didn't shrink expectedly!?");
     });
 } // namespace swift::test

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1174,7 +1174,7 @@ entry(%addr : $*X):
   return %retval : $()
 }
 
-// Even though the apply of %empty is not a deinit barrier (c.f.
+// Even though the apply of %empty is not a deinit barrier (cf.
 // hoist_over_apply_of_non_barrier_fn), verify that the destroy_addr is not
 // hoisted, because MoS is move-only.
 // CHECK-LABEL: sil [ossa] @dont_move_destroy_addr_of_moveonly_struct : {{.*}} {

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -5,8 +5,12 @@ import Swift
 
 class C {}
 
+struct X {}
+
 sil [ossa] @get_owned_c : $@convention(thin) () -> (@owned C)
 sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @barrier : $@convention(thin) () -> ()
+
 
 // CHECK-LABEL: begin running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 // CHECK-NOT: DELETED:
@@ -29,3 +33,37 @@ entry:
   return %retval : $(C, C)
 }
 
+// CHECK-LABEL: begin running test {{.*}} on nohoist_over_access_scope_barrier_1
+// CHECK:       Result: did not shrink
+// CHECK-LABEL: end running test {{.*}} on nohoist_over_access_scope_barrier_1
+sil [ossa] @nohoist_over_access_scope_barrier_1 : $@convention(thin) (@guaranteed C, @inout X) -> () {
+entry(%c : @guaranteed $C, %addr : $*X):
+  %borrow = begin_borrow %c : $C
+  specify_test "shrink_borrow_scope %borrow"
+  %access = begin_access [modify] [dynamic] %addr : $*X
+  cond_br undef, kill_introducer, newly_local_gen
+
+kill_introducer:
+  cond_br undef, left, right
+
+left:
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+right:
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+newly_local_gen:
+  end_access %access : $*X
+  end_borrow %borrow : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -11,10 +11,11 @@ sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
 // CHECK-LABEL: begin running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 // CHECK-NOT: DELETED:
 // CHECK-NOT: end_borrow
+// CHECK: Result: did not shrink
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 sil [ossa] @nohoist_over_rewritten_copy : $@convention(thin) () -> (@owned C, @owned C) {
 entry:
-  specify_test "shrink-borrow-scope @trace true @trace[1]"
+  specify_test "shrink_borrow_scope %lifetime"
   %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
   %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C

--- a/validation-test/SILOptimizer/gh77693.swift
+++ b/validation-test/SILOptimizer/gh77693.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -c -O %s
+
+protocol P {}
+enum E {
+  case c(any P)
+  var d: [String:String] { [:] }
+}
+
+final class C {
+  var o: [String:String]?
+}
+
+func f(_ e: E?) {
+  if let e {
+    C().o?.merge(e.d) { c, _ in c }
+  }
+}


### PR DESCRIPTION
**Explanation**: Handle access scopes becoming deinit barriers when determining whether any access scope are.

A value's lifetime must not be shrunk into any access scope (i.e. regions defined by `begin_access` and all its corresponding `end_access`es) which contains a deinit barrier.  For a given value, all such access scopes are discovered in sweep via the `VisitBarrierAccessScopes` utility.  As the utility discovers such access scopes, it alerts its caller.  The caller in turn marks the `end_access` instructions as deinit barriers.

As a compile-time optimization, portions of the function which are known to be irrelevant before the utility begins running are excluded.  There are two cases of interest: (1) Local: if a lifetime end (e.g. `end_borrow`) and (before the utility runs) a deinit barrier occur in the same block, it's only necessary to visit the instructions between the end and the barrier looking for access scopes.  (2) Partial: when visiting a block which contains a lifetime end but (before the utility runs) no deinit barrier, it's only necessary to visit the instructions above the lifetime end in the block.

The code for the Local case visits the instructions between the lifetime end and the first encountered deinit barrier.  When the deinit barrier is found, it stops iterating and returns true.  If no deinit barrier is found after iterating to the beginning of the function, it returns false.

Previously, the code for the Partial case called to the code for the Local case.  It asserted that the latter returned false, indicating that it iterated all the instructions and phis in the block and found no deinit barrier.

If no deinit barriers were added while the utility runs, this would be correct.  But, as described above, new `end_access` instructions are discovered to be deinit barriers as the utility runs.

As a result, when visiting a block partially (case (2) above), if an `end_access` instruction was visited which had been determined to be a deinit barrier was encountered, in asserts builds, the assertion would trigger and in non-asserts builds, iteration would stop.

Here, this is handled by just visiting all instructions above the lifetime end in case (2).  If a deinit barrier is encountered, it's asserted that it's one of these newly discovered `end_access` deinit barriers.

**Scope**: Affects optimized code.
**Issue**: rdar://139840307
**Original PR**: https://github.com/swiftlang/swift/pull/77908
**Risk**: Low.  Amounts to removing an early bailout that would only be done incorrectly.
**Testing**: Added SIL and source test.
**Reviewer**: Andrew Trick ( @atrick )

