### PR TITLE
[6.1] SILVerifier: fix a wrong check for witness_method instructions

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2459,10 +2459,11 @@ public:
     PrintOptions QualifiedSILTypeOptions =
         PrintOptions::printQualifiedSILType();
     QualifiedSILTypeOptions.CurrentModule = WMI->getModule().getSwiftModule();
-    *this << "$" << WMI->getLookupType() << ", " << WMI->getMember() << " : ";
+    auto lookupType = WMI->getLookupType();
+    *this << "$" << lookupType << ", " << WMI->getMember() << " : ";
     WMI->getMember().getDecl()->getInterfaceType().print(
         PrintState.OS, QualifiedSILTypeOptions);
-    if (!WMI->getTypeDependentOperands().empty()) {
+    if ((getLocalArchetypeOf(lookupType) || lookupType->hasDynamicSelfType()) && !WMI->getTypeDependentOperands().empty()) {
       *this << ", ";
       *this << getIDAndType(WMI->getTypeDependentOperands()[0].get());
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4177,7 +4177,7 @@ public:
               "Must have a type dependent operand for the opened archetype");
       verifyLocalArchetype(AMI, lookupType);
     } else {
-      require(AMI->getTypeDependentOperands().empty(),
+      require(AMI->getTypeDependentOperands().empty() || lookupType->hasLocalArchetype(),
               "Should not have an operand for the opened existential");
     }
     if (!isa<ArchetypeType>(lookupType) && !isa<DynamicSelfType>(lookupType)) {

--- a/test/SILOptimizer/propagate_opaque_return_type.swift
+++ b/test/SILOptimizer/propagate_opaque_return_type.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
+
+protocol P {}
+extension P {
+  func foo() -> some Sequence<Int> {
+    [1, 2, 3]
+  }
+}
+
+struct B {
+  let p: P
+
+  @inline(never)
+  func bar() {
+    for x in p.foo() {
+      print(x)
+    }
+  }
+}
+
+
+struct S : P {
+  var x = 0
+}
+
+
+let b = B(p: S())
+
+// CHECK:      1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 3
+b.bar()
+


### PR DESCRIPTION
* **Explanation**: Fixes a verification error caused by a wrong check in the verifier for calling a method of an existential with an opaque return type.
* **Scope**: Can affect code which uses existentials with opaque return type methods.
* **Risk**: Very low. It relaxes a verifier condition
* **Testing**: Tested by a test case.
* **Issue**: https://github.com/swiftlang/swift/issues/77955, rdar://140939536
* **Reviewer**:  @jckarter
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/77972
