### PR TITLE
[BitwiseCopyable] Fix resilient enum type info.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6838,6 +6838,14 @@ namespace {
                           IsABIAccessible_t abiAccessible)
       : EnumTypeInfoBase(strategy, irTy, copyable, abiAccessible) {}
   };
+
+  class BitwiseCopyableEnumTypeInfo
+      : public EnumTypeInfoBase<BitwiseCopyableTypeInfo> {
+  public:
+    BitwiseCopyableEnumTypeInfo(EnumImplStrategy &strategy, llvm::Type *irTy,
+                                IsABIAccessible_t abiAccessible)
+        : EnumTypeInfoBase(strategy, irTy, abiAccessible) {}
+  };
 } // end anonymous namespace
 
 const EnumImplStrategy &
@@ -7383,7 +7391,8 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
           KnownProtocolKind::BitwiseCopyable);
   if (bitwiseCopyableProtocol &&
       checkConformance(Type.getASTType(), bitwiseCopyableProtocol)) {
-    return BitwiseCopyableTypeInfo::create(enumTy, abiAccessible);
+    return registerEnumTypeInfo(
+        new BitwiseCopyableEnumTypeInfo(*this, enumTy, abiAccessible));
   }
   return registerEnumTypeInfo(
                        new ResilientEnumTypeInfo(*this, enumTy, cp,

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -136,6 +136,8 @@ class BitwiseCopyableTypeInfo
     : public WitnessSizedTypeInfo<BitwiseCopyableTypeInfo> {
   using Self = BitwiseCopyableTypeInfo;
   using Super = WitnessSizedTypeInfo<Self>;
+
+protected:
   BitwiseCopyableTypeInfo(llvm::Type *type, IsABIAccessible_t abiAccessible)
       : Super(type, Alignment(1), IsNotTriviallyDestroyable,
               IsNotBitwiseTakable, IsCopyable, abiAccessible) {}

--- a/test/IRGen/bitwise_copyable_resilient.swift
+++ b/test/IRGen/bitwise_copyable_resilient.swift
@@ -9,8 +9,14 @@
 // RUN:     -emit-module-path %t/Library.swiftmodule
 
 // RUN: %target-swift-frontend                           \
-// RUN:     %t/Downstream.swift                          \
+// RUN:     %t/DownstreamDiagnostics.swift               \
 // RUN:     -typecheck -verify                           \
+// RUN:     -debug-diagnostic-names                      \
+// RUN:     -I %t
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Downstream.swift                          \
+// RUN:     -emit-irgen                                  \
 // RUN:     -debug-diagnostic-names                      \
 // RUN:     -I %t
 
@@ -29,7 +35,14 @@ public struct Integer {
   var value: Int
 }
 
-//--- Downstream.swift
+public enum Int2: BitwiseCopyable {
+    case zero
+    case one
+    case two
+    case three
+}
+
+//--- DownstreamDiagnostics.swift
 import Library
 
 func take<T: BitwiseCopyable>(_ t: T) {}
@@ -51,3 +64,13 @@ func passWoopsional<T>(_ t: Woopsional<T>) { take(t) } // expected-error    {{ty
 
 extension Integer : @retroactive BitwiseCopyable {} // expected-error {{bitwise_copyable_outside_module}}
 
+struct S_Explicit_With_Int2 {
+  var i: Int2
+}
+
+//--- Downstream.swift
+import Library
+
+class C_With_Int2 {
+  let i = Int2.one
+}


### PR DESCRIPTION
Like other `EnumTypeInfo`s, the `TypeInfo` subclasses `EnumTypeInfoBase` and store the `EnumImplStrategy`.
