### PR TITLE
SILCombine: enable alloc_stack optimization for OSSA

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -629,9 +629,6 @@ bool SILCombiner::optimizeStackAllocatedEnum(AllocStackInst *AS) {
 }
 
 SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
-  if (AS->getFunction()->hasOwnership())
-    return nullptr;
-
   if (optimizeStackAllocatedEnum(AS))
     return nullptr;
 

--- a/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
@@ -6,11 +6,11 @@ import Builtin
 import Swift
 
 // CHECK-LABEL: sil [ossa] @convert_inject_enum_addr_select_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout, @in_guaranteed any CustomStringConvertible) -> ()
-// XHECK-NOT: init_existential_addr
-// XHECK-NOT: inject_enum_addr
-// XHECK-NOT: select_enum_addr
-// XHECK-NOT: unchecked_take_enum_data_addr
-// XHECK: return
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK-NOT: select_enum_addr
+// CHECK-NOT: unchecked_take_enum_data_addr
+// CHECK: return
 // CHEcK: } // end sil function 'convert_inject_enum_addr_select_enum_addr_into_cond_br'
 sil [ossa] @convert_inject_enum_addr_select_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout, @in_guaranteed CustomStringConvertible) -> () {
 bb0(%0 : $*Int, %1 : $*_Stdout, %1a : $*CustomStringConvertible):
@@ -48,12 +48,12 @@ bb2:
 
 
 // CHECK-LABEL: sil [ossa] @convert_inject_enum_addr_switch_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout, @in_guaranteed any CustomStringConvertible) -> ()
-// XHECK-NOT: init_existential_addr
-// XHECK-NOT: inject_enum_addr
-// XHECK-NOT: switch_enum_addr
-// XHECK-NOT: unchecked_take_enum_data_addr
-// XHECK: return
-// XHECK: } // end sil function 'convert_inject_enum_addr_switch_enum_addr_into_cond_br'
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK-NOT: switch_enum_addr
+// CHECK-NOT: unchecked_take_enum_data_addr
+// CHECK: return
+// CHECK: } // end sil function 'convert_inject_enum_addr_switch_enum_addr_into_cond_br'
 sil [ossa] @convert_inject_enum_addr_switch_enum_addr_into_cond_br : $@convention(thin) (@in Int, @inout _Stdout, @in_guaranteed CustomStringConvertible) -> () {
 bb0(%0 : $*Int, %1 : $*_Stdout, %1a : $*CustomStringConvertible):
   %2 = alloc_stack $CustomStringConvertible
@@ -92,14 +92,12 @@ bb3:
 // simplify-cfg that has not been updated yet for ossa.
 //
 // CHECK-LABEL: sil [ossa] @convert_checked_cast_addr_br_into_unconditional_checked_cast_addr_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> ()
-// XHECK: checked_cast_addr_br
-// XHECK: } // end sil function 'convert_checked_cast_addr_br_into_unconditional_checked_cast_addr_cond_br'
-// xXHECK: store
-// xXHECK-NOT: checked_cast_addr_br
-// xXHECK-NOT: bb1
-// xXHECK: inject_enum_addr %{{.*}} : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
-// xXHECK: dealloc_stack
-// xXHECK: return
+// CHECK:         store
+// CHECK-NOT:     checked_cast_addr_br
+// CHECK-NOT:   bb1
+// CHECK:         inject_enum_addr %{{.*}}, #Optional.some!enumelt
+// CHECK:         dealloc_stack
+// CHECK:       } // end sil function 'convert_checked_cast_addr_br_into_unconditional_checked_cast_addr_cond_br'
 sil [ossa] @convert_checked_cast_addr_br_into_unconditional_checked_cast_addr_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> () {
 bb0(%0 : $*Int, %1 : $*_Stdout):
   %2 = alloc_stack $CustomStringConvertible
@@ -195,14 +193,12 @@ bb22:
 // yet for OSSA so just validate we don't optimize this.
 //
 // CHECK-LABEL: sil [ossa] @convert_checked_cast_addr_br_with_private_type : $@convention(thin) (@in B, @inout _Stdout) -> ()
-// XHECK: checked_cast_addr_br
-// XHECK: } // end sil function 'convert_checked_cast_addr_br_with_private_type'
-// xXHECK: store
-// xXHECK-NOT: checked_cast_addr_br
-// xXHECK-NOT: bb1
-// xXHECK: inject_enum_addr %{{.*}} : $*Optional<CustomStringConvertible>, #Optional.none!enumelt
-// xXHECK: dealloc_stack
-// xXHECK: return
+// CHECK:         store
+// CHECK-NOT:     checked_cast_addr_br
+// CHECK-NOT:   bb1
+// CHECK:         inject_enum_addr %{{.*}}, #Optional.none!enumelt
+// CHECK:         dealloc_stack
+// CHECK: } // end sil function 'convert_checked_cast_addr_br_with_private_type'
 sil [ossa] @convert_checked_cast_addr_br_with_private_type : $@convention(thin) (@in B, @inout _Stdout) -> () {
 bb0(%0 : $*B, %1 : $*_Stdout):
   %2 = alloc_stack $CustomStringConvertible

--- a/test/SILOptimizer/sil_combine_enums_ossa.sil
+++ b/test/SILOptimizer/sil_combine_enums_ossa.sil
@@ -147,11 +147,11 @@ bb0(%0 : $*G<T>):
 }
 
 // CHECK-LABEL: sil [ossa] @canonicalize_init_enum_data_addr
-// XHECK-NOT: init_enum_data_addr
-// XHECK-NOT: inject_enum_addr
-// XHECK: enum $Optional<Int32>, #Optional.some!enumelt
-// XHECK-NOT: inject_enum_addr
-// XHECK: return
+// CHECK-NOT: init_enum_data_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK: enum $Optional<Int32>, #Optional.some!enumelt
+// CHECK-NOT: inject_enum_addr
+// CHECK: return
 sil [ossa] @canonicalize_init_enum_data_addr : $@convention(thin) (@inout Int32, Builtin.Int32, Optional<Int32>) -> Int32 {
 bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Optional<Int32>):
   %s1 = alloc_stack $Optional<Int32>
@@ -171,11 +171,11 @@ bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Optional<Int32>):
 }
 
 // CHECK-LABEL: sil [ossa] @canonicalize_init_enum_data_addr
-// XHECK-NOT: init_enum_data_addr
-// XHECK-NOT: inject_enum_addr
-// XHECK: enum $Optional<SomeClass>, #Optional.some!enumelt
-// XHECK-NOT: inject_enum_addr
-// XHECK: return
+// CHECK-NOT: init_enum_data_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK: enum $Optional<SomeClass>, #Optional.some!enumelt
+// CHECK-NOT: inject_enum_addr
+// CHECK: return
 sil [ossa] @canonicalize_init_enum_data_addr_non_trivial : $@convention(thin) (@inout SomeClass, @owned Optional<SomeClass>) -> @owned Optional<SomeClass> {
 bb0(%0 : $*SomeClass, %2 : @owned $Optional<SomeClass>):
   %s1 = alloc_stack $Optional<SomeClass>
@@ -194,11 +194,11 @@ bb0(%0 : $*SomeClass, %2 : @owned $Optional<SomeClass>):
 }
 
 // CHECK-LABEL: sil [ossa] @canonicalize_init_enum_data_addr_diff_basic_blocks
-// XHECK-NOT: init_enum_data_addr
-// XHECK-NOT: inject_enum_addr
-// XHECK: enum $Optional<Int32>, #Optional.some!enumelt
-// XHECK-NOT: inject_enum_addr
-// XHECK: return
+// CHECK-NOT: init_enum_data_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK: enum $Optional<Int32>, #Optional.some!enumelt
+// CHECK-NOT: inject_enum_addr
+// CHECK: return
 sil [ossa] @canonicalize_init_enum_data_addr_diff_basic_blocks : $@convention(thin) (@inout Int32, Builtin.Int32, Optional<Int32>) -> Int32 {
 bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Optional<Int32>):
   %s1 = alloc_stack $Optional<Int32>
@@ -221,10 +221,10 @@ bb1:                                              // Preds: bb0
 }
 
 // CHECK-LABEL: sil [ossa] @fail_to_canonicalize_init_enum_data_addr_reach_entry
