### PR TITLE
Revert three PRs to fix the windows arm64 CI

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -26,24 +26,9 @@ set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-unknown-windows-msvc CACHE STRING "")
 set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
-
-set(default_targets
-      x86_64-unknown-windows-msvc
+set(LLVM_RUNTIME_TARGETS
       aarch64-unknown-windows-msvc
-      i686-unknown-windows-msvc)
-set(LLVM_RUNTIME_TARGETS ${default_targets} CACHE STRING "")
-
-# Build the android builtins if NDK path is provided.
-if(NOT "$ENV{NDKPATH}" STREQUAL "")
-  list(APPEND default_targets
-       aarch64-unknown-linux-android
-       x86_64-unknown-linux-android
-       i686-unknown-linux-android
-       armv7-unknown-linux-androideabi)
-endif()
-
-set(LLVM_BUILTIN_TARGETS ${default_targets} CACHE STRING "")
-
+    CACHE STRING "")
 foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
         compiler-rt
@@ -51,40 +36,11 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS YES CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
-  # Sanitizers will be configured, but not built. We have separate build
-  # steps for that, because we need a different shell for each target.
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
-endforeach()
-
-foreach(target ${LLVM_BUILTIN_TARGETS})
-  set(BUILTINS_${target}_CMAKE_MT mt CACHE STRING "")
-  if(${target} MATCHES windows-msvc)
-    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
-  elseif(${target} MATCHES linux-android)
-    # Use a single 'linux' directory and arch-based lib names on Android.
-    set(BUILTINS_${target}_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR NO CACHE BOOL "")
-    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
-    if(${target} MATCHES aarch64)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "")
-    elseif(${target} MATCHES armv7)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI armeabi-v7a CACHE STRING "")
-    elseif(${target} MATCHES i686)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86 CACHE STRING "")
-    else()
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86_64 CACHE STRING "")
-    endif()
-    set(BUILTINS_${target}_CMAKE_ANDROID_NDK $ENV{NDKPATH} CACHE PATH "")
-    set(BUILTINS_${target}_CMAKE_ANDROID_API 21 CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_C_COMPILER_TARGET "${target}21" CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_CXX_COMPILER_TARGET "${target}21" CACHE STRING "")
-  endif()
-  set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
 endforeach()
 
 set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
@@ -211,7 +167,6 @@ set(LLVM_DISTRIBUTION_COMPONENTS
       libclang
       libclang-headers
       LTO
-      builtins
       runtimes
       ${LLVM_TOOLCHAIN_TOOLS}
       ${CLANG_TOOLS}

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -27,22 +27,24 @@ set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
 
-set(default_targets
+set(DEFAULT_BUILTIN_TARGETS
       x86_64-unknown-windows-msvc
-      aarch64-unknown-windows-msvc
-      i686-unknown-windows-msvc)
-set(LLVM_RUNTIME_TARGETS ${default_targets} CACHE STRING "")
-
+      aarch64-unknown-windows-msvc)
 # Build the android builtins if NDK path is provided.
 if(NOT "$ENV{NDKPATH}" STREQUAL "")
-  list(APPEND default_targets
+  list(APPEND DEFAULT_BUILTIN_TARGETS
        aarch64-unknown-linux-android
-       x86_64-unknown-linux-android
-       i686-unknown-linux-android
-       armv7-unknown-linux-androideabi)
+       x86_64-unknown-linux-android)
 endif()
 
-set(LLVM_BUILTIN_TARGETS ${default_targets} CACHE STRING "")
+# The builtin targets are used to build the compiler-rt builtins.
+set(LLVM_BUILTIN_TARGETS ${DEFAULT_BUILTIN_TARGETS} CACHE STRING "")
+
+# The runtime targets are used to build the compiler-rt profile library.
+set(LLVM_RUNTIME_TARGETS
+      x86_64-unknown-windows-msvc
+      aarch64-unknown-windows-msvc
+    CACHE STRING "")
 
 foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
@@ -51,15 +53,13 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS YES CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
-  # Sanitizers will be configured, but not built. We have separate build
-  # steps for that, because we need a different shell for each target.
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
 endforeach()
 
 foreach(target ${LLVM_BUILTIN_TARGETS})
@@ -72,10 +72,6 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
     set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
     if(${target} MATCHES aarch64)
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "")
-    elseif(${target} MATCHES armv7)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI armeabi-v7a CACHE STRING "")
-    elseif(${target} MATCHES i686)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86 CACHE STRING "")
     else()
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86_64 CACHE STRING "")
     endif()

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -1,5 +1,3 @@
-// UNSUPPORTED: OS=windows-msvc
-
 // Different sanitizer coverage types
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=func -sanitize=address %s | %FileCheck -check-prefix=SANCOV_FUNC %s
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=bb -sanitize=address %s | %FileCheck -check-prefix=SANCOV_BB %s

--- a/test/IRGen/address_sanitizer_use_odr_indicator.swift
+++ b/test/IRGen/address_sanitizer_use_odr_indicator.swift
@@ -1,4 +1,3 @@
-// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: asan_runtime
 
 // Default instrumentation that does not use ODR indicators

--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -1,5 +1,3 @@
-// UNSUPPORTED: OS=windows-msvc
-
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env ASAN_OPTIONS=detect_leaks=0 %target-run %t_asan-binary

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,5 +1,4 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-// UNSUPPORTED: OS=windows-msvc
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,5 +1,3 @@
-// UNSUPPORTED: OS=windows-msvc
-
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run %t_asan-binary 2>&1 | %FileCheck %s

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -9,7 +9,6 @@
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
 // UNSUPPORTED: remote_run
