### PR TITLE
[ASTGen] Syntax-tree based interface hash

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -42,6 +42,7 @@ class DeclNameLoc;
 class DeclNameRef;
 class DiagnosticArgument;
 class DiagnosticEngine;
+class Fingerprint;
 class Identifier;
 class IfConfigClauseRangeInfo;
 struct LabeledStmtInfo;
@@ -915,6 +916,8 @@ BridgedUnavailableFromAsyncAttr BridgedUnavailableFromAsyncAttr_createParsed(
 // MARK: Decls
 //===----------------------------------------------------------------------===//
 
+struct BridgedFingerprint;
+
 SWIFT_NAME("BridgedDecl.setAttrs(self:_:)")
 void BridgedDecl_setAttrs(BridgedDecl decl, BridgedDeclAttributes attrs);
 
@@ -1034,9 +1037,10 @@ BridgedTypeAliasDecl BridgedTypeAliasDecl_createParsed(
     BridgedSourceLoc cEqualLoc, BridgedTypeRepr underlyingType,
     BridgedNullableTrailingWhereClause genericWhereClause);
 
-SWIFT_NAME("BridgedExtensionDecl.setParsedMembers(self:_:)")
+SWIFT_NAME("BridgedExtensionDecl.setParsedMembers(self:_:fingerprint:)")
 void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl decl,
-                                           BridgedArrayRef members);
+                                           BridgedArrayRef members,
+                                           BridgedFingerprint fingerprint);
 
 SWIFT_NAME(
     "BridgedEnumDecl.createParsed(_:declContext:enumKeywordLoc:name:nameLoc:"
@@ -1269,9 +1273,10 @@ SWIFT_NAME("BridgedNominalTypeDecl.isGenericAtAnyLevel(self:)")
 BRIDGED_INLINE
 bool BridgedNominalTypeDecl_isGenericAtAnyLevel(BridgedNominalTypeDecl decl);
 
-SWIFT_NAME("BridgedNominalTypeDecl.setParsedMembers(self:_:)")
+SWIFT_NAME("BridgedNominalTypeDecl.setParsedMembers(self:_:fingerprint:)")
 void BridgedNominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl decl,
-                                             BridgedArrayRef members);
+                                             BridgedArrayRef members,
+                                             BridgedFingerprint fingerprint);
 
 SWIFT_NAME("BridgedNominalTypeDecl.getSourceLocation(self:)")
 BRIDGED_INLINE BridgedSourceLoc BridgedNominalTypeDecl_getSourceLocation(BridgedNominalTypeDecl decl);
