### PR TITLE
[test] Disable `variadic_generic_opaque_type.swift` for back deployment

### DIFF
--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -10,6 +10,9 @@
 
 // REQUIRES: executable_test
 
+// This test needs a Swift 5.9 runtime or newer.
+// UNSUPPORTED: back_deployment_runtime
+
 import variadic_generic_opaque_type_other
 import StdlibUnittest
 


### PR DESCRIPTION
Like #78164, this test requires at least a 5.9 runtime.

rdar://139913681