### PR TITLE
[6.1] Fix reborrow verifier to look through borrowed from

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1605,10 +1605,15 @@ void swift::visitExtendedReborrowPhiBaseValuePairs(
     // the reborrow, its phi value will be the new base value.
     for (auto &op : phiOp.getBranch()->getAllOperands()) {
       PhiOperand otherPhiOp(&op);
-      if (otherPhiOp.getSource() != currentBaseValue) {
+      auto *borrowedFromUser = getBorrowedFromUser(currentBaseValue);
+      if (borrowedFromUser && borrowedFromUser == otherPhiOp.getSource()) {
+        newBaseValue = otherPhiOp.getValue();
         continue;
       }
-      newBaseValue = otherPhiOp.getValue();
+      if (otherPhiOp.getSource() == currentBaseValue) {
+        newBaseValue = otherPhiOp.getValue();
+        continue;
+      }
     }
 
     // Call the visitor function

--- a/test/SIL/OwnershipVerifier/guaranteed_phis.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_phis.sil
@@ -334,3 +334,30 @@ bb3(%phi1 : @guaranteed $Wrapper2, %phi2 : @guaranteed $Wrapper1):
   %9999 = tuple()
   return %9999 : $()
 }
+
+
+sil hidden [ossa] @borrowed_from_reborrow : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load_borrow %0 : $*Klass
+  %2 = begin_borrow [lexical] %1 : $Klass
+  br bb1(%1 : $Klass, %2 : $Klass)
+
+bb1(%4 : @reborrow $Klass, %5 : @reborrow $Klass):
+  %6 = borrowed %5 : $Klass from (%4 : $Klass)
+  %7 = borrowed %4 : $Klass from ()
+  br bb2(%7 : $Klass, %6 : $Klass)
+
+bb2(%9 : @reborrow $Klass, %10 : @reborrow $Klass):
+  %11 = borrowed %10 : $Klass from (%9 : $Klass)
+  %12 = borrowed %9 : $Klass from ()
+  br bb3(%12 : $Klass, %11 : $Klass)
+
+bb3(%14 : @reborrow $Klass, %15 : @reborrow $Klass):
+  %16 = borrowed %15 : $Klass from (%14 : $Klass)
+  %17 = borrowed %14 : $Klass from ()
+  end_borrow %16 : $Klass
+  end_borrow %17 : $Klass
+  %20 = tuple ()
+  return %20 : $()
+}
+


### PR DESCRIPTION
Explanation: "borrowed from" is a recently added SIL instruction. While looking for new reborrows we should always look through these instructions. The reborrow verifier was not doing it leading to a false verification error.
Scope: This fixes a false ownership verification error in the ReborrowVerifier.
Original PR: https://github.com/swiftlang/swift/pull/78217
Risk: Very Low
Testing: Swift CI testing
Reviewed by: @nate-chandler 
Issue: rdar://141490868