### PR TITLE
[cxx-interop] Fix memory layout for structs with out-of-order base types

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -2029,6 +2029,17 @@ public:
 /// Workaround to disable thumb-mode until debugger support is there.
 bool shouldRemoveTargetFeature(StringRef);
 
+struct CXXBaseRecordLayout {
+  const clang::CXXRecordDecl *decl;
+  Size offset;
+  Size size;
+};
+
+/// Retrieves the base classes of a C++ struct/class ordered by their offset in
+/// the derived type's memory layout.
+SmallVector<CXXBaseRecordLayout, 1>
+getBasesAndOffsets(const clang::CXXRecordDecl *decl);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -132,3 +132,27 @@ struct DerivedHasTailPadding : public BaseAlign8 {
 struct DerivedUsesBaseTailPadding : public DerivedHasTailPadding {
   short field2 = 789;
 }; // sizeof=16, dsize=14, align=8
+
+// MARK: Types with an out-of-order inheritance.
+
+struct BaseWithVirtualDestructor {
+  int baseField = 123;
+
+  virtual ~BaseWithVirtualDestructor() {}
+};
+
+struct DerivedWithVirtualDestructor : public BaseWithVirtualDestructor {
+  int derivedField = 456;
+
+  ~DerivedWithVirtualDestructor() override {}
+};
+
+struct DerivedOutOfOrder : public HasOneField,
+                           public DerivedWithVirtualDestructor {
+  // DerivedWithVirtualDestructor is the primary base class despite being the
+  // second one the list.
+
+  int leafField = 789;
+
+  ~DerivedOutOfOrder() override {}
+};

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -124,4 +124,11 @@ FieldsTestSuite.test("Field in tail padding of base class") {
   expectEqual(usesBaseTailPadding.field8, 123)
 }
 
+FieldsTestSuite.test("Out-of-order inheritance") {
+  let d = DerivedOutOfOrder()
+  expectEqual(d.leafField, 789)
+  expectEqual(d.derivedField, 456)
+  expectEqual(d.baseField, 123)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -27,3 +27,44 @@ public:
     SubT(const SubT &) = delete;
     static SubT &getSubT() { static SubT singleton; return singleton; }
 };
+
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+BaseWithVirtualDestructor {
+    int baseField = 123;
+
+    BaseWithVirtualDestructor() {}
+    virtual ~BaseWithVirtualDestructor() {}
+};
+
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+DerivedWithVirtualDestructor : public BaseWithVirtualDestructor {
+    int derivedField = 456;
+
+    DerivedWithVirtualDestructor() : BaseWithVirtualDestructor() {}
+    ~DerivedWithVirtualDestructor() override {}
+};
+
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+DerivedOutOfOrder : public BaseT, public DerivedWithVirtualDestructor {
+    // DerivedWithVirtualDestructor is the primary base class despite being the
+    // second one the list.
+
+    int leafField = 789; 
+
+    DerivedOutOfOrder() = default;
+    ~DerivedOutOfOrder() override {}
+
+    static DerivedOutOfOrder& getInstance() {
+      static DerivedOutOfOrder singleton;
+      return singleton;
+    }
+};

--- a/test/Interop/Cxx/foreign-reference/inheritance-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-irgen.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions -disable-availability-checking
+
+// This ensured we do not crash during IRGen for inherited C++ foreign reference types.
+
+import Inheritance
+
+@inline(never)
+public func blackHole<T>(_ _: T) {}
+
+let x = DerivedOutOfOrder.getInstance()
+
+blackHole(x.baseField)
+blackHole(x.derivedField)
+blackHole(x.leafField)

--- a/test/Interop/Cxx/foreign-reference/inheritance-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-typechecker.swift
@@ -21,3 +21,8 @@ let b: BaseT = BaseT.getBaseT()
 assert(b.isBase)
 let bc: BaseT = cxxCast(b)      // should instantiate I and O both to BaseT
 assert(bc.isBase)
+
+let d = DerivedOutOfOrder.getInstance()
+let _ = d.baseField
+let _ = d.derivedField
+let _ = d.leafField

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -30,4 +30,11 @@ TemplatingTestSuite.test("BaseT") {
     expectTrue(bc.isBase)
 }
 
+TemplatingTestSuite.test("DerivedOutOfOrder") {
+    let d = DerivedOutOfOrder.getInstance()
+    expectEqual(123, d.baseField)
+    expectEqual(456, d.derivedField)
+    expectEqual(789, d.leafField)
+}
+
 runAllTests()


### PR DESCRIPTION
In C++, a primary base class that is placed in the beginning of the type's memory layout isn't always the type that is the first in the list of bases – the base types might be laid out in memory in a different order.

This makes sure that IRGen handles base types of C++ structs in the correct order.

This fixes an assertion in asserts-enabled compilers, and an out-of-memory error in asserts-disabled compilers. The issue was happening for both value types and foreign reference types. This change also includes a small refactoring to reuse the logic between the two code paths.

rdar://140848603