### PR TITLE
[CMake] Fix some issues in new runtime build for Linux and Windows builds

### DIFF
--- a/Runtimes/Core/cmake/modules/DefaultSettings.cmake
+++ b/Runtimes/Core/cmake/modules/DefaultSettings.cmake
@@ -28,7 +28,7 @@ endmacro()
 # If no such default variable exists, the variable is not created.
 macro(defaulted_set variable type helptext)
   if(DEFINED ${variable}_default)
-    set(${variable} ${variable}_default CACHE ${type} ${helptext})
+    set(${variable} ${${variable}_default} CACHE ${type} ${helptext})
   endif()
 endmacro()
 

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -108,10 +108,12 @@ if(SwiftCore_ENABLE_BACKTRACING)
     CrashHandlerLinux.cpp)
 endif()
 
+target_sources(swiftRuntime PRIVATE
+  ErrorObject.mm
+  SwiftObject.mm)
+
 if(SwiftCore_ENABLE_OBJC_INTEROP)
   target_sources(swiftRuntime PRIVATE
-    ErrorObject.mm
-    SwiftObject.mm
     SwiftValue.mm
     ReflectionMirrorObjC.mm
     ObjCRuntimeGetImageNameFromClass.mm)


### PR DESCRIPTION
Fixing some issues in the runtime build. The defaulted settings were not set right.
Also, not all of the ObjC files are actually ObjC or part of the ObjC interop. We need to build ErrorObject.mm and SwiftObject.mm as part of all builds or things don't link.