### PR TITLE
[embedded] Don't emit metadata references from C++ interop

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2564,7 +2564,7 @@ void IRGenModule::emitSILFunction(SILFunction *f) {
     return;
 
   // Type metadata for foreign references is not yet supported on Windows. Bug #76168.
-  if (Context.LangOpts.EnableCXXInterop &&
+  if (Context.LangOpts.EnableCXXInterop && !Context.LangOpts.hasFeature(Feature::Embedded) &&
       f->getLinkage() == SILLinkage::Public &&
       !Context.LangOpts.Target.isOSWindows())
     noteUseOfMetadataByCXXInterop(IRGen, f, TypeExpansionContext(*f));

--- a/test/embedded/cxx-no-metadata.swift
+++ b/test/embedded/cxx-no-metadata.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN header.h
+
+// C++
+struct CxxStruct {
+  int field;
+};
+
+// BEGIN module.modulemap
+
+module MyModule {
+  header "header.h"
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+public func foo(ptr: UnsafeMutablePointer<CxxStruct>?) {
+}
+
+foo(ptr: nil)


### PR DESCRIPTION
This resolves a compiler crash when using C++ interop in Embedded Swift:
```
Assertion failed: (LazyTypeMetadata.empty()), function emitLazyDefinitions, file GenDecl.cpp, line 1330.
...
8  swift-frontend           0x000000010093cf60 swift::irgen::IRGenerator::emitLazyDefinitions() + 3212
9  swift-frontend           0x0000000100a580f8 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const + 2632
10 swift-frontend           0x0000000100aa64a4 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const + 200
```
