### PR TITLE
Allow disabling ownership verification via blocklist

### DIFF
--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -23,5 +23,6 @@ BLOCKLIST_ACTION(ShouldUseBinaryModule)
 BLOCKLIST_ACTION(ShouldUseTextualModule)
 BLOCKLIST_ACTION(DowngradeInterfaceVerificationFailure)
 BLOCKLIST_ACTION(ShouldUseLayoutStringValueWitnesses)
+BLOCKLIST_ACTION(ShouldDisableOwnershipVerification)
 
 #undef BLOCKLIST_ACTION

--- a/test/SIL/disable_ossa_verification_blocklist.sil
+++ b/test/SIL/disable_ossa_verification_blocklist.sil
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+
+// RUN: echo "---" > %t/blocklist.yml
+// RUN: echo "ShouldDisableOwnershipVerification:" >> %t/blocklist.yml
+// RUN: echo "  ModuleName:" >> %t/blocklist.yml
+// RUN: echo "    - Foo" >> %t/blocklist.yml
+
+// RUN: %target-swift-frontend -emit-sil -module-name Foo -blocklist-file %t/blocklist.yml %s | %FileCheck %s
+
+class Klass {}
+
+// CHECK-LABEL: sil @invalid_destroy
+// CHECK: strong_release
+sil [ossa] @invalid_destroy : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  destroy_value %0 : $Klass
+  %t = tuple ()
+  return %t : $()
+}
+


### PR DESCRIPTION
In preparation for enabling ossa modules, provide a way to disable ownership verification via blocklist.