### PR TITLE
Fix compile error caused by customized mapping of enums during JSONSerialization

### DIFF
--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -443,21 +443,21 @@ public:
   template <typename T>
   void bitSetCase(T &Val, const char* Str, const T ConstVal) {
     if (bitSetMatch(Str, (Val & ConstVal) == ConstVal)) {
-      Val = Val | ConstVal;
+      Val = static_cast<T>(Val | ConstVal);
     }
   }
 
   template <typename T>
   void maskedBitSetCase(T &Val, const char *Str, T ConstVal, T Mask) {
     if (bitSetMatch(Str, (Val & Mask) == ConstVal))
-      Val = Val | ConstVal;
+      Val = static_cast<T>(Val | ConstVal);
   }
 
   template <typename T>
   void maskedBitSetCase(T &Val, const char *Str, uint32_t ConstVal,
                         uint32_t Mask) {
     if (bitSetMatch(Str, (Val & Mask) == ConstVal))
-      Val = Val | ConstVal;
+      Val = static_cast<T>(Val | ConstVal);
   }
 
   template <typename T>


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

# Changes

In `JSONSerialization.h`, if I map an enum into json by implementing `ScalarBitSetTraits::bitset()` method, the result of the logical operation of two enums (which is int) will be assigned to an enum, which causes the compile error.

The changes are:
* Use `static_cast<T>` to convert the result in all `bitset` related methods.

# Rationale

I'm trying to extract the Swift and Objective-C AST into separate JSON files. During the extraction, I take advantage of swift's JSONSerialization tools to perform the mapping from AST nodes to json objects. However, some compile errors occur during the process. The following demo is a simplified version of what I'm doing:

```c++
// Map Decl::ObjCDeclQualifier into json
template <>
struct ScalarBitSetTraits<Decl::ObjCDeclQualifier> {
    static void bitset(Output &out, Decl::ObjCDeclQualifier &kind) {
        out.bitSetCase(kind, "none",   Decl::ObjCDeclQualifier::OBJC_TQ_None);
        out.bitSetCase(kind, "in",   Decl::ObjCDeclQualifier::OBJC_TQ_In);
        out.bitSetCase(kind, "inout",   Decl::ObjCDeclQualifier::OBJC_TQ_Inout);
        out.bitSetCase(kind, "bycopy",   Decl::ObjCDeclQualifier::OBJC_TQ_Bycopy);
        out.bitSetCase(kind, "byref",   Decl::ObjCDeclQualifier::OBJC_TQ_Byref);
        out.bitSetCase(kind, "oneway",   Decl::ObjCDeclQualifier::OBJC_TQ_Oneway);
        out.bitSetCase(kind, "cs_nullability",   Decl::ObjCDeclQualifier::OBJC_TQ_CSNullability);
    }
};

int main(int argc, const char *argv[]) {
    std::error_code stream_error;
    llvm::raw_fd_ostream outputStream(StringRef("-"), stream_error);
    Output serializer(outputStream, {}, false);
    serializer.beginObject();
    Decl::ObjCDeclQualifier value = Decl::ObjCDeclQualifier::OBJC_TQ_None;
    serializer.mapRequired("key", value);
    serializer.endObject();
    return 0;
}
```

The above demo is built as a swift tool (the detail is omitted). When I run the demo, the compiler complains that: 
```bash
error: assigning to 'clang::Decl::ObjCDeclQualifier' from incompatible type 'int'
      Val = Val | ConstVal;
```

It turns out that `Decl::ObjCDeclQualifier` is enum but the result of `Val | ConstVal` is int. That seems to be the root cause of the error. Then I modify the source code of `JSONSerialization.h` by statically cast the result:

```c++
  template <typename T>
  void bitSetCase(T &Val, const char* Str, const T ConstVal) {
    if (bitSetMatch(Str, (Val & ConstVal) == ConstVal)) {
      Val = static_cast<T>(Val | ConstVal);
      // Val = Val | ConstVal;
    }
  }
```

After that, it works and the json serialization results are correct.