### PR TITLE
Sema: Filter out protocol extension default implementations of operators

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -118,6 +118,14 @@ public:
     return is("+") || is("-") || is("*") || is("/") || is("%");
   }
 
+  bool isBitwiseOperator() const {
+    return is("~") || is("&") || is("|") || is("^");
+  }
+
+  bool isShiftOperator() const {
+    return is("<<") || is(">>");
+  }
+
   // Returns whether this is a standard comparison operator,
   // such as '==', '>=' or '!=='.
   bool isStandardComparisonOperator() const {

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -737,7 +737,9 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
     auto *declA = LastSolvedChoice->first->getOverloadChoice().getDecl();
     auto *declB = static_cast<Constraint *>(choice)->getOverloadChoice().getDecl();
 
-    if (declA->getBaseIdentifier().isArithmeticOperator() &&
+    if ((declA->getBaseIdentifier().isArithmeticOperator() ||
+         declA->getBaseIdentifier().isBitwiseOperator() ||
+         declA->getBaseIdentifier().isShiftOperator()) &&
         TypeChecker::isDeclRefinementOf(declA, declB)) {
       return skip("subtype");
     }

--- a/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise.swift
+++ b/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=80000
+
+// REQUIRES: tools-release,no_asan
+
+func f2() { let _ = 0 << (~(~(~(~(~(~(~(~(~(~(~(0 << 0)))))))))))) }

--- a/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_2.swift
+++ b/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_2.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=2000
+
+func f896() { let _ = ((0 >> ((0 >> 0) + ((0 / 0) & 0))) >> (0 << ((0 << 0) >> (0 << (0 << 0))))) }

--- a/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_3.swift
+++ b/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_3.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=15000
+
+// REQUIRES: tools-release,no_asan
+
+// Reduced from https://github.com/leif-ibsen/SwiftHPKE
+
+struct Field25519 {
+    static let mask51 = UInt64(0x7ffffffffffff)
+    
+    var l0: UInt64
+    var l1: UInt64
+    var l2: UInt64
+    var l3: UInt64
+    var l4: UInt64
+
+    init(_ b: [UInt8]) {
+        self.l0 = UInt64(b[0]) | UInt64(b[1]) << 8 | UInt64(b[2]) << 16 | UInt64(b[3]) << 24 | UInt64(b[4]) << 32 | UInt64(b[5]) << 40 | UInt64(b[6]) << 48 | UInt64(b[7]) << 56
+        self.l1 = UInt64(b[6]) | UInt64(b[7]) << 8 | UInt64(b[8]) << 16 | UInt64(b[9]) << 24 | UInt64(b[10]) << 32 | UInt64(b[11]) << 40 | UInt64(b[12]) << 48 | UInt64(b[13]) << 56
+        self.l2 = UInt64(b[12]) | UInt64(b[13]) << 8 | UInt64(b[14]) << 16 | UInt64(b[15]) << 24 | UInt64(b[16]) << 32 | UInt64(b[17]) << 40 | UInt64(b[18]) << 48 | UInt64(b[19]) << 56
+        self.l3 = UInt64(b[19]) | UInt64(b[20]) << 8 | UInt64(b[21]) << 16 | UInt64(b[22]) << 24 | UInt64(b[23]) << 32 | UInt64(b[24]) << 40 | UInt64(b[25]) << 48 | UInt64(b[26]) << 56
+        self.l4 = UInt64(b[24]) | UInt64(b[25]) << 8 | UInt64(b[26]) << 16 | UInt64(b[27]) << 24 | UInt64(b[28]) << 32 | UInt64(b[29]) << 40 | UInt64(b[30]) << 48 | UInt64(b[31]) << 56
+    }
+}


### PR DESCRIPTION
In solution ranking we always prefer a protocol operator over
a protocol extension operator. So if their interface types are
identical, any set of fixed type assignments that satisfies
the default implementation will also satisfy the protocol requirement.

Thus, we can filter out the default implementation early and not
consider it at all.

This speeds up expressions involving bitwise shift operators,
for example.