### PR TITLE
[xcodegen] Allow `swift-plugin-server` to be added

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/SwiftTargets.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/SwiftTargets.swift
@@ -200,12 +200,17 @@ struct SwiftTargets {
 
     guard let buildArgs = try computeBuildArgs(for: rule) else { return }
 
-    let moduleName = buildArgs.lastValue(for: .moduleName)
+    // Pick up the module name from the arguments, or use an explicitly
+    // specified module name if we have one. The latter might be invalid so
+    // may not be part of the build args (e.g 'swift-plugin-server'), but is
+    // fine for generation.
+    let moduleName = buildArgs.lastValue(for: .moduleName) ??
+                       rule.attributes[.swiftModuleName]?.value
     guard let moduleName else {
       log.debug("! Skipping Swift target with output \(primaryOutput); no module name")
       return
     }
-    let moduleLinkName = rule.attributes[.swiftLibraryName]?.value ?? 
+    let moduleLinkName = rule.attributes[.swiftLibraryName]?.value ??
                            buildArgs.lastValue(for: .moduleLinkName)
     let name = moduleLinkName ?? moduleName
 

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectGenerator.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Generator/ProjectGenerator.swift
@@ -557,8 +557,10 @@ fileprivate final class ProjectGenerator {
 
     applySubstitutions(to: &buildArgs, target: target, targetInfo: targetInfo)
 
+    // Follow the same logic as swift-driver and set the module name to 'main'
+    // if we don't have one.
     let moduleName = buildArgs.takePrintedLastValue(for: .moduleName)
-    buildSettings.common.PRODUCT_MODULE_NAME = moduleName
+    buildSettings.common.PRODUCT_MODULE_NAME = moduleName ?? "main"
 
     // Emit a module if we need to.
     // TODO: This currently just uses the build rule command args, should we


### PR DESCRIPTION
Previously we would avoid adding this since it has an invalid module name, but we can follow the same logic as the driver and set the module name to `main`.
