### PR TITLE
[DebugInfo] Fix handling of @_originallyDefinedIn types

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -717,7 +717,7 @@ std::string ASTMangler::mangleTypeForDebugger(Type Ty, GenericSignature sig) {
                                         Ty);
 
   DWARFMangling = true;
-  RespectOriginallyDefinedIn = false;
+  RespectOriginallyDefinedIn = true;
   OptimizeProtocolNames = false;
   beginMangling();
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -979,7 +979,7 @@ const ExternalSourceLocs *Decl::getSerializedLocs() const {
 StringRef Decl::getAlternateModuleName() const {
   for (auto *Att: Attrs) {
     if (auto *OD = dyn_cast<OriginallyDefinedInAttr>(Att)) {
-      if (OD->isActivePlatform(getASTContext())) {
+      if (!OD->isInvalid() && OD->isActivePlatform(getASTContext())) {
         return OD->OriginalModuleName;
       }
     }

--- a/test/DebugInfo/Inputs/local_type_originally_defined_in_other.swift
+++ b/test/DebugInfo/Inputs/local_type_originally_defined_in_other.swift
@@ -1,2 +1,22 @@
-@available(macOS 10, *)
-@_originallyDefinedIn(module: "Barn", macOS 10.1) public struct Horse {}
+@_originallyDefinedIn(
+      module: "Barn", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+ @available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct Horse {
+  public init() {}
+}
+
+@_originallyDefinedIn(
+      module: "Barn", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+ @available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public class Cow {
+  public init() {}
+}
+
+
+@_originallyDefinedIn(
+      module: "Barn", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+ @available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public class Sheep {
+  public init() {}
+}
+

--- a/test/DebugInfo/module_abi_name.swift
+++ b/test/DebugInfo/module_abi_name.swift
@@ -3,11 +3,5 @@
 class SomeClass {}
 // CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "SomeClass",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye9SomeClassCD"
 
-@available(macOS 10.13, *)
-@_originallyDefinedIn(module: "ThirdModule", OSX 10.12)
-class DefinedElsewhere {}
-// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "DefinedElsewhere",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye16DefinedElsewhereCD")
-
 let v1 = SomeClass()
-let v2 = DefinedElsewhere()
 

--- a/test/DebugInfo/module_abi_name_and_orig_defined_in.swift
+++ b/test/DebugInfo/module_abi_name_and_orig_defined_in.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -module-name=Hello -module-abi-name Goodbye -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+//
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+@_originallyDefinedIn(
+     module: "ThirdModule", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+public class DefinedElsewhere {}
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "DefinedElsewhere",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s11ThirdModule16DefinedElsewhereCD")
+
+let v2 = DefinedElsewhere()

--- a/test/DebugInfo/originally_defined_in.swift
+++ b/test/DebugInfo/originally_defined_in.swift
@@ -1,14 +1,41 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o -
 
- @_originallyDefinedIn(
-      module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
- @available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
- public struct A {
-     let i = 10
- }
+// REQUIRES: OS=macosx
+//
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct A {
+    let i = 10
+}
 
- // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "A",{{.*}}identifier: "$s21originally_defined_in1AVD",{{.*}}specification: ![[S1:[0-9]+]]
- // CHECK: [[S1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "A", scope: ![[S2:[0-9]+]]
- // CHECK: [[S2]] = !DIModule({{.*}}name: "Other"
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct B {
+    let i = 10
+}
+
+// Test that a type with an invalid @_originallyDefinedIn does not change the mangled name.
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+private struct Invalid {
+    let i = 20
+}
+
+// CHECK: ![[MOD:[0-9]+]] = !DIModule(scope: null, name: "originally_defined_in"
+//
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "A",{{.*}}scope: ![[S:[0-9]+]]{{.*}}identifier: "$s5Other1AVD"
+// CHECK: [[S]] = !DIModule({{.*}}name: "Other"
+
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "Invalid",{{.*}}identifier: "$s21originally_defined_in
+
+// CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "$s5Other1AVD",{{.*}}scope: ![[MOD]]
+//
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s5Other1AV_ACtD",
 
 let a = A()
+let b = B.self
+let c = (A(), A())
+private let i = Invalid()

--- a/test/Runtime/demangleToMetadataMovedSymbols.swift
+++ b/test/Runtime/demangleToMetadataMovedSymbols.swift
@@ -12,17 +12,17 @@ let DemangleToMetadataMovedSymbolsTests = TestSuite("DemangleToMetadataMovedSymb
 
 @available(OSX 10.9, *)
 @_originallyDefinedIn(module: "foo", OSX 10.13)
-struct MovedS {
+public struct MovedS {
   struct Nested { }
 }
 
 @available(OSX 10.9, *)
 @_originallyDefinedIn(module: "foo", OSX 10.13)
-enum MovedE { case e }
+public enum MovedE { case e }
 
 @available(OSX 10.9, *)
 @_originallyDefinedIn(module: "bar", OSX 10.13)
-class MovedC {}
+public class MovedC {}
 
 DemangleToMetadataMovedSymbolsTests.test("Moved Nominals") {
   // Simple Struct


### PR DESCRIPTION
Emit an imported declaration for @_originallyDefinedIn under the real module that these types live in.

This patch also changes the mangling for the debugger to respect @_originallyDefinedIn, and fixes a bug where @_originallyDefinedIn that should be ignored was still being used when mangling.

rdar://137146961

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
