### PR TITLE
Fix test: SILOptimizer/propagate_opaque_return_type.swift

### DIFF
--- a/test/SILOptimizer/propagate_opaque_return_type.swift
+++ b/test/SILOptimizer/propagate_opaque_return_type.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
+// REQUIRES: executable_test
+
 protocol P {}
 extension P {
   func foo() -> some Sequence<Int> {


### PR DESCRIPTION
Add REQUIRES: executable_test

Fixes rdar://141008973 (🟠 OSS Swift CI:
oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed: test: SILOptimizer/propagate_opaque_return_type.swift (exit code 2))

(cherry picked from commit 1202dd8cff074c4a707c094d9f8b4c9510f06bcc)
