### PR TITLE
[cxx-interop] Diagnose conditional casts from an existential to a foreign reference type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4538,8 +4538,8 @@ NOTE(silence_inject_forced_downcast,none,
      "add parentheses around the cast to silence this warning", ())
 
 ERROR(conditional_downcast_foreign,none,
-      "conditional downcast to CoreFoundation type %0 will always succeed",
-      (Type))
+      "conditional downcast to %select{CoreFoundation|foreign reference}1 type %0 will always succeed",
+      (Type, bool))
 NOTE(note_explicitly_compare_cftypeid,none,
       "did you mean to explicitly compare the CFTypeIDs of %0 and %1?",
       (DeclBaseName, Type))

--- a/test/Interop/Cxx/foreign-reference/witness-table-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table-typechecker.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
+
+import WitnessTable
+
+public protocol ListNode {
+  associatedtype Element
+  func next() -> Element?
+}
+
+@available(SwiftStdlib 5.8, *)
+extension CxxLinkedList : ListNode { }
+
+let existential: any ListNode = makeLinkedList()
+let cast: CxxLinkedList? = existential as? CxxLinkedList // expected-error {{conditional downcast to foreign reference type 'CxxLinkedList' will always succeed}}

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -63,11 +63,10 @@ WitnessTableTestSuite.test("As a Sequence") {
 
 WitnessTableTestSuite.test("As an existential") {
   let existential: any ListNode = makeLinkedList()
-  let cast: CxxLinkedList? = existential as? CxxLinkedList
-  expectNotNil(cast)
-  expectEqual(cast?.value, 0)
-  expectEqual(cast?.next()?.value, 1)
-  expectEqual(cast?.next()?.next()?.value, 2)
+  let cast: CxxLinkedList = existential as! CxxLinkedList
+  expectEqual(cast.value, 0)
+  expectEqual(cast.next()?.value, 1)
+  expectEqual(cast.next()?.next()?.value, 2)
 }
 
 }


### PR DESCRIPTION
This is a follow-up to 84ae5fbe.

The Swift runtime doesn't have enough metadata to determine if a conditional cast from an existential to a C++ foreign reference type is successful. Clients should force-cast using `as!` instead. This change adds a diagnostic for such casts.

rdar://141227849

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
