### PR TITLE
[stdlib] fix android build

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -18,7 +18,9 @@
 #include "swift/Runtime/Concurrency.h"
 #include <atomic>
 #include <new>
+#if __has_feature(ptrauth_calls)
 #include <ptrauth.h>
+#endif
 
 #include "../CompatibilityOverride/CompatibilityOverride.h"
 #include "swift/ABI/Actor.h"


### PR DESCRIPTION
ptrauth isn't available when stdlib is built with NDK's clang