@@ -2325,6 +2330,13 @@ struct BridgedSubstitutionMap {
   BRIDGED_INLINE bool hasAnySubstitutableParams() const;
   BRIDGED_INLINE SwiftInt getNumConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getConformance(SwiftInt index) const;
+};
+
+struct BridgedFingerprint {
+  uint64_t v1;
+  uint64_t v2;
+
+  BRIDGED_INLINE swift::Fingerprint unbridged() const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -24,6 +24,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Fingerprint.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -459,6 +460,14 @@ SwiftInt BridgedSubstitutionMap::getNumConformances() const {
 
 BridgedConformance BridgedSubstitutionMap::getConformance(SwiftInt index) const {
   return unbridged().getConformances()[index];
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedFingerprint
+//===----------------------------------------------------------------------===//
+
+swift::Fingerprint BridgedFingerprint::unbridged() const {
+  return swift::Fingerprint({this->v1, this->v2});
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -88,7 +88,7 @@ public:
 struct SourceFileParsingResult {
   ArrayRef<ASTNode> TopLevelItems;
   std::optional<ArrayRef<Token>> CollectedTokens;
-  std::optional<StableHasher> InterfaceHasher;
+  std::optional<Fingerprint> Fingerprint;
 };
 
 /// Parse the top-level items of a SourceFile.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -153,7 +153,7 @@ private:
   /// this source file.
   ///
   /// We only collect interface hash for primary input files.
-  std::optional<StableHasher> InterfaceHasher;
+  std::optional<Fingerprint> InterfaceHash;
 
   /// The ID for the memory buffer containing this file's source.
   unsigned BufferID;
@@ -756,19 +756,14 @@ public:
     return ParsingOpts.contains(ParsingFlags::EnableInterfaceHash);
   }
 
-  /// Retrieve a fingerprint value that summarizes the declarations in this
-  /// source file.
+  /// Retrieve a fingerprint value that summarizes the top-level declarations in
+  /// this source file.
   ///
   /// Note that the interface hash merely summarizes the top-level declarations
   /// in this file. Type body fingerprints are currently implemented such that
   /// they divert tokens away from the hasher used for fingerprints. That is,
   /// changes to the bodies of types and extensions will not result in a change
-  /// to the interface hash.
-  ///
-  /// In order for the interface hash to be enabled, this source file must be a
-  /// primary and the compiler must be set in incremental mode. If this is not
-  /// the case, this function will try to signal with an assert. It is useful
-  /// to guard requests for the interface hash with \c hasInterfaceHash().
+  /// to the source file interface hash.
   Fingerprint getInterfaceHash() const;
 
   void dumpInterfaceHash(llvm::raw_ostream &out) {

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -61,6 +61,10 @@ void swift_ASTGen_buildTopLevelASTNodes(
     void *_Nonnull outputContext,
     void (*_Nonnull)(BridgedASTNode, void *_Nonnull));
 
+BridgedFingerprint
+swift_ASTGen_getSourceFileFingerprint(void *_Nonnull sourceFile,
+                                      BridgedASTContext astContext);
+
 void swift_ASTGen_freeBridgedString(BridgedStringRef);
 
 // MARK: - Regex parsing

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -338,12 +338,14 @@ BridgedTypeAliasDecl BridgedTypeAliasDecl_createParsed(
   return decl;
 }
 
-static void setParsedMembers(IterableDeclContext *IDC,
-                             BridgedArrayRef bridgedMembers) {
+static void setParsedMembers(IterableDeclContext *IDC, BridgedArrayRef cMembers,
+                             BridgedFingerprint cFingerprint) {
   auto &ctx = IDC->getDecl()->getASTContext();
 
+  Fingerprint fp = cFingerprint.unbridged();
+
   SmallVector<Decl *> members;
-  for (auto *decl : bridgedMembers.unbridged<Decl *>()) {
+  for (auto *decl : cMembers.unbridged<Decl *>()) {
     members.push_back(decl);
 
     // Add any variables bound to the list of decls.
@@ -364,19 +366,22 @@ static void setParsedMembers(IterableDeclContext *IDC,
 
   IDC->setMaybeHasOperatorDeclarations();
   IDC->setMaybeHasNestedClassDeclarations();
+  // FIXME: Split requests. e.g. DeclMembersFingerprintRequest.
   ctx.evaluator.cacheOutput(
       ParseMembersRequest{IDC},
-      FingerprintAndMembers{std::nullopt, ctx.AllocateCopy(members)});
+      FingerprintAndMembers{fp, ctx.AllocateCopy(members)});
 }
 
-void BridgedNominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl bridgedDecl,
-                                             BridgedArrayRef bridgedMembers) {
-  setParsedMembers(bridgedDecl.unbridged(), bridgedMembers);
+void BridgedNominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl cDecl,
+                                             BridgedArrayRef cMembers,
+                                             BridgedFingerprint cFingerprint) {
+  setParsedMembers(cDecl.unbridged(), cMembers, cFingerprint);
 }
 
-void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl bridgedDecl,
-                                           BridgedArrayRef bridgedMembers) {
-  setParsedMembers(bridgedDecl.unbridged(), bridgedMembers);
+void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl cDecl,
+                                           BridgedArrayRef cMembers,
+                                           BridgedFingerprint cFingerprint) {
+  setParsedMembers(cDecl.unbridged(), cMembers, cFingerprint);
 }
 
 static ArrayRef<InheritedEntry>

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1551,10 +1551,8 @@ Fingerprint SourceFile::getInterfaceHash() const {
   assert(hasInterfaceHash() && "Interface hash not enabled");
   auto &eval = getASTContext().evaluator;
   auto *mutableThis = const_cast<SourceFile *>(this);
-  std::optional<StableHasher> interfaceHasher =
-      evaluateOrDefault(eval, ParseSourceFileRequest{mutableThis}, {})
-          .InterfaceHasher;
-  return Fingerprint{StableHasher{interfaceHasher.value()}.finalize()};
+  return evaluateOrDefault(eval, ParseSourceFileRequest{mutableThis}, {})
+      .Fingerprint.value();
 }
 
 Fingerprint SourceFile::getInterfaceHashIncludingTypeMembers() const {

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -239,6 +239,12 @@ extension BridgedSourceRange {
   }
 }
 
+extension Fingerprint {
+  var bridged: BridgedFingerprint {
+    BridgedFingerprint(v1: self.core.0, v2: self.core.1)
+  }
+}
+
 /// Helper collection type that lazily concatenates two collections.
 struct ConcatCollection<C1: Collection, C2: Collection> where C1.Element == C2.Element {
   let c1: C1

--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -8,12 +8,14 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   Diagnostics.swift
   DiagnosticsBridge.swift
   Exprs.swift
+  Fingerprint.swift
   Generics.swift
   Literals.swift
   ParameterClause.swift
   Patterns.swift
   Regex.swift
   SourceFile.swift
+  StableHasher.swift
   Stmts.swift
   TypeAttrs.swift
   Types.swift

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -131,9 +131,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }
@@ -160,9 +165,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }
@@ -190,9 +200,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }
@@ -220,9 +235,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }
@@ -252,9 +272,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }
@@ -299,9 +324,14 @@ extension ASTGenVisitor {
     )
     decl.asDecl.setAttrs(attrs.attributes)
 
-    self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members).lazy.bridgedArray(in: self))
+    let members = self.withDeclContext(decl.asDeclContext) {
+      self.generate(memberBlockItemList: node.memberBlock.members)
     }
