### PR TITLE
[6.1][build-script] Stop installing the llbuildSwift library that is no longer used

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2984,7 +2984,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_LLBUILD}" ]] ; then
                     continue
                 fi
-                INSTALL_TARGETS="install-swift-build-tool install-libllbuildSwift"
+                INSTALL_TARGETS="install-swift-build-tool"
                 ;;
             # Products from this here install themselves; they don't fall-through.
             lldb)


### PR DESCRIPTION
__Explanation:__ This installed library in the toolchain has been [unused on linux](https://github.com/swiftlang/swift/pull/77647#issue-2662354785) and [macOS](https://github.com/swiftlang/swift/pull/77647#issuecomment-2480524069) for years.

__Scope:__ Remove a single unused library from the linux and macOS toolchains

__Issue:__ None

__Original PRs:__ #77647

__Risk:__ Very low

__Testing:__ Passed all CI on trunk

__Reviewer:__ @bnbarham

@DougGregor, another unused library cleanup.