### PR TITLE
xcodegen: Show absolute path in skipping warning

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectSpec.swift
@@ -130,8 +130,9 @@ extension ProjectSpec {
     _ path: RelativePath, for description: String
   ) -> RelativePath? {
     let path = mapKnownPath(path)
-    guard repoRoot.appending(path).exists else {
-      log.warning("Skipping \(description) at '\(path)'; does not exist")
+    let absPath = repoRoot.appending(path)
+    guard absPath.exists else {
+      log.warning("Skipping \(description) at '\(absPath)'; does not exist")
       return nil
     }
     return path


### PR DESCRIPTION
This would have saved me the time I spent figuring out why something went wrong with the project generation. In my case, the absolute path shown by this warning would have been overtly invalid because the tool was failing to infer the source root directory.