### PR TITLE
[OSSACompleteLifetime] Recurse into scoped addresses.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -134,6 +134,7 @@ public:
 
 protected:
   bool analyzeAndUpdateLifetime(SILValue value, Boundary boundary);
+  bool analyzeAndUpdateLifetime(ScopedAddressValue value, Boundary boundary);
 };
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -62,6 +62,8 @@ sil [ossa] @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStr
 sil [ossa] @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
 sil [ossa] @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
 sil [ossa] @take_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+sil @get : $@convention(thin) () -> @owned FakeOptional<Klass>
+sil @use : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 
 ///////////
 // Tests //
@@ -1486,4 +1488,64 @@ bb1:
   dealloc_stack %1 : $*FakeOptional<Klass>
   %t = tuple ()
   return %t : $()
+}
+
+// Ensure no verification failure
+sil [ossa] @test_store_enum_value_in_multiple_locs1 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @get : $@convention(thin) () -> @owned FakeOptional<Klass>
+  %1 = apply %0() : $@convention(thin) () -> @owned FakeOptional<Klass>
+  %2 = begin_borrow [lexical] %1
+  cond_br undef, bb2, bb1
+
+bb1:
+  br bb3
+
+bb2:
+  %5 = alloc_stack [lexical] $FakeOptional<Klass>
+  %6 = store_borrow %2 to %5
+  cond_br undef, bb8, bb9
+
+bb3:
+  cond_br undef, bb5, bb4
+
+bb4:
+  unreachable
+
+bb5:
+  %11 = alloc_stack $FakeOptional<Klass>
+  %12 = store_borrow %2 to %11
+  %14 = load_borrow %12
+  %15 = begin_borrow [lexical] %14
+  %16 = alloc_stack $FakeOptional<Klass>
+  %17 = store_borrow %15 to %16
+  cond_br undef, bb6, bb7
+
+bb6:
+  fix_lifetime %17
+  end_borrow %17
+  dealloc_stack %16
+  end_borrow %15
+  end_borrow %14
+  end_borrow %12
+  dealloc_stack %11
+  end_borrow %2
+  destroy_value %1
+  %29 = tuple ()
+  return %29
+
+bb7:
+  end_borrow %17
+  dealloc_stack %16
+  unreachable
+
+bb8:
+  end_borrow %6
+  dealloc_stack %5
+  unreachable
+
+bb9:
+  end_borrow %6
+  dealloc_stack %5
+  br bb3
 }

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -817,6 +817,90 @@ die:
   unreachable
 }
 
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_store_borrow_1: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_store_borrow_1 : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[TOKEN]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_borrow [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_store_borrow_1'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_store_borrow_1: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_store_borrow_1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %token availability"
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr
+  %load = load_borrow %token
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_borrow %token
+  dealloc_stack %addr
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_store_borrow_2: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_store_borrow_2 : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[TOKEN]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_borrow [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_store_borrow_2'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_store_borrow_2: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_store_borrow_2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %token availability"
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr
+  %load = load_borrow %token
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_borrow %token
+  dealloc_stack %addr
+  %retval = tuple ()
+  return %retval : $()
+die:
+  end_borrow %borrow
+  end_borrow %load
+  unreachable
+}
+
+sil [ossa] @load_borrow_1 : $@convention(thin) (@in_guaranteed C) -> () {
+entry(%addr : $*C):
+  specify_test "ossa_lifetime_completion %load availability"
+  %load = load_borrow %addr
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
 // CHECK-LABEL: begin running test {{.*}} on begin_access: ossa_lifetime_completion
 // CHECK-LABEL: sil [ossa] @begin_access : {{.*}} {
 // CHECK:         [[TOKEN:%[^,]+]] = begin_access
@@ -836,6 +920,37 @@ entry(%instance : @guaranteed $C):
 exit:
   end_access %access : $*C
   dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_begin_access: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_begin_access : {{.*}} {
+// CHECK:         [[ACCESS:%[^,]+]] = begin_access
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[ACCESS]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_access [[ACCESS]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_begin_access'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_begin_access: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_begin_access : $@convention(thin) (@in_guaranteed C) -> () {
+entry(%addr : $*C):
+  specify_test "ossa_lifetime_completion %access availability"
+  %access = begin_access [static] [read] %addr : $*C
+  %load = load_borrow %access
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_access %access : $*C
   %retval = tuple ()
   return %retval : $()
 die:


### PR DESCRIPTION
Previously, when determining and completing lifetimes of scoped addresses, `computeTransitiveLiveness` was used to determine the liveness used for completing the lifetime.

That approach had two problems:
(1) The function does not find scope-ending uses of `load_borrow`s. The result was determining that the lifetime of the enclosing `store_borrow` ended before that of the `load_borrow`.
(2) The function did not complete lifetimes of values defined within the scoped address whose lifetimes the scoped address had to contain. This was an inconsistency between the handling of scoped addresses and that of values.

Here, both are addressed by implementing a `TransitiveAddressWalker` (as `computeTransitiveLiveness`'s callee does) which not only visits existing `end_borrow`s of `load_borrows` but completes them (and other inner guaranteed values or scoped addresses).

rdar://141246601
