### PR TITLE
runtime: avoid the toolchain Swift registrar

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -318,6 +318,8 @@ target_link_libraries(swiftCore
     swiftDemangling
     swiftStdlibStubs
     swiftThreading)
+target_link_options(swiftCore PRIVATE
+  -nostartfiles)
 if(NOT POLICY CMP0157)
   target_compile_options(swiftCore PRIVATE
     $<TARGET_OBJECTS:swiftRuntime>


### PR DESCRIPTION
Pass `-nostartfiles` to the driver as a staged toolchain would attempt to link the Swift registrar which may not exist if the SDK is not integrated. Furthermore, the registrar to be used is locally built and not the one from the previous build.