### PR TITLE
Add regression test for fixed compiler crash

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/issue-66041.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-66041.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+// https://github.com/apple/swift/issues/66041
+
+protocol Middleware<Input, Output, NextInput, NextOutput> {
+    associatedtype Input
+    associatedtype Output
+    associatedtype NextInput
+    associatedtype NextOutput
+}
+
+protocol Routes<Input, Output> {
+    associatedtype Input
+    associatedtype Output
+}
+
+extension Routes {
+    func compose<M>(_ middleware: M) -> any Routes<M.NextInput, M.NextOutput> where
+        M: Middleware,
+        M.Input == Input,
+        M.Output == Output
+    {
+        fatalError()
+    }
+
+    func mapInput<NewInput>(
+        _ transform: @escaping (Input) -> NewInput
+    ) -> any Routes<NewInput, Output> {
+        fatalError()
+    }
+}
+
+struct Request {}
+struct Response {}
+struct User {}
+
+struct AuthMiddleware<Input, Output>: Middleware {
+    typealias NextInput = (Input, login: User)
+    typealias NextOutput = Output
+}
+
+func main(routes: any Routes<Request, Response>) {
+    let routes = routes.compose(AuthMiddleware())
+        .mapInput {
+            (request: $0.0, login: $0.login)
+        }
+}


### PR DESCRIPTION
I previously reported a compiler crash bug as #66041.
Although it remained untriaged and unfixed for over a year, I recently noticed that it has been resolved in the latest version.
This patch adds test cases to prevent a recurrence of this bug.
