### PR TITLE
🍒[cxx-interop] Fix runtime crash when casting from an existential to a foreign reference type

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -591,6 +591,16 @@ tryCastToForeignClass(
   return DynamicCastResult::Failure;
 }
 
+static DynamicCastResult tryCastToForeignReferenceType(
+    OpaqueValue *destLocation, const Metadata *destType, OpaqueValue *srcValue,
+    const Metadata *srcType, const Metadata *&destFailureType,
+    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks) {
+  assert(srcType != destType);
+  assert(destType->getKind() == MetadataKind::ForeignReferenceType);
+
+  return DynamicCastResult::Failure;
+}
+
 /******************************************************************************/
 /***************************** Enum Destination *******************************/
 /******************************************************************************/
@@ -2187,6 +2197,8 @@ static tryCastFunctionType *selectCasterForDest(const Metadata *destType) {
     return tryCastToOptional;
   case MetadataKind::ForeignClass:
     return tryCastToForeignClass;
+  case MetadataKind::ForeignReferenceType:
+    return tryCastToForeignReferenceType;
   case MetadataKind::Opaque:
     return tryCastToOpaque;
   case MetadataKind::Tuple:

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -61,6 +61,15 @@ WitnessTableTestSuite.test("As a Sequence") {
   expectEqual(count, 3)
 }
 
+WitnessTableTestSuite.test("As an existential") {
+  let existential: any ListNode = makeLinkedList()
+  let cast: CxxLinkedList? = existential as? CxxLinkedList
+  expectNotNil(cast)
+  expectEqual(cast?.value, 0)
+  expectEqual(cast?.next()?.value, 1)
+  expectEqual(cast?.next()?.next()?.value, 2)
+}
+
 }
 
 runAllTests()


### PR DESCRIPTION
**Explanation**: When a C++ foreign reference type is conformed to a Swift protocol via a Swift extension, trying to cast `any MyProtocol` to the foreign reference type crashes the runtime. This was because `selectCasterForDest` wasn't handling C++ foreign reference types, and we were hitting `swift_unreachable`.
**Scope**: This changes the dynamic casting behavior for foreign reference types in the Swift runtime.
**Risk**: Low, this only changes a code path that is specific to foreign reference types.
**Testing**: Added compiler tests.
**Issue**: rdar://141227849
**Reviewer**: @mikeash @tbkka 

Original PR: https://github.com/swiftlang/swift/pull/78223