### PR TITLE
CSSimplify: Do not unfold pack type variable into pack of type variables 

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2381,40 +2381,30 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
   auto pattern1 = expansion1->getPatternType();
   auto pattern2 = expansion2->getPatternType();
 
+  auto *const pack1 = pattern1->getAs<PackType>();
+  auto *const pack2 = pattern2->getAs<PackType>();
+
   // If both sides are expanded or neither side is, just match them
   // directly.
-  if (pattern1->is<PackType>() == pattern2->is<PackType>()) {
+  if ((bool)pack1 == (bool)pack2) {
     return matchTypes(pattern1, pattern2, kind, flags, locator);
-
-  // If the right hand side is expanded, we have something like
-  // Foo<$T0>... vs Pack{Foo<Int>, Foo<String>}...; We're going to
-  // bind $T0 to Pack{Int, String}.
-  } else if (!pattern1->is<PackType>() && pattern2->is<PackType>()) {
-    if (auto *pack2 = pattern2->getAs<PackType>()) {
-      if (auto *pack1 = replaceTypeVariablesWithFreshPacks(
-             *this, pattern1, pack2, locator)) {
-        addConstraint(kind, pack1, pack2, locator);
-        return getTypeMatchSuccess();
-      }
-    }
-
-    return getTypeMatchFailure(locator);
-
-  // If the left hand side is expanded, we have something like
-  // Pack{Foo<Int>, Foo<String>}... vs Foo<$T0>...; We're going to
-  // bind $T0 to Pack{Int, String}.
-  } else {
-    assert(pattern1->is<PackType>() && !pattern2->is<PackType>());
-    if (auto *pack1 = pattern1->getAs<PackType>()) {
-      if (auto *pack2 = replaceTypeVariablesWithFreshPacks(
-              *this, pattern2, pack1, locator)) {
-        addConstraint(kind, pack1, pack2, locator);
-        return getTypeMatchSuccess();
-      }
-    }
-
-    return getTypeMatchFailure(locator);
   }
+
+  // We have something like `Foo<$T0>` vs `Pack{Foo<Int>, Foo<String>}` or vice
+  // versa. We're going to bind $T0 to Pack{Int, String}.
+  if (pack1) {
+    pack2 = replaceTypeVariablesWithFreshPacks(*this, pattern2, pack1, locator);
+  } else {
+    pack1 = replaceTypeVariablesWithFreshPacks(*this, pattern1, pack2, locator);
+  }
+
+  if (pack1 && pack2) {
+    addConstraint(kind, pack1, pack2, locator);
+
+    return getTypeMatchSuccess();
+  }
+
+  return getTypeMatchFailure(locator);
 }
 
 /// Check where a representation is a subtype of another.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2381,16 +2381,19 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
   auto pattern1 = expansion1->getPatternType();
   auto pattern2 = expansion2->getPatternType();
 
+  auto *const typeVar1 = pattern1->getAs<TypeVariableType>();
+  auto *const typeVar2 = pattern2->getAs<TypeVariableType>();
+
   auto *const pack1 = pattern1->getAs<PackType>();
   auto *const pack2 = pattern2->getAs<PackType>();
 
-  // If both sides are expanded or neither side is, proceed to matching them
-  // directly.
+  // If either side is a type variable, neither side is expanded, or both sides
+  // are expanded, proceed to matching them directly.
   // Otherwise, we have something like `Foo<$T0>` vs.
   // `Pack{Foo<Int>, Foo<String>}` or vice versa.
   // We're going to bind `$T0` to `Pack{Int, String}` and unfold `Foo<$T0>` into
