### PR TITLE
CapturePropagation: handle keypaths which are upcast.

### DIFF
--- a/test/SILOptimizer/capture_propagate_keypath.swift
+++ b/test/SILOptimizer/capture_propagate_keypath.swift
@@ -28,7 +28,14 @@ struct GenStr<T> {
   }
 }
 
+struct GetID<C: RandomAccessCollection, ID> {
+  var getID: (C.Element) -> ID
 
+  @inline(__always)
+  init(id: KeyPath<C.Element, ID>) {
+    getID = { $0[keyPath: id] }
+  }
+}
 
 // CHECK-LABEL: sil {{.*}} @$s4test0A6SimpleyyySiAA3StrVXEXEF :
 // CHECK-NOT:     keypath
@@ -49,6 +56,14 @@ func testGenStr(_ mymap: ((GenStr<Int>)->Int) -> ()) {
   mymap(\.j)
   mymap(\.c)
 }
+
+// CHECK-LABEL: sil {{.*}} @$s4test0A22GenericEscapingClosureAA5GetIDVySayAA3StrVGSiGyF :
+// CHECK-NOT:     keypath
+// CHECK-LABEL:  } // end sil function '$s4test0A22GenericEscapingClosureAA5GetIDVySayAA3StrVGSiGyF'
+@inline(never)
+func testGenericEscapingClosure() -> GetID<[Str], Int> {
+    GetID(id: \.i)
+} 
 
 // CHECK-LABEL: sil {{.*}} @$s4test0A7GenericyyyxAA6GenStrVyxGXEXElF :
 // CHECK:         keypath
@@ -103,6 +118,11 @@ func calltests() {
     print(c(s))
   }
 
+  // CHECK-OUTPUT-LABEL: testGenericEscapingClosure:
+  print("testGenericEscapingClosure:")
+
+  // CHECK-OUTPUT-NEXT:  27
+  print(testGenericEscapingClosure().getID(Str()))
 }
 
 calltests()

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -530,6 +530,23 @@ bb0:
   return %7 : $()
 }
 
+// CHECK-LABEL: sil @testCastKeypath :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function 'testCastKeypath'
+sil @testCastKeypath : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $WritableKeyPath<Str, Int>, (root $Str; stored_property #Str.a : $Int)
+  %c = upcast %0 to $KeyPath<Str, Int>
+  %1 = function_ref @closureWithKeypath : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %2 = partial_apply [callee_guaranteed] %1(%c) : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %3 = convert_escape_to_noescape %2 : $@callee_guaranteed (Str) -> Int to $@noescape @callee_guaranteed (Str) -> Int
+  %4 = function_ref @calleeWithKeypath : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  strong_release %2 : $@callee_guaranteed (Str) -> Int
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: sil shared @$s18closureWithKeypath{{.*}}main3StrVSiTf3npk_n : $@convention(thin) (Str) -> Int {
 // CHECK:         [[K:%[0-9]+]] = keypath
 // CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
@@ -557,6 +574,24 @@ bb0:
   %0 = keypath $KeyPath<Str, Int>, (root $Str; stored_property #Str.a : $Int)
   %1 = function_ref @closureWithKeypathOSSA : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
   %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %3 = convert_escape_to_noescape %2 : $@callee_guaranteed (Str) -> Int to $@noescape @callee_guaranteed (Str) -> Int
+  %4 = function_ref @calleeWithKeypath : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  destroy_value %3 : $@noescape @callee_guaranteed (Str) -> Int
+  destroy_value %2 : $@callee_guaranteed (Str) -> Int
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testCastKeypathOSSA :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function 'testCastKeypathOSSA'
+sil [ossa] @testCastKeypathOSSA : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $WritableKeyPath<Str, Int>, (root $Str; stored_property #Str.a : $Int)
+  %c = upcast %0 to $KeyPath<Str, Int>
+  %1 = function_ref @closureWithKeypathOSSA : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %2 = partial_apply [callee_guaranteed] %1(%c) : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
   %3 = convert_escape_to_noescape %2 : $@callee_guaranteed (Str) -> Int to $@noescape @callee_guaranteed (Str) -> Int
   %4 = function_ref @calleeWithKeypath : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
   %5 = apply %4(%3) : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()


### PR DESCRIPTION
Deal with upcast instructions which cast keypath instructions before they are passed to a partial_apply.

rdar://141370412
