### PR TITLE
Suppress strict safety diagnostics in `@unsafe` declarations

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -86,6 +86,10 @@ public:
   /// Returns true if this context is `@_unavailableInEmbedded`.
   bool isUnavailableInEmbedded() const;
 
+  /// Returns true if this context allows the use of unsafe constructs inside
+  /// it.
+  bool allowsUnsafe() const;
+
   /// Constrain with another `AvailabilityContext`.
   void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);
 

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -43,6 +43,10 @@ struct AvailabilityContext::PlatformInfo {
   /// platform.
   unsigned IsDeprecated : 1;
 
+  /// Whether or not the context allows unsafe code within it, e.g., via the
+  /// `@unsafe` attribute.
+  unsigned AllowsUnsafe: 1;
+
   /// Sets each field to the value of the corresponding field in `other` if the
   /// other is more restrictive. Returns true if any field changed as a result
   /// of adding this constraint.
@@ -63,6 +67,7 @@ struct AvailabilityContext::PlatformInfo {
     ID.AddBoolean(IsUnavailableInEmbedded);
     ID.AddInteger(static_cast<uint8_t>(UnavailablePlatform));
     ID.AddBoolean(IsDeprecated);
+    ID.AddBoolean(AllowsUnsafe);
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1191,6 +1191,10 @@ public:
   /// used in a "safe" dialect.
   bool isUnsafe() const;
 
+  /// Whether this declaration explicitly states that it is allowed to contain
+  /// unsafe code.
+  bool allowsUnsafe() const;
+
 private:
   bool isUnsafeComputed() const {
     return Bits.Decl.IsUnsafeComputed;
@@ -1908,6 +1912,7 @@ class ExtensionDecl final : public GenericContext, public Decl,
   friend class Decl;
 public:
   using Decl::getASTContext;
+  using Decl::allowsUnsafe;
 
   /// Create a new extension declaration.
   static ExtensionDecl *create(ASTContext &ctx, SourceLoc extensionLoc,
@@ -3380,6 +3385,7 @@ public:
   using DeclContext::operator new;
   using DeclContext::operator delete;
   using TypeDecl::getDeclaredInterfaceType;
+  using Decl::allowsUnsafe;
 
   static bool classof(const DeclContext *C) {
     if (auto D = C->getAsDecl())

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -504,7 +504,7 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
   159)
 
 SIMPLE_DECL_ATTR(unsafe, Unsafe,
-  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType | OnExtension |
   UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   160)

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -713,6 +713,10 @@ public:
   /// target. Used for conformance lookup disambiguation.
   bool isAlwaysAvailableConformanceContext() const;
 
+  /// Determines whether this context is explicitly allowed to use unsafe
+  /// constructs.
+  bool allowsUnsafe() const;
+
   /// \returns true if traversal was aborted, false otherwise.
   bool walkContext(ASTWalker &Walker);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8091,6 +8091,15 @@ GROUPED_WARNING(reference_to_unsafe_typed_decl,Unsafe,none,
       (bool, const ValueDecl *, Type))
 NOTE(unsafe_decl_here,none,
      "unsafe %kindbase0 declared here", (const ValueDecl *))
+NOTE(make_enclosing_context_unsafe,none,
+     "mark the enclosing %kindbase0 '@unsafe' to allow it to use unsafe constructs",
+     (const Decl *))
+NOTE(make_subclass_unsafe,none,
+     "mark the class %0 '@unsafe' to allow unsafe overrides of safe superclass methods",
+     (DeclName))
+NOTE(make_conforming_context_unsafe,none,
+     "mark the enclosing %0 with '@unsafe' to allow unsafe conformance to protocol %1",
+     (DescriptiveDeclKind, DeclName))
 
 //===----------------------------------------------------------------------===//
 // MARK: Value Generics

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -241,6 +241,9 @@ void AvailabilityContext::print(llvm::raw_ostream &os) const {
 
   if (isDeprecated())
     os << " deprecated";
+
+  if (allowsUnsafe())
+    os << " allows_unsafe";
 }
 
 void AvailabilityContext::dump() const { print(llvm::errs()); }

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -46,6 +46,7 @@ bool AvailabilityContext::PlatformInfo::constrainWith(
         CONSTRAIN_BOOL(IsUnavailableInEmbedded, other.IsUnavailableInEmbedded);
   }
   isConstrained |= CONSTRAIN_BOOL(IsDeprecated, other.IsDeprecated);
+  isConstrained |= CONSTRAIN_BOOL(AllowsUnsafe, other.AllowsUnsafe);
 
   return isConstrained;
 }
@@ -63,6 +64,7 @@ bool AvailabilityContext::PlatformInfo::constrainWith(const Decl *decl) {
   }
 
   isConstrained |= CONSTRAIN_BOOL(IsDeprecated, decl->isDeprecated());
+  isConstrained |= CONSTRAIN_BOOL(AllowsUnsafe, decl->allowsUnsafe());
 
   return isConstrained;
 }
@@ -128,7 +130,8 @@ AvailabilityContext::forPlatformRange(const AvailabilityRange &range,
   PlatformInfo platformInfo{range, PlatformKind::none,
                             /*IsUnavailable*/ false,
                             /*IsUnavailableInEmbedded*/ false,
-                            /*IsDeprecated*/ false};
+                            /*IsDeprecated*/ false,
+                            /*AllowsUnsafe*/ false};
   return AvailabilityContext(Storage::get(platformInfo, ctx));
 }
 
@@ -151,7 +154,8 @@ AvailabilityContext::get(const AvailabilityRange &platformAvailability,
                                 ? *unavailablePlatform
                                 : PlatformKind::none,
                             unavailablePlatform.has_value(),
-                            /*IsUnavailableInEmbedded*/ false, deprecated};
+                            /*IsUnavailableInEmbedded*/ false, deprecated,
+                            /*AllowsUnsafe*/ false};
   return AvailabilityContext(Storage::get(platformInfo, ctx));
 }
 
