### PR TITLE
AST: Introduce `SemanticAvailableAttr`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3235,6 +3235,7 @@ public:
 
   Range::iterator begin() const { return attrRange.begin(); }
   Range::iterator end() const { return attrRange.end(); }
+  bool empty() const { return attrRange.empty(); }
 };
 
 class alignas(1 << AttrAlignInBits) TypeAttribute

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3199,7 +3199,9 @@ class SemanticAvailableAttr final {
 
 public:
   SemanticAvailableAttr(const AvailableAttr *attr, AvailabilityDomain domain)
-      : attr(attr), domain(domain) {}
+      : attr(attr), domain(domain) {
+    assert(attr);
+  }
 
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const { return domain; }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -783,12 +783,6 @@ public:
   /// Indicates where the Obsoleted version was specified.
   const SourceRange ObsoletedRange;
 
-  /// Whether this is a language-version-specific entity.
-  bool isLanguageVersionSpecific() const;
-
-  /// Whether this is a PackageDescription version specific entity.
-  bool isPackageDescriptionVersionSpecific() const;
-
   /// Whether this is an unconditionally unavailable entity.
   bool isUnconditionallyUnavailable() const;
 
@@ -831,17 +825,6 @@ public:
 
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx) const;
-
-  /// Returns the active version from the AST context corresponding to
-  /// the available kind. For example, this will return the effective language
-  /// version for swift version-specific availability kind, PackageDescription
-  /// version for PackageDescription version-specific availability.
-  llvm::VersionTuple getActiveVersion(const ASTContext &ctx) const;
-
-  /// Compare this attribute's version information against the platform or
-  /// language version (assuming the this attribute pertains to the active
-  /// platform).
-  AvailableVersionComparison getVersionAvailability(const ASTContext &ctx) const;
 
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
@@ -3213,6 +3196,34 @@ public:
   /// Returns the platform kind that the attribute applies to, or
   /// `PlatformKind::none` if the attribute is not platform specific.
   PlatformKind getPlatformKind() const { return domain.getPlatformKind(); }
+
+  /// Whether this attribute has an introduced, deprecated, or obsoleted
+  /// version.
+  bool isVersionSpecific() const {
+    return attr->Introduced || attr->Deprecated || attr->Obsoleted;
+  }
+
+  /// Whether this is a language mode specific attribute.
+  bool isSwiftLanguageModeSpecific() const {
+    return domain.isSwiftLanguage() && isVersionSpecific();
+  }
+
+  /// Whether this is a PackageDescription version specific attribute.
+  bool isPackageDescriptionVersionSpecific() const {
+    return domain.isPackageDescription() && isVersionSpecific();
+  }
+
+  /// Returns the active version from the AST context corresponding to
+  /// the available kind. For example, this will return the effective language
+  /// version for swift version-specific availability kind, PackageDescription
+  /// version for PackageDescription version-specific availability.
+  llvm::VersionTuple getActiveVersion(const ASTContext &ctx) const;
+
+  /// Compare this attribute's version information against the platform or
+  /// language version (assuming the this attribute pertains to the active
+  /// platform).
+  AvailableVersionComparison
+  getVersionAvailability(const ASTContext &ctx) const;
 
   /// Returns true if this attribute is considered active in the current
   /// compilation context.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3205,6 +3205,18 @@ public:
 
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const { return domain; }
+
+  /// Returns the platform kind that the attribute applies to, or
+  /// `PlatformKind::none` if the attribute is not platform specific.
+  bool isPlatformSpecific() const { return domain.isPlatform(); }
+
+  /// Returns the platform kind that the attribute applies to, or
+  /// `PlatformKind::none` if the attribute is not platform specific.
+  PlatformKind getPlatformKind() const { return domain.getPlatformKind(); }
+
+  /// Returns true if this attribute is considered active in the current
+  /// compilation context.
+  bool isActive(ASTContext &ctx) const;
 };
 
 /// An iterable range of `SemanticAvailableAttr`s.

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -380,7 +380,8 @@ public:
   annotatedAvailableRange(const Decl *D);
 
   static AvailabilityRange
-  annotatedAvailableRangeForAttr(const SpecializeAttr *attr, ASTContext &ctx);
+  annotatedAvailableRangeForAttr(const Decl *D, const SpecializeAttr *attr,
+                                 ASTContext &ctx);
 
   /// For the attribute's introduction version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
+class ASTContext;
 
 /// Represents a dimension of availability (e.g. macOS platform or Swift
 /// language mode).
@@ -87,6 +88,10 @@ public:
     assert(kind == Kind::Platform);
     return platform;
   }
