### PR TITLE
Sema: Optimize ConstraintGraph::computeConnectedComponents() 

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -311,14 +311,6 @@ public:
                     llvm::function_ref<bool(Constraint *)> acceptConstraint =
                         [](Constraint *constraint) { return true; });
 
-  /// Retrieve the type variables that correspond to nodes in the graph.
-  ///
-  /// The subscript operator can be used to retrieve the nodes that
-  /// correspond to these type variables.
-  ArrayRef<TypeVariableType *> getTypeVariables() const {
-    return TypeVariables;
-  }
-
   /// Describes a single component, as produced by the connected components
   /// algorithm.
   struct Component {
@@ -461,9 +453,6 @@ private:
 
   /// The constraint system.
   ConstraintSystem &CS;
-
-  /// The type variables in this graph, in stable order.
-  std::vector<TypeVariableType *> TypeVariables;
 
   /// Constraints that are "orphaned" because they contain no type variables.
   SmallVector<Constraint *, 4> OrphanedConstraints;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2339,7 +2339,7 @@ private:
   ConstraintList InactiveConstraints;
 
   /// The constraint graph.
-  ConstraintGraph &CG;
+  ConstraintGraph CG;
 
   /// A mapping from constraint locators to the set of opened types associated
   /// with that locator.
@@ -2707,7 +2707,7 @@ public:
   ~ConstraintSystem();
 
   /// Retrieve the constraint graph associated with this constraint system.
-  ConstraintGraph &getConstraintGraph() const { return CG; }
+  ConstraintGraph &getConstraintGraph() { return CG; }
 
   /// Retrieve the AST context.
   ASTContext &getASTContext() const { return Context; }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -339,10 +339,6 @@ class TypeVariableType::Implementation {
   /// The corresponding node in the constraint graph.
   constraints::ConstraintGraphNode *GraphNode = nullptr;
 
-  ///  Index into the list of type variables, as used by the
-  ///  constraint graph.
-  unsigned GraphIndex;
-
   friend class constraints::SolverTrail;
 
 public:
@@ -405,17 +401,6 @@ public:
   /// Set the corresponding node in the constraint graph.
   void setGraphNode(constraints::ConstraintGraphNode *newNode) { 
     GraphNode = newNode; 
-  }
-
-  /// Retrieve the index into the constraint graph's list of type variables.
-  unsigned getGraphIndex() const { 
-    assert(GraphNode && "Graph node isn't set");
-    return GraphIndex;
-  }
-
-  /// Set the index into the constraint graph's list of type variables.
-  void setGraphIndex(unsigned newIndex) {
-    GraphIndex = newIndex;
   }
   
   /// Check whether this type variable either has a representative that

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -721,19 +721,9 @@ namespace {
     ConstraintGraph &cg;
     ArrayRef<TypeVariableType *> typeVars;
 
-    /// A mapping from each type variable to its representative in a union-find
-    /// data structure, excluding entries where the type variable is its own
-    /// representative.
-    mutable llvm::SmallDenseMap<TypeVariableType *, TypeVariableType *>
-        representatives;
-
-    // Figure out which components have unbound type variables and/or
-    // constraints. These are the only components we want to report.
-    llvm::SmallDenseSet<TypeVariableType *> validComponents;
-
-    /// The complete set of constraints that were visited while computing
-    /// connected components.
-    llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
+    /// The number of connected components discovered so far. Decremented when
+    /// we merge equivalence classes.
+    unsigned validComponentCount = 0;
 
     /// Describes the one-way incoming and outcoming adjacencies of
     /// a component within the directed graph of one-way constraints.
@@ -776,10 +766,9 @@ namespace {
       // The final return value.
       SmallVector<Component, 1> flatComponents;
 
-
       // We don't actually need to partition the graph into components if
       // there are fewer than 2.
-      if (validComponents.size() < 2 && cg.getOrphanedConstraints().empty())
+      if (validComponentCount < 2 && cg.getOrphanedConstraints().empty())
         return flatComponents;
 
       // Mapping from representatives to components.
@@ -790,8 +779,8 @@ namespace {
       for (auto typeVar : typeVars) {
         // Find the representative. If we aren't creating a type variable
         // for this component, skip it.
-        auto rep = findRepresentative(typeVar);
-        if (validComponents.count(rep) == 0)
+        auto rep = typeVar->getImpl().getComponent();
+        if (!rep->getImpl().isValidComponent())
           continue;
 
         auto pair = components.insert({rep, Component(components.size())});
@@ -829,7 +818,7 @@ namespace {
           typeVar = constraintTypeVars.front();
         }
 
-        auto rep = findRepresentative(typeVar);
+        auto rep = typeVar->getImpl().getComponent();
         getComponent(rep).addConstraint(&constraint);
       }
 
@@ -857,7 +846,7 @@ namespace {
           auto &oneWayComponent = knownOneWayComponent->second;
           auto &component = getComponent(typeVar);
           for (auto inAdj : oneWayComponent.inAdjacencies) {
-            if (validComponents.count(inAdj) == 0)
+            if (!inAdj->getImpl().isValidComponent())
               continue;
 
             component.recordDependency(getComponent(inAdj));
@@ -899,23 +888,6 @@ namespace {
       return flatComponents;
     }
 
-    /// Find the representative for the given type variable within the set
-    /// of representatives in a union-find data structure.
-    TypeVariableType *findRepresentative(TypeVariableType *typeVar) const {
-      // If we don't have a record of this type variable, it is it's own
-      // representative.
-      auto known = representatives.find(typeVar);
-      if (known == representatives.end() || known->second == typeVar)
-        return typeVar;
-
-      // Find the representative of the parent.
-      auto parent = known->second;
-      auto rep = findRepresentative(parent);
-      representatives[typeVar] = rep;
-
-      return rep;
-    }
-
   private:
     /// Perform the union of two type variables in a union-find data structure
     /// used for connected components.
@@ -923,20 +895,27 @@ namespace {
     /// \returns true if the two components were separate and have now been
     /// joined, \c false if they were already in the same set.
     bool unionSets(TypeVariableType *typeVar1, TypeVariableType *typeVar2) {
-      auto rep1 = findRepresentative(typeVar1);
-      auto rep2 = findRepresentative(typeVar2);
+      auto rep1 = typeVar1->getImpl().getComponent();
+      auto rep2 = typeVar2->getImpl().getComponent();
       if (rep1 == rep2)
         return false;
 
       // Reparent the type variable with the higher ID. The actual choice doesn't
       // matter, but this makes debugging easier.
-      if (rep1->getID() < rep2->getID()) {
-        validComponents.erase(rep2);
-        representatives[rep2] = rep1;
-      } else {
-        validComponents.erase(rep1);
-        representatives[rep1] = rep2;
+      if (rep1->getID() > rep2->getID())
+        std::swap(rep1, rep2);
+
+      if (rep2->getImpl().isValidComponent()) {
+        // If both are valid components, decrement the valid component counter
+        // by one. Otherwise, propagate the valid component flag.
+        if (!rep1->getImpl().markValidComponent()) {
+          ASSERT(validComponentCount > 0);
+          --validComponentCount;
+        }
       }
+
+      rep2->getImpl().setComponent(rep1);
+
       return true;
     }
 
@@ -949,51 +928,49 @@ namespace {
 
       auto &cs = cg.getConstraintSystem();
 
-      // Perform a depth-first search from each type variable to identify
-      // what component it is in.
       for (auto typeVar : typeVars) {
-        // If we've already assigned a representative to this type variable,
-        // we're done.
-        if (representatives.count(typeVar) > 0)
-          continue;
+        auto &impl = typeVar->getImpl();
+        if (auto *rep = impl.getRepresentativeOrFixed().dyn_cast<TypeVariableType *>()) {
+          impl.setComponent(rep);
+          if (typeVar == rep) {
+            if (impl.markValidComponent())
+              ++validComponentCount;
+          }
+        } else {
+          impl.setComponent(typeVar);
+        }
+      }
 
-        // Perform a depth-first search to mark those type variables that are
-        // in the same component as this type variable.
-        depthFirstSearch(
-            cg, typeVar,
-            [&](TypeVariableType *found) {
-              // If we have already seen this node, we're done.
-              auto inserted = representatives.insert({found, typeVar});
-              assert((inserted.second || inserted.first->second == typeVar) &&
-                     "Wrong component?");
-
-              if (inserted.second)
-                if (!cs.getFixedType(found))
-                  validComponents.insert(typeVar);
-
-              return inserted.second;
-            },
-            [&](Constraint *constraint) {
-              // Record and skip one-way constraints.
-              if (constraint->isOneWayConstraint()) {
-                oneWayConstraints.push_back(constraint);
-                return false;
-              }
-
-              return true;
-            },
-            visitedConstraints);
+      for (auto typeVar : typeVars) {
+        auto &impl = typeVar->getImpl();
+        if (auto fixedType = impl.getRepresentativeOrFixed().dyn_cast<TypeBase *>()) {
+          auto &node = cg[typeVar];
+          for (auto otherTypeVar : node.getReferencedVars()) {
+            unionSets(typeVar, otherTypeVar);
+          }
+        }
       }
 
       for (auto &constraint : cs.getConstraints()) {
-        if (constraint.getKind() == ConstraintKind::Disjunction ||
-            constraint.getKind() == ConstraintKind::Conjunction) {
-          for (auto typeVar : constraint.getTypeVariables()) {
-            auto rep = findRepresentative(typeVar);
-            if (validComponents.insert(rep).second)
-              ASSERT(cs.getFixedType(typeVar));
-          }
+        if (constraint.isOneWayConstraint()) {
+          oneWayConstraints.push_back(&constraint);
+          auto *typeVar = constraint.getFirstType()->castTo<TypeVariableType>();
+          typeVar = typeVar->getImpl().getComponent();
+          if (typeVar->getImpl().markValidComponent())
+            ++validComponentCount;
+          continue;
         }
+
+        auto typeVars = constraint.getTypeVariables();
+        if (typeVars.empty())
+          continue;
+
+        auto *firstTypeVar = typeVars[0]->getImpl().getComponent();
+        if (firstTypeVar->getImpl().markValidComponent())
+          ++validComponentCount;
+
+        for (auto *otherTypeVar : typeVars.slice(1))
+          unionSets(firstTypeVar, otherTypeVar);
       }
 
       return oneWayConstraints;
@@ -1016,7 +993,7 @@ namespace {
       SmallPtrSet<TypeVariableType *, 2> typeVars;
       type->getTypeVariables(typeVars);
       for (auto typeVar : typeVars) {
-        auto rep = findRepresentative(typeVar);
+        auto rep = typeVar->getImpl().getComponent();
         insertIfUnique(results, rep);
       }
 
@@ -1226,7 +1203,7 @@ namespace {
             rep,
             [&](TypeVariableType *typeVar) -> ArrayRef<TypeVariableType *> {
               // Traverse the outgoing adjacencies for the subcomponent
-              assert(typeVar == findRepresentative(typeVar));
+              assert(typeVar == typeVar->getImpl().getComponent());
               auto oneWayComponent = oneWayDigraph.find(typeVar);
               if (oneWayComponent == oneWayDigraph.end()) {
                 return { };
@@ -1240,7 +1217,7 @@ namespace {
             [&](TypeVariableType *typeVar) {
               // Record this type variable, if it's one of the representative
               // type variables.
-              if (validComponents.count(typeVar) > 0)
+              if (typeVar->getImpl().isValidComponent())
                 orderedReps.push_back(typeVar);
             });
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -130,7 +130,13 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
     Options |= ConstraintSystemFlags::UseClangFunctionTypes;
 }
 
-ConstraintSystem::~ConstraintSystem() {}
+ConstraintSystem::~ConstraintSystem() {
+  for (unsigned i = 0, n = TypeVariables.size(); i != n; ++i) {
+    auto &impl = TypeVariables[i]->getImpl();
+    delete impl.getGraphNode();
+    impl.setGraphNode(nullptr);
+  }
+}
 
 void ConstraintSystem::startExpressionTimer(ExpressionTimer::AnchorType anchor) {
   ASSERT(!Timer);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -117,7 +117,7 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
   : Context(dc->getASTContext()), DC(dc), Options(options),
     diagnosticTransaction(diagnosticTransaction),
     Arena(dc->getASTContext(), Allocator),
-    CG(*new ConstraintGraph(*this))
+    CG(*this)
 {
   assert(DC && "context required");
   // Respect the global debugging flag, but turn off debugging while
@@ -130,9 +130,7 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
     Options |= ConstraintSystemFlags::UseClangFunctionTypes;
 }
 
-ConstraintSystem::~ConstraintSystem() {
-  delete &CG;
-}
+ConstraintSystem::~ConstraintSystem() {}
 
 void ConstraintSystem::startExpressionTimer(ExpressionTimer::AnchorType anchor) {
   ASSERT(!Timer);
@@ -1102,7 +1100,7 @@ TypeVariableType *ConstraintSystem::isRepresentativeFor(
   if (getRepresentative(typeVar) != typeVar)
     return nullptr;
 
-  auto &CG = getConstraintGraph();
+  auto &CG = const_cast<ConstraintSystem *>(this)->getConstraintGraph();
   auto &result = CG[typeVar];
   auto equivalence = result.getEquivalenceClass();
   auto member = llvm::find_if(equivalence, [=](TypeVariableType *eq) {


### PR DESCRIPTION
Further improvement upon https://github.com/swiftlang/swift/pull/76962.

Instead of starting a depth-first search from each type variable
and marking all type variables that haven't been marked yet,
we can implement this as a union-find.

We can also store the temporary state directly inside the
TypeVariableType::Implementation, instead of creating large
DenseMaps whose keys range over all type variables.