### PR TITLE
Allow SimplifyCFG::simplifyArgument on borrowed values

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3730,8 +3730,6 @@ bool SimplifyCFG::simplifyArgument(SILBasicBlock *BB, unsigned i) {
     }
     if (inst->getOwnershipKind() == OwnershipKind::Owned)
       return !inst->getSingleUse();
-    if (BorrowedValue borrow = BorrowedValue(inst->getOperand(0)))
-      return borrow.isLocalScope();
     return false;
   };
 

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -266,7 +266,7 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @test_simplify_enum_arg_guaranteed1 : 
-// CHECK: bb1([[ARG:%.*]] : @guaranteed $FakeOptional<Klass>)
+// CHECK: bb1([[ARG:%.*]] : @guaranteed $Klass)
 // CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_guaranteed1'
 sil [ossa] @test_simplify_enum_arg_guaranteed1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -290,7 +290,9 @@ bb2:
   return %t : $()
 }
 
-// CHECK: bb1([[ARG:%.*]] : @guaranteed $NonTrivialStruct)
+// CHECK-LABEL: sil [ossa] @test_simplify_enum_arg_guaranteed2 : 
+// CHECK: bb1([[ARG:%.*]] : @guaranteed $Klass)
+// CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_guaranteed2'
 sil [ossa] @test_simplify_enum_arg_guaranteed2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   specify_test "simplify_cfg_simplify_argument @block[1] 0"

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1453,6 +1453,8 @@ skip-build-tvos
 skip-test-tvos
 skip-build-watchos
 skip-test-watchos
+skip-build-xros
+skip-test-xros
 
 [preset: buildbot_osx_package]
 mixin-preset=


### PR DESCRIPTION
This was previously disabled because passing borrow introducers as branch operands was considered a reborrow. Now that we have removed this restriction, enable this.  

Also piggybacking a build change to skip building xros in macos_only preset