### PR TITLE
[cmake] add -headerpad_max_install_names when building dylibs

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -266,9 +266,7 @@ if(SwiftCore_ENABLE_VECTOR_TYPES)
 endif()
 
 if(APPLE AND BUILD_SHARED_LIBS)
-  target_link_options(swiftCore PRIVATE
-    "SHELL:-Xlinker -headerpad_max_install_names"
-  )
+  target_link_options(swiftCore PRIVATE "SHELL:-Xlinker -headerpad_max_install_names")
 endif()
 
 target_compile_options(swiftCore PRIVATE

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -265,6 +265,12 @@ if(SwiftCore_ENABLE_VECTOR_TYPES)
     "${CMAKE_CURRENT_BINARY_DIR}/SIMDVectorTypes.swift")
 endif()
 
+if(APPLE AND BUILD_SHARED_LIBS)
+  target_link_options(swiftCore PRIVATE
+    "SHELL:-Xlinker -headerpad_max_install_names"
+  )
+endif()
+
 target_compile_options(swiftCore PRIVATE
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdimport>


### PR DESCRIPTION
add ` -headerpad_max_install_names` linker flag when appropriate