### PR TITLE
swift-plugin-server: update for throwing SwiftSyntax API

### DIFF
--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -21,6 +21,6 @@ final class SwiftPluginServer {
       connection: connection,
       provider: LibraryPluginProvider.shared
     )
-    listener.main()
+    try listener.main()
   }
 }


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift-syntax/pull/2915

The `main` method on `CompilerPluginMessageListener` in SwiftSyntax can synchronously clean up resources that cannot be dealt with in a deinitializer due to possible errors thrown during the clean up. Usually this includes closure of file handles, sockets, shutting down external processes and IPC resources set up for these processes, etc.