### PR TITLE
[cxx-interop] Fix assert failure exporting C++ types to Obj-C

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -918,7 +918,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
           interopContext, CFunctionSignatureTypePrinterModifierDelegate(),
           emittedModule, declPrinter);
       auto s = typePrinter.visit(ty, optionalKind, param.isInOut());
-      assert(!s.isUnsupported());
+      resultingRepresentation.merge(s);
     };
     signature.visitParameterList(
         [&](const LoweredFunctionSignature::IndirectResultValue

--- a/test/Interop/CxxToSwiftToObjC/Inputs/cxxmodule.h
+++ b/test/Interop/CxxToSwiftToObjC/Inputs/cxxmodule.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct Foo {
+  void *foo;
+};

--- a/test/Interop/CxxToSwiftToObjC/Inputs/module.modulemap
+++ b/test/Interop/CxxToSwiftToObjC/Inputs/module.modulemap
@@ -1,0 +1,5 @@
+module CxxModule [system] {
+  header "cxxmodule.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
+++ b/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -module-name UseCxxModule -emit-objc-header -emit-objc-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -clang-header-expose-decls=all-public -cxx-interoperability-mode=default
+// RUN: %FileCheck %s < %t/UseCxxTy.h
+
+import CxxModule
+
+public func bar(x: Foo, y: UnsafeMutablePointer<UnsafeMutableRawPointer?>) {}
+
+// CHECK: // Unavailable in C++: Swift global function 'bar(x:y:)'.
+// TODO: the message above is not correct, this is actually unavailable in Obj-C.


### PR DESCRIPTION
This is not supported, of course. But now, instead of an assertion failure we properly mark the declaration as unavailable.

Fixes #78190.

rdar://141492654