-  // `Pack{Foo<$T3>, Foo<$T4>} first.
-  if ((bool)pack1 != (bool)pack2) {
+  // `Pack{Foo<$T3>, Foo<$T4>} first, then match.
+  if (!typeVar1 && !typeVar2 && (bool)pack1 != (bool)pack2) {
     if (pack1) {
       pattern2 =
           replaceTypeVariablesWithFreshPacks(*this, pattern2, pack1, locator);

--- a/test/Constraints/pack_type_with_pack_expansions.swift
+++ b/test/Constraints/pack_type_with_pack_expansions.swift
@@ -66,3 +66,46 @@ do {
     Multiply
   > = m
 }
+
+// FIXME: The constraint system cannot handle these!
+do {
+  // expected-note@+2 {{arguments to generic parameter 'T' ('[Int], [Bool]' and 'Array<_>') are expected to be equal}}
+  // expected-note@+1 {{arguments to generic parameter 'T' ('[Int], [Bool], [Bool], [String], [Never]' and 'Array<_>, Array<_>, Array<_>') are expected to be equal}}
+  struct G<each T> {}
+
+  do {
+    func f<each T>(
+      _: G<repeat [each T]> // expected-note {{in inferring pack element #0 of '_'}}
+    ) -> G<repeat [each T], [Bool]> {}
+
+    let g1: G<[Int], [Bool]>
+
+    // expected-error@+3 {{could not infer pack element #0 from context}}
+    // expected-error@+2 {{pack expansion requires that '[Int], [Bool]' and '_' have the same shape}}
+    // expected-error@+1 {{cannot convert value of type 'G<[Int], [Bool]>' to expected argument type 'G<Array<_>>'}}
+    let _ = f(f(g1))
+  }
+
+  do {
+    func g<each T, each U>(
+      _: G<repeat each U>,
+      _: G<repeat each T>
+    ) -> G<repeat [each T], [Bool], repeat [each U]> {}
+    func f<each T>(
+      // expected-note@+3 {{in inferring pack element #2 of '_'}}
+      // expected-note@+2 {{in inferring pack element #1 of '_'}}
+      // expected-note@+1 {{in inferring pack element #0 of '_'}}
+      _: G<repeat [each T]>
+    ) -> G<repeat [each T], [Bool]> {}
+
+    let g1: G<String, Never>
+    let g2: G<Int, Bool>
+
+    // expected-error@+5 {{cannot convert value of type 'G<[Int], [Bool], [Bool], [String], [Never]>' to expected argument type 'G<Array<_>, Array<_>, Array<_>>'}}
+    // expected-error@+4 {{pack expansion requires that '[Int], [Bool], [Bool], [String], [Never]' and '_, _, _' have the same shape}}
+    // expected-error@+3 {{could not infer pack element #2 from context}}
+    // expected-error@+2 {{could not infer pack element #1 from context}}
+    // expected-error@+1 {{could not infer pack element #0 from context}}
+    let _ = f(g(g1, g2))
+  }
+}

--- a/test/Constraints/pack_type_with_pack_expansions.swift
+++ b/test/Constraints/pack_type_with_pack_expansions.swift
@@ -1,0 +1,68 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+// rdar://137125054
+
+do {
+  struct Tuple<each T> {
+    func withBool() -> Tuple<repeat each T, Bool> {}
+  }
+
+  let t = Tuple<Int>()
+    .withBool()
+    .withBool()
+    .withBool()
+  let _: Tuple<
+    Int,
+    Bool,
+    Bool,
+    Bool
+  > = t
+}
+
+protocol View {}
+
+struct Zero: View {}
+struct One: View {}
+
+protocol ViewModifier {}
+
+struct Add: ViewModifier {}
+struct Multiply: ViewModifier {}
+
+struct ModifiedContent<Content: View, each Modifier: ViewModifier>: View {
+  func add() -> ModifiedContent<Content, repeat each Modifier, Add> {}
+  func multiply() -> ModifiedContent<Content, repeat each Modifier, Multiply> {}
+}
+
+extension View {
+  func add() -> ModifiedContent<Self, Add> {}
+  func multiply() -> ModifiedContent<Self, Multiply> {}
+}
+
+do {
+  let m = Zero()
+    .add()
+    .multiply()
+    .add()
+    .multiply()
+    .add()
+    .multiply()
+    .add()
+    .multiply()
+    .add()
+    .multiply()
+
+  let _: ModifiedContent<
+    Zero,
+    Add,
+    Multiply,
+    Add,
+    Multiply,
+    Add,
+    Multiply,
+    Add,
+    Multiply,
+    Add,
+    Multiply
+  > = m
+}

--- a/validation-test/Sema/type_checker_perf/slow/nested_pack_expansion-1.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nested_pack_expansion-1.swift.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --invert-result --begin 1 --end 8 --step 1 --select NumLeafScopes %s -Xfrontend=-typecheck
+// REQUIRES: asserts,no_asan
+
+protocol Number {}
+
+struct Zero: Number {}
+struct One: Number {}
+
+extension Number {
+  func plusZero() -> Sum<Self, Zero> {}
+}
+
+struct Sum<each N>: Number {
+  func plusZero() -> Sum<repeat each N, Zero> {}
+}
+
+let m = Zero()
+%for i in range(0, N):
+  .plusZero()
+%end

--- a/validation-test/Sema/type_checker_perf/slow/nested_pack_expansion-2.swift
+++ b/validation-test/Sema/type_checker_perf/slow/nested_pack_expansion-2.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple -solver-expression-time-threshold=2
+// REQUIRES: tools-release,no_asan
+
+struct Tuple<each T> {
+  func withBool() -> Tuple<repeat [each T], repeat (each T, Bool)> {}
+}
+let tuple = Tuple<Int>()
+let _ = tuple // expected-error {{reasonable time}}
+  .withBool()
+  .withBool()
+  .withBool()
+  .withBool()
+  .withBool()
+  .withBool()
+  .withBool()
+

--- a/validation-test/compiler_crashers_2/issue-78156.swift
+++ b/validation-test/compiler_crashers_2/issue-78156.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-frontend -target %target-swift-5.9-abi-triple -typecheck %s
+
+// https://github.com/apple/swift/issues/78156
+
+func f<each T>(_: repeat [each T]) -> (repeat [each T], Bool) {}
+let _ = f(f(f([4])))


### PR DESCRIPTION
This is a targeted fix for rdar://137125054 that can be safely cherry-picked. The bigger problem is that `replaceTypeVariablesWithFreshPacks` does the wrong thing for a pack expansion type variable element. The even bigger problem is that pack matching chickens out when there are multiple pack expansions among the elements.