### PR TITLE
Gracefully handle incorrect SwiftName arg count

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/SwiftName.h
+++ b/test/ClangImporter/Inputs/custom-modules/SwiftName.h
@@ -32,6 +32,8 @@ typedef int my_int_t SWIFT_NAME(MyInt);
 void spuriousAPINotedSwiftName(int);
 void poorlyNamedFunction(const char *);
 
+PointType readPoint(const char *path, void **errorOut) SWIFT_NAME(Point.init(path:));
+
 struct BoxForConstants {
   int dummy;
 };

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -22,6 +22,9 @@ func test() {
   var p = Point()
   var p2 = PointType() // FIXME: should provide Fix-It expected-error{{cannot find 'PointType' in scope}} {{none}}
 
+  // Initializers with incorrect argument count (rdar://141124373)
+  var p3 = Point(path: "/dev/zero", nil) // expected-warning {{'init(path:_:)' is deprecated: declared Swift name 'init(path:)' was adjusted to 'init(path:_:)' because it does not have the correct number of parameters (1 vs. 2); please report this to its maintainer}}
+
   // Field name remapping
   p.x = 7
 


### PR DESCRIPTION
…at least in the specific case of initializers.

Normally, clang validates that a SwiftNameAttr’s specified name seems to have the right number of argument labels for the declaration it’s applied to; if it doesn’t, it diagnoses and drops the attribute. However, this checking isn’t perfect because clang doesn’t know all of Clang Importer’s throwing rules. The upshot is that it’s possible to get a mismatched SwiftNameAttr into Clang Importer if the last parameter looks like an out parameter. This trips an assertion in asserts compilers, but release compilers get past that and don’t seem to notice the mismatch at all.

Add code to the compiler to tolerate this condition, at least in initializers, by modifying the Swift name to have the correct number of argument labels and deprecating the declaration with a message explaining the problem.

Fixes rdar://141124373.