@@ -168,6 +172,10 @@ AvailabilityContext::getUnavailablePlatformKind() const {
 
 bool AvailabilityContext::isUnavailableInEmbedded() const {
   return Info->Platform.IsUnavailableInEmbedded;
+}
+
+bool AvailabilityContext::allowsUnsafe() const {
+  return Info->Platform.AllowsUnsafe;
 }
 
 bool AvailabilityContext::isDeprecated() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1079,6 +1079,10 @@ bool Decl::isUnsafe() const {
       false);
 }
 
+bool Decl::allowsUnsafe() const {
+  return isUnsafe();
+}
+
 Type AbstractFunctionDecl::getThrownInterfaceType() const {
   if (!getThrownTypeRepr())
     return ThrownType.getType();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1549,3 +1549,10 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
 
   return deploymentTarget.isContainedIn(conformanceAvailability);
 }
+
+bool DeclContext::allowsUnsafe() const {
+  if (auto decl = getAsDecl())
+    return decl->allowsUnsafe();
+
+  return false;
+}

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -366,9 +366,11 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
     diagnoseUnsafeType(ctx,
                        loc,
                        type,
+                       conformance->getDeclContext(),
                        [&](Type specificType) {
       ctx.Diags.diagnose(
           loc, diag::type_witness_unsafe, specificType, assocType->getName());
+      suggestUnsafeMarkerOnConformance(conformance);
       assocType->diagnose(diag::decl_declared_here, assocType);
     });
   }

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -240,6 +240,10 @@ bool witnessHasImplementsAttrForRequiredName(ValueDecl *witness,
 bool witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
                                                  ValueDecl *requirement);
 
+/// Suggest that the context of the given conformance be marked to suppress
+/// warnings about uses of unsafe constructs.
+void suggestUnsafeMarkerOnConformance(NormalProtocolConformance *conformance);
+
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -24,6 +24,7 @@
 namespace swift {
 
 class ASTContext;
+class AvailabilityContext;
 class QualifiedIdentTypeRepr;
 class TypeRepr;
 class PackElementTypeRepr;
@@ -750,6 +751,13 @@ bool diagnoseMissingOwnership(ParamSpecifier ownership,
 /// If the given type involves an unsafe type, diagnose it by calling the
 /// diagnose function with the most specific unsafe type that can be provided.
 void diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+                        AvailabilityContext availability,
+                        llvm::function_ref<void(Type)> diagnose);
+
+/// If the given type involves an unsafe type, diagnose it by calling the
+/// diagnose function with the most specific unsafe type that can be provided.
+void diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+                        const DeclContext *dc,
                         llvm::function_ref<void(Type)> diagnose);
 
 } // end namespace swift

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -55,16 +55,20 @@ struct MyContainer {
 import Test
 import CoreFoundation
 
+// expected-note@+1{{mark the enclosing global function 'useUnsafeParam' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 func useUnsafeParam(x: Unannotated) { // expected-warning{{reference to unsafe struct 'Unannotated'}}
 }
 
+// expected-note@+2{{mark the enclosing global function 'useUnsafeParam2' '@unsafe' to allow it to use unsafe constructs}}{{10:1-1=@unsafe }}
 @available(SwiftStdlib 5.8, *)
 func useUnsafeParam2(x: UnsafeReference) { // expected-warning{{reference to unsafe class 'UnsafeReference'}}
 }
 
