### PR TITLE
[cxx-interop] Fix spurious ambiguous member lookup

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -24,7 +24,6 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "clang/AST/Type.h"
-#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/TinyPtrVector.h"
 

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -146,10 +146,11 @@ struct ClangRecordMemberLookupDescriptor final {
 
   // Recursive lookup on inherited classes
   ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name,
-        clang::AccessSpecifier inheritance)
+                                    clang::AccessSpecifier inheritance)
       : recordDecl(recordDecl), name(name), inheritance(inheritance) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
-    assert(inheritance != clang::AS_none && "class inheritance should be specified");
+    assert(inheritance != clang::AS_none &&
+           "class inheritance should be specified");
   }
 
   friend llvm::hash_code

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -24,6 +24,7 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
@@ -135,10 +136,20 @@ private:
 struct ClangRecordMemberLookupDescriptor final {
   NominalTypeDecl *recordDecl;
   DeclName name;
+  clang::AccessSpecifier inheritance;
 
+  // Base case lookup on (most) derived class
   ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name)
-      : recordDecl(recordDecl), name(name) {
+      : recordDecl(recordDecl), name(name), inheritance(clang::AS_none) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
+  }
+
+  // Recursive lookup on inherited classes
+  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name,
+        clang::AccessSpecifier inheritance)
+      : recordDecl(recordDecl), name(name), inheritance(inheritance) {
+    assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
+    assert(inheritance != clang::AS_none && "class inheritance should be specified");
   }
 
   friend llvm::hash_code

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -136,21 +136,12 @@ private:
 struct ClangRecordMemberLookupDescriptor final {
   NominalTypeDecl *recordDecl;
   DeclName name;
-  clang::AccessSpecifier inheritance;
+  bool inherited;
 
-  // Base case lookup on (most) derived class
-  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name)
-      : recordDecl(recordDecl), name(name), inheritance(clang::AS_none) {
-    assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
-  }
-
-  // Recursive lookup on inherited classes
   ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name,
-                                    clang::AccessSpecifier inheritance)
-      : recordDecl(recordDecl), name(name), inheritance(inheritance) {
+                                    bool inherited = false)
+      : recordDecl(recordDecl), name(name), inherited(inherited) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
-    assert(inheritance != clang::AS_none &&
-           "class inheritance should be specified");
   }
 
   friend llvm::hash_code

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -63,8 +63,8 @@
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LangStandard.h"
 #include "clang/Basic/Module.h"