+    let fp = self.generateFingerprint(declGroup: node)
+    decl.setParsedMembers(
+      members.lazy.bridgedArray(in: self),
+      fingerprint: fp.bridged
+    )
 
     return decl
   }

--- a/lib/ASTGen/Sources/ASTGen/Fingerprint.swift
+++ b/lib/ASTGen/Sources/ASTGen/Fingerprint.swift
@@ -1,0 +1,79 @@
+//===--- Fingerprint.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax)
+import SwiftSyntax
+import SwiftIfConfig
+
+struct Fingerprint: Equatable {
+  typealias Core = (UInt64, UInt64)
+  var core: Core
+  init(core: Core) {
+    self.core = core
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.core == rhs.core
+  }
+}
+
+extension StableHasher {
+  @inline(__always)
+  mutating func combine(text: SyntaxText) {
+    let buffer = UnsafeRawBufferPointer(
+      start: UnsafeRawPointer(text.baseAddress),
+      count: text.count
+    )
+    self.combine(UInt(truncatingIfNeeded: buffer.count))
+    self.combine(bytes: buffer)
+  }
+}
+
+final class FingerprintVisitor: SyntaxVisitor {
+  let configuredRegions: ConfiguredRegions
+  var hasher: StableHasher
+
+  init(configuredRegions: ConfiguredRegions) {
+    self.configuredRegions = configuredRegions
+    self.hasher = StableHasher()
+    super.init(viewMode: .sourceAccurate)
+  }
+
+  func finalize() -> Fingerprint {
+    Fingerprint(core: hasher.finalize())
+  }
+
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    // Collect all token texts.
+    hasher.combine(text: token.rawText)
+    return .skipChildren
+  }
+
+  override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
+    // Skip nominal decl / extension member blocks.
+    return .skipChildren
+  }
+
+  override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
+    // Skip function bodies.
+    // FIXME: Don't skip closure bodies or other control flow statement blocks.
+    //        E.g. 'var val = { if condition { "foo" } else { "bar" } }()'
+    return .skipChildren
+  }
+
+  override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    if let active = configuredRegions.activeClause(for: node) {
+      self.walk(active)
+    }
+    return .skipChildren
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/StableHasher.swift
+++ b/lib/ASTGen/Sources/ASTGen/StableHasher.swift
@@ -1,0 +1,306 @@
+//===--- StableHasher.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@inline(__always)
+private func _loadPartialUnalignedUInt64LE(
+  _ p: UnsafeRawPointer,
+  byteCount: Int
+) -> UInt64 {
+  var result: UInt64 = 0
+  switch byteCount {
+  case 7:
+    result |= UInt64(p.load(fromByteOffset: 6, as: UInt8.self)) &<< 48
+    fallthrough
+  case 6:
+    result |= UInt64(p.load(fromByteOffset: 5, as: UInt8.self)) &<< 40
+    fallthrough
+  case 5:
+    result |= UInt64(p.load(fromByteOffset: 4, as: UInt8.self)) &<< 32
+    fallthrough
+  case 4:
+    result |= UInt64(p.load(fromByteOffset: 3, as: UInt8.self)) &<< 24
+    fallthrough
+  case 3:
+    result |= UInt64(p.load(fromByteOffset: 2, as: UInt8.self)) &<< 16
+    fallthrough
+  case 2:
+    result |= UInt64(p.load(fromByteOffset: 1, as: UInt8.self)) &<< 8
+    fallthrough
+  case 1:
+    result |= UInt64(p.load(fromByteOffset: 0, as: UInt8.self))
+    fallthrough
+  case 0:
+    return result
+  default:
+    preconditionFailure()
+  }
+}
+
+/// SipHash-1-3 128bit hasher.
+extension StableHasher {
+  /// This is a buffer for segmenting arbitrary data into 8-byte chunks.  Buffer
+  /// storage is represented by a single 64-bit value in the format used by the
+  /// finalization step of SipHash. (The least significant 56 bits hold the
+  /// trailing bytes, while the most significant 8 bits hold the count of bytes
+  /// appended so far, modulo 256. The count of bytes currently stored in the
+  /// buffer is in the lower three bits of the byte count.)
+  struct _TailBuffer {
+    // msb                                                             lsb
+    // +---------+-------+-------+-------+-------+-------+-------+-------+
+    // |byteCount|                 tail (<= 56 bits)                     |
+    // +---------+-------+-------+-------+-------+-------+-------+-------+
+    var value: UInt64
+
+    @inline(__always)
+    init() {
+      self.value = 0
+    }
+
+    var tail: UInt64 {
+      @inline(__always)
+      get { return value & ~(0xFF &<< 56) }
+    }
+
+    var byteCount: UInt64 {
+      @inline(__always)
+      get { return value &>> 56 }
+    }
+
+    @inline(__always)
+    mutating func append(_ bytes: UInt64) -> UInt64 {
+      let c = byteCount & 7
+      if c == 0 {
+        value = value &+ (8 &<< 56)
+        return bytes
+      }
+      let shift = c &<< 3
+      let chunk = tail | (bytes &<< shift)
+      value = (((value &>> 56) &+ 8) &<< 56) | (bytes &>> (64 - shift))
+      return chunk
+    }
+
+    @inline(__always)
+    internal
+    mutating func append(_ bytes: UInt64, count: UInt64) -> UInt64? {
+      precondition(count >= 0 && count < 8)
+      precondition(bytes & ~((1 &<< (count &<< 3)) &- 1) == 0)
+      let c = byteCount & 7
+      let shift = c &<< 3
+      if c + count < 8 {
+        value = (value | (bytes &<< shift)) &+ (count &<< 56)
+        return nil
+      }
+      let chunk = tail | (bytes &<< shift)
+      value = ((value &>> 56) &+ count) &<< 56
+      if c + count > 8 {
+        value |= bytes &>> (64 - shift)
+      }
+      return chunk
+    }
+  }
+}
+
+struct StableHasher {
+  private var _buffer: _TailBuffer
+  private var _state: _State
+
+  @inline(__always)
+  init(state: _State) {
+    self._buffer = _TailBuffer()
+    self._state = state
+  }
+
+  @inline(__always)
+  init() {
+    self.init(state: _State(seed: 0))
+  }
+
+  @inline(__always)
+  init(seed: Int) {
+    self.init(state: _State(seed: seed))
+  }
+
+  @inline(__always)
+  mutating func combine(_ value: UInt) {
+#if _pointerBitWidth(_64)
+    combine(UInt64(truncatingIfNeeded: value))
+#elseif _pointerBitWidth(_32)
+    combine(UInt32(truncatingIfNeeded: value))
+#else
+#error("Unknown platform")
+#endif
+  }
+
+  @inline(__always)
+  mutating func combine(_ value: UInt64) {
+    _state.compress(_buffer.append(value))
+  }
+
+  @inline(__always)
+  mutating func combine(_ value: UInt32) {
+    let value = UInt64(truncatingIfNeeded: value)
+    if let chunk = _buffer.append(value, count: 4) {
+      _state.compress(chunk)
+    }
+  }
+
+  @inline(__always)
+  mutating func combine(_ value: UInt16) {
+    let value = UInt64(truncatingIfNeeded: value)
+    if let chunk = _buffer.append(value, count: 2) {
+      _state.compress(chunk)
+    }
+  }
+
+  @inline(__always)
+  mutating func combine(_ value: UInt8) {
+    let value = UInt64(truncatingIfNeeded: value)
+    if let chunk = _buffer.append(value, count: 1) {
+      _state.compress(chunk)
+    }
+  }
+
+  @inline(__always)
+  mutating func combine(bytes: UInt64, count: Int) {
+    precondition(count >= 0 && count < 8)
+    let count = UInt64(truncatingIfNeeded: count)
+    if let chunk = _buffer.append(bytes, count: count) {
+      _state.compress(chunk)
+    }
+  }
+
+  @inline(__always)
+  mutating func combine(bytes: UnsafeRawBufferPointer) {
+    var remaining = bytes.count
+    guard remaining > 0 else { return }
+    var data = bytes.baseAddress!
+
+    // Load first unaligned partial word of data
+    do {
+      let start = UInt(bitPattern: data)
+      let end = (start &+ 7) & ~7 // roundUp(start, toAlignment: MemoryLayout<UInt64>.alignment)
+      let c = min(remaining, Int(end &- start))
+      if c > 0 {
+        let chunk = _loadPartialUnalignedUInt64LE(data, byteCount: c)
+        combine(bytes: chunk, count: c)
+        data += c
+        remaining &-= c
+      }
+    }
+    precondition(
+      remaining == 0 ||
+      Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
+
+    // Load as many aligned words as there are in the input buffer
+    while remaining >= MemoryLayout<UInt64>.size {
+      combine(UInt64(littleEndian: data.load(as: UInt64.self)))
+      data += MemoryLayout<UInt64>.size
+      remaining &-= MemoryLayout<UInt64>.size
+    }
+
+    // Load last partial word of data
+    precondition(remaining >= 0 && remaining < 8)
+    if remaining > 0 {
+      let chunk = _loadPartialUnalignedUInt64LE(data, byteCount: remaining)
+      combine(bytes: chunk, count: remaining)
+    }
+  }
+
+  @inline(__always)
+  mutating func finalize() -> (UInt64, UInt64) {
+    return _state.finalize(tailAndByteCount: _buffer.value)
+  }
+}
+
+extension StableHasher {
+  struct _State {
+    // "somepseudorandomlygeneratedbytes"
+    private var v0: UInt64 = 0x736f6d6570736575
+    private var v1: UInt64 = 0x646f72616e646f6d
+    private var v2: UInt64 = 0x6c7967656e657261
+    private var v3: UInt64 = 0x7465646279746573
+
+    @inline(__always)
+    init(rawSeed: (UInt64, UInt64)) {
+      v3 ^= rawSeed.1
+      v2 ^= rawSeed.0
+      v1 ^= rawSeed.1
+      v0 ^= rawSeed.0
+
+      v1 ^= 0xee;
+    }
+  }
+}
+
+extension StableHasher._State {
+  @inline(__always)
+  init(seed: Int) {
+    self.init(rawSeed: (UInt64(truncatingIfNeeded: seed), 0))
+  }
+}
+
+extension StableHasher._State {
+  @inline(__always)
+  private static func _rotateLeft(_ x: UInt64, by amount: UInt64) -> UInt64 {
+    return (x &<< amount) | (x &>> (64 - amount))
+  }
+
+  @inline(__always)
+  private mutating func _round() {
+    v0 = v0 &+ v1
+    v1 = Self._rotateLeft(v1, by: 13)
+    v1 ^= v0
+    v0 = Self._rotateLeft(v0, by: 32)
+    v2 = v2 &+ v3
+    v3 = Self._rotateLeft(v3, by: 16)
+    v3 ^= v2
+    v0 = v0 &+ v3
+    v3 = Self._rotateLeft(v3, by: 21)
+    v3 ^= v0
+    v2 = v2 &+ v1
+    v1 = Self._rotateLeft(v1, by: 17)
+    v1 ^= v2
+    v2 = Self._rotateLeft(v2, by: 32)
+  }
+
+  @inline(__always)
+  private func _extract() -> UInt64 {
+    return v0 ^ v1 ^ v2 ^ v3
+  }
+}
+
+extension StableHasher._State {
+  @inline(__always)
+  mutating func compress(_ m: UInt64) {
+    v3 ^= m
+    _round()
+    v0 ^= m
+  }
+
+  @inline(__always)
+  mutating func finalize(tailAndByteCount: UInt64) -> (UInt64, UInt64) {
+    compress(tailAndByteCount)
+    v2 ^= 0xee
+    for _ in 0..<3 {
+      _round()
+    }
+    let h1 = _extract()
+
+    v1 ^= 0xdd
+    for _ in 0..<3 {
+      _round()
+    }
+    let h2 = _extract()
+
+    return (h1, h2)
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/StableHasher.swift
+++ b/lib/ASTGen/Sources/ASTGen/StableHasher.swift
@@ -131,12 +131,10 @@ struct StableHasher {
 
   @inline(__always)
   mutating func combine(_ value: UInt) {
-#if _pointerBitWidth(_64)
-    combine(UInt64(truncatingIfNeeded: value))
-#elseif _pointerBitWidth(_32)
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) // FIXME: Adopt _pointerBitWidth(_:).
     combine(UInt32(truncatingIfNeeded: value))
 #else
-#error("Unknown platform")
+    combine(UInt64(truncatingIfNeeded: value))
 #endif
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1198,8 +1198,11 @@ void ParserUnit::parse() {
   if (auto tokens = P.takeTokenReceiver()->finalize())
     tokensRef = ctx.AllocateCopy(*tokens);
 
-  auto result = SourceFileParsingResult{ctx.AllocateCopy(items), tokensRef,
-                                        P.CurrentTokenHash};
+  std::optional<Fingerprint> fp;
+  if (P.CurrentTokenHash)
+    fp = Fingerprint(std::move(*P.CurrentTokenHash));
+
+  auto result = SourceFileParsingResult{ctx.AllocateCopy(items), tokensRef, fp};
   ctx.evaluator.cacheOutput(ParseSourceFileRequest{&P.SF}, std::move(result));
 }
 


### PR DESCRIPTION
Added `StableHasher` in ASTGen. Mostly copied from `stdlib/public/core/Hasher.swift` and ``stdlib/public/core/SipHash.swift``

For now, interface hash / fingerprint are emitted during the AST generation, but it should really be a separate request. I will separate fingerprint things from `ParseSourceFileRequest` and `ParseMembersRequest` in followups

https://github.com/swiftlang/swift/issues/76527
rdar://117150870