### PR TITLE
[CAS] Cache symbol graph outputs

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -98,6 +98,7 @@ TYPE("swiftoverlay",        SwiftOverlayFile,          "swiftoverlay",    "")
 
 // Misc types
 TYPE("pcm",                 ClangModuleFile,           "pcm",             "")
+TYPE("symbol-graph",        SymbolGraphFile,           "symbols.json",    "")
 TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
 

--- a/include/swift/Frontend/CASOutputBackends.h
+++ b/include/swift/Frontend/CASOutputBackends.h
@@ -46,6 +46,7 @@ public:
                         llvm::cas::ActionCache &Cache,
                         llvm::cas::ObjectRef BaseKey,
                         const FrontendInputsAndOutputs &InputsAndOutputs,
+                        const FrontendOptions &Opts,
                         FrontendOptions::ActionType Action);
   ~SwiftCASOutputBackend();
 

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -36,7 +36,7 @@ createSwiftCachingOutputBackend(
     llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
     llvm::cas::ObjectRef BaseKey,
     const FrontendInputsAndOutputs &InputsAndOutputs,
-    FrontendOptions::ActionType Action);
+    const FrontendOptions &Opts, FrontendOptions::ActionType Action);
 
 /// Replay the output of the compilation from cache.
 /// Return true if outputs are replayed, false otherwise.

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -116,6 +116,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
   case file_types::TY_ConstValues:
+  case file_types::TY_SymbolGraphFile:
     return true;
   case file_types::TY_Image:
   case file_types::TY_Object:
@@ -202,6 +203,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SymbolGraphFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -263,6 +265,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SymbolGraphFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -324,6 +327,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_SwiftAPIDescriptor:
   case file_types::TY_ConstValues:
   case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_SymbolGraphFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1708,6 +1708,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_SwiftFixIt:
       case file_types::TY_ModuleSemanticInfo:
       case file_types::TY_CachedDiagnostics:
+      case file_types::TY_SymbolGraphFile:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -779,6 +779,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SymbolGraphFile:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -1054,6 +1055,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_SwiftFixIt:
     case file_types::TY_ModuleSemanticInfo:
     case file_types::TY_CachedDiagnostics:
+    case file_types::TY_SymbolGraphFile:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -54,14 +54,13 @@ using namespace llvm::vfs;
 
 namespace swift {
 
-llvm::IntrusiveRefCntPtr<SwiftCASOutputBackend>
-createSwiftCachingOutputBackend(
+llvm::IntrusiveRefCntPtr<SwiftCASOutputBackend> createSwiftCachingOutputBackend(
     llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
     llvm::cas::ObjectRef BaseKey,
     const FrontendInputsAndOutputs &InputsAndOutputs,
-    FrontendOptions::ActionType Action) {
-  return makeIntrusiveRefCnt<SwiftCASOutputBackend>(CAS, Cache, BaseKey,
-                                                    InputsAndOutputs, Action);
+    const FrontendOptions &Opts, FrontendOptions::ActionType Action) {
+  return makeIntrusiveRefCnt<SwiftCASOutputBackend>(
+      CAS, Cache, BaseKey, InputsAndOutputs, Opts, Action);
 }
 
 Error cas::CachedResultLoader::replay(CallbackTy Callback) {
@@ -197,6 +196,31 @@ bool replayCachedCompilerOutputs(
             assert(!DiagnosticsOutput && "more than 1 diagnotics found");
             DiagnosticsOutput.emplace(
                 OutputEntry{OutputPath->second, OutID, Kind, Input, *Proxy});
+          } else if (Kind == file_types::ID::TY_SymbolGraphFile &&
+                     !Opts.SymbolGraphOutputDir.empty()) {
+            auto Err = Proxy->forEachReference([&](ObjectRef Ref) -> Error {
+              auto Proxy = CAS.getProxy(Ref);
+              if (!Proxy)
+                return Proxy.takeError();
+              auto PathRef = Proxy->getReference(0);
+              auto ContentRef = Proxy->getReference(1);
+              auto Path = CAS.getProxy(PathRef);
+              auto Content = CAS.getProxy(ContentRef);
+              if (!Path)
+                return Path.takeError();
+              if (!Content)
+                return Content.takeError();
+
+              SmallString<128> OutputPath(Opts.SymbolGraphOutputDir);
+              llvm::sys::path::append(OutputPath, Path->getData());
+
+              OutputProxies.emplace_back(OutputEntry{
+                  std::string(OutputPath), OutID, Kind, Input, *Content});
+
+              return Error::success();
+            });
+            if (Err)
+              return Err;
           } else
             OutputProxies.emplace_back(
                 OutputEntry{OutputPath->second, OutID, Kind, Input, *Proxy});
@@ -233,6 +257,9 @@ bool replayCachedCompilerOutputs(
     // Add cached diagnostic entry for lookup. Output path doesn't matter here.
     Outputs.try_emplace(file_types::ID::TY_CachedDiagnostics,
                         "<cached-diagnostics>");
+
+    // Add symbol graph entry for lookup. Output path doesn't matter here.
+    Outputs.try_emplace(file_types::ID::TY_SymbolGraphFile, "<symbol-graph>");
 
     return replayOutputsForInputFile(Input, InputPath, InputIndex, Outputs);
   };

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -486,6 +486,7 @@ void CompilerInstance::setupOutputBackend() {
     auto &InAndOuts = Invocation.getFrontendOptions().InputsAndOutputs;
     CASOutputBackend = createSwiftCachingOutputBackend(
         *CAS, *ResultCache, *CompileJobBaseKey, InAndOuts,
+        Invocation.getFrontendOptions(),
         Invocation.getFrontendOptions().RequestedAction);
 
     if (Invocation.getIRGenOptions().UseCASBackend) {

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph1
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
+// RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph1 \
+// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+
+// CACHE-MISS: remark: cache miss for input
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
+// RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph2 \
+// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test.symbols.json': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test@A.symbols.json': key 'llvmcas://{{.*}}'
+
+// RUN: diff -r -u %t/symbol-graph1 %t/symbol-graph2
+
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+
+public struct A {}
+
+//--- main.swift
+import A
+
+public struct Foo {}
+
+extension A {
+  public func bar() {}
+}


### PR DESCRIPTION
- **Explanation**: Adds support for caching symbol graph outputs. Previously, if symbol graph was enabled in a caching build it would crash.
- **Scope**: Affects caching builds that enable symbol graph output.
- **Issues**: rdar://140286819
- **Original PRs**: #77935
- **Risk**: Low. This only affects builds that were previously crashing.
- **Testing**: Regression test added.
- **Reviewers**: @cachemeifyoucan 

---

The symbol graph output from a module can contain an arbitrary number of files, depending on what extensions it contains, so cache a list of symbol graph files with their base name and contents so that they can be replayed.

rdar://140286819
(cherry picked from commit e7c37655e40897d3468bed85a2a1b29b2edd923d)
