### PR TITLE
[6.1] TypeLowering: assume that C unions can contain a pointer

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -280,6 +280,8 @@ public:
     }
 
     void setNonTrivial() { Flags |= NonTrivialFlag; }
+    void setIsOrContainsRawPointer() { Flags |= HasRawPointerFlag; }
+
     void setNonFixedABI() { Flags |= NonFixedABIFlag; }
     void setAddressOnly() { Flags |= AddressOnlyFlag; }
     void setTypeExpansionSensitive(

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -44,6 +44,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/Test.h"
 #include "clang/AST/Type.h"
+#include "clang/AST/Decl.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 
@@ -2506,6 +2507,15 @@ namespace {
         properties.setAddressOnly();
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
+      }
+
+      if (auto *clangDecl = D->getClangDecl()) {
+        if (auto *recordDecl = dyn_cast<clang::RecordDecl>(clangDecl)) {
+          // C unions are imported as opaque types. Therefore we have to assume
+          // that a union contains a pointer.
+          if (recordDecl->isOrContainsUnion())
+            properties.setIsOrContainsRawPointer();
+        }
       }
 
       // [is_or_contains_pack_unsubstituted] Visit the fields of the

--- a/test/SILOptimizer/Inputs/include/cunion.h
+++ b/test/SILOptimizer/Inputs/include/cunion.h
@@ -1,0 +1,9 @@
+
+struct S {
+   int i;
+};
+
+union U {
+  struct S *p;
+};
+

--- a/test/SILOptimizer/Inputs/include/module.modulemap
+++ b/test/SILOptimizer/Inputs/include/module.modulemap
@@ -2,3 +2,9 @@ module gizmo {
   header "Gizmo.h"
   export *
 }
+
+module CUnion {
+  header "cunion.h"
+  export *
+}
+

--- a/test/SILOptimizer/dead_store_elim_c.sil
+++ b/test/SILOptimizer/dead_store_elim_c.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt %s -dead-store-elimination -I %S/Inputs/include | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+import CUnion
+
+
+sil [noinline] @modify_U : $@convention(thin) (@inout U) -> () {
+[%0: read v**]
+[global: read,write,copy,destroy,allocate,deinit_barrier]
+}
+
+// CHECK-LABEL: sil @pointer_escape_via_c_union :
+// CHECK:         store %0 to %1
+// CHECK:       } // end sil function 'pointer_escape_via_c_union'
+sil @pointer_escape_via_c_union : $@convention(thin) (S) -> () {
+[global: read,write,copy,destroy,allocate,deinit_barrier]
+bb0(%0 : $S):
+  %1 = alloc_stack [var_decl] $S, var, name "vs"
+  store %0 to %1 : $*S
+  %3 = address_to_pointer [stack_protection] %1 : $*S to $Builtin.RawPointer
+  %4 = struct $UnsafeMutablePointer<S> (%3 : $Builtin.RawPointer)
+  %5 = alloc_stack [var_decl] $U, var, name "u"
+  %6 = enum $Optional<UnsafeMutablePointer<S>>, #Optional.some!enumelt, %4 : $UnsafeMutablePointer<S>
+  %7 = alloc_stack [var_decl] $U
+  %8 = address_to_pointer %7 : $*U to $Builtin.RawPointer
+  %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Optional<UnsafeMutablePointer<S>>
+  store %6 to %9 : $*Optional<UnsafeMutablePointer<S>>
+  %11 = load %7 : $*U
+  dealloc_stack %7 : $*U
+  store %11 to %5 : $*U
+  %14 = function_ref @modify_U : $@convention(thin) (@inout U) -> ()
+  %15 = apply %14(%5) : $@convention(thin) (@inout U) -> ()
+  dealloc_stack %5 : $*U
+  dealloc_stack %1 : $*S
+  %18 = tuple ()
+  return %18 : $()
+}
+


### PR DESCRIPTION
* **Explanation**: Fixes a miscompile caused by C unions containing a pointer. C unions are imported as opaque types. Therefore we have to assume that a union contains a pointer. This is important for alias analysis to catch escaping pointers via C unions.
* **Risk**: Low. It is a simple change which makes alias analysis more conservative for C unions.
* **Testing**: Tested by a test case.
* **Issue**: rdar://141555290
* **Reviewer**:  @jckarter
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/78221
