### PR TITLE
Add @safe(unchecked) to allow unsafe code within a declaration's body

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2837,6 +2837,26 @@ public:
   UNIMPLEMENTED_CLONE(RawLayoutAttr)
 };
 
+class SafeAttr final : public DeclAttribute {
+public:
+  /// The optional message.
+  const StringRef message;
+
+  SafeAttr(SourceLoc atLoc, SourceRange range, StringRef message,
+           bool isImplicit = false)
+      : DeclAttribute(DeclAttrKind::Safe, atLoc, range, isImplicit),
+        message(message) { }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::Safe;
+  }
+
+  /// Create a copy of this attribute.
+  SafeAttr *clone(ASTContext &ctx) const {
+    return new (ctx) SafeAttr(AtLoc, Range, message, isImplicit());
+  }
+};
+
 class LifetimeAttr final : public DeclAttribute {
   LifetimeEntry *entry;
 

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -106,6 +106,9 @@ public:
   constrainWithDeclAndPlatformRange(const Decl *decl,
                                     const AvailabilityRange &platformRange);
 
+  /// Constrain to allow unsafe code.
+  void constrainWithAllowsUnsafe(ASTContext &ctx);
+
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const AvailabilityContext other) const;
 

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -504,8 +504,8 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
   159)
 
 SIMPLE_DECL_ATTR(unsafe, Unsafe,
-  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType | OnExtension |
-  UserInaccessible |
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
+  OnExtension | OnTypeAlias | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   160)
 
@@ -517,7 +517,13 @@ SIMPLE_DECL_ATTR(_addressableSelf, AddressableSelf,
   OnAccessor | OnConstructor | OnFunc | OnSubscript | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | UserInaccessible,
   162)
 
-LAST_DECL_ATTR(AddressableSelf)
+DECL_ATTR(safe, Safe,
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
+  OnExtension | OnTypeAlias | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  163)
+
+LAST_DECL_ATTR(Safe)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2106,6 +2106,9 @@ ERROR(parser_new_parser_errors,none,
       "new Swift parser generated errors for code that C++ parser accepted",
        ())
 
+ERROR(safe_attr_unchecked,none,
+      "'@safe' attribute must be written as '@safe(unchecked)'", ())
+
 // MARK: Reference Binding Diagnostics
 ERROR(sil_markuncheckedreferencebinding_requires_attribute,none,
       "mark_unchecked_reference_binding requires an attribute like [inout]", ())

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4116,6 +4116,11 @@ public:
     }
     printFoot();
   }
