### PR TITLE
lib: use `CXX_MODULE_NAME` constant for module identifier (NFC)

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/Strings.h"
 #include "clang/CAS/IncludeTree.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
@@ -500,7 +501,7 @@ swift::dependencies::registerCxxInteropLibraries(
     RegistrationCallback(LinkLibrary("stdc++", LibraryKind::Library));
 
   // Do not try to link Cxx with itself.
-  if (mainModuleName != "Cxx") {
+  if (mainModuleName != CXX_MODULE_NAME) {
     RegistrationCallback(LinkLibrary(Target.isOSWindows() && hasStaticCxx
                                         ? "libswiftCxx"
                                         : "swiftCxx",
@@ -509,7 +510,7 @@ swift::dependencies::registerCxxInteropLibraries(
 
   // Do not try to link CxxStdlib with the C++ standard library, Cxx or
   // itself.
-  if (llvm::none_of(llvm::ArrayRef{"Cxx", "CxxStdlib", "std"},
+  if (llvm::none_of(llvm::ArrayRef<StringRef>{CXX_MODULE_NAME, "CxxStdlib", "std"},
                     [mainModuleName](StringRef Name) {
                       return mainModuleName == Name;
                     })) {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1505,7 +1505,7 @@ static void resolveImplicitLinkLibraries(const CompilerInstance &instance,
     addLinkLibrary({"objc", LibraryKind::Library});
 
   if (langOpts.EnableCXXInterop) {
-    auto OptionalCxxDep = cache.findDependency("Cxx");
+    auto OptionalCxxDep = cache.findDependency(CXX_MODULE_NAME);
     auto OptionalCxxStdLibDep = cache.findDependency("CxxStdlib");
     bool hasStaticCxx =
         OptionalCxxDep.has_value() && OptionalCxxDep.value()->isStaticLibrary();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -30,6 +30,7 @@
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/RuntimeFnWrappersGen.h"
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/CharInfo.h"
@@ -1677,7 +1678,7 @@ void IRGenModule::addLinkLibraries() {
   if (Context.LangOpts.EnableCXXInterop) {
     bool hasStaticCxx = false;
     bool hasStaticCxxStdlib = false;
-    if (const auto *M = Context.getModuleByName("Cxx"))
+    if (const auto *M = Context.getModuleByName(CXX_MODULE_NAME))
       hasStaticCxx = M->isStaticLibrary();
     if (Context.LangOpts.Target.getOS() == llvm::Triple::Win32)
       if (const auto *M = Context.getModuleByName("CxxStdlib"))


### PR DESCRIPTION
Use the well known specifier for explicit references to the `Cxx` module rather than re-spelling the name at the various sites.