### PR TITLE
[embedded] Make stdlib APIs automatically available on older Darwin versions in Embedded Swift

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -434,6 +434,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
   set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
 
+  # Under Embedded Swift, all stdlib APIs should be available always. Replace
+  # all availability macros with very very old OS versions.
+  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
+  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+    string(REGEX REPLACE ":.*" ":macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0" replaced "${def}")
+    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
+  endforeach()
+  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
+
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)

--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -1,0 +1,13 @@
+// Checks that in Embedded Swift, we allow using stdlib types even when they
+// have declared availability to be higher than our macOS deployment target.
+
+// RUN: %target-typecheck-verify-swift -target arm64-apple-macos14 -enable-experimental-feature Embedded -enable-experimental-feature Span
+// RUN: %target-typecheck-verify-swift -target arm64-apple-macos15 -enable-experimental-feature Embedded -enable-experimental-feature Span
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Span
+// REQUIRES: OS=macosx
+
+func f(_: Span<Int>) { } // Span is @available(SwiftStdlib 6.1, *)
+func g(_: Int128) { } // Int128 is @available(SwiftStdlib 6.0, *)


### PR DESCRIPTION
The motivation here is about using types and API that have been recently added to the stdlib with an availability only in a recent macOS release (for regular Swift) because the stdlib ships as part of the OS. However, we don't have that constraint with Embedded Swift where the stdlib/runtime is statically included into the produced binaries, and therefore we should be able to use such stdlib types regardless of the "official" availability for regular Swift.