### PR TITLE
[Runtime] load debug env vars from Android system properties

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -195,13 +195,13 @@ extern "C" char **_environ;
 // On Android, also try loading runtime debug env variables from system props.
 static void platformInitialize(void *context) {
   (void)context;
-  char propValueString[PROP_VALUE_MAX] = "";
+  char buffer[PROP_VALUE_MAX] = "";
 #define SYSPROP_PREFIX "debug.org.swift.runtime."
-#define VARIABLE(name, type, defaultValue, help)                      \
-  if (__system_property_get(SYSPROP_PREFIX #name, propValueString)) { \
-    swift::runtime::environment::name##_isSet_variable = true;        \
-    swift::runtime::environment::name##_variable =                    \
-        parse_##type(#name, propValueString, defaultValue);           \
+#define VARIABLE(name, type, defaultValue, help)                \
+  if (__system_property_get(SYSPROP_PREFIX #name, buffer)) {    \
+    swift::runtime::environment::name##_isSet_variable = true;  \
+    swift::runtime::environment::name##_variable =              \
+        parse_##type(#name, buffer, defaultValue);              \
   }
 #include "EnvironmentVariables.def"
 #undef VARIABLE

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -21,6 +21,10 @@
 #include <string.h>
 #include <inttypes.h>
 
+#if defined(__ANDROID__)
+#include <sys/system_properties.h>
+#endif
+
 using namespace swift;
 
 namespace {
@@ -187,9 +191,32 @@ extern "C" char **_environ;
 #endif
 #endif
 
+#if defined(__ANDROID__)
+// On Android, also try loading runtime debug env variables from system props.
+static void platformInitialize(void *context) {
+  (void)context;
+#define SYSPROP_PREFIX "debug.swift.runtime."
+#define VARIABLE(name, type, defaultValue, help)                          \
+  do {                                                                    \
+    char name##_string[PROP_VALUE_MAX] = "";                              \
+    if (__system_property_get(SYSPROP_PREFIX #name, name##_string) > 0) { \
+      swift::runtime::environment::name##_isSet_variable = true;          \
+      swift::runtime::environment::name##_variable =                      \
+        parse_##type(#name, name##_string, defaultValue);                 \
+    }                                                                     \
+  } while (0);
+#include "EnvironmentVariables.def"
+#undef VARIABLE
+}
+#else
+static void platformInitialize(void *context) {
+  (void)context;
+}
+#endif
+
 #if !SWIFT_STDLIB_HAS_ENVIRON
 void swift::runtime::environment::initialize(void *context) {
-  (void)context;
+  platformInitialize(context);
 }
 #elif defined(ENVIRON)
 void swift::runtime::environment::initialize(void *context) {
@@ -242,6 +269,8 @@ void swift::runtime::environment::initialize(void *context) {
     }
   }
 
+  platformInitialize(context);
+
   if (SWIFT_DEBUG_HELP_variable)
     printHelp(nullptr);
 }
@@ -257,6 +286,8 @@ void swift::runtime::environment::initialize(void *context) {
     name##_variable = parse_##type(#name, name##_string, defaultValue);        \
   } while (0);
 #include "EnvironmentVariables.def"
+
+  platformInitialize(context);
 
   // Print help if requested.
   if (parse_bool("SWIFT_DEBUG_HELP", getenv("SWIFT_DEBUG_HELP"), false))

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -196,6 +196,7 @@ extern "C" char **_environ;
 static void platformInitialize(void *context) {
   (void)context;
   char buffer[PROP_VALUE_MAX] = "";
+// Only system properties prefixed with "debug." can be set without root access.
 #define SYSPROP_PREFIX "debug.org.swift.runtime."
 #define VARIABLE(name, type, defaultValue, help)                \
   if (__system_property_get(SYSPROP_PREFIX #name, buffer)) {    \

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -195,16 +195,14 @@ extern "C" char **_environ;
 // On Android, also try loading runtime debug env variables from system props.
 static void platformInitialize(void *context) {
   (void)context;
-#define SYSPROP_PREFIX "debug.swift.runtime."
-#define VARIABLE(name, type, defaultValue, help)                          \
-  do {                                                                    \
-    char name##_string[PROP_VALUE_MAX] = "";                              \
-    if (__system_property_get(SYSPROP_PREFIX #name, name##_string) > 0) { \
-      swift::runtime::environment::name##_isSet_variable = true;          \
-      swift::runtime::environment::name##_variable =                      \
-        parse_##type(#name, name##_string, defaultValue);                 \
-    }                                                                     \
-  } while (0);
+  char propValueString[PROP_VALUE_MAX] = "";
+#define SYSPROP_PREFIX "debug.org.swift.runtime."
+#define VARIABLE(name, type, defaultValue, help)                      \
+  if (__system_property_get(SYSPROP_PREFIX #name, propValueString)) { \
+    swift::runtime::environment::name##_isSet_variable = true;        \
+    swift::runtime::environment::name##_variable =                    \
+        parse_##type(#name, propValueString, defaultValue);           \
+  }
 #include "EnvironmentVariables.def"
 #undef VARIABLE
 }


### PR DESCRIPTION
### Purpose
Enable setting `SWIFT_DEBUG_` vars in Swift Android apps by reading `debug.swift.runtime.SWIFT_DEBUG_` system properties during runtime init on Android. 

### Overview
* Add a private `platformInitialize()` function to the env var setup in the Swift runtime and implement it only for Android
* Call the new `platformInitialize` function from each of the `swift::runtime::environment::initialize` implementations

### Background
Because all Android app processes all fork from the same process, they don't pick-up environment changes on launch. Android system properties give us an alternative, standard mechanism to do something similar. **Only system properties prefixed with `debug.` can be set without root permissions.** 

### Validation
Set system properties on an Android device:
```
adb -d shell setprop debug.org.swift.runtime.SWIFT_DEBUG_ENABLE_METADATA_BACKTRACE_LOGGING 1
adb -d shell setprop debug.org.swift.runtime.SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION 1
```
Kill and re-launch a simple Android app that initializes the Swift runtime from `Application.onCreate`.
```
adb -d shell am force-stop com.example.SwiftAppPackage
adb -d shell am start com.example.SwiftAppPackage/.MainActivity
```
Using the debugger, confirm these variables are set to `true`:
```
swift::runtime::environment::SWIFT_DEBUG_ENABLE_METADATA_BACKTRACE_LOGGING_variable
swift::runtime::environment::SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION _variable
```