### PR TITLE
Optimizer: add a new destroy-hoisting optimization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
@@ -40,9 +40,6 @@ import SIL
 /// destruct this data structure, e.g. in a `defer {}` block.
 struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
   
-  /// The dominating begin instruction.
-  let begin: Instruction
-  
   /// The underlying block range.
   private(set) var blockRange: BasicBlockRange
 
@@ -52,23 +49,24 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
   private var inExclusiveRange: InstructionSet
 
   init(begin beginInst: Instruction, _ context: some Context) {
-    self.begin = beginInst
-    self.blockRange = BasicBlockRange(begin: beginInst.parentBlock, context)
-    self.insertedInsts = InstructionSet(context)
-    self.inExclusiveRange = InstructionSet(context)
+    self = InstructionRange(beginBlock: beginInst.parentBlock, context)
     self.inExclusiveRange.insert(beginInst)
   }
 
   init(for value: Value, _ context: some Context) {
-    self = InstructionRange(begin: InstructionRange.beginningInstruction(for: value), context)
+    if let inst = value.definingInstruction {
+      self = InstructionRange(begin: inst, context)
+    } else if let arg = value as? Argument {
+      self = InstructionRange(beginBlock: arg.parentBlock, context)
+    } else {
+      fatalError("cannot build an instruction range for \(value)")
+    }
   }
 
-  static func beginningInstruction(for value: Value) -> Instruction {
-    if let def = value.definingInstructionOrTerminator {
-      return def
-    }
-    assert(Phi(value) != nil || value is FunctionArgument)
-    return value.parentBlock.instructions.first!
+  private init(beginBlock: BasicBlock, _ context: some Context) {
+    self.blockRange = BasicBlockRange(begin: beginBlock, context)
+    self.insertedInsts = InstructionSet(context)
+    self.inExclusiveRange = InstructionSet(context)
   }
 
   /// Insert a potential end instruction.
@@ -76,12 +74,12 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
     insertedInsts.insert(inst)
     insertIntoRange(instructions: ReverseInstructionList(first: inst.previous))
     blockRange.insert(inst.parentBlock)
-    if inst.parentBlock != begin.parentBlock {
+    if inst.parentBlock != blockRange.begin {
       // The first time an instruction is inserted in another block than the begin-block we need to insert
       // instructions from the begin instruction to the end of the begin block.
       // For subsequent insertions this is a no-op: `insertIntoRange` will return immediately because those
       // instruction are already inserted.
-      insertIntoRange(instructions: begin.parentBlock.instructions.reversed())
+      insertIntoRange(instructions: blockRange.begin.instructions.reversed())
     }
   }
 
@@ -98,20 +96,12 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
       return true
     }
     let block = inst.parentBlock
-    return block != begin.parentBlock && blockRange.contains(block)
+    return block != blockRange.begin && blockRange.contains(block)
   }
 
   /// Returns true if the inclusive range contains `inst`.
   func inclusiveRangeContains (_ inst: Instruction) -> Bool {
     contains(inst) || insertedInsts.contains(inst)
-  }
-
-  /// Returns true if the range is valid and that's iff the begin instruction
-  /// dominates all instructions of the range.
-  var isValid: Bool {
-    blockRange.isValid &&
-    // Check if there are any inserted instructions before the begin instruction in its block.
-    !ReverseInstructionList(first: begin).dropFirst().contains { insertedInsts.contains($0) }
   }
 
   /// Returns the end instructions.
@@ -155,6 +145,10 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
     }
   }
 
