### PR TITLE
Fix JSONSerialization bit value comma

### DIFF
--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -140,6 +140,7 @@ bool Output::bitSetMatch(const char *Str, bool Matches) {
     }
     llvm::StringRef StrRef(Str);
     scalarString(StrRef, true);
+    NeedBitValueComma = true;
   }
   return false;
 }


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

This PR is related to a [previous one](https://github.com/swiftlang/swift/pull/78009). Feel free to review them together. 

# Changes

Set `NeedBitValueComma` to true during `bitSetMatch()`. Otherwise, the output will not be separated by comma if a bit set match multiple cases.

# Rationale

I'm trying to extract the Swift and Objective-C AST into separate JSON files. During the extraction, I take advantage of swift's JSONSerialization tools to perform the mapping from AST nodes to json objects. The following demo is a simplified version of what I'm doing:

```c++
// Map Decl::ObjCDeclQualifier into json
template <>
struct ScalarBitSetTraits<Decl::ObjCDeclQualifier> {
    static void bitset(Output &out, Decl::ObjCDeclQualifier &kind) {
        out.bitSetCase(kind, "none",   Decl::ObjCDeclQualifier::OBJC_TQ_None);
        out.bitSetCase(kind, "in",   Decl::ObjCDeclQualifier::OBJC_TQ_In);
        out.bitSetCase(kind, "inout",   Decl::ObjCDeclQualifier::OBJC_TQ_Inout);
        out.bitSetCase(kind, "bycopy",   Decl::ObjCDeclQualifier::OBJC_TQ_Bycopy);
        out.bitSetCase(kind, "byref",   Decl::ObjCDeclQualifier::OBJC_TQ_Byref);
        out.bitSetCase(kind, "oneway",   Decl::ObjCDeclQualifier::OBJC_TQ_Oneway);
        out.bitSetCase(kind, "cs_nullability",   Decl::ObjCDeclQualifier::OBJC_TQ_CSNullability);
    }
};

int main(int argc, const char *argv[]) {
    std::error_code stream_error;
    llvm::raw_fd_ostream outputStream(StringRef("-"), stream_error);
    Output serializer(outputStream, {}, false);
    serializer.beginObject();
    Decl::ObjCDeclQualifier value = static_cast<Decl::ObjCDeclQualifier>(0x7);
    serializer.mapRequired("key", value);
    serializer.endObject();
    return 0;
}
```

Since the `value` is 0x7 which matches the following cases: `OBJC_TQ_None`, `OBJC_TQ_In` and `OBJC_TQ_Inout`, the output should be: "none", "in" and "inout" separated by comma. However, when I run the demo, the output is:

```bash
{"key":["none""in""inout"]}
```

It turns out that `NeedBitValueComma` is not set to true after the first match. It works fine if the value matches only one case. However, the value is a bit set and it might match multiple cases which causes the issue. Then I modify the source code of `JSONSerialization.cpp` by setting `NeedBitValueComma` to true:

```c++
bool Output::bitSetMatch(const char *Str, bool Matches) {
  if (Matches) {
    if (NeedBitValueComma) {
      Stream << ',';
      if (PrettyPrint)
        Stream << ' ';
    }
    llvm::StringRef StrRef(Str);
    scalarString(StrRef, true);
// Set to true
    NeedBitValueComma = true;
  }
  return false;
}
```

After that, it works and the json serialization results are correct.