### PR TITLE
runtime: add missing linked library

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -89,7 +89,8 @@ target_include_directories(swiftRuntime PRIVATE
   "${PROJECT_BINARY_DIR}/include"
   "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(swiftRuntime PRIVATE swiftShims)
+target_link_libraries(swiftRuntime PRIVATE
+  swiftShims)
 
 # FIXME: Refactor so that we're not pulling sources from the compiler files
 target_sources(swiftRuntime PRIVATE

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -90,6 +90,7 @@ target_include_directories(swiftRuntime PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(swiftRuntime PRIVATE
+  $<$<PLATFORM_ID:Windows>:User32>
   swiftShims)
 
 # FIXME: Refactor so that we're not pulling sources from the compiler files

--- a/Runtimes/Core/stubs/CMakeLists.txt
+++ b/Runtimes/Core/stubs/CMakeLists.txt
@@ -30,8 +30,9 @@ target_compile_definitions(swiftStdlibStubs PRIVATE
   $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
   $<$<BOOL:${SwiftCore_ENABLE_UNICODE_DATA}>:-DSWIFT_STDLIB_ENABLE_UNICODE_DATA>)
 
+target_link_libraries(swiftStdlibStubs PRIVATE
+  swiftShims)
 
-target_link_libraries(swiftStdlibStubs PRIVATE swiftShims)
 target_include_directories(swiftStdlibStubs PRIVATE
   "${PROJECT_BINARY_DIR}/include"
   # FIXME: pulls in headers from the main compiler build


### PR DESCRIPTION
This depends on #78133. Once merged, this can be rebased.

The runtime uses functions from User32 and needs to link against it to
fulfill that dependency.