### PR TITLE
[cxx-interop] allow shared ref retain function to return self

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -231,10 +231,14 @@ ERROR(foreign_reference_types_invalid_retain_release, none,
       "type '%2'",
       (bool, StringRef, StringRef))
 
-ERROR(foreign_reference_types_retain_release_non_void_return_type, none,
-      "specified %select{retain|release}0 function '%1' is invalid; "
-      "%select{retain|release}0 function must have 'void' return type",
-      (bool, StringRef))
+ERROR(foreign_reference_types_retain_non_void_or_self_return_type, none,
+      "specified retain function '%0' is invalid; "
+      "retain function must have 'void' or parameter return type",
+      (StringRef))
+ERROR(foreign_reference_types_release_non_void_return_type, none,
+      "specified release function '%0' is invalid; "
+      "release function must have 'void' return type",
+      (StringRef))
 ERROR(foreign_reference_types_retain_release_not_a_function_decl, none,
       "specified %select{retain|release}0 function '%1' is not a function",
       (bool, StringRef))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2536,19 +2536,18 @@ namespace {
 
       enum class RetainReleaseOperationKind {
         notAfunction,
-        doesntReturnVoid,
+        doesntReturnVoidOrSelf,
         invalidParameters,
         valid
       };
 
       auto getOperationValidity =
-          [&](ValueDecl *operation) -> RetainReleaseOperationKind {
+          [&](ValueDecl *operation,
+              CustomRefCountingOperationKind operationKind)
+          -> RetainReleaseOperationKind {
         auto operationFn = dyn_cast<FuncDecl>(operation);
         if (!operationFn)
           return RetainReleaseOperationKind::notAfunction;
-
-        if (!operationFn->getResultInterfaceType()->isVoid())
-          return RetainReleaseOperationKind::doesntReturnVoid;
 
         if (operationFn->getParameters()->size() != 1)
           return RetainReleaseOperationKind::invalidParameters;
@@ -2561,6 +2560,16 @@ namespace {
         }
 
         swift::NominalTypeDecl *paramDecl = paramType->getAnyNominal();
+
+        // The return type should be void (for release functions), or void
+        // or the parameter type (for retain functions).
+        auto resultInterfaceType = operationFn->getResultInterfaceType();
+        if (!resultInterfaceType->isVoid()) {
+          if (operationKind == CustomRefCountingOperationKind::release ||
+              !resultInterfaceType->lookThroughSingleOptionalType()->isEqual(paramType))
+            return RetainReleaseOperationKind::doesntReturnVoidOrSelf;
+        }
+
         // The parameter of the retain/release function should be pointer to the
         // same FRT or a base FRT.
         if (paramDecl != classDecl) {
@@ -2574,6 +2583,7 @@ namespace {
           }
           return RetainReleaseOperationKind::invalidParameters;
         }
+
         return RetainReleaseOperationKind::valid;
       };
 
@@ -2612,7 +2622,8 @@ namespace {
       } else if (retainOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
         RetainReleaseOperationKind operationKind =
-            getOperationValidity(retainOperation.operation);
+            getOperationValidity(retainOperation.operation,
+                                 CustomRefCountingOperationKind::retain);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
         case RetainReleaseOperationKind::notAfunction:
@@ -2621,11 +2632,11 @@ namespace {
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               false, retainOperation.name);
           break;
-        case RetainReleaseOperationKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoidOrSelf:
           Impl.diagnose(
               loc,
-              diag::foreign_reference_types_retain_release_non_void_return_type,
-              false, retainOperation.name);
+              diag::foreign_reference_types_retain_non_void_or_self_return_type,
+              retainOperation.name);
           break;
         case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,
@@ -2676,7 +2687,8 @@ namespace {
       } else if (releaseOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
         RetainReleaseOperationKind operationKind =
-            getOperationValidity(releaseOperation.operation);
+            getOperationValidity(releaseOperation.operation,
+                                 CustomRefCountingOperationKind::release);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
         case RetainReleaseOperationKind::notAfunction:
@@ -2685,11 +2697,11 @@ namespace {
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               true, releaseOperation.name);
           break;
-        case RetainReleaseOperationKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoidOrSelf:
           Impl.diagnose(
               loc,
-              diag::foreign_reference_types_retain_release_non_void_return_type,
-              true, releaseOperation.name);
+              diag::foreign_reference_types_release_non_void_return_type,
+              releaseOperation.name);
           break;
         case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2534,7 +2534,7 @@ namespace {
     void validateForeignReferenceType(const clang::CXXRecordDecl *decl,
                                       ClassDecl *classDecl) {
 
-      enum class RetainReleaseOperatonKind {
+      enum class RetainReleaseOperationKind {
         notAfunction,
         doesntReturnVoid,
         invalidParameters,
@@ -2542,16 +2542,16 @@ namespace {
       };
 
       auto getOperationValidity =
-          [&](ValueDecl *operation) -> RetainReleaseOperatonKind {
+          [&](ValueDecl *operation) -> RetainReleaseOperationKind {
         auto operationFn = dyn_cast<FuncDecl>(operation);
         if (!operationFn)
-          return RetainReleaseOperatonKind::notAfunction;
+          return RetainReleaseOperationKind::notAfunction;
 
         if (!operationFn->getResultInterfaceType()->isVoid())
-          return RetainReleaseOperatonKind::doesntReturnVoid;
+          return RetainReleaseOperationKind::doesntReturnVoid;
 
         if (operationFn->getParameters()->size() != 1)
-          return RetainReleaseOperatonKind::invalidParameters;
+          return RetainReleaseOperationKind::invalidParameters;
 
         Type paramType =
             operationFn->getParameters()->get(0)->getInterfaceType();
@@ -2568,13 +2568,13 @@ namespace {
             if (const auto *paramTypeDecl =
                     dyn_cast<clang::CXXRecordDecl>(paramClangDecl)) {
               if (decl->isDerivedFrom(paramTypeDecl)) {
-                return RetainReleaseOperatonKind::valid;
+                return RetainReleaseOperationKind::valid;
               }
             }
           }
-          return RetainReleaseOperatonKind::invalidParameters;
+          return RetainReleaseOperationKind::invalidParameters;
         }
-        return RetainReleaseOperatonKind::valid;
+        return RetainReleaseOperationKind::valid;
       };
 
       auto retainOperation = evaluateOrDefault(
@@ -2611,28 +2611,28 @@ namespace {
                       false, retainOperation.name, decl->getNameAsString());
       } else if (retainOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
-        RetainReleaseOperatonKind operationKind =
+        RetainReleaseOperationKind operationKind =
             getOperationValidity(retainOperation.operation);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
-        case RetainReleaseOperatonKind::notAfunction:
+        case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               false, retainOperation.name);
           break;
-        case RetainReleaseOperatonKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoid:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_non_void_return_type,
               false, retainOperation.name);
           break;
-        case RetainReleaseOperatonKind::invalidParameters:
+        case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,
                         diag::foreign_reference_types_invalid_retain_release,
                         false, retainOperation.name, classDecl->getNameStr());
           break;
-        case RetainReleaseOperatonKind::valid:
+        case RetainReleaseOperationKind::valid:
           break;
         }
       } else {
@@ -2675,28 +2675,28 @@ namespace {
                       true, releaseOperation.name, decl->getNameAsString());
       } else if (releaseOperation.kind ==
                  CustomRefCountingOperationResult::foundOperation) {
-        RetainReleaseOperatonKind operationKind =
+        RetainReleaseOperationKind operationKind =
             getOperationValidity(releaseOperation.operation);
         HeaderLoc loc(decl->getLocation());
         switch (operationKind) {
-        case RetainReleaseOperatonKind::notAfunction:
+        case RetainReleaseOperationKind::notAfunction:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_not_a_function_decl,
               true, releaseOperation.name);
           break;
-        case RetainReleaseOperatonKind::doesntReturnVoid:
+        case RetainReleaseOperationKind::doesntReturnVoid:
           Impl.diagnose(
               loc,
               diag::foreign_reference_types_retain_release_non_void_return_type,
               true, releaseOperation.name);
           break;
-        case RetainReleaseOperatonKind::invalidParameters:
+        case RetainReleaseOperationKind::invalidParameters:
           Impl.diagnose(loc,
                         diag::foreign_reference_types_invalid_retain_release,
                         true, releaseOperation.name, classDecl->getNameStr());
           break;
-        case RetainReleaseOperatonKind::valid:
+        case RetainReleaseOperationKind::valid:
           break;
         }
       } else {

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -48,6 +48,15 @@ void goodRelease(GoodRetainRelease *v);
 
 struct
     __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:goodRetainWithRetainReturningSelf")))
+    __attribute__((swift_attr("release:goodReleaseWithRetainReturningSelf")))
+GoodRetainReleaseWithRetainReturningSelf {};
+
+GoodRetainReleaseWithRetainReturningSelf *goodRetainWithRetainReturningSelf(GoodRetainReleaseWithRetainReturningSelf *v);
+void goodReleaseWithRetainReturningSelf(GoodRetainReleaseWithRetainReturningSelf *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:goodRetainWithNullabilityAnnotations")))
     __attribute__((swift_attr("release:goodReleaseWithNullabilityAnnotations")))
 GoodRetainReleaseWithNullabilityAnnotations {};
@@ -226,7 +235,7 @@ public func test(x: NonExistent) { }
 @available(macOS 13.3, *)
 public func test(x: NoRetainRelease) { }
 
-// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have 'void' return type
+// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have 'void' or parameter return type
 // CHECK: error: specified release function 'badRelease' is invalid; release function must have exactly one argument of type 'BadRetainRelease'
 @available(macOS 13.3, *)
 public func test(x: BadRetainRelease) { }
@@ -238,6 +247,9 @@ public func test(x: BadRetainReleaseWithNullabilityAnnotations) { }
 
 @available(macOS 13.3, *)
 public func test(x: GoodRetainRelease) { }
+
+@available(macOS 13.3, *)
+public func test(x: GoodRetainReleaseRetainReturningSelf) { }
 
 @available(macOS 13.3, *)
 public func test(x: GoodRetainReleaseWithNullabilityAnnotations) { }


### PR DESCRIPTION
  - **Explanation**: allow C++ interop shared reference retain function to return self
  - **Scope**: additive, rather than breaking, to existing code
  - **Issues**:
  - **Original PRs**: #77837
  - **Risk**: Minimal
  - **Testing**: New tests added
  - **Reviewers**: @DougGregor @egorzhdan 