-// XHECK: init_enum_data_addr
-// XHECK: inject_enum_addr
-// XHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt
-// XHECK: return
+// CHECK: init_enum_data_addr
+// CHECK: inject_enum_addr
+// CHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt
+// CHECK: return
 sil [ossa] @fail_to_canonicalize_init_enum_data_addr_reach_entry : $@convention(thin) (@inout Int32, Builtin.Int32, Builtin.Int1) -> Int32 {
 bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Builtin.Int1):
   %s1 = alloc_stack $Optional<Int32>
@@ -255,10 +255,10 @@ bb2:                                              // Preds: bb0 bb1
 }
 
 // CHECK-LABEL: sil [ossa] @fail_to_canonicalize_init_enum_data_addr
-// XHECK: init_enum_data_addr
-// XHECK: inject_enum_addr
-// XHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt
-// XHECK: return
+// CHECK: init_enum_data_addr
+// CHECK: inject_enum_addr
+// CHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt
+// CHECK: return
 sil [ossa] @fail_to_canonicalize_init_enum_data_addr : $@convention(thin) (@inout Int32, Builtin.Int32) -> Int32 {
 bb0(%0 : $*Int32, %1 : $Builtin.Int32):
   %s1 = alloc_stack $Optional<Int32>
@@ -455,13 +455,13 @@ bb3(%14 : @owned $C):
 }
 
 // CHECK-LABEL: sil [ossa] @test_inject_tuple
