### PR TITLE
stdlib: make  DropFirstSequence.makeIterator inline always

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -495,6 +495,7 @@ extension DropFirstSequence: Sequence {
   public typealias SubSequence = AnySequence<Element>
   
   @inlinable
+  @inline(__always)
   public __consuming func makeIterator() -> Iterator {
     var it = _base.makeIterator()
     var dropped = 0


### PR DESCRIPTION
Usually this function is inlined anyway. But if it is not (and that can happen), it has a dramatic performance impact. Also, usually code size regresses if this function is not inlined.

This is part of fixing benchmark regressions when enabling OSSA modules.
rdar://139773406