### PR TITLE
[swift-inspect] incorrect error logged by `swift-inspect dump-arrays` on Windows

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -476,7 +476,7 @@ internal final class WindowsRemoteProcess: RemoteProcess {
       return false
     }
 
-    if dwExitCode != 0 {
+    if dwExitCode == 0 {
       print("FreeLibrary failed \(dwExitCode)")
       return false
     }

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -470,13 +470,13 @@ internal final class WindowsRemoteProcess: RemoteProcess {
       return false
     }
 
-    var dwExitCode: DWORD = 1
+    var dwExitCode: DWORD = 0
     guard GetExitCodeThread(hThread, &dwExitCode) else {
       print("GetExitCodeThread for unload failed \(GetLastError())")
       return false
     }
 
-    guard dwExitCode == 0 else {
+    guard dwExitCode != 0 else {
       print("FreeLibrary failed \(dwExitCode)")
       return false
     }

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -476,7 +476,7 @@ internal final class WindowsRemoteProcess: RemoteProcess {
       return false
     }
 
-    guard dwExitCode != 0 else {
+    if dwExitCode != 0 {
       print("FreeLibrary failed \(dwExitCode)")
       return false
     }


### PR DESCRIPTION
## Purpose
Fixes an incorrect error logged by `swift-inspect dump-arrays` on Windows:
```
FreeLibrary failed 1
Failed to unload the remote dll
```
This error log is incorrect-- the library is successfully unloaded in the remote process.

## Background
`FreeLibrary` returns a Win32 `BOOL`, so `TRUE` on success and `FALSE` on failure. Since we're invoking `FreeLibrary` as the `lpStartAddress` passed to `CreateRemoteThread`, the return value of `FreeLibrary` will be the thread's exit code. Therefore, we should be checking the thread exit code against 0 for failure and non-zero for success.

## Validation
Ran `swift-inspect dump-arrays` with the PID of a simple Swift test app and verified the error is no longer logged.
```
S:\swift\tools\swift-inspect>S:\swift\tools\swift-inspect\.build\x86_64-unknown-windows-msvc\debug\swift-inspect.exe dump-arrays 62868
Address Size    Count   Is Class
0x13b18bcab30   48      1       false
0x13b18bcabf0   48      1       false
0x13b18bd20d0   48      1       false
0x13b18bdc590   64      1       false

S:\swift\tools\swift-inspect>
```