### PR TITLE
test: disable failing test on Linux

### DIFF
--- a/test/Interpreter/shebang-env.swift
+++ b/test/Interpreter/shebang-env.swift
@@ -1,4 +1,5 @@
 // This file is also used by shebang-direct.swift.
+// REQUIRES: SR77996
 
 // RUN: echo '#!/usr/bin/env' 'swift ' > %t.shebang.swift
 // RUN: cat %s >> %t.shebang.swift


### PR DESCRIPTION
Disable the test until someone can look into why the path is getting corrupted.