### PR TITLE
LifetimeDependence: redesign dependence scope handling

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -98,107 +98,133 @@ extension LifetimeDependentApply {
   
   /// A lifetime argument that either inherits or creates a new scope for the lifetime of the argument value.
   struct LifetimeSource {
+    let targetKind: TargetKind
     let convention: LifetimeDependenceConvention
     let value: Value
   }
 
   /// List of lifetime dependencies for a single target.
-  struct LifetimeSources {
-    let targetKind: TargetKind
+  struct LifetimeSourceInfo {
     var sources = SingleInlineArray<LifetimeSource>()
+    var bases = [Value]()
   }
 
-  func getResultDependenceSources() -> LifetimeSources? {
-    guard applySite.hasResultDependence else { return nil }
-    var sources: LifetimeSources
-    switch applySite {
-    case let beginApply as BeginApplyInst:
-      if beginApply.yieldedValues.contains(where: { $0.type.isAddress }) {
-        sources = LifetimeSources(targetKind: .yieldAddress)
-      } else {
-        sources = LifetimeSources(targetKind: .yield)
-      }
-    default:
-      sources = LifetimeSources(targetKind: .result)
+  func getResultDependenceSources() -> LifetimeSourceInfo? {
+    guard applySite.hasResultDependence else {
+      return nil
+    }
+    var info = LifetimeSourceInfo()
+    if let beginApply = applySite as? BeginApplyInst {
+      return getYieldDependenceSources(beginApply: beginApply)
     }
     for operand in applySite.parameterOperands {
       guard let dep = applySite.resultDependence(on: operand) else {
         continue
       }
-      sources.sources.push(LifetimeSource(convention: dep, value: operand.value))
+      info.sources.push(LifetimeSource(targetKind: .result, convention: dep, value: operand.value))
     }
-    return sources
+    return info
   }
 
-  func getParameterDependenceSources(target: Operand) -> LifetimeSources? {
+  func getYieldDependenceSources(beginApply: BeginApplyInst) -> LifetimeSourceInfo? {
+    var info = LifetimeSourceInfo()
+    let hasScopedYield = applySite.parameterOperands.contains {
+      if let dep = applySite.resultDependence(on: $0) {
+        return dep == .scope
+      }
+      return false
+    }
+    if hasScopedYield {
+      // for consistency, we you yieldAddress if any yielded value is an address.
+      let targetKind = beginApply.yieldedValues.contains(where: { $0.type.isAddress })
+        ? TargetKind.yieldAddress : TargetKind.yield
+      info.sources.push(LifetimeSource(targetKind: targetKind, convention: .scope, value: beginApply.token))
+    }
+    for operand in applySite.parameterOperands {
+      guard let dep = applySite.resultDependence(on: operand) else {
+        continue
+      }
+      switch dep {
+      case .inherit:
+        continue
+      case .scope:
+        for yieldedValue in beginApply.yieldedValues {
+          let targetKind = yieldedValue.type.isAddress ? TargetKind.yieldAddress : TargetKind.yield
+          info.sources.push(LifetimeSource(targetKind: targetKind, convention: .inherit, value: operand.value))
+        }
+      }
+    }
+    return info
+  }
+
+  func getParameterDependenceSources(target: Operand) -> LifetimeSourceInfo? {
     guard let deps = applySite.parameterDependencies(target: target) else {
       return nil
     }
-    var sources: LifetimeSources
-    let convention = applySite.convention(of: target)!
-    switch convention {
-    case .indirectInout, .indirectInoutAliasable, .packInout:
-      sources = LifetimeSources(targetKind: .inoutParameter)
-    case .indirectIn, .indirectInGuaranteed, .indirectInCXX, .directOwned, .directUnowned, .directGuaranteed,
-         .packOwned, .packGuaranteed:
-      sources = LifetimeSources(targetKind: .inParameter)
-    case .indirectOut, .packOut:
-      debugLog("\(applySite)")
-      fatalError("Lifetime dependencies cannot target \(convention) parameter")
-    }
+    var info = LifetimeSourceInfo()
+    let targetKind = {
+      let convention = applySite.convention(of: target)!
+      switch convention {
+      case .indirectInout, .indirectInoutAliasable, .packInout:
+        return TargetKind.inoutParameter
+      case .indirectIn, .indirectInGuaranteed, .indirectInCXX, .directOwned, .directUnowned, .directGuaranteed,
+           .packOwned, .packGuaranteed:
+        return TargetKind.inParameter
+      case .indirectOut, .packOut:
+        debugLog("\(applySite)")
+        fatalError("Lifetime dependencies cannot target \(convention) parameter")
+      }
+    }()
     for (dep, operand) in zip(deps, applySite.parameterOperands) {
       guard let dep = dep else {
         continue
       }
-      sources.sources.push(LifetimeSource(convention: dep, value: operand.value))
+      info.sources.push(LifetimeSource(targetKind: targetKind, convention: dep, value: operand.value))
     }
-    return sources
+    return info
+  }
+}
+
+private extension LifetimeDependentApply.LifetimeSourceInfo {
+  mutating func initializeBases(_ context: FunctionPassContext) {
+    for source in sources {
+      // Inherited dependencies do not require a mark_dependence if the target is a result or yielded value. The
+      // inherited lifetime is nonescapable, so either
+      //
+      // (a) the result or yield is never returned from this function
+      //
+      // (b) the inherited lifetime has a dependence root within this function (it comes from a dependent function
+      // argument or scoped dependence). In this case, when that depedence root is diagnosed, the analysis will find
+      // transtive uses of this apply's result.
+      //
+      // (c) the dependent value is passed to another call with a dependent inout argument, or it is stored to a yielded
+      // address of a coroutine that has a dependent inout argument. In this case, a mark_dependence will already be
+      // created for that inout argument.
+      switch source.convention {
+      case .inherit:
+        break
+      case .scope:
+        initializeScopedBases(source: source, context)
+      }
+    }
   }
 
   // Scoped dependencies require a mark_dependence for every variable that introduces this scope.
-  //
-  // Inherited dependencies do not require a mark_dependence if the target is a result or yielded value. The inherited
-  // lifetime is nonescapable, so either
-  //
-  // (a) the result or yield is never returned from this function
-  //
-  // (b) the inherited lifetime has a dependence root within this function (it comes from a dependent function argument
-  // or scoped dependence). In this case, when that depedence root is diagnosed, the analysis will find transtive uses
-  // of this apply's result.
-  //
-  // (c) the dependent value is passed to another call with a dependent inout argument, or it is stored to a yielded
-  // address of a coroutine that has a dependent inout argument. In this case, a mark_dependence will already be created
-  // for that inout argument.
-  //
-  // Parameter dependencies and yielded addresses always require a mark_dependence.
-  static func findDependenceBases(sources: LifetimeSources, _ context: FunctionPassContext) -> [Value] {
-    var bases: [Value] = []
-    for source in sources.sources {
-      switch source.convention {
-      case .inherit:
-        switch sources.targetKind {
-        case .result, .yield:
-          continue
-        case .inParameter, .inoutParameter, .yieldAddress:
-          _ = LifetimeDependence.visitDependenceRoots(enclosing: source.value, context) { scope in
-            log("Inherited lifetime from \(source.value)")
-            log("  scope: \(scope)")
-            bases.append(scope.parentValue)
-            return .continueWalk
-          }
-        }
-      case .scope:
-        // Create a new dependence on the apply's access to the argument.
-        for varIntoducer in gatherVariableIntroducers(for: source.value, context) {
-          if let scope = LifetimeDependence.Scope(base: varIntoducer, context) {
-            log("Scoped lifetime from \(source.value)")
-            log("  scope: \(scope)")
-            bases.append(scope.parentValue)
-          }
+  mutating func initializeScopedBases(source: LifetimeDependentApply.LifetimeSource, _ context: FunctionPassContext) {
+    switch source.targetKind {
+    case .yield, .yieldAddress:
+      // A coroutine creates its own borrow scope, nested within its borrowed operand.
+      bases.append(source.value)
+    case .result, .inParameter, .inoutParameter:
+      // Create a new dependence on the apply's access to the argument.
+      for varIntoducer in gatherVariableIntroducers(for: source.value, context) {
+        if let scope = LifetimeDependence.Scope(base: varIntoducer, context) {
+          log("Scoped lifetime from \(source.value)")
+          log("  scope: \(scope)")
+          bases.append(scope.parentValue)
         }
       }
     }
-    return bases
   }
 }
 
@@ -207,16 +233,17 @@ extension LifetimeDependentApply {
 /// result on each argument so that the result is recognized as a
 /// dependent value within each scope.
 private func insertResultDependencies(for apply: LifetimeDependentApply, _ context: FunctionPassContext ) {
-  guard let sources = apply.getResultDependenceSources() else {
+  guard var sources = apply.getResultDependenceSources() else {
     return
   }
   log("Creating dependencies for \(apply.applySite)")
 
-  let bases = LifetimeDependentApply.findDependenceBases(sources: sources, context)
+  // Find the dependence base for each source.
+  sources.initializeBases(context)
 
   for dependentValue in apply.applySite.resultOrYields {
     let builder = Builder(before: dependentValue.nextInstruction, context)
-    insertMarkDependencies(value: dependentValue, initializer: nil, bases: bases, builder: builder, context)
+    insertMarkDependencies(value: dependentValue, initializer: nil, bases: sources.bases, builder: builder, context)
   }
   for resultOper in apply.applySite.indirectResultOperands {
     let accessBase = resultOper.value.accessBase
@@ -231,23 +258,23 @@ private func insertResultDependencies(for apply: LifetimeDependentApply, _ conte
     }
     assert(initializingStore == resultOper.instruction, "an indirect result is a store")
     Builder.insert(after: apply.applySite, context) { builder in
-      insertMarkDependencies(value: initialAddress, initializer: initializingStore, bases: bases, builder: builder,
-                             context)
+      insertMarkDependencies(value: initialAddress, initializer: initializingStore, bases: sources.bases,
+                             builder: builder, context)
     }
   }
 }
 
 private func insertParameterDependencies(apply: LifetimeDependentApply, target: Operand,
                                          _ context: FunctionPassContext ) {
-  guard let sources = apply.getParameterDependenceSources(target: target) else {
+  guard var sources = apply.getParameterDependenceSources(target: target) else {
     return
   }
   log("Creating dependencies for \(apply.applySite)")
 
-  let bases = LifetimeDependentApply.findDependenceBases(sources: sources, context)
+  sources.initializeBases(context)
 
   Builder.insert(after: apply.applySite, context) {
-    insertMarkDependencies(value: target.value, initializer: nil, bases: bases, builder: $0, context)    
+    insertMarkDependencies(value: target.value, initializer: nil, bases: sources.bases, builder: $0, context)
   }
 }
 
@@ -259,11 +286,18 @@ private func insertMarkDependencies(value: Value, initializer: Instruction?,
     let markDep = builder.createMarkDependence(
       value: currentValue, base: base, kind: .Unresolved)
 
-    let uses = currentValue.uses.lazy.filter {
-      let inst = $0.instruction
-      return inst != markDep && inst != initializer && !(inst is Deallocation)
+    // Address dependencies cannot be represented as SSA values, so it doesn not make sense to replace any uses of the
+    // dependent address. TODO: consider a separate mark_dependence_addr instruction since the semantics are different.
+    if !value.type.isAddress {
+      let uses = currentValue.uses.lazy.filter {
+        if $0.isScopeEndingUse {
+          return false
+        }
+        let inst = $0.instruction
+        return inst != markDep && inst != initializer && !(inst is Deallocation)
+      }
+      uses.replaceAll(with: markDep, context)
     }
-    uses.replaceAll(with: markDep, context)
     currentValue = markDep
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -218,11 +218,10 @@ private extension LifetimeDependentApply.LifetimeSourceInfo {
     case .result, .inParameter, .inoutParameter:
       // Create a new dependence on the apply's access to the argument.
       for varIntoducer in gatherVariableIntroducers(for: source.value, context) {
-        if let scope = LifetimeDependence.Scope(base: varIntoducer, context) {
-          log("Scoped lifetime from \(source.value)")
-          log("  scope: \(scope)")
-          bases.append(scope.parentValue)
-        }
+        let scope = LifetimeDependence.Scope(base: varIntoducer, context)
+        log("Scoped lifetime from \(source.value)")
+        log("  scope: \(scope)")
+        bases.append(scope.parentValue)
       }
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -2,21 +2,38 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===---------------------------------------------------------------------===//
-
-// For an apply that returns a lifetime dependent value, 
-// LifetimeDependenceInsertion inserts mark_dependence [unresolved] on parent
-// value's access scope. LifetimeDependenceScopeFixup then extends the access
-// scope to cover all uses of the dependent value.
-
-// This pass must run after LifetimeDependenceInsertion and before
-// LifetimeDependenceDiagnostics.
+///
+/// LifetimeDependenceScopeFixup pass dependencies:
+///
+/// - must run after OSSA lifetime completion (and before invalidation)
+///
+/// - must run after LifetimeDependenceInsertion
+///
+/// - must run before LifetimeDependenceDiagnostics
+///
+/// Step 1. LifetimeDependenceInsertion inserts 'mark_dependence [unresolved]' instructions for applies that return a
+/// lifetime dependent value.
+///
+/// Step 2. LifetimeDependenceScopeFixup visits each 'mark_dependence [unresolved]'. If the dependence base is an access
+/// scope, then it extends the access and any parent accesses to cover all uses of the dependent value.
+///
+/// Step 3. DiagnoseStaticExclusivity diagnoses an error for any overlapping access scopes. We prefer to diagnose a
+/// static exclusivity violation over a escaping violation. LifetimeDependenceScopeFixup is, therefore, allowed to
+/// create overlapping access scopes.
+///
+/// Step 4. LifetimeDependenceDiagnostics visits each 'mark_dependence [unresolved]' again and will report a violation
+/// for any dependent use that was not covered by the access scope.
+///
+/// This is conceptually a SILGen cleanup pass, because lifetime dependencies are invalid before it runs.
+///
+//===---------------------------------------------------------------------===//
 
 import SIL
 
@@ -28,6 +45,60 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
   }
 }
 
+/// LifetimeDependenceScopeFixup visits each mark_dependence [unresolved]. It finds the access scope of the dependence
+/// base and extends it to cover the dependent uses.
+///
+/// If the base's access scope ends before a dependent use:
+///
+///     %dependentVal = mark_dependence [unresolved] %v on %innerAccess
+///     end_access %innerAccess
+///     apply %f(%dependentVal)
+///
+/// Then sink the end_access:
+///
+///     %dependentVal = mark_dependence [unresolved] %v on %innerAccess
+///     end_access %innerAccess
+///     apply %f(%dependentVal)
+///
+/// Recursively extend all enclosing access scopes up to an owned value or function argument. If the inner dependence is
+/// on a borrow scope, extend it first:
+///
+///     %outerAccess = begin_access %base
+///     %innerAccess = begin_access %outerAccess
+///     %innerBorrow = begin_borrow [var_decl] %innerAccess
+///     %dependentVal = mark_dependence [unresolved] %v on %innerBorrow
+///     end_borrow %innerBorrow
+///     end_access %innerAccess
+///     end_access %outerAccess
+///     apply %f(%dependentVal)
+///
+/// Is rewritten as:
+///
+///     apply %f(%dependentVal)
+///     end_borrow %innerBorrow
+///     end_access %innerAccess
+///     end_access %outerAccess
+///
+/// If the borrow scope is not marked [var_decl], then it has no meaningful scope for diagnostics. Rather than extending
+/// such scope, could redirect the dependence base to its operand:
+///
+///     %dependentVal = mark_dependence [unresolved] %v on %innerAccess
+///
+/// If a dependent use is on a function return:
+///
+///     sil @f $(@inout) -> () {
+///     bb0(%0: $*T)
+///       %outerAccess = begin_access [modify] %0
+///       %innerAccess = begin_access %outerAccess
+///       %dependentVal = mark_dependence [unresolved] %v on %innerAccess
+///       end_access %innerAccess
+///       end_access %outerAccess
+///       return %dependentVal
+///
+/// Then rewrite the mark_dependence base operand to a function argument:
+///
+///       %dependentVal = mark_dependence [unresolved] %v on %0
+///
 let lifetimeDependenceScopeFixupPass = FunctionPass(
   name: "lifetime-dependence-scope-fixup")
 { (function: Function, context: FunctionPassContext) in
@@ -44,75 +115,72 @@ let lifetimeDependenceScopeFixupPass = FunctionPass(
     guard let markDep = instruction as? MarkDependenceInst else {
       continue
     }
-    guard let lifetimeDep = LifetimeDependence(markDep, context) else {
+    guard let innerLifetimeDep = LifetimeDependence(markDep, context) else {
       continue
     }
-    if let arg = extendAccessScopes(dependence: lifetimeDep, localReachabilityCache, context) {
-      markDep.baseOperand.set(to: arg, context)
+    // Redirect the dependence base to ignore irrelevant borrow scopes.
+    guard let newLifetimeDep = markDep.rewriteSkippingBorrow(scope: innerLifetimeDep.scope, context) else {
+      continue
+    }
+    // Recursively sink enclosing end_access, end_borrow, or end_apply.
+    let args = extendScopes(dependence: newLifetimeDep, localReachabilityCache, context)
+
+    // Redirect the dependence base to the function arguments. This may create additional mark_dependence instructions.
+    markDep.redirectFunctionReturn(to: args, context)
+  }
+}
+
+private extension MarkDependenceInst {
+  /// Rewrite the mark_dependence base operand to ignore inner borrow scopes (begin_borrow, load_borrow).
+  ///
+  /// Note: this could be done as a general simplification, e.g. after inlining. But currently this is only relevant for
+  /// diagnostics.
+  func rewriteSkippingBorrow(scope: LifetimeDependence.Scope, _ context: FunctionPassContext) -> LifetimeDependence? {
+    guard let newScope = scope.ignoreBorrowScope(context) else {
+      return nil
+    }
+    let newBase = newScope.parentValue
+    if newBase != self.baseOperand.value {
+      self.baseOperand.set(to: newBase, context)
+    }
+    return LifetimeDependence(scope: newScope, dependentValue: self)
+  }
+
+  /// Rewrite the mark_dependence base operand, setting it to a function argument.
+  ///
+  /// To handle more than one function argument, new mark_dependence instructions will be chained.
+  /// This is called when the dependent value is returned by the function and the dependence base is in the caller.
+  func redirectFunctionReturn(to args: SingleInlineArray<FunctionArgument>, _ context: FunctionPassContext) {
+    var updatedMarkDep: MarkDependenceInst?
+    for arg in args {
+      guard let currentMarkDep = updatedMarkDep else {
+        self.baseOperand.set(to: arg, context)
+        updatedMarkDep = self
+        continue
+      }
+      let newMarkDep = Builder(after: currentMarkDep, location: currentMarkDep.location, context)
+        .createMarkDependence(value: currentMarkDep, base: arg, kind: .Unresolved)
+      let uses = currentMarkDep.uses.lazy.filter {
+        let inst = $0.instruction
+        return inst != newMarkDep
+      }
+      uses.replaceAll(with: newMarkDep, context)
+      updatedMarkDep = newMarkDep
     }
   }
 }
 
-/// Extend all access scopes that enclose `dependence`. If dependence is on an access scope in the caller, then return
-/// the function argument that represents the dependence scope.
-private func extendAccessScopes(dependence: LifetimeDependence,
-                                _ localReachabilityCache: LocalVariableReachabilityCache,
-                                _ context: FunctionPassContext) -> FunctionArgument? {
-  log("Scope fixup for lifetime dependent instructions: \(dependence)")
-
-  guard case .access(let beginAccess) = dependence.scope else {
-    return nil
-  }
-  let function = beginAccess.parentFunction
-
-  // Get the range accessBase lifetime. The accessRange cannot exceed this without producing invalid SIL.
-  guard var ownershipRange = AddressOwnershipLiveRange.compute(for: beginAccess.address, at: beginAccess,
-                                                               localReachabilityCache, context) else {
-    return nil
-  }
-  defer { ownershipRange.deinitialize() }
-
-  var accessRange = InstructionRange(begin: beginAccess, context)
-  defer {accessRange.deinitialize()}
-
-  var walker = LifetimeDependenceScopeFixupWalker(function, localReachabilityCache, context) {
-    // Do not extend the accessRange past the ownershipRange.
-    let dependentInst = $0.instruction
-    if ownershipRange.coversUse(dependentInst) {
-      accessRange.insert(dependentInst)
-    }
-    return .continueWalk
-  }
-  defer {walker.deinitialize()}
-
-  _ = walker.walkDown(root: dependence.dependentValue)
-
-  log("Scope fixup for dependent uses:\n\(accessRange)")
-
-  // Lifetime dependenent uses may not be dominated by the access. The dependent value may be used by a phi or stored
-  // into a memory location. The access may be conditional relative to such uses. If any use was not dominated, then
-  // `accessRange` will include the function entry.
-  let firstInst = function.entryBlock.instructions.first!
-  if firstInst != beginAccess, accessRange.contains(firstInst) {
-    return nil
-  }
-  if let arg = extendAccessScope(beginAccess: beginAccess, range: &accessRange, context) {
-    // If the dependent value is returned, then return the FunctionArgument that it depends on.
-    assert(walker.dependsOnCaller)
-    return arg
-  }
-  return nil
-}
-
-/// Extend this access scope to cover the dependent uses. Recursively extend outer accesses to maintain nesting.
+/// Transitively extend nested scopes that enclose the dependence base.
 ///
-/// Note that we cannot simply rewrite the `mark_dependence` to depend on an outer access scope. For 'read' access, this
-/// could let us avoid extending the inner scope, but that would not accomplish anything useful because inner 'read's
-/// can always be extended up to the extent of their outer 'read' (ignoring the special case when the dependence is on a
-/// caller scope, which is handled separately). A nested 'read' access can never interfere with another access in the
-/// same outer 'read', because it is impossible to nest a 'modify' access within a 'read'. For 'modify' accesses,
-/// however, the inner scope must be extended for correctness. A 'modify' access can interfere with other 'modify'
-/// access in the same scope. We rely on exclusivity diagnostics to report these interferences. For example:
+/// If the parent function returns the dependent value, then this returns the function arguments that represent the
+/// caller's scope.
+///
+/// Note that we cannot simply rewrite the `mark_dependence` to depend on an outer access scope. Although that would be
+/// valid for a 'read' access, it would not accomplish anything useful. An inner 'read' can always be extended up to
+/// the end of its outer 'read'. A nested 'read' access can never interfere with another access in the same outer
+/// 'read', because it is impossible to nest a 'modify' access within a 'read'. For 'modify' accesses, however, the
+/// inner scope must be extended for correctness. A 'modify' access can interfere with other 'modify' access in the same
+/// scope. We rely on exclusivity diagnostics to report these interferences. For example:
 ///
 ///     sil @foo : $(@inout C) -> () {
 ///       bb0(%0 : $*C):
@@ -127,66 +195,481 @@ private func extendAccessScopes(dependence: LifetimeDependence,
 ///         return
 ///     }
 ///
-/// The call to `@useDependent` is an exclusivity violation because it uses a value that depends on a 'modify'
-/// access. This scope fixup pass must extend '%a1' to cover the `@useDependent` but must not extend the base of the
-/// `mark_dependence` to the outer access `%0`. This ensures that exclusivity diagnostics correctly reports the
-/// violation, and that subsequent optimizations do not shrink the inner access `%a1`.
-private func extendAccessScope(beginAccess: BeginAccessInst, range: inout InstructionRange,
-                               _ context: FunctionPassContext) -> FunctionArgument? {
-  var endAccesses = [Instruction]()
-  // Collect the original end_access instructions and extend the range to to cover them. The resulting access scope must
-  // cover the original scope because it may protect other memory operations.
-  var requiresExtension = false
-  for end in beginAccess.endInstructions {
-    endAccesses.append(end)
-    if range.contains(end) {
-      // If any end_access is inside the new range, then all end_accesses must be rewritten.
-      requiresExtension = true
-    } else {
-      range.insert(end)
-    }
+// The above call to `@useDependent` is an exclusivity violation because it uses a value that depends on a 'modify'
+// access. This scope fixup pass must extend '%a1' to cover the `@useDependent` but must not extend the base of the
+// `mark_dependence` to the outer access `%0`. This ensures that exclusivity diagnostics correctly reports the
+// violation, and that subsequent optimizations do not shrink the inner access `%a1`.
+private func extendScopes(dependence: LifetimeDependence,
+                          _ localReachabilityCache: LocalVariableReachabilityCache,
+                          _ context: FunctionPassContext) -> SingleInlineArray<FunctionArgument> {
+  log("Scope fixup for lifetime dependent instructions: \(dependence)")
+
+  // Each scope extension is a set of nested scopes and an owner. The owner is a value that represents ownerhip of the
+  // outermost scope, which cannot be extended; it limits how far the nested scopes can be extended.
+  guard let scopeExtensions = dependence.scope.gatherExtensions(context) else {
+    return SingleInlineArray()
   }
-  if !requiresExtension {
-    return nil
-  }
-  // Create new end_access at the end of extended uses
-  var dependsOnCaller = false
-  for end in range.ends {
-    let location = end.location.autoGenerated
-    if end is ReturnInst {
-      dependsOnCaller = true
-      let endAccess = Builder(before: end, location: location, context).createEndAccess(beginAccess: beginAccess)
-      range.insert(endAccess)
+  var dependsOnArgs = SingleInlineArray<FunctionArgument>()
+  for scopeExtension in scopeExtensions {
+    var scopeExtension = scopeExtension
+    guard var useRange = computeDependentUseRange(of: dependence.dependentValue, within: &scopeExtension,
+                                                  localReachabilityCache, context) else {
       continue
     }
-    Builder.insert(after: end, location: location, context) {
-      let endAccess = $0.createEndAccess(beginAccess: beginAccess)
-      // This scope should be nested in any outer scopes.
-      range.insert(endAccess)
+    defer { useRange.deinitialize() }
+
+    scopeExtension.extend(over: &useRange, context)
+
+    if scopeExtension.dependsOnCaller, let arg = scopeExtension.dependsOnArg {
+      dependsOnArgs.push(arg)
     }
   }
-  for exitInst in range.exits {
-    let location = exitInst.location.autoGenerated
-    let endAccess = Builder(before: exitInst, location: location, context).createEndAccess(beginAccess: beginAccess)
-    range.insert(endAccess)
-  }
-  // Delete original end_access instructions
-  for endAccess in endAccesses {
-    context.erase(instruction: endAccess)
-  }
-  // TODO: Add SIL support for lifetime dependence and write unit test for nested access scopes
-  switch beginAccess.address.enclosingAccessScope {
-  case let .scope(enclosingBeginAccess):
-    return extendAccessScope(beginAccess: enclosingBeginAccess, range: &range, context)
-  case let .base(accessBase):
-    if case let .argument(arg) = accessBase, dependsOnCaller {
-      return arg
+  return dependsOnArgs
+}
+
+/// All scopes nested within a single dependence base that require extension.
+private struct ScopeExtension {
+  /// The ownership lifetime of the dependence base, which cannot be extended.
+  let owner: Value
+
+  /// The scopes nested under 'value' that may be extended, in inside-out order. There is always at
+  /// least one element, otherwise there is nothing to consider extending.
+  let nestedScopes: SingleInlineArray<LifetimeDependence.Scope>
+
+  var innerScope: LifetimeDependence.Scope { get { nestedScopes.first! } }
+
+  /// `dependsOnArg` is set to the function argument that represents the caller's dependency source.
+  var dependsOnArg: FunctionArgument?
+
+  /// `dependsOnCaller` is true if the dependent value is returned by the function.
+  /// Initialized during computeDependentUseRange().
+  var dependsOnCaller = false
+}
+
+private extension LifetimeDependence.Scope {
+  /// The instruction that introduces an extendable scope. This returns a non-nil scope introducer for
+  /// Extendable.nestedScopes.
+  var extendableBegin: Instruction? {
+    switch self {
+    case let .access(beginAccess):
+      return beginAccess
+    case let .borrowed(beginBorrow):
+      return beginBorrow.value.definingInstruction!
+    case let .yield(yieldedValue):
+      return yieldedValue.definingInstruction!
+    default:
+      return nil
     }
-    return nil
+  }
+
+  /// Find any nested scopes that may be extended.
+  ///
+  /// Return 'nil' if 'self' is not extendable.
+  ///
+  /// TODO: handle trivial variable scopes
+  func gatherExtensions(innerScopes: SingleInlineArray<LifetimeDependence.Scope>? = nil, _ context: FunctionPassContext)
+    -> SingleInlineArray<ScopeExtension>? {
+
+    var innerScopes = innerScopes ?? SingleInlineArray()
+    switch self {
+    case let .access(beginAccess):
+      // Finding the access base also finds all intermediate nested scopes; there is no need to recursively call
+      // gatherExtensions().
+      let (accessBase, nestedAccesses) = beginAccess.accessBaseWithScopes
+      let ownerAddress: Value
+      var dependsOnArg: FunctionArgument? = nil
+      switch accessBase {
+      case .global, .unidentified:
+        ownerAddress = beginAccess.address
+      case let .argument(arg):
+        ownerAddress = beginAccess.address
+        dependsOnArg = arg
+      case .box, .stack, .class, .tail, .yield, .storeBorrow,
+           .pointer, .index:
+        ownerAddress = accessBase.address!
+      }
+      assert(!nestedAccesses.isEmpty)
+      for nestedAccess in nestedAccesses {
+        innerScopes.push(.access(nestedAccess))
+      }
+      // This is the outermost scope. We only see nested access scopes after inlining.
+      //
+      // TODO: could we have a nested access within an yielded inout address?
+      return SingleInlineArray(element: ScopeExtension(owner: ownerAddress, nestedScopes: innerScopes,
+                                                       dependsOnArg: dependsOnArg))
+    case let .borrowed(beginBorrow):
+      let borrowedValue = beginBorrow.baseOperand!.value
+      guard let enclosingScope = LifetimeDependence.Scope(base: borrowedValue, context) else {
+        return nil
+      }
+      innerScopes.push(self)
+      var innerBorrowScopes = innerScopes
+      innerBorrowScopes.push(enclosingScope)
+      if let extensions = enclosingScope.gatherExtensions(innerScopes: innerBorrowScopes, context) {
+        return extensions
+      }
+      // This is the outermost scope that can be extended because gatherExtensions did not find an enclosing scope.
+      var dependsOnArg: FunctionArgument? = nil
+      if case let .caller(arg) = enclosingScope {
+        dependsOnArg = arg
+      }
+      return SingleInlineArray(element: ScopeExtension(owner: enclosingScope.parentValue, nestedScopes: innerScopes,
+                                                       dependsOnArg: dependsOnArg))
+    case let .yield(yieldedValue):
+      innerScopes.push(self)
+      var extensions = SingleInlineArray<ScopeExtension>()
+      let applySite = yieldedValue.definingInstruction as! BeginApplyInst
+      for operand in applySite.parameterOperands {
+        guard let dep = applySite.resultDependence(on: operand), dep == .scope else {
+          continue
+        }
+        guard let enclosingScope = LifetimeDependence.Scope(base: operand.value, context) else {
+          continue
+        }
+        if let operandExtensions = enclosingScope.gatherExtensions(innerScopes: innerScopes, context) {
+          extensions.append(contentsOf: operandExtensions)
+        } else {
+          // This is the outermost scope that can be extended because gatherExtensions did not find an enclosing scope.
+          var dependsOnArg: FunctionArgument? = nil
+          if case let .caller(arg) = enclosingScope {
+            dependsOnArg = arg
+          }
+          extensions.push(ScopeExtension(owner: enclosingScope.parentValue, nestedScopes: innerScopes,
+                                         dependsOnArg: dependsOnArg))
+        }
+      }
+      return extensions
+    default:
+      return nil
+    }
   }
 }
 
-private struct LifetimeDependenceScopeFixupWalker : LifetimeDependenceDefUseWalker {
+/// Compute the range of the a scope owner. Nested scopes must stay within this range.
+///
+/// Abstracts over lifetimes for both addresses and values.
+extension ScopeExtension {
+  enum Range {
+    case fullRange
+    case addressRange(AddressOwnershipLiveRange)
+    case valueRange(InstructionRange)
+
+    func coversUse(_ inst: Instruction) -> Bool {
+      switch self {
+      case .fullRange:
+        return true
+      case let .addressRange(range):
+        return range.coversUse(inst)
+      case let .valueRange(range):
+        return range.inclusiveRangeContains(inst)
+      }
+    }
+
+    mutating func deinitialize() {
+      switch self {
+      case .fullRange:
+        break
+      case var .addressRange(range):
+        return range.deinitialize()
+      case var .valueRange(range):
+        return range.deinitialize()
+      }
+    }
+  }
+
+  /// Return nil if the scope's owner is valid across the function, such as a guaranteed function argument.
+  func computeRange(_ localReachabilityCache: LocalVariableReachabilityCache, _ context: FunctionPassContext) -> Range?
+  {
+    if owner.type.isAddress {
+      // Get the range of the accessBase lifetime at the point where the outermost extendable scope begins.
+      if let range = AddressOwnershipLiveRange.compute(for: owner, at: nestedScopes.last!.extendableBegin!,
+                                                       localReachabilityCache, context) {
+        return .addressRange(range)
+      }
+      return nil
+    }
+    if owner.ownership == .owned {
+      return .valueRange(computeLinearLiveness(for: owner, context))
+    }
+    // Trivial or guaranted owner.
+    //
+    // TODO: limit extension to the begin_borrow [var_decl] scope
+    return .fullRange
+  }
+}
+
+/// Return an InstructionRange covering all the dependent uses of 'value'.
+private func computeDependentUseRange(of value: Value, within scopeExtension: inout ScopeExtension,
+                                      _ localReachabilityCache: LocalVariableReachabilityCache,
+                                      _ context: FunctionPassContext)
+  -> InstructionRange? {
+
+  guard var ownershipRange = scopeExtension.computeRange(localReachabilityCache, context) else {
+    return nil
+  }
+  defer {ownershipRange.deinitialize()}
+
+  // The innermost scope that must be extended must dominate all uses.
+  var useRange = InstructionRange(begin: scopeExtension.innerScope.extendableBegin!, context)
+  let function = value.parentFunction
+  var walker = LifetimeDependentUseWalker(function, localReachabilityCache, context) {
+    // Do not extend the useRange past the ownershipRange.
+    let dependentInst = $0.instruction
+    if ownershipRange.coversUse(dependentInst) {
+      useRange.insert(dependentInst)
+    }
+    return .continueWalk
+  }
+  defer {walker.deinitialize()}
+
+  _ = walker.walkDown(root: value)
+
+  log("Scope fixup for dependent uses:\n\(useRange)")
+
+  scopeExtension.dependsOnCaller = walker.dependsOnCaller
+
+  // Lifetime dependenent uses may not be dominated by the access. The dependent value may be used by a phi or stored
+  // into a memory location. The access may be conditional relative to such uses. If any use was not dominated, then
+  // `useRange` will include the function entry.
+  let firstInst = function.entryBlock.instructions.first!
+  if firstInst != useRange.begin, useRange.contains(firstInst) {
+    return nil
+  }
+  return useRange
+}
+
+// Extend nested scopes across a use-range within their owner's range.
+extension ScopeExtension {
+  func extend(over useRange: inout InstructionRange, _ context: some MutatingContext) {
+
+    // Prepare to extend each scope.
+    var scopesToExtend = SingleInlineArray<LifetimeDependence.Scope>()
+    for innerScope in nestedScopes {
+      guard let beginInst = innerScope.extendableBegin as? ScopedInstruction else {
+        fatalError("all nested scopes must have a scoped begin instruction")
+      }
+      // Extend 'useRange' to to cover this scope's end instructions. The extended scope must at least cover the
+      // original scope because the original scope may protect other operations.
+      var requiresExtension = false
+      for endInst in beginInst.endInstructions {
+        if useRange.contains(endInst) {
+          // If any end instruction is inside the new range, then all end instructions must be rewritten.
+          requiresExtension = true
+        } else {
+          // Update 'range' with the current scope-ending instructions.
+          useRange.insert(endInst)
+        }
+      }
+      if !requiresExtension {
+        break
+      }
+      if !innerScope.canExtend(over: &useRange, context) {
+        // Scope ending instructions cannot be inserted at the 'range' boundary. Ignore all nested scopes.
+        //
+        // Note: We could still extend previously prepared inner scopes up to this 'innerScope'. To do that, we would
+        // need to repeat the steps above: treat 'innerScope' as the new owner, and recompute 'useRange'. But this
+        // scenario could only happen with nested coroutine, where the range boundary is reachable from the outer
+        // coroutine's EndApply and AbortApply--it is vanishingly unlikely if not impossible.
+        return
+      }
+      scopesToExtend.push(innerScope)
+    }
+
+    // Extend the scopes that actually required extension.
+    for innerScope in scopesToExtend {
+      innerScope.extend(over: &useRange, context)
+    }
+  }
+}
+
+// Extend a dependence scope to cover the dependent uses.
+private extension LifetimeDependence.Scope {
+  /// Return true if new scope-ending instruction can be inserted at the range boundary.
+  func canExtend(over range: inout InstructionRange, _ context: some Context) -> Bool {
+    switch self {
+    case let .yield(yieldedValue):
+      let beginApply = yieldedValue.definingInstruction as! BeginApplyInst
+      let canEndAtBoundary = { (boundaryInst: Instruction) in
+        switch beginApply.endReaches(block: boundaryInst.parentBlock, context) {
+        case .abortReaches, .endReaches:
+          return true
+        case .none:
+          return false
+        }
+      }
+      for end in range.ends {
+        if (!canEndAtBoundary(end)) {
+          return false
+        }
+      }
+      for exit in range.exits {
+        if (!canEndAtBoundary(exit)) {
+          return false
+        }
+      }
+      return true
+    default:
+      // non-yield scopes can always be ended at any point.
+      return true
+    }
+  }
+
+  /// Extend this scope over the 'range' boundary.
+  func extend(over range: inout InstructionRange, _ context: some MutatingContext) {
+    guard let beginInst = extendableBegin as? ScopedInstruction else {
+      fatalError("all nested scoped must have a scoped begin instruction")
+    }
+    // Collect the original end instructions and extend the range to to cover them. The resulting access scope
+    // must cover the original scope because it may protect other memory operations.
+    var endInsts = [Instruction]()
+    for end in beginInst.endInstructions {
+      assert(range.inclusiveRangeContains(end))
+      endInsts.append(end)
+    }
+    insertBoundaryEnds(range: &range, context)
+
+    // Delete original end instructions
+    for endInst in endInsts {
+      context.erase(instruction: endInst)
+    }
+  }
+
+  /// Create new scope-ending instructions at the boundary of 'range'.
+  func insertBoundaryEnds(range: inout InstructionRange, _ context: some MutatingContext) {
+    for end in range.ends {
+      let location = end.location.autoGenerated
+      if end is ReturnInst {
+        // End this inner scope just before the return. The mark_dependence base operand will be redirected to a
+        // function argument.
+        let builder = Builder(before: end, location: location, context)
+        // Insert newEnd so that this scope will be nested in any outer scopes.
+        range.insert(createEndInstruction(builder, context)!)
+        continue
+      }
+      Builder.insert(after: end, location: location, context) {
+        range.insert(createEndInstruction($0, context)!)
+      }
+    }
+    for exitInst in range.exits {
+      let location = exitInst.location.autoGenerated
+      let builder = Builder(before: exitInst, location: location, context)
+      range.insert(createEndInstruction(builder, context)!)
+    }
+  }
+
+  /// Create a scope-ending instruction at 'builder's insertion point.
+  func createEndInstruction(_ builder: Builder, _ context: some Context) -> Instruction? {
+    switch self {
+    case let .access(beginAccess):
+      return builder.createEndAccess(beginAccess: beginAccess)
+    case let .borrowed(beginBorrow):
+      return builder.createEndBorrow(of: beginBorrow.value)
+    case let .yield(yieldedValue):
+      let beginApply = yieldedValue.definingInstruction as! BeginApplyInst
+      return beginApply.createEnd(builder, context)
+    default:
+      return nil
+    }
+  }
+}
+
+private extension BeginApplyInst {
+  /// Create either an end_apply or abort_apply at the builder's insertion point.
+  /// Return nil if it isn't possible.
+  func createEnd(_ builder: Builder, _ context: some Context) -> Instruction? {
+    guard let insertionBlock = builder.insertionBlock else {
+      return nil
+    }
+    switch endReaches(block: insertionBlock, context) {
+    case .none:
+      return nil
+    case .endReaches:
+      return builder.createEndApply(beginApply: self)
+    case .abortReaches:
+      return builder.createAbortApply(beginApply: self)
+    }
+  }
+
+  enum EndReaches {
+    case endReaches
+    case abortReaches
+  }
+
+  /// Return the single kind of coroutine termination that reaches 'reachableBlock' or nil.
+  func endReaches(block reachableBlock: BasicBlock, _ context: some Context) -> EndReaches? {
+    var endBlocks = BasicBlockSet(context)
+    var abortBlocks = BasicBlockSet(context)
+    defer {
+      endBlocks.deinitialize()
+      abortBlocks.deinitialize()
+    }
+    for endInst in endInstructions {
+      switch endInst {
+      case let endApply as EndApplyInst:
+        // Cannot extend the scope of a coroutine when the resume produces a value.
+        if !endApply.type.isEmpty(in: parentFunction) {
+          return nil
+        }
+        endBlocks.insert(endInst.parentBlock)
+      case is AbortApplyInst:
+        abortBlocks.insert(endInst.parentBlock)
+      default:
+        fatalError("invalid begin_apply ending instruction")
+      }
+    }
+    var endReaches: EndReaches?
+    var backwardWalk = BasicBlockWorklist(context)
+    defer { backwardWalk.deinitialize() }
+
+    let backwardVisit = { (block: BasicBlock) -> WalkResult in
+      if endBlocks.contains(block) {
+        switch endReaches {
+        case .none:
+          endReaches = .endReaches
+          break
+        case .endReaches:
+          break
+        case .abortReaches:
+          return .abortWalk
+        }
+        return .continueWalk
+      }
+      if abortBlocks.contains(block) {
+        switch endReaches {
+        case .none:
+          endReaches = .abortReaches
+          break
+        case .abortReaches:
+          break
+        case .endReaches:
+          return .abortWalk
+        }
+        return .continueWalk
+      }
+      if block == self.parentBlock {
+        // the insertion point is not dominated by the coroutine
+        return .abortWalk
+      }
+      backwardWalk.pushIfNotVisited(contentsOf: block.predecessors)
+      return .continueWalk
+    }
+
+    if backwardVisit(reachableBlock) == .abortWalk {
+      return nil
+    }
+    while let block = backwardWalk.pop() {
+      if backwardVisit(block) == .abortWalk {
+        return nil
+      }
+    }
+    return endReaches
+  }
+}
+
+/// Visit all dependent uses.
+///
+/// Set 'dependsOnCaller' if a use escapes the function.
+private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   let function: Function
   let context: Context
   let visitor: (Operand) -> WalkResult

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -299,9 +299,7 @@ private extension LifetimeDependence.Scope {
                                                        dependsOnArg: dependsOnArg))
     case let .borrowed(beginBorrow):
       let borrowedValue = beginBorrow.baseOperand!.value
-      guard let enclosingScope = LifetimeDependence.Scope(base: borrowedValue, context) else {
-        return nil
-      }
+      let enclosingScope = LifetimeDependence.Scope(base: borrowedValue, context)
       innerScopes.push(self)
       var innerBorrowScopes = innerScopes
       innerBorrowScopes.push(enclosingScope)
@@ -323,9 +321,7 @@ private extension LifetimeDependence.Scope {
         guard let dep = applySite.resultDependence(on: operand), dep == .scope else {
           continue
         }
-        guard let enclosingScope = LifetimeDependence.Scope(base: operand.value, context) else {
-          continue
-        }
+        let enclosingScope = LifetimeDependence.Scope(base: operand.value, context)
         if let operandExtensions = enclosingScope.gatherExtensions(innerScopes: innerScopes, context) {
           extensions.append(contentsOf: operandExtensions)
         } else {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -341,8 +341,9 @@ extension AddressInitializationWalker {
   }
 
   mutating func yieldedAddressUse(of operand: Operand) -> WalkResult {
-    // An inout yield is a partial write.
-    return .abortWalk
+    // An inout yield is a partial write. Initialization via coroutine is not supported, so we assume a prior
+    // initialization must dominate the yield.
+    return .continueWalk
   }
 
   mutating func dependentAddressUse(of operand: Operand, into value: Value)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -597,11 +597,6 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefWalker {
     if let inst = value.definingInstruction, VariableScopeInstruction(inst) != nil {
       return introducer(value, owner)
     }
-    // Finding a variable introducer requires following the mark_dependence forwarded value, not the base value like the
-    // default LifetimeDependenceUseDefWalker.
-    if value is MarkDependenceInst {
-      return walkUpDefault(forwarded: value, owner)
-    }
     return walkUpDefault(dependent: value, owner: owner)
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -56,8 +56,9 @@ func computeLinearLiveness(for definingValue: Value, _ context: Context)
   -> InstructionRange {
 
   assert(definingValue.ownership == .owned
-    || BeginBorrowValue(definingValue) != nil,
-    "value must define an OSSA lifetime")
+           || BeginBorrowValue(definingValue) != nil
+           || VariableScopeInstruction(definingValue.definingInstruction) != nil,
+         "value must define an OSSA lifetime or variable scope")
 
   // InstructionRange cannot directly represent the beginning of the block
   // so we fake it with getRepresentativeInstruction().

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -119,7 +119,7 @@ extension LazyFilterSequence : /*@retroactive*/ SIL.CollectionLikeSequence,
 //===----------------------------------------------------------------------===//
 
 public struct SingleInlineArray<Element>: RandomAccessCollection, FormattedLikeArray {
-  private var singleElement: Element?
+  public var singleElement: Element?
   private var multipleElements: [Element] = []
 
   public init() {}

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -358,6 +358,9 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// Enable returning non-escapable types from functions.
 EXPERIMENTAL_FEATURE(LifetimeDependence, true)
 
+/// Enable LifetimeDependence diagnostics for trivial types.
+EXPERIMENTAL_FEATURE(LifetimeDependenceDiagnoseTrivial, false)
+
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -262,6 +262,8 @@ static bool usesFeatureLifetimeDependence(Decl *decl) {
       ->hasLifetimeDependencies();
 }
 
+UNINTERESTING_FEATURE(LifetimeDependenceDiagnoseTrivial)
+
 UNINTERESTING_FEATURE(DynamicActorIsolation)
 UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,8 +1,10 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: -enable-experimental-feature SuppressedAssociatedTypes
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 // expected-note@+1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -1,13 +1,16 @@
 // RUN: %target-sil-opt                                      \
 // RUN:     %s                                               \
 // RUN:     -enable-experimental-feature LifetimeDependence   \
+// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: |                                                    \
 // RUN: %target-sil-opt                                      \
 // RUN:     -enable-experimental-feature LifetimeDependence   \
+// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: |                                                    \
 // RUN: %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // For -enable-experimental-feature LifetimeDependence
 

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -1,7 +1,10 @@
 // RUN: %target-sil-opt %s \
-// RUN:   -enable-experimental-feature LifetimeDependence | %FileCheck %s
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage canonical
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -2,9 +2,11 @@
 // RUN: -emit-sil  \
 // RUN: -enable-builtin-module \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 import Builtin
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -7,6 +7,14 @@
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
+@_unsafeNonescapableResult
+@lifetime(source)
+func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  dependent: consuming T, dependsOn source: borrowing U)
+  -> T {
+  dependent
+}
+
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
@@ -136,6 +144,7 @@ struct GenericBufferView<Element> : ~Escapable {
   let count: Int
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5countACyxGSV_SitcfC : $@convention(method) <Element> (UnsafeRawPointer, Int, @thin GenericBufferView<Element>.Type) -> @lifetime(borrow 0) @owned GenericBufferView<Element> {
+  @lifetime(borrow baseAddress)
   init<Storage>(baseAddress: Pointer,
                 count: Int,
                 dependsOn: borrowing Storage) {
@@ -162,10 +171,13 @@ struct GenericBufferView<Element> : ~Escapable {
 // CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewVyACyxGAA9FakeRangeVySVGcig : $@convention(method) <Element> (FakeRange<UnsafeRawPointer>, @guaranteed GenericBufferView<Element>) -> @lifetime(copy 1) @owned GenericBufferView<Element> {
   subscript(bounds: FakeRange<Pointer>) -> Self {
     get {
-      GenericBufferView(
-        baseAddress: UnsafeRawPointer(bounds.lowerBound),
+      let pointer = UnsafeRawPointer(bounds.lowerBound)
+      let result = GenericBufferView(
+        baseAddress: pointer,
         count: bounds.upperBound.distance(to:bounds.lowerBound) / MemoryLayout<Element>.stride
       )
+      // assuming that bounds is within self
+      return unsafeLifetime(dependent: result, dependsOn: self)
     }
   }
 }

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  -target %target-swift-5.1-abi-triple \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,10 +1,12 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 protocol P {

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -1,8 +1,10 @@
 // RUN: %target-swift-frontend %s -emit-silgen \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 
 public struct Span<Element> : ~Escapable {

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,8 +1,11 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature LifetimeDependence | %FileCheck %s
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Use real Range
 public struct FakeRange<Bound> {

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -1,8 +1,10 @@
 // RUN: %target-sil-opt -test-runner \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   %s -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage raw
 

--- a/test/SILGen/accessor_borrow.swift
+++ b/test/SILGen/accessor_borrow.swift
@@ -1,8 +1,10 @@
 // RUN: %target-swift-emit-silgen -module-name accessor_borrow \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: %s | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NE: ~Escapable {}
 

--- a/test/SILOptimizer/argument_conventions.sil
+++ b/test/SILOptimizer/argument_conventions.sil
@@ -1,10 +1,12 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 import Builtin
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -1,8 +1,11 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -capture-promotion \
-// RUN: -enable-experimental-feature LifetimeDependence -module-name Swift \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: -module-name Swift \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Check to make sure that the process of promoting closure captures results in
 // a correctly cloned and modified closure function body. This test

--- a/test/SILOptimizer/lifetime_dependence/coroutine.swift
+++ b/test/SILOptimizer/lifetime_dependence/coroutine.swift
@@ -1,0 +1,107 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
+
+struct View : ~Escapable {
+  let ptr: UnsafeRawBufferPointer
+  let c: Int
+  @lifetime(borrow ptr)
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+    self.ptr = ptr
+    self.c = c
+  }
+  init(_ otherBV: borrowing View) {
+    self.ptr = otherBV.ptr
+    self.c = otherBV.c
+  }
+  init(_ k: borrowing NCContainer) {
+    self.ptr = k.ptr
+    self.c = k.c
+  }
+  // This overload requires a separate label because overloading
+  // on borrowing/consuming attributes is not allowed
+  init(consumingView k: consuming View) {
+    self.ptr = k.ptr
+    self.c = k.c
+  }
+}
+
+struct Wrapper : ~Escapable {
+  var _view: View
+
+  // Nested coroutine access.
+  var view: View {
+    _read {
+      yield _view
+    }
+    _modify {
+      yield &_view
+    }
+  }
+  init(_ view: consuming View) {
+    self._view = view
+  }
+}
+
+struct NCContainer : ~Copyable {
+  let ptr: UnsafeRawBufferPointer
+  let c: Int
+
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+    self.ptr = ptr
+    self.c = c
+  }
+
+  // Nested coroutine access.
+  var view: View {
+    _read {
+      yield View(self)
+    }
+  }
+
+  // Doubly nested coroutine access.
+  var wrapper: Wrapper {
+    _read {
+      yield Wrapper(view)
+    }
+  }
+}
+
+func use(_ o : borrowing View) {}
+
+// Extend access scopes across chained coroutines.
+//
+// CHECK-LABEL: sil hidden @$s9coroutine20testDoubleNestedRead2ncyAA11NCContainerVn_tF : $@convention(thin) (@owned NCContainer) -> () {
+// CHECK: bb0(%0 : $NCContainer):
+// CHECK:   [[NC:%.*]] = alloc_stack [lexical] [var_decl] $NCContainer, var, name "nc", type $NCContainer
+// CHECK:   store %0 to [[NC]]
+//       let wrapper = nc.wrapper
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [static] [[NC]]
+// CHECK:   [[NCVAL:%.*]] = load [[ACCESS]] 
+// CHECK:   ([[YIELD1:%.*]], [[TOKEN1:%.*]]) = begin_apply %{{.*}}([[NCVAL]]) : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed Wrapper
+// CHECK:   [[WRAPPER:%.*]] = mark_dependence [nonescaping] [[YIELD1]] on [[TOKEN1]]
+// CHECK:   retain_value [[WRAPPER]]
+// CHECK:   debug_value [[WRAPPER]], let, name "wrapper"
+//       let view = wrapper.view
+// CHECK:   ([[VIEW:%.*]], [[TOKEN2:%.*]]) = begin_apply %{{.*}}([[WRAPPER]]) : $@yield_once @convention(method) (@guaranteed Wrapper) -> @lifetime(copy 0) @yields @guaranteed View
+// CHECK:   retain_value [[VIEW]]
+// CHECK:   end_apply [[TOKEN2]] as $()
+// CHECK:   debug_value [[VIEW]], let, name "view"
+//       use(view)
+// CHECK:   apply %{{.*}}([[VIEW]]) : $@convention(thin) (@guaranteed View) -> ()
+// CHECK:   release_value [[VIEW]]
+// CHECK:   release_value [[WRAPPER]]
+// CHECK:   %24 = end_apply [[TOKEN1]] as $()
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   destroy_addr [[NC]]
+// CHECK-LABEL: } // end sil function '$s9coroutine20testDoubleNestedRead2ncyAA11NCContainerVn_tF'
+func testDoubleNestedRead(nc: consuming NCContainer) {
+  let wrapper = nc.wrapper
+  let view = wrapper.view
+  use(view)
+}

--- a/test/SILOptimizer/lifetime_dependence/diagnostic_passes.sil
+++ b/test/SILOptimizer/lifetime_dependence/diagnostic_passes.sil
@@ -1,0 +1,133 @@
+// RUN: %target-sil-opt -test-runner %s \
+// RUN:     -diagnostics -sil-verify-all \
+// RUN:     -enable-experimental-feature LifetimeDependence \
+// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN:     2>&1 | %FileCheck %s
+
+// Test SIL expected from SILGen output. Run all diagnostic passes which includes lifetime dependence handling:
+// -lifetime-dependence-insertion
+// -lifetime-dependence-scopefixup
+// -lifetime-dependence-diagnostics
+//
+// This is a good place to put reduced .sil tests.
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct Owner {}
+struct NE: ~Escapable {}
+struct OtherNE: ~Escapable {}
+
+sil @getNE : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+sil @copyNE : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+sil @makeOwner : $@convention(c) () -> Owner
+
+// Modify a local via 'inout' assignment.
+// Do not insert a mark_dep.
+// Do not extend any scopes.
+// Consider all uses of the local to be potential uses of the argument.
+//
+// CHECK-LABEL: sil [ossa] @copyToLocal : $@convention(thin) (@owned NE) -> () {
+// CHECK: bb0(%0 : @owned $NE):
+// CHECK:   [[ALLOC:%.*]] = alloc_stack [var_decl] $NE, var, name "v1"
+// CHECK:   [[MV:%.*]] = move_value [var_decl] %0
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[ALLOC]]
+// CHECK:   apply %{{.*}}([[MV]], [[ACCESS]]) : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   destroy_value [[MV]]
+// CHECK:   destroy_addr [[ALLOC]]
+// CHECK-LABEL: } // end sil function 'copyToLocal'
+sil [ossa] @copyToLocal : $@convention(thin) (@owned NE) -> () {
+bb0(%0 : @owned $NE):
+  %1 = alloc_box ${ var NE }, var, name "v1"
+  %2 = begin_borrow [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = move_value [var_decl] %0
+  %5 = begin_borrow %4
+  // assign the local to the argument
+  %6 = begin_access [modify] [unknown] %3
+  %7 = function_ref @copyNE : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  %8 = apply %7(%5, %6) : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  end_access %6
+  end_borrow %5
+  // destroy the argument
+  destroy_value %4
+  end_borrow %2
+  // destroy the local
+  destroy_value %1
+  %14 = tuple ()
+  return %14
+}
+
+// rdar://140424699
+//
+// Reassign into a local that outlives the original.
+//
+// CHECK-LABEL: sil [ossa] @testInoutReassign : $@convention(thin) () -> () {
+// CHECK:   [[V1:%.*]] = alloc_stack [var_decl] $NE, var, name "v1", type $NE
+// CHECK:   [[MD1:%.*]] = mark_dependence [nonescaping]
+// CHECK:   store [[MD1]] to [init] [[V1]]
+// CHECK:   [[MD2:%.*]] = mark_dependence [nonescaping]
+// CHECK:   [[MV:%.*]] = move_value [var_decl] [[MD2]]
+// CHECK:   debug_value [[MV]], let, name "v2"
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[V1]]
+// CHECK:   apply %{{.*}}([[MV]], [[ACCESS]]) : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   destroy_value [[MV]]
+// CHECK:   destroy_addr [[V1]]
+// CHECK-LABEL: } // end sil function 'testInoutReassign'
+sil [ossa] @testInoutReassign : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @makeOwner : $@convention(c) () -> Owner // user: %1
+  %1 = apply %0() : $@convention(c) () -> Owner
+  %2 = move_value [var_decl] %1 : $Owner
+  debug_value %2 : $Owner, let, name "o"
+
+  // Declare v1: NE
+  %8 = alloc_box ${ var NE }, var, name "v1"
+  %9 = begin_borrow [var_decl] %8 : ${ var NE }
+  %10 = project_box %9 : ${ var NE }, 0
+
+  // v1 = owner.ne
+  %11 = alloc_stack $Owner
+  store %2 to [trivial] %11 : $*Owner
+  %13 = function_ref @getNE : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  %14 = apply %13(%11) : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  dealloc_stack %11 : $*Owner
+  store %14 to [init] %10 : $*NE
+
+  // v2 = owner.ne
+  %17 = alloc_stack $Owner
+  store %2 to [trivial] %17 : $*Owner
+  %22 = apply %13(%17) : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  dealloc_stack %17 : $*Owner
+  %25 = move_value [var_decl] %22 : $NE
+  debug_value %25 : $NE, let, name "v2"
+
+  // copyView(v2, &v1)
+  %81 = begin_borrow %25 : $NE
+  %82 = begin_access [modify] [unknown] %10 : $*NE
+  %83 = function_ref @copyNE : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  %84 = apply %83(%81, %82) : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  end_access %82 : $*NE
+  end_borrow %81 : $NE
+
+  // destroy v2
+  destroy_value %25 : $NE
+
+  // destroy v1
+  end_borrow %9 : ${ var NE }
+  destroy_value %8 : ${ var NE }
+
+  // Owner covers all uses.
+  extend_lifetime %2 : $Owner
+  %93 = tuple ()
+  return %93 : $()
+}

--- a/test/SILOptimizer/lifetime_dependence/diagnostic_passes_todo.sil
+++ b/test/SILOptimizer/lifetime_dependence/diagnostic_passes_todo.sil
@@ -1,0 +1,78 @@
+// RUN: %target-sil-opt -test-runner %s \
+// RUN:     -diagnostics -sil-verify-all \
+// RUN:     -enable-experimental-feature LifetimeDependence \
+// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN:     2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
+
+// Test SIL expected from SILGen output. Run all diagnostic passes which includes lifetime dependence handling.
+// These tests are not fully implemented.
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct Owner {}
+struct NE: ~Escapable {}
+struct OtherNE: ~Escapable {}
+
+sil @getNE : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+sil @copyNE : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+sil @makeOwner : $@convention(c) () -> Owner
+
+// TODO: Diagnostics should report that end of the 'owner' variable scope end before 'v1' is destroyed.
+//
+// CHECK-LABEL: sil [ossa] @testInoutReassign_fail : $@convention(thin) () -> () {
+sil [ossa] @testInoutReassign_fail : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @makeOwner : $@convention(c) () -> Owner // user: %1
+  %1 = apply %0() : $@convention(c) () -> Owner
+  %2 = move_value [var_decl] %1 : $Owner
+  debug_value %2 : $Owner, let, name "owner"
+
+  // Declare v1: NE
+  %8 = alloc_box ${ var NE }, var, name "v1"
+  %9 = begin_borrow [var_decl] %8 : ${ var NE }
+  %10 = project_box %9 : ${ var NE }, 0
+
+  // v1 = owner.ne
+  %11 = alloc_stack $Owner
+  store %2 to [trivial] %11 : $*Owner
+  %13 = function_ref @getNE : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  %14 = apply %13(%11) : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  dealloc_stack %11 : $*Owner
+  store %14 to [init] %10 : $*NE
+
+  // v2 = owner.ne
+  %17 = alloc_stack $Owner
+  store %2 to [trivial] %17 : $*Owner
+  %22 = apply %13(%17) : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @autoreleased NE
+  dealloc_stack %17 : $*Owner
+  %25 = move_value [var_decl] %22 : $NE
+  debug_value %25 : $NE, let, name "v2"
+
+  // copyView(v2, &v1)
+  %81 = begin_borrow %25 : $NE
+  %82 = begin_access [modify] [unknown] %10 : $*NE
+  %83 = function_ref @copyNE : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  %84 = apply %83(%81, %82) : $@convention(c) (NE, @lifetime(copy 0) @inout NE) -> ()
+  end_access %82 : $*NE
+  end_borrow %81 : $NE
+
+  // destroy v2
+  destroy_value %25 : $NE
+
+  // Owner does not cover v1.
+  extend_lifetime %2 : $Owner
+
+  // destroy v1
+  end_borrow %9 : ${ var NE }
+  destroy_value %8 : ${ var NE }
+
+  %93 = tuple ()
+  return %93 : $()
+}

--- a/test/SILOptimizer/lifetime_dependence/initializer.swift
+++ b/test/SILOptimizer/lifetime_dependence/initializer.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>

--- a/test/SILOptimizer/lifetime_dependence/inout.swift
+++ b/test/SILOptimizer/lifetime_dependence/inout.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence.sil
@@ -2,10 +2,12 @@
 // RUN:   -o /dev/null \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name Swift \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test the SIL representation for lifetime dependence.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence 
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Some container-ish thing.
 struct CN: ~Copyable {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NCInt: ~Copyable {
   var value: Int

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -2,10 +2,12 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence 
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
@@ -58,7 +58,8 @@ func bv_borrow_var(p: UnsafeRawPointer, i: Int) {
 // CHECK: apply %{{.*}}<UnsafePointer<Int>, UnsafeRawPointer>([[RAW:%.*]], %{{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
 // CHECK: [[RAW:%.*]] = load [trivial] %6 : $*UnsafeRawPointer
 // CHECK: [[BV:%.*]] = apply %13([[RAW]], {{.*}}) : $@convention(method) (UnsafeRawPointer, Int, @thin BV.Type) -> @lifetime(borrow 0) @owned BV
-// CHECK: return [[BV]] : $BV
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[BV]] : $BV on %0 : $UnsafePointer<Int>
+// CHECK: return [[MD]] : $BV
 // CHECK-LABEL: } // end sil function '$s4test18bv_pointer_convert1pAA2BVVSPySiG_tF'
 @lifetime(borrow p)
 func bv_pointer_convert(p: UnsafePointer<Int>) -> BV {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
@@ -3,10 +3,12 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct MutableSpan : ~Escapable, ~Copyable {
   let base: UnsafeMutableRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -2,6 +2,7 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
+// RUN:   -disable-access-control \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
@@ -59,7 +60,8 @@ extension Array where Element == Int {
   mutating func mutspan() -> /* dependsOn(scoped self) */ MutableSpan {
     /* not the real implementation */
     let p = self.withUnsafeMutableBufferPointer { $0.baseAddress! }
-    return MutableSpan(p, count)
+    let span = MutableSpan(p, count)
+    return _overrideLifetime(span, borrowing: self)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -2,10 +2,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Simply test that it is possible for a module to define a pseudo-Optional type without triggering any compiler errors.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
@@ -2,10 +2,12 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test LifetimeDependenceScopeFixup.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-frontend %s -Xllvm -sil-print-types -emit-sil \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NCContainer : ~Copyable {
   let ptr: UnsafeRawBufferPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -159,14 +159,15 @@ func test6(_ a: Array<Int>) {
 // CHECK-LABEL: sil hidden @$s31lifetime_dependence_scope_fixup5test7yySWF : $@convention(thin) (UnsafeRawBufferPointer) -> () {
 // CHECK:   [[CONT:%.*]] = alloc_stack [var_decl] $View
 // function_ref View.init(_:_:)
-// CHECK:   [[VIEW1:%.*]] = apply %{{.*}}(%0, %{{.*}}, %{{.*}}) : $@convention(method) (UnsafeRawBufferPointer, Int, @thin View.Type) -> @lifetime(borrow 0) @owned View // users: %14, %9, %12, %8
+// CHECK:   [[VIEW1:%.*]] = apply %{{.*}}(%0, %{{.*}}, %{{.*}}) : $@convention(method) (UnsafeRawBufferPointer, Int, @thin View.Type) -> @lifetime(borrow 0) @owned View
+// CHECK:   [[MD1:%.*]] = mark_dependence [nonescaping] %{{.*}} : $View on %0 : $UnsafeRawBufferPointer
 // CHECK:   [[BA:%.*]] = begin_access [read] [static] [[CONT]] : $*View
 // CHECK:   [[FUNC:%.*]] = function_ref @$s31lifetime_dependence_scope_fixup16getBorrowingViewyAA0G0VADF : $@convention(thin) (@guaranteed View) -> @lifetime(borrow 0) @owned View
-// CHECK:   [[VIEW2:%.*]] = apply [[FUNC]]([[VIEW1]]) : $@convention(thin) (@guaranteed View) -> @lifetime(borrow 0) @owned View
-// CHECK:   [[MDI:%.*]] = mark_dependence [nonescaping] [[VIEW2]] : $View on [[BA]] : $*View
+// CHECK:   [[VIEW2:%.*]] = apply [[FUNC]]([[MD1]]) : $@convention(thin) (@guaranteed View) -> @lifetime(borrow 0) @owned View
+// CHECK:   [[MD2:%.*]] = mark_dependence [nonescaping] [[VIEW2]] : $View on [[BA]] : $*View
 // CHECK:   [[USE:%.*]] = function_ref @$s31lifetime_dependence_scope_fixup3useyyAA4ViewVF : $@convention(thin) (@guaranteed View) -> ()
-// CHECK:   apply [[USE]]([[MDI]]) : $@convention(thin) (@guaranteed View) -> ()
-// CHECK:   release_value [[MDI]] : $View
+// CHECK:   apply [[USE]]([[MD2]]) : $@convention(thin) (@guaranteed View) -> ()
+// CHECK:   release_value [[MD2]] : $View
 // CHECK:   end_access [[BA]] : $*View
 // CHECK-LABEL: } // end sil function '$s31lifetime_dependence_scope_fixup5test7yySWF'
 func test7(_ a: UnsafeRawBufferPointer) {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -133,7 +133,10 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D, %4 : $*D):
   %trivial_mark = mark_dependence [nonescaping] %yield_mark : $C on %zero : $Builtin.Int1
   specify_test "lifetime_dependence_scope %trivial_mark"
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %trivial_mark
-// CHECK-NEXT: Trivial Dependence
+// CHECK-NEXT: Unknown:   %{{.*}} = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: Dependent: %{{.*}} = mark_dependence [nonescaping]
+// CHECK-NEXT: begin:     %{{.*}} = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: ends:{{[ ]+$}}
 // CHECK: dependence_scope: lifetime_dependence_scope with: %trivial_mark
 
   %f = ref_element_addr %borrow : $D, #D.object

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -1,10 +1,12 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:     -module-name Swift \
 // RUN:     -enable-experimental-feature LifetimeDependence \
+// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:     -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage canonical
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -110,9 +110,10 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D, %4 : $*D):
   %guaranteed_mark = mark_dependence [nonescaping] %owned_mark : $C on %pair : $PairC
   specify_test "lifetime_dependence_scope %guaranteed_mark"
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %guaranteed_mark
-// CHECK-NEXT: Caller:      %2 = argument of bb0 : $D
+// CHECK-NEXT: Borrowed:    %{{.*}} = begin_borrow %2 : $D
 // CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $PairC
-// CHECK-NEXT: Caller range
+// CHECK-NEXT: begin:       %{{.*}} = begin_borrow %2 : $D
+// CHECK-NEXT: ends:        end_borrow {{.*}} : $D
 // CHECK: dependence_scope: lifetime_dependence_scope with: %guaranteed_mark
 
   %m = class_method %2 : $D, #D.field!read : (D) -> () -> (), $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
@@ -195,7 +196,7 @@ entry(%0 : @owned $D, %1 : @owned $C):
   %load = load [copy] %access : $*C
   specify_test "lifetime_dependence_root %load"
 // CHECK-LABEL: dependence_root: lifetime_dependence_root with: %load
-// No root: Inheriting a dependence from an Escapable value.
+// CHECK-NEXT: Scope: Unknown:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: dependence_root: lifetime_dependence_root with: %load
 
   destroy_value %load : $C

--- a/test/SILOptimizer/lifetime_dependence/scopefixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scopefixup.sil
@@ -7,6 +7,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test the SIL representation for lifetime dependence scope fixup.
 

--- a/test/SILOptimizer/lifetime_dependence/scopefixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scopefixup.sil
@@ -1,0 +1,84 @@
+// RUN: %target-sil-opt %s \
+// RUN:   --lifetime-dependence-scope-fixup \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN:   2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+
+// Test the SIL representation for lifetime dependence scope fixup.
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+struct NE : ~Escapable {
+}
+
+struct Wrapper : ~Escapable {
+  @_hasStorage var _ne: NE { get set }
+  var ne: NE { get set } // _read
+  init(_ ne: consuming NE)
+}
+
+struct NCContainer : ~Copyable {
+  @_hasStorage let ptr: UnsafeRawBufferPointer { get }
+  @_hasStorage let c: Int { get }
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int)
+  var ne: NE { get } // _read
+  var wrapper: Wrapper { get } // _read
+}
+
+sil [ossa] @Wrapper_init : $@convention(method) (@owned NE, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper
+
+sil [ossa] @NCContainer_ne_read : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed NE
+
+// NCContainer.wrapper._read:
+//   var wrapper: Wrapper {
+//     _read {
+//       yield Wrapper(view)
+//     }
+//   }
+//
+// Sink end_apply into the resume and unwind paths.
+//
+// CHECK-LABEL: sil hidden [ossa] @NCContainer_wrapper_read : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed Wrapper {
+// CHECK: ([[YIELD:%.*]], [[TOKEN:%.*]]) = begin_apply %{{.*}}(%0) : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed NE
+// CHECK:   [[MD:%.*]] = mark_dependence [unresolved] [[YIELD]] on [[TOKEN]]
+// CHECK:   [[CP:%.*]] = copy_value [[MD]]
+// CHECK:   [[WRAPPER:%.*]] = apply %{{.*}}([[CP]], %{{.*}}) : $@convention(method) (@owned NE, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper
+// CHECK:   yield [[WRAPPER]], resume bb1, unwind bb2
+// CHECK: bb1:
+// CHECK:   destroy_value [[WRAPPER]]
+// CHECK:   end_apply [[TOKEN]] as $()
+// CHECK:   return
+// CHECK: bb2:
+// CHECK:   destroy_value [[WRAPPER]]
+// CHECK:   end_apply [[TOKEN]] as $()
+// CHECK:   unwind
+// CHECK-LABEL: } // end sil function 'NCContainer_wrapper_read'
+sil hidden [ossa] @NCContainer_wrapper_read : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed Wrapper {
+bb0(%0 : @guaranteed $NCContainer):
+  debug_value %0, let, name "self", argno 1
+  %2 = metatype $@thin Wrapper.Type
+  %3 = function_ref @NCContainer_ne_read : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed NE
+  (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed NE
+  %6 = mark_dependence [unresolved] %4 on %5
+  %7 = copy_value %6
+  %8 = end_apply %5 as $()
+  %9 = function_ref @Wrapper_init : $@convention(method) (@owned NE, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper
+  %10 = apply %9(%7, %2) : $@convention(method) (@owned NE, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper
+  yield %10, resume bb1, unwind bb2
+
+bb1:
+  destroy_value %10
+  %13 = tuple ()
+  return %13
+
+bb2:
+  destroy_value %10
+  unwind
+}

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -11,7 +11,6 @@
 // REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Lifetime dependence semantics by example.
-
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>
   private var count: Int
@@ -31,7 +30,8 @@ struct Span<T>: ~Escapable {
 
 extension Span {
   consuming func dropFirst() -> Span<T> {
-    let local = Span(base: self.base + 1, count: self.count - 1)
+    let nextPointer = self.base + 1
+    let local = Span(base: nextPointer, count: self.count - 1)
     return unsafeLifetime(dependent: local, dependsOn: self)
   }
 }
@@ -67,11 +67,12 @@ extension Span {
 }
 
 extension Array {
-  // TODO: comment out
-  borrowing func span() -> /* */ Span<Element> {
+  @lifetime(borrow self)
+  borrowing func span() -> Span<Element> {
     /* not the real implementation */
     let p = self.withUnsafeBufferPointer { $0.baseAddress! }
-    return Span(base: p, count: 1)
+    let span = Span(base: p, count: 1)
+    return unsafeLifetime(dependent: span, scope: self)
   }
 }
 
@@ -160,3 +161,16 @@ func testScopedOfInheritedWithLet(_ arg: [Int] ) {
   // expected-note @-1{{it depends on the lifetime of this parent value}}  
   _ = result
 } // expected-note {{this use of the lifetime-dependent value is out of scope}}
+
+// =============================================================================
+// Scoped dependence on trivial values
+// =============================================================================
+
+@lifetime(borrow a)
+func testTrivialScope<T>(a: Array<T>) -> Span<T> {
+  let p = a.withUnsafeBufferPointer { $0.baseAddress! }
+  return Span(base: p, count: 1)
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note  @-3{{it depends on the lifetime of variable 'p'}}
+  // expected-note  @-3{{this use causes the lifetime-dependent value to escape}}
+}

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -3,10 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Lifetime dependence semantics by example.
 

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -1,9 +1,21 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature LifetimeDependence %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature LifetimeDependence %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify \
+// RUN: -enable-experimental-feature NoImplicitCopy \
+// RUN: -enable-experimental-feature MoveOnlyClasses \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
+
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify \
+// RUN: -enable-experimental-feature NoImplicitCopy \
+// RUN: -enable-experimental-feature MoveOnlyClasses \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
+// RUN: %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on


### PR DESCRIPTION
Handle arbitrarily nested accesses, borrows, and coroutines.

Handle dependence on variable bindings that hold trivial values.

This overhaul is currently blocking a SILGen fix that adds mark_dependence to unsafeAddress, so that addressors can be used to implement borrowed properties. More tests will be added for addressors at that time.

Fixes rdar://140424699 (Invalid SIL is generated by some passes for certain `@` `lifetime` annotations)