-// XHECK:   [[A:%[0-9]+]] = alloc_stack $Optional<(Int, Int)>
-// XHECK:   [[T:%[0-9]+]] = tuple (%0 : $Int, %1 : $Int)
-// XHECK:   [[E:%[0-9]+]] = enum $Optional<(Int, Int)>, #Optional.some!enumelt, [[T]] : $(Int, Int)
-// XHECK:   store [[E]] to [trivial] [[A]]
-// XHECK:   [[L:%[0-9]+]] = load [trivial] [[A]]
-// XHECK:   return [[L]]
-// XHECK: } // end sil function 'test_inject_tuple'
+// CHECK:   [[A:%[0-9]+]] = alloc_stack $Optional<(Int, Int)>
+// CHECK:   [[T:%[0-9]+]] = tuple (%0 : $Int, %1 : $Int)
+// CHECK:   [[E:%[0-9]+]] = enum $Optional<(Int, Int)>, #Optional.some!enumelt, [[T]] : $(Int, Int)
+// CHECK:   store [[E]] to [trivial] [[A]]
+// CHECK:   [[L:%[0-9]+]] = load [trivial] [[A]]
+// CHECK:   return [[L]]
+// CHECK: } // end sil function 'test_inject_tuple'
 sil [ossa] @test_inject_tuple : $@convention(thin) (Int, Int) -> Optional<(Int, Int)> {
 bb0(%0 : $Int, %1 : $Int):
   %17 = alloc_stack $Optional<(Int, Int)>
@@ -486,14 +486,14 @@ sil [ossa] @take_t : $@convention(thin) (@in T) -> ()
 sil [ossa] @use_mp : $@convention(thin) (@in_guaranteed MP) -> ()
 
 // CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum1
-// XHECK:        [[A:%[0-9]+]] = alloc_stack $S
-// XHECK:      bb1:
-// XHECK-NEXT:   store %0 to [trivial] [[A]]
-// XHECK:      bb2:
-// XHECK-NEXT:   store %0 to [trivial] [[A]]
-// XHECK:      bb3:
-// XHECK:        apply {{%[0-9]+}}([[A]])
-// XHECK: } // end sil function 'expand_alloc_stack_of_enum1'
+// CHECK:        [[A:%[0-9]+]] = alloc_stack $S
+// CHECK:      bb1:
+// CHECK-NEXT:   store %0 to [trivial] [[A]]
+// CHECK:      bb2:
+// CHECK-NEXT:   store %0 to [trivial] [[A]]
+// CHECK:      bb3:
+// CHECK:        apply {{%[0-9]+}}([[A]])
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum1'
 sil [ossa] @expand_alloc_stack_of_enum1 : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
@@ -521,14 +521,14 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum_without_take
-// XHECK:        [[A:%[0-9]+]] = alloc_stack $S
-// XHECK:      bb1:
-// XHECK-NEXT:   store %0 to [trivial] [[A]]
-// XHECK:      bb2:
-// XHECK-NEXT:   store %0 to [trivial] [[A]]
-// XHECK:      bb3:
-// XHECK:        destroy_addr [[A]]
-// XHECK: } // end sil function 'expand_alloc_stack_of_enum_without_take'
+// CHECK:        [[A:%[0-9]+]] = alloc_stack $S
+// CHECK:      bb1:
+// CHECK-NEXT:   store %0 to [trivial] [[A]]
+// CHECK:      bb2:
+// CHECK-NEXT:   store %0 to [trivial] [[A]]
+// CHECK:      bb3:
+// CHECK:        destroy_addr [[A]]
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum_without_take'
 sil [ossa] @expand_alloc_stack_of_enum_without_take : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
@@ -554,15 +554,15 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum_multiple_cases
-// XHECK:        [[A:%[0-9]+]] = alloc_stack $T
-// XHECK:      bb1:
-// XHECK-NEXT:   [[COPY_ARG:%.*]] = copy_value %0
-// XHECK-NEXT:   store [[COPY_ARG]] to [init] [[A]]
-// XHECK:        apply {{%[0-9]+}}([[A]])
-// XHECK:      bb2:
-// XHECK-NEXT:   br bb3
-// XHECK:      bb3:
-// XHECK: } // end sil function 'expand_alloc_stack_of_enum_multiple_cases'
+// CHECK:        [[A:%[0-9]+]] = alloc_stack $T
+// CHECK:      bb1:
+// CHECK-NEXT:   [[COPY_ARG:%.*]] = copy_value %0
+// CHECK-NEXT:   store [[COPY_ARG]] to [init] [[A]]
+// CHECK:        apply {{%[0-9]+}}([[A]])
+// CHECK:      bb2:
+// CHECK-NEXT:   br bb3
+// CHECK:      bb3:
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum_multiple_cases'
 sil [ossa] @expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (@guaranteed T) -> () {
 bb0(%0 : @guaranteed $T):
   %1 = alloc_stack $X
@@ -590,8 +590,8 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases
-// XHECK:   alloc_stack $MP
-// XHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
+// CHECK:   alloc_stack $MP
+// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
 sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
@@ -617,8 +617,8 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases2
-// XHECK:   alloc_stack $X
-// XHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases2'
+// CHECK:   alloc_stack $X
+// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases2'
 sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases2 : $@convention(method) (@guaranteed T) -> () {
 bb0(%0 : @guaranteed $T):
   %1 = alloc_stack $X
@@ -643,8 +643,8 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @dont_expand_alloc_stack_of_enum_unknown_use
-// XHECK:   alloc_stack $MP
-// XHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_unknown_use'
+// CHECK:   alloc_stack $MP
+// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_unknown_use'
 sil [ossa] @dont_expand_alloc_stack_of_enum_unknown_use : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -3197,9 +3197,9 @@ bb3 (%10: $Builtin.Int32):
 }
 
 // CHECK-LABEL: sil [ossa] @delete_dead_alloc_stack
-// XHECK: bb0
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @delete_dead_alloc_stack : $(@inout B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
@@ -3211,10 +3211,10 @@ bb0(%0 : $*B):
 }
 
 // CHECK-LABEL: sil [ossa] @delete_dead_alloc_stack2
-// XHECK: bb0
-// XHECK-NEXT: destroy_addr %0
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0
+// CHECK-NEXT: destroy_addr %0
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @delete_dead_alloc_stack2 : $(@in B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
@@ -3380,9 +3380,9 @@ enum VendingMachineError: Error {
 // Check that we can delete exceptions if we can inline the `throw`
 // block into the `try` block.
 // CHECK-LABEL: @RemoveUnusedException
-// XHECK-NOT: alloc_existential_box
-// XHECK-NOT: enum $VendingMachineError
-// XHECK: return
+// CHECK-NOT: alloc_existential_box
+// CHECK-NOT: enum $VendingMachineError
+// CHECK: return
 sil hidden [ossa] @RemoveUnusedException : $@convention(thin) (Int32) -> (Double, @error Error) {
 bb0(%0 : $Int32):
   debug_value %0 : $Int32, let, name "x" // id: %1
@@ -3865,16 +3865,16 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
 }
 
 // CHECK-LABEL: sil [ossa] @enum_promotion_case3 :
-// XHECK: bb0([[B_PTR:%[0-9]+]]
-// XHECK-NEXT: [[ALLOCA:%[0-9]+]] = alloc_stack $FakeOptional<B>
-// XHECK-NEXT: [[LIFETIME_EXTEND_B_PTR:%.*]] = copy_value [[B_PTR]]
-// XHECK-NEXT: destroy_value [[B_PTR]]
-// XHECK-NEXT: [[ENUM:%[0-9]+]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[LIFETIME_EXTEND_B_PTR]] : $B
-// XHECK-NEXT: store [[ENUM]] to [init] [[ALLOCA]]
-// XHECK-NEXT: [[RESULT:%[0-9]+]] = load [take] [[ALLOCA]]
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: return [[RESULT]]
-// XHECK: } // end sil function 'enum_promotion_case3'
+// CHECK: bb0([[B_PTR:%[0-9]+]]
+// CHECK-NEXT: [[ALLOCA:%[0-9]+]] = alloc_stack $FakeOptional<B>
+// CHECK-NEXT: [[LIFETIME_EXTEND_B_PTR:%.*]] = copy_value [[B_PTR]]
+// CHECK-NEXT: destroy_value [[B_PTR]]
+// CHECK-NEXT: [[ENUM:%[0-9]+]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[LIFETIME_EXTEND_B_PTR]] : $B
+// CHECK-NEXT: store [[ENUM]] to [init] [[ALLOCA]]
+// CHECK-NEXT: [[RESULT:%[0-9]+]] = load [take] [[ALLOCA]]
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: return [[RESULT]]
+// CHECK: } // end sil function 'enum_promotion_case3'
 sil [ossa] @enum_promotion_case3 : $@convention(thin) (@owned B) -> @owned FakeOptional<B> {
 bb0(%0 : @owned $B):
   %2 = alloc_stack $FakeOptional<B>
@@ -3918,13 +3918,13 @@ sil [ossa] @init_enum : $@convention(thin) () -> @out B
 // Localize the initialization of the enum payload to enable mem2reg for the enum.
 
 // CHECK-LABEL: sil [ossa] @enum_promotion_case4
-// XHECK:  [[V1:%.*]] = alloc_stack $FakeOptional
-// XHECK:  [[V2:%.*]] = function_ref @init_enum
-// XHECK:  [[V3:%.*]] = alloc_stack $B
-// XHECK:               apply [[V2]]([[V3]])
-// XHECK:  [[V4:%.*]] = load [take] [[V3]]
-// XHECK:  [[V5:%.*]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[V4]]
-// XHECK:  store [[V5]] to [init] [[V1]]
+// CHECK:  [[V1:%.*]] = alloc_stack $FakeOptional
+// CHECK:  [[V2:%.*]] = function_ref @init_enum
+// CHECK:  [[V3:%.*]] = alloc_stack $B
+// CHECK:               apply [[V2]]([[V3]])
+// CHECK:  [[V4:%.*]] = load [take] [[V3]]
+// CHECK:  [[V5:%.*]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[V4]]
+// CHECK:  store [[V5]] to [init] [[V1]]
 
 sil [ossa] @enum_promotion_case4 : $@convention(thin) () -> @owned FakeOptional<B> {
 bb0:
@@ -3993,9 +3993,9 @@ sil [ossa] @plus : $@convention(method) <Self where Self : PM> (@in_guaranteed S
 sil [ossa] @minus : $@convention(method) <Self where Self : PM> (@in_guaranteed Self) -> ()
 
 // CHECK-LABEL: sil [ossa] @silcombine_dont_change_allocstack_for_opened_archetypes
-// XHECK-NOT: alloc_stack{{.*}}opened
-// XHECK: open_existential_addr immutable_access {{%[0-9]+}} : $*PM to $*@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", PM) Self
-// XHECK: return
+// CHECK-NOT: alloc_stack{{.*}}opened
+// CHECK: open_existential_addr immutable_access {{%[0-9]+}} : $*any PM to $*@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", any PM) Self
+// CHECK: return
 sil [ossa] @silcombine_dont_change_allocstack_for_opened_archetypes : $@convention(thin) (@owned VV) -> () {
 bb0(%0 : @owned $VV):
   %8 = alloc_stack $PM, let, name "x"
@@ -4295,10 +4295,10 @@ bb0(%0 : $*Builtin.Int64, %1 : @owned $B):
 }
 
 // CHECK-LABEL: sil [ossa] @mark_dependence_trivial_object_base :
-// XHECK: bb0(
-// XHECK-NEXT: copy_value
-// XHECK-NEXT: return
-// XHECK: } // end sil function 'mark_dependence_trivial_object_base'
+// CHECK: bb0(
+// CHECK-NEXT: copy_value
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'mark_dependence_trivial_object_base'
 sil [ossa] @mark_dependence_trivial_object_base : $@convention(thin) (@guaranteed B) -> @owned B {
 bb0(%0 : @guaranteed $B):
   %0a = copy_value %0 : $B


### PR DESCRIPTION
This is part of fixing regressions when enabling OSSA modules:
rdar://140229560