### PR TITLE
[cxx-interop] Use the right assertion function in tests

### DIFF
--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -16,18 +16,18 @@ var TemplatingTestSuite = TestSuite("Foreign references work with templates")
 
 TemplatingTestSuite.test("SubT") {
     let s: SubT = SubT.getSubT()
-    assert(!s.isBase)
+    expectFalse(s.isBase)
     let sc: BaseT = cast(s)
-    assert(!sc.isBase)
+    expectFalse(sc.isBase)
     let sx: BaseT = cxxCast(s)      // should instantiate I to SubT and O to BaseT
-    assert(!sc.isBase)
+    expectFalse(sc.isBase)
 }
 
 TemplatingTestSuite.test("BaseT") {
     let b: BaseT = BaseT.getBaseT()
-    assert(b.isBase)
+    expectTrue(b.isBase)
     let bc: BaseT = cxxCast(b)      // should instantiate I and O both to BaseT
-    assert(bc.isBase)
+    expectTrue(bc.isBase)
 }
 
 runAllTests()


### PR DESCRIPTION
`assert`s get stripped away in release builds. To make sure the checks in tests still run in release builds, this switches to `expectTrue`/`expectFalse` instead of `assert`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