+  void visitSafeAttr(SafeAttr *Attr, StringRef label) {
+    printCommon(Attr, "safe_attr", label);
+    printFieldQuoted(Attr->message, "message");
+    printFoot();
+  }
   void visitSILGenNameAttr(SILGenNameAttr *Attr, StringRef label) {
     printCommon(Attr, "silgen_name_attr", label);
     printFlag(Attr->Raw, "raw");

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1715,7 +1715,8 @@ StringRef DeclAttribute::getAttrName() const {
     AccessLevel access = cast<AbstractAccessControlAttr>(this)->getAccess();
     return getAccessLevelSpelling(access);
   }
-
+  case DeclAttrKind::Safe:
+    return "safe";
   case DeclAttrKind::SPIAccessControl:
     return "_spi";
   case DeclAttrKind::ReferenceOwnership:

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -194,6 +194,15 @@ void AvailabilityContext::constrainWithDecl(const Decl *decl) {
   constrainWithDeclAndPlatformRange(decl, AvailabilityRange::alwaysAvailable());
 }
 
+void AvailabilityContext::constrainWithAllowsUnsafe(ASTContext &ctx) {
+  if (allowsUnsafe())
+    return;
+
+  PlatformInfo platformInfo{Info->Platform};
+  platformInfo.AllowsUnsafe = true;
+  Info = Storage::get(platformInfo, ctx);
+}
+
 void AvailabilityContext::constrainWithPlatformRange(
     const AvailabilityRange &platformRange, ASTContext &ctx) {
   PlatformInfo platformAvailability{Info->Platform};

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1080,7 +1080,7 @@ bool Decl::isUnsafe() const {
 }
 
 bool Decl::allowsUnsafe() const {
-  return isUnsafe();
+  return getAttrs().hasAttribute<SafeAttr>() || isUnsafe();
 }
 
 Type AbstractFunctionDecl::getThrownInterfaceType() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1080,7 +1080,7 @@ bool Decl::isUnsafe() const {
 }
 
 bool Decl::allowsUnsafe() const {
-  return getAttrs().hasAttribute<SafeAttr>() || isUnsafe();
+  return isUnsafe();
 }
 
 Type AbstractFunctionDecl::getThrownInterfaceType() const {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -164,6 +164,8 @@ extension ASTGenVisitor {
         return handle(self.generateProjectedValuePropertyAttr(attribute: node)?.asDeclAttribute)
       case .rawLayout:
         fatalError("unimplemented")
+      case .safe:
+        fatalError("unimplemented")
       case .section:
         return handle(self.generateSectionAttr(attribute: node)?.asDeclAttribute)
       case .semantics:

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -387,6 +387,7 @@ public:
   void visitWeakLinkedAttr(WeakLinkedAttr *attr);
   void visitSILGenNameAttr(SILGenNameAttr *attr);
   void visitUnsafeAttr(UnsafeAttr *attr);
+  void visitSafeAttr(SafeAttr *attr);
   void visitLifetimeAttr(LifetimeAttr *attr);
   void visitAddressableSelfAttr(AddressableSelfAttr *attr);
 };
@@ -7769,6 +7770,13 @@ void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {
 }
 
 void AttributeChecker::visitUnsafeAttr(UnsafeAttr *attr) {
+  if (Ctx.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
+    return;
+
+  diagnoseAndRemoveAttr(attr, diag::unsafe_attr_disabled);
+}
+
+void AttributeChecker::visitSafeAttr(SafeAttr *attr) {
   if (Ctx.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
     return;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4058,6 +4058,9 @@ private:
 
 static void suggestUnsafeOnEnclosingDecl(
     SourceRange referenceRange, const DeclContext *referenceDC) {
+  if (referenceRange.isInvalid())
+    return;
+
   ASTContext &ctx = referenceDC->getASTContext();
   std::optional<ASTNode> versionCheckNode;
   const Decl *memberLevelDecl = nullptr;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1737,6 +1737,7 @@ namespace  {
     UNINTERESTING_ATTR(Lifetime)
     UNINTERESTING_ATTR(AddressableSelf)
     UNINTERESTING_ATTR(Unsafe)
+    UNINTERESTING_ATTR(Safe)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6308,6 +6308,15 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::Safe_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::SafeDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) SafeAttr(SourceLoc(), SourceRange(), blobData,
+                                  isImplicit);
+        break;
+      }
+
       case decls_block::MacroRole_DECL_ATTR: {
         bool isImplicit;
         uint8_t rawMacroSyntax;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2271,6 +2271,12 @@ namespace decls_block {
                      BCArray<BCFixed<1>> // concatenated param indices
                      >;
 
+  using SafeDeclAttrLayout = BCRecordLayout<
+    Safe_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // message
+  >;
+
   using AbstractClosureExprLayout = BCRecordLayout<
     ABSTRACT_CLOSURE_EXPR_CONTEXT,
     TypeIDField, // type

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3376,6 +3376,15 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::Safe: {
+      auto *theAttr = cast<SafeAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[SafeDeclAttrLayout::Code];
+      SafeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                     theAttr->isImplicit(),
+                                     theAttr->message);
+      return;
+    }
+
     case DeclAttrKind::MacroRole: {
       auto *theAttr = cast<MacroRoleAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[MacroRoleDeclAttrLayout::Code];

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -print-diagnostic-groups
+
+// REQUIRES: swift_feature_AllowUnsafeAttribute
+// REQUIRES: swift_feature_WarnUnsafe
+
+@unsafe
+func unsafeFunction() { }
+
+@unsafe
+struct UnsafeType { } // expected-note{{unsafe struct 'UnsafeType' declared here}}
+
+@safe(unchecked)
+func f() {
+  unsafeFunction()
+}
+
+@safe(unchecked, message: "I was careful")
+func g() {
+  unsafeFunction()
+}
+
+// expected-note@+2{{mark the enclosing global function 'h' '@unsafe' to allow it to use unsafe constructs}}
+@safe(unchecked, message: "I was careful")
+func h(_: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+  unsafeFunction()
+}
+
+// Parsing issues
+@safe // expected-error{{expected '(' in 'safe' attribute}}
+func bad1() { }
+
+@safe() // expected-error{{'@safe' attribute must be written as '@safe(unchecked)'}}
+func bad2() { }
+
+@safe(blah) // expected-error{{'@safe' attribute must be written as '@safe(unchecked)'}}
+func bad3() { }
+
+@safe(5) // expected-error{{'@safe' attribute must be written as '@safe(unchecked)'}}
+func bad4() { }
+
+@safe(unchecked, blah) // expected-error{{unknown option 'blah' for attribute 'safe'}}
+func bad5() { }
+
+@safe(unchecked, message) // expected-error{{expected ':' after label 'message'}}
+func bad6() { }
+
+@safe(unchecked, message: "a\(b)") // expected-error{{message cannot be an interpolated string literal}}
+func bad7() { }


### PR DESCRIPTION
Introduce an attribute to allow unsafe code within the annotated declaration's body without presenting an unsafe interface to users. This is, by its nature, and unsafe construct, and is used to document where unsafe behavior is encapsulated in safe constructs.

There is an optional message that can be used as part of an audit trail.