### PR TITLE
[6.1][stdlib] Fix recoverable [U]Int128 division-by-zero

### DIFF
--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -366,7 +366,13 @@ extension Int128 {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public static func /(a: Self, b: Self) -> Self {
-    a.dividedReportingOverflow(by: b).partialValue
+    if _slowPath(b == .zero) {
+      _preconditionFailure("Division by zero")
+    }
+    if _slowPath(a == .min && b == (-1 as Self)) {
+      _preconditionFailure("Division results in an overflow")
+    }
+    return Self(Builtin.sdiv_Int128(a._value, b._value))
   }
 
   @available(SwiftStdlib 6.0, *)
@@ -378,7 +384,13 @@ extension Int128 {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public static func %(a: Self, b: Self) -> Self {
-    a.remainderReportingOverflow(dividingBy: b).partialValue
+    if _slowPath(b == .zero) {
+      _preconditionFailure("Division by zero in remainder operation")
+    }
+    if _slowPath(a == .min && b == (-1 as Self)) {
+      _preconditionFailure("Division results in an overflow in remainder operation")
+    }
+    return Self(Builtin.srem_Int128(a._value, b._value))
   }
 
   @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -297,8 +297,12 @@ extension Int128 {
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    if other == .zero { return (self, true) }
-    if self == .min && other == -1 { return (.min, true) }
+    if _slowPath(other == .zero) {
+      return (self, true)
+    }
+    if _slowPath(self == .min && other == (-1 as Self)) {
+      return (.min, true)
+    }
     return (Self(Builtin.sdiv_Int128(self._value, other._value)), false)
   }
 
@@ -307,8 +311,12 @@ extension Int128 {
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    if other == .zero { return (self, true) }
-    if self == .min && other == -1 { return (0, true) }
+    if _slowPath(other == .zero) {
+      return (self, true)
+    }
+    if _slowPath(self == .min && other == (-1 as Self)) {
+      return (0, true)
+    }
     return (Self(Builtin.srem_Int128(self._value, other._value)), false)
   }
 }

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -314,6 +314,9 @@ extension Int128 {
     if _slowPath(other == .zero) {
       return (self, true)
     }
+    // This case is interesting because the remainder does not overflow; the
+    // analogous division does. Counting it as overflowing is consistent with
+    // documented behavior.
     if _slowPath(self == .min && other == (-1 as Self)) {
       return (0, true)
     }
@@ -395,6 +398,9 @@ extension Int128 {
     if _slowPath(b == .zero) {
       _preconditionFailure("Division by zero in remainder operation")
     }
+    // This case is interesting because the remainder does not overflow; the
+    // analogous division does. Counting it as overflowing is consistent with
+    // documented behavior.
     if _slowPath(a == .min && b == (-1 as Self)) {
       _preconditionFailure("Division results in an overflow in remainder operation")
     }

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -297,7 +297,7 @@ extension Int128 {
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    _precondition(other != .zero, "Division by zero")
+    if other == .zero { return (self, true) }
     if self == .min && other == -1 { return (.min, true) }
     return (Self(Builtin.sdiv_Int128(self._value, other._value)), false)
   }
@@ -307,7 +307,7 @@ extension Int128 {
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    _precondition(other != .zero, "Division by zero in remainder operation")
+    if other == .zero { return (self, true) }
     if self == .min && other == -1 { return (0, true) }
     return (Self(Builtin.srem_Int128(self._value, other._value)), false)
   }

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -349,7 +349,10 @@ extension UInt128 {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public static func /(a: Self, b: Self) -> Self {
-    a.dividedReportingOverflow(by: b).partialValue
+    if _slowPath(b == .zero) {
+      _preconditionFailure("Division by zero")
+    }
+    return Self(Builtin.udiv_Int128(a._value, b._value))
   }
 
   @available(SwiftStdlib 6.0, *)
@@ -361,7 +364,10 @@ extension UInt128 {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public static func %(a: Self, b: Self) -> Self {
-    a.remainderReportingOverflow(dividingBy: b).partialValue
+    if _slowPath(b == .zero) {
+      _preconditionFailure("Division by zero in remainder operation")
+    }
+    return Self(Builtin.urem_Int128(a._value, b._value))
   }
 
   @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -280,7 +280,9 @@ extension UInt128 {
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    if other == .zero { return (self, true) }
+    if _slowPath(other == .zero) {
+      return (self, true)
+    }
     // Unsigned divide never overflows.
     return (Self(Builtin.udiv_Int128(self._value, other._value)), false)
   }
@@ -290,7 +292,9 @@ extension UInt128 {
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    if other == .zero { return (self, true) }
+    if _slowPath(other == .zero) {
+      return (self, true)
+    }
     // Unsigned divide never overflows.
     return (Self(Builtin.urem_Int128(self._value, other._value)), false)
   }

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -280,7 +280,7 @@ extension UInt128 {
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    _precondition(other != .zero, "Division by zero")
+    if other == .zero { return (self, true) }
     // Unsigned divide never overflows.
     return (Self(Builtin.udiv_Int128(self._value, other._value)), false)
   }
@@ -290,7 +290,7 @@ extension UInt128 {
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    _precondition(other != .zero, "Division by zero in remainder operation")
+    if other == .zero { return (self, true) }
     // Unsigned divide never overflows.
     return (Self(Builtin.urem_Int128(self._value, other._value)), false)
   }

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -356,6 +356,7 @@ extension UInt128 {
     if _slowPath(b == .zero) {
       _preconditionFailure("Division by zero")
     }
+    // Unsigned divide never overflows.
     return Self(Builtin.udiv_Int128(a._value, b._value))
   }
 
@@ -371,6 +372,7 @@ extension UInt128 {
     if _slowPath(b == .zero) {
       _preconditionFailure("Division by zero in remainder operation")
     }
+    // Unsigned divide never overflows.
     return Self(Builtin.urem_Int128(a._value, b._value))
   }
 


### PR DESCRIPTION
- **Explanation**: `Int128` and `UInt128` division by zero did not behave like smaller binary integer division by zero. This contribution updates the various division operations accordingly. It adds a missing precondition in signed `%(_:_:)` and replaces the preconditions in `*ReportingOverflow` with recoverable results consistent with documented behavior.
- **Scope**: Updates Int128 and UInt128 division methods.
- **Issues**: https://github.com/oscbyspro/Ultimathnum/issues/143
- **Original PRs**: #77854
- **Risk**: It updates some arithmetic functions of relatively new types.
- **Testing**: Adding corresponding 128-bit division unit tests would be prudent.
- **Reviewers**: @stephentyrone (approved) @xwu (commented)