### PR TITLE
[Concurrency] Fix start of version ranges in install name magic symbols.

### DIFF
--- a/stdlib/public/Concurrency/linker-support/magic-symbols-for-install-name.c
+++ b/stdlib/public/Concurrency/linker-support/magic-symbols-for-install-name.c
@@ -34,6 +34,12 @@
 // Xcode inserting a runpath search path of /usr/lib/swift based on the deployment target being less than
 // SupportedTargets[target][SwiftConcurrencyMinimumDeploymentTarget] in SDKSettings.plist.
 
+// Clients can back deploy to OS versions that predate Concurrency as an embedded library, and conditionally
+// use it behind an #availability check. Such clients will still need to link the embedded library instead
+// of the OS version. To support that, set the start version to Swift's first supported versions: macOS (née
+// OS X) 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0 rather than Concurrency's first supported versions listed
+// above.
+
 // The linker uses a specially formatted symbol to do the back deployment:
 // $ld$previous$<install-name>$<compatibility-version>$<platform>$<start-version>$<end-version>$<symbol-name>$
 // compatibility-version and symbol-name are left off to apply to all library versions and symbols.
@@ -49,25 +55,25 @@
   RPATH_PREVIOUS_DIRECTIVE_IMPL(SWIFT_TARGET_LIBRARY_NAME, platform, startVersion, endVersion)
 
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_MACOS, 10.15, 12.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_MACOS, 10.9, 12.0)
 RPATH_PREVIOUS_DIRECTIVE(PLATFORM_MACCATALYST, 13.1, 15.0)
 #elif TARGET_OS_IOS && !TARGET_OS_VISION
 #if TARGET_OS_SIMULATOR
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_IOSSIMULATOR, 13.0, 15.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_IOSSIMULATOR, 7.0, 15.0)
 #else
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_IOS, 13.0, 15.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_IOS, 7.0, 15.0)
 #endif
 #elif TARGET_OS_WATCH
 #if TARGET_OS_SIMULATOR
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_WATCHOSSIMULATOR, 6.0, 8.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_WATCHOSSIMULATOR, 2.0, 8.0)
 #else
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_WATCHOS, 6.0, 8.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_WATCHOS, 2.0, 8.0)
 #endif
 #elif TARGET_OS_TV
 #if TARGET_OS_SIMULATOR
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_TVOSSIMULATOR, 13.0, 15.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_TVOSSIMULATOR, 9.0, 15.0)
 #else
-RPATH_PREVIOUS_DIRECTIVE(PLATFORM_TVOS, 13.0, 15.0)
+RPATH_PREVIOUS_DIRECTIVE(PLATFORM_TVOS, 9.0, 15.0)
 #endif
 #endif
 // Concurrency wasn't supported as an embedded library in any other OS, so no need to create back deployment

--- a/test/abi/Inputs/macOS/arm64/concurrency/baseline
+++ b/test/abi/Inputs/macOS/arm64/concurrency/baseline
@@ -1,4 +1,4 @@
-$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.15$12.0$$
+$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.9$12.0$$
 $ld$previous$@rpath/libswift_Concurrency.dylib$$6$13.1$15.0$$
 _$s13AsyncIteratorSciTl
 _$s7ElementScITl

--- a/test/abi/Inputs/macOS/arm64/concurrency/baseline-asserts
+++ b/test/abi/Inputs/macOS/arm64/concurrency/baseline-asserts
@@ -1,4 +1,4 @@
-$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.15$12.0$$
+$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.9$12.0$$
 $ld$previous$@rpath/libswift_Concurrency.dylib$$6$13.1$15.0$$
 _$s13AsyncIteratorSciTl
 _$s7ElementScITl

--- a/test/abi/Inputs/macOS/x86_64/concurrency/baseline
+++ b/test/abi/Inputs/macOS/x86_64/concurrency/baseline
@@ -1,4 +1,4 @@
-$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.15$12.0$$
+$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.9$12.0$$
 $ld$previous$@rpath/libswift_Concurrency.dylib$$6$13.1$15.0$$
 _$s13AsyncIteratorSciTl
 _$s7ElementScITl

--- a/test/abi/Inputs/macOS/x86_64/concurrency/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/concurrency/baseline-asserts
@@ -1,4 +1,4 @@
-$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.15$12.0$$
+$ld$previous$@rpath/libswift_Concurrency.dylib$$1$10.9$12.0$$
 $ld$previous$@rpath/libswift_Concurrency.dylib$$6$13.1$15.0$$
 _$s13AsyncIteratorSciTl
 _$s7ElementScITl


### PR DESCRIPTION
The magic symbols specify a version range where clients should reference a @rpath relative path to libswift_Concurrency.dylib instead of the standard absolute path. This version range started at macOS 10.15 and aligned versions, which is the oldest target supported by Concurrency. However, clients that use Concurrency can target earlier OSes as long as they availability-check their use of Concurrency. When targeting something earlier than 10.15, they'd reference the absolute path, then fail to find the back-deployment Concurrency runtime on OS versions that need it.

Fix this by setting the start of the range to macOS 10.9 and aligned, which is the oldest target supported by Swift.

rdar://140476764