### PR TITLE
Optimizer: don't run the UsePrespecialized pass in embedded mode

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1091,7 +1091,11 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
 
   // Finally perform some small transforms.
   P.startPipeline("Rest of Onone");
-  P.addUsePrespecialized();
+
+  // There are not pre-specialized parts of the stdlib in embedded mode.
+  if (!Options.EmbeddedSwift) {
+    P.addUsePrespecialized();
+  }
 
   // Has only an effect if the -assume-single-thread option is specified.
   if (P.getOptions().AssumeSingleThreaded) {


### PR DESCRIPTION
There are not pre-specialized parts of the stdlib in embedded mode.

Fixes a compiler crash.
Unfortunately I con't have a test case for this.

https://github.com/swiftlang/swift/issues/78167
