### PR TITLE
🍒[cxx-interop] Do not emit C++ interop flag in textual interfaces

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -794,12 +794,12 @@ def enable_experimental_concise_pound_file : Flag<["-"],
 
 def enable_experimental_cxx_interop :
   Flag<["-"], "enable-experimental-cxx-interop">,
-  Flags<[NoDriverOption, FrontendOption, HelpHidden, ModuleInterfaceOption]>,
+  Flags<[NoDriverOption, FrontendOption, HelpHidden]>,
   HelpText<"Enable experimental C++ interop code generation and config directives">;
 
 def cxx_interoperability_mode :
   Joined<["-"], "cxx-interoperability-mode=">,
-  Flags<[FrontendOption, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
+  Flags<[FrontendOption, SwiftSymbolGraphExtractOption,
          SwiftSynthesizeInterfaceOption]>,
   HelpText<"Enables C++ interoperability; pass 'default' to enable or 'off' to disable">;
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2002,6 +2002,10 @@ swift::getDisallowedOriginKind(const Decl *decl,
   if (SF->getASTContext().LangOpts.EnableCXXInterop && where.getDeclContext() &&
       where.getDeclContext()->getAsDecl() &&
       where.getDeclContext()->getAsDecl()->getModuleContext()->isResilient() &&
+      !where.getDeclContext()
+           ->getAsDecl()
+           ->getModuleContext()
+           ->getUnderlyingModuleIfOverlay() &&
       decl->hasClangNode() && !decl->getModuleContext()->isSwiftShimsModule() &&
       isFragileClangNode(decl->getClangNode()) &&
       !SF->getASTContext().LangOpts.hasFeature(

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -50,7 +50,6 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -cxx-interoperability-mode=default
     -Xfrontend -module-interface-preserve-types-as-written
-    -enable-experimental-feature AssumeResilientCxxTypes
 
     SWIFT_COMPILE_FLAGS_LINUX
     ${SWIFT_SDK_LINUX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS}

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -51,6 +51,10 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     -cxx-interoperability-mode=default
     -Xfrontend -module-interface-preserve-types-as-written
 
+    # This flag is unnecessary when building with newer compilers that allow
+    # using C++ symbols in resilient overlays (see f4204568).
+    -enable-experimental-feature AssumeResilientCxxTypes
+
     SWIFT_COMPILE_FLAGS_LINUX
     ${SWIFT_SDK_LINUX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS}
 

--- a/test/Interop/Cxx/modules/emit-module-interface.swift
+++ b/test/Interop/Cxx/modules/emit-module-interface.swift
@@ -3,15 +3,18 @@
 // Check if fragile Swift interface with struct
 // extensions can be reparsed:
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -emit-module-interface-path %t/UsesCxxStruct.swiftinterface %s -I %S/Inputs -swift-version 5 -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift
-// RUN: %target-swift-frontend -swift-version 5 -typecheck-module-from-interface  %t/UsesCxxStruct.swiftinterface -I %S/Inputs
+// RUN: %target-swift-frontend -swift-version 5 -typecheck-module-from-interface  %t/UsesCxxStruct.swiftinterface -I %S/Inputs -enable-experimental-cxx-interop
 // RUN: %FileCheck --input-file=%t/UsesCxxStruct.swiftinterface %s
-// CHECK: -enable-experimental-cxx-interop
+
+// The textual module interface should not contain the C++ interop flag.
+// CHECK-NOT: -enable-experimental-cxx-interop
+// CHECK-NOT: -cxx-interoperability-mode
 
 
 // Check if resilient Swift interface with builtin
 // type extensions can be reparsed:
 // RUN: %target-swift-emit-module-interface(%t/ResilientStruct.swiftinterface) %s -I %S/Inputs -enable-library-evolution -swift-version 5 -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift -DRESILIENT
-// RUN: %target-swift-typecheck-module-from-interface(%t/ResilientStruct.swiftinterface) -I %S/Inputs -DRESILIENT
+// RUN: %target-swift-typecheck-module-from-interface(%t/ResilientStruct.swiftinterface) -I %S/Inputs -DRESILIENT -enable-experimental-cxx-interop
 // RUN: %FileCheck --input-file=%t/ResilientStruct.swiftinterface %s
 
 import Namespaces

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -46,15 +46,10 @@ for filename in os.listdir(sdk_overlay_dir):
         "DifferentiationUnittest",
         "Swift",
         "SwiftLang",
-        "std",  # swiftstd uses `-module-interface-preserve-types-as-written`
+        # swiftCxxStdlib uses `-module-interface-preserve-types-as-written`
+        "CxxStdlib",
     ]:
         continue
-
-    # Cxx and CxxStdlib are built without library evolution and don't have a
-    # .swiftinterface file
-    if module_name in ["Cxx", "CxxStdlib"]:
-        if not os.path.exists(interface_file):
-            continue
 
     # swift -build-module-from-parseable-interface
     output_path = os.path.join(output_dir, module_name + ".swiftmodule")


### PR DESCRIPTION
**Explanation**: This makes sure that the compiler does not emit `-enable-experimental-cxx-interop`/`-cxx-interoperability-mode` flags in `.swiftinterface` files. Those flags were breaking explicit module builds. The module can still be rebuilt from its textual interface if C++ interop was enabled in the current compilation.
**Scope**: This alters the logic that emits and reads compiler flags from `.swiftinterface` files.
**Risk**: Medium, this changes the textual interfaces emitted by the compiler, which can theoretically have adverse effects on dependencies of the current module.
**Testing**: This is covered by compiler tests.
**Issue**: rdar://140203932
**Reviewer**: @artemcm @Xazax-hun 

Original PR: https://github.com/swiftlang/swift/pull/77754