### PR TITLE
Fix array bounds check optimization for ossa

### DIFF
--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -496,6 +496,10 @@ ApplyInst *swift::ArraySemanticsCall::hoistOrCopy(SILInstruction *InsertBefore,
                              ->begin());
       } else {
         NewArrayProps = IsNative.copyTo(InsertBefore, DT);
+        ArraySemanticsCall NewIsNative(NewArrayProps);
+        if (NewIsNative.getSelf() != HoistedSelf) {
+          NewIsNative.getSelfOperand().set(HoistedSelf);
+        }
       }
 
       // Replace all uses of the check subscript call by a use of the empty

--- a/test/SILOptimizer/abcopts_ossa_guaranteed.sil
+++ b/test/SILOptimizer/abcopts_ossa_guaranteed.sil
@@ -1458,3 +1458,176 @@ bb3:
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil [ossa] @isNativeUnavailable1 :
+// CHECK: [[ISNATIVE:%.*]] = function_ref @arrayPropertyIsNative :
+// CHECK: bb1:
+// CHECK: [[CHECKBOUNDS:%.*]] = function_ref @checkbounds :
+// CHECK: apply [[ISNATIVE]]
+// CHECK: apply [[CHECKBOUNDS]]
+// CHECK: bb2
+// CHECK-LABEL: } // end sil function 'isNativeUnavailable1'
+sil [ossa] @isNativeUnavailable1 : $@convention(thin) (Int32, @owned ArrayInt) -> Int32 {
+bb0(%0 : $Int32, %1 : @owned $ArrayInt):
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = struct $Bool (%2)
+  %4 = struct_extract %0, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = builtin "cmp_eq_Int32"(%5, %4) : $Builtin.Int1
+  %7 = begin_borrow %1
+  %8 = copy_value %7
+  %9 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  %10 = apply %9(%7) : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  end_borrow %7
+  cond_br %6, bb2, bb1
+
+bb1:
+  br bb3(%5)
+
+bb2:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%5)
+
+bb3(%17 : $Builtin.Int32):
+  %18 = struct $Int32 (%17)
+  %19 = function_ref @checkbounds : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %20 = apply %19(%18, %10, %8) : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %21 = integer_literal $Builtin.Int32, 1
+  %22 = integer_literal $Builtin.Int1, -1
+  %23 = builtin "sadd_with_overflow_Int32"(%17, %21, %22) : $(Builtin.Int32, Builtin.Int1)
+  %24 = tuple_extract %23, 0
+  %25 = tuple_extract %23, 1
+  cond_fail %25, ""
+  %27 = builtin "cmp_eq_Int32"(%24, %4) : $Builtin.Int1
+  cond_br %27, bb5, bb4
+
+bb4:
+  br bb3(%24)
+
+bb5:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%24)
+
+bb6(%33 : $Builtin.Int32):
+  %34 = struct $Int32 (%33)
+  return %34
+}
+
+// CHECK-LABEL: sil [ossa] @isNativeUnavailable2 :
+// CHECK: [[ISNATIVE:%.*]] = function_ref @arrayPropertyIsNative :
+// CHECK: bb1:
+// CHECK: [[CHECKBOUNDS:%.*]] = function_ref @checkbounds :
+// CHECK: apply [[ISNATIVE]]
+// CHECK: apply [[CHECKBOUNDS]]
+// CHECK: bb2
+// CHECK-LABEL: } // end sil function 'isNativeUnavailable2'
+sil [ossa] @isNativeUnavailable2 : $@convention(thin) (Int32, @owned ArrayInt) -> Int32 {
+bb0(%0 : $Int32, %1 : @owned $ArrayInt):
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = struct $Bool (%2)
+  %4 = struct_extract %0, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = builtin "cmp_eq_Int32"(%5, %4) : $Builtin.Int1
+  %7 = copy_value %1
+  %8 = copy_value %7
+  %9 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  %10 = apply %9(%7) : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  destroy_value %7
+  cond_br %6, bb2, bb1
+
+bb1:
+  br bb3(%5)
+
+bb2:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%5)
+
+bb3(%17 : $Builtin.Int32):
+  %18 = struct $Int32 (%17)
+  %19 = function_ref @checkbounds : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %20 = apply %19(%18, %10, %8) : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %21 = integer_literal $Builtin.Int32, 1
+  %22 = integer_literal $Builtin.Int1, -1
+  %23 = builtin "sadd_with_overflow_Int32"(%17, %21, %22) : $(Builtin.Int32, Builtin.Int1)
+  %24 = tuple_extract %23, 0
+  %25 = tuple_extract %23, 1
+  cond_fail %25, ""
+  %27 = builtin "cmp_eq_Int32"(%24, %4) : $Builtin.Int1
+  cond_br %27, bb5, bb4
+
+bb4:
+  br bb3(%24)
+
+bb5:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%24)
+
+bb6(%33 : $Builtin.Int32):
+  %34 = struct $Int32 (%33)
+  return %34
+}
+
+struct Wrapper {
+  let arr: ArrayInt
+}
+
+// CHECK-LABEL: sil [ossa] @isNativeUnavailable3 :
+// CHECK: [[ISNATIVE:%.*]] = function_ref @arrayPropertyIsNative :
+// CHECK: bb1:
+// CHECK: [[CHECKBOUNDS:%.*]] = function_ref @checkbounds :
+// CHECK: apply [[ISNATIVE]]
+// CHECK: apply [[CHECKBOUNDS]]
+// CHECK: bb2
+// CHECK-LABEL: } // end sil function 'isNativeUnavailable3'
+sil [ossa] @isNativeUnavailable3 : $@convention(thin) (Int32, @owned Wrapper) -> Int32 {
+bb0(%0 : $Int32, %1 : @owned $Wrapper):
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = struct $Bool (%2)
+  %4 = struct_extract %0, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = builtin "cmp_eq_Int32"(%5, %4) : $Builtin.Int1
+  %7 = begin_borrow %1
+  %7a = struct_extract %7, #Wrapper.arr
+  %8 = copy_value %7a
+  %9 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  %10 = apply %9(%7a) : $@convention(method) (@guaranteed ArrayInt) -> Bool
+  end_borrow %7
+  cond_br %6, bb2, bb1
+
+bb1:
+  br bb3(%5)
+
+bb2:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%5)
+
+bb3(%17 : $Builtin.Int32):
+  %18 = struct $Int32 (%17)
+  %19 = function_ref @checkbounds : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %20 = apply %19(%18, %10, %8) : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %21 = integer_literal $Builtin.Int32, 1
+  %22 = integer_literal $Builtin.Int1, -1
+  %23 = builtin "sadd_with_overflow_Int32"(%17, %21, %22) : $(Builtin.Int32, Builtin.Int1)
+  %24 = tuple_extract %23, 0
+  %25 = tuple_extract %23, 1
+  cond_fail %25, ""
+  %27 = builtin "cmp_eq_Int32"(%24, %4) : $Builtin.Int1
+  cond_br %27, bb5, bb4
+
+bb4:
+  br bb3(%24)
+
+bb5:
+  destroy_value %8
+  destroy_value %1
+  br bb6(%24)
+
+bb6(%33 : $Builtin.Int32):
+  %34 = struct $Int32 (%33)
+  return %34
+}


### PR DESCRIPTION
While hoisting `check_subscript` call, `isNativeTypeChecked` call is also created in the preheater .
The array value used in the `isNativeTypeChecked` may not be available if its lifetime had ended before (ossa only). Proactively set the array value of the `isNativeTypeChecked` call to the array value in the `check_subscript` call.

rdar://141630349

