### PR TITLE
[6.1] Optimizer: don't run the UsePrespecialized pass in embedded mode

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1091,7 +1091,11 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
 
   // Finally perform some small transforms.
   P.startPipeline("Rest of Onone");
-  P.addUsePrespecialized();
+
+  // There are not pre-specialized parts of the stdlib in embedded mode.
+  if (!Options.EmbeddedSwift) {
+    P.addUsePrespecialized();
+  }
 
   // Has only an effect if the -assume-single-thread option is specified.
   if (P.getOptions().AssumeSingleThreaded) {


### PR DESCRIPTION
* **Explanation**: Fixes a compiler crash in embedded mode. The `UsePrespecialized` pass is not needed and does not work correctly in embedded mode because there are no pre-specialized parts of the embedded stdlib, i.e. there is no OnoneSupport library in embedded swift.
* **Risk**: Very low. Disabling the pass only affects embedded swift. And in embedded swift, the pass was basically a no-op.
* **Testing**: Tested by existing tests: for regular swift there are tests which check that pre-specialization works. For embedded swift there are many tests which check that embedded swift works without pre-specializations.
* **Issue**: https://github.com/swiftlang/swift/issues/78167
* **Reviewer**:  @kubamracek
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/78234