### PR TITLE
[6.1] Sema: Relax availability checking in universally unavailable contexts

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -345,8 +345,8 @@ static bool computeContainedByDeploymentTarget(AvailabilityScope *scope,
 static bool isInsideCompatibleUnavailableDeclaration(
     const Decl *D, AvailabilityContext availabilityContext,
     const AvailableAttr *attr) {
-  auto referencedPlatform = availabilityContext.getUnavailablePlatformKind();
-  if (!referencedPlatform)
+  auto contextPlatform = availabilityContext.getUnavailablePlatformKind();
+  if (!contextPlatform)
     return false;
 
   if (!attr->isUnconditionallyUnavailable())
@@ -354,8 +354,8 @@ static bool isInsideCompatibleUnavailableDeclaration(
 
   // Refuse calling universally unavailable functions from unavailable code,
   // but allow the use of types.
-  PlatformKind platform = attr->Platform;
-  if (platform == PlatformKind::none && !attr->isForEmbedded() &&
+  PlatformKind declPlatform = attr->Platform;
+  if (declPlatform == PlatformKind::none && !attr->isForEmbedded() &&
       !isa<TypeDecl>(D) && !isa<ExtensionDecl>(D))
     return false;
 
@@ -364,8 +364,9 @@ static bool isInsideCompatibleUnavailableDeclaration(
   if (attr->isForEmbedded())
     return availabilityContext.isUnavailableInEmbedded();
 
-  return (*referencedPlatform == platform ||
-          inheritsAvailabilityFromPlatform(platform, *referencedPlatform));
+  return (*contextPlatform == PlatformKind::none ||
+          *contextPlatform == declPlatform ||
+          inheritsAvailabilityFromPlatform(declPlatform, *contextPlatform));
 }
 
 const AvailableAttr *

--- a/test/Sema/property_wrapper_availability.swift
+++ b/test/Sema/property_wrapper_availability.swift
@@ -32,7 +32,7 @@ struct WrappedValueUnavailableOnMacOS<T> {
   init(wrappedValue: T) { fatalError() }
 
   @available(macOS, unavailable)
-  var wrappedValue: T { // expected-note 9 {{'wrappedValue' has been explicitly marked unavailable here}}
+  var wrappedValue: T { // expected-note 6 {{'wrappedValue' has been explicitly marked unavailable here}}
     get { fatalError() }
     set { fatalError() }
   }
@@ -98,7 +98,7 @@ struct UnavailableStruct {
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
 
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S // expected-error {{'wrappedValue' is unavailable in macOS}}
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S
   @WrappedValueAvailable51 var wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
@@ -159,14 +159,14 @@ func unavailableFunc(
   @Available51Wrapper _ available51: S,
   @DeprecatedWrapper _ deprecated: S,
   @UnavailableWrapper _ unavailable: S,
-  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
+  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S,
   @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 ) {
   @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
   @Available51Wrapper var available51Local = S()
   @DeprecatedWrapper var deprecatedLocal = S()
   @UnavailableWrapper var unavailableLocal = S()
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
+  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S()
   @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -89,8 +89,8 @@ func never_available_func(
   never() // expected-error {{'never()' is unavailable}}
   osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
-  osx() // expected-error {{'osx()' is unavailable}}
-  osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+  osx()
+  osx_ios()
   osx_extension()
 }
 
@@ -160,8 +160,8 @@ var never_var: (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   osx_future(), // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
-  osx(), // expected-error {{'osx()' is unavailable}}
-  osx_ios(), // expected-error {{'osx_ios()' is unavailable}}
+  osx(),
+  osx_ios(),
   osx_extension()
 )
 
@@ -219,8 +219,8 @@ struct NeverAvailableContainer { // expected-note 2 {{'NeverAvailableContainer' 
   let always_var: AlwaysAvailabile = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
-  let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
-  let osx_ios_var: MultiPlatformUnavailable = osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+  let osx_var: OSXUnavailable = osx()
+  let osx_ios_var: MultiPlatformUnavailable = osx_ios()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
@@ -303,8 +303,8 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 
@@ -321,8 +321,8 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 
@@ -339,8 +339,8 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 
@@ -357,8 +357,8 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 }
@@ -400,8 +400,8 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 
@@ -479,8 +479,8 @@ extension ExtendMe { // expected-note * {{add @available attribute to enclosing 
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_ios() // expected-error {{'osx_ios()' is unavailable}}
+    osx()
+    osx_ios()
     osx_extension()
   }
 

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -49,8 +49,8 @@ func never_available_func(
   _: OSXAppExtensionsUnavailable
 ) {
   never() // expected-error {{'never()' is unavailable}}
-  osx() // expected-error {{'osx()' is unavailable}}
-  osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  osx()
+  osx_extension()
 }
 
 @available(OSX, unavailable)
@@ -94,8 +94,8 @@ var never_var: (
   OSXAppExtensionsUnavailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
-  osx(), // expected-error {{'osx()' is unavailable}}
-  osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  osx(),
+  osx_extension()
 )
 
 @available(OSX, unavailable)
@@ -134,8 +134,8 @@ struct AlwaysAvailabileContainer {
 @available(*, unavailable)
 struct NeverAvailableContainer { // expected-note {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
-  let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
-  let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  let osx_var: OSXUnavailable = osx()
+  let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
 @available(OSX, unavailable)
@@ -201,8 +201,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 
   @available(*, unavailable)
@@ -212,8 +212,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 
   @available(OSX, unavailable)
@@ -223,8 +223,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 
   @available(OSXApplicationExtension, unavailable)
@@ -234,8 +234,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 }
 
@@ -263,8 +263,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 
   @available(OSX, unavailable)
@@ -314,8 +314,8 @@ extension ExtendMe {
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx()
+    osx_extension()
   }
 
   @available(OSX, unavailable)

--- a/test/type/opaque_availability.swift
+++ b/test/type/opaque_availability.swift
@@ -10,12 +10,47 @@ func alwaysOpaque() -> some P { return X() } // expected-only-available-error{{'
 @available(SwiftStdlib 5.1, *)
 func sometimesOpaque() -> some P { return X() }
 
-struct NotP {}
+struct NeverConformsToP {}
 
 @available(*, unavailable)
-extension NotP: P {} // expected-note {{conformance of 'NotP' to 'P' has been explicitly marked unavailable here}}
+extension NeverConformsToP: P {} // expected-note 2 {{conformance of 'NeverConformsToP' to 'P' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
-func requireP() -> some P {
-  NotP() // expected-error {{conformance of 'NotP' to 'P' is unavailable}}
+struct Outer {
+  func returnsNeverConformsToP() -> some P {
+    NeverConformsToP() // expected-error {{conformance of 'NeverConformsToP' to 'P' is unavailable}}
+  }
+
+  @available(macOS, unavailable)
+  func returnsNeverConformsToP_macOSUnavailable() -> some P {
+    NeverConformsToP() // expected-error {{conformance of 'NeverConformsToP' to 'P' is unavailable}}
+  }
+
+  @available(*, unavailable)
+  func returnsNeverConformsToP_alwaysUnavailable() -> some P {
+    NeverConformsToP()
+  }
+}
+
+struct ConformsToPExeceptOnMacOS {}
+
+@available(macOS, unavailable)
+extension ConformsToPExeceptOnMacOS: P {} // expected-note {{conformance of 'ConformsToPExeceptOnMacOS' to 'P' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+extension Outer {
+  func returnsConformsToPExeceptOnMacOS() -> some P {
+    ConformsToPExeceptOnMacOS() // expected-error {{conformance of 'ConformsToPExeceptOnMacOS' to 'P' is unavailable in macOS}}
+  }
+
+  @available(macOS, unavailable)
+  func returnsConformsToPExeceptOnMacOS_macOSUnavailable() -> some P {
+    ConformsToPExeceptOnMacOS()
+  }
+
+  @available(*, unavailable)
+  func returnsConformsToPExeceptOnMacOS_alwaysUnavailable() -> some P {
+    ConformsToPExeceptOnMacOS()
+  }
+
 }


### PR DESCRIPTION
- **Explanation:** Recent refactoring fixed a bug in availability checking that affected code where a universally unavailable context is nested inside a context that is unavailable on the current platform. Previously, the nested context would be treated as if it were only unavailable on the platform, which is incorrect since universal unavailability supersedes platform specific unavailability. Fixing this bug caused a source compatibility issue, though, because it changed the rules for which declarations are available to the affected contexts. To preserve source compatibility, this change relaxes the rules that control which declarations are available in universally unavailable contexts, which is a good change to make anyways since the previous rules were not logically consistent.
- **Scope:** Relaxes availability checking diagnostics in contexts that are universally unavailable. 
- **Issue/Radar:** rdar://141124478
- **Original PR:** https://github.com/swiftlang/swift/pull/78077
- **Risk:** Since this is a relaxation of type checker diagnostics, it only accepts more code which lowers the risk of regression.
- **Testing:** New tests in the test suite.
- **Reviewer:** @artemcm 
