### PR TITLE
Fix a crash in type lowering verification when using variadic optional tuples

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3012,6 +3012,9 @@ bool TypeConverter::visitAggregateLeaves(
     std::optional<unsigned> index;
     std::tie(ty, origTy, field, index) = popFromWorklist();
     assert(!field || !index && "both field and index!?");
+    if (auto origEltTy = origTy.getVanishingTupleElementPatternType()) {
+      origTy = *origEltTy;
+    }
     if (isAggregate(ty) && !isLeafAggregate(ty, origTy, field, index)) {
       if (auto packTy = dyn_cast<SILPackType>(ty)) {
         for (auto packIndex : indices(packTy->getElementTypes())) {

--- a/test/IRGen/variadic_generic_types.swift
+++ b/test/IRGen/variadic_generic_types.swift
@@ -31,3 +31,9 @@ blackHole(G<Int, String>.self)
 let g = G<Int, String, Float>()
 blackHole(g.makeTuple1())
 blackHole(g.makeTuple2())
+
+struct VariadicOptionalTuple<each V> {
+    var v: (repeat (each V)?)
+}
+
+func useVOT(_: VariadicOptionalTuple<String>) {}


### PR DESCRIPTION
I reported a compiler crash in issue #77970.
Upon further investigation, I was able to narrow down the conditions under which this issue occurs. The crash happens when combining *variadic generics*, *tuples*, and *optionals*, as shown below:

```swift
struct VariadicOptionalTuple<each V> {
    var v: (repeat (each V)?)
}

func useVOT(_: VariadicOptionalTuple<String>) {}
```

In this example, when the `LoadableByAddress` pass is applied to `useVOT`, the type lowering process for `VariadicOptionalTuple<String>` triggers the problem internally.

In `TypeConverter::visitAggregateLeaves`, `origTy` is as follows:

```
AP::Type<each τ_0_0 where repeat each τ_0_0 : Copyable, repeat each τ_0_0 : Escapable>@<Pack{String}>((tuple_type num_elements=1
  (tuple_type_elt
    (pack_expansion_type
      (pattern=bound_generic_enum_type decl="Swift.(file).Optional"
        (generic_type_param_type depth=0 index=0 param_kind=pack))
      (count=generic_type_param_type depth=0 index=0 param_kind=pack))))
)
```

However, `ty` is:

```
(bound_generic_enum_type decl="Swift.(file).Optional"
  (struct_type decl="Swift.(file).String"))
```

Since their shapes do not match, an error occurs in the subsequent processing.

This patch fixes the issue by peeling off the single-element tuple using `getVanishingTupleElementPatternType`, similar to how other parts of the type lowering process handle this case.

Additionally, this patch adds a test case for the aforementioned crash.
Without applying this patch, the test crashes as follows:

<details>

```
+ /opt/homebrew/opt/python@3.13/bin/python3.13 /Users/omochi/swift/swift/utils/PathSanitizingFileCheck --allow-unused-prefixes --sanitize BUILD_DIR=/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64 --sanitize SOURCE_DIR=/Users/omochi/swift/swift --use-filecheck /Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/llvm-macosx-arm64/bin/FileCheck --color /Users/omochi/swift/swift/test/IRGen/variadic_generic_types.swift
Assertion failed: (0 && "Bad base type"), function getContextSubstitutions, file TypeSubstitution.cpp, line 818.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend -target arm64-apple-macosx13.0 -module-cache-path /Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/swift-test-results/arm64-apple-macosx13.0/clang-module-cache -sdk /Applications/Xcode16.2-rc.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -swift-version 4 -define-availability "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -define-availability "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2" -define-availability "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0" -define-availability "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4" -define-availability "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0" -define-availability "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5" -define-availability "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0" -define-availability "SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4" -define-availability "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0" -define-availability "SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4" -define-availability "SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0" -define-availability "SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1" -define-availability "SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0" -define-availability "SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" -typo-correction-limit 10 -emit-ir -primary-file /Users/omochi/swift/swift/test/IRGen/variadic_generic_types.swift -target arm64-apple-macosx14.0
1.	Swift version 6.2-dev (LLVM be8c96d78337932, Swift 0bbaa3519b62071)
2.	Compiling with effective version 4.1.50
3.	While evaluating request IRGenRequest(IR Generation for file "/Users/omochi/swift/swift/test/IRGen/variadic_generic_types.swift")
4.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { IRGen Preparation } on SIL for variadic_generic_types)
5.	While running pass #12 SILModuleTransform "LoadableByAddress".
6.	While converting type 'VariadicOptionalTuple<String>' (declared at [/Users/omochi/swift/swift/test/IRGen/variadic_generic_types.swift:35:1 - line:37:1] RangeText="struct VariadicOptionalTuple<each V> {
    var v: (repeat (each V)?)
")
 #0 0x00000001063e3814 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x105b37814)
 #1 0x00000001063e1dd0 llvm::sys::RunSignalHandlers() (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x105b35dd0)
 #2 0x00000001063e3e58 SignalHandler(int) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x105b37e58)
 #3 0x000000019ae4c184 (/usr/lib/system/libsystem_platform.dylib+0x180484184)
 #4 0x000000019ae16f70 (/usr/lib/system/libsystem_pthread.dylib+0x18044ef70)
 #5 0x000000019ad23908 (/usr/lib/system/libsystem_c.dylib+0x18035b908)
 #6 0x000000019ad22c1c (/usr/lib/system/libsystem_c.dylib+0x18035ac1c)
 #7 0x00000001064f4270 swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (.cold.31) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x105c48270)
 #8 0x00000001022cf80c swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x101a2380c)
 #9 0x00000001022cf8bc swift::TypeBase::getContextSubstitutionMap(swift::DeclContext const*, swift::GenericEnvironment*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x101a238bc)
#10 0x00000001022cfcb0 swift::TypeBase::getTypeOfMember(swift::ValueDecl const*, swift::Type) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x101a23cb0)
#11 0x00000001018a6800 swift::Lowering::AbstractionPattern::unsafeGetSubstFieldType(swift::ValueDecl*, swift::CanType, swift::SubstitutionMap) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100ffa800)
#12 0x0000000101970704 swift::Lowering::TypeConverter::visitAggregateLeaves(swift::Lowering::AbstractionPattern, swift::CanType, swift::TypeExpansionContext, std::__1::function<bool (swift::CanType, swift::Lowering::AbstractionPattern, swift::ValueDecl*, std::__1::optional<unsigned int>)>, std::__1::function<bool (swift::CanType, swift::Lowering::AbstractionPattern, swift::ValueDecl*, std::__1::optional<unsigned int>)>) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1010c4704)
#13 0x0000000101970ac4 swift::Lowering::TypeConverter::verifyLexicalLowering(swift::Lowering::TypeLowering const&, swift::Lowering::AbstractionPattern, swift::CanType, swift::TypeExpansionContext) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1010c4ac4)
#14 0x000000010196f660 swift::Lowering::TypeConverter::getTypeLowering(swift::Lowering::AbstractionPattern, swift::Type, swift::TypeExpansionContext) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1010c3660)
#15 0x00000001019642d8 swift::SILType::getFieldType(swift::VarDecl*, swift::Lowering::TypeConverter&, swift::TypeExpansionContext) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1010b82d8)
#16 0x00000001019632c0 swift::SILType::getFieldType(swift::VarDecl*, swift::SILModule&, swift::TypeExpansionContext) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1010b72c0)
#17 0x0000000100fc1c04 swift::irgen::TypeConverter::convertStructType(swift::TypeBase*, swift::CanType, swift::StructDecl*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100715c04)
#18 0x0000000100feae34 swift::irgen::TypeConverter::convertAnyNominalType(swift::CanType, swift::NominalTypeDecl*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x10073ee34)
#19 0x0000000100fe9a94 swift::irgen::TypeConverter::convertType(swift::CanType) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x10073da94)
#20 0x0000000100fe9440 swift::irgen::TypeConverter::getTypeEntry(swift::CanType) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x10073d440)
#21 0x00000001010938e4 isLargeLoadableType(swift::GenericEnvironment*, swift::SILType, swift::irgen::IRGenModule&) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1007e78e4)
#22 0x0000000101092db4 LargeSILTypeMapper::getNewSILType(swift::GenericEnvironment*, swift::SILType, swift::irgen::IRGenModule&) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1007e6db4)
#23 0x00000001010a49c8 (anonymous namespace)::LoadableStorageAllocation::allocateLoadableStorage() (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1007f89c8)
#24 0x000000010109484c (anonymous namespace)::LoadableByAddress::run() (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1007e884c)
#25 0x00000001014e16cc swift::SILPassManager::runModulePass(unsigned int) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c356cc)
#26 0x00000001014e3be8 swift::SILPassManager::execute() (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c37be8)
#27 0x00000001014de268 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c32268)
#28 0x00000001014de204 swift::ExecuteSILPipelineRequest::evaluate(swift::Evaluator&, swift::SILPipelineExecutionDescriptor) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c32204)
#29 0x0000000101531498 swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::ExecuteSILPipelineRequest const&, swift::Evaluator&) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c85498)
#30 0x00000001014feb48 swift::ExecuteSILPipelineRequest::OutputType swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()>(swift::ExecuteSILPipelineRequest const&, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c52b48)
#31 0x00000001014de458 swift::executePassPipelinePlan(swift::SILModule*, swift::SILPassPipelinePlan const&, bool, swift::irgen::IRGenModule*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100c32458)
#32 0x0000000101001ef8 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100755ef8)
#33 0x0000000101065454 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x1007b9454)
#34 0x0000000101009464 swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x10075d464)
#35 0x0000000101003d90 swift::performIRGeneration(swift::FileUnit*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::StringRef, llvm::GlobalVariable**) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100757d90)
#36 0x0000000100b15f38 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100269f38)
#37 0x0000000100b12c1c performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100266c1c)
#38 0x0000000100b1209c swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x10026609c)
#39 0x0000000100b1e118 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100272118)
#40 0x0000000100b13d40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100267d40)
#41 0x0000000100b13594 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100267594)
#42 0x00000001008e5a30 swift::mainEntry(int, char const**) (/Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swift-frontend+0x100039a30)
#43 0x000000019aa94274 
FileCheck error: '<stdin>' is empty.
FileCheck command line:  /Users/omochi/swift/build/Ninja-RelWithDebInfoAssert/llvm-macosx-arm64/bin/FileCheck --allow-unused-prefixes --color /Users/omochi/swift/swift/test/IRGen/variadic_generic_types.swift

--

********************
********************
Failed Tests (1):
  Swift(macosx-arm64) :: IRGen/variadic_generic_types.swift

```
</details>