-#include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/Specifiers.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/CodeGen/ObjectFilePCHContainerOperations.h"
@@ -6202,7 +6202,9 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
         // Add Clang members that are imported lazily.
         auto baseResults = evaluateOrDefault(
             ctx.evaluator,
-            ClangRecordMemberLookup({cast<NominalTypeDecl>(import), name, baseAccess}), {});
+            ClangRecordMemberLookup(
+                {cast<NominalTypeDecl>(import), name, baseAccess}),
+            {});
         // Add members that are synthesized eagerly, such as subscripts.
         for (auto member :
              cast<NominalTypeDecl>(import)->getCurrentMembersWithoutLoading()) {
@@ -6226,7 +6228,8 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
           // some class's superclass. importBaseMemberDecl() caches synthesized
           // members, which does not work if we call it on its result, e.g.:
           //
-          //    importBaseMemberDecl(importBaseMemberDecl(foundInBase, recorDecl), recordDecl)
+          //    importBaseMemberDecl(importBaseMemberDecl(foundInBase,
+          //    recorDecl), recordDecl)
           //
           // Instead, we simply pass on the imported decl (foundInBase) as is,
           // so that only the top-most request calls importBaseMemberDecl().

--- a/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
@@ -1,0 +1,9 @@
+#pragma once
+
+struct Base1 {
+  int method(void) const { return 1; }
+};
+
+struct IBase1 : Base1 { };
+
+struct IIBase1 : IBase1 { };

--- a/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
@@ -1,9 +1,11 @@
 #pragma once
 
 struct Base1 {
-  int method(void) const { return 1; }
+  int methodBase(void) const { return 1; }
 };
 
-struct IBase1 : Base1 {};
+struct IBase1 : Base1 {
+  int methodIBase(void) const { return 11; }
+};
 
 struct IIBase1 : IBase1 {};

--- a/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
@@ -8,4 +8,6 @@ struct IBase1 : Base1 {
   int methodIBase(void) const { return 11; }
 };
 
-struct IIBase1 : IBase1 {};
+struct IIBase1 : IBase1 {
+  int methodIIBase(void) const { return 111; }
+};

--- a/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/inherited-lookup.h
@@ -4,6 +4,6 @@ struct Base1 {
   int method(void) const { return 1; }
 };
 
-struct IBase1 : Base1 { };
+struct IBase1 : Base1 {};
 
-struct IIBase1 : IBase1 { };
+struct IIBase1 : IBase1 {};

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -43,3 +43,8 @@ module FunctionsObjC {
   requires cplusplus
   requires objc
 }
+
+module InheritedLookup {
+  header "inherited-lookup.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/fields-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-irgen.swift
@@ -9,6 +9,6 @@ func testGetX() -> CInt {
 
 let _ = testGetX()
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{(.*)(30CopyTrackedDerivedDerivedClass33__synthesizedBaseGetterAccessor_x|__synthesizedBaseGetterAccessor_x@CopyTrackedDerivedDerivedClass)(.*)}}(ptr {{.*}} %[[THIS_PTR:.*]])
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
 // CHECK: %[[X:.*]] = getelementptr inbounds %class.CopyTrackedBaseClass, ptr %[[ADD_PTR]], i32 0, i32 0

--- a/test/Interop/Cxx/class/inheritance/fields-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-irgen.swift
@@ -9,6 +9,6 @@ func testGetX() -> CInt {
 
 let _ = testGetX()
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}__synthesizedBaseCall___synthesizedBaseGetterAccessor{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
-// CHECK: call{{.*}} i32 @{{.*}}__synthesizedBaseGetterAccessor{{.*}}(ptr {{.*}} %[[ADD_PTR]])
+// CHECK: %[[X:.*]] = getelementptr inbounds %class.CopyTrackedBaseClass, ptr %[[ADD_PTR]], i32 0, i32 0

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
@@ -10,6 +10,7 @@ InheritedMemberTestSuite.test("IIBase1::method() resolves to grandparent") {
   let iibase1 = IIBase1()
   expectEqual(iibase1.methodBase(), 1)
   expectEqual(iibase1.methodIBase(), 11)
+  expectEqual(iibase1.methodIIBase(), 111)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
@@ -8,7 +8,8 @@ var InheritedMemberTestSuite = TestSuite("Test if inherited lookup works")
 
 InheritedMemberTestSuite.test("IIBase1::method() resolves to grandparent") {
   let iibase1 = IIBase1()
-  expectEqual(iibase1.method(), 1)
+  expectEqual(iibase1.methodBase(), 1)
+  expectEqual(iibase1.methodIBase(), 11)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
@@ -1,0 +1,14 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+import InheritedLookup
+import StdlibUnittest
+
+var InheritedMemberTestSuite = TestSuite("Test if inherited lookup works")
+
+InheritedMemberTestSuite.test("IIBase1::method() resolves to grandparent") {
+  let iibase1 = IIBase1()
+  expectEqual(iibase1.method(), 1)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
@@ -12,6 +12,7 @@ extension IIBase1 {
         // the following to appear ambiguous:
         methodBase()
         methodIBase()
+        methodIIBase()
     }
 }
 
@@ -19,4 +20,5 @@ func f(v: IIBase1) {
     v.missing() // expected-error {{'IIBase1' has no member 'missing'}}
     v.methodBase()
     v.methodIBase()
+    v.methodIIBase()
 }

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
+import InheritedLookup
+
+extension IIBase1 {
+    func ext() {
+        // NOTE: we deliberately look up a missing member above because doing so
+        // forces multiple ClangRecordMemberLookup requests, which should be
+        // idempotent (though this hasn't always been the case, because bugs).
+        missing() // expected-error {{cannot find 'missing' in scope}}
+
+        // For instance, a non-idempotent ClangRecordMemberLookup would cause
+        // the following to appear ambiguous:
+        method()
+    }
+}
+
+func f(v: IIBase1) {
+    v.missing() // expected-error {{'IIBase1' has no member 'missing'}}
+    v.method()
+}

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-typechecker.swift
@@ -10,11 +10,13 @@ extension IIBase1 {
 
         // For instance, a non-idempotent ClangRecordMemberLookup would cause
         // the following to appear ambiguous:
-        method()
+        methodBase()
+        methodIBase()
     }
 }
 
 func f(v: IIBase1) {
     v.missing() // expected-error {{'IIBase1' has no member 'missing'}}
-    v.method()
+    v.methodBase()
+    v.methodIBase()
 }

--- a/test/Interop/Cxx/class/inheritance/subscript-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/subscript-irgen.swift
@@ -9,6 +9,6 @@ func testGetX() -> CInt {
 
 let _ = testGetX()
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}__synthesizedBaseCall___synthesizedBaseCall_operatorSubscript{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]], i32 {{.*}})
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}39__synthesizedBaseCall_operatorSubscript{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]], i32 {{.*}})
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
-// CHECK: call{{.*}} i32 @{{.*}}__synthesizedBaseCall_operatorSubscript{{.*}}(ptr {{.*}} %[[ADD_PTR]], i32 {{.*}})
+// CHECK: %[[CALL:.*]] = call {{.*}} i32 @{{.*}}20CopyTrackedBaseClass{{.*}}(ptr {{.*}} %[[ADD_PTR]], i32 {{.*}})

