### PR TITLE
SILVerifier: fix a wrong check for witness_method instructions

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2520,10 +2520,11 @@ public:
     PrintOptions QualifiedSILTypeOptions =
         PrintOptions::printQualifiedSILType();
     QualifiedSILTypeOptions.CurrentModule = WMI->getModule().getSwiftModule();
-    *this << "$" << WMI->getLookupType() << ", " << WMI->getMember() << " : ";
+    auto lookupType = WMI->getLookupType();
+    *this << "$" << lookupType << ", " << WMI->getMember() << " : ";
     WMI->getMember().getDecl()->getInterfaceType().print(
         PrintState.OS, QualifiedSILTypeOptions);
-    if (!WMI->getTypeDependentOperands().empty()) {
+    if ((getLocalArchetypeOf(lookupType) || lookupType->hasDynamicSelfType()) && !WMI->getTypeDependentOperands().empty()) {
       *this << ", ";
       *this << getIDAndForcedPrintedType(WMI->getTypeDependentOperands()[0].get());
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4177,7 +4177,7 @@ public:
               "Must have a type dependent operand for the opened archetype");
       verifyLocalArchetype(AMI, lookupType);
     } else {
-      require(AMI->getTypeDependentOperands().empty(),
+      require(AMI->getTypeDependentOperands().empty() || lookupType->hasLocalArchetype(),
               "Should not have an operand for the opened existential");
     }
     if (!isa<ArchetypeType>(lookupType) && !isa<DynamicSelfType>(lookupType)) {

--- a/test/SILOptimizer/propagate_opaque_return_type.swift
+++ b/test/SILOptimizer/propagate_opaque_return_type.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
+
+protocol P {}
+extension P {
+  func foo() -> some Sequence<Int> {
+    [1, 2, 3]
+  }
+}
+
+struct B {
+  let p: P
+
+  @inline(never)
+  func bar() {
+    for x in p.foo() {
+      print(x)
+    }
+  }
+}
+
+
+struct S : P {
+  var x = 0
+}
+
+
+let b = B(p: S())
+
+// CHECK:      1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 3
+b.bar()
+


### PR DESCRIPTION
Consider that the lookup-type can be an opaque return type.

Also fixing the SILPrinter.

Fixes a verifier crash
https://github.com/swiftlang/swift/issues/77955
rdar://140939536
