### PR TITLE
AST: simplify debug flag computation

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -33,6 +33,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -697,24 +698,21 @@ public:
   std::string getDebugFlags(StringRef PrivateDiscriminator,
                             bool EnableCXXInterop,
                             bool EnableEmbeddedSwift) const {
-    std::string Flags = DebugFlags;
-    if (!PrivateDiscriminator.empty()) {
-      if (!Flags.empty())
-        Flags += " ";
-      Flags += ("-private-discriminator " + PrivateDiscriminator).str();
-    }
-    if (EnableCXXInterop) {
-      if (!Flags.empty())
-        Flags += " ";
-      Flags += "-enable-experimental-cxx-interop";
-    }
-    if (EnableEmbeddedSwift) {
-      if (!Flags.empty())
-        Flags += " ";
-      Flags += "-enable-embedded-swift";
-    }
+    llvm::SmallVector<std::string, 4> Flags{DebugFlags};
 
-    return Flags;
+    if (!PrivateDiscriminator.empty()) {
+      Flags.emplace_back("-private-discriminator");
+      Flags.emplace_back(PrivateDiscriminator);
+    }
+    if (EnableCXXInterop)
+      Flags.emplace_back("-enable-experimental-cxx-interop");
+    if (EnableEmbeddedSwift)
+      Flags.emplace_back("-enable-embedded-swift");
+
+    std::ostringstream buffer;
+    std::copy(std::begin(Flags), std::end(Flags),
+              std::ostream_iterator<std::string>(buffer, " "));
+    return buffer.str();
   }
 
   /// Return a hash code of any components from these options that should


### PR DESCRIPTION
Use an algorithmic approach to string concatenation rather than building the space delimited string manually. This allows us to extend the flags embedding more easily in the future.