### PR TITLE
[6.1][ScanDependency] Fix a regression caused by rewrite in #76700

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -451,6 +451,11 @@ private:
   }
 
   void pruneUnusedVFSOverlay() {
+    // Pruning of unused VFS overlay options for Clang dependencies is performed
+    // by the Clang dependency scanner.
+    if (moduleID.Kind == ModuleDependencyKind::Clang)
+      return;
+
     std::vector<std::string> resolvedCommandLine;
     size_t skip = 0;
     for (auto it = commandline.begin(), end = commandline.end();

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -65,3 +65,10 @@ import F
 
 /// --------Clang module F
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
+// CHECK: "commandLine": [
+// CHECK: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: ],


### PR DESCRIPTION
  - **Explanation**: In the refactoring change #76700, it accidentally introduced a behavior change that causes the generated PCM command-line to have useful VFSOverlay files getting dropped. Clang module command-line and its unused VFS pruning should be done by the clang dependency scanner already so there is no need to touch that in the swift scanner. Since the original logics is not used to handle clang module commands, it will actually dropped the useful vfs overlay that is needed when none of the dependencies uses it. Fix the regression by restoring the old behavior and ignoring clang modules when pruning VFS overlay.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Fix a regression from rewrite that can cause explicit module build to fail when VFS overlay is used.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://139233781
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/77966
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Restore to hold behavior
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: UnitTest
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @artemcm 