+  var begin: Instruction? {
+    blockRange.begin.instructions.first(where: inExclusiveRange.contains)
+  }
+
   private mutating func insertIntoRange(instructions: ReverseInstructionList) {
     for inst in instructions {
       if !inExclusiveRange.insert(inst) {
@@ -164,9 +158,9 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
   }
 
   var description: String {
-    return (isValid ? "" : "<invalid>\n") +
+    return (blockRange.isValid ? "" : "<invalid>\n") +
       """
-      begin:    \(begin)
+      begin:    \(begin?.description ?? blockRange.begin.name)
       ends:     \(ends.map { $0.description }.joined(separator: "\n          "))
       exits:    \(exits.map { $0.description }.joined(separator: "\n          "))
       interiors:\(interiors.map { $0.description }.joined(separator: "\n          "))

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -17,6 +17,7 @@ swift_compiler_sources(Optimizer
   ComputeSideEffects.swift
   DeadStoreElimination.swift
   DeinitDevirtualizer.swift
+  DestroyHoisting.swift
   InitializeStaticGlobals.swift
   LetPropertyLowering.swift
   LifetimeDependenceDiagnostics.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
@@ -1,0 +1,361 @@
+//===--- DestroyHoisting.swift ---------------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Hoists `destroy_value` instructions  without shrinking an object's lifetime.
+/// This is done if it can be proved that another copy of a value (either in an SSA value or in memory) keeps
+/// the referenced object(s) alive until the original position of the `destroy_value`.
+///
+/// ```
+///   %1 = copy_value %0
+///   ...
+///   last_use_of %0
+///   // other instructions
+///   destroy_value %0       // %1 is still alive here
+/// ```
+/// ->
+/// ```
+///   %1 = copy_value %0
+///   ...
+///   last_use_of %0
+///   destroy_value %0
+///   // other instructions
+/// ```
+///
+/// This also works if a copy of the value is kept alive  in memory:
+///
+/// ```
+///   %1 = copy_value %0
+///   store %1 to [assign] %a
+///   ...
+///   last_use_of %0
+///   // other instructions
+///   destroy_value %0       // memory location %a is not modified since the store
+/// ```
+/// ->
+/// ```
+///   %1 = copy_value %0
+///   store %0 to [assign] %a
+///   ...
+///   last_use_of %0
+///   destroy_value %0
+///   // other instructions
+/// ```
+///
+/// The benefit of this optimization is that it can enable copy-propagation by moving
+/// destroys above deinit barries and access scopes.
+///
+let destroyHoisting = FunctionPass(name: "destroy-hoisting") {
+  (function: Function, context: FunctionPassContext) in
+
+  if !function.hasOwnership {
+    return
+  }
+
+  for block in function.blocks {
+    for arg in block.arguments {
+      optimize(value: arg, context)
+      if !context.continueWithNextSubpassRun() {
+        return
+      }
+    }
+    for inst in block.instructions {
+      for result in inst.results {
+        optimize(value: result, context)
+        if !context.continueWithNextSubpassRun(for: inst) {
+          return
+        }
+      }
+    }
+  }
+}
+
+private func optimize(value: Value, _ context: FunctionPassContext) {
+  guard value.ownership == .owned,
+        // Avoid all the analysis effort if there are no destroys to hoist.
+        !value.uses.filterUsers(ofType: DestroyValueInst.self).isEmpty
+  else {
+    return
+  }
+
+  var hoistableDestroys = selectHoistableDestroys(of: value, context)
+  defer { hoistableDestroys.deinitialize() }
+
+  var minimalLiverange = InstructionRange(withLiverangeOf: value, ignoring: hoistableDestroys, context)
+  defer { minimalLiverange.deinitialize() }
+
+  hoistDestroys(of: value, toEndOf: minimalLiverange, restrictingTo: &hoistableDestroys, context)
+}
+
+private func selectHoistableDestroys(of value: Value, _ context: FunctionPassContext) -> InstructionSet {
+  // Also includes liveranges of copied values and values stored to memory.
+  var forwardExtendedLiverange = InstructionRange(withForwardExtendedLiverangeOf: value, context)
+  defer { forwardExtendedLiverange.deinitialize() }
+
+  let deadEndBlocks = context.deadEndBlocks
+  var hoistableDestroys = InstructionSet(context)
+
+  for use in value.uses {
+    if let destroy = use.instruction as? DestroyValueInst,
+       // We can hoist all destroys for which another copy of the value is alive at the destroy.
+       forwardExtendedLiverange.contains(destroy),
+       // TODO: once we have complete OSSA lifetimes we don't need to handle dead-end blocks.
+       !deadEndBlocks.isDeadEnd(destroy.parentBlock)
+    {
+      hoistableDestroys.insert(destroy)
+    }
+  }
+  return hoistableDestroys
+}
+
+private func hoistDestroys(of value: Value,
+                           toEndOf minimalLiverange: InstructionRange,
+                           restrictingTo hoistableDestroys: inout InstructionSet,
+                           _ context: FunctionPassContext)
+{
+  createNewDestroys(for: value, atEndPointsOf: minimalLiverange, reusing: &hoistableDestroys, context)
+
+  createNewDestroys(for: value, atExitPointsOf: minimalLiverange, reusing: &hoistableDestroys, context)
+
+  removeDestroys(of: value, restrictingTo: hoistableDestroys, context)
+}
+
+private func createNewDestroys(
+  for value: Value,
+  atEndPointsOf liverange: InstructionRange,
+  reusing hoistableDestroys: inout InstructionSet,
+  _ context: FunctionPassContext
+) {
+  let deadEndBlocks = context.deadEndBlocks
+
+  for endInst in liverange.ends {
+    if !endInst.endsLifetime(of: value) {
+      Builder.insert(after: endInst, context) { builder in
+        builder.createDestroy(of: value, reusing: &hoistableDestroys, notIn: deadEndBlocks)
+      }
+    }
+  }
+}
+
+private func createNewDestroys(
+  for value: Value,
+  atExitPointsOf liverange: InstructionRange,
+  reusing hoistableDestroys: inout InstructionSet,
+  _ context: FunctionPassContext
+) {
+  let deadEndBlocks = context.deadEndBlocks
+
+  for exitBlock in liverange.exitBlocks {
+    let builder = Builder(atBeginOf: exitBlock, context)
+    builder.createDestroy(of: value, reusing: &hoistableDestroys, notIn: deadEndBlocks)
+  }
+}
+
+private func removeDestroys(
+  of value: Value,
+  restrictingTo hoistableDestroys: InstructionSet,
+  _ context: FunctionPassContext
+) {
+  for use in value.uses {
+    if let destroy = use.instruction as? DestroyValueInst,
+       hoistableDestroys.contains(destroy)
+    {
+      context.erase(instruction: destroy)
+    }
+  }
+}
+
+private extension InstructionRange {
+
+  init(withLiverangeOf initialDef: Value, ignoring ignoreDestroys: InstructionSet, _ context: FunctionPassContext)
+  {
+    var liverange = InstructionRange(for: initialDef, context)
+    var visitor = InteriorUseWalker(definingValue: initialDef, ignoreEscape: true, visitInnerUses: false, context) {
+      if !ignoreDestroys.contains($0.instruction) {
+        liverange.insert($0.instruction)
+      }
+      return .continueWalk
+    }
+    defer { visitor.deinitialize() }
+
+    _ = visitor.visitUses()
+    self = liverange
+  }
+
+  // In addition to the forward-extended liverange, also follows copy_value's transitively.
+  init(withForwardExtendedLiverangeOf initialDef: Value, _ context: FunctionPassContext) {
+    self.init(for: initialDef, context)
+
+    var worklist = ValueWorklist(context)
+    defer { worklist.deinitialize() }
+
+    worklist.pushIfNotVisited(initialDef)
+    while let value = worklist.pop() {
+      assert(value.ownership == .owned)
+
+      for use in value.uses {
+        let user = use.instruction
+        if !use.endsLifetime {
+          if let copy = user as? CopyValueInst {
+            worklist.pushIfNotVisited(copy)
+          }
+          continue
+        }
+
+        switch user {
+        case let store as StoreInst:
+          extendLiverangeInMemory(of: initialDef, with: store, context)
+
+        case let termInst as TermInst & ForwardingInstruction:
+          worklist.pushIfNotVisited(contentsOf: termInst.forwardedResults.lazy.filter({ $0.ownership != .none }))
+
+        case is ForwardingInstruction, is MoveValueInst:
+          if let result = user.results.lazy.filter({ $0.ownership != .none }).singleElement {
+            worklist.pushIfNotVisited(result)
+          }
+
+        default:
+          // We cannot extend a lexical liverange with a non-lexical liverange, because afterwards the
+          // non-lexical liverange could be shrunk over a deinit barrier which would let the original
+          // lexical liverange to be shrunk, too.
+          if !initialDef.isInLexicalLiverange(context) || value.isInLexicalLiverange(context) {
+            self.insert(user)
+          }
+        }
+      }
+    }
+  }
+
+  private mutating func extendLiverangeInMemory(
+    of initialDef: Value,
+    with store: StoreInst,
+    _ context: FunctionPassContext
+  ) {
+    let domTree = context.dominatorTree
+
+    if initialDef.destroyUsers(dominatedBy: store.parentBlock, domTree).isEmpty {
+      return
+    }
+
+    // We have to take care of lexical lifetimes. See comment above.
+    if initialDef.isInLexicalLiverange(context) &&
+       !store.destination.accessBase.isInLexicalOrGlobalLiverange(context)
+    {
+      return
+    }
+
+    if isTakeOrDestroy(ofAddress: store.destination, after: store, beforeDestroysOf: initialDef, context) {
+      return
+    }
+
+    self.insert(contentsOf: initialDef.destroyUsers(dominatedBy: store.parentBlock, domTree).map { $0.next! })
+  }
+}
+
+private func isTakeOrDestroy(
+  ofAddress address: Value,
+  after store: StoreInst,
+  beforeDestroysOf initialDef: Value,
+  _ context: FunctionPassContext
+) -> Bool {
+  let aliasAnalysis = context.aliasAnalysis
+  let domTree = context.dominatorTree
+  var worklist = InstructionWorklist(context)
+  defer { worklist.deinitialize() }
+
+  worklist.pushIfNotVisited(store.next!)
+  while let inst = worklist.pop() {
+    if inst.endsLifetime(of: initialDef) {
+      continue
+    }
+    if inst.mayTakeOrDestroy(address: address, aliasAnalysis) {
+      return true
+    }
+    if let next = inst.next {
+      worklist.pushIfNotVisited(next)
+    } else {
+      for succ in inst.parentBlock.successors where store.parentBlock.dominates(succ, domTree) {
+        worklist.pushIfNotVisited(succ.instructions.first!)
+      }
+    }
+  }
+  return false
+}
+
+private extension Builder {
+  func createDestroy(of value: Value,
+                     reusing hoistableDestroys: inout InstructionSet,
+                     notIn deadEndBlocks: DeadEndBlocksAnalysis) {
+    guard case .before(let insertionPoint) = insertionPoint else {
+      fatalError("unexpected kind of insertion point")
+    }
+    if deadEndBlocks.isDeadEnd(insertionPoint.parentBlock) {
+      return
+    }
+    if hoistableDestroys.contains(insertionPoint) {
+      hoistableDestroys.erase(insertionPoint)
+    } else {
+      createDestroyValue(operand: value)
+    }
+  }
+}
+
+private extension Value {
+  func destroyUsers(dominatedBy domBlock: BasicBlock, _ domTree: DominatorTree) ->
+        LazyMapSequence<LazyFilterSequence<LazyMapSequence<UseList, DestroyValueInst?>>, DestroyValueInst> {
+    return uses.lazy.compactMap { use in
+      if let destroy = use.instruction as? DestroyValueInst,
+         domBlock.dominates(destroy.parentBlock, domTree)
+      {
+         return destroy
+      }
+      return nil
+    }
+  }
+}
+
+private extension Instruction {
+  func endsLifetime(of value: Value) -> Bool {
+    return operands.contains { $0.value == value && $0.endsLifetime }
+  }
+
+  func mayTakeOrDestroy(address: Value, _ aliasAnalysis: AliasAnalysis) -> Bool {
+    switch self {
+    case is BeginAccessInst, is EndAccessInst, is EndBorrowInst:
+      return false
+    default:
+      return mayWrite(toAddress: address, aliasAnalysis)
+    }
+  }
+}
+
+private extension AccessBase {
+  func isInLexicalOrGlobalLiverange(_ context: FunctionPassContext) -> Bool {
+    switch self {
+    case .box(let pbi):      return pbi.box.isInLexicalLiverange(context)
+    case .class(let rea):    return rea.instance.isInLexicalLiverange(context)
+    case .tail(let rta):     return rta.instance.isInLexicalLiverange(context)
+    case .stack(let asi):    return asi.isLexical
+    case .global:            return true
+    case .argument(let arg):
+      switch arg.convention {
+      case .indirectIn, .indirectInGuaranteed, .indirectInout, .indirectInoutAliasable:
+        return arg.isLexical
+      default:
+        return false
+      }
+    case .yield, .storeBorrow, .pointer, .index, .unidentified:
+      return false
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -75,6 +75,7 @@ private func registerSwiftPasses() {
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
   registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })
   registerPass(computeSideEffects, { computeSideEffects.run($0) })
+  registerPass(destroyHoisting, { destroyHoisting.run($0) })
   registerPass(initializeStaticGlobalsPass, { initializeStaticGlobalsPass.run($0) })
   registerPass(objCBridgingOptimization, { objCBridgingOptimization.run($0) })
   registerPass(objectOutliner, { objectOutliner.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -913,7 +913,7 @@ struct LivenessBoundary : CustomStringConvertible {
 
   // Compute the boundary of a singly-defined range.
   init(value: Value, range: InstructionRange, _ context: Context) {
-    assert(range.isValid)
+    assert(range.blockRange.isValid)
 
     lastUsers = Stack<Instruction>(context)
     boundaryEdges = Stack<BasicBlock>(context)

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -32,6 +32,8 @@ public class Argument : Value, Hashable {
 
   public var isReborrow: Bool { bridged.isReborrow() }
 
+  public var isLexical: Bool { false }
+
   public var varDecl: VarDecl? { bridged.getVarDecl().getAs(VarDecl.self) }
 
   public var sourceLoc: SourceLoc? { varDecl?.nameLoc }
@@ -48,6 +50,10 @@ public class Argument : Value, Hashable {
 final public class FunctionArgument : Argument {
   public var convention: ArgumentConvention {
     parentFunction.argumentConventions[index]
+  }
+
+  public override var isLexical: Bool {
+    bridged.FunctionArgument_isLexical()
   }
 
   public var isSelf: Bool {

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -24,14 +24,14 @@ public struct Builder {
     case staticInitializer(GlobalVariable)
   }
 
-  let insertAt: InsertionPoint
+  public let insertionPoint: InsertionPoint
   let location: Location
   private let notificationHandler: BridgedChangeNotificationHandler
   private let notifyNewInstruction: (Instruction) -> ()
 
   /// Return 'nil' when inserting at the start of a function or in a global initializer.
   public var insertionBlock: BasicBlock? {
-    switch insertAt {
+    switch insertionPoint {
     case let .before(inst):
       return inst.parentBlock
     case let .atEndOf(block):
@@ -42,7 +42,7 @@ public struct Builder {
   }
 
   public var bridged: BridgedBuilder {
-    switch insertAt {
+    switch insertionPoint {
     case .before(let inst):
       return BridgedBuilder(insertAt: .beforeInst, insertionObj: inst.bridged.obj,
                             loc: location.bridged)
@@ -73,7 +73,7 @@ public struct Builder {
   public init(insertAt: InsertionPoint, location: Location,
               _ notifyNewInstruction: @escaping (Instruction) -> (),
               _ notificationHandler: BridgedChangeNotificationHandler) {
-    self.insertAt = insertAt
+    self.insertionPoint = insertAt
     self.location = location;
     self.notifyNewInstruction = notifyNewInstruction
     self.notificationHandler = notificationHandler

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -198,6 +198,8 @@ public class SingleValueInstruction : Instruction, Value {
   public static func ==(lhs: SingleValueInstruction, rhs: SingleValueInstruction) -> Bool {
     lhs === rhs
   }
+
+  public var isLexical: Bool { false }
 }
 
 public final class MultipleValueInstructionResult : Value, Hashable {
@@ -208,6 +210,8 @@ public final class MultipleValueInstructionResult : Value, Hashable {
   public var definingInstruction: Instruction? { parentInstruction }
 
   public var parentBlock: BasicBlock { parentInstruction.parentBlock }
+
+  public var isLexical: Bool { false }
 
   public var index: Int { bridged.getIndex() }
 
@@ -1028,7 +1032,7 @@ final public class UncheckedOwnershipConversionInst : SingleValueInstruction {}
 final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {
   public var fromValue: Value { operand.value }
 
-  public var isLexical: Bool { bridged.MoveValue_isLexical() }
+  public override var isLexical: Bool { bridged.MoveValue_isLexical() }
   public var hasPointerEscape: Bool { bridged.MoveValue_hasPointerEscape() }
   public var isFromVarDecl: Bool { bridged.MoveValue_isFromVarDecl() }
 }
@@ -1253,7 +1257,7 @@ extension BorrowIntroducingInstruction {
 final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction, BorrowIntroducingInstruction {
   public var borrowedValue: Value { operand.value }
 
-  public var isLexical: Bool { bridged.BeginBorrow_isLexical() }
+  public override var isLexical: Bool { bridged.BeginBorrow_isLexical() }
   public var hasPointerEscape: Bool { bridged.BeginBorrow_hasPointerEscape() }
   public var isFromVarDecl: Bool { bridged.BeginBorrow_isFromVarDecl() }
 

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -71,7 +71,7 @@ extension FormattedLikeArray {
 public protocol CollectionLikeSequence : FormattedLikeArray {
 }
 
-public extension CollectionLikeSequence {
+public extension Sequence {
   var isEmpty: Bool { !contains(where: { _ in true }) }
 
   var singleElement: Element? {

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -37,6 +37,8 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
   /// True if the value has a trivial type which is and does not contain a Builtin.RawPointer.
   var hasTrivialNonPointerType: Bool { get }
+
+  var isLexical: Bool { get }
 }
 
 public enum Ownership {
@@ -269,6 +271,8 @@ public final class Undef : Value {
   /// Undef has not parent function, therefore the default `hasTrivialNonPointerType` does not work.
   /// Return the conservative default in this case.
   public var hasTrivialNonPointerType: Bool { false }
+
+  public var isLexical: Bool { false }
 }
 
 final class PlaceholderValue : Value {
@@ -277,6 +281,8 @@ final class PlaceholderValue : Value {
   public var parentBlock: BasicBlock {
     fatalError("PlaceholderValue has no defining block")
   }
+
+  public var isLexical: Bool { false }
 
   public var parentFunction: Function { bridged.PlaceholderValue_getParentFunction().function }
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -865,6 +865,7 @@ struct BridgedArgument {
   BRIDGED_INLINE swift::SILArgument * _Nonnull getArgument() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock getParent() const;
   BRIDGED_INLINE bool isReborrow() const;
+  BRIDGED_INLINE bool FunctionArgument_isLexical() const;
   BRIDGED_INLINE void setReborrow(bool reborrow) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getVarDecl() const;
   BRIDGED_INLINE void copyFlags(BridgedArgument fromArgument) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -676,6 +676,10 @@ void BridgedArgument::setReborrow(bool reborrow) const {
   getArgument()->setReborrow(reborrow);
 }
 
+bool BridgedArgument::FunctionArgument_isLexical() const {
+  return llvm::cast<swift::SILFunctionArgument>(getArgument())->getLifetime().isLexical();
+}
+
 OptionalBridgedDeclObj BridgedArgument::getVarDecl() const {
   return {llvm::dyn_cast_or_null<swift::VarDecl>(getArgument()->getDecl())};
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -195,6 +195,8 @@ PASS(DefiniteInitialization, "definite-init",
      "Definite Initialization for Diagnostics")
 PASS(DestroyAddrHoisting, "destroy-addr-hoisting",
      "Hoist destroy_addr for uniquely identified values")
+SWIFT_FUNCTION_PASS(DestroyHoisting, "destroy-hoisting",
+     "Hoist destroy_value instructions")
 PASS(Devirtualizer, "devirtualizer",
      "Indirect Call Devirtualization")
 PASS(DiagnoseInfiniteRecursion, "diagnose-infinite-recursion",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -508,6 +508,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
 
   // We earlier eliminated ownership if we are not compiling the stdlib. Now
   // handle the stdlib functions, re-simplifying, eliminating ARC as we do.
+  P.addDestroyHoisting();
   if (P.getOptions().CopyPropagation != CopyPropagationOption::Off) {
     P.addCopyPropagation();
   }
@@ -605,6 +606,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
 
   // Run a final round of ARC opts when ownership is enabled.
   if (P.getOptions().EnableOSSAModules) {
+    P.addDestroyHoisting();
     if (P.getOptions().CopyPropagation != CopyPropagationOption::Off) {
       P.addCopyPropagation();
     }

--- a/test/SILOptimizer/destroy-hoisting.sil
+++ b/test/SILOptimizer/destroy-hoisting.sil
@@ -1,0 +1,372 @@
+// RUN: %target-sil-opt -destroy-hoisting %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {
+}
+
+class C {
+  @_hasStorage var k: Klass
+}
+
+struct S {
+  var k: Klass
+  var i: Int
+}
+
+
+sil [ossa] @deinit_barrier : $@convention(thin) () -> ()
+sil [ossa] @createKlass : $@convention(thin) () -> @owned Klass
+sil [ossa] @createC : $@convention(thin) () -> @owned C
+sil [ossa] @useKlass : $@convention(thin) (@guaranteed Klass) -> ()
+
+// CHECK-LABEL: sil [ossa] @extend_forwarded_lifetime :
+// CHECK:         %2 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'extend_forwarded_lifetime'
+sil [ossa] @extend_forwarded_lifetime : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  %3 = move_value [lexical] %2
+  %4 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  destroy_value %0
+  %7 = struct $S (%3, %1)
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @extend_forwarded_lifetime2 :
+// CHECK:         %4 = copy_value %3
+// CHECK-NEXT:    destroy_value %3
+// CHECK:       } // end sil function 'extend_forwarded_lifetime2'
+sil [ossa] @extend_forwarded_lifetime2 : $@convention(thin) (Int) -> @owned S {
+bb0(%0 : $Int):
+  %1 = function_ref @createKlass : $@convention(thin) () -> @owned Klass
+  %2 = apply %1() : $@convention(thin) () -> @owned Klass
+  %3 = move_value [lexical] [var_decl] %2
+  %4 = copy_value %3
+  %5 = move_value [lexical] %4
+  %6 = struct $S (%5, %0)
+  %7 = move_value [lexical] [var_decl] %6
+  %8 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  %9 = apply %8() : $@convention(thin) () -> ()
+  destroy_value %3
+  return %7
+} // end sil function '$s3nix6testitAA1SVyF'
+
+// CHECK-LABEL: sil [ossa] @no_hoisting_into_non_lexical_lifetime :
+// CHECK:         apply
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'no_hoisting_into_non_lexical_lifetime'
+sil [ossa] @no_hoisting_into_non_lexical_lifetime : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned  $Klass, %1 : $Int):
+  %3 = copy_value %0
+  %4 = struct $S (%3, %1)
+  %5 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  apply %5() : $@convention(thin) () -> () 
+  destroy_value %0
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @degenerated_liferange :
+// CHECK:       bb0(%0 : @owned  $Klass):
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'degenerated_liferange'
+sil [ossa] @degenerated_liferange : $@convention(method) (@owned Klass) -> () {
+bb0(%0 : @owned  $Klass):
+  destroy_value %0
+  %2 = tuple ()
+  return %2
+}
+
+// CHECK-LABEL: sil [ossa] @hoist_multi_block :
+// CHECK:         %4 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'hoist_multi_block'
+sil [ossa] @hoist_multi_block : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  cond_br undef, bb1, bb2
+bb1:
+  %4 = copy_value %0
+  destroy_value %4
+  destroy_value %0
+  br bb3
+bb2:
+  %8 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  apply %8() : $@convention(thin) () -> () 
+  destroy_value %0
+  br bb3
+bb3:
+  %12 = move_value [lexical] %2
+  %13 = struct $S (%12, %1)
+  return %13
+}
+
+// CHECK-LABEL: sil [ossa] @partial_hoist_multi_block :
+// CHECK:         %6 = copy_value %0
+// CHECK-NEXT:    destroy_value %6
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'partial_hoist_multi_block'
+sil [ossa] @partial_hoist_multi_block : $@convention(thin) (@owned Klass, Int) -> () {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  %3 = move_value [lexical] %2
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %3
+  %6 = copy_value %0
+  destroy_value %6
+  destroy_value %0
+  br bb3
+bb2:
+  %9 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  apply %9() : $@convention(thin) () -> () 
+  destroy_value %0
+  destroy_value %3
+  br bb3
+bb3:
+  %14 = tuple ()
+  return %14
+}
+
+// CHECK-LABEL: sil [ossa] @already_at_lifetime_end :
+// CHECK:         %4 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'already_at_lifetime_end'
+sil [ossa] @already_at_lifetime_end : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  cond_br undef, bb1, bb2
+bb1:
+  %4 = copy_value %0
+  destroy_value %0
+  destroy_value %4
+  br bb3
+bb2:
+  destroy_value %0
+  br bb3
+bb3:
+  %10 = move_value [lexical] %2
+  %11 = struct $S (%10, %1)
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @reborrow_phi :
+// CHECK:         end_borrow
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'reborrow_phi'
+sil [ossa] @reborrow_phi : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  cond_br undef, bb1, bb2
+bb1:
+  %4 = begin_borrow %0
+  br bb3(%4)
+bb2:
+  %6 = begin_borrow %0
+  br bb3(%6)
+bb3(%8 : @reborrow $Klass):
+  %9 = borrowed %8 from (%0)
+  end_borrow %9
+  %11 = function_ref @deinit_barrier : $@convention(thin) () -> ()
+  apply %11() : $@convention(thin) () -> () 
+  destroy_value %0
+  %14 = move_value [lexical] %2
+  %15 = struct $S (%14, %1)
+  return %15
+}
+
+// CHECK-LABEL: sil [ossa] @store :
+// CHECK:         %2 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'store'
+sil [ossa] @store : $@convention(method) (@owned Klass, @guaranteed C) -> () {
+bb0(%0 : @owned  $Klass, %1 : @guaranteed  $C):
+  %2 = copy_value %0
+  %3 = ref_element_addr %1, #C.k
+  %4 = begin_access [modify] [dynamic] %3
+  store %2 to [assign] %4
+  end_access %4
+  destroy_value %0
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: sil [ossa] @dominating_store :
+// CHECK:         %2 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'dominating_store'
+sil [ossa] @dominating_store : $@convention(method) (@owned Klass, @guaranteed C) -> () {
+bb0(%0 : @owned  $Klass, %1 : @guaranteed  $C):
+  %2 = copy_value %0
+  %3 = ref_element_addr %1, #C.k
+  %4 = begin_access [modify] [dynamic] %3
+  store %2 to [assign] %4
+  end_access %4
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %0
+  br bb3
+bb2:
+  destroy_value %0
+  br bb3
+bb3:
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: sil [ossa] @not_dominating_store :
+// CHECK:       bb3:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'not_dominating_store'
+sil [ossa] @not_dominating_store : $@convention(method) (@owned Klass, @guaranteed C) -> () {
+bb0(%0 : @owned  $Klass, %1 : @guaranteed  $C):
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = copy_value %0
+  %3 = ref_element_addr %1, #C.k
+  %4 = begin_access [modify] [dynamic] %3
+  store %2 to [assign] %4
+  end_access %4
+  br bb3
+bb2:
+  br bb3
+bb3:
+  destroy_value %0
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: sil [ossa] @write_to_memory :
+// CHECK:       bb3:
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'write_to_memory'
+sil [ossa] @write_to_memory : $@convention(method) (@owned Klass, @guaranteed C) -> () {
+bb0(%0 : @owned  $Klass, %1 : @guaranteed  $C):
+  %2 = copy_value %0
+  %3 = ref_element_addr %1, #C.k
+  %4 = begin_access [modify] [dynamic] %3
+  store %2 to [assign] %4
+  end_access %4
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_addr %4
+  br bb3
+bb2:
+  br bb3
+bb3:
+  destroy_value %0
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: sil [ossa] @not_lexical_access_base :
+// CHECK:         end_borrow
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'not_lexical_access_base'
+sil [ossa] @not_lexical_access_base : $@convention(method) (@owned Klass) -> () {
+bb0(%0 : @owned  $Klass):
+  %1 = copy_value %0
+  %2 = function_ref @createC : $@convention(thin) () -> @owned C
+  %3 = apply %2() : $@convention(thin) () -> @owned C
+  %4 = begin_borrow %3
+  %5 = ref_element_addr %4, #C.k
+  store %1 to [assign] %5
+  end_borrow %4
+  destroy_value %0
+  destroy_value %3
+  %11 = tuple ()
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @lexical_access_base :
+// CHECK:         %1 = copy_value %0
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'lexical_access_base'
+sil [ossa] @lexical_access_base : $@convention(method) (@owned Klass) -> () {
+bb0(%0 : @owned  $Klass):
+  %1 = copy_value %0
+  %2 = function_ref @createC : $@convention(thin) () -> @owned C
+  %3 = apply %2() : $@convention(thin) () -> @owned C
+  %4 = move_value [lexical] %3
+  %5 = begin_borrow %4
+  %6 = ref_element_addr %5, #C.k
+  store %1 to [assign] %6
+  end_borrow %5
+  destroy_value %0
+  destroy_value %4
+  %11 = tuple ()
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_of_access_base :
+// CHECK:         end_borrow
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'destroy_of_access_base'
+sil [ossa] @destroy_of_access_base : $@convention(method) (@owned Klass) -> () {
+bb0(%0 : @owned  $Klass):
+  %1 = copy_value %0
+  %2 = function_ref @createC : $@convention(thin) () -> @owned C
+  %3 = apply %2() : $@convention(thin) () -> @owned C
+  %4 = move_value [lexical] %3
+  %5 = begin_borrow %4
+  %6 = ref_element_addr %5, #C.k
+  store %1 to [assign] %6
+  end_borrow %5
+  destroy_value %4
+  destroy_value %0
+  %11 = tuple ()
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @incomplete_liferange_at_unreachable :
+// CHECK:       bb2:
+// CHECK-NOT:     destroy_value %0
+// CHECK:       } // end sil function 'incomplete_liferange_at_unreachable'
+sil [ossa] @incomplete_liferange_at_unreachable : $@convention(thin) (@owned Klass, Int) -> @owned S {
+bb0(%0 : @owned $Klass, %1 : $Int):
+  %2 = copy_value %0
+  %3 = alloc_stack $Klass
+  %4 = store_borrow %0 to %3
+  cond_br undef, bb1, bb2
+bb1:
+  end_borrow %4
+  dealloc_stack %3
+  destroy_value %0
+  %14 = move_value %2
+  %15 = struct $S (%14, %1)
+  return %15
+bb2:
+  end_borrow %4
+  dealloc_stack %3
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @partial_apply_liferange :
+// CHECK:         %3 = convert_function %2
+// CHECK-NEXT:    destroy_value %3
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'partial_apply_liferange'
+sil [ossa] @partial_apply_liferange : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = function_ref @useKlass : $@convention(thin) (@guaranteed Klass) -> ()
+  %2 = partial_apply [callee_guaranteed] [on_stack] %1(%0) : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = convert_function %2 to $@noescape @callee_guaranteed () -> ()
+  destroy_value %3
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -157,7 +157,7 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D, %4 : $*D):
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %inguaranteed_arg_mark
 // CHECK-NEXT: Initialized: %3 = argument of bb0 : $*D
 // CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %3 : $*D
-// CHECK-NEXT: begin:      %{{.*}} = move_value %{{.*}} : $D
+// CHECK-NEXT: begin:      bb0
 // CHECK-NEXT: ends:     
 // CHECK: dependence_scope: lifetime_dependence_scope with: %inguaranteed_arg_mark
   

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -433,7 +433,7 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
 
 // CHECK-LABEL: begin running test 2 of 2 on testInteriorDropDeinit: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $NCInt
-// CHECK-NEXT: begin:      [[DD:%.*]] = drop_deinit %0 : $NCInt
+// CHECK-NEXT: begin:      bb0
 // CHECK-NEXT: ends:       [[DD]] = drop_deinit %0 : $NCInt
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
@@ -1122,7 +1122,7 @@ bb4(%inner4 : @guaranteed $D):
 
 // CHECK-LABEL: testInnerNonAdjacentReborrow: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
-// CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
+// CHECK-NEXT: begin:      bb3
 // CHECK-NEXT: ends:
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -129,22 +129,3 @@ bb3:
   return %r : $()
 }
 
-// CHECK-LABEL:Instruction range in valid_blocks_invalid_instructions:
-// CHECK-NEXT: <invalid>
-// CHECK:      Block range in valid_blocks_invalid_instructions:
-// CHECK-NEXT: begin:     bb0
-// CHECK-NEXT: range:     []
-// CHECK-NEXT: inclrange: [bb0]
-// CHECK-NEXT: ends:      [bb0]
-// CHECK-NEXT: exits:     []
-// CHECK-NEXT: interiors: []
-// CHECK-NEXT: End function valid_blocks_invalid_instructions
-sil @valid_blocks_invalid_instructions : $@convention(thin) () -> () {
-bb0:
-  %0 = string_literal utf8 "end"
-  %1 = string_literal utf8 "begin"
-  %2 = string_literal utf8 "end"
-  %r = tuple()
-  return %r : $()
-}
-


### PR DESCRIPTION
It hoists `destroy_value` instructions  without shrinking an object's lifetime.
This is done if it can be proved that another copy of a value (either in an SSA value or in memory) keeps the referenced object(s) alive until the original position of the `destroy_value`.
```
  %1 = copy_value %0
  ...
  last_use_of %0
  // other instructions
  destroy_value %0       // %1 is still alive here
```
->
```
  %1 = copy_value %0
  ...
  last_use_of %0
  destroy_value %0
  // other instructions
```

The benefit of this optimization is that it can enable copy-propagation by moving destroys above deinit barries and access scopes.

This is part of fixing benchmark regressions when enabling OSSA modules.
rdar://139773406
