### PR TITLE
Stop rebuilding the world whenever a diagnostic changes

### DIFF
--- a/include/swift/AST/DiagnosticGroups.h
+++ b/include/swift/AST/DiagnosticGroups.h
@@ -18,13 +18,13 @@
 #ifndef SWIFT_DIAGNOSTICGROUPS_H
 #define SWIFT_DIAGNOSTICGROUPS_H
 
-#include "swift/AST/DiagnosticList.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <array>
 #include <string_view>
 #include <unordered_map>
 
 namespace swift {
+enum class DiagID : uint32_t;
 
 enum class DiagGroupID : uint16_t {
 #define GROUP(Name, Version) Name,

--- a/lib/AST/DiagnosticGroups.cpp
+++ b/lib/AST/DiagnosticGroups.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticGroups.h"
+#include "swift/AST/DiagnosticList.h"
 #include <unordered_set>
 
 namespace swift {


### PR DESCRIPTION
The inclusion of the full diagnostic list (via DiagnosticList.h) in DiagnosticGroups.h meant that touching any diagnostic caused most of the world to rebuild, making me sad. Use forward declarations to limit how much needs to be rebuilt when changing diagnostics.
