### PR TITLE
[xcodegen] Clean up buildable folder checking a bit

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/PathProtocol.swift
@@ -38,6 +38,10 @@ public extension PathProtocol {
     storage.lastComponent?.string ?? ""
   }
 
+  var isEmpty: Bool {
+    storage.isEmpty
+  }
+
   func appending(_ relPath: RelativePath) -> Self {
     Self(storage.pushing(relPath.storage))
   }


### PR DESCRIPTION
Factor out the checking and consistently apply the "all sources files must be covered" rule across both Clang and Swift targets.