### PR TITLE
Avoid build error with Visual Studio 17.8.7 MSVC 19.38.33135.0 compiler

### DIFF
--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -467,7 +467,7 @@ BridgedConformance BridgedSubstitutionMap::getConformance(SwiftInt index) const 
 //===----------------------------------------------------------------------===//
 
 swift::Fingerprint BridgedFingerprint::unbridged() const {
-  return swift::Fingerprint({this->v1, this->v2});
+  return swift::Fingerprint(swift::Fingerprint::Core{this->v1, this->v2});
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The error message from a local build:
```
S:\SourceCache\swift\include\swift/AST/ASTBridgingImpl.h(470): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'swift::Fingerprint'
S:\SourceCache\swift\include\swift/AST/ASTBridgingImpl.h(470): note: 'swift::Fingerprint::Fingerprint': ambiguous call to overloaded function
S:\SourceCache\swift\include\swift/Basic/Fingerprint.h(79): note: could be 'swift::Fingerprint::Fingerprint(swift::StableHasher &&)'
S:\SourceCache\swift\include\swift/Basic/Fingerprint.h(70): note: or       'swift::Fingerprint::Fingerprint(swift::Fingerprint::Core)'
S:\SourceCache\swift\include\swift/AST/ASTBridgingImpl.h(470): note: while trying to match the argument list '(initializer list)'
S
```
This might be a bug in that version of MSVC but it'd be great if we can compile with it as VS 17.9.x and 17.10.x have an arm64 miscompile bug: https://github.com/llvm/llvm-project/issues/97631 https://developercommunity.visualstudio.com/t/VC-17103-arm64-C-compiler:-a-potenti/10699487