### PR TITLE
Temporarily disable package-cmo-serialize-tables.swift on armv7k

### DIFF
--- a/test/SILOptimizer/package-cmo-serialize-tables.swift
+++ b/test/SILOptimizer/package-cmo-serialize-tables.swift
@@ -17,6 +17,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// Temporarily disabling on armv7k:
+// rdar://140330692 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed...
+// UNSUPPORTED: CPU=armv7k
 
 //--- main.swift
 


### PR DESCRIPTION
Workaround for: rdar://140330692
