### PR TITLE
[IRGen] Indirectly pass typed errors for closures with indirect results

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1188,6 +1188,7 @@ public:
 
       if (resultSchema.requiresIndirect() ||
           errorSchema.shouldReturnTypedErrorIndirectly() ||
+          outConv.hasIndirectSILResults() ||
           outConv.hasIndirectSILErrorResults()) {
         auto *typedErrorResultPtr = origParams.claimNext();
         args.add(typedErrorResultPtr);
@@ -1378,6 +1379,7 @@ public:
 
       if (resultSchema.requiresIndirect() ||
           errorSchema.shouldReturnTypedErrorIndirectly() ||
+          outConv.hasIndirectSILResults() ||
           outConv.hasIndirectSILErrorResults()) {
         auto *typedErrorResultPtr = origParams.claimNext();
         args.add(typedErrorResultPtr);

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -265,3 +265,23 @@ func conditionallyCallsThrowError(b: Bool) throws(SmallError) -> Int {
     return 0
   }
 }
+
+func passthroughFixedErrorCall<T>(_ body: () throws(TinyError) -> T) throws(TinyError) -> T {
+  try body()
+}
+
+func passthroughFixedErrorAsync<T>(_ body: () async throws(TinyError) -> T) async throws(TinyError) -> T {
+  try await body()
+}
+
+func callClosureSync<T>(t: T) {
+  _ = try! passthroughFixedErrorCall { () throws(TinyError) -> T in
+    return t
+  }
+}
+
+func callClosureAsync<T>(t: T) async {
+  _ = try! await passthroughFixedErrorAsync { () async throws(TinyError) -> T in
+    return t
+  }
+}


### PR DESCRIPTION
rdar://141575655

In partial application forwarder emission, we were missing a check for indirect results. When results are being returned indirectly, we have to return the error indirectly as well.
