### PR TITLE
Fix arm64e lit tests for -sil-print-types

### DIFF
--- a/test/IRGen/loadable_by_address_objc_method.swift
+++ b/test/IRGen/loadable_by_address_objc_method.swift
@@ -25,5 +25,5 @@ test()
 
 
 // SIL: sil hidden @$s31loadable_by_address_objc_method4testyyF : $@convention(thin) () -> () {
-// SIL: [[C:%.*]] = convert_function {{.*}} : $@convention(objc_method) (SamplesType, @opened({{.*}}, any P) Self) -> SamplesType to $@convention(objc_method) (@in_guaranteed SamplesType, @opened({{.*}}, any P) Self) -> @out SamplesType
+// SIL: [[C:%.*]] = convert_function {{.*}} to $@convention(objc_method) (@in_guaranteed SamplesType, @opened({{.*}}, any P) Self) -> @out SamplesType
 // SIL:             partial_apply [callee_guaranteed] [[C]]({{.*}}) : $@convention(objc_method) (@in_guaranteed SamplesType, @opened({{.*}}, any P) Self) -> @out SamplesType

--- a/test/SILGen/ptrauth_field_fptr_import.swift
+++ b/test/SILGen/ptrauth_field_fptr_import.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend %s -emit-silgen -target arm64e-apple-ios13.0 -I %S/Inputs/ | %FileCheck %s
+// RUN: %swift-frontend %s -emit-silgen -Xllvm -sil-print-types -target arm64e-apple-ios13.0 -I %S/Inputs/ | %FileCheck %s
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios


### PR DESCRIPTION
Fixes rdar://141001921 (OSS Swift CI:
oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed: test: IRGen/loadable_by_address_objc
test: SILGen/ptrauth_field_fptr_import)
