### PR TITLE
Simplifies PlaygroundTransform tests by moving boilerplate code to a macro

### DIFF
--- a/test/PlaygroundTransform/Inputs/PlaygroundModuleAndFileIDs.swift
+++ b/test/PlaygroundTransform/Inputs/PlaygroundModuleAndFileIDs.swift
@@ -1,11 +1,5 @@
-// testxx (module-name) -> 1 (module-id)
-internal let __builtin_pg_module_test5a: Int = 1
-internal let __builtin_pg_module_test5b: Int = 1
-internal let __builtin_pg_module_test6a: Int = 1
-internal let __builtin_pg_module_test6b: Int = 1
+// main (module-name) -> 1 (module-id)
+internal let __builtin_pg_module_main: Int = 1
 
-// testxx (module-name), main (file-name), main_ (file-name-punycode) -> 2 (file-id)
-internal let __builtin_pg_module_test5a_pg_file_main_: Int = 2
-internal let __builtin_pg_module_test5b_pg_file_main_: Int = 2
-internal let __builtin_pg_module_test6a_pg_file_main_: Int = 2
-internal let __builtin_pg_module_test6b_pg_file_main_: Int = 2
+// main (module-name), main (file-name), main_ (file-name-punycode) -> 2 (file-id)
+internal let __builtin_pg_module_main_pg_file_main_: Int = 2

--- a/test/PlaygroundTransform/array.swift
+++ b/test/PlaygroundTransform/array.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/array_did_set.swift
+++ b/test/PlaygroundTransform/array_did_set.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/array_in_struct.swift
+++ b/test/PlaygroundTransform/array_in_struct.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 // FIXME: We need to instrument mutations of objects that are accessed in

--- a/test/PlaygroundTransform/async_let.swift
+++ b/test/PlaygroundTransform/async_let.swift
@@ -1,30 +1,14 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -disable-availability-checking -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -disable-availability-checking -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -disable-availability-checking -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -disable-availability-checking -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -disable-availability-checking -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -disable-availability-checking -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-
+//
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
@@ -42,25 +26,25 @@ async let fac4 = factorial(4)
 print(await fac4)
 
 //             return await x * factorial(x - 1)
-// CHECK:      [36:{{[[:digit:]]+}}-36:{{[[:digit:]]+}}] __builtin_log[='1']
+// CHECK:      [20:{{[[:digit:]]+}}-20:{{[[:digit:]]+}}] __builtin_log[='1']
 
 //             return await x * factorial(x - 1)
-// CHECK:      [38:{{[[:digit:]]+}}-38:{{[[:digit:]]+}}] __builtin_log[='1']
+// CHECK:      [22:{{[[:digit:]]+}}-22:{{[[:digit:]]+}}] __builtin_log[='1']
 
 //             return await x * factorial(x - 1)
-// CHECK:      [38:{{[[:digit:]]+}}-38:{{[[:digit:]]+}}] __builtin_log[='2']
+// CHECK:      [22:{{[[:digit:]]+}}-22:{{[[:digit:]]+}}] __builtin_log[='2']
 
 //             return await x * factorial(x - 1)
-// CHECK:      [38:{{[[:digit:]]+}}-38:{{[[:digit:]]+}}] __builtin_log[='6']
+// CHECK:      [22:{{[[:digit:]]+}}-22:{{[[:digit:]]+}}] __builtin_log[='6']
 
 //             return await x * factorial(x - 1)
-// CHECK:      [38:{{[[:digit:]]+}}-38:{{[[:digit:]]+}}] __builtin_log[='24']
+// CHECK:      [22:{{[[:digit:]]+}}-22:{{[[:digit:]]+}}] __builtin_log[='24']
 
 //             func factorial(_ x : Int) { ... }
-// CHECK-NEXT: [34:{{[[:digit:]]+}}-39:{{[[:digit:]]+}}] __builtin_log_scope_exit
+// CHECK-NEXT: [18:{{[[:digit:]]+}}-23:{{[[:digit:]]+}}] __builtin_log_scope_exit
 
 // (actually print the thing)
 // CHECK-NEXT: 24
 
 //             print(await fac4)
-// CHECK-NEXT: [42:{{[[:digit:]]+}}-42:{{[[:digit:]]+}}] __builtin_postPrint
+// CHECK-NEXT: [26:{{[[:digit:]]+}}-26:{{[[:digit:]]+}}] __builtin_postPrint

