### PR TITLE
DefiniteInitialization: correctly handle upcasts in delegating initializers

### DIFF
--- a/test/SILOptimizer/definite_init_crashes_objc.sil
+++ b/test/SILOptimizer/definite_init_crashes_objc.sil
@@ -37,8 +37,8 @@ class Sub : Super {
 // CHECK:         switch_enum
 // CHECK-SAME:        case #Optional.none!enumelt: [[NONE:bb[0-9]+]]
 // CHECK:       [[NONE]]:
-// CHECK:         [[SUB_META_1:%[^,]+]] = metatype $@thick Sub.Type
 // CHECK:         [[SUB_1:%[^,]+]] = unchecked_ref_cast [[SUPER_1]] : $Super to $Sub
+// CHECK:         [[SUB_META_1:%[^,]+]] = metatype $@thick Sub.Type
 // CHECK:         dealloc_partial_ref
 // CHECK-SAME:        [[SUB_1]]
 // CHECK-SAME:        [[SUB_META_1]]

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -148,6 +148,31 @@ bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
   return %13 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_delegating_derived_with_upcast :
+// CHECK:       bb0([[ARG:%.*]] : @owned $DerivedClassWithNontrivialStoredProperties):
+// CHECK-NEXT:    [[SELFBOX:%[0-9]+]] = alloc_stack $DerivedClassWithNontrivialStoredProperties
+// CHECK-NEXT:    store [[ARG]] to [init] [[SELFBOX]]
+// CHECK-NEXT:    [[SELF:%[0-9]+]] = load [take] [[SELFBOX]]
+// CHECK-NEXT:    [[UC:%[0-9]+]] = upcast [[SELF]]
+// CHECK-NEXT:    [[DC:%[0-9]+]] = unchecked_ref_cast [[UC]]
+// CHECK-NEXT:    [[METATYPE:%[0-9]+]] = value_metatype $@thick DerivedClassWithNontrivialStoredProperties.Type, [[DC]] : $DerivedClassWithNontrivialStoredProperties
+// CHECK-NEXT:    dealloc_partial_ref [[DC]] : $DerivedClassWithNontrivialStoredProperties, [[METATYPE]] : $@thick DerivedClassWithNontrivialStoredProperties.Type
+// CHECK-NEXT:    dealloc_stack [[SELFBOX]]
+sil [ossa] @test_delegating_derived_with_upcast : $@convention(method) (@owned DerivedClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
+  %1 = alloc_stack $DerivedClassWithNontrivialStoredProperties
+  %2 = mark_uninitialized [delegatingselfallocated] %1 : $*DerivedClassWithNontrivialStoredProperties
+  store %0 to [init] %2 : $*DerivedClassWithNontrivialStoredProperties
+  %4 = load [take] %2
+  %5 = upcast %4 to $RootClassWithNontrivialStoredProperties
+
+  destroy_value %5
+  dealloc_stack %1 : $*DerivedClassWithNontrivialStoredProperties
+
+  %13 = tuple ()
+  return %13 : $()
+}
+
 // <rdar://problem/20608881> DI miscompiles this testcase into a memory leak
 struct MyStruct3 {
   @_hasStorage var c: C


### PR DESCRIPTION
Fixes a crash due to a wrong class type when creating a value_metatype instruction

rdar://140926647
