### PR TITLE
Revert "[swiftinterface] Handle target variants the same as targets (#77156)"

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -573,8 +573,7 @@ public:
 bool extractCompilerFlagsFromInterface(
     StringRef interfacePath, StringRef buffer, llvm::StringSaver &ArgSaver,
     SmallVectorImpl<const char *> &SubArgs,
-    std::optional<llvm::Triple> PreferredTarget = std::nullopt,
-    std::optional<llvm::Triple> PreferredTargetVariant = std::nullopt);
+    std::optional<llvm::Triple> PreferredTarget = std::nullopt);
 
 /// Extract the user module version number from an interface file.
 llvm::VersionTuple extractUserModuleVersionFromInterface(StringRef moduleInterfacePath);

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -454,7 +454,7 @@ public:
      : ctx(ctx),
        fs(*ctx.SourceMgr.getFileSystem()),
        requiresOSSAModules(requiresOSSAModules) {}
-
+  
   // Check if all the provided file dependencies are up-to-date compared to
   // what's currently on disk.
   bool dependenciesAreUpToDate(StringRef modulePath,
@@ -524,7 +524,7 @@ public:
     moduleBuffer = std::move(*OutBuf);
     return serializedASTBufferIsUpToDate(modulePath, *moduleBuffer, rebuildInfo, AllDeps);
   }
-
+  
   enum class DependencyStatus {
     UpToDate,
     OutOfDate,
@@ -1513,8 +1513,7 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
 static bool readSwiftInterfaceVersionAndArgs(
     SourceManager &SM, DiagnosticEngine &Diags, llvm::StringSaver &ArgSaver,
     SwiftInterfaceInfo &interfaceInfo, StringRef interfacePath,
-    SourceLoc diagnosticLoc, llvm::Triple preferredTarget,
-    std::optional<llvm::Triple> preferredTargetVariant) {
+    SourceLoc diagnosticLoc, llvm::Triple preferredTarget) {
   llvm::vfs::FileSystem &fs = *SM.getFileSystem();
   auto FileOrError = swift::vfs::getFileOrSTDIN(fs, interfacePath);
   if (!FileOrError) {
@@ -1538,8 +1537,7 @@ static bool readSwiftInterfaceVersionAndArgs(
 
   if (extractCompilerFlagsFromInterface(interfacePath, SB, ArgSaver,
                                         interfaceInfo.Arguments,
-                                        preferredTarget,
-                                        preferredTargetVariant)) {
+                                        preferredTarget)) {
     InterfaceSubContextDelegateImpl::diagnose(
         interfacePath, diagnosticLoc, SM, &Diags,
         diag::error_extracting_version_from_module_interface);
@@ -1594,7 +1592,7 @@ bool ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
     StringRef outputPath, bool ShouldSerializeDeps,
     ArrayRef<std::string> CompiledCandidates,
     DependencyTracker *tracker) {
-
+  
   if (!Instance.getInvocation().getIRGenOptions().AlwaysCompile) {
     // First, check if the expected output already exists and possibly
     // up-to-date w.r.t. all of the dependencies it was built with. If so, early
@@ -1615,7 +1613,7 @@ bool ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
       return false;
     }
   }
-
+  
   // Read out the compiler version.
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver ArgSaver(alloc);
@@ -1623,8 +1621,7 @@ bool ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
   readSwiftInterfaceVersionAndArgs(
       Instance.getSourceMgr(), Instance.getDiags(), ArgSaver, InterfaceInfo,
       interfacePath, SourceLoc(),
-      Instance.getInvocation().getLangOptions().Target,
-      Instance.getInvocation().getLangOptions().TargetVariant);
+      Instance.getInvocation().getLangOptions().Target);
 
   auto Builder = ExplicitModuleInterfaceBuilder(
       Instance, &Instance.getDiags(), Instance.getSourceMgr(),
@@ -1671,15 +1668,6 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     // So the Swift interface should know that as well to load these PCMs properly.
     GenericArgs.push_back("-clang-target");
     GenericArgs.push_back(triple);
-  }
-
-  if (LangOpts.TargetVariant.has_value()) {
-    genericSubInvocation.getLangOptions().TargetVariant = LangOpts.TargetVariant;
-    auto variantTriple = ArgSaver.save(genericSubInvocation.getLangOptions().TargetVariant->str());
-    if (!variantTriple.empty()) {
-      GenericArgs.push_back("-target-variant");
-      GenericArgs.push_back(variantTriple);
-    }
   }
 
   // Inherit the target SDK name and version
@@ -1821,8 +1809,7 @@ bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
     StringRef interfacePath, SourceLoc diagnosticLoc) {
   if (readSwiftInterfaceVersionAndArgs(SM, *Diags, ArgSaver, interfaceInfo,
                                        interfacePath, diagnosticLoc,
-                                       subInvocation.getLangOptions().Target,
-                                       subInvocation.getLangOptions().TargetVariant))
+                                       subInvocation.getLangOptions().Target))
     return true;
 
   // Prior to Swift 5.9, swiftinterfaces were always built (accidentally) with

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1389,13 +1389,6 @@ void swift::serialization::diagnoseSerializedASTLoadFailureTransitive(
   }
 }
 
