### PR TITLE
[swift-inspect] stop leaking memory in Windows heap iteration

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -86,6 +86,8 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     return swift_addr_t(range.location)
   }
 
+  static var Free: FreeFunction? { return nil }
+
   static var ReadBytes: ReadBytesFunction {
     return { (context, address, size, _) in
       let process: DarwinRemoteProcess = DarwinRemoteProcess.fromOpaque(context!)

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -46,12 +46,6 @@ internal protocol RemoteProcess: AnyObject {
 }
 
 extension RemoteProcess {
-  static var Free: FreeFunction? {
-    return nil
-  }
-}
-
-extension RemoteProcess {
   internal func toOpaqueRef() -> UnsafeMutableRawPointer {
     return Unmanaged.passRetained(self).toOpaque()
   }

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -59,7 +59,7 @@ internal final class WindowsRemoteProcess: RemoteProcess {
     }
   }
 
-  static var Free: FreeFunction {
+  static var Free: FreeFunction? {
     return { (_, bytes, _) in
       free(UnsafeMutableRawPointer(mutating: bytes))
     }


### PR DESCRIPTION
## Purpose
Fixes a memory leak when running `swift-inspect dump-arrays` on Windows.

## Overview
* Update the `Free` property in `WindowsRemoteProcess` to be optional `FreeFunction?` type.
* Remove the default `Free` property implementation from `RemoteProcess` to avoid similar mistakes in the future.
* Implement `Free` property to return `nil` in `DarwinRemoteProcess` since it was previously relying on the default from `RemoteProcess`.

## Background
Each call to the `ReadBytes` function allocates a buffer with `malloc` and returns it to the caller. The buffer is expected to be freed with a call to `FreeFunction`, but it never gets called.

The root cause is that the `RemoteProcess` protocol defines the following prototype for the `FreeFunction` static field getter as optional:
```
  static var Free: FreeFunction? { get }
```
And the `WindowsRemoteProcess` protocol incorrectly implements the getter as non-optional:
```
  static var Free: FreeFunction {
    return { (_, bytes, _) in
      free(UnsafeMutableRawPointer(mutating: bytes))
    }
  }
```
Since the `WindowsRemoteProcess` version is defined differently, the default implementation from a `RemoteProcess` extension gets called instead:
```
extension RemoteProcess {
  static var Free: FreeFunction? {
    return nil
  }
}
```
The caller handles a `nil` `Free` by assuming the memory doesn't have to be freed.

## Validation
Add a ` print()` call to the free function body to confirm free is called with this fix and never called without it.