### PR TITLE
Collected fixes for `@unsafe` and the Fix-Its it emits

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -429,7 +429,7 @@ CONTEXTUAL_DECL_ATTR(weak, ReferenceOwnership,
   49)
 CONTEXTUAL_DECL_ATTR_ALIAS(unowned, ReferenceOwnership)
 SIMPLE_DECL_ATTR(rethrows, Rethrows,
-  OnFunc | OnConstructor | RejectByParser | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  OnFunc | OnConstructor | DeclModifier | RejectByParser | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   57)
 CONTEXTUAL_SIMPLE_DECL_ATTR(indirect, Indirect,
   DeclModifier | OnEnum | OnEnumElement | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -505,7 +505,7 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
 
 SIMPLE_DECL_ATTR(unsafe, Unsafe,
   OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
-  OnExtension | OnTypeAlias | UserInaccessible |
+  OnExtension | OnTypeAlias | OnEnumElement | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   160)
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -861,12 +861,26 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     DA->print(Printer, Options, D);
 }
 
+static bool attributeIsNotAtStart(const DeclAttribute *attr) {
+  switch (attr->getKind()) {
+  case DeclAttrKind::Rethrows:
+  case DeclAttrKind::Reasync:
+    return true;
+
+  default:
+    return false;
+  }
+}
+
 SourceLoc DeclAttributes::getStartLoc(bool forModifiers) const {
   if (isEmpty())
     return SourceLoc();
 
   const DeclAttribute *lastAttr = nullptr;
   for (auto attr : *this) {
+    if (attributeIsNotAtStart(attr))
+      continue;
+
     if (attr->getRangeWithAt().Start.isValid() &&
         (!forModifiers || attr->isDeclModifier()))
       lastAttr = attr;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1598,6 +1598,18 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::Safe: {
+    auto *attr = cast<SafeAttr>(this);
+    Printer.printAttrName("@safe");
+    Printer << "(unchecked";
+    if (!attr->message.empty()) {
+      Printer << ", message: ";
+      Printer.printEscapedStringLiteral(attr->message);
+    }
+    Printer << ")";
+    break;
+  }
+
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
 #include "swift/AST/DeclAttr.def"
     llvm_unreachable("handled above");

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4335,7 +4335,14 @@ SourceLoc Decl::getAttributeInsertionLoc(bool forModifier) const {
     return SourceLoc();
 
   SourceLoc resultLoc = getAttrs().getStartLoc(forModifier);
-  return resultLoc.isValid() ? resultLoc : introDecl->getStartLoc();
+  if (resultLoc.isInvalid())
+    return introDecl->getStartLoc();
+
+  SourceLoc startLoc = introDecl->getStartLoc();
+  if (!forModifier && getASTContext().SourceMgr.isBefore(startLoc, resultLoc))
+    return startLoc;
+
+  return resultLoc;
 }
 
 /// Returns true if \p VD needs to be treated as publicly-accessible

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1853,8 +1853,8 @@ static bool isTypeLevelDeclForAvailabilityFixit(const Decl *D) {
 
   bool IsModuleScopeContext = D->getDeclContext()->isModuleScopeContext();
 
-  // We consider global functions to be "type level"
-  if (isa<FuncDecl>(D)) {
+  // We consider global functions, type aliases, and macros to be "type level"
+  if (isa<FuncDecl>(D) || isa<MacroDecl>(D) || isa<TypeAliasDecl>(D)) {
     return IsModuleScopeContext;
   }
 
@@ -4073,8 +4073,6 @@ private:
 };
 } // end anonymous namespace
 
-llvm::DenseSet<const Decl *> reportedDecls;
-
 static void suggestUnsafeOnEnclosingDecl(
     SourceRange referenceRange, const DeclContext *referenceDC) {
   if (referenceRange.isInvalid())
@@ -4092,9 +4090,6 @@ static void suggestUnsafeOnEnclosingDecl(
   if (!decl)
     return;
 
-  if (!reportedDecls.insert(decl).second)
-    return;
-  
   if (versionCheckNode.has_value()) {
     // The unsafe construct is inside the body of the entity, so suggest
     // @safe(unchecked) on the declaration.

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -950,6 +950,12 @@ private:
     if (auto accessor = dyn_cast<AccessorDecl>(decl))
       return declHasSafeAttr(accessor->getStorage());
 
+    // Attributes for pattern binding declarations are on the first variable.
+    if (auto pbd = dyn_cast<PatternBindingDecl>(decl)) {
+      if (auto var = pbd->getAnchoringVarDecl(0))
+        return declHasSafeAttr(var);
+    }
+
     return false;
   }
 

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -10,6 +10,7 @@ struct X { }
 
 @freestanding(expression) macro m1() -> X = #externalMacro(module: "A", type: "B") // expected-error{{'X' is only available in macOS 12.0 or newer}}
 // expected-warning@-1{{external macro implementation type 'A.B' could not be found for macro 'm1()'}}
+// expected-note@-2{{add @available attribute to enclosing macro}}
 
 @available(macOS 12.0, *)
 @freestanding(expression) macro m2() -> X = #externalMacro(module: "A", type: "B")

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -33,6 +33,19 @@ class HasStatics {
   static func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
 }
 
+@unsafe
+func unsafeInt() -> Int { 5 }
+
+struct HasProperties {
+  @safe(unchecked) var computed: Int {
+    unsafeInt()
+  }
+
+  @unsafe var computedUnsafe: Int {
+    unsafeInt()
+  }
+}
+
 // Parsing issues
 @safe // expected-error{{expected '(' in 'safe' attribute}}
 func bad1() { }

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -31,6 +31,8 @@ func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-warn
 class HasStatics {
   // expected-note@+1{{make static method 'f' @unsafe to indicate that its use is not memory-safe}}{{3-3=@unsafe }}
   static internal func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+
+  
 }
 
 @unsafe
@@ -44,6 +46,14 @@ struct HasProperties {
   @unsafe var computedUnsafe: Int {
     unsafeInt()
   }
+
+  @safe(unchecked) static var blah: Int = {
+    unsafeInt()
+  }()
+
+  @unsafe static var blahUnsafe: Int = {
+    unsafeInt()
+  }()
 }
 
 // Parsing issues

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -7,7 +7,7 @@
 func unsafeFunction() { }
 
 @unsafe
-struct UnsafeType { } // expected-note{{unsafe struct 'UnsafeType' declared here}}
+struct UnsafeType { } // expected-note 3{{unsafe struct 'UnsafeType' declared here}}
 
 @safe(unchecked)
 func f() {
@@ -23,6 +23,14 @@ func g() {
 @safe(unchecked, message: "I was careful")
 func h(_: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
   unsafeFunction()
+}
+
+// expected-note@+1 {{make global function 'rethrowing' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+
+class HasStatics {
+  // expected-note@+1{{make static method 'f' @unsafe to indicate that its use is not memory-safe}}{{3-3=@unsafe }}
+  static func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
 }
 
 // Parsing issues

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -30,7 +30,7 @@ func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-warn
 
 class HasStatics {
   // expected-note@+1{{make static method 'f' @unsafe to indicate that its use is not memory-safe}}{{3-3=@unsafe }}
-  static func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+  static internal func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
 }
 
 @unsafe

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -61,7 +61,7 @@ struct SuperHolder {
 // -----------------------------------------------------------------------
 // Inheritance of @unsafe
 // -----------------------------------------------------------------------
-@unsafe class UnsafeSuper { // expected-note 3{{'UnsafeSuper' declared here}}
+@unsafe class UnsafeSuper { // expected-note 5{{'UnsafeSuper' declared here}}
   func f() { } // expected-note{{unsafe instance method 'f' declared here}}
 };
 
@@ -87,4 +87,17 @@ func testMe(
   // expected-warning@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
 
   _ = getPointers() // expected-warning{{call to global function 'getPointers' involves unsafe type 'PointerType'}}
+}
+
+// -----------------------------------------------------------------------
+// Various declaration kinds
+// -----------------------------------------------------------------------
+typealias SuperUnsafe = UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper' [Unsafe]}}
+@unsafe typealias SuperUnsafe2 = UnsafeSuper
+
+enum HasUnsafeThings {
+// expected-note@+1{{make enum case 'one' @unsafe to indicate that its use is not memory-safe}}
+case one(UnsafeSuper) // expected-warning{{reference to unsafe class 'UnsafeSuper' [Unsafe]}}
+
+@unsafe case two(UnsafeSuper)
 }

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -92,6 +92,7 @@ func testMe(
 // -----------------------------------------------------------------------
 // Various declaration kinds
 // -----------------------------------------------------------------------
+// expected-note@+1{{make type alias 'SuperUnsafe' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
 typealias SuperUnsafe = UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper' [Unsafe]}}
 @unsafe typealias SuperUnsafe2 = UnsafeSuper
 

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -29,23 +29,23 @@ Constructor Mirror.init(_:children:displayStyle:ancestorRepresentation:) has gen
 
 // Generalizations due to typed throws.
 Func AnyBidirectionalCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
-Func AnyBidirectionalCollection.map(_:) is now without @rethrows
+Func AnyBidirectionalCollection.map(_:) is now without rethrows
 Func AnyCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
-Func AnyCollection.map(_:) is now without @rethrows
+Func AnyCollection.map(_:) is now without rethrows
 Func AnyRandomAccessCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
-Func AnyRandomAccessCollection.map(_:) is now without @rethrows
+Func AnyRandomAccessCollection.map(_:) is now without rethrows
 Func AnySequence.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
-Func AnySequence.map(_:) is now without @rethrows
+Func AnySequence.map(_:) is now without rethrows
 Func Collection.map(_:) has generic signature change from <Self, T where Self : Swift.Collection> to <Self, T, E where Self : Swift.Collection, E : Swift.Error>
-Func Collection.map(_:) is now without @rethrows
+Func Collection.map(_:) is now without rethrows
 Func Sequence.map(_:) has generic signature change from <Self, T where Self : Swift.Sequence> to <Self, T, E where Self : Swift.Sequence, E : Swift.Error>
-Func Sequence.map(_:) is now without @rethrows
-Func withUnsafeMutablePointer(to:_:) is now without @rethrows
-Func withUnsafePointer(to:_:) is now without @rethrows
-Func withUnsafeBytes(of:_:) is now without @rethrows
-Func withUnsafeMutableBytes(of:_:) is now without @rethrows
+Func Sequence.map(_:) is now without rethrows
+Func withUnsafeMutablePointer(to:_:) is now without rethrows
+Func withUnsafePointer(to:_:) is now without rethrows
+Func withUnsafeBytes(of:_:) is now without rethrows
+Func withUnsafeMutableBytes(of:_:) is now without rethrows
 Func withoutActuallyEscaping(_:do:) has generic signature change from <ClosureType, ResultType> to <ClosureType, ResultType, Failure where Failure : Swift.Error>
-Func withoutActuallyEscaping(_:do:) is now without @rethrows
+Func withoutActuallyEscaping(_:do:) is now without rethrows
 
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self : Swift.BitwiseCopyable, Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
 
@@ -317,51 +317,51 @@ Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
 Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) is now without @rethrows
+Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) is now without rethrows
 Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) is now without @rethrows
+Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) is now without rethrows
 Func ManagedBuffer.withUnsafeMutablePointers(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBuffer.withUnsafeMutablePointers(_:) is now without @rethrows
+Func ManagedBuffer.withUnsafeMutablePointers(_:) is now without rethrows
 Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) is now without rethrows
 Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) is now without rethrows
 Func ManagedBufferPointer.withUnsafeMutablePointers(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, Element : ~Copyable, R : ~Copyable>
-Func ManagedBufferPointer.withUnsafeMutablePointers(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointers(_:) is now without rethrows
 Func Optional.flatMap(_:) has generic signature change from <Wrapped, U> to <Wrapped, E, U where E : Swift.Error, U : ~Copyable>
-Func Optional.flatMap(_:) is now without @rethrows
+Func Optional.flatMap(_:) is now without rethrows
 Func Optional.map(_:) has generic signature change from <Wrapped, U> to <Wrapped, E, U where E : Swift.Error, U : ~Copyable>
-Func Optional.map(_:) is now without @rethrows
+Func Optional.map(_:) is now without rethrows
 Func Result.flatMap(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
 Func Result.flatMapError(_:) has generic signature change from <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error> to <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error, Success : ~Copyable>
 Func Result.flatMapError(_:) has self access kind changing from NonMutating to Consuming
 Func Result.map(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
 Func Result.mapError(_:) has generic signature change from <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error> to <Success, Failure, NewFailure where Failure : Swift.Error, NewFailure : Swift.Error, Success : ~Copyable>
 Func UnsafeBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, T : ~Copyable, Result : ~Copyable>
-Func UnsafeBufferPointer.withMemoryRebound(to:_:) is now without @rethrows
+Func UnsafeBufferPointer.withMemoryRebound(to:_:) is now without rethrows
 Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, Element : ~Copyable, T : ~Copyable, Result : ~Copyable>
-Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) is now without @rethrows
+Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) is now without rethrows
 Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, T : ~Copyable, Result : ~Copyable>
-Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
+Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) is now without rethrows
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, Pointee : ~Copyable, T : ~Copyable, Result : ~Copyable>
-Func UnsafePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
+Func UnsafePointer.withMemoryRebound(to:capacity:_:) is now without rethrows
 Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
-Func withExtendedLifetime(_:_:) is now without @rethrows
+Func withExtendedLifetime(_:_:) is now without rethrows
 Func Array.withUnsafeBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
-Func Array.withUnsafeBufferPointer(_:) is now without @rethrows
+Func Array.withUnsafeBufferPointer(_:) is now without rethrows
 Func Array.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func Array.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
-Func Array.withUnsafeMutableBufferPointer(_:) is now without @rethrows
+Func Array.withUnsafeMutableBufferPointer(_:) is now without rethrows
 Func ArraySlice.withUnsafeBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
-Func ArraySlice.withUnsafeBufferPointer(_:) is now without @rethrows
+Func ArraySlice.withUnsafeBufferPointer(_:) is now without rethrows
 Func ArraySlice.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ArraySlice.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
-Func ArraySlice.withUnsafeMutableBufferPointer(_:) is now without @rethrows
+Func ArraySlice.withUnsafeMutableBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
-Func ContiguousArray.withUnsafeBufferPointer(_:) is now without @rethrows
+Func ContiguousArray.withUnsafeBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
-Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without @rethrows
+Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
 
 // Adoption of @unsafe
 Func unsafeBitCast(_:to:) is now with @unsafe

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -94,10 +94,10 @@ Func Sequence.map(_:) has been removed
 Constructor Result.init(catching:) has been removed
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'
-Func withoutActuallyEscaping(_:do:) is now without @rethrows
+Func withoutActuallyEscaping(_:do:) is now without rethrows
 Func _openExistential(_:do:) has been renamed to Func __abi_openExistential(_:do:)
 Func _openExistential(_:do:) has mangled name changing from 'Swift._openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C' to 'Swift.__abi_openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C'
-Func _openExistential(_:do:) is now without @rethrows
+Func _openExistential(_:do:) is now without rethrows
 
 
 // These haven't actually been removed; they are simply marked unavailable.
@@ -122,11 +122,11 @@ Func UnsafeBufferPointer.withMemoryRebound(to:_:) has been removed
 Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has been removed
 Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has been removed
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) has been removed
-Func _AnySequenceBox._map(_:) is now without @rethrows
-Func _BidirectionalCollectionBox._map(_:) is now without @rethrows
-Func _CollectionBox._map(_:) is now without @rethrows
-Func _RandomAccessCollectionBox._map(_:) is now without @rethrows
-Func _SequenceBox._map(_:) is now without @rethrows
+Func _AnySequenceBox._map(_:) is now without rethrows
+Func _BidirectionalCollectionBox._map(_:) is now without rethrows
+Func _CollectionBox._map(_:) is now without rethrows
+Func _RandomAccessCollectionBox._map(_:) is now without rethrows
+Func _SequenceBox._map(_:) is now without rethrows
 Func UnsafeMutableRawBufferPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableBufferPointer.assign(repeating:) has been removed

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -50,5 +50,5 @@ extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') c
 // CHECK-FIXITS: {
 // CHECK-FIXITS: "file":
 // CHECK-FIXITS: "offset":
-// CHECK-FIXITS: "text": " as! Int",
-// CHECK-FIXITS: },
+// CHECK-FIXITS: "text": " as! Int"
+// CHECK-FIXITS: }

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -34,8 +34,6 @@ def apply_edits(path):
     for remap_file in remap_files:
         with open(remap_file) as f:
             json_data = f.read()
-        json_data = json_data.replace(",\n }", "\n }")
-        json_data = json_data.replace(",\n]", "\n]")
         curr_edits = json.loads(json_data)
         for ed in curr_edits:
             fname = ed["file"]


### PR DESCRIPTION
This pull request cleans up some source location and note infrastructure to help with Fix-Its of various kinds, including:
* Get the right starting location for inserting an attribute, fixes problems with `rethrows` and `static`.
* Emit proper JSON from the Fix-It remapping file writer, instead of massaging it in the (not-totally-working) Python script
* Suggest `@available`, `@unsafe`, etc. on top-level declarations that need them.

This is interspersed with fixes for `@unsafe` and `@safe(unchecked)` that uncovered the issues above, as I work on automatically annotating the standard library for the strict safety mode. These include:
* Fix semantics for `@safe(unchecked)` on computed properties and variable initializers
* Allow `@unsafe` on enum cases
* Print `@safe(unchecked)` properly

Fixes #80714