+// expected-note@+1{{mark the enclosing global function 'useUnsafeParam3' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-warning{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
 }
 
+// expected-note@+1{{mark the enclosing global function 'useSafeParams' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer) {
     let _ = c.__beginUnsafe() // expected-warning{{call to unsafe instance method '__beginUnsafe'}}
 }

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -1,0 +1,111 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -print-diagnostic-groups
+
+// Make sure everything compiles without error when unsafe code is allowed.
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute -warnings-as-errors %s
+
+// REQUIRES: swift_feature_AllowUnsafeAttribute
+// REQUIRES: swift_feature_WarnUnsafe
+
+@unsafe
+func iAmUnsafe() { }
+
+@unsafe
+struct UnsafeType { } // expected-note{{unsafe struct 'UnsafeType' declared here}}
+
+// expected-warning@+1{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+func iAmImpliedUnsafe() -> UnsafeType? { nil }
+// expected-note@-1{{mark the enclosing global function 'iAmImpliedUnsafe' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
+
+@unsafe
+func labeledUnsafe(_: UnsafeType) {
+  iAmUnsafe()
+  let _ = iAmImpliedUnsafe()
+}
+
+
+class C {
+  func method() { } // expected-note{{overridden declaration is here}}
+}
+
+class D1: C { // expected-note{{mark the class 'D1' '@unsafe' to allow unsafe overrides of safe superclass methods}}{{1-1=@unsafe }}
+  @unsafe
+  override func method() { } // expected-warning{{override of safe instance method with unsafe instance method [Unsafe]}}
+}
+
+@unsafe class D2: C {
+  @unsafe // do not diagnose
+  override func method() { }
+}
+
+protocol P {
+  func protoMethod()
+}
+
+struct S1: P {
+  // expected-note@-1{{mark the enclosing struct with '@unsafe' to allow unsafe conformance to protocol 'P'}}{{1-1=@unsafe }}
+  @unsafe
+  func protoMethod() { } // expected-warning{{unsafe instance method 'protoMethod()' cannot satisfy safe requirement}}
+}
+
+@unsafe
+struct S2: P {
+  @unsafe // okay
+  func protoMethod() { }
+}
+
+struct S3 { }
+
+extension S3: P {
+  // expected-note@-1{{mark the enclosing extension with '@unsafe' to allow unsafe conformance to protocol 'P'}}{{1-1=@unsafe }}
+  @unsafe
+  func protoMethod() { } // expected-warning{{unsafe instance method 'protoMethod()' cannot satisfy safe requirement}}
+}
+
+struct S4 { }
+
+@unsafe
+extension S4: P {
+  @unsafe
+  func protoMethod() { } // okay
+}
+
+
+@unsafe
+class SendableC1: @unchecked Sendable { }
+
+class SendableC2 { }
+
+@unsafe
+extension SendableC2: @unchecked Sendable { }
+
+
+struct Wrapper {
+  @unsafe
+  unowned(unsafe) var reference: C
+}
+
+@_nonSendable
+class NonSendable { }
+
+@unsafe nonisolated(unsafe) var notSendable: NonSendable = .init() // okay
+
+
+@unsafe
+struct UnsafeOuter { // expected-note{{unsafe struct 'UnsafeOuter' declared here}}
+  func f(_: UnsafeType) { } // okay
+
+  @unsafe func g(_ y: UnsafeType) {
+    let x: UnsafeType = y
+    let _ = x
+  }
+}
+
+// expected-note@+1{{mark the enclosing extension of struct 'UnsafeOuter' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
+extension UnsafeOuter { // expected-warning{{reference to unsafe struct 'UnsafeOuter' [Unsafe]}}
+  func h(_: UnsafeType) { }
+}
+
+@unsafe
+extension UnsafeOuter {
+  func i(_: UnsafeType) { }
+}

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -20,6 +20,7 @@ protocol P {
 }
 
 struct XP: P {
+  // expected-note@-1{{mark the enclosing struct with '@unsafe' to allow unsafe conformance to protocol 'P'}}{{1-1=@unsafe }}
   @unsafe func f() { } // expected-warning{{unsafe instance method 'f()' cannot satisfy safe requirement [Unsafe]}}
   @unsafe func g() { }
 }
@@ -33,17 +34,18 @@ protocol Ptrable2 {
 }
 
 extension HasAPointerType: Ptrable2 { } // expected-warning{{unsafe type 'HasAPointerType.Ptr' (aka 'PointerType') cannot satisfy safe associated type 'Ptr'}}
+  // expected-note@-1{{mark the enclosing extension with '@unsafe' to allow unsafe conformance to protocol 'Ptrable2'}}{{1-1=@unsafe }}
 
 // -----------------------------------------------------------------------
 // Overrides
 // -----------------------------------------------------------------------
 class Super {
-  func f() { }
+  func f() { } // expected-note{{overridden declaration is here}}
   @unsafe func g() { }
 }
 
