### PR TITLE
Update buildbot_linux_crosscompile_android preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -997,8 +997,6 @@ build-ninja
 android
 android-ndk=%(ndk_path)s
 android-api-level=21
-build-swift-static-stdlib
-build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 
 # Path to the root of the installation filesystem.
@@ -1011,13 +1009,11 @@ host-test
 
 install-prefix=/usr
 install-llvm
-install-static-linux-config
 install-swift
 install-swiftsyntax
 
 skip-test-linux
 skip-build-benchmarks
-skip-early-swiftsyntax
 
 reconfigure
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1022,6 +1022,11 @@ mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
 
 android-arch=aarch64
 
+[preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,x86_64]
+mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
+
+android-arch=x86_64
+
 # Ubuntu 18.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux


### PR DESCRIPTION
Pursuant to https://github.com/swiftlang/swift-community-hosted-continuous-integration/pull/55, this change removes `skip-early-swiftsyntax`, which we need for the Android build. It also removes the static stdlib build, which I was having issues with (I anticipate they will be added back later once the Android CI starts building successfully and I can further diagnose).