### PR TITLE
ASTDumper: Do not escape Unicode chars in quoted fields

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -32,6 +32,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/STLExtras.h"
+#include "swift/Basic/StringExtras.h"
 #include "clang/AST/Type.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallString.h"
@@ -180,7 +181,7 @@ public:
 
 private:
   virtual void write_impl(const char *Ptr, size_t Size) override {
-    base_os.write_escaped(StringRef(Ptr, Size), /*UseHexEscapes=*/true);
+    writeEscaped(StringRef(Ptr, Size), base_os);
   }
 
   virtual uint64_t current_pos() const override {

--- a/test/Generics/minimal_conformances_compare_concrete.swift
+++ b/test/Generics/minimal_conformances_compare_concrete.swift
@@ -14,9 +14,9 @@ struct G<X> {}
 // CHECK-NEXT: Generic signature: <X where X == Derived>
 extension G where X : Base, X : P, X == Derived {}
 
-// RULE: + (requirement "\xCF\x84_0_0" subclass_of "Base")
-// RULE: + (requirement "\xCF\x84_0_0" conforms_to "P")
-// RULE: + (requirement "\xCF\x84_0_0" same_type "Derived")
+// RULE: + (requirement "τ_0_0" subclass_of "Base")
+// RULE: + (requirement "τ_0_0" conforms_to "P")
+// RULE: + (requirement "τ_0_0" same_type "Derived")
 
 // RULE: Rewrite system: {
 // RULE-NEXT: - [Copyable].[Copyable] => [Copyable] [permanent]

--- a/test/Parse/raw_string.swift
+++ b/test/Parse/raw_string.swift
@@ -77,7 +77,7 @@ _ = ##"""
 /// passes again.
 /// See https://github.com/apple/swift/issues/51192.
 _ = #"​"​"#
-// CHECK: "\xE2\x80\x8B\"\xE2\x80\x8B"
+// CHECK: "​\"​"
 
 _ = #""""#
 // CHECK: "\"\""

--- a/unittests/AST/ASTDumperTests.cpp
+++ b/unittests/AST/ASTDumperTests.cpp
@@ -52,6 +52,6 @@ TEST(ASTDumper, ArchetypeType) {
   }
 
   EXPECT_EQ(str,
-            " name=\"\\xCF\\x84_0_0\"\n"
+            " name=\"τ_0_0\"\n"
             "  (interface_type=generic_type_param_type depth=0 index=0 param_kind=type))\n");
 }


### PR DESCRIPTION
Context: https://github.com/swiftlang/swift/pull/68438#discussion_r1449272860