--- a/test/PlaygroundTransform/bare_value.swift
+++ b/test/PlaygroundTransform/bare_value.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/closure_parameters.swift
+++ b/test/PlaygroundTransform/closure_parameters.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/control-flow.swift
+++ b/test/PlaygroundTransform/control-flow.swift
@@ -1,31 +1,14 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport
-
 
 var a = true
 if (a) {

--- a/test/PlaygroundTransform/declarations.swift
+++ b/test/PlaygroundTransform/declarations.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/defer.swift
+++ b/test/PlaygroundTransform/defer.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/disable_transform_only.swift
+++ b/test/PlaygroundTransform/disable_transform_only.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -disable-playground-transform -I=%t %t/PlaygroundSupport.o -o %t/main5a %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -disable-playground-transform -I=%t %t/PlaygroundSupport.o -o %t/main6a %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -disable-playground-transform) | %FileCheck %s -allow-empty
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -disable-playground-transform) | %FileCheck %s -allow-empty
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform -I=%t %t/PlaygroundSupport.o -o %t/main5b %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform -I=%t %t/PlaygroundSupport.o -o %t/main6b %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s -allow-empty
-// RUN: %target-run %t/main5b | %FileCheck %s -allow-empty
-// RUN: %target-run %t/main6a | %FileCheck %s -allow-empty
-// RUN: %target-run %t/main6b | %FileCheck %s -allow-empty
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform) | %FileCheck %s -allow-empty
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform) | %FileCheck %s -allow-empty
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/do-catch.swift
+++ b/test/PlaygroundTransform/do-catch.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/do.swift
+++ b/test/PlaygroundTransform/do.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/existential.swift
+++ b/test/PlaygroundTransform/existential.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 // rdar://136459076

--- a/test/PlaygroundTransform/extended_callbacks.swift
+++ b/test/PlaygroundTransform/extended_callbacks.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks) | %FileCheck %s
+//
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_PlaygroundExtendedCallbacks
 
@@ -37,26 +21,26 @@ if (a) {
 for i in 0..<3 {
   i
 }
-// CHECK: [{{.*}}] __builtin_log_with_id_extended[a='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='5' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK: [{{.*}}] __builtin_log_with_id_extended[a='true' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='5' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*/main.swift}}]
 
 var b = true
 for i in 0..<3 {
   i
   continue
 }
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[b='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[b='true' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*/main.swift}}]
 
 var c = true
 for i in 0..<3 {
   i
   break
 }
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[c='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[c='true' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]

--- a/test/PlaygroundTransform/function_parameters.swift
+++ b/test/PlaygroundTransform/function_parameters.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/high_performance.swift
+++ b/test/PlaygroundTransform/high_performance.swift
@@ -4,37 +4,17 @@
 //
 // REQUIRES: executable_test
 //
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground -playground-high-performance
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance) | %FileCheck %s
+//
 // -pc-macro -playground  -playground-high-performance
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance) | %FileCheck %s
+//
 // -playground -playground-option NoScopeEvents -playground-option NoFunctionParameters
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -playground-option -Xfrontend NoScopeEvents -Xfrontend -playground-option -Xfrontend NoFunctionParameters -o %t/main5c -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -playground-option -Xfrontend NoScopeEvents -Xfrontend -playground-option -Xfrontend NoFunctionParameters -o %t/main6c -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main5c
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-// RUN: %target-codesign %t/main6c
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main5c | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-// RUN: %target-run %t/main6c | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -playground-option -Xfrontend NoScopeEvents -Xfrontend -playground-option -Xfrontend NoFunctionParameters) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -playground-option -Xfrontend NoScopeEvents -Xfrontend -playground-option -Xfrontend NoFunctionParameters) | %FileCheck %s
 
 import PlaygroundSupport
 

--- a/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
+++ b/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/implicit_return_func_is.swift
+++ b/test/PlaygroundTransform/implicit_return_func_is.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/implicit_return_func_stringliteral.swift
+++ b/test/PlaygroundTransform/implicit_return_func_stringliteral.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/implicit_return_init_nil.swift
+++ b/test/PlaygroundTransform/implicit_return_init_nil.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/implicit_return_subscript_chain.swift
+++ b/test/PlaygroundTransform/implicit_return_subscript_chain.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/implicit_return_var_intliteral.swift
+++ b/test/PlaygroundTransform/implicit_return_var_intliteral.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/init.swift
+++ b/test/PlaygroundTransform/init.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/iuo.swift
+++ b/test/PlaygroundTransform/iuo.swift
@@ -1,12 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5 -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground)
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground)
 
 import PlaygroundSupport
 

--- a/test/PlaygroundTransform/lit.local.cfg
+++ b/test/PlaygroundTransform/lit.local.cfg
@@ -1,0 +1,28 @@
+# Local lit cfg for PlaygroundTransform
+
+# Copied from lit.cfg
+def escape_for_substitute_captures(s):
+    return s.replace("\\", "\\\\")
+
+# Macro to simplify most PlaygroundTransform tests
+config.target_playground_build_run_swift_parameterized = SubstituteCaptures(
+      # Clear temp directory
+      r'rm -rf "%%t" && mkdir -p "%%t" && '
+      # Build PlaygroundSupport module
+      r'%s -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %%t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %%t/PlaygroundSupport.o %%S/Inputs/SilentPCMacroRuntime.swift %%S/Inputs/PlaygroundsRuntime.swift && '
+      # Create main.swift
+      r'cp %%s %%t/main.swift && '
+      # Build test source
+      r'%s \1 -o %%t/a.out -module-name main -I=%%t %%t/PlaygroundSupport.o %%t/main.swift && '
+      # Codesign executable
+      r'%s %%t/a.out && '
+      # Run executable
+      r'%s %%t/a.out'
+      % (escape_for_substitute_captures(config.target_build_swift),
+         escape_for_substitute_captures(config.target_build_swift),
+         escape_for_substitute_captures(config.target_codesign),
+         escape_for_substitute_captures(config.target_run))
+)
+
+config.substitutions.append(('%target-playground-build-run-swift\(([^)]+)\)',
+                            config.target_playground_build_run_swift_parameterized))

--- a/test/PlaygroundTransform/module_file_id.swift
+++ b/test/PlaygroundTransform/module_file_id.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/test5a -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/test6a -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground %S/Inputs/PlaygroundModuleAndFileIDs.swift) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground %S/Inputs/PlaygroundModuleAndFileIDs.swift) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/test5b -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/test6b -I=%t %t/PlaygroundSupport.o %S/Inputs/PlaygroundModuleAndFileIDs.swift %t/main.swift
-
-// RUN: %target-codesign %t/test5a
-// RUN: %target-codesign %t/test5b
-// RUN: %target-codesign %t/test6a
-// RUN: %target-codesign %t/test6b
-
-// RUN: %target-run %t/test5a | %FileCheck %s
-// RUN: %target-run %t/test5b | %FileCheck %s
-// RUN: %target-run %t/test6a | %FileCheck %s
-// RUN: %target-run %t/test6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground %S/Inputs/PlaygroundModuleAndFileIDs.swift) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground %S/Inputs/PlaygroundModuleAndFileIDs.swift) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/mutation.swift
+++ b/test/PlaygroundTransform/mutation.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/nested_accessors.swift
+++ b/test/PlaygroundTransform/nested_accessors.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/nested_function.swift
+++ b/test/PlaygroundTransform/nested_function.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/nested_init.swift
+++ b/test/PlaygroundTransform/nested_init.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/noncopyable_assignment.swift
+++ b/test/PlaygroundTransform/noncopyable_assignment.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/noncopyable_declaration.swift
+++ b/test/PlaygroundTransform/noncopyable_declaration.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/noncopyable_functions.swift
+++ b/test/PlaygroundTransform/noncopyable_functions.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/playground_options.swift
+++ b/test/PlaygroundTransform/playground_options.swift
@@ -3,30 +3,14 @@
 // Also test that unknown options are gracefully ignored.
 //
 // REQUIRES: executable_test
-
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
+//
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground-option -Xfrontend FunctionParameters -Xfrontend -playground-option -Xfrontend ScopeEvents -Xfrontend -playground-option -Xfrontend ThisOptionShouldBeGracefullyIgnored) | %FileCheck %s
 
 import PlaygroundSupport
 

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -1,27 +1,11 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-
-// Build PlaygroundSupport module
-// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
-
 // -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -playground -o %t/main5a -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -playground -o %t/main6a -I=%t %t/PlaygroundSupport.o %t/main.swift
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -playground) | %FileCheck %s
+//
 // -pc-macro -playground
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main5b -I=%t %t/PlaygroundSupport.o %t/main.swift
-// RUN: %target-build-swift -swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground -o %t/main6b -I=%t %t/PlaygroundSupport.o %t/main.swift
-
-// RUN: %target-codesign %t/main5a
-// RUN: %target-codesign %t/main5b
-// RUN: %target-codesign %t/main6a
-// RUN: %target-codesign %t/main6b
-
-// RUN: %target-run %t/main5a | %FileCheck %s
-// RUN: %target-run %t/main5b | %FileCheck %s
-// RUN: %target-run %t/main6a | %FileCheck %s
-// RUN: %target-run %t/main6b | %FileCheck %s
-
+// RUN: %target-playground-build-run-swift(-swift-version 5 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+// RUN: %target-playground-build-run-swift(-swift-version 6 -Xfrontend -pc-macro -Xfrontend -playground) | %FileCheck %s
+//
 // REQUIRES: executable_test
 
 import PlaygroundSupport


### PR DESCRIPTION
Defines the `%target-playground-build-run-swift macro` in the local lit config for PlaygroundTransform which contains all the boilerplate code used by most PlaygroundTransform tests:
* Build a PlaygroundSupport module
* Build the test source into an executable, linking PlaygroundSupport
* Codesign and run the executable

All the relevant PlaygroundTransform tests were updated to use the new macro.

rdar://141101900