### PR TITLE
[cxx-interop] Fix runtime crash when casting from an existential to a foreign reference type

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -591,6 +591,16 @@ tryCastToForeignClass(
   return DynamicCastResult::Failure;
 }
 
+static DynamicCastResult tryCastToForeignReferenceType(
+    OpaqueValue *destLocation, const Metadata *destType, OpaqueValue *srcValue,
+    const Metadata *srcType, const Metadata *&destFailureType,
+    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks) {
+  assert(srcType != destType);
+  assert(destType->getKind() == MetadataKind::ForeignReferenceType);
+
+  return DynamicCastResult::Failure;
+}
+
 /******************************************************************************/
 /***************************** Enum Destination *******************************/
 /******************************************************************************/
@@ -2187,6 +2197,8 @@ static tryCastFunctionType *selectCasterForDest(const Metadata *destType) {
     return tryCastToOptional;
   case MetadataKind::ForeignClass:
     return tryCastToForeignClass;
+  case MetadataKind::ForeignReferenceType:
+    return tryCastToForeignReferenceType;
   case MetadataKind::Opaque:
     return tryCastToOpaque;
   case MetadataKind::Tuple:

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -61,6 +61,15 @@ WitnessTableTestSuite.test("As a Sequence") {
   expectEqual(count, 3)
 }
 
+WitnessTableTestSuite.test("As an existential") {
+  let existential: any ListNode = makeLinkedList()
+  let cast: CxxLinkedList? = existential as? CxxLinkedList
+  expectNotNil(cast)
+  expectEqual(cast?.value, 0)
+  expectEqual(cast?.next()?.value, 1)
+  expectEqual(cast?.next()?.next()?.value, 2)
+}
+
 }
 
 runAllTests()


### PR DESCRIPTION
When a C++ foreign reference type is conformed to a Swift protocol via a Swift extension, trying to cast `any MyProtocol` to the foreign reference type crashes the runtime.

This was because `selectCasterForDest` wasn't handling C++ foreign reference types, and we were hitting `swift_unreachable`.

This change makes sure the runtime doesn't crash for such casts.

Notably, Swift doesn't have enough metadata to determine if the conditional cast actually succeeded. This is also a problem for CF types. Casting CF types in a similar fashion triggers a typechecker diagnostic. That diagnostic will be amended in a follow-up patch to also trigger for foreign reference types.

rdar://141227849

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