-class Sub: Super {
-  @unsafe override func f() { }
+class Sub: Super { // expected-note{{mark the class 'Sub' '@unsafe' to allow unsafe overrides of safe superclass methods}}{{1-1=@unsafe }}
+  @unsafe override func f() { } // expected-warning{{override of safe instance method with unsafe instance method [Unsafe]}}
   @unsafe override func g() { }  
 }
 
@@ -53,23 +55,26 @@ class Sub: Super {
 struct SuperHolder {
   unowned var s1: Super
   unowned(unsafe) var s2: Super // expected-warning{{unowned(unsafe) involves unsafe code}}
+  // expected-note@-1{{mark the enclosing property 's2' '@unsafe' to allow it to use unsafe constructs}}{{3-3=@unsafe }}
 }
 
 // -----------------------------------------------------------------------
 // Inheritance of @unsafe
 // -----------------------------------------------------------------------
 @unsafe class UnsafeSuper { // expected-note 3{{'UnsafeSuper' declared here}}
-  func f() { } // expected-note{{'f()' declared here}}
+  func f() { } // expected-note{{unsafe instance method 'f' declared here}}
 };
 
 class UnsafeSub: UnsafeSuper { } // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
+// expected-note@-1{{mark the enclosing class 'UnsafeSub' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 
 // -----------------------------------------------------------------------
 // Declaration references
 // -----------------------------------------------------------------------
-@unsafe func unsafeF() { } // expected-note{{'unsafeF()' declared here}}
+@unsafe func unsafeF() { } // expected-note{{unsafe global function 'unsafeF' declared here}}
 @unsafe var unsafeVar: Int = 0 // expected-note{{'unsafeVar' declared here}}
 
+// expected-note@+1 7{{mark the enclosing global function 'testMe' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 func testMe(
   _ pointer: PointerType, // expected-warning{{reference to unsafe struct 'PointerType'}}
   _ unsafeSuper: UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper'}}

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -5,14 +5,16 @@
 // REQUIRES: swift_feature_StrictConcurrency
 // REQUIRES: swift_feature_WarnUnsafe
 
-// expected-warning@+1{{@unchecked conformance involves unsafe code}}
+// expected-warning@+2{{@unchecked conformance involves unsafe code}}
+// expected-note@+1{{mark the enclosing class with '@unsafe' to allow unsafe conformance to protocol 'Sendable'}}{{1-1=@unsafe }}
 class C: @unchecked Sendable {
   var counter: Int = 0
 }
 
 @available(SwiftStdlib 5.1, *)
 func f() async {
-  // expected-warning@+1{{nonisolated(unsafe) involves unsafe code}}
+  // expected-warning@+2{{nonisolated(unsafe) involves unsafe code}}
+  // expected-note@+1{{mark the enclosing var 'counter' '@unsafe' to allow it to use unsafe constructs}}
   nonisolated(unsafe) var counter = 0
   Task.detached {
     counter += 1

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -5,6 +5,7 @@
 
 import unsafe_decls
 
+// expected-note@+1 3{{mark the enclosing global function 'testUnsafe' '@unsafe' to allow it to use unsafe constructs}}
 func testUnsafe(_ ut: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType'}}
   unsafe_c_function() // expected-warning{{call to unsafe global function 'unsafe_c_function'}}
 

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -6,6 +6,7 @@
 // REQUIRES: swift_feature_AllowUnsafeAttribute
 // REQUIRES: swift_feature_WarnUnsafe
 
+// expected-note@+1 4{{mark the enclosing global function 'test' '@unsafe' to allow it to use unsafe constructs}}{{1-1=@unsafe }}
 func test(
   x: OpaquePointer, // expected-warning{{reference to unsafe struct 'OpaquePointer'}}
   other: UnsafeMutablePointer<Int> // expected-warning{{reference to unsafe generic struct 'UnsafeMutablePointer'}}


### PR DESCRIPTION
When a declaration is `@unsafe`, don't emit strict safety diagnostics for uses of unsafe entities, constructs, or types within it. This allows one to account for all unsafe behavior in a module using strict memory safety by marking the appropriate declarations `@unsafe`.

Enhance the strict-safety diagnostics to suggest the addition of `@unsafe` where it is needed to suppress them, with a Fix-It. Ensure that all such diagnostics can be suppressed via `@unsafe` so it's possible to get to the above state.

Also includes a drive-by bug fix where we weren't diagnosing unsafe methods overriding safe ones in some cases.

Fixes rdar://139467327.
