### PR TITLE
Fix test failure on non-darwin bots

### DIFF
--- a/test/DebugInfo/dropped-var.sil
+++ b/test/DebugInfo/dropped-var.sil
@@ -1,7 +1,5 @@
- // RUN: %target-sil-opt --diagnose-unreachable -o - %s -sil-stats-lost-variables --target=aarch64-apple-darwin 2>&1 | %FileCheck %s
+ // RUN: %target-sil-opt --diagnose-unreachable -o - %s -sil-stats-lost-variables 2>&1 | %FileCheck %s
  // REQUIRES:CPU=aarch64
-
- // REQUIRES: rdar141272451
 
  // CHECK: function, lostvars, Pass List Pipeline, DiagnoseUnreachable, 1, 1, {{[0-9]+}}, $s4test3bar1yS2i_tF
 


### PR DESCRIPTION
The test still fails on non-Darwin bots, for example:

https://ci.swift.org/job/oss-swift-package-amazon-linux-2-aarch64

```
RUN: at line 1: /home/build-user/build/buildbot_linux/swift-linux-aarch64/bin/sil-opt -target aarch64-unknown-linux-gnu  -module-cache-path /home/build-user/build/buildbot_linux/swift-linux-aarch64/swift-test-results/aarch64-unknown-linux-gnu/clang-module-cache  --diagnose-unreachable -o - /home/build-user/swift/test/DebugInfo/dropped-var.sil -sil-stats-lost-variables --target=aarch64-apple-darwin 2>&1 | /usr/bin/python3.7 /home/build-user/swift/utils/PathSanitizingFileCheck --allow-unused-prefixes --sanitize BUILD_DIR=/home/build-user/build/buildbot_linux/swift-linux-aarch64 --sanitize SOURCE_DIR=/home/build-user/swift --use-filecheck /home/build-user/build/buildbot_linux/llvm-linux-aarch64/bin/FileCheck   /home/build-user/swift/test/DebugInfo/dropped-var.sil
+ /usr/bin/python3.7 /home/build-user/swift/utils/PathSanitizingFileCheck --allow-unused-prefixes --sanitize BUILD_DIR=/home/build-user/build/buildbot_linux/swift-linux-aarch64 --sanitize SOURCE_DIR=/home/build-user/swift --use-filecheck /home/build-user/build/buildbot_linux/llvm-linux-aarch64/bin/FileCheck /home/build-user/swift/test/DebugInfo/dropped-var.sil
+ /home/build-user/build/buildbot_linux/swift-linux-aarch64/bin/sil-opt -target aarch64-unknown-linux-gnu -module-cache-path /home/build-user/build/buildbot_linux/swift-linux-aarch64/swift-test-results/aarch64-unknown-linux-gnu/clang-module-cache --diagnose-unreachable -o - /home/build-user/swift/test/DebugInfo/dropped-var.sil -sil-stats-lost-variables --target=aarch64-apple-darwin
/home/build-user/swift/test/DebugInfo/dropped-var.sil:4:12: error: CHECK: expected string not found in input
 // CHECK: function, lostvars, Pass List Pipeline, DiagnoseUnreachable, 1, 1, {{[0-9]+}}, $s4test3bar1yS2i_tF
           ^
<stdin>:1:1: note: scanning from here
SOURCE_DIR/test/DebugInfo/dropped-var.sil:9:8: error: no such module 'Swift'
^

Input file: <stdin>
Check file: /home/build-user/swift/test/DebugInfo/dropped-var.sil

-dump-input=help explains the following input dump.

Input was:
<<<<<<
         1: SOURCE_DIR/test/DebugInfo/dropped-var.sil:9:8: error: no such module 'Swift' 
check:4     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
         2: import Swift 
check:4     ~~~~~~~~~~~~~
         3:  ^ 
check:4     ~~~
>>>>>>

```