--- a/test/Interop/Cxx/class/inheritance/subscript-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/subscript-irgen.swift
@@ -9,6 +9,6 @@ func testGetX() -> CInt {
 
 let _ = testGetX()
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}39__synthesizedBaseCall_operatorSubscript{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]], i32 {{.*}})
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{(.*)(30CopyTrackedDerivedDerivedClass39__synthesizedBaseCall_operatorSubscript|__synthesizedBaseCall_operatorSubscript@CopyTrackedDerivedDerivedClass)(.*)}}(ptr {{.*}} %[[THIS_PTR:.*]], i32 {{.*}})
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
-// CHECK: %[[CALL:.*]] = call {{.*}} i32 @{{.*}}20CopyTrackedBaseClass{{.*}}(ptr {{.*}} %[[ADD_PTR]], i32 {{.*}})
+// CHECK: %[[CALL:.*]] = call {{.*}} i32 @{{.*}}CopyTrackedBaseClass{{.*}}(ptr {{.*}} %[[ADD_PTR]], i32 {{.*}})

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -17,14 +17,10 @@ func testSetX(_ x: CInt) {
 
 testSetX(2)
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseCall___synthesizedBaseGetterAccessor{{.*}}
-
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseCall___synthesizedBaseSetterAccessor{{.*}}
-
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseGetterAccessor{{.*}}
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}}
 // CHECK: %[[VPTR:.*]] = getelementptr inbounds %struct.NonCopyableHolder
 // CHECK: ret ptr %[[VPTR]]
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseSetterAccessor{{.*}}
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseSetterAccessor_x{{.*}}
 // CHECK: %[[VPTRS:.*]] = getelementptr inbounds %struct.NonCopyableHolder
 // CHECK: ret ptr %[[VPTRS]]

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -17,10 +17,10 @@ func testSetX(_ x: CInt) {
 
 testSetX(2)
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}}
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{(.*)(31NonCopyableHolderDerivedDerived*33__synthesizedBaseGetterAccessor_x|__synthesizedBaseGetterAccessor_x@NonCopyableHolderDerivedDerived)(.*)}}
 // CHECK: %[[VPTR:.*]] = getelementptr inbounds %struct.NonCopyableHolder
 // CHECK: ret ptr %[[VPTR]]
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseSetterAccessor_x{{.*}}
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{(.*)(31NonCopyableHolderDerivedDerived33__synthesizedBaseSetterAccessor_x|__synthesizedBaseSetterAccessor_x@NonCopyableHolderDerivedDerived)(.*)}}
 // CHECK: %[[VPTRS:.*]] = getelementptr inbounds %struct.NonCopyableHolder
 // CHECK: ret ptr %[[VPTRS]]

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -26,8 +26,8 @@ testSetX(2)
 
 // CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvlu : $@convention(method) (@{{(in_)?}}guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
 // CHECK: {{.*}}(%[[SELF_VAL:.*]] : ${{(\*)?}}NonCopyableHolderDerivedDerived):
-// CHECK: function_ref @{{.*}}__synthesizedBaseCall___synthesizedBaseGetterAccessor{{.*}} : $@convention(cxx_method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
+// CHECK: function_ref @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}} : $@convention(cxx_method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
 // CHECK-NEXT: apply %{{.*}}
 
 // CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvau : $@convention(method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>
-// CHECK: function_ref @{{.*}}__synthesizedBaseCall___synthesizedBaseSetterAccessor{{.*}} : $@convention(cxx_method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>
+// CHECK: function_ref @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseSetterAccessor_x{{.*}} : $@convention(cxx_method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -26,8 +26,8 @@ testSetX(2)
 
 // CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvlu : $@convention(method) (@{{(in_)?}}guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
 // CHECK: {{.*}}(%[[SELF_VAL:.*]] : ${{(\*)?}}NonCopyableHolderDerivedDerived):
-// CHECK: function_ref @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseGetterAccessor_x{{.*}} : $@convention(cxx_method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
+// CHECK: function_ref @{{(.*)(31NonCopyableHolderDerivedDerived33__synthesizedBaseGetterAccessor_x|__synthesizedBaseGetterAccessor_x@NonCopyableHolderDerivedDerived)(.*)}} : $@convention(cxx_method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
 // CHECK-NEXT: apply %{{.*}}
 
 // CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvau : $@convention(method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>
-// CHECK: function_ref @{{.*}}31NonCopyableHolderDerivedDerived{{.*}}33__synthesizedBaseSetterAccessor_x{{.*}} : $@convention(cxx_method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>
+// CHECK: function_ref @{{(.*)(31NonCopyableHolderDerivedDerived33__synthesizedBaseSetterAccessor_x|__synthesizedBaseSetterAccessor_x@NonCopyableHolderDerivedDerived)(.*)}} : $@convention(cxx_method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>

--- a/test/Interop/Cxx/foreign-reference/function-inheritance-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/function-inheritance-irgen.swift
@@ -10,6 +10,6 @@ func testGetX() -> CInt {
 let _ = testGetX()
 
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}26__synthesizedBaseCall_getX{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{(.*)(30CopyTrackedDerivedDerivedClass26__synthesizedBaseCall_getX|__synthesizedBaseCall_getX@CopyTrackedDerivedDerivedClass)(.*)}}(ptr {{.*}} %[[THIS_PTR:.*]])
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
 // CHECK: call{{.*}} i32 @{{.*}}(ptr {{.*}} %[[ADD_PTR]])

--- a/test/Interop/Cxx/foreign-reference/function-inheritance-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/function-inheritance-irgen.swift
@@ -10,6 +10,6 @@ func testGetX() -> CInt {
 let _ = testGetX()
 
 
-// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}__synthesizedBaseCall___synthesizedBaseCall_{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
+// CHECK: define {{.*}}linkonce_odr{{.*}} i32 @{{.*}}30CopyTrackedDerivedDerivedClass{{.*}}26__synthesizedBaseCall_getX{{.*}}(ptr {{.*}} %[[THIS_PTR:.*]])
 // CHECK: %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i{{32|64}} 4
 // CHECK: call{{.*}} i32 @{{.*}}(ptr {{.*}} %[[ADD_PTR]])


### PR DESCRIPTION
Nested calls to `importBaseMemberDecl()` subvert its cache and compromise its idempotence, causing the semantic checker to spuriously report ambiguous member lookups when multiple `ClangRecordMemberLookup` requests are made (e.g., because of an unrelated missing member lookup).

One such scenario is documented in the test case I checked into the test suite in f818a5d72a595c90bf2f3672960081ed495f6f7e, which fails without this fix (in particular, `inherited-lookup-typechecker.swift` fails because of the expected error from the `missing` member; `inherited-lookup-executable.swift` works because it does not attempt to access a `missing` member).

I noticed this bug in #77726 when I found that my `expected-error`s seemed to be triggering this unrelated error. I'm breaking out a small piece of that PR because (1) it is getting quite large, (2) it is getting stale, and (3) I am trying to separate this bug fix from that feature work.

rdar://141069984