### PR TITLE
[cxx-interop] Support CxxStdlib overlay for libc++ on Linux

### DIFF
--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -172,12 +172,6 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
   using namespace llvm::sys;
   using namespace file_types;
 
-  // If an overlay for CxxStdlib was requested, only proceed if compiling with
-  // the platform-default C++ stdlib.
-  if (module->getName() == module->getASTContext().Id_CxxStdlib &&
-      !module->getASTContext().LangOpts.isUsingPlatformDefaultCXXStdlib())
-    return;
-
   // If cross import information is passed on command-line, prefer use that.
   auto &crossImports = module->getASTContext().SearchPathOpts.CrossImportInfo;
   auto overlays = crossImports.find(module->getNameStr());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4355,10 +4355,8 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     }
     // If this Clang module is a part of the C++ stdlib, and we haven't loaded
     // the overlay for it so far, it is a split libc++ module (e.g. std_vector).
-    // Load the CxxStdlib overlay explicitly, if building with the
-    // platform-default C++ stdlib.
-    if (!overlay && importer::isCxxStdModule(clangModule) &&
-        Ctx.LangOpts.isUsingPlatformDefaultCXXStdlib()) {
+    // Load the CxxStdlib overlay explicitly.
+    if (!overlay && importer::isCxxStdModule(clangModule)) {
       ImportPath::Module::Builder builder(Ctx.Id_CxxStdlib);
       overlay = owner.loadModule(SourceLoc(), std::move(builder).get());
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -398,6 +398,15 @@ void CompilerInvocation::computeCXXStdlibOptions() {
     LangOpts.CXXStdlib = toCXXStdlibKind(cxxStdlibKind);
     LangOpts.PlatformDefaultCXXStdlib = toCXXStdlibKind(cxxDefaultStdlibKind);
   }
+
+  if (!LangOpts.isUsingPlatformDefaultCXXStdlib()) {
+    // The CxxStdlib overlay was built for the platform default C++ stdlib, and
+    // its .swiftmodule file refers to implementation-specific symbols (such as
+    // namespace __1 in libc++, or namespace __cxx11 in libstdc++). Let's
+    // proactively rebuild the CxxStdlib module from its .swiftinterface if a
+    // non-default C++ stdlib is used.
+    FrontendOpts.PreferInterfaceForModules.push_back("CxxStdlib");
+  }
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2035,6 +2035,15 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
 
     GenericArgs.push_back(
         ArgSaver.save("-cxx-interoperability-mode=" + compatVersion));
+
+    if (!langOpts.isUsingPlatformDefaultCXXStdlib() &&
+        langOpts.CXXStdlib == CXXStdlibKind::Libcxx) {
+      genericSubInvocation.getLangOptions().CXXStdlib = CXXStdlibKind::Libcxx;
+      genericSubInvocation.getClangImporterOptions().ExtraArgs.push_back(
+          "-stdlib=libc++");
+      GenericArgs.push_back("-Xcc");
+      GenericArgs.push_back("-stdlib=libc++");
+    }
   }
 }
 

--- a/test/Interop/Cxx/stdlib/use-std-chrono-libcxx.swift
+++ b/test/Interop/Cxx/stdlib/use-std-chrono-libcxx.swift
@@ -1,0 +1,10 @@
+// This test runs another test, use-std-chrono.swift, with libc++ explicitly specified as the C++ stdlib.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/use-std-chrono.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=upcoming-swift -Xcc -stdlib=libc++
+// RUN: %target-codesign %t/exe
+// RUN: %target-run %t/exe
+
+// REQUIRES: executable_test
+// REQUIRES: OS=linux-gnu
+// REQUIRES: system_wide_libcxx

--- a/test/Interop/Cxx/stdlib/use-std-string-view-libcxx.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view-libcxx.swift
@@ -1,0 +1,10 @@
+// This test runs another test, use-std-string-view.swift, with libc++ explicitly specified as the C++ stdlib.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/use-std-string-view.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=upcoming-swift -Xcc -stdlib=libc++
+// RUN: %target-codesign %t/exe
+// RUN: %target-run %t/exe
+
+// REQUIRES: executable_test
+// REQUIRES: OS=linux-gnu
+// REQUIRES: system_wide_libcxx


### PR DESCRIPTION
This teaches Swift to rebuild the CxxStdlib overlay module from its interface when using a C++ standard library that is not the platform default, specifically libc++ on Linux.

rdar://138838506

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
