### PR TITLE
[6.1][IRGen] Check if type is empty instead of void in CallEmission::emitToUnmappedExplosionWithDirectTypedError

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4564,7 +4564,7 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
   }
 
   // If the regular result type is void, there is nothing to explode
-  if (!resultType.isVoid()) {
+  if (!nativeSchema.empty()) {
     Explosion resultExplosion;
     if (auto *structTy =
             dyn_cast<llvm::StructType>(nativeSchema.getExpandedType(IGF.IGM))) {

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -252,3 +252,16 @@ public func reabstractAsyncVoidThrowsNever() async {
 struct LoadableGeneric<E>: Error {}
 
 func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {}
+
+@inline(never)
+func throwError() throws(SmallError) -> Never {
+  throw SmallError(x: 1)
+}
+
+func conditionallyCallsThrowError(b: Bool) throws(SmallError) -> Int {
+  if b {
+    try throwError()
+  } else {
+    return 0
+  }
+}


### PR DESCRIPTION
  - **Explanation**: The check was too narrow, only checking for `Void`, which caused assertions to fail when using other empty types, like `Never` as the result type on typed throwing functions.
  - **Scope**: Typed throws, when compiling with asserting compiler.
  - **Issues**: rdar://140573912
  - **Original PRs**: https://github.com/swiftlang/swift/pull/77965
  - **Risk**: Low. Crash only occurred on asserting compilers and the change does not change the generated code.
  - **Testing**: Added a regression test. Existing tests still pass.
  - **Reviewers**: @rjmccall 