### PR TITLE
🍒 [cxx-interop] Improve the warnings for unannotated c++ APIs returning SWIFT_SHARED_REFERENCE types

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -259,23 +259,28 @@ ERROR(failed_base_method_call_synthesis,none,
       (ValueDecl *, ValueDecl *))
 
 ERROR(both_returns_retained_returns_unretained, none,
-      "%0 cannot be annotated with both swift_attr('returns_retained') and "
-      "swift_attr('returns_unretained') attributes",
+      "%0 cannot be annotated with both SWIFT_RETURNS_RETAINED and "
+      "SWIFT_RETURNS_UNRETAINED",
       (const clang::NamedDecl *))
 
 ERROR(returns_retained_or_returns_unretained_for_non_cxx_frt_values, none,
-      "%0 cannot be annotated with either swift_attr('returns_retained') or "
-      "swift_attr('returns_unretained') attribute because it is not returning "
-      "a 'SWIFT_SHARED_REFERENCE' type",
+      "%0 cannot be annotated with either SWIFT_RETURNS_RETAINED or "
+      "SWIFT_RETURNS_UNRETAINED because it is not returning "
+      "a SWIFT_SHARED_REFERENCE type",
       (const clang::NamedDecl *))
 
 // TODO: make this case an error in next cxx-interop versions rdar://138806722
-WARNING(
-    no_returns_retained_returns_unretained, none,
-    "%0 is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated "
-    "with either swift_attr('returns_retained') or "
-    "swift_attr('returns_unretained') attributes",
-    (const clang::NamedDecl *))
+WARNING(no_returns_retained_returns_unretained, none,
+        "%0 should be annotated with either SWIFT_RETURNS_RETAINED or "
+        "SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE",
+        (const clang::NamedDecl *))
+
+WARNING(returns_retained_returns_unretained_on_overloaded_operator, none,
+        "SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED is not supported "
+        "yet for overloaded C++ %0. Overloaded C++ operators always "
+        "return "
+        "SWIFT_SHARED_REFERENCE types as owned ",
+        (const clang::NamedDecl *))
 
 NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))
 NOTE(record_field_not_imported, none, "field %0 unavailable (cannot import)", (const clang::NamedDecl*))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3336,8 +3336,15 @@ namespace {
         return property->getParsedAccessor(AccessorKind::Set);
       }
 
-      // Emit diagnostics for incorrect usage of "returns_unretained" and
-      // "returns_unretained" attributes
+      checkBridgingAttrs(decl);
+
+      return importFunctionDecl(decl, importedName, correctSwiftName,
+                                std::nullopt);
+    }
+
+    /// Emit diagnostics for incorrect usage of SWIFT_RETURNS_RETAINED and
+    /// SWIFT_RETURNS_UNRETAINED
+    void checkBridgingAttrs(const clang::FunctionDecl *decl) {
       bool returnsRetainedAttrIsPresent = false;
       bool returnsUnretainedAttrIsPresent = false;
       if (decl->hasAttrs()) {
@@ -3359,8 +3366,41 @@ namespace {
                         decl);
         } else if (!returnsRetainedAttrIsPresent &&
                    !returnsUnretainedAttrIsPresent) {
-          Impl.diagnose(loc, diag::no_returns_retained_returns_unretained,
-                        decl);
+          bool unannotatedCxxAPIWarningNeeded = false;
+          if (!isa<clang::CXXDeductionGuideDecl>(decl)) {
+            if (const auto *methodDecl = dyn_cast<clang::CXXMethodDecl>(decl)) {
+              // FIXME: In the future we should support SWIFT_RETURNS_RETAINED
+              // and SWIFT_RETURNS_UNRETAINED for overloaded C++ operators
+              // returning SWIFT_SHARED_REFERENCE types
+              if (!isa<clang::CXXConstructorDecl>(methodDecl) &&
+                  !isa<clang::CXXDestructorDecl>(methodDecl) &&
+                  !methodDecl->isOverloadedOperator() &&
+                  methodDecl->isUserProvided()) {
+                // normal c++ member method
+                unannotatedCxxAPIWarningNeeded = true;
+              }
+            } else {
+              // global or top-level function
+              unannotatedCxxAPIWarningNeeded = true;
+            }
+          }
+
+          if (unannotatedCxxAPIWarningNeeded) {
+            HeaderLoc loc(decl->getLocation());
+            Impl.diagnose(loc, diag::no_returns_retained_returns_unretained,
+                          decl);
+          }
+        } else if (const auto *methodDecl =
+                       dyn_cast<clang::CXXMethodDecl>(decl)) {
+          // Warning for annotated overloaded C++ operators as they currently
+          // follow Swift method's convention and always return owned.
+          if (methodDecl->isOverloadedOperator()) {
+            Impl.diagnose(
+                loc,
+                diag::
+                    returns_retained_returns_unretained_on_overloaded_operator,
+                decl);
+          }
         }
       } else {
         if (returnsRetainedAttrIsPresent || returnsUnretainedAttrIsPresent) {
@@ -3371,9 +3411,6 @@ namespace {
               decl);
         }
       }
