### PR TITLE
runtime: address a declaration FIXME

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -59,18 +59,6 @@ struct YieldOnceResult {
   ResultTy YieldValue;
 };
 
-template <class FnTy>
-struct YieldOnceCoroutine;
-
-/// A template which generates the type of the ramp function of a
-/// yield-once coroutine.
-template <class ResultTy, class... ArgTys>
-struct YieldOnceCoroutine<ResultTy(ArgTys...)> {
-  using type =
-    SWIFT_CC(swift) YieldOnceResult<ResultTy> (YieldOnceBuffer *buffer,
-                                               ArgTys...);
-};
-
 #if SWIFT_OBJC_INTEROP
 
   // Const cast shorthands for ObjC types.
@@ -1012,33 +1000,29 @@ const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type
 SWIFT_RUNTIME_EXPORT
 const HeapObject *swift_getKeyPath(const void *pattern, const void *arguments);
 
-// For some reason, MSVC doesn't accept these declarations outside of
-// swiftCore.  TODO: figure out a reasonable way to declare them.
-#if defined(swiftCore_EXPORTS)
-
 /// Given a pointer to a borrowed value of type `Root` and a
 /// `KeyPath<Root, Value>`, project a pointer to a borrowed value of type
 /// `Value`.
-SWIFT_RUNTIME_EXPORT
-YieldOnceCoroutine<const OpaqueValue* (const OpaqueValue *root,
-                                       void *keyPath)>::type
-swift_readAtKeyPath;
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+YieldOnceResult<const OpaqueValue *>
+swift_readAtKeyPath(YieldOnceBuffer *buffer, const OpaqueValue *root,
+                    void *keypath);
 
 /// Given a pointer to a mutable value of type `Root` and a
 /// `WritableKeyPath<Root, Value>`, project a pointer to a mutable value
 /// of type `Value`.
-SWIFT_RUNTIME_EXPORT
-YieldOnceCoroutine<OpaqueValue* (OpaqueValue *root, void *keyPath)>::type
-swift_modifyAtWritableKeyPath;
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+YieldOnceResult<OpaqueValue *>
+swift_modifyAtWritableKeyPath(YieldOnceBuffer *buffer, OpaqueValue *root,
+                              void *keyPath);
 
 /// Given a pointer to a borrowed value of type `Root` and a
 /// `ReferenceWritableKeyPath<Root, Value>`, project a pointer to a
 /// mutable value of type `Value`.
-SWIFT_RUNTIME_EXPORT
-YieldOnceCoroutine<OpaqueValue* (const OpaqueValue *root, void *keyPath)>::type
-swift_modifyAtReferenceWritableKeyPath;
-
-#endif // swiftCore_EXPORTS
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+YieldOnceResult<OpaqueValue *>
+swift_modifyAtReferenceWritableKeyPath(YieldOnceBuffer *buffer,
+                                       const OpaqueValue *root, void *keyPath);
 
 SWIFT_RUNTIME_EXPORT
 void swift_enableDynamicReplacementScope(const DynamicReplacementScope *scope);


### PR DESCRIPTION
Adjust the declarations to match the definitions and then remove the conditional declaration which was marked with a FIXME. This allows building the runtime without warnings in the new Runtimes build.