### PR TITLE
build-script: fix trailing newlines in `--preset-vars-file`

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -601,7 +601,7 @@ def main_preset():
             with open(file, 'r') as f:
                 for _, line in enumerate(f):
                     name, value = line.split("=", 1)
-                    args.preset_substitutions[name] = value
+                    args.preset_substitutions[name] = value.strip()
 
     for arg in args.preset_substitutions_raw:
         name, value = arg.split("=", 1)


### PR DESCRIPTION
Currently, usage of `--preset-vars-file` (added in https://github.com/swiftlang/swift/pull/76058) introduces newlines in values of preset variables passed via this file. Calling `strip()` will remove trailing and preceding whitespace characters, including newlines.
