### PR TITLE
[xcodegen] Infer project root from xcodegen location

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Error.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Error.swift
@@ -13,7 +13,7 @@
 enum XcodeGenError: Error, CustomStringConvertible {
   case pathNotFound(AbsolutePath)
   case noSwiftBuildDir(AbsolutePath, couldBeParent: Bool)
-  case expectedParent(AbsolutePath)
+  case couldNotInferProjectRoot(reason: String)
 
   var description: String {
     switch self {
@@ -23,8 +23,11 @@ enum XcodeGenError: Error, CustomStringConvertible {
       let base = "no swift build directory found in '\(basePath)'"
       let note = "; did you mean to pass the path of the parent?"
       return couldBeParent ? "\(base)\(note)" : base
-    case .expectedParent(let basePath):
-      return "expected '\(basePath)' to have parent directory"
+    case .couldNotInferProjectRoot(let reason):
+      return """
+        could not infer project root path; \(reason); please manually specify \
+        using '--project-root-dir' instead
+        """
     }
   }
 }

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
@@ -28,6 +28,12 @@ public extension PathProtocol {
     return Self(result)
   }
 
+  /// Drops the last `n` components, or all components if `n` is greater
+  /// than the number of components.
+  func dropLast(_ n: Int = 1) -> Self {
+    Self(FilePath(root: storage.root, storage.components.dropLast(n)))
+  }
+
   var fileName: String {
     storage.lastComponent?.string ?? ""
   }

--- a/utils/swift-xcodegen/Tests/SwiftXcodeGenTest/PathTests.swift
+++ b/utils/swift-xcodegen/Tests/SwiftXcodeGenTest/PathTests.swift
@@ -25,4 +25,16 @@ class PathTests: XCTestCase {
     XCTAssertEqual(AbsolutePath("/foo").parentDir, "/")
     XCTAssertEqual(AbsolutePath("/foo/bar").parentDir, "/foo")
   }
+
+  func testDropLast() throws {
+    XCTAssertEqual(AbsolutePath("/").dropLast(), "/")
+    XCTAssertEqual(AbsolutePath("/foo/bar").dropLast(), "/foo")
+    XCTAssertEqual(AbsolutePath("/foo/bar").dropLast(2), "/")
+    XCTAssertEqual(AbsolutePath("/foo/bar").dropLast(5), "/")
+
+    XCTAssertEqual(RelativePath("").dropLast(), "")
+    XCTAssertEqual(RelativePath("foo/bar").dropLast(), "foo")
+    XCTAssertEqual(RelativePath("foo/bar").dropLast(2), "")
+    XCTAssertEqual(RelativePath("foo/bar").dropLast(5), "")
+  }
 }


### PR DESCRIPTION
Instead of inferring from the build directory location, infer from the location of swift-xcodegen itself since we know that's in the swift repo.

Resolves #77478