### PR TITLE
Add REQUIRES: aarch64 for dropped-var.sil test

### DIFF
--- a/test/DebugInfo/dropped-var.sil
+++ b/test/DebugInfo/dropped-var.sil
@@ -1,4 +1,5 @@
- // RUN: %target-sil-opt --diagnose-unreachable -o - %s -sil-stats-lost-variables 2>&1 | %FileCheck %s
+ // RUN: %target-sil-opt --diagnose-unreachable -o - %s -sil-stats-lost-variables --target=aarch64-apple-darwin 2>&1 | %FileCheck %s
+ // REQUIRES:CPU=aarch64
 
  // CHECK: function, lostvars, Pass List Pipeline, DiagnoseUnreachable, 1, 1, {{[0-9]+}}, $s4test3bar1yS2i_tF
 


### PR DESCRIPTION
rdar://141272451 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed: test: DebugInfo/dropped-var.sil (exit code 1))

The dropped-var.sil test fails on watchos-armv7k with the following error:

`SOURCE_DIR/test/DebugInfo/dropped-var.sil:36:43: error: value '%5' defined with mismatching type 'Builtin.Int32' (expected 'Builtin.Int64')`

This is not true on other architecture, so I am guarding the test with a REQUIRES:CPU=aarch64

https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/8009/consoleText