### PR TITLE
Core: check for `-mcx16` flag

### DIFF
--- a/Runtimes/Core/cmake/modules/CompilerSettings.cmake
+++ b/Runtimes/Core/cmake/modules/CompilerSettings.cmake
@@ -44,3 +44,8 @@ HAVE_SWIFT_ASYNC_CALL)
 if(NOT HAVE_SWIFT_ASYNC_CALL)
   message(SEND_ERROR "CXX Compiler must support Swift async calling conventions")
 endif()
+
+check_compiler_flag(CXX "-mcx16" HAVE_CXX_MCX16)
+if(HAVE_CXX_MCX16)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-mcx16>)
+endif()


### PR DESCRIPTION
The Swift runtime requires the CMPXCHG16B ISA extension on x86. This is controlled by the `-mcx16` flag when targeting the CPU baseline that we use. Add a check and pass along the flag to repair the build.