### PR TITLE
[cxx-interop] Avoid spurious type aliases in reverse interop

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -257,6 +257,9 @@ private:
       for (const Decl *member : members) {
         if (member->getModuleContext()->isStdlibModule())
           break;
+        auto VD = dyn_cast<ValueDecl>(member);
+        if (!VD || !shouldInclude(VD))
+          continue;
         // TODO: support nested classes.
         if (isa<ClassDecl>(member))
           continue;

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -60,3 +60,9 @@ public func makeRecordConfig() -> RecordConfig {
 public func makeAudioFileType() -> AudioFileType {
     return AudioFileType.CAF(AudioFileType.SubType(id: 42))
 }
+
+public class TestObject {
+    enum CustomError: Swift.Error {
+        case invalid
+    }
+}


### PR DESCRIPTION
To support nested structs, we emit type aliases in the outer class. Unfortunately, we emitted these type aliases unconditionally, even if the actualy nested struct was not emitted to the reverse interop header (due to visibility or the construct being unsupported). This PR fixed this issue by checking first if the nested entity should be included in the reverse interop header.

rdar://141688074
