### PR TITLE
[test] Disable `isolated_deinit_main_sync.swift` for back-deployment

### DIFF
--- a/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
+++ b/test/Concurrency/Runtime/isolated_deinit_main_sync.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
 var isDead: Bool = false
 


### PR DESCRIPTION

This test relies on `_swift_task_deinitOnExecutor`, which is only available in newer runtimes.