### PR TITLE
IRGen: simplify the stdlib special casing for Windows

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1396,9 +1396,9 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type,
                                 bool relativeReference) {
   // Native PE binaries shouldn't reference data symbols across DLLs, so disable
   // this on Windows, unless we're forming a relative indirectable reference.
-  if (IGM.useDllStorage() && !relativeReference)
+  if (useDllStorage(IGM.Triple) && !relativeReference)
     return {};
-  
+
   if (auto nom = type->getAnyNominal()) {
     // TODO: Non-C enums have extra inhabitants and also need additional value
     // witnesses for their tag manipulation (except when they're empty, in

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -968,8 +968,6 @@ public:
   void fatal_unimplemented(SourceLoc, StringRef Message);
   void error(SourceLoc loc, const Twine &message);
 
-  bool useDllStorage();
-
   bool shouldPrespecializeGenericMetadata();
   
   bool canMakeStaticObjectReadOnly(SILType objectType);
@@ -1510,7 +1508,6 @@ public:
   llvm::Module *getModule() const;
   llvm::AttributeList getAllocAttrs();
   llvm::Constant *getDeletedAsyncMethodErrorAsyncFunctionPointer();
-  bool isStandardLibrary() const;
 
 private:
   llvm::Constant *EmptyTupleMetadata = nullptr;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -602,7 +602,7 @@ irgen::tryEmitConstantHeapMetadataRef(IRGenModule &IGM,
 ConstantReference
 irgen::tryEmitConstantTypeMetadataRef(IRGenModule &IGM, CanType type,
                                       SymbolReferenceKind refKind) {
-  if (IGM.isStandardLibrary())
+  if (IGM.getSwiftModule()->isStdlibModule())
     return ConstantReference();
   if (isCanonicalCompleteTypeMetadataStaticallyAddressable(IGM, type))
     return ConstantReference();


### PR DESCRIPTION
Remove `IRGenModule::useDllStorage()` as there is a standalone version that is available and the necessary information is public from the `IRGenModule` type. Additionally, avoid the wrapped `isStandardLibrary` preferring to use the same method off of the public accessors. This works towards removing some of the standard library special casing so that it is possible to support both static and dynamic standard libraries on Windows.