### PR TITLE
[6.1] ClangImporter: Ignore missing imports in `SwiftDeclConverter::recordObjCOverride()`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7165,9 +7165,9 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
     return;
   // Dig out the Objective-C superclass.
   SmallVector<ValueDecl *, 4> results;
-  superDecl->lookupQualified(superDecl, DeclNameRef(decl->getName()),
-                             decl->getLoc(), NL_QualifiedDefault,
-                             results);
+  superDecl->lookupQualified(
+      superDecl, DeclNameRef(decl->getName()), decl->getLoc(),
+      NL_QualifiedDefault | NL_IgnoreMissingImports, results);
   for (auto member : results) {
     if (member->getKind() != decl->getKind() ||
         member->isInstanceMember() != decl->isInstanceMember() ||

--- a/test/NameLookup/Inputs/MemberImportVisibility/Bridging.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Bridging.h
@@ -1,9 +1,18 @@
 @import Categories_A;
 
+@interface NSObject (BridgingHeader)
+- (void)overridesCategoryMethodOnNSObject;
+@end
+
 @interface X (BridgingHeader)
 - (void)fromBridgingHeader;
+- (void)overridesCategoryMethodOnNSObject;
 @end
 
 struct StructInBridgingHeader {
   int member;
 };
+
+@interface ObjectInBridgingHeader : NSObject
+- (void)overridesCategoryMethodOnNSObject;
+@end

--- a/test/NameLookup/members_transitive_objc.swift
+++ b/test/NameLookup/members_transitive_objc.swift
@@ -24,6 +24,7 @@ func test(x: X) {
   x.fromOverlayForC() // expected-member-visibility-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
+  x.overridesCategoryMethodOnNSObject()
 }
 
 func testAnyObject(a: AnyObject) {
@@ -37,6 +38,7 @@ func testAnyObject(a: AnyObject) {
   a.fromC() // expected-error {{value of type 'AnyObject' has no member 'fromC'}}
   a.fromOverlayForCObjC() // expected-error {{value of type 'AnyObject' has no member 'fromOverlayForCObjC'}}
   a.fromBridgingHeader()
+  a.overridesCategoryMethodOnNSObject()
 }
 
 extension StructInBridgingHeader {
@@ -46,5 +48,11 @@ extension StructInBridgingHeader {
 
   var wrappedMember: Int32 {
     return member
+  }
+}
+
+extension ObjectInBridgingHeader {
+  func test() {
+    overridesCategoryMethodOnNSObject()
   }
 }


### PR DESCRIPTION
- **Explanation:** `recordObjCOverride()` records semantic overrides for imported Obj-C methods. Since these methods are imported from a different language, it doesn't make sense to enforce Swift's member import visibility rules when performing lookups to find overridden methods. Doing so caused the Constraint Solver to lack important information needed to eliminate overloads, resulting in erroneous ambiguities.
- **Scope:** Affects projects adopting `-enable-upcoming-feature MemberImportVisibility`.
- **Issue/Radar:** rdar://141636723
- **Original PR:** https://github.com/swiftlang/swift/pull/78265
- **Risk:** Low. The change in behavior only affects adopters of `MemberImportVisibility`, which hasn't been included in a released toolchain yet.
- **Testing:** A new test in the compiler test suite.
- **Reviewer:** @DougGregor 