### PR TITLE
[Build] Do not strip swift prefix for WASI SDK bundle

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -140,7 +140,7 @@ class WasmSwiftSDK(product.Product):
         swift_run = os.path.join(toolchain_path, 'bin', 'swift-run')
 
         swift_version = os.environ.get('TOOLCHAIN_VERSION',
-                                       'swift-DEVELOPMENT-SNAPSHOT').lstrip('swift-')
+                                       'swift-DEVELOPMENT-SNAPSHOT')
         run_args = [
             swift_run,
             '--package-path', self.source_dir,


### PR DESCRIPTION
Match the static Linux SDK - leave the `swift-` prefix on the generated artifact bundle.