### PR TITLE
[SourceKit] Use canonical type in `printTypeUSR`

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -39,8 +39,9 @@ static inline StringRef getUSRSpacePrefix() {
 
 bool ide::printTypeUSR(Type Ty, raw_ostream &OS) {
   assert(!Ty->hasArchetype() && "cannot have contextless archetypes mangled.");
+  Ty = Ty->getCanonicalType()->getRValueType();
   Mangle::ASTMangler Mangler(Ty->getASTContext());
-  OS << Mangler.mangleTypeAsUSR(Ty->getRValueType());
+  OS << Mangler.mangleTypeAsUSR(Ty);
   return false;
 }
 

--- a/test/SourceKit/ConformingMethods/rdar141168628.swift
+++ b/test/SourceKit/ConformingMethods/rdar141168628.swift
@@ -1,0 +1,16 @@
+@resultBuilder struct Builder {
+  static func buildBlock<T>(_ x: T) -> T { x }
+}
+
+struct S {}
+
+struct R<T> {
+  init(@Builder fn: () -> T) {}
+}
+
+// rdar://141168628 - Make sure we can compute the USR here without crashing.
+R {
+  S()
+  // RUN: %sourcekitd-test -req=conformingmethods -pos %(line + 1):2 %s  -- %s | %FileCheck %s
+}
+// CHECK: key.typeusr: "$s13rdar1411686281RVyAA1SVGD"

--- a/test/SourceKit/CursorInfo/cursor_info_container.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_container.swift
@@ -65,4 +65,4 @@ func SArrayGen() -> [S] { return [] }
 // CHECK6: <Container>$s21cursor_info_container1EOmD</Container>
 
 // RUN: %sourcekitd-test -req=cursor -pos=37:22 %s -- %s | %FileCheck -check-prefix=CHECK7 %s
-// CHECK7: <Container>$s21cursor_info_container1SVXSaD</Container>
+// CHECK7: <Container>$sSay21cursor_info_container1SVGD</Container>


### PR DESCRIPTION
Mangling a non-canonical type can run into unexpected type sugar such as the newly introduced LocatableType. USRs should be based on canonical types anyway, so make sure we canonicalize before mangling.

rdar://141168628