### PR TITLE
[6.1] [test] Disable `variadic_generic_opaque_type.swift` for back deployment

### DIFF
--- a/test/Interpreter/variadic_generic_opaque_type.swift
+++ b/test/Interpreter/variadic_generic_opaque_type.swift
@@ -10,6 +10,9 @@
 
 // REQUIRES: executable_test
 
+// This test needs a Swift 5.9 runtime or newer.
+// UNSUPPORTED: back_deployment_runtime
+
 import variadic_generic_opaque_type_other
 import StdlibUnittest
 


### PR DESCRIPTION
*6.1 cherry-pick of #78213*

- Explanation: Disables `variadic_generic_opaque_type.swift` for back deployment
- Scope: Test-only change
- Issue: rdar://139913681
- Risk: None, test-only change
- Testing: N/A
- Reviewer: Slava Pestov