+
+  /// Returns true if this domain is considered active in the current
+  /// compilation context.
+  bool isActive(ASTContext &ctx) const;
 
   /// Returns the string to use in diagnostics to identify the domain. May
   /// return an empty string.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -84,10 +84,7 @@ public:
   bool isPackageDescription() const { return kind == Kind::PackageDescription; }
 
   /// Returns the platform kind for this domain if applicable.
-  PlatformKind getPlatformKind() const {
-    assert(kind == Kind::Platform);
-    return platform;
-  }
+  PlatformKind getPlatformKind() const { return platform; }
 
   /// Returns true if this domain is considered active in the current
   /// compilation context.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1401,9 +1401,12 @@ public:
   SemanticAvailableAttributes
   getSemanticAvailableAttrs(bool includeInactive = true) const;
 
-  /// Returns the availability domain associated with the given `AvailableAttr`
-  /// that is attached to this decl.
-  AvailabilityDomain getDomainForAvailableAttr(const AvailableAttr *attr) const;
+  /// Returns the SemanticAvailableAttr associated with the given
+  /// `AvailableAttr` that is attached to this decl. Returns `std::nullopt` if a
+  /// valid semantic version of the attribute cannot be constructed (e.g. the
+  /// domain cannot be resolved).
+  std::optional<SemanticAvailableAttr>
+  getSemanticAvailableAttr(const AvailableAttr *attr) const;
 
   /// Returns the active platform-specific `@available` attribute for this decl.
   /// There may be multiple `@available` attributes that are relevant to the

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1395,6 +1395,12 @@ public:
   /// and its DeclContext does not.
   bool isOutermostPrivateOrFilePrivateScope() const;
 
