### PR TITLE
🍒[cxx-interop] Allow more C++ decls in public Swift interfaces

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1885,9 +1885,11 @@ bool isFragileClangNode(const ClangNode &node) {
   if (auto *typedefDecl = dyn_cast<clang::TypedefNameDecl>(decl))
     return isFragileClangType(typedefDecl->getUnderlyingType());
   if (auto *rd = dyn_cast<clang::RecordDecl>(decl)) {
-    if (!isa<clang::CXXRecordDecl>(rd))
+    auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(rd);
+    if (!cxxRecordDecl)
       return false;
-    return !rd->getDeclContext()->isExternCContext();
+    return !cxxRecordDecl->isCLike() &&
+           !cxxRecordDecl->getDeclContext()->isExternCContext();
   }
   return true;
 }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1844,6 +1844,8 @@ bool isFragileClangType(clang::QualType type) {
   // Pointers to non-fragile types are non-fragile.
   if (underlyingTypePtr->isPointerType())
     return isFragileClangType(underlyingTypePtr->getPointeeType());
+  if (auto tagDecl = underlyingTypePtr->getAsTagDecl())
+    return isFragileClangDecl(tagDecl);
   return true;
 }
 
@@ -1892,6 +1894,11 @@ bool isFragileClangDecl(const clang::Decl *decl) {
     return !cxxRecordDecl->isCLike() &&
            !cxxRecordDecl->getDeclContext()->isExternCContext();
   }
+  if (auto *varDecl = dyn_cast<clang::VarDecl>(decl))
+    return isFragileClangType(varDecl->getType());
+  if (auto *fieldDecl = dyn_cast<clang::FieldDecl>(decl))
+    return isFragileClangType(fieldDecl->getType()) ||
+           isFragileClangDecl(fieldDecl->getParent());
   return true;
 }
 

--- a/test/Interop/Cxx/library-evolution/Inputs/module.modulemap
+++ b/test/Interop/Cxx/library-evolution/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module MyCLibrary {
+  header "my_c_header.h"
+  export *
+}

--- a/test/Interop/Cxx/library-evolution/Inputs/my_c_header.h
+++ b/test/Interop/Cxx/library-evolution/Inputs/my_c_header.h
@@ -1,0 +1,3 @@
+struct MyCStruct {
+  int x;
+};

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
@@ -18,8 +18,24 @@ public func getMyCStruct() -> MyCStruct {
   return MyCStruct()
 }
 
+extension MyCStruct {
+  @inlinable public var y: CInt {
+    get {
+      return self.x
+    }
+  }
+
+  @inlinable public var anotherInstanceOfSelf: MyCStruct {
+    get {
+      return MyCStruct(x: self.x + 1)
+    }
+  }
+}
+
 //--- main.swift
 
 import UsesCLibrary
 
 let _ = getMyCStruct()
+let _ = getMyCStruct().y
+let _ = getMyCStruct().anotherInstanceOfSelf

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build a Swift library that uses symbols from a C library without enabling C++ interop.
+// RUN: %target-build-swift %t/uses-c-library.swift -emit-module -emit-library -enable-library-evolution -module-name UsesCLibrary -emit-module-path %t/artifacts/UsesCLibrary.swiftmodule -emit-module-interface-path %t/artifacts/UsesCLibrary.swiftinterface -I %S/Inputs
+
+// Make sure the module interface can be type-checked with C++ interop enabled.
+// RUN: %target-swift-frontend -typecheck-module-from-interface -cxx-interoperability-mode=default %t/artifacts/UsesCLibrary.swiftinterface -I %S/Inputs
+
+// Make sure we can build a Swift executable that uses the library and enables C++ interop.
+// RUN: %target-swift-frontend -typecheck -cxx-interoperability-mode=default -module-name Main %t/main.swift -I %t/artifacts -I %S/Inputs
+
+//--- uses-c-library.swift
+
+import MyCLibrary
+
+public func getMyCStruct() -> MyCStruct {
+  return MyCStruct()
+}
+
+//--- main.swift
+
+import UsesCLibrary
+
+let _ = getMyCStruct()


### PR DESCRIPTION
**Explanation**: When compiling with C++ interop enabled, we enable extra safety checks to prevent library authors from accidentally exposing ABI-fragile C++ symbols in resilient Swift interfaces. The heuristic we use is overly strict, and it prevents the compiler from being able to typecheck various modules from their interfaces when C++ interop is enabled. Darwin and System are two of such modules. This relaxes the heuristic to allow exposing C-like structs, as well as constructors and fields of such structs in resilient interfaces.
**Scope**: Changes the resilience validation mechanism in the typechecker.
**Risk**: Low, this doesn't change the binaries that are produced by the compiler in any way.
**Issue**: rdar://140203932 & rdar://141124318
**Reviewer**: @Xazax-hun @tshortli 

Original PRs: https://github.com/swiftlang/swift/pull/78022 & https://github.com/swiftlang/swift/pull/78057