### PR TITLE
Remove the experimental LifetimeDependenceDiagnoseTrivial feature.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -101,10 +101,11 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
 private func analyze(dependence: LifetimeDependence, _ context: FunctionPassContext) -> Bool {
   log("Dependence scope:\n\(dependence)")
 
-  // Early versions of Span in the standard library violate trivial lifetimes. Contemporary versions of the compiler
-  // simply ignored dependencies on trivial values.
-  if !context.options.hasFeature(.LifetimeDependenceDiagnoseTrivial) {
-    if dependence.parentValue.type.objectType.isTrivial(in: dependence.function) {
+  // Briefly, some versions of Span in the standard library violated trivial lifetimes; versions of the compiler built
+  // at that time simply ignored dependencies on trivial values. For now, disable trivial dependencies to allow newer
+  // compilers to build against those older standard libraries. This check is only relevant for ~6 mo (until July 2025).
+  if dependence.parentValue.type.objectType.isTrivial(in: dependence.function) {
+    if let sourceFileKind = dependence.function.sourceFileKind, sourceFileKind == .interface {
       return true
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -256,6 +256,27 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
         fatalError()
     }
   }
+
+  public enum SourceFileKind {
+    case library         /// A normal .swift file.
+    case main            /// A .swift file that can have top-level code.
+    case sil             /// Came from a .sil file.
+    case interface       /// Came from a .swiftinterface file, representing another module.
+    case macroExpansion  /// Came from a macro expansion.
+    case defaultArgument /// Came from default argument at caller side
+  };
+
+  public var sourceFileKind: SourceFileKind? {
+    switch bridged.getSourceFileKind() {
+    case .Library: return .library
+    case .Main: return .main
+    case .SIL: return .sil
+    case .Interface: return .interface
+    case .MacroExpansion: return .macroExpansion
+    case .DefaultArgument: return .defaultArgument
+    case .None: return nil
+    }
+  }
 }
 
 public func == (lhs: Function, rhs: Function) -> Bool { lhs === rhs }

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -362,9 +362,6 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// Enable returning non-escapable types from functions.
 EXPERIMENTAL_FEATURE(LifetimeDependence, true)
 
-/// Enable LifetimeDependence diagnostics for trivial types.
-EXPERIMENTAL_FEATURE(LifetimeDependenceDiagnoseTrivial, false)
-
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -477,6 +477,16 @@ struct BridgedFunction {
     IsSerializedForPackage
   };
 
+  enum class OptionalSourceFileKind {
+    Library,
+    Main,
+    SIL,
+    Interface,
+    MacroExpansion,
+    DefaultArgument, // must match swift::SourceFileKind::DefaultArgument
+    None
+  };
+
   SWIFT_NAME("init(obj:)")
   BridgedFunction(SwiftObject obj) : obj(obj) {}
   BridgedFunction() {}
@@ -529,6 +539,7 @@ struct BridgedFunction {
   bool isAutodiffVJP() const;
   SwiftInt specializationLevel() const;
   SWIFT_IMPORT_UNSAFE BridgedSubstitutionMap getMethodSubstitutions(BridgedSubstitutionMap contextSubs) const;
+  BRIDGED_INLINE OptionalSourceFileKind getSourceFileKind() const;
 
   enum class ParseEffectsMode {
     argumentEffectsFromSource,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -22,6 +22,7 @@
 #include "SILBridging.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/BasicBridging.h"
@@ -922,6 +923,14 @@ BridgedType BridgedFunction::getLoweredType(BridgedType type) const {
 
 swift::SILFunction * _Nullable OptionalBridgedFunction::getFunction() const {
   return static_cast<swift::SILFunction *>(obj);
+}
+
+BridgedFunction::OptionalSourceFileKind BridgedFunction::getSourceFileKind() const {
+  if (auto *dc = getFunction()->getDeclContext()) {
+    if (auto *sourceFile = dc->getParentSourceFile())
+      return (OptionalSourceFileKind)sourceFile->Kind;
+  }
+  return OptionalSourceFileKind::None;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -263,8 +263,6 @@ static bool usesFeatureLifetimeDependence(Decl *decl) {
       ->hasLifetimeDependencies();
 }
 
-UNINTERESTING_FEATURE(LifetimeDependenceDiagnoseTrivial)
-
 UNINTERESTING_FEATURE(DynamicActorIsolation)
 UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,10 +1,8 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: -enable-experimental-feature SuppressedAssociatedTypes
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 // expected-note@+1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -1,16 +1,13 @@
 // RUN: %target-sil-opt                                      \
 // RUN:     %s                                               \
 // RUN:     -enable-experimental-feature LifetimeDependence   \
-// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: |                                                    \
 // RUN: %target-sil-opt                                      \
 // RUN:     -enable-experimental-feature LifetimeDependence   \
-// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: |                                                    \
 // RUN: %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // For -enable-experimental-feature LifetimeDependence
 

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -1,10 +1,8 @@
 // RUN: %target-sil-opt %s \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage canonical
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -2,11 +2,9 @@
 // RUN: -emit-sil  \
 // RUN: -enable-builtin-module \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 import Builtin
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,11 +1,9 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  -target %target-swift-5.1-abi-triple \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 @_unsafeNonescapableResult
 @lifetime(source)

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,12 +1,10 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 protocol P {

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-silgen \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 
 public struct Span<Element> : ~Escapable {

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,11 +1,9 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Use real Range
 public struct FakeRange<Bound> {

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -1,10 +1,8 @@
 // RUN: %target-sil-opt -test-runner \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   %s -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage raw
 

--- a/test/SILGen/accessor_borrow.swift
+++ b/test/SILGen/accessor_borrow.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-emit-silgen -module-name accessor_borrow \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: %s | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NE: ~Escapable {}
 

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -97,7 +97,7 @@ func test1() -> Int32 {
 // CHECK: [[PTR:%.*]] = apply [[ACCESSOR]]({{%.*}}, [[A]]) : $@convention(method) (Int32, A) -> UnsafePointer<Int32>
 // CHECK: [[T0:%.*]] = struct_extract [[PTR]] : $UnsafePointer<Int32>, #UnsafePointer._rawValue
 // CHECK: [[T1:%.*]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Int32
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[T1]] : $*Int32 on [[A]] : $A
+// CHECK: [[MD:%.*]] = mark_dependence [[T1]] : $*Int32 on [[A]] : $A
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unsafe] [[MD]] : $*Int32
 // CHECK: [[T2:%.*]] = load [[ACCESS]] : $*Int32
 // CHECK: return [[T2]] : $Int32

--- a/test/SILOptimizer/argument_conventions.sil
+++ b/test/SILOptimizer/argument_conventions.sil
@@ -1,12 +1,10 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 import Builtin
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -1,11 +1,9 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -capture-promotion \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: -module-name Swift \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Check to make sure that the process of promoting closure captures results in
 // a correctly cloned and modified closure function body. This test

--- a/test/SILOptimizer/lifetime_dependence/coroutine.swift
+++ b/test/SILOptimizer/lifetime_dependence/coroutine.swift
@@ -1,11 +1,9 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct View : ~Escapable {
   let ptr: UnsafeRawBufferPointer

--- a/test/SILOptimizer/lifetime_dependence/diagnostic_passes.sil
+++ b/test/SILOptimizer/lifetime_dependence/diagnostic_passes.sil
@@ -1,7 +1,6 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:     -diagnostics -sil-verify-all \
 // RUN:     -enable-experimental-feature LifetimeDependence \
-// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:     2>&1 | %FileCheck %s
 
 // Test SIL expected from SILGen output. Run all diagnostic passes which includes lifetime dependence handling:
@@ -13,7 +12,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage raw
 

--- a/test/SILOptimizer/lifetime_dependence/diagnostic_passes_todo.sil
+++ b/test/SILOptimizer/lifetime_dependence/diagnostic_passes_todo.sil
@@ -1,11 +1,9 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:     -diagnostics -sil-verify-all \
 // RUN:     -enable-experimental-feature LifetimeDependence \
-// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:     2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test SIL expected from SILGen output. Run all diagnostic passes which includes lifetime dependence handling.
 // These tests are not fully implemented.

--- a/test/SILOptimizer/lifetime_dependence/initializer.swift
+++ b/test/SILOptimizer/lifetime_dependence/initializer.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>

--- a/test/SILOptimizer/lifetime_dependence/inout.swift
+++ b/test/SILOptimizer/lifetime_dependence/inout.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence.sil
@@ -2,12 +2,10 @@
 // RUN:   -o /dev/null \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name Swift \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test the SIL representation for lifetime dependence.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Some container-ish thing.
 struct CN: ~Copyable {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NCInt: ~Copyable {
   var value: Int

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -2,12 +2,10 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
@@ -3,12 +3,10 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -4,12 +4,10 @@
 // RUN:   -sil-verify-all \
 // RUN:   -disable-access-control \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct MutableSpan : ~Escapable, ~Copyable {
   let base: UnsafeMutableRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -2,12 +2,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Simply test that it is possible for a module to define a pseudo-Optional type without triggering any compiler errors.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
@@ -2,12 +2,10 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test LifetimeDependenceScopeFixup.
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -1,11 +1,9 @@
 // RUN: %target-swift-frontend %s -Xllvm -sil-print-types -emit-sil \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 struct NCContainer : ~Copyable {
   let ptr: UnsafeRawBufferPointer

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -1,12 +1,10 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:     -module-name Swift \
 // RUN:     -enable-experimental-feature LifetimeDependence \
-// RUN:     -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:     -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 sil_stage canonical
 

--- a/test/SILOptimizer/lifetime_dependence/scopefixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scopefixup.sil
@@ -2,12 +2,10 @@
 // RUN:   --lifetime-dependence-scope-fixup \
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Test the SIL representation for lifetime dependence scope fixup.
 

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -3,12 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature LifetimeDependenceDiagnoseTrivial
+// RUN:   -enable-experimental-feature LifetimeDependence
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // Lifetime dependence semantics by example.
 struct Span<T>: ~Escapable {

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -2,20 +2,17 @@
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify \
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
 // RUN: -enable-experimental-feature LifetimeDependence \
-// RUN: -enable-experimental-feature LifetimeDependenceDiagnoseTrivial \
 // RUN: %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_LifetimeDependenceDiagnoseTrivial
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on

--- a/test/SILOptimizer/unsafeAddress.swift
+++ b/test/SILOptimizer/unsafeAddress.swift
@@ -95,10 +95,15 @@ func testSMod(s: inout S) {
   mod(&s.mutableData)
 }
 
+// Accessing s.data causes an escaping dependence because we don't extend the local access scope of 's'.
+//
+// TODO: could we notice the local access is already nested inside the same kind of access (modify) and consider this to
+// be 'mark_dependence [nonescaping]'?
+//
 // CHECK-LABEL: sil hidden @$s4main16testSInoutBorrow5mut_syAA1SVz_tF : $@convention(thin) (@inout S) -> () {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0
 // CHECK: [[ADR:%.*]] = pointer_to_address %{{.*}} to [strict] $*NC
-// CHECK: [[MD:%.*]] = mark_dependence [nonescaping] [[ADR]] on [[ACCESS]]
+// CHECK: [[MD:%.*]] = mark_dependence [[ADR]] on [[ACCESS]]
 // CHECK: begin_access [read] [unsafe] [[MD]]
 // CHECK: apply
 // CHECK: end_access


### PR DESCRIPTION
 This was never used to generate a .swiftinterface, so can be safely removed. It
was used to guard compiler fixes that might break older .swiftinterface
files. Now, we guard the same fixes by checking the source file type.

This depends on fixing Span initialization from CxxSpan.