+  /// Returns an iterable list of the valid `AvailableAttr` and
+  /// `AvailabilityDomain` pairs. Unless \p includeInactive is true, attributes
+  /// that are considered inactive for the compilation context are filtered out.
+  SemanticAvailableAttributes
+  getSemanticAvailableAttrs(bool includeInactive = true) const;
+
   /// Returns the availability domain associated with the given `AvailableAttr`
   /// that is attached to this decl.
   AvailabilityDomain getDomainForAvailableAttr(const AvailableAttr *attr) const;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -341,9 +341,6 @@ struct PrintOptions {
   /// Whether to print the internal layout name instead of AnyObject, etc.
   bool PrintInternalLayoutName = false;
 
-  /// Suppress emitting @available(*, noasync)
-  bool SuppressNoAsyncAvailabilityAttr = false;
-
   /// Suppress emitting isolated or async deinit, and emit open containing class
   /// as public
   bool SuppressIsolatedDeinit = false;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1159,8 +1159,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DeclAttrKind::Available: {
     auto Attr = cast<AvailableAttr>(this);
-    if (Options.SuppressNoAsyncAvailabilityAttr && Attr->isNoAsync())
-      return false;
     if (Options.printPublicInterface() && Attr->isSPI()) {
       assert(Attr->hasPlatform());
       assert(Attr->Introduced.has_value());

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -909,6 +909,23 @@ ParsedDeclAttrFilter::operator()(const DeclAttribute *Attr) const {
   return Attr;
 }
 
+std::optional<SemanticAvailableAttr>
+SemanticAvailableAttributes::Filter::operator()(
+    const DeclAttribute *attr) const {
+  auto availableAttr = dyn_cast<AvailableAttr>(attr);
+  if (!availableAttr)
+    return std::nullopt;
+
+  if (availableAttr->isInvalid())
+    return std::nullopt;
+
+  auto domain = decl->getDomainForAvailableAttr(availableAttr);
+  if (!includeInactive && !domain.isActive(decl->getASTContext()))
+    return std::nullopt;
+
+  return SemanticAvailableAttr(availableAttr, domain);
+}
+
 static void printAvailableAttr(const Decl *D, const AvailableAttr *Attr,
                                ASTPrinter &Printer,
                                const PrintOptions &Options) {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -791,15 +791,17 @@ bool Decl::requiresUnavailableDeclABICompatibilityStubs() const {
 }
 
 AvailabilityRange AvailabilityInference::annotatedAvailableRangeForAttr(
-    const SpecializeAttr *attr, ASTContext &ctx) {
+    const Decl *D, const SpecializeAttr *attr, ASTContext &ctx) {
 
   const AvailableAttr *bestAvailAttr = nullptr;
 
   for (auto *availAttr : attr->getAvailableAttrs()) {
-    if (availAttr == nullptr || !availAttr->Introduced.has_value() ||
-        !availAttr->isActivePlatform(ctx) ||
-        availAttr->isLanguageVersionSpecific() ||
-        availAttr->isPackageDescriptionVersionSpecific()) {
+    auto semanticAttr = D->getSemanticAvailableAttr(availAttr);
+    if (!semanticAttr)
+      continue;
+
+    if (!availAttr->Introduced.has_value() || !semanticAttr->isActive(ctx) ||
+        !semanticAttr->isPlatformSpecific()) {
       continue;
     }
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -16,32 +16,6 @@
 
 using namespace swift;
 
-SemanticAvailableAttributes
-Decl::getSemanticAvailableAttrs(bool includeInactive) const {
-  return SemanticAvailableAttributes(getAttrs(), this, includeInactive);
-}
-
-AvailabilityDomain
-Decl::getDomainForAvailableAttr(const AvailableAttr *attr) const {
-  if (attr->hasPlatform())
-    return AvailabilityDomain::forPlatform(attr->getPlatform());
-
-  switch (attr->getPlatformAgnosticAvailability()) {
-  case PlatformAgnosticAvailabilityKind::Deprecated:
-  case PlatformAgnosticAvailabilityKind::Unavailable:
-  case PlatformAgnosticAvailabilityKind::NoAsync:
-  case PlatformAgnosticAvailabilityKind::None:
-    return AvailabilityDomain::forUniversal();
-
-  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-    return AvailabilityDomain::forSwiftLanguage();
-
-  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-    return AvailabilityDomain::forPackageDescription();
-  }
-}
-
 bool AvailabilityDomain::isActive(ASTContext &ctx) const {
   switch (kind) {
   case Kind::Universal:

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -11,9 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/AvailabilityDomain.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 
 using namespace swift;
+
+SemanticAvailableAttributes
+Decl::getSemanticAvailableAttrs(bool includeInactive) const {
+  return SemanticAvailableAttributes(getAttrs(), this, includeInactive);
+}
 
 AvailabilityDomain
 Decl::getDomainForAvailableAttr(const AvailableAttr *attr) const {
@@ -33,6 +39,17 @@ Decl::getDomainForAvailableAttr(const AvailableAttr *attr) const {
 
   case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
     return AvailabilityDomain::forPackageDescription();
+  }
+}
+
+bool AvailabilityDomain::isActive(ASTContext &ctx) const {
+  switch (kind) {
+  case Kind::Universal:
+  case Kind::SwiftLanguage:
+  case Kind::PackageDescription:
+    return true;
+  case Kind::Platform:
+    return isPlatformActive(getPlatformKind(), ctx.LangOpts);
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9278,7 +9278,9 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
   // `getAttrs` is in reverse source order, so the last attribute is the
   // first in source.
   AbstractFunctionDecl *alternative = nullptr;
-  for (const auto *attr : getAttrs().getAttributes<AvailableAttr>()) {
+  for (auto semanticAttr : getSemanticAvailableAttrs()) {
+    auto attr = semanticAttr.getParsedAttr();
+
     if (attr->isNoAsync())
       continue;
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -451,7 +451,9 @@ class InheritedProtocolCollector {
 
     cache.emplace();
     while (D) {
-      for (auto *nextAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
+      for (auto semanticAttr : D->getSemanticAvailableAttrs()) {
+        auto nextAttr = semanticAttr.getParsedAttr();
+
         // FIXME: This is just approximating the effects of nested availability
         // attributes for the same platform; formally they'd need to be merged.
         bool alreadyHasMoreSpecificAttrForThisPlatform =

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1688,7 +1688,9 @@ public:
       hasPrintedAnything = true;
     };
 
-    for (auto AvAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
+    for (auto semanticAttr : D->getSemanticAvailableAttrs()) {
+      auto AvAttr = semanticAttr.getParsedAttr();
+
       if (AvAttr->getPlatform() == PlatformKind::none) {
         if (AvAttr->getPlatformAgnosticAvailability() ==
             PlatformAgnosticAvailabilityKind::Unavailable) {

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -89,9 +89,8 @@ void SILFunctionBuilder::addFunctionAttributes(
     if (hasSPI) {
       spiGroupIdent = spiGroups[0];
     }
-    auto availability =
-      AvailabilityInference::annotatedAvailableRangeForAttr(SA,
-         M.getSwiftModule()->getASTContext());
+    auto availability = AvailabilityInference::annotatedAvailableRangeForAttr(
+        attributedFuncDecl, SA, M.getSwiftModule()->getASTContext());
     auto specializedSignature = SA->getSpecializedSignature(attributedFuncDecl);
     if (targetFunctionDecl) {
       SILDeclRef declRef(targetFunctionDecl, constant.kind, false);

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -60,7 +60,7 @@ static void transferSpecializeAttributeTargets(SILModule &M,
         spiGroupIdent = spiGroups[0];
       }
       auto availability = AvailabilityInference::annotatedAvailableRangeForAttr(
-          SA, M.getSwiftModule()->getASTContext());
+          vd, SA, M.getSwiftModule()->getASTContext());
 
       auto *attr = SILSpecializeAttr::create(
           M, SA->getSpecializedSignature(vd), SA->getTypeErasedParams(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2171,10 +2171,12 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   if (SF && SF->Kind == SourceFileKind::Interface)
     return;
 
-  // The remaining diagnostics are only for attributes that are active for the
-  // current target triple.
-  if (!attr->isActivePlatform(Ctx) && !attr->isLanguageVersionSpecific() &&
-      !attr->isPackageDescriptionVersionSpecific())
+  // The remaining diagnostics are only for attributes that are active.
+  auto semanticAttr = D->getSemanticAvailableAttr(attr);
+  if (!semanticAttr)
+    return;
+
+  if (!semanticAttr->isActive(Ctx))
     return;
 
   // Make sure there isn't a more specific attribute we should be using instead.
@@ -2195,7 +2197,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   }
 
   SourceLoc attrLoc = attr->getLocation();
-  auto versionAvailability = attr->getVersionAvailability(Ctx);
+  auto versionAvailability = semanticAttr->getVersionAvailability(Ctx);
   if (versionAvailability == AvailableVersionComparison::Obsoleted ||
       versionAvailability == AvailableVersionComparison::Unavailable) {
     if (auto cannotBeUnavailable =

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3061,8 +3061,11 @@ getExplicitUnavailabilityDiagnosticInfo(const Decl *decl,
   if (!attr)
     return std::nullopt;
 
+  auto semanticAttr = decl->getSemanticAvailableAttr(attr);
+  if (!semanticAttr)
+    return std::nullopt;
+
   ASTContext &ctx = decl->getASTContext();
-  auto domain = decl->getDomainForAvailableAttr(attr);
 
   switch (attr->getVersionAvailability(ctx)) {
   case AvailableVersionComparison::Available:
@@ -3075,17 +3078,18 @@ getExplicitUnavailabilityDiagnosticInfo(const Decl *decl,
         attr->Introduced.has_value()) {
       return UnavailabilityDiagnosticInfo(
           UnavailabilityDiagnosticInfo::Status::IntroducedInVersion, attr,
-          domain);
+          semanticAttr->getDomain());
     } else {
       return UnavailabilityDiagnosticInfo(
           UnavailabilityDiagnosticInfo::Status::AlwaysUnavailable, attr,
-          domain);
+          semanticAttr->getDomain());
     }
     break;
 
   case AvailableVersionComparison::Obsoleted:
     return UnavailabilityDiagnosticInfo(
-        UnavailabilityDiagnosticInfo::Status::Obsoleted, attr, domain);
+        UnavailabilityDiagnosticInfo::Status::Obsoleted, attr,
+        semanticAttr->getDomain());
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6587,7 +6587,9 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
            ? enclosing->getDeclContext()->getAsDecl()
            : nullptr) {
     bool anyPlatformSpecificAttrs = false;
-    for (auto available: enclosing->getAttrs().getAttributes<AvailableAttr>()) {
+    for (auto semanticAttr : enclosing->getSemanticAvailableAttrs()) {
+      auto available = semanticAttr.getParsedAttr();
+
       if (available->getPlatform() == PlatformKind::none)
         continue;
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -243,14 +243,18 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
 static bool isUnavailableInAllVersions(ValueDecl *decl) {
   ASTContext &ctx = decl->getASTContext();
   auto *attr = decl->getUnavailableAttr();
-
   if (!attr)
     return false;
+
+  auto semanticAttr = decl->getSemanticAvailableAttr(attr);
+  if (!semanticAttr)
+    return false;
+
   if (attr->isUnconditionallyUnavailable())
     return true;
 
-  return attr->getVersionAvailability(ctx)
-             == AvailableVersionComparison::Unavailable;
+  return semanticAttr->getVersionAvailability(ctx) ==
+         AvailableVersionComparison::Unavailable;
 }
 
 /// Perform basic checking to determine whether a declaration can override a

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -916,13 +916,11 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
           static AvailabilityRange from(const ValueDecl *VD) {
             AvailabilityRange result;
             for (auto semanticAttr : VD->getSemanticAvailableAttrs()) {
-              auto attr = semanticAttr.getParsedAttr();
-              auto domain = semanticAttr.getDomain();
-              if (domain.isSwiftLanguage()) {
-                if (attr->Introduced)
-                  result.introduced = attr->Introduced;
-                if (attr->Obsoleted)
-                  result.obsoleted = attr->Obsoleted;
+              if (semanticAttr.isSwiftLanguageModeSpecific()) {
+                if (auto introduced = semanticAttr.getParsedAttr()->Introduced)
+                  result.introduced = introduced;
+                if (auto obsoleted = semanticAttr.getParsedAttr()->Obsoleted)
+                  result.obsoleted = obsoleted;
               }
             }
             return result;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -915,8 +915,10 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
         public:
           static AvailabilityRange from(const ValueDecl *VD) {
             AvailabilityRange result;
-            for (auto *attr : VD->getAttrs().getAttributes<AvailableAttr>()) {
-              if (attr->isLanguageVersionSpecific()) {
+            for (auto semanticAttr : VD->getSemanticAvailableAttrs()) {
+              auto attr = semanticAttr.getParsedAttr();
+              auto domain = semanticAttr.getDomain();
+              if (domain.isSwiftLanguage()) {
                 if (attr->Introduced)
                   result.introduced = attr->Introduced;
                 if (attr->Obsoleted)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3044,6 +3044,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       assert(theAttr->Rename.empty() || !theAttr->hasCachedRenamedDecl());
 
+      bool isPackageDescriptionVersionSpecific =
+          theAttr->getPlatformAgnosticAvailability() ==
+          PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific;
+
       llvm::SmallString<32> blob;
       blob.append(theAttr->Message);
       blob.append(theAttr->Rename);
@@ -3054,7 +3058,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isUnconditionallyUnavailable(),
           theAttr->isUnconditionallyDeprecated(),
           theAttr->isNoAsync(),
-          theAttr->isPackageDescriptionVersionSpecific(),
+          isPackageDescriptionVersionSpecific,
           theAttr->isSPI(),
           theAttr->isForEmbedded(),
           LIST_VER_TUPLE_PIECES(Introduced),

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -97,11 +97,18 @@ func manyAttrsNew() async { }
 @available(SwiftStdlib 5.5, *)
 func manyAttrsNewOther() async { }
 
-@available(macOS, introduced: 12, renamed: "platformOnlyNew()")
-func platformOnly(completionHandler: @escaping () -> Void) { }
-// expected-note@+2 {{'platformOnlyNew()' declared here}}
+@available(macOS, introduced: 12, renamed: "macOSOnlyNew()")
+func macOSOnly(completionHandler: @escaping () -> Void) { }
+// expected-note@+2 {{'macOSOnlyNew()' declared here}}
 @available(SwiftStdlib 5.5, *)
-func platformOnlyNew() async { }
+func macOSOnlyNew() async { }
+
+@available(iOS, introduced: 15, renamed: "iOSOnlyNew()")
+func iOSOnly(completionHandler: @escaping () -> Void) { }
+// expected-note@+2 {{'iOSOnlyNew()' declared here}}
+@available(SwiftStdlib 5.5, *)
+func iOSOnlyNew() async { }
+
 
 @available(SwiftStdlib 5.5, *)
 struct AnotherStruct {
@@ -282,7 +289,9 @@ func asyncContext(t: HandlerTest) async {
   // expected-warning@+1{{'manyAttrs(completionHandler:)' is deprecated [DeprecatedDeclaration]}}
   manyAttrs() { }
   // expected-warning@+1{{consider using asynchronous alternative function}}
-  platformOnly() { }
+  macOSOnly() { }
+  // expected-warning@+1{{consider using asynchronous alternative function}}
+  iOSOnly() { }
 
   // These don't get the warning because we failed to resolve the name to a
   // single async decl


### PR DESCRIPTION
Currently, an `@available` attribute's `AvailabilityDomain` can be resolved eagerly when parsing, but in the future resolving some availability domains will require name lookup which will have to be done lazily after parsing and may also fail. `SemanticAvailableAttr` is a new type that wraps an `AvailableAttr` and its resolved `AvailabilityDomain`. It should be used throughout the compiler for queries and operations that require valid `AvailableAttrs` that have successfully resolved domains.

This PR only partially adopts `SemanticAvailableAttr`. The remainder of the adoption should happen piecemeal, driven by moving the majority of the methods on `AvailableAttr` over to `SemanticAvailableAttr` until all that's left on `AvailableAttr` is the raw, parsed representation which is only accessed through `SemanticAvailableAttr`.