### PR TITLE
[Derived] When adding members to conformance context on extension, add to nominal

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -51,7 +51,12 @@ ModuleDecl *DerivedConformance::getParentModule() const {
 
 void DerivedConformance::addMembersToConformanceContext(
     ArrayRef<Decl *> children) {
-  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  IterableDeclContext *IDC;
+  if (auto ext = dyn_cast<ExtensionDecl>(ConformanceDecl)) {
+    IDC = cast<IterableDeclContext>(ext->getExtendedNominal());
+  } else {
+    IDC = cast<IterableDeclContext>(ConformanceDecl);
+  }
   for (auto child : children)
     IDC->addMember(child);
 }

--- a/test/Distributed/distributedactorsystem_conformance_extension.swift
+++ b/test/Distributed/distributedactorsystem_conformance_extension.swift
@@ -1,0 +1,162 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.7-abi-triple -I %t
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+import Distributed
+
+final class MyActorSystem {
+
+}
+
+extension MyActorSystem: DistributedActorSystem {
+  public typealias ActorID = String
+  public typealias InvocationDecoder = DummyInvocationDecoder
+  public typealias InvocationEncoder = DummyInvocationEncoder
+  public typealias SerializationRequirement = any Codable
+  public typealias ResultHandler = DummyResultHandler
+
+  func assignID<Act>(
+    _ actorType: Act.Type
+  ) -> String
+    where
+    Act: DistributedActor,
+    Act.ID == String
+  {
+    return "1"
+  }
+
+  func resignID(_ id: some Codable) {
+    // nothing to do
+  }
+
+  func actorReady<Act>(
+    _ actor: Act
+  )
+    where
+    Act: DistributedActor,
+    Act.ID == String
+  {
+    // nothing to do
+  }
+
+  func resolve<Act>(
+    id: some Codable,
+    as actorType: Act.Type
+  ) throws -> Act?
+    where
+    Act: DistributedActor,
+    Act.ID: Codable
+  {
+    return nil
+  }
+
+  func makeInvocationEncoder() -> DummyInvocationEncoder {
+    fatalError("Cannot create an InvocationEncoder")
+  }
+
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where
+    Act: DistributedActor,
+    Act.ID == String,
+    Err: Error
+  {
+    fatalError("Cannot make remote call")
+  }
+
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where
+    Act: DistributedActor,
+    Act.ID == String,
+    Err: Error,
+    Res: Codable
+  {
+    fatalError("Cannot make remote call")
+  }
+}
+
+
+// MARK: - DummyInvocationEncoder
+
+struct DummyInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+
+  mutating func doneRecording() throws {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+
+  mutating func makeDecoder() -> DummyInvocationDecoder {
+    fatalError("Cannot use DummyInvocationEncoder for distributed targets")
+  }
+}
+
+// MARK: - DummyInvocationDecoder
+
+struct DummyInvocationDecoder: DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] {
+    fatalError("Cannot use DummyInvocationDecoder for distributed targets")
+  }
+
+  mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
+    fatalError("Cannot use DummyInvocationDecoder for distributed targets")
+  }
+
+  func decodeErrorType() throws -> Any.Type? {
+    fatalError("Cannot use DummyInvocationDecoder for distributed targets")
+  }
+
+  func decodeReturnType() throws -> Any.Type? {
+    fatalError("Cannot use DummyInvocationDecoder for distributed targets")
+  }
+}
+
+// MARK: - DummyResultHandler
+
+struct DummyResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = Codable
+
+  func onReturnVoid() async throws {
+    fatalError("Cannot use DummyResultHandler for distributed targets")
+  }
+
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    fatalError("Cannot use DummyResultHandler for distributed targets")
+  }
+
+  func onThrow<Err>(error: Err) async throws where Err: Error {
+    fatalError("Cannot use DummyResultHandler for distributed targets")
+  }
+}


### PR DESCRIPTION
Without this we're adding the members to the extension itself which then triggers 'Added member to the wrong context' assertions in debug builds, so instead we can try to add to the nominal.

Basically: derived infra adds members to where we synthesize the conformance, but when that is an extension we assert that adding in wrong context, instead we should have on the nominal I guess?
But what if the extension is somewhat conditional, perhaps then this would be wrong? Ideas what the proper solution would be?

🚧 Yeah this isn't right given conditional extensions... Need to think more about this.

Resolves rdar://140888172