### PR TITLE
[CSSimplify] Avoid resolving extraneous (trailing) closures

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar141012049.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar141012049.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+func test(_ v: [Int]) {
+  let result = v.filter { }.flatMap(\.wrong) {
+    // expected-error@-1 {{type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
+    // expected-error@-2 {{cannot convert value of type '()' to closure result type 'Bool'}}
+    // expected-error@-3 {{value of type 'Int' has no member 'wrong'}}
+    // expected-error@-4 {{extra trailing closure passed in call}}
+    print(result)
+  }
+
+  let otherResult = v.filter { _ in false }.flatMap(\.wrong, { $0 }, 42)
+  // expected-error@-1 {{value of type 'Int' has no member 'wrong'}}
+  // expected-error@-2 {{extra arguments at positions #2, #3 in call}}
+}


### PR DESCRIPTION
If a (trailing) closure is determined to be an extraneous argument 
for one of the overload choices it needs to be marked as hole as 
eagerly as possible and prevented from being resolved because
otherwise it's going to be disconnected from the rest of the 
constraint system and resolution might not be able to find all of 
the referenced variables. This could result either in crashes or 
superfluous diagnostics.

Resolves: rdar://141012049

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
