### PR TITLE
Disable package-cmo-serialize-tables on watchOS

### DIFF
--- a/test/SILOptimizer/package-cmo-serialize-tables.swift
+++ b/test/SILOptimizer/package-cmo-serialize-tables.swift
@@ -17,9 +17,9 @@
 
 // REQUIRES: swift_in_compiler
 
-// Temporarily disabling on armv7k:
+// Temporarily disabling on watchOS (both arm64_32 & armv7k):
 // rdar://140330692 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed...
-// UNSUPPORTED: CPU=armv7k
+// UNSUPPORTED: OS=watchos
 
 //--- main.swift
 


### PR DESCRIPTION
Workaround: rdar://140330692 (🟠 OSS Swift CI:
oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed: test: SILOptimizer/package-cmo-serialize-tables.swift
