### PR TITLE
[6.1][ClangImporter] Share CASOptions when cloning CompilerInstance

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2007,6 +2007,9 @@ ClangImporter::cloneCompilerInstanceForPrecompiling() {
   if (FrontendOpts.CASIncludeTreeID.empty())
     FrontendOpts.Inputs.clear();
 
+  // Share the CASOption and the underlying CAS.
+  invocation->setCASOption(Impl.Invocation->getCASOptsPtr());
+
   auto clonedInstance = std::make_unique<clang::CompilerInstance>(
     Impl.Instance->getPCHContainerOperations(),
     &Impl.Instance->getModuleCache());

--- a/test/CAS/cached_diagnostics_pcm.swift
+++ b/test/CAS/cached_diagnostics_pcm.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -I %t \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -module-load-mode prefer-serialized
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-MISS
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: cache miss for input
+// CHECK: <module-includes>:1
+// CHECK-SAME: note: in file included from <module-includes>:1:
+// CHECK: warning: warning a.h
+// CACHE-HIT: remark: replay output file
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
+// RUN:   -emit-module -o %t/test.swiftmodule
+
+//--- module.modulemap
+module A {
+  header "a.h"
+  export *
+}
+
+//--- a.h
+#warning warning a.h
+
+//--- test.swift
+import A


### PR DESCRIPTION
  - **Explanation**: When cloning the clang instance in ClangImporter to perform tasks like PCM/PCH compilation, make two compiler instance to share the same CASOptions so they can share the CAS ObjectStore and life time.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: This fixes a case where clang emits a diagnostics in a source buffer that gets mapped in via CAS, and mapped into swift source manager. While CAS has the ownship from CompilerInvocation -> CASOptions -> CAS, if the CompilerInvocation is deleted when the cloned instance is deleted, it left an invalid buffer in the swift source manager.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://141284501
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78138
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: UnitTest added
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @Xazax-hun 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
