### PR TITLE
Error on duplicate module names in Swift module maps

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -414,6 +414,7 @@ private:
     if (moduleName.empty())
       return true;
 
+    bool didInsert;
     if (swiftModulePath.has_value()) {
       assert((clangModuleMapPath.empty() &&
               clangModulePath.empty()) &&
@@ -425,7 +426,7 @@ private:
                                          isFramework,
                                          isSystem,
                                          swiftModuleCacheKey);
-      swiftModuleMap.try_emplace(moduleName, std::move(entry));
+      didInsert = swiftModuleMap.try_emplace(moduleName, std::move(entry)).second;
     } else {
       assert((!clangModuleMapPath.empty() ||
               !clangModulePath.empty()) &&
@@ -436,10 +437,10 @@ private:
                                          isSystem,
                                          isBridgingHeaderDependency,
                                          clangModuleCacheKey);
-      clangModuleMap.try_emplace(moduleName, std::move(entry));
+      didInsert = clangModuleMap.try_emplace(moduleName, std::move(entry)).second;
     }
-
-    return false;
+    // Prevent duplicate module names.
+    return !didInsert;
   }
 
   llvm::StringSaver Saver;

--- a/test/ScanDependencies/cannot_import_with_map_duplicate_entries.swift
+++ b/test/ScanDependencies/cannot_import_with_map_duplicate_entries.swift
@@ -1,0 +1,77 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: split-file %s %t
+// RUN: sed -e "s|INPUTDIR|%t|g" -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/inputs/valid_map.json.template > %t/inputs/valid_map.json
+// RUN: sed -e "s|INPUTDIR|%t|g" -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/inputs/map_with_duped_swift_module.json.template > %t/inputs/map_with_duped_swift_module.json
+// RUN: sed -e "s|INPUTDIR|%t|g" -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/inputs/map_with_duped_clang_module.json.template > %t/inputs/map_with_duped_clang_module.json
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+
+// RUN: %target-swift-frontend -typecheck %t/foo.swift -explicit-swift-module-map-file %t/inputs/valid_map.json
+// RUN: not %target-swift-frontend -typecheck %t/foo.swift -explicit-swift-module-map-file %t/inputs/map_with_duped_swift_module.json
+// RUN: not %target-swift-frontend -typecheck %t/foo.swift -explicit-swift-module-map-file %t/inputs/map_with_duped_clang_module.json
+
+//--- foo.swift
+public func foo() {}
+
+//--- inputs/valid_map.json.template
+[{
+	"moduleName": "Foo",
+	"modulePath": "INPUTDIR/inputs/Foo.swiftmodule",
+	"docPath": "INPUTDIR/inputs/Foo.swiftdoc",
+	"sourceInfoPath": "INPUTDIR/inputs/Foo.swiftsourceinfo",
+	"isFramework": false
+},
+{
+	"moduleName": "SwiftShims",
+	"isFramework": false,
+	"clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+	"clangModulePath": "INPUTDIR/inputs/SwiftShims.pcm"
+}]
+
+//--- inputs/map_with_duped_swift_module.json.template
+[{
+	"moduleName": "Foo",
+	"modulePath": "INPUTDIR/inputs/Foo.swiftmodule",
+	"docPath": "INPUTDIR/inputs/Foo.swiftdoc",
+	"sourceInfoPath": "INPUTDIR/inputs/Foo.swiftsourceinfo",
+	"isFramework": false
+},
+{
+
+	"moduleName": "Foo",
+	"modulePath": "INPUTDIR/inputs/Foo.swiftmodule",
+	"docPath": "INPUTDIR/inputs/Foo.swiftdoc",
+	"sourceInfoPath": "INPUTDIR/inputs/Foo.swiftsourceinfo",
+	"isFramework": false
+},
+{
+	"moduleName": "SwiftShims",
+	"isFramework": false,
+	"clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+	"clangModulePath": "INPUTDIR/inputs/SwiftShims.pcm"
+}]
+
+//--- inputs/map_with_duped_clang_module.json.template
+[{
+	"moduleName": "Foo",
+	"modulePath": "INPUTDIR/inputs/Foo.swiftmodule",
+	"docPath": "INPUTDIR/inputs/Foo.swiftdoc",
+	"sourceInfoPath": "INPUTDIR/inputs/Foo.swiftsourceinfo",
+	"isFramework": false
+},
+{
+	"moduleName": "SwiftShims",
+	"isFramework": false,
+	"clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+	"clangModulePath": "INPUTDIR/inputs/SwiftShims.pcm"
+},
+{
+	"moduleName": "SwiftShims",
+	"isFramework": false,
+	"clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+	"clangModulePath": "INPUTDIR/inputs/SwiftShims.pcm"
+}]


### PR DESCRIPTION
Duplicate module names on search paths produces an error, but providing duplicate module names in a Swift explicit module map file does not, instead the first entry will be chosen. Modify the module map parser to error on duplicated module names as well.
