### PR TITLE
utils: unlock building swift-inspect

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2669,8 +2669,7 @@ function Build-Inspect() {
     -Bin (Get-HostProjectBinaryCache SwiftInspect) `
     -InstallTo "$($HostArch.ToolchainInstallRoot)\usr" `
     -Arch $HostArch `
-    -UseBuiltCompilers Swift `
-    -UseSwiftSwiftDriver `
+    -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SDKRoot `
     -Defines @{
       CMAKE_Swift_FLAGS = @("-Xcc", "-I$SDKRoot\usr\include\swift\SwiftRemoteMirror");
@@ -2873,6 +2872,7 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-Format $HostArch
   Invoke-BuildStep Build-IndexStoreDB $HostArch
   Invoke-BuildStep Build-SourceKitLSP $HostArch
+  Invoke-BuildStep Build-Inspect $HostArch
 }
 
 Install-HostToolchain
@@ -2882,7 +2882,6 @@ if (-not $SkipBuild -and $Allocator -eq "mimalloc") {
 }
 
 if (-not $SkipBuild -and -not $IsCrossCompiling) {
-  Invoke-BuildStep Build-Inspect $HostArch
   Invoke-BuildStep Build-DocC $HostArch
 }
 


### PR DESCRIPTION
When building for ARM64, we can now build swift-inspect as we use CMake for the cross-compilation.

This is a second attempt for https://github.com/swiftlang/swift/pull/77810

This should fix https://ci-external.swift.org/job/swift-main-windows-toolchain-arm64/792/
```
         C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-installer-scripts\platforms\Windows\dbg\dbg.wxs(110): error WIX0103: Cannot find the File file 'T:\\Program Files\\Swift\\Toolchains\\6.0.0+Asserts\\usr\bin\swift-inspect.exe'. The following paths were checked: T:\\Program Files\\Swift\\Toolchains\\6.0.0+Asserts\\usr\bin\swift-inspect.exe [C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-installer-scripts\platforms\Windows\dbg\dbg.wixproj]
```
