### PR TITLE
[6.1 🍒] Add additional implicit framework search path for Darwin platforms

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -405,9 +405,13 @@ public:
     SmallString<128> systemFrameworksScratch(NewSDKPath);
     llvm::sys::path::append(systemFrameworksScratch, "System", "Library",
                             "Frameworks");
+    SmallString<128> systemSubFrameworksScratch(NewSDKPath);
+    llvm::sys::path::append(systemSubFrameworksScratch, "System", "Library",
+                            "SubFrameworks");
     SmallString<128> frameworksScratch(NewSDKPath);
     llvm::sys::path::append(frameworksScratch, "Library", "Frameworks");
     DarwinImplicitFrameworkSearchPaths = {systemFrameworksScratch.str().str(),
+                                          systemSubFrameworksScratch.str().str(),
                                           frameworksScratch.str().str()};
 
     Lookup.searchPathsDidChange();

--- a/test/ScanDependencies/subframework_implicit_search_path.swift
+++ b/test/ScanDependencies/subframework_implicit_search_path.swift
@@ -1,0 +1,23 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/mock.sdk/System/Library)
+
+// RUN: %empty-directory(%t/mock.sdk/System/Library/Frameworks)
+// RUN: %empty-directory(%t/mock.sdk/System/Library/SubFrameworks)
+
+// RUN: %empty-directory(%t/mock.sdk/System/Library/Frameworks/E.framework/Modules/E.swiftmodule)
+// RUN: %empty-directory(%t/mock.sdk/System/Library/SubFrameworks/SubE.framework/Modules/SubE.swiftmodule)
+
+// RUN: cp %S/Inputs/Swift/E.swiftinterface %t/mock.sdk/System/Library/Frameworks/E.framework/Modules/E.swiftmodule/%target-swiftinterface-name
+// RUN: cp %S/Inputs/Swift/SubE.swiftinterface %t/mock.sdk/System/Library/SubFrameworks/SubE.framework/Modules/SubE.swiftmodule/%target-swiftinterface-name
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -sdk %t/mock.sdk
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+import E
+import SubE
+
+// CHECK: "mainModuleName": "deps"
+// CHECK: "swift": "E"
+// CHECK: "swift": "SubE"

--- a/test/Serialization/search-paths-sdk-auxiliary.swift
+++ b/test/Serialization/search-paths-sdk-auxiliary.swift
@@ -1,0 +1,21 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/System/Library/Frameworks/TestFramework.framework/Modules/TestFramework.swiftmodule)
+// RUN: %empty-directory(%t/System/Library/SubRFrameworksLibrary/Frameworks/TestFramework2.framework/Modules/TestFramework2.swiftmodule)
+
+// RUN: %target-build-swift -emit-module -o %t/System/Library/Frameworks/TestFramework.framework/Modules/TestFramework.swiftmodule/%target-swiftmodule-name -module-name TestFramework %s -DFRAMEWORK
+// RUN: %target-build-swift -emit-module -o %t/System/Library/SubFrameworks/TestFramework2.framework/Modules/TestFramework2.swiftmodule/%target-swiftmodule-name -module-name TestFramework2 %s -DFRAMEWORK
+
+// RUN: %target-swift-frontend -typecheck -sdk %t %s -diagnostic-style llvm -Rmodule-loading 2>&1 | %FileCheck %s
+
+#if FRAMEWORK
+public func foo() {}
+#else
+
+import TestFramework
+import TestFramework2
+
+#endif // FRAMEWORK
+
+// CHECK: remark: loaded module 'TestFramework'
+// CHECK: remark: loaded module 'TestFramework2'


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/77991
---------------------------------------
`/System/Library/SubFrameworks` will be searched for frameworks by the compiler implicitly when an SDK path is specified.

Resolves rdar://137454957