### PR TITLE
runtime: use `_strdup` on Windows

### DIFF
--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -84,7 +84,11 @@ private:
   static char *getCString(char *str) { return str; }
 
   static char *getCString(const std::string &str) {
+#if defined(_WIN32)
+    return _strdup(str.c_str());
+#else
     return strdup(str.c_str());
+#endif
   }
 
 public:

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -330,7 +330,11 @@ reportOnCrash(uint32_t flags, const char *message)
     if (previous)
       swift_asprintf(&current, "%s%s", current, message);
     else
+#if defined(_WIN32)
+      current = ::_strdup(message);
+#else
       current = ::strdup(message);
+#endif
   } while (!std::atomic_compare_exchange_strong_explicit(&kFatalErrorMessage,
                                                          &previous,
                                                          static_cast<const char *>(current),

--- a/stdlib/public/runtime/SymbolInfo.cpp
+++ b/stdlib/public/runtime/SymbolInfo.cpp
@@ -115,7 +115,7 @@ static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
       if (pwszFileName != wszBuffer)
         ::free(pwszFileName);
 
-      return { ::strdup("<unknown>"), mi.lpBaseOfDll };
+      return { ::_strdup("<unknown>"), mi.lpBaseOfDll };
     }
 
     const char *result = _swift_win32_copyUTF8FromWide(pwszFileName);
@@ -125,7 +125,7 @@ static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
 
     return { result, mi.lpBaseOfDll };
   } else {
-    return { ::strdup("<unknown>"), nullptr };
+    return { ::_strdup("<unknown>"), nullptr };
   }
 }
 #endif
@@ -156,7 +156,7 @@ std::optional<SymbolInfo> SymbolInfo::lookup(const void *address) {
 
   if (bRet) {
     return SymbolInfo((const void *)package.si.Address,
-                      ::strdup(package.si.Name),
+                      ::_strdup(package.si.Name),
                       moduleInfo.name,
                       moduleInfo.base);
   } else {

--- a/stdlib/public/runtime/SymbolInfo.h
+++ b/stdlib/public/runtime/SymbolInfo.h
@@ -64,8 +64,8 @@ private:
 
   void initializeFrom(const SymbolInfo &other) {
     _symbolAddress = other._symbolAddress;
-    _symbolName = ::strdup(other._symbolName);
-    _moduleFileName = ::strdup(other._moduleFileName);
+    _symbolName = ::_strdup(other._symbolName);
+    _moduleFileName = ::_strdup(other._moduleFileName);
     _moduleBaseAddress = other._moduleBaseAddress;
   }
 


### PR DESCRIPTION
Windows prefers the `_strdup` extension over `strdup`. This avoids unnecessary warnings when building the standard library.