### PR TITLE
6.1: [OSSACompleteLifetime] Recurse into scoped addresses.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -134,6 +134,7 @@ public:
 
 protected:
   bool analyzeAndUpdateLifetime(SILValue value, Boundary boundary);
+  bool analyzeAndUpdateLifetime(ScopedAddressValue value, Boundary boundary);
 };
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -62,6 +62,8 @@ sil [ossa] @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStr
 sil [ossa] @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
 sil [ossa] @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
 sil [ossa] @take_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+sil @get : $@convention(thin) () -> @owned FakeOptional<Klass>
+sil @use : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 
 ///////////
 // Tests //
@@ -1486,4 +1488,64 @@ bb1:
   dealloc_stack %1 : $*FakeOptional<Klass>
   %t = tuple ()
   return %t : $()
+}
+
+// Ensure no verification failure
+sil [ossa] @test_store_enum_value_in_multiple_locs1 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @get : $@convention(thin) () -> @owned FakeOptional<Klass>
+  %1 = apply %0() : $@convention(thin) () -> @owned FakeOptional<Klass>
+  %2 = begin_borrow [lexical] %1
+  cond_br undef, bb2, bb1
+
+bb1:
+  br bb3
+
+bb2:
+  %5 = alloc_stack [lexical] $FakeOptional<Klass>
+  %6 = store_borrow %2 to %5
+  cond_br undef, bb8, bb9
+
+bb3:
+  cond_br undef, bb5, bb4
+
+bb4:
+  unreachable
+
+bb5:
+  %11 = alloc_stack $FakeOptional<Klass>
+  %12 = store_borrow %2 to %11
+  %14 = load_borrow %12
+  %15 = begin_borrow [lexical] %14
+  %16 = alloc_stack $FakeOptional<Klass>
+  %17 = store_borrow %15 to %16
+  cond_br undef, bb6, bb7
+
+bb6:
+  fix_lifetime %17
+  end_borrow %17
+  dealloc_stack %16
+  end_borrow %15
+  end_borrow %14
+  end_borrow %12
+  dealloc_stack %11
+  end_borrow %2
+  destroy_value %1
+  %29 = tuple ()
+  return %29
+
+bb7:
+  end_borrow %17
+  dealloc_stack %16
+  unreachable
+
+bb8:
+  end_borrow %6
+  dealloc_stack %5
+  unreachable
+
+bb9:
+  end_borrow %6
+  dealloc_stack %5
+  br bb3
 }

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -1495,7 +1495,7 @@ sil [ossa] @test_store_enum_value_in_multiple_locs1 : $@convention(thin) () -> (
 bb0:
   %0 = function_ref @get : $@convention(thin) () -> @owned FakeOptional<Klass>
   %1 = apply %0() : $@convention(thin) () -> @owned FakeOptional<Klass>
-  %2 = begin_borrow [lexical] %1
+  %2 = begin_borrow [lexical] %1 : $FakeOptional<Klass>
   cond_br undef, bb2, bb1
 
 bb1:
@@ -1503,7 +1503,7 @@ bb1:
 
 bb2:
   %5 = alloc_stack [lexical] $FakeOptional<Klass>
-  %6 = store_borrow %2 to %5
+  %6 = store_borrow %2 to %5 : $*FakeOptional<Klass>
   cond_br undef, bb8, bb9
 
 bb3:
@@ -1514,38 +1514,38 @@ bb4:
 
 bb5:
   %11 = alloc_stack $FakeOptional<Klass>
-  %12 = store_borrow %2 to %11
-  %14 = load_borrow %12
-  %15 = begin_borrow [lexical] %14
+  %12 = store_borrow %2 to %11 : $*FakeOptional<Klass>
+  %14 = load_borrow %12 : $*FakeOptional<Klass>
+  %15 = begin_borrow [lexical] %14 : $FakeOptional<Klass>
   %16 = alloc_stack $FakeOptional<Klass>
-  %17 = store_borrow %15 to %16
+  %17 = store_borrow %15 to %16 : $*FakeOptional<Klass>
   cond_br undef, bb6, bb7
 
 bb6:
-  fix_lifetime %17
-  end_borrow %17
-  dealloc_stack %16
-  end_borrow %15
-  end_borrow %14
-  end_borrow %12
-  dealloc_stack %11
-  end_borrow %2
-  destroy_value %1
+  fix_lifetime %17 : $*FakeOptional<Klass>
+  end_borrow %17 : $*FakeOptional<Klass>
+  dealloc_stack %16 : $*FakeOptional<Klass>
+  end_borrow %15 : $FakeOptional<Klass>
+  end_borrow %14 : $FakeOptional<Klass>
+  end_borrow %12 : $*FakeOptional<Klass>
+  dealloc_stack %11 : $*FakeOptional<Klass>
+  end_borrow %2 : $FakeOptional<Klass>
+  destroy_value %1 : $FakeOptional<Klass>
   %29 = tuple ()
-  return %29
+  return %29 : $()
 
 bb7:
-  end_borrow %17
-  dealloc_stack %16
+  end_borrow %17 : $*FakeOptional<Klass>
+  dealloc_stack %16 : $*FakeOptional<Klass>
   unreachable
 
 bb8:
-  end_borrow %6
-  dealloc_stack %5
+  end_borrow %6 : $*FakeOptional<Klass>
+  dealloc_stack %5 : $*FakeOptional<Klass>
   unreachable
 
 bb9:
-  end_borrow %6
-  dealloc_stack %5
+  end_borrow %6 : $*FakeOptional<Klass>
+  dealloc_stack %5 : $*FakeOptional<Klass>
   br bb3
 }

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -817,6 +817,90 @@ die:
   unreachable
 }
 
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_store_borrow_1: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_store_borrow_1 : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[TOKEN]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_borrow [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_store_borrow_1'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_store_borrow_1: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_store_borrow_1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %token availability"
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr
+  %load = load_borrow %token
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_borrow %token
+  dealloc_stack %addr
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_store_borrow_2: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_store_borrow_2 : {{.*}} {
+// CHECK:         [[TOKEN:%[^,]+]] = store_borrow
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[TOKEN]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_borrow [[TOKEN]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_store_borrow_2'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_store_borrow_2: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_store_borrow_2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  specify_test "ossa_lifetime_completion %token availability"
+  %addr = alloc_stack $C
+  %token = store_borrow %instance to %addr
+  %load = load_borrow %token
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_borrow %token
+  dealloc_stack %addr
+  %retval = tuple ()
+  return %retval : $()
+die:
+  end_borrow %borrow
+  end_borrow %load
+  unreachable
+}
+
+sil [ossa] @load_borrow_1 : $@convention(thin) (@in_guaranteed C) -> () {
+entry(%addr : $*C):
+  specify_test "ossa_lifetime_completion %load availability"
+  %load = load_borrow %addr
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
 // CHECK-LABEL: begin running test {{.*}} on begin_access: ossa_lifetime_completion
 // CHECK-LABEL: sil [ossa] @begin_access : {{.*}} {
 // CHECK:         [[TOKEN:%[^,]+]] = begin_access
@@ -836,6 +920,37 @@ entry(%instance : @guaranteed $C):
 exit:
   end_access %access : $*C
   dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+die:
+  unreachable
+}
+
+// CHECK-LABEL: begin running test {{.*}} on load_borrow_of_begin_access: ossa_lifetime_completion
+// CHECK-LABEL: sil [ossa] @load_borrow_of_begin_access : {{.*}} {
+// CHECK:         [[ACCESS:%[^,]+]] = begin_access
+// CHECK:         [[LOAD:%[^,]+]] = load_borrow [[ACCESS]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LOAD]]
+// CHECK:         cond_br undef, {{bb[0-9]+}}, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    end_borrow [[BORROW]]
+// CHECK-NEXT:    end_borrow [[LOAD]]
+// CHECK-NEXT:    end_access [[ACCESS]]
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'load_borrow_of_begin_access'
+// CHECK-LABEL: end running test {{.*}} on load_borrow_of_begin_access: ossa_lifetime_completion
+sil [ossa] @load_borrow_of_begin_access : $@convention(thin) (@in_guaranteed C) -> () {
+entry(%addr : $*C):
+  specify_test "ossa_lifetime_completion %access availability"
+  %access = begin_access [static] [read] %addr : $*C
+  %load = load_borrow %access
+  %borrow = begin_borrow %load
+  cond_br undef, exit, die
+
+exit:
+  end_borrow %borrow
+  end_borrow %load
+  end_access %access : $*C
   %retval = tuple ()
   return %retval : $()
 die:

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -834,16 +834,16 @@ sil [ossa] @load_borrow_of_store_borrow_1 : $@convention(thin) (@guaranteed C) -
 entry(%instance : @guaranteed $C):
   specify_test "ossa_lifetime_completion %token availability"
   %addr = alloc_stack $C
-  %token = store_borrow %instance to %addr
-  %load = load_borrow %token
-  %borrow = begin_borrow %load
+  %token = store_borrow %instance to %addr : $*C
+  %load = load_borrow %token : $*C
+  %borrow = begin_borrow %load : $C
   cond_br undef, exit, die
 
 exit:
-  end_borrow %borrow
-  end_borrow %load
-  end_borrow %token
-  dealloc_stack %addr
+  end_borrow %borrow : $C
+  end_borrow %load : $C
+  end_borrow %token : $*C
+  dealloc_stack %addr : $*C
   %retval = tuple ()
   return %retval : $()
 die:
@@ -867,34 +867,34 @@ sil [ossa] @load_borrow_of_store_borrow_2 : $@convention(thin) (@guaranteed C) -
 entry(%instance : @guaranteed $C):
   specify_test "ossa_lifetime_completion %token availability"
   %addr = alloc_stack $C
-  %token = store_borrow %instance to %addr
-  %load = load_borrow %token
-  %borrow = begin_borrow %load
+  %token = store_borrow %instance to %addr : $*C
+  %load = load_borrow %token : $*C
+  %borrow = begin_borrow %load : $C
   cond_br undef, exit, die
 
 exit:
-  end_borrow %borrow
-  end_borrow %load
-  end_borrow %token
-  dealloc_stack %addr
+  end_borrow %borrow : $C
+  end_borrow %load : $C
+  end_borrow %token : $*C
+  dealloc_stack %addr : $*C
   %retval = tuple ()
   return %retval : $()
 die:
-  end_borrow %borrow
-  end_borrow %load
+  end_borrow %borrow : $C
+  end_borrow %load : $C
   unreachable
 }
 
 sil [ossa] @load_borrow_1 : $@convention(thin) (@in_guaranteed C) -> () {
 entry(%addr : $*C):
   specify_test "ossa_lifetime_completion %load availability"
-  %load = load_borrow %addr
-  %borrow = begin_borrow %load
+  %load = load_borrow %addr : $*C
+  %borrow = begin_borrow %load : $C
   cond_br undef, exit, die
 
 exit:
-  end_borrow %borrow
-  end_borrow %load
+  end_borrow %borrow : $C
+  end_borrow %load : $C
   %retval = tuple ()
   return %retval : $()
 die:
@@ -943,13 +943,13 @@ sil [ossa] @load_borrow_of_begin_access : $@convention(thin) (@in_guaranteed C) 
 entry(%addr : $*C):
   specify_test "ossa_lifetime_completion %access availability"
   %access = begin_access [static] [read] %addr : $*C
-  %load = load_borrow %access
-  %borrow = begin_borrow %load
+  %load = load_borrow %access : $*C
+  %borrow = begin_borrow %load : $C
   cond_br undef, exit, die
 
 exit:
-  end_borrow %borrow
-  end_borrow %load
+  end_borrow %borrow : $C
+  end_borrow %load : $C
   end_access %access : $*C
   %retval = tuple ()
   return %retval : $()


### PR DESCRIPTION
**Explanation**: Fix lifetime completion of scoped addresses.

In https://github.com/swiftlang/swift/pull/78081 , support for completing lifetimes of scoped addresses (`store_borrow`, `begin_access`) was added.  That support relied on the `ScopedAddressValue::computeTransitiveLiveness` function, however.  That function does not actually produce liveness that includes all transitive uses: specifically, it doesn't include the `end_borrow`s of `load_borrow`s.  The result was that lifetimes of scoped addresses would be ended before the lifetimes of `load_borrow`s that they enclose, which is invalid.

Here, this is fixed by writing a variation of `computeTransitiveLiveness`'s callee `findTransitiveUsesForAddress`.  Like the latter, the new variation (written directly in `OSSALifetimeCompletion`) uses a `TransitiveAddressWalker`.  Unlike it, however, it includes the `end_borrow`s of `load_borrow`s.  

Additionally, the new walker completes inner lifetimes that are discovered while visiting the transitive uses of the scoped address.  That brings this case into parity with what's done when completing lifetimes for values.

**Scope**: Affects optimized code.
**Issue**: rdar://141246601
**Original PR**: https://github.com/swiftlang/swift/pull/78180
**Risk**: Low.  
**Testing**: Added test.
**Reviewer**: Meghana Gupta ( @meg-gupta )