### PR TITLE
🍒[6.1] Frontend: set-up mechanisms to opt-out of collecting fine grained module tracing

### DIFF
--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -23,5 +23,6 @@ BLOCKLIST_ACTION(ShouldUseBinaryModule)
 BLOCKLIST_ACTION(ShouldUseTextualModule)
 BLOCKLIST_ACTION(DowngradeInterfaceVerificationFailure)
 BLOCKLIST_ACTION(ShouldUseLayoutStringValueWitnesses)
+BLOCKLIST_ACTION(SkipEmittingFineModuleTrace)
 
 #undef BLOCKLIST_ACTION

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -565,6 +565,10 @@ public:
 
   /// All block list configuration files to be honored in this compilation.
   std::vector<std::string> BlocklistConfigFilePaths;
+
+  /// Whether explicitly disble fine-grained module tracing in this compiler
+  /// invocation.
+  bool DisableFineModuleTracing = false;
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1241,6 +1241,10 @@ def skip_import_in_public_interface:
   HelpText<"Skip the import statement corresponding to a module name "
            "when printing the public interface.">;
 
+def disable_fine_module_tracing:
+  Flag<["-"], "disable-fine-module-tracing">,
+  HelpText<"Skip the emission of fine grained module tracing file.">;
+
 def clang_header_expose_decls:
   Joined<["-"], "clang-header-expose-decls=">,
   HelpText<"Which declarations should be exposed in the generated clang header.">,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -386,7 +386,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   }
 
   Opts.DisableSandbox = Args.hasArg(OPT_disable_sandbox);
-
+  Opts.DisableFineModuleTracing = Args.hasArg(OPT_disable_fine_module_tracing);
   return false;
 }
 

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -946,6 +946,9 @@ static bool shouldActionTypeEmitFineModuleTrace(FrontendOptions::ActionType acti
 
 bool swift::emitFineModuleTraceIfNeeded(CompilerInstance &Instance,
                                         const FrontendOptions &opts) {
+  if (opts.DisableFineModuleTracing) {
+    return false;
+  }
   if (!shouldActionTypeEmitFineModuleTrace(opts.RequestedAction)) {
     return false;
   }

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -951,6 +951,9 @@ bool swift::emitFineModuleTraceIfNeeded(CompilerInstance &Instance,
   }
   ModuleDecl *mainModule = Instance.getMainModule();
   ASTContext &ctxt = mainModule->getASTContext();
+  if (ctxt.blockListConfig.hasBlockListAction(mainModule->getNameStr(),
+      BlockListKeyKind::ModuleName, BlockListAction::SkipEmittingFineModuleTrace))
+    return false;
   assert(!ctxt.hadError() &&
          "We should've already exited earlier if there was an error.");
 

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -19,6 +19,9 @@
 // RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_3.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name FooBar -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -blocklist-file %t/blocklist.yml
 // RUN: not ls %t/given_trace_3.json
 
+// RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_4.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name FooBar -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -disable-fine-module-tracing
+// RUN: not ls %t/given_trace_4.json
+
 // REQUIRES: objc_interop
 
 import Foo

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -10,6 +10,15 @@
 // RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_2.json %target-swift-frontend  -I %t/lib/swift -emit-module %s %S/Inputs/objc_send_collector_2.swift -module-name main -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -enable-library-evolution
 // RUN: not ls %t/given_trace_2.json
 
+
+// RUN: echo "---" > %t/blocklist.yml
+// RUN: echo "SkipEmittingFineModuleTrace:" >> %t/blocklist.yml
+// RUN: echo "  ModuleName:" >> %t/blocklist.yml
+// RUN: echo "    - FooBar" >> %t/blocklist.yml
+
+// RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_3.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name FooBar -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -blocklist-file %t/blocklist.yml
+// RUN: not ls %t/given_trace_3.json
+
 // REQUIRES: objc_interop
 
 import Foo


### PR DESCRIPTION
• Description: the emission of fine-grained module tracing is a new addition. To avoid that the bugs that happened during the emission preventing other compilation jobs, we introduce two mechanisms for out-out: blocklist support and a compiler flag.
• Testing: Updated regression tests
• Reviewed by: Allan Shortlidge
• Original PR: #78178
• Risk: very low