### PR TITLE
[cxx-interop] Add support for SWIFT_RETURNS_(UN)RETAINED for ObjC APIs returning C++ FRT

### DIFF
--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes.swift
@@ -245,4 +245,3 @@ func testVirtualMethods(base: Base, derived: Derived) {
     var frt4 = mutableDerived.VirtualMethodReturningFRTOwned()
     // CHECK: function_ref @{{.*}}VirtualMethodReturningFRTOwned{{.*}} : $@convention(cxx_method) (@inout Derived) -> @owned FRTStruct
 }
-

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
@@ -1,0 +1,38 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-extension"
+#pragma clang assume_nonnull begin
+
+struct CxxRefType {
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainCxxRefType")))
+__attribute__((swift_attr("release:releaseCxxRefType")));
+
+void retainCxxRefType(CxxRefType *_Nonnull b) {}
+void releaseCxxRefType(CxxRefType *_Nonnull b) {}
+
+@interface Bridge : NSObject
+
++ (struct CxxRefType *)objCMethodReturningFRTUnannotated;
++ (struct CxxRefType *)objCMethodReturningFRTUnowned
+    __attribute__((swift_attr("returns_unretained")));
++ (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained")));
+
+@end
+
+@implementation Bridge
++ (struct CxxRefType *)objCMethodReturningFRTUnannotated {
+};
++ (struct CxxRefType *)objCMethodReturningFRTUnowned
+    __attribute__((swift_attr("returns_unretained"))) {
+}
++ (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained"))) {
+}
+
+@end
+
+#pragma clang diagnostic pop
+#pragma clang assume_nonnull end

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -44,3 +44,8 @@ module ID {
   requires objc
   requires cplusplus
 }
+
+module CxxForeignRef {
+  header "cxx-frt.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -disable-availability-checking -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+
+import CxxForeignRef
+
+// REQUIRES: objc_interop
+
+func testObjCMethods() {
+    var frt1 = Bridge.objCMethodReturningFRTUnannotated()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTUnannotated!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> CxxRefType
+
+    var frt2 = Bridge.objCMethodReturningFRTUnowned()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTUnowned!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> CxxRefType
+
+    var frt3 = Bridge.objCMethodReturningFRTOwned()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTOwned!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> @owned CxxRefType
+ }


### PR DESCRIPTION
Extending https://github.com/swiftlang/swift/pull/75897 so that the new annotations  `SWIFT_RETURNS_(UN)RETAINED` can be used on ObjC APIs as well.

rdar://135360972