-static bool tripleNeedsSubarchitectureAdjustment(const llvm::Triple &lhs, const llvm::Triple &rhs) {
-  return (lhs.getSubArch() != rhs.getSubArch() &&
-          lhs.getArch() == rhs.getArch() &&
-          lhs.getVendor() == rhs.getVendor() &&
-          lhs.getOS() == rhs.getOS() &&
-          lhs.getEnvironment() == rhs.getEnvironment());
-}
 
 static std::optional<StringRef> getFlagsFromInterfaceFile(StringRef &file,
                                                           StringRef prefix) {
@@ -1418,8 +1411,7 @@ static std::optional<StringRef> getFlagsFromInterfaceFile(StringRef &file,
 bool swift::extractCompilerFlagsFromInterface(
     StringRef interfacePath, StringRef buffer, llvm::StringSaver &ArgSaver,
     SmallVectorImpl<const char *> &SubArgs,
-    std::optional<llvm::Triple> PreferredTarget,
-    std::optional<llvm::Triple> PreferredTargetVariant) {
+    std::optional<llvm::Triple> PreferredTarget) {
   auto FlagMatch = getFlagsFromInterfaceFile(buffer, SWIFT_MODULE_FLAGS_KEY);
   if (!FlagMatch)
     return true;
@@ -1430,19 +1422,19 @@ bool swift::extractCompilerFlagsFromInterface(
   // we have loaded a Swift interface from a different-but-compatible
   // architecture slice. Use the compatible subarchitecture.
   for (unsigned I = 1; I < SubArgs.size(); ++I) {
-    if (strcmp(SubArgs[I - 1], "-target") == 0) {
-      llvm::Triple target(SubArgs[I]);
-      if (PreferredTarget &&
-          tripleNeedsSubarchitectureAdjustment(target, *PreferredTarget))
-        target.setArch(PreferredTarget->getArch(), PreferredTarget->getSubArch());
-      SubArgs[I] = ArgSaver.save(target.str()).data();
-    } else if (strcmp(SubArgs[I - 1], "-target-variant") == 0) {
-      llvm::Triple targetVariant(SubArgs[I]);
-      if (PreferredTargetVariant &&
-          tripleNeedsSubarchitectureAdjustment(targetVariant, *PreferredTargetVariant))
-        targetVariant.setArch(PreferredTargetVariant->getArch(), PreferredTargetVariant->getSubArch());
-      SubArgs[I] = ArgSaver.save(targetVariant.str()).data();
+    // FIXME: Also fix up -target-variant (rdar://135322077).
+    if (strcmp(SubArgs[I - 1], "-target") != 0) {
+      continue;
     }
+    llvm::Triple target(SubArgs[I]);
+    if (PreferredTarget &&
+        target.getSubArch() != PreferredTarget->getSubArch() &&
+        target.getArch() == PreferredTarget->getArch() &&
+        target.getVendor() == PreferredTarget->getVendor() &&
+        target.getOS() == PreferredTarget->getOS() &&
+        target.getEnvironment() == PreferredTarget->getEnvironment())
+      target.setArch(PreferredTarget->getArch(), PreferredTarget->getSubArch());
+    SubArgs[I] = ArgSaver.save(target.str()).data();
   }
 
   auto IgnFlagMatch =


### PR DESCRIPTION
This reverts commit 4e2fbe17c347a960d58a2f8c1f484dafb7505b38.

This commit has been causing a project build failure as indicated in rdar://141569534. To address this failure, revert the commit from release/6.1 branch while investigating a root-cause fix on main.

