### PR TITLE
[embedded] Include and use cxxshims in the embedded/ resource dir

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -574,7 +574,7 @@ void importer::getNormalInvocationArguments(
   }
 
   if (LangOpts.EnableCXXInterop) {
-    if (auto path = getCxxShimModuleMapPath(searchPathOpts, triple)) {
+    if (auto path = getCxxShimModuleMapPath(searchPathOpts, LangOpts, triple)) {
       invocationArgStrs.push_back((Twine("-fmodule-map-file=") + *path).str());
     }
   }

--- a/lib/ClangImporter/ClangIncludePaths.h
+++ b/lib/ClangImporter/ClangIncludePaths.h
@@ -18,7 +18,8 @@
 namespace swift {
 
 std::optional<SmallString<128>>
-getCxxShimModuleMapPath(SearchPathOptions &opts, const llvm::Triple &triple);
+getCxxShimModuleMapPath(SearchPathOptions &opts, const LangOptions &langOpts,
+                        const llvm::Triple &triple);
 
 } // namespace swift
 

--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -67,6 +67,27 @@ foreach(sdk ${SWIFT_SDKS})
   endif()
 endforeach()
 
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  set(module_dir "${SWIFTLIB_DIR}/embedded")
+  add_custom_command(OUTPUT ${module_dir}
+                     COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir}")
+  set(outputs)
+  foreach(source libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h)
+    add_custom_command(OUTPUT ${module_dir}/${source}
+                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
+                       COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir}/${source}"
+                       COMMENT "Copying ${source} to ${module_dir}")
+    list(APPEND outputs "${module_dir}/${source}")
+  endforeach()
+  add_custom_target(cxxshim-embedded ALL
+                    DEPENDS ${outputs}
+                    COMMENT "Copying cxxshims to ${module_dir}")
+  list(APPEND libcxxshim_modulemap_target_list cxxshim-embedded)
+  swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
+                             DESTINATION "lib/swift/embedded"
+                             COMPONENT compiler)
+endif()
+
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})
 set_property(TARGET libcxxshim_modulemap PROPERTY FOLDER "Miscellaneous")
 add_dependencies(sdk-overlay libcxxshim_modulemap)

--- a/test/embedded/cxxshim.swift
+++ b/test/embedded/cxxshim.swift
@@ -3,9 +3,12 @@
 
 // RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
 
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
 // BEGIN header.h
 
-// C++
 struct Base { int field; };
 struct Derived : Base {};
 

--- a/test/embedded/cxxshim.swift
+++ b/test/embedded/cxxshim.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
+
+// BEGIN header.h
+
+// C++
+struct Base { int field; };
+struct Derived : Base {};
+
+// BEGIN module.modulemap
+
+module MyModule {
+  header "header.h"
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+public func foo() {
+  var d = Derived()
+  d.field = 123
+}
+
+foo()


### PR DESCRIPTION
We did not have the libcxxshim.h and the modulemap in the embedded/ resource dir (only in macos/, etc.) previously. This should resolve compiler crashes when we need to emit calls to `__swift_interopStaticCast` while in Embedded Swift mode.

Attached testcase without this fix crashes the compiler with:
```
Assertion failed: (wrapperModule && "CxxShim module is required when using members of a base class. " "Make sure you `import CxxShim`."), function getInteropStaticCastDeclRefExpr, file ClangImporter.cpp, line 5205.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
```
