### PR TITLE
Exclude the build directory of `swift-xcodegen` from Python lint tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -44,6 +44,7 @@ filename =
 exclude =
     .git,
     __pycache__,
+    .build,
 
 ignore =
     # The black tool treats slices consistently, the E203 warning is not PEP8


### PR DESCRIPTION
Using `swift-xcodegen` creates a build directory at `utils/swift-xcodegen/.build`.

When running `test/Python/python_lint.swift`, Python files inside the build directory are scanned, resulting in a large number of lint errors being reported.

This patch resolves the issue by specifying an option for the lint command to exclude the `.build` directory from being scanned.

The lint errors that were occurring are below.
Some parts have been truncated due to GitHub’s limitations.

<details>

```
FAIL: Swift(macosx-arm64) :: Python/python_lint.swift (1 of 1)
******************** TEST 'Swift(macosx-arm64) :: Python/python_lint.swift' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:5:1: I100 Import statements are in the wrong order. 'import json' should be before 'import os'
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:10:1: I100 Import statements are in the wrong order. 'import errno' should be before 'import sys'
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:19:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:25:1: E305 expected 2 blank lines after class or function definition, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:30:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:39:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:44:89: E501 line too long (100 > 88 characters)
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:50:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:51:89: E501 line too long (95 > 88 characters)
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:55:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:56:89: E501 line too long (97 > 88 characters)
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:60:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:61:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:62:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:63:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:65:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:66:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:67:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:68:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:69:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:71:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:72:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:73:5: E121 continuation line under-indented for hanging indent
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:78:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:81:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:82:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:84:7: E121 continuation line under-indented for hanging indent
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:88:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:90:7: E121 continuation line under-indented for hanging indent
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:99:7: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:102:7: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:105:7: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:106:9: E121 continuation line under-indented for hanging indent
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:112:7: E114 indentation is not a multiple of 4 (comment)
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:113:7: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:114:9: E121 continuation line under-indented for hanging indent
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:117:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:120:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:122:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:123:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:124:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:125:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:127:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:129:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:130:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:131:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:133:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:136:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:137:3: E111 indentation is not a multiple of 4
./utils/swift-xcodegen/.build/checkouts/swift-driver/Utilities/build-script-helper.py:138:89: E501 line too long (98 > 88 characters)
...
./utils/swift-xcodegen/.build/checkouts/swift-tools-support-core/Utilities/build-script-helper.py:198:89: E501 line too long (109 > 88 characters)
./utils/swift-xcodegen/.build/checkouts/swift-tools-support-core/Utilities/build-script-helper.py:225:1: E302 expected 2 blank lines, found 1
./utils/swift-xcodegen/.build/checkouts/swift-tools-support-core/Utilities/build-script-helper.py:233:1: E305 expected 2 blank lines after class or function definition, found 1

--
Command Output (stderr):
--
RUN: at line 8: /opt/homebrew/opt/python@3.13/bin/python3.13 /Users/omochi/swift/swift/utils/python_lint.py
+ /opt/homebrew/opt/python@3.13/bin/python3.13 /Users/omochi/swift/swift/utils/python_lint.py
<unknown>:563: SyntaxWarning: invalid escape sequence '\U'
<unknown>:241: SyntaxWarning: invalid escape sequence '\s'
<unknown>:303: SyntaxWarning: invalid escape sequence '\p'

--

********************
********************
Failed Tests (1):
  Swift(macosx-arm64) :: Python/python_lint.swift
```
</details>

@hamishknight could you take a look at this patch?