-// UNSUPPORTED: OS=windows-msvc
 
 func sayHello() {
   print("Hello")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2878,7 +2878,7 @@ if (-not $SkipBuild -and $Allocator -eq "mimalloc") {
   Invoke-BuildStep Build-Mimalloc $HostArch
 }
 
-if (-not $SkipBuild) {
+if (-not $SkipBuild -and -not $IsCrossCompiling) {
   Invoke-BuildStep Build-Inspect $HostArch
   Invoke-BuildStep Build-DocC $HostArch
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1834,21 +1834,6 @@ function Build-CURL([Platform]$Platform, $Arch) {
     })
 }
 
-function Build-Sanitizers([Platform]$Platform, $Arch, $InstallTo) {
-  Isolate-EnvVars {
-    # Use configured compilers
-    Build-CMakeProject `
-      -Src $SourceCache\llvm-project\runtimes `
-      -Bin "$(Get-HostProjectBinaryCache Compilers)\runtimes\runtimes-$($Arch.LLVMTarget)-bins" `
-      -InstallTo $InstallTo `
-      -Arch $Arch `
-      -Platform $Platform `
-      -Defines (@{
-        COMPILER_RT_BUILD_SANITIZERS = "YES"
-      })
-  }
-}
-
 function Build-Runtime([Platform]$Platform, $Arch) {
   $PlatformDefines = @{}
   if ($Platform -eq [Platform]::Android) {
@@ -2856,11 +2841,6 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-CMark $HostArch
   Invoke-BuildStep Build-XML2 Windows $HostArch
   Invoke-BuildStep Build-Compilers $HostArch
-
-  $InstallTo = "$($HostArch.ToolchainInstallRoot)\usr"
-  foreach ($Arch in $WindowsSDKArchs) {
-    Invoke-BuildStep Build-Sanitizers Windows $Arch $InstallTo
-  }
 }
 
 if ($Clean) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -127,6 +127,7 @@ param(
   [string] $PinnedBuild = "",
   [string] $PinnedSHA256 = "",
   [string] $PinnedVersion = "",
+  [string] $PythonVersion = "3.9.10",
   [string] $AndroidNDKVersion = "r26b",
   [string] $WinSDKVersion = "",
   [switch] $Android = $false,
@@ -141,7 +142,7 @@ param(
   [switch] $Clean,
   [switch] $DebugInfo,
   [switch] $EnableCaching,
-  [string] $Cache = "$BinaryCache\sccache",
+  [string] $Cache = "",
   [string] $Allocator = "",
   [switch] $Summary,
   [switch] $ToBatch
@@ -162,6 +163,22 @@ $env:SDKROOT = ""
 $BuildArchName = $env:PROCESSOR_ARCHITEW6432
 if ($null -eq $BuildArchName) { $BuildArchName = $env:PROCESSOR_ARCHITECTURE }
 
+if ($PinnedBuild -eq "") {
+  switch ($BuildArchName) {
+    "AMD64" {
+      $PinnedBuild = "https://download.swift.org/swift-5.10.1-release/windows10/swift-5.10.1-RELEASE/swift-5.10.1-RELEASE-windows10.exe"
+      $PinnedSHA256 = "3027762138ACFA1BBE3050FF6613BBE754332E84C9EFA5C23984646009297286"
+      $PinnedVersion = "5.10.1"
+    }
+    "ARM64" {
+      $PinnedBuild = "https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a-windows10-arm64.exe"
+      $PinnedSHA256 = "037BDBF9D1A1A99D7156584948870A8A958FD27CC4FF5711691CC0A76F2E88F5"
+      $PinnedVersion = "0.0.0"
+    }
+    default { throw "Unsupported processor architecture" }
+  }
+}
+
 # Store the revision zero variant of the Windows SDK version (no-op if unspecified)
 $WindowsSDKMajorMinorBuildMatch = [Regex]::Match($WinSDKVersion, "^\d+\.\d+\.\d+")
 $WinSDKVersionRevisionZero = if ($WindowsSDKMajorMinorBuildMatch.Success) { $WindowsSDKMajorMinorBuildMatch.Value + ".0" } else { "" }
@@ -171,70 +188,8 @@ $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.e
 $VSInstallRoot = & $vswhere -nologo -latest -products "*" -all -prerelease -property installationPath
 $msbuild = "$VSInstallRoot\MSBuild\Current\Bin\$BuildArchName\MSBuild.exe"
 
-# Update package hashes when changing versions
+# Hoist to global scope as this is used in two sites.
 $WiXVersion = "4.0.5"
-$PythonVersion = "3.9.10"
-$WinFlexBisonVersion = "2.5.25"
-
-$Components = @{
-  WiX = @{
-    URL = "https://www.nuget.org/api/v2/package/wix/$WiXVersion"
-    Hash = "DF9BDB347183716F82EFE2CECB8C54BB3554AA907A69F47A41741D6FA4D0A754"
-  }
-  PythonAMD64 = @{
-    URL = "https://www.nuget.org/api/v2/package/python/$PythonVersion"
-    Hash = "ac43b491e9488ac926ed31c5594f0c9409a21ecbaf99dc7a93f8c7b24cf85867"
-  }
-  PythonARM64 = @{
-    URL = "https://www.nuget.org/api/v2/package/pythonarm64/$PythonVersion"
-    Hash = "429ada77e7f30e4bd8ff22953a1f35f98b2728e84c9b1d006712561785641f69"
-  }
-  PinnedSwiftAMD64 = @{
-    URL = "https://download.swift.org/swift-5.10.1-release/windows10/swift-5.10.1-RELEASE/swift-5.10.1-RELEASE-windows10.exe"
-    Hash = "3027762138ACFA1BBE3050FF6613BBE754332E84C9EFA5C23984646009297286"
-    Version = "5.10.1"
-  }
-  PinnedSwiftARM64 = @{
-    URL = "https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a-windows10-arm64.exe"
-    Hash = "037BDBF9D1A1A99D7156584948870A8A958FD27CC4FF5711691CC0A76F2E88F5"
-    Version = "0.0.0"
-  }
-  PinnedSwiftCustom = @{
-    URL = $PinnedBuild
-    Hash = $PinnedSHA256
-    Version = $PinnedVersion
-  }
-  NDK = @{
-    URL = "https://dl.google.com/android/repository/android-ndk-r26b-windows.zip"
-    Hash = "A478D43D4A45D0D345CDA6BE50D79642B92FB175868D9DC0DFC86181D80F691E"
-  }
-  WinFlexBison = @{
-    URL = "https://github.com/lexxmark/winflexbison/releases/download/v$WinFlexBisonVersion/win_flex_bison-$WinFlexBisonVersion.zip"
-    Hash = "8D324B62BE33604B2C45AD1DD34AB93D722534448F55A16CA7292DE32B6AC135"
-  }
-  packaging = @{
-    URL = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl"
-    Hash = "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
-  }
-  distutils = @{
-    # 'setuptools' provides 'distutils' module for Python 3.12+, required for SWIG support
-    # https://github.com/swiftlang/llvm-project/issues/9289
-    URL = "https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl"
-    Hash = "35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"
-  }
-}
-
-if ($PinnedBuild -eq "") {
-  $PinnedSwift = "PinnedSwift$BuildArchName"
-  if ($Components[$PinnedSwift] -eq $null) {
-    throw "Unsupported processor architecture"
-  }
-} else {
-  $PinnedSwift = "PinnedSwiftCustom"
-  if ($Components[$PinnedSwift].Version -eq "") {
-    throw "PinnedVersion must be set"
-  }
-}
 
 # Avoid $env:ProgramFiles in case this script is running as x86
 $UnixToolsBinDir = "$env:SystemDrive\Program Files\Git\usr\bin"
@@ -420,7 +375,7 @@ function Get-HostSwiftSDK() {
 }
 
 $NugetRoot = "$BinaryCache\nuget"
-$PinnedToolchain = [IO.Path]::GetFileNameWithoutExtension($Components[$PinnedSwift].URL)
+$PinnedToolchain = [IO.Path]::GetFileNameWithoutExtension($PinnedBuild)
 
 $LibraryRoot = "$ImageRoot\Library"
 
@@ -675,26 +630,22 @@ function Fetch-Dependencies {
 
   $WebClient = New-Object Net.WebClient
 
-  function DownloadAndVerify($Component, $Destination) {
+  function DownloadAndVerify($URL, $Destination, $Hash) {
     if (Test-Path $Destination) {
       return
-    }
-    $Comp = $Components[$Component]
-    if ($Comp -eq $null) {
-      throw "Unknown component requested"
     }
 
     Write-Output "$Destination not found. Downloading ..."
     if ($ToBatch) {
       Write-Output "md `"$(Split-Path -Path $Destination -Parent)`""
-      Write-Output "curl.exe -sL $($Comp.URL) -o $Destination"
-      Write-Output "(certutil -HashFile $Destination SHA256) == $($Comp.Hash) || (exit /b)"
+      Write-Output "curl.exe -sL $URL -o $Destination"
+      Write-Output "(certutil -HashFile $Destination SHA256) == $Hash || (exit /b)"
     } else {
       New-Item -ItemType Directory (Split-Path -Path $Destination -Parent) -ErrorAction Ignore | Out-Null
-      $WebClient.DownloadFile($Comp.URL, $Destination)
+      $WebClient.DownloadFile($URL, $Destination)
       $SHA256 = Get-FileHash -Path $Destination -Algorithm SHA256
-      if ($SHA256.Hash -ne $Comp.Hash) {
-        throw "SHA256 mismatch ($($SHA256.Hash) vs $($Comp.Hash))"
+      if ($SHA256.Hash -ne $Hash) {
+        throw "SHA256 mismatch ($($SHA256.Hash) vs $Hash)"
       }
     }
   }
@@ -759,27 +710,67 @@ function Fetch-Dependencies {
     Get-ChildItem "$BinaryCache\toolchains\WixAttachedContainer" -Filter "*.msi" | ForEach-Object {
       $LogFile = [System.IO.Path]::ChangeExtension($_.Name, "log")
       $TARGETDIR = if ($_.Name -eq "rtl.msi") { "$BinaryCache\toolchains\$ToolchainName\LocalApp\Programs\Swift\Runtimes\$(Get-PinnedToolchainVersion)\usr\bin" } else { "$BinaryCache\toolchains\$ToolchainName" }
-      Invoke-Program -OutNull msiexec.exe /lvx! $BinaryCache\toolchains\$LogFile /qn /a $BinaryCache\toolchains\WixAttachedContainer\$($_.Name) ALLUSERS=0 TARGETDIR=$TARGETDIR
+    Invoke-Program -OutNull msiexec.exe /lvx! $BinaryCache\toolchains\$LogFile /qn /a $BinaryCache\toolchains\WixAttachedContainer\$($_.Name) ALLUSERS=0 TARGETDIR=$TARGETDIR
     }
   }
 
   if ($SkipBuild -and $SkipPackaging) { return }
 
-  DownloadAndVerify "WiX" "$BinaryCache\WiX-$WiXVersion.zip"
+  $WiXURL = "https://www.nuget.org/api/v2/package/wix/$WiXVersion"
+  $WiXHash = "DF9BDB347183716F82EFE2CECB8C54BB3554AA907A69F47A41741D6FA4D0A754"
+  DownloadAndVerify $WixURL "$BinaryCache\WiX-$WiXVersion.zip" $WiXHash
   Extract-ZipFile WiX-$WiXVersion.zip $BinaryCache WiX-$WiXVersion
 
   if ($SkipBuild) { return }
 
-  DownloadAndVerify $PinnedSwift "$BinaryCache\$PinnedToolchain.exe"
+  DownloadAndVerify $PinnedBuild "$BinaryCache\$PinnedToolchain.exe" $PinnedSHA256
 
   # TODO(compnerd) stamp/validate that we need to re-extract
   New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
   Extract-Toolchain "$PinnedToolchain.exe" $BinaryCache $PinnedToolchain
 
   function Download-Python($ArchName) {
-    DownloadAndVerify "Python$ArchName" "$BinaryCache\Python$ArchName-$PythonVersion.zip"
+    $PythonAMD64URL = "https://www.nuget.org/api/v2/package/python/$PythonVersion"
+    $PythonAMD64Hash = "ac43b491e9488ac926ed31c5594f0c9409a21ecbaf99dc7a93f8c7b24cf85867"
+
+    $PythonARM64URL = "https://www.nuget.org/api/v2/package/pythonarm64/$PythonVersion"
+    $PythonARM64Hash = "429ada77e7f30e4bd8ff22953a1f35f98b2728e84c9b1d006712561785641f69"
+
+    DownloadAndVerify (Get-Variable -Name "Python${ArchName}URL").Value $BinaryCache\Python$ArchName-$PythonVersion.zip (Get-Variable -Name "Python${ArchName}Hash").Value
+
     if (-not $ToBatch) {
       Extract-ZipFile Python$ArchName-$PythonVersion.zip $BinaryCache Python$ArchName-$PythonVersion
+    }
+  }
+
+  function Ensure-PythonModules($Python) {
+    # First ensure pip is installed, else bootstrap it
+    try {
+      Invoke-Program -OutNull $Python -m pip *> $null
+    } catch {
+      Write-Output "Installing pip ..."
+      Invoke-Program -OutNull $Python '-I' -m ensurepip -U --default-pip
+    }
+    # 'packaging' is required for building LLVM 18+
+    try {
+      Invoke-Program -OutNull $Python -c 'import packaging' *> $null
+    } catch {
+      $WheelURL = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl"
+      $WheelHash = "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+      DownloadAndVerify $WheelURL "$BinaryCache\python\packaging-24.1-py3-none-any.whl" $WheelHash
+      Write-Output "Installing 'packaging-24.1-py3-none-any.whl' ..."
+      Invoke-Program -OutNull $Python '-I' -m pip install "$BinaryCache\python\packaging-24.1-py3-none-any.whl" --disable-pip-version-check
+    }
+    # 'setuptools' provides 'distutils' module for Python 3.12+, required for SWIG support
+    # https://github.com/swiftlang/llvm-project/issues/9289
+    try {
+      Invoke-Program -OutNull $Python -c 'import distutils' *> $null
+    } catch {
+      $WheelURL = "https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl"
+      $WheelHash = "35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"
+      DownloadAndVerify $WheelURL "$BinaryCache\python\setuptools-75.1.0-py3-none-any.whl" $WheelHash
+      Write-Output "Installing 'setuptools-75.1.0-py3-none-any.whl' ..."
+      Invoke-Program -OutNull $Python '-I' -m pip install "$BinaryCache\python\setuptools-75.1.0-py3-none-any.whl" --disable-pip-version-check
     }
   }
 
@@ -787,46 +778,27 @@ function Fetch-Dependencies {
   if ($IsCrossCompiling) {
     Download-Python $BuildArchName
   }
-
-  # Ensure pip is installed, else bootstrap it
-  try {
-    Invoke-Program -OutNull $(Get-PythonExecutable) -m pip *> $null
-  } catch {
-    Write-Output "Installing pip ..."
-    Invoke-Program -OutNull $(Get-PythonExecutable) '-I' -m ensurepip -U --default-pip
-  }
-
-  function Ensure-PythonModule($Name) {
-    $Info = $Components[$Name]
-    if ($Info -eq $null) {
-      throw "Unknown component requested"
-    }
-    $CanonicalName = [IO.Path]::GetFileNameWithoutExtension($Info.URL)
-    
-    try {
-      Invoke-Program -OutNull $(Get-PythonExecutable) -c 'import $name' *> $null
-    } catch {
-      DownloadAndVerify $Name "$BinaryCache\python\$CanonicalName.whl"
-      Write-Output "Installing '$CanonicalName.whl' ..."
-      Invoke-Program -OutNull $(Get-PythonExecutable) '-I' -m pip install "$BinaryCache\python\$CanonicalName.whl" --disable-pip-version-check
-    }
-  }
-
   # Ensure Python modules that are required as host build tools
-  Ensure-PythonModule "packaging"
-  Ensure-PythonModule "distutils"
+  Ensure-PythonModules "$(Get-PythonExecutable)"
 
   if ($Android) {
     # Only a specific NDK version is supported right now.
     if ($AndroidNDKVersion -ne "r26b") {
       throw "Unsupported Android NDK version"
     }
-    DownloadAndVerify "NDK" "$BinaryCache\android-ndk-$AndroidNDKVersion-windows.zip"
+    $NDKURL = "https://dl.google.com/android/repository/android-ndk-r26b-windows.zip"
+    $NDKHash = "A478D43D4A45D0D345CDA6BE50D79642B92FB175868D9DC0DFC86181D80F691E"
+    DownloadAndVerify $NDKURL "$BinaryCache\android-ndk-$AndroidNDKVersion-windows.zip" $NDKHash
+
     Extract-ZipFile -ZipFileName "android-ndk-$AndroidNDKVersion-windows.zip" -BinaryCache $BinaryCache -ExtractPath "android-ndk-$AndroidNDKVersion" -CreateExtractPath $false
   }
 
   if ($IncludeDS2) {
-    DownloadAndVerify "WinFlexBison" "$BinaryCache\win_flex_bison-$WinFlexBisonVersion.zip"
+    $WinFlexBisonVersion = "2.5.25"
+    $WinFlexBisonURL = "https://github.com/lexxmark/winflexbison/releases/download/v$WinFlexBisonVersion/win_flex_bison-$WinFlexBisonVersion.zip"
+    $WinFlexBisonHash = "8D324B62BE33604B2C45AD1DD34AB93D722534448F55A16CA7292DE32B6AC135"
+    DownloadAndVerify $WinFlexBisonURL "$BinaryCache\win_flex_bison-$WinFlexBisonVersion.zip" $WinFlexBisonHash
+
     Extract-ZipFile -ZipFileName "win_flex_bison-$WinFlexBisonVersion.zip" -BinaryCache $BinaryCache -ExtractPath "win_flex_bison"
   }
 
@@ -857,16 +829,11 @@ function Fetch-Dependencies {
   }
 }
 
-function Get-PinnedToolchainTool([string] $Name) {
+function Get-PinnedToolchainTool() {
   if (Test-Path "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin") {
-    $Path = "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin"
-  } else {
-    $Path = "$BinaryCache\toolchains\${PinnedToolchain}\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin"
+    return "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin"
   }
-  if ($Name) {
-    $Path = "$Path\$Name"
-  }
-  return $Path
+  return "$BinaryCache\toolchains\${PinnedToolchain}\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin"
 }
 
 function Get-PinnedToolchainSDK() {
@@ -884,32 +851,10 @@ function Get-PinnedToolchainRuntime() {
 }
 
 function Get-PinnedToolchainVersion() {
-  $Components[$PinnedSwift].Version
-}
-
-$CompilersBinaryCache = if ($IsCrossCompiling) {
-  Get-BuildProjectBinaryCache Compilers
-} else {
-  Get-HostProjectBinaryCache Compilers
-}
-
-function Get-BuiltToolchainTool([string] $Name) {
-  if ($Name) { "$CompilersBinaryCache\bin\$Name" } else { "$CompilersBinaryCache\bin" }
-}
-
-function Get-ClangDriverName([Platform] $Platform, [string] $Lang) {
-  switch ($Platform) {
-    Windows {
-      "clang-cl.exe"
-    }
-    Android {
-      switch ($Lang) {
-        C { "clang.exe" }
-        ASM { "clang.exe" }
-        CXX { "clang++.exe" }
-      }
-    }
+  if (Test-Path variable:PinnedVersion) {
+    return $PinnedVersion
   }
+  throw "PinnedVersion must be set"
 }
 
 function TryAdd-KeyValue([hashtable]$Hashtable, [string]$Key, [string]$Value) {
@@ -945,36 +890,19 @@ enum Platform {
   Android
 }
 
-enum Compiler {
-  Unspecified = 0
-  MSVC = 1
-  Pinned
-  Built
-  NDK
-}
-
-function Get-ToolchainTool([Compiler] $Compiler, [string] $Name) {
-  switch ($Compiler) {
-    Pinned { return Get-PinnedToolchainTool $Name }
-    Built { return Get-BuiltToolchainTool $Name }
-    UseNDK { return "$(Get-AndroidNDKPath)\toolchains\llvm\prebuilt\windows-x86_64\bin\$Name" }
-  }
-}
-
 function Build-CMakeProject {
   [CmdletBinding(PositionalBinding = $false)]
   param(
     [string] $Src,
     [string] $Bin,
     [string] $InstallTo = "",
-    [Platform] $Platform = [Platform]::Windows,
+    [Platform] $Platform = "Windows",
     [hashtable] $Arch,
     [string] $Generator = "Ninja",
     [string] $CacheScript = "",
-    [Compiler] $UseCCompiler = [Compiler]::Unspecified,
-    [Compiler] $UseCXXCompiler = [Compiler]::Unspecified,
-    [Compiler] $UseASMCompiler = [Compiler]::Unspecified,
-    [Compiler] $UseSwiftCompiler = [Compiler]::Unspecified,
+    [string[]] $UseMSVCCompilers = @(), # C,CXX
+    [string[]] $UseBuiltCompilers = @(), # ASM,C,CXX,Swift
+    [string[]] $UsePinnedCompilers = @(), # ASM,C,CXX,Swift
     [switch] $UseSwiftSwiftDriver = $false,
     [switch] $AddAndroidCMakeEnv = $false,
     [string] $SwiftSDK = "",
@@ -994,28 +922,38 @@ function Build-CMakeProject {
   # Enter the developer command shell early so we can resolve cmake.exe
   # for version checks.
   Isolate-EnvVars {
-    if ($Platform -eq [Platform]::Windows) {
+    if ($Platform -eq "Windows") {
       Invoke-VsDevShell $Arch
     }
 
+    $CompilersBinaryCache = if ($IsCrossCompiling) {
+      Get-BuildProjectBinaryCache Compilers
+    } else {
+      Get-HostProjectBinaryCache Compilers
+    }
+    $DriverBinaryCache = Get-HostProjectBinaryCache Driver
+
     if ($EnableCaching) {
       $env:SCCACHE_DIRECT = "true"
-      $env:SCCACHE_DIR = $Cache
+      if ($Cache -eq "") {
+        $env:SCCACHE_DIR = "$BinaryCache\sccache"
+      } else {
+        $env:SCCACHE_DIR = $Cache
+      }
     }
     if ($UseSwiftSwiftDriver) {
       $env:SWIFT_DRIVER_SWIFT_FRONTEND_EXEC = ([IO.Path]::Combine($CompilersBinaryCache, "bin", "swift-frontend.exe"))
     }
 
     # TODO(compnerd) workaround swiftc.exe symlink not existing.
-    $DriverToolDir = "$(Get-HostProjectBinaryCache Driver)\bin"
     if ($UseSwiftSwiftDriver) {
-      Copy-Item -Force "$DriverToolDir\swift-driver.exe" "$DriverToolDir\swiftc.exe"
+      Copy-Item -Force ([IO.Path]::Combine($DriverBinaryCache, "bin", "swift-driver.exe")) ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
     }
 
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
 
-    if (($Platform -ne [Platform]::Windows) -or ($Arch.CMakeName -ne $BuildArch.CMakeName)) {
+    if (($Platform -ne "Windows") -or ($Arch.CMakeName -ne $BuildArch.CMakeName)) {
       TryAdd-KeyValue $Defines CMAKE_SYSTEM_NAME $Platform
       TryAdd-KeyValue $Defines CMAKE_SYSTEM_PROCESSOR $Arch.CMakeName
     }
@@ -1026,7 +964,7 @@ function Build-CMakeProject {
       # ensure that it can be accessed from the cmake cache file.
       $env:NDKPATH = Get-AndroidNDKPath
     }
-    if ($Platform -eq [Platform]::Android) {
+    if ($Platform -eq "Android") {
       $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
       $VSInstallPath = & $vswhere -nologo -latest -products * -property installationPath
       if (Test-Path "${VSInstallPath}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin") {
@@ -1035,8 +973,9 @@ function Build-CMakeProject {
       } else {
         throw "Missing CMake and Ninja in the visual studio installation that are needed to build Android"
       }
-      TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-ToolchainTool NDK "clang.exe")
-      TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Get-ToolchainTool NDK "clang++.exe")
+      $androidNDKPath = Get-AndroidNDKPath
+      TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Join-Path -Path $androidNDKPath -ChildPath "toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe")
+      TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Join-Path -Path $androidNDKPath -ChildPath "toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe")
       TryAdd-KeyValue $Defines CMAKE_ANDROID_API "$AndroidAPILevel"
       TryAdd-KeyValue $Defines CMAKE_ANDROID_ARCH_ABI $Arch.AndroidArchABI
       TryAdd-KeyValue $Defines CMAKE_ANDROID_NDK "$androidNDKPath"
@@ -1061,51 +1000,62 @@ function Build-CMakeProject {
     }
 
     $CXXFlags = @()
-    if ($Platform -eq [Platform]::Windows) {
+    if ($Platform -eq "Windows") {
       $CXXFlags += $CFlags.Clone() + @("/Zc:__cplusplus")
     }
 
-    if ($UseCCompiler -Or $UseCXXCompiler) {
-      if ($DebugInfo -and $Platform -eq [Platform]::Windows) {
+    if ($UseMSVCCompilers.Contains("C") -Or $UseMSVCCompilers.Contains("CXX") -Or
+        $UseBuiltCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("CXX") -Or
+        $UsePinnedCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("CXX")) {
+      if ($DebugInfo -and $Platform -eq "Windows") {
         Append-FlagsDefine $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
         Append-FlagsDefine $Defines CMAKE_POLICY_CMP0141 NEW
         # Add additional linker flags for generating the debug info.
         Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "/debug"
         Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "/debug"
-      } elseif ($Platform -eq [Platform]::Android) {
+      } elseif ($Platform -eq "Android") {
         # Use a built lld linker as the Android's NDK linker might be too
         # old and not support all required relocations needed by the Swift
         # runtime.
-        $ldPath = (Get-BuiltToolchainTool "ld.lld")
+        $ldPath = ([IO.Path]::Combine($CompilersBinaryCache, "bin", "ld.lld"))
         Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ldPath"
         Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ldPath"
       }
     }
 
-    if ($EnableCaching) {
-      TryAdd-KeyValue $Defines CMAKE_C_COMPILER_LAUNCHER sccache
-      TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
-    }
-
-    if ($UseCCompiler -eq [Compiler]::MSVC) {
+    if ($UseMSVCCompilers.Contains("C")) {
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER cl
+      if ($EnableCaching) {
+        TryAdd-KeyValue $Defines CMAKE_C_COMPILER_LAUNCHER sccache
+      }
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
-    if ($UseCXXCompiler -eq [Compiler]::MSVC) {
+    if ($UseMSVCCompilers.Contains("CXX")) {
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER cl
+      if ($EnableCaching) {
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
+      }
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
-    if ($UseASMCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
-      $Driver = (Get-ClangDriverName $Platform -Lang "ASM")
-      TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Get-ToolchainTool -Compiler $UseASMCompiler -Name $Driver)
+    if ($UsePinnedCompilers.Contains("ASM") -Or $UseBuiltCompilers.Contains("ASM")) {
+      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang.exe" }
+      if ($UseBuiltCompilers.Contains("ASM")) {
+        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+      } else {
+        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+      }
       Append-FlagsDefine $Defines CMAKE_ASM_FLAGS "--target=$($Arch.LLVMTarget)"
-      if ($Platform -eq [Platform]::Windows) {
+      if ($Platform -eq "Windows") {
         TryAdd-KeyValue $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
       }
     }
-    if ($UseCCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
-      $Driver = (Get-ClangDriverName $Platform -Lang "C")
-      TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-ToolchainTool -Compiler $UseCCompiler -Name $Driver)
+    if ($UsePinnedCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("C")) {
+      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang.exe" }
+      if ($UseBuiltCompilers.Contains("C")) {
+        TryAdd-KeyValue $Defines CMAKE_C_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+      } else {
+        TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+      }
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
 
       if ($DebugInfo -and $CDebugFormat -eq "dwarf") {
@@ -1113,9 +1063,13 @@ function Build-CMakeProject {
       }
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
-    if ($UseCXXCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
-      $Driver = (Get-ClangDriverName $Platform -Lang "CXX")
-      TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Get-ToolchainTool -Compiler $UseCXXCompiler -Name $Driver)
+    if ($UsePinnedCompilers.Contains("CXX") -Or $UseBuiltCompilers.Contains("CXX")) {
+      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang++.exe" }
+      if ($UseBuiltCompilers.Contains("CXX")) {
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+      } else {
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+      }
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
 
       if ($DebugInfo -and $CDebugFormat -eq "dwarf") {
@@ -1123,19 +1077,21 @@ function Build-CMakeProject {
       }
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
-    if ($UseSwiftCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
+    if ($UsePinnedCompilers.Contains("Swift") -Or $UseBuiltCompilers.Contains("Swift")) {
       $SwiftArgs = @()
 
       if ($UseSwiftSwiftDriver) {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER "$DriverToolDir\swiftc.exe"
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
+      } elseif ($UseBuiltCompilers.Contains("Swift")) {
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", "swiftc.exe"))
       } else {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Get-ToolchainTool -Compiler $UseSwiftCompiler -Name "swiftc.exe")
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath  "swiftc.exe")
       }
-      if ($Platform -ne [Platform]::Windows) {
+      if (-not ($Platform -eq "Windows")) {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER_WORKS = "YES"
       }
       TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER_TARGET $Arch.LLVMTarget.Replace("$AndroidAPILevel", "")
-      if ($UseSwiftCompiler -eq [Compiler]::Built) {
+      if ($UseBuiltCompilers.Contains("Swift")) {
         $RuntimeBinaryCache = Get-TargetProjectBinaryCache $Arch Runtime
         $SwiftResourceDir = "${RuntimeBinaryCache}\lib\swift"
 
@@ -1180,7 +1136,7 @@ function Build-CMakeProject {
 
       # Debug Information
       if ($DebugInfo) {
-        if ($Platform -eq [Platform]::Windows) {
+        if ($Platform -eq "Windows") {
           if ($SwiftDebugFormat -eq "dwarf") {
             $SwiftArgs += @("-g", "-Xlinker", "/DEBUG:DWARF", "-use-ld=lld-link")
           } else {
@@ -1193,7 +1149,7 @@ function Build-CMakeProject {
         $SwiftArgs += "-gnone"
       }
 
-      if ($Platform -eq [Platform]::Windows) {
+      if ($Platform -eq "Windows") {
         $SwiftArgs += @("-Xlinker", "/INCREMENTAL:NO")
         # Swift requires COMDAT folding and de-duplication
         $SwiftArgs += @("-Xlinker", "/OPT:REF")
@@ -1244,9 +1200,9 @@ function Build-CMakeProject {
       $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
     }
 
-    if ($UseSwiftCompiler -eq [Compiler]::Built) {
+    if ($UseBuiltCompilers.Contains("Swift")) {
       $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$(Get-CMarkBinaryCache $Arch)\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
-    } elseif ($UseSwiftCompiler -eq [Compiler]::Pinned) {
+    } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
     Invoke-Program cmake.exe @cmakeGenerateArgs
@@ -1440,8 +1396,7 @@ function Build-BuildTools($Arch) {
     -Src $SourceCache\llvm-project\llvm `
     -Bin (Get-BuildProjectBinaryCache BuildTools) `
     -Arch $Arch `
-    -UseCCompiler MSVC `
-    -UseCXXCompiler MSVC `
+    -UseMSVCCompilers C,CXX `
     -BuildTargets llvm-tblgen,clang-tblgen,clang-pseudo-gen,clang-tidy-confusable-chars-gen,lldb-tblgen,llvm-config,swift-def-to-strings-converter,swift-serialize-diagnostics,swift-compatibility-symbols `
     -Defines @{
       CMAKE_CROSSCOMPILING = "NO";
@@ -1489,6 +1444,11 @@ function Build-Compilers() {
   )
 
   Isolate-EnvVars {
+    $CompilersBinaryCache = if ($Build) {
+      Get-BuildProjectBinaryCache Compilers
+    } else {
+      Get-HostProjectBinaryCache Compilers
+    }
     $BuildTools = Join-Path -Path (Get-BuildProjectBinaryCache BuildTools) -ChildPath bin
 
     if ($TestClang -or $TestLLD -or $TestLLDB -or $TestLLVM -or $TestSwift) {
@@ -1533,9 +1493,8 @@ function Build-Compilers() {
       -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
       -Arch $Arch `
       -AddAndroidCMakeEnv:$Android `
-      -UseCCompiler MSVC `
-      -UseCXXCompiler MSVC `
-      -UseSwiftCompiler Pinned `
+      -UseMSVCCompilers C,CXX `
+      -UsePinnedCompilers Swift `
       -BuildTargets $Targets `
       -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Arch.LLVMName).cmake `
       -Defines ($TestingDefines + @{
@@ -1636,8 +1595,7 @@ function Build-LLVM([Platform]$Platform, $Arch) {
     -Bin (Get-TargetProjectBinaryCache $Arch LLVM) `
     -Arch $Arch `
     -Platform $Platform `
-    -UseCCompiler MSVC `
-    -UseCXXCompiler MSVC `
+    -UseMSVCCompilers C,CXX `
     -Defines @{
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LLVM_HOST_TRIPLE = $Arch.LLVMTarget;
@@ -1653,7 +1611,7 @@ function Build-ZLib([Platform]$Platform, $Arch) {
     -InstallTo $LibraryRoot\zlib-1.3.1\usr `
     -Arch $Arch `
     -Platform $Platform `
-    -UseCCompiler MSVC `
+    -UseMSVCCompilers C `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
@@ -1672,8 +1630,7 @@ function Build-XML2([Platform]$Platform, $Arch) {
     -InstallTo "$LibraryRoot\libxml2-2.11.5\usr" `
     -Arch $Arch `
     -Platform $Platform `
-    -UseCCompiler MSVC `
-    -UseCXXCompiler MSVC `
+    -UseMSVCCompilers C,CXX `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_INSTALL_BINDIR = "bin/$Platform/$ArchName";
@@ -1698,8 +1655,7 @@ function Build-RegsGen2($Arch) {
     -Bin "$(Get-BuildProjectBinaryCache RegsGen2)" `
     -Arch $Arch `
     -BuildTargets default `
-    -UseCCompiler MSVC `
-    -UseCXXCompiler MSVC `
+    -UseMSVCCompilers C,CXX `
     -Defines @{
       BISON_EXECUTABLE = "$(Get-BisonExecutable)";
       FLEX_EXECUTABLE = "$(Get-FlexExecutable)";
@@ -1728,7 +1684,7 @@ function Build-CURL([Platform]$Platform, $Arch) {
   $ArchName = $Arch.LLVMName
 
   $PlatformDefines = @{}
-  if ($Platform -eq [Platform]::Android) {
+  if ($Platform -eq "Android") {
     $PlatformDefines += @{
       HAVE_FSEEKO = "0";
     }
@@ -1740,7 +1696,7 @@ function Build-CURL([Platform]$Platform, $Arch) {
     -InstallTo "$LibraryRoot\curl-8.9.1\usr" `
     -Arch $Arch `
     -Platform $Platform `
-    -UseCCompiler MSVC `
+    -UseMSVCCompilers C `
     -Defines ($PlatformDefines + @{
       BUILD_SHARED_LIBS = "NO";
       BUILD_TESTING = "NO";
@@ -1803,9 +1759,9 @@ function Build-CURL([Platform]$Platform, $Arch) {
       CURL_USE_LIBSSH2 = "NO";
       CURL_USE_MBEDTLS = "NO";
       CURL_USE_OPENSSL = "NO";
-      CURL_USE_SCHANNEL = if ($Platform -eq [Platform]::Windows) { "YES" } else { "NO" };
+      CURL_USE_SCHANNEL = if ($Platform -eq "Windows") { "YES" } else { "NO" };
       CURL_USE_WOLFSSL = "NO";
-      CURL_WINDOWS_SSPI = if ($Platform -eq [Platform]::Windows) { "YES" } else { "NO" };
+      CURL_WINDOWS_SSPI = if ($Platform -eq "Windows") { "YES" } else { "NO" };
       CURL_ZLIB = "YES";
       CURL_ZSTD = "NO";
       ENABLE_ARES = "NO";
@@ -1826,8 +1782,8 @@ function Build-CURL([Platform]$Platform, $Arch) {
       USE_NGTCP2 = "NO";
       USE_QUICHE = "NO";
       USE_OPENSSL_QUIC = "NO";
-      USE_WIN32_IDN = if ($Platform -eq [Platform]::Windows) { "YES" } else { "NO" };
-      USE_WIN32_LARGE_FILES = if ($Platform -eq [Platform]::Windows) { "YES" } else { "NO" };
+      USE_WIN32_IDN = if ($Platform -eq "Windows") { "YES" } else { "NO" };
+      USE_WIN32_LARGE_FILES = if ($Platform -eq "Windows") { "YES" } else { "NO" };
       USE_WIN32_LDAP = "NO";
       ZLIB_ROOT = "$LibraryRoot\zlib-1.3.1\usr";
       ZLIB_LIBRARY = "$LibraryRoot\zlib-1.3.1\usr\lib\$Platform\$ArchName\zlibstatic.lib";
@@ -1836,7 +1792,7 @@ function Build-CURL([Platform]$Platform, $Arch) {
 
 function Build-Runtime([Platform]$Platform, $Arch) {
   $PlatformDefines = @{}
-  if ($Platform -eq [Platform]::Android) {
+  if ($Platform -eq "Android") {
     $PlatformDefines += @{
       LLVM_ENABLE_LIBCXX = "YES";
       SWIFT_USE_LINKER = "lld";
@@ -1849,6 +1805,12 @@ function Build-Runtime([Platform]$Platform, $Arch) {
   Isolate-EnvVars {
     $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$(Get-PinnedToolchainRuntime);${env:Path}"
 
+    $CompilersBinaryCache = if ($IsCrossCompiling) {
+      Get-BuildProjectBinaryCache Compilers
+    } else {
+      Get-HostProjectBinaryCache Compilers
+    }
+
     Build-CMakeProject `
       -Src $SourceCache\swift `
       -Bin (Get-TargetProjectBinaryCache $Arch Runtime) `
@@ -1856,9 +1818,7 @@ function Build-Runtime([Platform]$Platform, $Arch) {
       -Arch $Arch `
       -Platform $Platform `
       -CacheScript $SourceCache\swift\cmake\caches\Runtime-$Platform-$($Arch.LLVMName).cmake `
-      -UseCCompiler Built `
-      -UseCXXCompiler Built `
-      -UseSwiftCompiler Built `
+      -UseBuiltCompilers C,CXX,Swift `
       -Defines ($PlatformDefines + @{
         CMAKE_Swift_COMPILER_TARGET = $Arch.LLVMTarget.Replace("$AndroidAPILevel", "");
         CMAKE_Swift_COMPILER_WORKS = "YES";
@@ -1876,7 +1836,7 @@ function Build-Runtime([Platform]$Platform, $Arch) {
         SWIFT_NATIVE_SWIFT_TOOLS_PATH = (Join-Path -Path $CompilersBinaryCache -ChildPath "bin");
         SWIFT_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
         SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
-        CMAKE_SHARED_LINKER_FLAGS = if ($Platform -eq [Platform]::Windows) { @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF") } else { @() };
+        CMAKE_SHARED_LINKER_FLAGS = if ($Platform -eq "Windows") { @("/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF") } else { @() };
       })
   }
 
@@ -1899,9 +1859,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
     -InstallTo $InstallPath `
     -Arch $Arch `
     -Platform $Platform `
-    -UseCCompiler Built `
-    -UseCXXCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,CXX,Swift `
     -Defines @{
       ENABLE_SWIFT = "YES";
     }
@@ -1944,13 +1902,13 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
     $ShortArch = $Arch.LLVMName
 
     Isolate-EnvVars {
-      $SDKRoot = if ($Platform -eq [Platform]::Windows) {
+      $SDKRoot = if ($Platform -eq "Windows") {
         ""
       } else {
         (Get-Variable "${Platform}$($Arch.ShortName)" -ValueOnly).SDKInstallRoot
       }
 
-      $SDKRoot = if ($Platform -eq [Platform]::Windows) {
+      $SDKRoot = if ($Platform -eq "Windows") {
         ""
       } else {
         (Get-Variable "${Platform}$($Arch.ShortName)" -ValueOnly).SDKInstallRoot
@@ -1962,18 +1920,15 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -InstallTo "$($Arch.SDKInstallRoot)\usr" `
         -Arch $Arch `
         -Platform $Platform `
-        -UseASMCompiler Built `
-        -UseCCompiler Built `
-        -UseCXXCompiler Built `
-        -UseSwiftCompiler Built `
+        -UseBuiltCompilers ASM,C,CXX,Swift `
         -SwiftSDK:$SDKRoot `
         -Defines (@{
           ENABLE_TESTING = "NO";
-          FOUNDATION_BUILD_TOOLS = if ($Platform -eq [Platform]::Windows) { "YES" } else { "NO" };
+          FOUNDATION_BUILD_TOOLS = if ($Platform -eq "Windows") { "YES" } else { "NO" };
           CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
           CURL_DIR = "$LibraryRoot\curl-8.9.1\usr\lib\$Platform\$ShortArch\cmake\CURL";
           LibXml2_DIR = "$LibraryRoot\libxml2-2.11.5\usr\lib\$Platform\$ShortArch\cmake\libxml2-2.11.5";
-          ZLIB_LIBRARY = if ($Platform -eq [Platform]::Windows) {
+          ZLIB_LIBRARY = if ($Platform -eq "Windows") {
             "$LibraryRoot\zlib-1.3.1\usr\lib\$Platform\$ShortArch\zlibstatic.lib"
           } else {
             "$LibraryRoot\zlib-1.3.1\usr\lib\$Platform\$ShortArch\libz.a"
@@ -2031,7 +1986,7 @@ function Build-FoundationMacros() {
     -InstallTo:$InstallDir `
     -Arch $Arch `
     -Platform $Platform `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -SwiftSDK:$SwiftSDK `
     -BuildTargets:$Targets `
     -Defines @{
@@ -2068,7 +2023,7 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
       -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform $Platform `
-      -UseSwiftCompiler Built `
+      -UseBuiltCompilers Swift `
       -BuildTargets $Targets `
       -Defines (@{
         CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
@@ -2097,9 +2052,7 @@ function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
       -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform $Platform `
-      -UseCCompiler Built `
-      -UseCXXCompiler Built `
-      -UseSwiftCompiler Built `
+      -UseBuiltCompilers C,CXX,Swift `
       -Defines (@{
         BUILD_SHARED_LIBS = "YES";
         CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
@@ -2212,7 +2165,7 @@ function Build-SQLite($Arch) {
     -Bin "$($Arch.BinaryCache)\sqlite-3.46.0" `
     -InstallTo $LibraryRoot\sqlite-3.46.0\usr `
     -Arch $Arch `
-    -UseCCompiler MSVC `
+    -UseMSVCCompilers C `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
     }
@@ -2225,8 +2178,7 @@ function Build-System($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2245,8 +2197,7 @@ function Build-ToolsSupportCore($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2284,8 +2235,8 @@ function Build-LLBuild($Arch, [switch]$Test = $false) {
       -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform Windows `
-      -UseCXXCompiler MSVC `
-      -UseSwiftCompiler Built `
+      -UseMSVCCompilers CXX `
+      -UseBuiltCompilers Swift `
       -SwiftSDK (Get-HostSwiftSDK) `
       -BuildTargets $Targets `
       -Defines ($TestingDefines + @{
@@ -2303,8 +2254,7 @@ function Build-Yams($Arch) {
     -Bin (Get-HostProjectBinaryCache Yams) `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -BuildTargets default `
     -Defines @{
@@ -2320,7 +2270,7 @@ function Build-ArgumentParser($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2335,9 +2285,7 @@ function Build-Driver($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseCXXCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2361,7 +2309,7 @@ function Build-Crypto($Arch) {
     -Bin (Get-HostProjectBinaryCache Crypto) `
     -Arch $Arch `
     -Platform Windows `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -BuildTargets default `
     -Defines @{
@@ -2376,8 +2324,7 @@ function Build-Collections($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2389,8 +2336,7 @@ function Build-ASN1($Arch) {
     -Src $SourceCache\swift-asn1 `
     -Bin (Get-HostProjectBinaryCache ASN1) `
     -Arch $Arch `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -BuildTargets default `
     -Defines @{
@@ -2404,7 +2350,7 @@ function Build-Certificates($Arch) {
     -Bin (Get-HostProjectBinaryCache Certificates) `
     -Arch $Arch `
     -Platform Windows `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -BuildTargets default `
     -Defines @{
@@ -2427,8 +2373,7 @@ function Build-PackageManager($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2455,8 +2400,7 @@ function Build-Markdown($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -2472,8 +2416,8 @@ function Build-Format($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler MSVC `
-    -UseSwiftCompiler Built `
+    -UseMSVCCompilers C `
+    -UseBuiltCompilers Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -2530,9 +2474,7 @@ function Build-IndexStoreDB($Arch) {
     -Bin (Get-HostProjectBinaryCache IndexStoreDB) `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseCXXCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SDKInstallRoot `
     -BuildTargets default `
     -Defines @{
@@ -2549,8 +2491,7 @@ function Build-SourceKitLSP($Arch) {
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -Platform Windows `
-    -UseCCompiler Built `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers C,Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -Defines @{
       SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
@@ -2687,7 +2628,7 @@ function Build-TestingMacros() {
     -InstallTo:$InstallDir  `
     -Arch $Arch `
     -Platform $Platform `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -SwiftSDK:$SwiftSDK `
     -BuildTargets:$Targets `
     -Defines @{
@@ -2723,7 +2664,7 @@ function Build-Inspect() {
     -Bin (Get-HostProjectBinaryCache SwiftInspect) `
     -InstallTo "$($HostArch.ToolchainInstallRoot)\usr" `
     -Arch $HostArch `
-    -UseSwiftCompiler Built `
+    -UseBuiltCompilers Swift `
     -UseSwiftSwiftDriver `
     -SwiftSDK $SDKRoot `
     -Defines @{


### PR DESCRIPTION
Revert "[windows] Various improvements in build.ps1" https://github.com/swiftlang/swift/pull/77948
Revert "[windows][toolchain] Enable builtins and sanitizers" https://github.com/swiftlang/swift/pull/77770
Revert "utils: unlock building swift-inspect" https://github.com/swiftlang/swift/pull/77810

To fix CI https://ci-external.swift.org/job/swift-main-windows-toolchain-arm64
