### PR TITLE
[6.1] [IDE] Handle UnresolvedMemberExpr for solver-based cursor info

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -552,6 +552,10 @@ public:
   /// \c nullptr.
   ArgumentList *getArgs() const;
 
+  /// If the expression has a DeclNameLoc, returns it. Otherwise, returns
+  /// an nullp DeclNameLoc.
+  DeclNameLoc getNameLoc() const;
+
   /// Produce a mapping from each subexpression to its parent
   /// expression, with the provided expression serving as the root of
   /// the parent map.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -874,6 +874,25 @@ ArgumentList *Expr::getArgs() const {
   return nullptr;
 }
 
+DeclNameLoc Expr::getNameLoc() const {
+  if (auto *DRE = dyn_cast<DeclRefExpr>(this))
+    return DRE->getNameLoc();
+  if (auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(this))
+    return UDRE->getNameLoc();
+  if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(this))
+    return ODRE->getNameLoc();
+  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(this))
+    return UDE->getNameLoc();
+  if (auto *UME = dyn_cast<UnresolvedMemberExpr>(this))
+    return UME->getNameLoc();
+  if (auto *MRE = dyn_cast<MemberRefExpr>(this))
+    return MRE->getNameLoc();
+  if (auto *DRME = dyn_cast<DynamicMemberRefExpr>(this))
+    return DRME->getNameLoc();
+
+  return DeclNameLoc();
+}
+
 llvm::DenseMap<Expr *, Expr *> Expr::getParentMap() {
   class RecordingTraversal : public ASTWalker {
   public:

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -214,23 +214,6 @@ private:
     return Action::Continue();
   }
 
-  /// Retrieve the name location for an expression that supports cursor info.
-  DeclNameLoc getExprNameLoc(Expr *E) {
-    if (auto *DRE = dyn_cast<DeclRefExpr>(E))
-      return DRE->getNameLoc();
-    
-    if (auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(E))
-      return UDRE->getNameLoc();
-
-    if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(E))
-      return ODRE->getNameLoc();
-
-    if (auto *UDE = dyn_cast<UnresolvedDotExpr>(E))
-      return UDE->getNameLoc();
-
-    return DeclNameLoc();
-  }
-
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (auto closure = dyn_cast<ClosureExpr>(E)) {
       DeclContextStack.push_back(closure);
@@ -247,7 +230,7 @@ private:
       }
     }
 
-    if (getExprNameLoc(E).getBaseNameLoc() != LocToResolve)
+    if (E->getNameLoc().getBaseNameLoc() != LocToResolve)
       return Action::Continue(E);
 
     assert(Result == nullptr);

--- a/test/SourceKit/CursorInfo/issue-77981.swift
+++ b/test/SourceKit/CursorInfo/issue-77981.swift
@@ -1,0 +1,14 @@
+struct S {
+  static func foo(_ x: Int) -> S {}
+  static func foo(_ x: String) -> S {}
+}
+
+// https://github.com/swiftlang/swift/issues/77981 - Make sure we can resolve
+// solver-based cursor info for UnresolvedMemberExprs.
+func bar() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):15 %s -- %s | %FileCheck %s
+  let _: S = .foo()
+}
+
+// CHECK-DAG: source.lang.swift.ref.function.method.static (2:15-2:28)
+// CHECK-DAG: source.lang.swift.ref.function.method.static (3:15-3:31)


### PR DESCRIPTION
*6.1 cherry-pick part of c4efa0d5f0980b2d8b026df426fd5fc6a067d14d*

- Explanation: Allows solver-based cursor info to be used with UnresolvedMemberExprs
- Scope: Affects solver-based cursor info
- Issue: rdar://140980197
- Risk: Low, applies existing logic to more cases
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen