### PR TITLE
build: Unhardcode Swift source directory name

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -203,6 +203,7 @@ KNOWN_SETTINGS=(
     llvm-ninja-targets-for-cross-compile-hosts    ""                "list of ninja targets to build for LLVM for hosts that are cross-compiled"
 
     ## Swift Options
+    swift-source-dirname                          ""                "The name of the Swift source directory"
     swift-analyze-code-coverage                   "not-merged"      "Code coverage analysis mode for Swift (false, not-merged, merged). Defaults to false if the argument is not present, and not-merged if the argument is present without a modifier."
     swift-enable-assertions                       "1"               "enable assertions in Swift"
     swift-enable-ast-verifier                     "1"               "If enabled, and the assertions are enabled, the built Swift compiler will run the AST verifier every time it is invoked"
@@ -1233,7 +1234,7 @@ function host_has_darwin_symbols() {
 # Calculate source directories for each product.
 #
 NINJA_SOURCE_DIR="${WORKSPACE}/ninja"
-SWIFT_SOURCE_DIR="${WORKSPACE}/swift"
+SWIFT_SOURCE_DIR="${WORKSPACE}/${SWIFT_SOURCE_DIRNAME}"
 LLVM_SOURCE_DIR="${WORKSPACE}/llvm-project/llvm"
 CMARK_SOURCE_DIR="${WORKSPACE}/cmark"
 LLDB_SOURCE_DIR="${WORKSPACE}/llvm-project/lldb"

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -138,6 +138,7 @@ class BuildScriptInvocation(object):
             '--build-swift-clang-overlays', str(
                 args.build_swift_clang_overlays).lower(),
             '--build-swift-remote-mirror', str(args.build_swift_remote_mirror).lower(),
+            "--swift-source-dirname", products.Swift.product_source_name(),
         ]
 
         # Compute any product specific cmake arguments.

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -10,6 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
+from build_swift.build_swift.constants import SWIFT_REPO_NAME
+
 from . import cmark
 from . import earlyswiftdriver
 from . import libcxx
@@ -98,6 +100,14 @@ class Swift(product.Product):
             self._enable_experimental_parser_validation)
 
         self._handle_swift_debuginfo_non_lto_args()
+
+    @classmethod
+    def product_source_name(cls):
+        """product_source_name() -> str
+
+        The name of the source code directory of this product.
+        """
+        return SWIFT_REPO_NAME
 
     @classmethod
     def is_build_script_impl_product(cls):

--- a/validation-test/BuildSystem/build_worktree.test
+++ b/validation-test/BuildSystem/build_worktree.test
@@ -1,0 +1,19 @@
+# REQUIRES: OS=macosx
+# REQUIRES: standalone_build
+# REQUIRES: target-same-as-host
+
+# RUN: %empty-directory(%t)
+# RUN: %empty-directory(%t/build)
+
+# Set up a local clone of swift in a temporary workspace and add a sibling
+# linked worktree to the clone.
+# RUN: git clone --depth 1 file://%swift_src_root %t/swift
+# RUN: git -C %t/swift worktree add --detach %t/swift-worktree
+
+# Invoke the build script from the worktree.
+# RUN: %t/swift-worktree/utils/build-script --dry-run | %FileCheck -DARCH=%target-arch %s
+
+# We should generate a build system for the linked worktree, not the main
+# worktree.
+# CHECK: {{^}}+ mkdir -p {{.*}}/swift-macosx-[[ARCH]]{{$}}
+# CHECK: {{^}}+ env {{.+}}/cmake -G Ninja {{.*}}/swift-worktree{{$}}


### PR DESCRIPTION
This is useful if you maintain several swift worktrees that also reside in the source root directory. Note that I am not breaking  the assumption that the source directory is an immediate child of the source root. Not sure how difficult or worthwhile changing that is.
