### PR TITLE
Runtime: control `swiftCore_EXPORTS` based on the build

### DIFF
--- a/Runtimes/Core/Demangling/CMakeLists.txt
+++ b/Runtimes/Core/Demangling/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(swiftDemangling OBJECT
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/Errors.cpp")
-target_compile_definitions(swiftDemangling PRIVATE swiftCore_EXPORTS
+target_compile_definitions(swiftDemangling PRIVATE
+  $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
   $<$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>:-DSWIFT_SUPPORT_OLD_MANGLING>
   $<$<BOOL:${SwiftCore_ENABLE_TYPE_PRINTING}>:-DSWIFT_STDLIB_HAS_TYPE_PRINTING>
   $<$<BOOL:${SwiftCore_ENABLE_CRASH_REPORTER_CLIENT}>:-DSWIFT_HAVE_CRASHREPORTERCLIENT>)

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -306,7 +306,7 @@ target_compile_definitions(swiftCore PRIVATE
   $<$<BOOL:${SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS}>:-DSWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER>
   $<$<COMPILE_LANGUAGE:C,CX>:-DSWIFT_TARGET_LIBRARY_NAME=swiftCore>)
 target_compile_options(swiftCore PRIVATE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DswiftCore_EXPORTS>")
+  "$<$<AND:$<BOOL:${BUILD_SHARED_LIBS}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xcc -DswiftCore_EXPORTS>")
 
 target_link_libraries(swiftCore PRIVATE swiftShims)
 target_link_libraries(swiftCore

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -76,9 +76,9 @@ endif()
 #       file rather than pushing them through macro flags.
 target_compile_definitions(swiftRuntime
   PRIVATE
-    -DswiftCore_EXPORTS
     -DSWIFT_RUNTIME
     -DSWIFT_TARGET_LIBRARY_NAME=swiftRuntime
+    $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
     $<$<BOOL:${SwiftCore_ENABLE_BACKTRACING}>:-DSWIFT_ENABLE_BACKTRACING>
     $<$<BOOL:${SwiftCore_ENABLE_OVERRIDABLE_RETAIN_RELEASE}>:-DSWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE>
     $<$<BOOL:${SwiftCore_ENABLE_MALLOC_TYPE}>:-DSWIFT_STDLIB_HAS_MALLOC_TYPE>

--- a/Runtimes/Core/stubs/CMakeLists.txt
+++ b/Runtimes/Core/stubs/CMakeLists.txt
@@ -27,8 +27,10 @@ endif()
 
 
 target_compile_definitions(swiftStdlibStubs PRIVATE
-  swiftCore_EXPORTS
+  $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
   $<$<BOOL:${SwiftCore_ENABLE_UNICODE_DATA}>:-DSWIFT_STDLIB_ENABLE_UNICODE_DATA>)
+
+
 target_link_libraries(swiftStdlibStubs PRIVATE swiftShims)
 target_include_directories(swiftStdlibStubs PRIVATE
   "${PROJECT_BINARY_DIR}/include"


### PR DESCRIPTION
This define is meant to be present only when performing a build of a dynamic library. The general pattern for this is:

```c
#if defined(LIBRARY_STATIC)
# define LIBRARY_ABI /**/
#else
# if defined(_WIN32)
#   if defined(LIBRARY_EXPORTS)
#     define LIBRARY_ABI __declspec(dllexport)
#   else
#     define LIBRARY_ABI __declspec(dllimport)
#   endif
# elseif defined(__linux__) && !defined(__ANDROID__)
#   define LIBRARY_ABI __attribute__((__visibility__("protected")))
# else
#   define LIBRARY_ABI __attribute__((__visibility__("default")))
# endif
#endif
```

For AIX this would require an additional flag to be specified (`-mdefault-visibility-export-mapping=explicit`). The same applies for other non-AIX, non-Windows platforms with a different set of flags: `-fvisibility=hidden -fvisibility-inlines-hidden`.

This is required to start trying to build the standard library statically on Windows (which also requires further changes to the Swift compiler).