### PR TITLE
FineModuleTrace: avoid emitting trace file when lazy type checking is enabled.

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -917,6 +917,10 @@ static void createFineModuleTraceFile(const InputFile &input, ModuleDecl *MD) {
 
 bool swift::emitFineModuleTraceIfNeeded(ModuleDecl *mainModule,
                                         const FrontendOptions &opts) {
+  // When lazy type checking is enabled, we may end up with a partial AST.
+  // Walking on these partial AST completely may expose latent bugs.
+  if (mainModule->getASTContext().TypeCheckerOpts.EnableLazyTypecheck)
+    return false;
   ASTContext &ctxt = mainModule->getASTContext();
   assert(!ctxt.hadError() &&
          "We should've already exited earlier if there was an error.");

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -7,6 +7,9 @@
 // RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE
 // RUN: cat %t/given_trace.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s
 
+// RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_2.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -enable-library-evolution -experimental-lazy-typecheck
+// RUN: not ls %t/given_trace_2.json
+
 // REQUIRES: objc_interop
 
 import Foo


### PR DESCRIPTION
When lazy type checking is enabled, the generated AST to walk on may contain function bodies that are not fully type-checked. Walking on these function bodies could expose latent bugs.

Resolves rdar://140818215
