### PR TITLE
utils: drop cmake version check

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -926,20 +926,6 @@ function Append-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value
   }
 }
 
-function Test-CMakeAtLeast([int]$Major, [int]$Minor, [int]$Patch = 0) {
-  if ($ToBatch) { return $false }
-
-  $CMakeVersionString = @(& cmake.exe --version)[0]
-  if (-not ($CMakeVersionString -match "^cmake version (\d+)\.(\d+)(?:\.(\d+))?")) {
-    throw "Unexpected CMake version string format"
-  }
-
-  if ([int]$Matches.1 -ne $Major) { return [int]$Matches.1 -gt $Major }
-  if ([int]$Matches.2 -ne $Minor) { return [int]$Matches.2 -gt $Minor }
-  if ($null -eq $Matches.3) { return 0 -gt $Patch }
-  return [int]$Matches.3 -ge $Patch
-}
-
 function Test-SCCacheAtLeast([int]$Major, [int]$Minor, [int]$Patch = 0) {
   if ($ToBatch) { return $false }
 
@@ -2853,9 +2839,6 @@ try {
 Fetch-Dependencies
 
 if (-not $SkipBuild) {
-  if (-Not (Test-CMakeAtLeast -Major 3 -Minor 28)) {
-    throw "Minimum required CMake version is 3.28"
-  }
   if ($EnableCaching -And (-Not (Test-SCCacheAtLeast -Major 0 -Minor 7 -Patch 4))) {
     throw "Minimum required sccache version is 0.7.4"
   }


### PR DESCRIPTION
There is no guarantee that `cmake` is available in the path. CMake may be provided through VS or the VS Build Tools, in which case, you must be in a VSDevCmd environment to invoke `cmake`. This adds quite a bit of complexity for little gain as the projects will check of the minimum version required (`cmake_minimum_required`).