### PR TITLE
[cxx-interop] Avoid "libstdc++ not found" warning when `-nostdinc++` is passed

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -288,6 +288,12 @@ static void getLibStdCxxFileMapping(
                                               stdlibArgStrings);
   auto parsedStdlibArgs = parseClangDriverArgs(clangDriver, stdlibArgStrings);
 
+  // If we were explicitly asked to not bring in the C++ stdlib, bail.
+  if (parsedStdlibArgs.hasArg(clang::driver::options::OPT_nostdinc,
+                              clang::driver::options::OPT_nostdincxx,
+                              clang::driver::options::OPT_nostdlibinc))
+    return;
+
   Path cxxStdlibDir;
   if (auto dir = findFirstIncludeDir(parsedStdlibArgs,
                                      {"cstdlib", "string", "vector"}, vfs)) {

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -69,3 +69,9 @@ module StdFunction {
   requires cplusplus
   export *
 }
+
+module NoCXXStdlib {
+  header "no-cxx-stdlib.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/no-cxx-stdlib.h
+++ b/test/Interop/Cxx/stdlib/Inputs/no-cxx-stdlib.h
@@ -1,0 +1,5 @@
+// This file intentionally does not import anything from the C++ stdlib.
+
+inline int my_sum(int a, int b) {
+  return a + b;
+}

--- a/test/Interop/Cxx/stdlib/no-cxx-stdlib.swift
+++ b/test/Interop/Cxx/stdlib/no-cxx-stdlib.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -nostdinc++
+
+import NoCXXStdlib
+
+let _ = my_sum(12, 15)


### PR DESCRIPTION
When explicitly asked not to load the C++ standard library, Swift should not emit warnings for missing libstdc++.

This fixes a compiler warning when building the Cxx module on Linux.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
