### PR TITLE
Remove diagnostic error for importing non-ossa module to ossa module when EBM is not enabled

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1193,8 +1193,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
                        moduleBufferID);
     break;
   case serialization::Status::NotInOSSA:
-    if (Ctx.SerializationOpts.ExplicitModuleBuild ||
-        !Ctx.SILOpts.EnableRecompilationToOSSAModule) {
+    if (Ctx.SerializationOpts.ExplicitModuleBuild) {
       Ctx.Diags.diagnose(diagLoc,
                          diag::serialization_non_ossa_module_incompatible,
                          ModuleName);


### PR DESCRIPTION
Importing non-ossa module to ossa module in implicit builds is supported with one time recompilation of the non-ossa module. https://github.com/swiftlang/swift/pull/77314 introduced an error when importing non-ossa module to ossa module whenever `EnableRecompilationToOSSAModule` is not set.  Remove this error since we have to support old swiftinterfaces  with this scenario. 