-
-      return importFunctionDecl(decl, importedName, correctSwiftName,
-                                std::nullopt);
     }
 
     /// Handles special functions such as subscripts and dereference operators.

--- a/test/Interop/Cxx/foreign-reference/Inputs/cxx-functions-and-methods-returning-frt.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/cxx-functions-and-methods-returning-frt.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 
 // FRT or SWIFT_SHARED_REFERENCE type
 struct FRTStruct {
@@ -280,3 +281,48 @@ template <typename T>
 FRTStruct
     *_Nonnull global_templated_function_returning_FRT_create_with_attr_returns_unretained(
         T a) __attribute__((swift_attr("returns_unretained")));
+
+template <typename T>
+T global_function_returning_templated_retrun_frt(T);
+
+template <typename T>
+T global_function_returning_templated_retrun_frt_owned(T)
+    __attribute__((swift_attr("returns_retained")));
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain_FRTOverloadedOperators")))
+__attribute__((swift_attr(
+    "release:release_FRTOverloadedOperators"))) FRTOverloadedOperators {
+
+public:
+  FRTOverloadedOperators *_Nonnull
+  operator+(const FRTOverloadedOperators &other)
+      __attribute__((swift_attr("returns_unretained")));
+  FRTOverloadedOperators *_Nonnull
+  operator-(const FRTOverloadedOperators &other);
+};
+
+FRTOverloadedOperators *_Nonnull returnFRTOverloadedOperators();
+
+void retain_FRTOverloadedOperators(FRTOverloadedOperators *_Nonnull v);
+void release_FRTOverloadedOperators(FRTOverloadedOperators *_Nonnull v);
+
+using FunctionVoidToFRTStruct =
+    std::function<FRTStruct *_Nonnull(void)> __attribute__((
+        swift_attr("returns_retained")));
+
+struct Base {
+public:
+  virtual FRTStruct *_Nonnull VirtualMethodReturningFRTOwned()
+      __attribute__((swift_attr("returns_retained")));
+  virtual FRTStruct *_Nonnull VirtualMethodReturningFRTUnowned()
+      __attribute__((swift_attr("returns_unretained")));
+};
+
+struct Derived : Base {
+public:
+  FRTStruct *_Nonnull VirtualMethodReturningFRTOwned() override
+      __attribute__((swift_attr("returns_retained")));
+  FRTStruct *_Nonnull VirtualMethodReturningFRTUnowned() override
+      __attribute__((swift_attr("returns_unretained")));
+};

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
@@ -2,42 +2,54 @@
 // RUN: not %target-swift-frontend -typecheck -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift 2>&1 | %FileCheck %s
 
 import FunctionsAndMethodsReturningFRT
+import CxxStdlib
 
 let frtLocalVar1 = global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained()
-// CHECK: error: 'global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained' cannot be annotated with both swift_attr('returns_retained') and swift_attr('returns_unretained') attributes
+// CHECK: error: 'global_function_returning_FRT_with_both_attrs_returns_retained_returns_unretained' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED
 
 let frtLocalVar2 = StructWithStaticMethodsReturningFRTWithBothAttributesReturnsRetainedAndReturnsUnretained.StaticMethodReturningFRT()
-// CHECK: error: 'StaticMethodReturningFRT' cannot be annotated with both swift_attr('returns_retained') and swift_attr('returns_unretained') attributes
-
+// CHECK: error: 'StaticMethodReturningFRT' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED
 let frtLocalVar3 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrt()
-// CHECK: warning: 'StaticMethodReturningCxxFrt' is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attributes
+// CHECK: warning: 'StaticMethodReturningCxxFrt' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE
 let frtLocalVar4 = StructWithAPIsReturningCxxFrt.StaticMethodReturningCxxFrtWithAnnotation()
 
 let frtLocalVar5 = global_function_returning_cxx_frt()
-// CHECK: warning: 'global_function_returning_cxx_frt' is returning a 'SWIFT_SHARED_REFERENCE' type but is not annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attributes
+// CHECK: warning: 'global_function_returning_cxx_frt' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE
 let frtLocalVar6 = global_function_returning_cxx_frt_with_annotations()
 
 let frtLocalVar7 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrt()
 let frtLocalVar8 = StructWithAPIsReturningNonCxxFrt.StaticMethodReturningNonCxxFrtWithAnnotation()
-// CHECK: error: 'StaticMethodReturningNonCxxFrtWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK: error: 'StaticMethodReturningNonCxxFrtWithAnnotation' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
 
 let frtLocalVar9 = global_function_returning_non_cxx_frt()
 let frtLocalVar10 = global_function_returning_non_cxx_frt_with_annotations()
-// CHECK: error: 'global_function_returning_non_cxx_frt_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK: error: 'global_function_returning_non_cxx_frt_with_annotations' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
 
 let frtLocalVar11 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReference()
 let frtLocalVar12 = StructWithAPIsReturningImmortalReference.StaticMethodReturningImmortalReferenceWithAnnotation()
-// CHECK: error: 'StaticMethodReturningImmortalReferenceWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK: error: 'StaticMethodReturningImmortalReferenceWithAnnotation' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
 
 let frtLocalVar13 = global_function_returning_immortal_reference()
 let frtLocalVar14 = global_function_returning_immortal_reference_with_annotations()
-// CHECK: error: 'global_function_returning_immortal_reference_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK: error: 'global_function_returning_immortal_reference_with_annotations' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
 
 let frtLocalVar15 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReference()
 let frtLocalVar16 = StructWithAPIsReturningUnsafeReference.StaticMethodReturningUnsafeReferenceWithAnnotation()
-// CHECK: error: 'StaticMethodReturningUnsafeReferenceWithAnnotation' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
+// CHECK: error: 'StaticMethodReturningUnsafeReferenceWithAnnotation' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
 
 let frtLocalVar17 = global_function_returning_unsafe_reference()
 let frtLocalVar18 = global_function_returning_unsafe_reference_with_annotations()
-// CHECK: error: 'global_function_returning_unsafe_reference_with_annotations' cannot be annotated with either swift_attr('returns_retained') or swift_attr('returns_unretained') attribute because it is not returning a 'SWIFT_SHARED_REFERENCE' type
- 
+// CHECK: error: 'global_function_returning_unsafe_reference_with_annotations' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type
+
+let x = returnFRTOverloadedOperators()
+// CHECK: warning: 'returnFRTOverloadedOperators' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE
+let y = returnFRTOverloadedOperators()
+// CHECK: warning: 'returnFRTOverloadedOperators' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE
+let z = x + y
+// CHECK: warning: SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED is not supported yet for overloaded C++ 'operator+'. Overloaded C++ operators always return SWIFT_SHARED_REFERENCE types as owned
+let w = x - y
+// CHECK-NOT: warning: 'operator-' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE
+
+let f = FunctionVoidToFRTStruct()
+let frt = f()
+// CHECK-NOT: warning: 'operator()' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -disable-availability-checking -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import FunctionsAndMethodsReturningFRT
 
@@ -185,7 +185,7 @@ func testStaticMethodsReturningNonFRT() {
     // CHECK: function_ref @{{.*}}StaticMethodReturningNonFRT_copy{{.*}} : $@convention(c) () -> UnsafeMutablePointer<NonFRTStruct> 
 }
 
-func testtFreeFunctionsTemplated() {
+func testtFreeFunctionsTemplated(frt : FRTStruct) {
     let frtLocalVar1 : Int = 1;
     
     let frtLocalVar2 = global_templated_function_returning_FRT(frtLocalVar1)
@@ -221,4 +221,28 @@ func testtFreeFunctionsTemplated() {
     let frtLocalVar12 = global_templated_function_returning_FRT_create_with_attr_returns_unretained(frtLocalVar1)
     // CHECK: function_ref @{{.*}}global_templated_function_returning_FRT_create_with_attr_returns_unretained{{.*}} : $@convention(c) (Int) -> FRTStruct
 
+    let frtLocalVar13 = global_function_returning_templated_retrun_frt(frt)
+    // CHECK: function_ref @{{.*}}global_function_returning_templated_retrun_frt{{.*}} : $@convention(c) (FRTStruct) -> FRTStruct
+
+    let frtLocalVar14 = global_function_returning_templated_retrun_frt_owned(frt)
+    // CHECK: function_ref @{{.*}}global_function_returning_templated_retrun_frt_owned{{.*}} : $@convention(c) (FRTStruct) -> @owned FRTStruct
+
 }
+
+func testVirtualMethods(base: Base, derived: Derived) {
+    var mutableBase = base
+    var mutableDerived = derived
+
+    var frt1 = mutableBase.VirtualMethodReturningFRTUnowned()
+    // CHECK: function_ref @{{.*}}VirtualMethodReturningFRTUnowned{{.*}} : $@convention(cxx_method) (@inout Base) -> FRTStruct
+    
+    var frt2 = mutableDerived.VirtualMethodReturningFRTUnowned()
+    // CHECK: function_ref @{{.*}}VirtualMethodReturningFRTUnowned{{.*}} : $@convention(cxx_method) (@inout Derived) -> FRTStruct
+    
+    var frt3 = mutableBase.VirtualMethodReturningFRTOwned()
+    // CHECK: function_ref @{{.*}}VirtualMethodReturningFRTOwned{{.*}} : $@convention(cxx_method) (@inout Base) ->  @owned FRTStruct
+    
+    var frt4 = mutableDerived.VirtualMethodReturningFRTOwned()
+    // CHECK: function_ref @{{.*}}VirtualMethodReturningFRTOwned{{.*}} : $@convention(cxx_method) (@inout Derived) -> @owned FRTStruct
+}
+


### PR DESCRIPTION
**Explanation:** Improved the diagnostic messages introduced by https://github.com/swiftlang/swift/pull/76798.
**Scope:** Changes new diagnostic messages. Removing warnings from certain cases where users can't suppress the warning easily.
**Risk:** Low, this reduces the cases where new warnings could trigger.
Reviewer: @egorzhdan  @Xazax-hun @j-hui 

Original PR: https://github.com/swiftlang/swift/pull/77397