### PR TITLE
[cxx-interop] Allow more C++ decls in public Swift interfaces 

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1844,6 +1844,8 @@ bool isFragileClangType(clang::QualType type) {
   // Pointers to non-fragile types are non-fragile.
   if (underlyingTypePtr->isPointerType())
     return isFragileClangType(underlyingTypePtr->getPointeeType());
+  if (auto tagDecl = underlyingTypePtr->getAsTagDecl())
+    return isFragileClangDecl(tagDecl);
   return true;
 }
 
@@ -1892,6 +1894,11 @@ bool isFragileClangDecl(const clang::Decl *decl) {
     return !cxxRecordDecl->isCLike() &&
            !cxxRecordDecl->getDeclContext()->isExternCContext();
   }
+  if (auto *varDecl = dyn_cast<clang::VarDecl>(decl))
+    return isFragileClangType(varDecl->getType());
+  if (auto *fieldDecl = dyn_cast<clang::FieldDecl>(decl))
+    return isFragileClangType(fieldDecl->getType()) ||
+           isFragileClangDecl(fieldDecl->getParent());
   return true;
 }
 

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
@@ -18,8 +18,24 @@ public func getMyCStruct() -> MyCStruct {
   return MyCStruct()
 }
 
+extension MyCStruct {
+  @inlinable public var y: CInt {
+    get {
+      return self.x
+    }
+  }
+
+  @inlinable public var anotherInstanceOfSelf: MyCStruct {
+    get {
+      return MyCStruct(x: self.x + 1)
+    }
+  }
+}
+
 //--- main.swift
 
 import UsesCLibrary
 
 let _ = getMyCStruct()
+let _ = getMyCStruct().y
+let _ = getMyCStruct().anotherInstanceOfSelf


### PR DESCRIPTION
This is a follow-up to 8859b629.

Let's allow usages of C++ global variables, fields and constructors, as long as the types involved aren't fragile, e.g. if they are C-like structs.

This resolves compiler errors when trying to rebuild System.swiftmodule from its textual interface with Xcode 16.1.

rdar://140203932
rdar://141124318