### PR TITLE
Remove unreachable blocks after inlining

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -19,6 +19,7 @@
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
@@ -1372,6 +1373,7 @@ public:
     // can further optimize this function before attempting to inline
     // in it again.
     if (Inliner.inlineCallsIntoFunction(getFunction())) {
+      removeUnreachableBlocks(*getFunction());
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
       restartPassPipeline();
     }

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -505,14 +505,6 @@ entry:
 // CHECK-NEXT:   [[MARKER:%.*]] = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-NEXT:   apply [[MARKER]]([[T0]]) : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-NEXT:   unreachable
-// CHECK:      bb1:
-// CHECK-NEXT:   // function_ref
-// CHECK-NEXT:   [[USE:%.*]] = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
-// CHECK-NEXT:   apply [[USE]](undef) : $@convention(thin) (@in Builtin.Int8) -> ()
-// CHECK-NEXT:   unreachable
-// CHECK:      bb2:
-// CHECK-NEXT:   [[T0:%.*]] = tuple ()
-// CHECK-NEXT:   return [[T0]] : $()
 // CHECK:      }
 sil [ossa] @test_simple_call_no_yields : $() -> () {
 entry:
@@ -618,11 +610,8 @@ bb0:
 // CHECK:   [[A16:%.*]] = alloc_stack $Builtin.Int16
 // CHECK:   [[A32:%.*]] = alloc_stack $Builtin.Int32
 // CHECK: bb1:
-// CHECK:   dealloc_stack [[A32]] : $*Builtin.Int32
 // CHECK:   unreachable
 // CHECK: bb2:
-// CHECK:   unreachable
-// CHECK: bb3:
 // CHECK:   dealloc_stack [[A32]] : $*Builtin.Int32
 // CHECK:   dealloc_stack [[A16]] : $*Builtin.Int16
 // CHECK:   return

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -684,10 +684,6 @@ bb0(%instance : @owned $C):
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
-// CHECK:       bb1:
-// CHECK:         destroy_addr [[ADDR]]
-// CHECK:         dealloc_stack [[ADDR]]
-// CHECK:         unreachable
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_coro_guaranteed'
 sil [ossa] @caller_owned_callee_coro_guaranteed : $@convention(thin) (@owned C) -> () {
 bb0(%instance : @owned $C):
@@ -724,10 +720,6 @@ bb0(%instance : @guaranteed $C):
 // CHECK-NOT:     end_borrow
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
-// CHECK:       bb1:
-// CHECK:         destroy_addr [[ADDR]]
-// CHECK:         dealloc_stack [[ADDR]]
-// CHECK:         unreachable
 // CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_coro_guaranteed'
 sil [ossa] @caller_guaranteed_callee_coro_guaranteed : $@convention(thin) (@guaranteed C) -> () {
 bb0(%instance : @guaranteed $C):
@@ -746,9 +738,6 @@ bb0(%instance : @guaranteed $C):
 // CHECK:         [[REGISTER_4:%[^,]+]] = tuple ()
 // CHECK:         [[REGISTER_5:%[^,]+]] = tuple ()
 // CHECK:         return [[REGISTER_5]] : $()
-// CHECK:       {{bb[0-9]+}}:
-// CHECK:         dealloc_stack [[REGISTER_1]] : $*S
-// CHECK:         unreachable
 // CHECK-LABEL: } // end sil function 'caller_trivial_callee_coro_trivial'
 sil hidden [ossa] @caller_trivial_callee_coro_trivial : $@convention(thin) (S) -> () {
 bb0(%instance : $S):
@@ -764,8 +753,6 @@ bb0(%instance : $S):
 // CHECK:         {{%[^,]+}} = tuple ()
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
-// CHECK:       {{bb[^,]+}}:
-// CHECK:         unreachable
 // CHECK-LABEL: } // end sil function 'caller_in_callee_coro_in'
 sil hidden [ossa] @caller_in_callee_coro_in : $@convention(thin) (@in S) -> () {
 bb0(%instance : $*S):

--- a/test/SILOptimizer/inline_tryApply.sil
+++ b/test/SILOptimizer/inline_tryApply.sil
@@ -9,7 +9,6 @@ import SwiftShims
 
 //CHECK-LABEL: sil @caller_function
 //CHECK-NOT: try_apply
-//CHECK: throw {{.*}} : $any Error
 sil @caller_function : $@convention(thin) () -> @error Error {
 bb0:
   // function_ref main.inner () throws -> ()

--- a/test/SILOptimizer/inline_unreachable.sil
+++ b/test/SILOptimizer/inline_unreachable.sil
@@ -1,0 +1,41 @@
+// RUN: %target-sil-opt -inline -mem2reg  %s  | %FileCheck %s
+
+import Builtin
+import Swift
+
+class Klass {
+}
+
+sil shared [ossa] @callee : $@convention(method) (@guaranteed Klass) -> @error any Error {
+bb0(%0 : @guaranteed $Klass):
+  %1 = tuple ()                                   
+  return %1                                       
+} 
+
+// CHECK-LABEL: sil shared [ossa] @caller :
+// CHECK-NOT: try_apply
+// CHECK-NOT: alloc_stack 
+// CHECK-LABEL: } // end sil function 'caller'
+sil shared [ossa] @caller : $@convention(thin) (@guaranteed Klass) -> @error any Error {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0                              
+  %2 = alloc_stack $Klass                         
+  store %1 to [init] %2                           
+  %4 = function_ref @callee : $@convention(method) (@guaranteed Klass) -> @error any Error 
+  %5 = load_borrow %2                             
+  try_apply %4(%5) : $@convention(method) (@guaranteed Klass) -> @error any Error, normal bb1, error bb2 
+
+bb1(%7 : $()):                                    
+  end_borrow %5                                   
+  destroy_addr %2                                 
+  dealloc_stack %2                                
+  %11 = tuple ()                                  
+  return %11                                      
+
+bb2(%13 : @owned $any Error):                     
+  end_borrow %5                                   
+  destroy_addr %2                                 
+  dealloc_stack %2                                
+  throw %13                                       
+} 
+


### PR DESCRIPTION
Inlining can lead to unreachable blocks which can cause false verification errors downstream. Remove unreachable code so we don't run  into such issues. 