### PR TITLE
[Caching] Fix the cache replay bugs from driver C APIs

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -306,7 +306,7 @@ public:
 
   /// Whether we're generating IR for the JIT.
   unsigned UseJIT : 1;
-  
+
   /// Whether we should run LLVM optimizations after IRGen.
   unsigned DisableLLVMOptzns : 1;
 
@@ -377,7 +377,7 @@ public:
   /// Force public linkage for private symbols. Used only by the LLDB
   /// expression evaluator.
   unsigned ForcePublicLinkage : 1;
-  
+
   /// Force lazy initialization of class metadata
   /// Used on Windows to avoid cross-module references.
   unsigned LazyInitializeClassMetadata : 1;
@@ -439,7 +439,7 @@ public:
   /// Whether to disable shadow copies for local variables on the stack. This is
   /// only used for testing.
   unsigned DisableDebuggerShadowCopies : 1;
-  
+
   /// Whether to disable using mangled names for accessing concrete type metadata.
   unsigned DisableConcreteTypeMetadataMangledNameAccessors : 1;
 
@@ -524,7 +524,7 @@ public:
   };
 
   TypeInfoDumpFilter TypeInfoFilter;
-  
+
   /// Pull in runtime compatibility shim libraries by autolinking.
   std::optional<llvm::VersionTuple> AutolinkRuntimeCompatibilityLibraryVersion;
   std::optional<llvm::VersionTuple>
@@ -543,13 +543,13 @@ public:
   llvm::CallingConv::ID PlatformCCallingConvention;
 
   /// Use CAS based object format as the output.
-  bool UseCASBackend;
+  bool UseCASBackend = false;
 
   /// The output mode for the CAS Backend.
   llvm::CASBackendMode CASObjMode;
 
   /// Emit a .casid file next to the object file if CAS Backend is used.
-  bool EmitCASIDFile;
+  bool EmitCASIDFile = false;
 
   /// Paths to the pass plugins registered via -load-pass-plugin.
   std::vector<std::string> LLVMPassPlugins;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -137,9 +137,6 @@ public:
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
-  /// Emit a .casid file next to the object file if CAS Backend is used.
-  bool EmitCASIDFile = false;
-
   /// CacheReplay PrefixMap.
   std::vector<std::string> CacheReplayPrefixMap;
 
@@ -389,7 +386,7 @@ public:
   /// are errors. The resulting serialized AST may include errors types and
   /// skip nodes entirely, depending on the errors involved.
   bool AllowModuleWithCompilerErrors = false;
-  
+
   /// Whether or not the compiler must be strict in ensuring that implicit downstream
   /// module dependency build tasks must inherit the parent compiler invocation's context,
   /// such as `-Xcc` flags, etc.
@@ -519,7 +516,7 @@ public:
 
   /// Whether we're configured to track system intermodule dependencies.
   bool shouldTrackSystemDependencies() const;
-  
+
   /// Whether we are configured with -typecheck or -typecheck-module-from-interface actuin
   bool isTypeCheckAction() const;
 
@@ -535,7 +532,7 @@ public:
   ///
   /// \sa SymbolGraphASTWalker
   std::string SymbolGraphOutputDir;
-  
+
   /// Whether to emit doc comment information in symbol graphs for symbols
   /// which are inherited through classes or default implementations.
   bool SkipInheritedDocs = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1662,7 +1662,7 @@ def emit_symbol_graph: Flag<["-"], "emit-symbol-graph">,
 
 def emit_symbol_graph_dir : Separate<["-"], "emit-symbol-graph-dir">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
-         SupplementaryOutput, HelpHidden]>,
+         SupplementaryOutput, HelpHidden, CacheInvariant]>,
   HelpText<"Emit a symbol graph to directory <dir>">,
   MetaVarName<"<dir>">;
 

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -325,8 +325,11 @@ bool replayCachedCompilerOutputs(
       }
     } else if (Output.Kind == file_types::ID::TY_Dependencies) {
       if (emitMakeDependenciesFromSerializedBuffer(
-              Output.Proxy.getData(), *File, Opts, Output.Input, Diag))
+            Output.Proxy.getData(), *File, Opts, Output.Input, Diag)) {
+        Diag.diagnose(SourceLoc(), diag::cache_replay_failed,
+                      "failed to emit dependency file");
         return false;
+      }
     } else
       *File << Output.Proxy.getData();
 

--- a/test/CAS/dependency_file.swift
+++ b/test/CAS/dependency_file.swift
@@ -56,6 +56,29 @@
 // RUN: %FileCheck %s --check-prefix=DEPS3 --input-file=%t/main-3.d -DTMP=%t
 // DEPS3: [[TMP]]{{/|\\}}main-3.o : [[TMP]]{{/|\\}}main.swift
 
+/// Test replay from driver interface
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN:   %target-swift-frontend \
+// RUN:   -c -o %t/main-4.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d > %t/key.casid
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend \
+// RUN:   -c -o %t/main-4.o -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT4
+// CACHE-HIT4: remark: replay output file '{{.*}}{{/|\\}}main-4.d': key 'llvmcas://{{.*}}'
+// RUN: %FileCheck %s --check-prefix=DEPS4 --input-file=%t/main-4.d -DTMP=%t
+// DEPS4: [[TMP]]{{/|\\}}main-4.o : [[TMP]]{{/|\\}}main.swift
+
+
 //--- main.swift
 import A
 

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -23,7 +23,7 @@
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph2 \
-// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test.symbols.json': key 'llvmcas://{{.*}}'
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test@A.symbols.json': key 'llvmcas://{{.*}}'

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -30,6 +30,23 @@
 
 // RUN: diff -r -u %t/symbol-graph1 %t/symbol-graph2
 
+/// Test replay from driver interface
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
+// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job > %t/key.casid
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
+// RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job
+
+// RUN: diff -r -u %t/symbol-graph1 %t/symbol-graph3
+
 //--- include/A.swiftinterface
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0


### PR DESCRIPTION
This patch contains a serials of changes that targeted to fix the missing function in C APIs when replaying results from build system. It teaches the driver/build-system to replay the newly specialized makefile dependency files and symbol graph files correctly.

It also tags along and fixes few bugs and small improvements that intertwined with the bug fix that hardly be separated so they comes in separated commits in this PR.