### PR TITLE
[scanner] setup the clang importer injected redirecting overlay vfs f…

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -767,6 +767,14 @@ ClangInvocationFileMapping getClangInvocationFileMapping(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr,
     bool suppressDiagnostic = false);
 
+/// Construct the clang overlay VFS that's needed for the clang instance
+/// used by the clang importer to find injected platform-specific modulemaps
+/// that are created by `getClangInvocationFileMapping`.
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+createClangInvocationFileMappingVFS(
+    const ClangInvocationFileMapping &fileMapping, ASTContext &ctx,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseVFS);
+
 } // end namespace swift
 
 #endif

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1333,39 +1333,8 @@ ClangImporter::create(ASTContext &ctx,
   // Avoid creating indirect file system when using include tree.
   if (!ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
     // Wrap Swift's FS to allow Clang to override the working directory
-    VFS = llvm::vfs::RedirectingFileSystem::create(
-        fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());
-    if (importerOpts.DumpClangDiagnostics) {
-      llvm::errs() << "clang importer redirected file mappings:\n";
-      for (const auto &mapping : fileMapping.redirectedFiles) {
-        llvm::errs() << "   mapping real file '" << mapping.second
-                     << "' to virtual file '" << mapping.first << "'\n";
-      }
-      llvm::errs() << "\n";
-    }
-
-    if (!fileMapping.overridenFiles.empty()) {
-      llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
-          new llvm::vfs::InMemoryFileSystem();
-      for (const auto &file : fileMapping.overridenFiles) {
-        if (importerOpts.DumpClangDiagnostics) {
-          llvm::errs() << "clang importer overriding file '" << file.first
-                       << "' with the following contents:\n";
-          llvm::errs() << file.second << "\n";
-        }
-        auto contents = ctx.Allocate<char>(file.second.size() + 1);
-        std::copy(file.second.begin(), file.second.end(), contents.begin());
-        // null terminate the buffer.
-        contents[contents.size() - 1] = '\0';
-        overridenVFS->addFile(file.first, 0,
-                              llvm::MemoryBuffer::getMemBuffer(StringRef(
-                                  contents.begin(), contents.size() - 1)));
-      }
-      llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlayVFS =
-          new llvm::vfs::OverlayFileSystem(VFS);
-      VFS = overlayVFS;
-      overlayVFS->pushOverlay(overridenVFS);
-    }
+    VFS = createClangInvocationFileMappingVFS(fileMapping, ctx,
+                                              ctx.SourceMgr.getFileSystem());
   }
 
   // Create a new Clang compiler invocation.

--- a/test/ScanDependencies/win-crt.swift
+++ b/test/ScanDependencies/win-crt.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies -Xcc -v %s -o - | %validate-json | %FileCheck %s
+
+// We want to explicitly import WinSDK's CRT.
+// REQUIRES: OS=windows-msvc
+
+import CRT
+
+// CHECK:        "modulePath": "{{.*}}\\ucrt-{{.*}}.pcm",
+// CHECK-NEXT:   "sourceFiles": [
+// CHECK-NEXT:      "{{.*}}\\ucrt\\module.modulemap"


### PR DESCRIPTION
…or correct clang dependency scanning

This makes its possible to use -explicit-module-build to correctly find 'crt' swift module on windows
