### PR TITLE
[xcodegen] Add support for new 'Runtimes' build

### DIFF
--- a/utils/swift-xcodegen/README.md
+++ b/utils/swift-xcodegen/README.md
@@ -105,6 +105,14 @@ PROJECT CONFIGURATION:
                           unfortunately means some Clang targes such as 'lib/Basic' and 'stdlib'
                           cannot currently use buildable folders. (default: --buildable-folders)
 
+  --runtimes-build-dir <runtimes-build-dir>
+                          Experimental: The path to a build directory for the new 'Runtimes/'
+                          stdlib CMake build. This creates a separate 'SwiftRuntimes' project, along
+                          with a 'Swift+Runtimes' workspace.
+
+                          Note: This requires passing '-DCMAKE_EXPORT_COMPILE_COMMANDS=YES' to
+                          CMake.
+
 MISC:
   --project-root-dir <project-root-dir>
                           The project root directory, which is the parent directory of the Swift repo.

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/RepoBuildDir.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/RepoBuildDir.swift
@@ -27,9 +27,9 @@ public final class RepoBuildDir: Sendable {
   init(_ repo: Repo, for parent: NinjaBuildDir) throws {
     self.projectRootDir = parent.projectRootDir
     self.repo = repo
-    self.path = parent.path.appending(
-      "\(repo.buildDirPrefix)-\(parent.tripleSuffix)"
-    )
+    self.path = try repo.buildDirPrefix.map { prefix in
+      parent.path.appending("\(prefix)-\(try parent.tripleSuffix)")
+    } ?? parent.path
     self.repoRelativePath = repo.relativePath
     self.repoPath = projectRootDir.appending(repo.relativePath)
     self.repoDirCache = DirectoryCache(root: repoPath)

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Repo.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Repo.swift
@@ -13,6 +13,7 @@
 // TODO: This really ought to be defined in swift-xcodegen
 public enum Repo: CaseIterable, Sendable {
   case swift
+  case swiftRuntimes
   case lldb
   case llvm
   case cmark
@@ -20,15 +21,17 @@ public enum Repo: CaseIterable, Sendable {
   public var relativePath: RelativePath {
     switch self {
     case .swift: "swift"
+    case .swiftRuntimes: "swift/Runtimes"
     case .cmark: "cmark"
     case .lldb:  "llvm-project/lldb"
     case .llvm:  "llvm-project"
     }
   }
 
-  public var buildDirPrefix: String {
+  public var buildDirPrefix: String? {
     switch self {
     case .swift: "swift"
+    case .swiftRuntimes: nil
     case .cmark: "cmark"
     case .lldb:  "lldb"
     case .llvm:  "llvm"

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/Options.swift
@@ -222,6 +222,19 @@ struct ProjectOptions: ParsableArguments {
   )
   var useBuildableFolders: Bool = true
 
+  @Option(
+    name: .customLong("runtimes-build-dir"),
+    help: """
+      Experimental: The path to a build directory for the new 'Runtimes/'
+      stdlib CMake build. This creates a separate 'SwiftRuntimes' project, along
+      with a 'Swift+Runtimes' workspace.
+      
+      Note: This requires passing '-DCMAKE_EXPORT_COMPILE_COMMANDS=YES' to
+      CMake.
+      """
+  )
+  var runtimesBuildDir: AnyPath?
+
   @Option(help: .hidden)
   var blueFolders: String = ""
 }


### PR DESCRIPTION
Generate a new 'SwiftRuntimes' xcodeproj if a build directory for 'Runtimes' is specified with `--runtimes-build-dir`, along with a combined 'Swift+Runtimes' workspace.