### PR TITLE
[OSSACompleteLifetime] Handle scoped addresses.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -90,12 +90,14 @@ public:
   ///
   /// Returns true if any new instructions were created to complete the
   /// lifetime.
-  ///
-  /// TODO: We also need to complete scoped addresses (e.g. store_borrow)!
   LifetimeCompletion completeOSSALifetime(SILValue value, Boundary boundary) {
     switch (value->getOwnershipKind()) {
-    case OwnershipKind::None:
-      return LifetimeCompletion::NoLifetime;
+    case OwnershipKind::None: {
+      auto scopedAddress = ScopedAddressValue(value);
+      if (!scopedAddress)
+        return LifetimeCompletion::NoLifetime;
+      break;
+    }
     case OwnershipKind::Owned:
       break;
     case OwnershipKind::Any:

--- a/include/swift/SIL/ScopedAddressUtils.h
+++ b/include/swift/SIL/ScopedAddressUtils.h
@@ -122,7 +122,8 @@ struct ScopedAddressValue {
   AddressUseKind updateTransitiveLiveness(SSAPrunedLiveness &liveness) const;
 
   /// Create appropriate scope ending instruction at \p insertPt.
-  void createScopeEnd(SILBasicBlock::iterator insertPt, SILLocation loc) const;
+  SILInstruction *createScopeEnd(SILBasicBlock::iterator insertPt,
+                                 SILLocation loc) const;
 
   /// Create scope ending instructions at \p liveness boundary.
   void endScopeAtLivenessBoundary(SSAPrunedLiveness *liveness) const;

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -422,7 +422,19 @@ static bool endLifetimeAtAvailabilityBoundary(SILValue value,
 static bool endLifetimeAtBoundary(SILValue value,
                                   SSAPrunedLiveness const &liveness,
                                   OSSALifetimeCompletion::Boundary boundary,
-                                  DeadEndBlocks &deadEndBlocks);
+                                  DeadEndBlocks &deadEndBlocks) {
+  bool changed = false;
+  switch (boundary) {
+  case OSSALifetimeCompletion::Boundary::Liveness:
+    changed |= endLifetimeAtLivenessBoundary(value, liveness, deadEndBlocks);
+    break;
+  case OSSALifetimeCompletion::Boundary::Availability:
+    changed |=
+        endLifetimeAtAvailabilityBoundary(value, liveness, deadEndBlocks);
+    break;
+  }
+  return changed;
+}
 
 /// End the lifetime of \p value at unreachable instructions.
 ///
@@ -443,23 +455,6 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(SILValue value,
   assert(liveness.getUnenclosedPhis().empty());
   return endLifetimeAtBoundary(value, liveness.getLiveness(), boundary,
                                deadEndBlocks);
-}
-
-static bool endLifetimeAtBoundary(SILValue value,
-                                  SSAPrunedLiveness const &liveness,
-                                  OSSALifetimeCompletion::Boundary boundary,
-                                  DeadEndBlocks &deadEndBlocks) {
-  bool changed = false;
-  switch (boundary) {
-  case OSSALifetimeCompletion::Boundary::Liveness:
-    changed |= endLifetimeAtLivenessBoundary(value, liveness, deadEndBlocks);
-    break;
-  case OSSALifetimeCompletion::Boundary::Availability:
-    changed |=
-        endLifetimeAtAvailabilityBoundary(value, liveness, deadEndBlocks);
-    break;
-  }
-  return changed;
 }
 
 namespace swift::test {

--- a/lib/SIL/Utils/ScopedAddressUtils.cpp
+++ b/lib/SIL/Utils/ScopedAddressUtils.cpp
@@ -151,16 +151,15 @@ AddressUseKind ScopedAddressValue::updateTransitiveLiveness(
   return addressKind;
 }
 
-void ScopedAddressValue::createScopeEnd(SILBasicBlock::iterator insertPt,
-                                        SILLocation loc) const {
+SILInstruction *
+ScopedAddressValue::createScopeEnd(SILBasicBlock::iterator insertPt,
+                                   SILLocation loc) const {
   switch (kind) {
   case ScopedAddressValueKind::StoreBorrow: {
-    SILBuilderWithScope(insertPt).createEndBorrow(loc, value);
-    return;
+    return SILBuilderWithScope(insertPt).createEndBorrow(loc, value);
   }
   case ScopedAddressValueKind::BeginAccess: {
-    SILBuilderWithScope(insertPt).createEndAccess(loc, value, false);
-    return;
+    return SILBuilderWithScope(insertPt).createEndAccess(loc, value, false);
   }
   case ScopedAddressValueKind::Invalid:
     llvm_unreachable("Using invalid case?!");

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -792,3 +792,52 @@ bb3:
   return %0 : $C
 }
 
+// CHECK-LABEL: begin running test {{.*}} on store_borrow: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @store_borrow : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'store_borrow'
+// CHECK-LABEL: end running test {{.*}} on store_borrow: ossa_lifetime_completion
+sil [ossa] @store_borrow : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %token availability"
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr : $*C
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %token : $*C
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on begin_access: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @begin_access : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = begin_access
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_access [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'begin_access'
+// CHECK-LABEL: end running test {{.*}} on begin_access: ossa_lifetime_completion
+sil [ossa] @begin_access : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %access availability"
+  %addr = alloc_stack $C
+  %access = begin_access [static] [read] %addr : $*C
+  cond_br undef, exit, die
+
+exit:
+  end_access %access : $*C
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}

--- a/test/SILOptimizer/silgen_cleanup_complete_ossa.sil
+++ b/test/SILOptimizer/silgen_cleanup_complete_ossa.sil
@@ -32,7 +32,7 @@ protocol P : AnyObject {}
 
 sil @unreachableHandler : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil [ossa] @testCompleteOSSALifetimes : $@convention(thin) (@owned FakeOptional<Klass>) -> () {
+// CHECK-LABEL: sil [ossa] @testCompleteOSSALifetimes : {{.*}} {
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var FakeOptional<Klass> }, var, name "c"
 // CHECK:   [[BORROW:%.,*]] = begin_borrow [lexical] [[BOX]] : ${ var FakeOptional<Klass> }
 // CHECK: bb2:
@@ -40,6 +40,7 @@ sil @unreachableHandler : $@convention(thin) () -> ()
 // CHECK:   end_borrow [[BORROW]] : ${ var FakeOptional<Klass> }
 // CHECK:   dealloc_box [dead_end] [[BOX]] : ${ var FakeOptional<Klass> }
 // CHECK:   unreachable
+// CHECK-LABEL: } // end sil function 'testCompleteOSSALifetimes'
 sil [ossa] @testCompleteOSSALifetimes : $@convention(thin) (@owned FakeOptional<Klass>) -> () {
 bb0(%0 : @owned $FakeOptional<Klass>):
   %box = alloc_box ${ var FakeOptional<Klass> }, var, name "c"
@@ -73,8 +74,9 @@ bb5:
   return %36 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @testExistentialLifetime : $@convention(thin) (@owned any P) -> @owned AnyObject {
+// CHECK-LABEL: sil [ossa] @testExistentialLifetime : {{.*}} {
 // CHECK-NOT: destroy
+// CHECK-LABEL: } // end sil function 'testExistentialLifetime'
 sil [ossa] @testExistentialLifetime : $@convention(thin) (@owned any P) -> @owned AnyObject {
 bb0(%0 : @owned $any P):
   %1 = open_existential_ref %0 : $any P to $@opened("34B79428-2E49-11ED-901A-8AC134504E1C", any P) Self

--- a/test/SILOptimizer/silgen_cleanup_complete_ossa.sil
+++ b/test/SILOptimizer/silgen_cleanup_complete_ossa.sil
@@ -11,6 +11,8 @@ class Klass {
 }
 class SubKlass : Klass {}
 
+class C {}
+
 enum FakeOptional<T> {
 case none
 case some(T)
@@ -82,4 +84,60 @@ bb0(%0 : @owned $any P):
   %1 = open_existential_ref %0 : $any P to $@opened("34B79428-2E49-11ED-901A-8AC134504E1C", any P) Self
   %2 = init_existential_ref %1 : $@opened("34B79428-2E49-11ED-901A-8AC134504E1C", any P) Self : $@opened("34B79428-2E49-11ED-901A-8AC134504E1C", any P) Self, $AnyObject
   return %2 : $AnyObject
+}
+
+// CHECK-LABEL: sil [ossa] @store_borrow : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow [[INSTANCE]] to [[ADDR]]
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[TOKEN]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         end_borrow [[LOAD]]
+// CHECK:         end_borrow [[TOKEN]]
+// CHECK:         destroy_value [dead_end] [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'store_borrow'
+sil [ossa] @store_borrow : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr : $*C
+  %load = load_borrow %token : $*C
+  cond_br undef, exit, die
+exit:
+  end_borrow %load : $C
+  end_borrow %token : $*C
+  dealloc_stack %addr : $*C
+  apply undef(%instance) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @begin_access : {{.*}} {
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         [[ACCESS:%[^,]+]] = begin_access [modify] [static] [[ADDR]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         end_access [[ACCESS]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'begin_access'
+sil [ossa] @begin_access : $@convention(thin) () -> () {
+entry:
+  %addr2 = alloc_stack $C
+  %access = begin_access [static] [modify] %addr2 : $*C
+  apply undef(%access) : $@convention(thin) () -> (@out C)
+  destroy_addr %access : $*C
+  cond_br undef, exit, die
+
+exit:
+  end_access %access : $*C
+  dealloc_stack %addr2 : $*C
+  %retval = tuple ()
+  return %retval : $()
+
+die:
+  unreachable
 }


### PR DESCRIPTION
Complete scopes of scoped addresses (introduced by `store_borrow` and `begin_access`) in dead end blocks via `ScopedAddressValue::computeTransitiveLiveness`.

rdar://141037060
