### PR TITLE
SIL: avoid truncation warnings on Windows (NFCI)

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -153,7 +153,9 @@ public:
   ~SILBasicBlock();
 
   enum { numCustomBits = std::numeric_limits<CustomBitsType>::digits };
-  enum { maxBitfieldID = std::numeric_limits<uint64_t>::max() };
+
+  constexpr static const size_t maxBitfieldID =
+      std::numeric_limits<uint64_t>::max();
 
   /// Gets the ID (= index in the function's block list) of the block.
   ///

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -127,7 +127,9 @@ public:
   enum { NumMarkDependenceKindBits = 2 };
 
   enum { numCustomBits = 20 };
-  enum { maxBitfieldID = std::numeric_limits<uint64_t>::max() >> numCustomBits };
+
+  constexpr static const size_t maxBitfieldID =
+      std::numeric_limits<uint64_t>::max() >> numCustomBits;
 
 protected:
   friend class SILInstruction;

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1021,7 +1021,9 @@ ValueOwnershipKind::getForwardingOperandOwnership(bool allowUnowned) const {
 class Operand {
 public:
   enum { numCustomBits = 8 };
-  enum { maxBitfieldID = std::numeric_limits<uint64_t>::max() >> numCustomBits };
+
+  constexpr static const size_t maxBitfieldID =
+      std::numeric_limits<uint64_t>::max() >> numCustomBits;
 
 private:
   template <class, class> friend class SILBitfield;


### PR DESCRIPTION
`enum` is a signed integer type on some platforms. The return value of `std::numeric_limits<T>::max()` is a `size_t` which is unsigned. Further manipulation retains the unsigned-ness until the assignment which results in truncation. Change the type to a `constexpr` constant definition and remove the `enum` type along with a type conversion to an explicitly unsigned integral type.