### PR TITLE
CopyToBorrowOptimization: correctly handle uses in dead-end blocks when removing a copy_value

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -98,8 +98,10 @@ private func optimize(copy: CopyValueInst, _ context: FunctionPassContext) {
     return
   }
 
-  var liverange = InstructionRange(begin: copy, ends: collectedUses.destroys, context)
+  var liverange = InstructionRange(begin: copy, context)
   defer { liverange.deinitialize() }
+  liverange.insert(contentsOf: collectedUses.destroys)
+  liverange.insert(contentsOf: collectedUses.usersInDeadEndBlocks)
 
   if !liverange.isFullyContainedIn(borrowScopeOf: copy.fromValue.lookThroughForwardingInstructions) {
     return

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -2106,3 +2106,16 @@ bb3:
   return %0
 }
 
+// CHECK-LABEL: sil [ossa] @user_in_dead_end_block :
+// CHECK:         %2 = copy_value %1
+// CHECK:       } // end sil function 'user_in_dead_end_block'
+sil [ossa] @user_in_dead_end_block : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0
+  %2 = copy_value %1
+  end_borrow %1
+  %4 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+  unreachable
+}
+


### PR DESCRIPTION
Fixes an ownership verifier crash
rdar://141278208
