### PR TITLE
[SwiftCompilerSources] Use interpolation instead of `String(describing:)`

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Registration.swift
+++ b/SwiftCompilerSources/Sources/AST/Registration.swift
@@ -49,7 +49,7 @@ public func registerAST() {
 }
 
 private func registerDecl<T: AnyObject>(_ cl: T.Type) {
-  String(describing: cl)._withBridgedStringRef { nameStr in
+  "\(cl)"._withBridgedStringRef { nameStr in
     let metatype = unsafeBitCast(cl, to: SwiftMetatype.self)
     registerBridgedDecl(nameStr, metatype)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -56,7 +56,7 @@ private func run<InstType: SILCombineSimplifyable>(_ instType: InstType.Type,
 private func registerForSILCombine<InstType: SILCombineSimplifyable>(
       _ instType: InstType.Type,
       _ runFn: @escaping (@convention(c) (BridgedInstructionPassCtxt) -> ())) {
-  String(describing: instType)._withBridgedStringRef { instClassStr in
+  "\(instType)"._withBridgedStringRef { instClassStr in
     SILCombine_registerInstructionPass(instClassStr, runFn)
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -14,7 +14,7 @@ import Basic
 import SILBridging
 
 private func register<T: AnyObject>(_ cl: T.Type) {
-  String(describing: cl)._withBridgedStringRef { nameStr in
+  "\(cl)"._withBridgedStringRef { nameStr in
     let metatype = unsafeBitCast(cl, to: SwiftMetatype.self)
     registerBridgedClass(nameStr, metatype)
   }


### PR DESCRIPTION
`String(describing:)` does a bunch of dynamic casts that can be pretty slow. Use interpolation instead, which bypasses them.

- For `swift-frontend`, this brings the time taken for type-checking an empty file down from ~100ms to ~70ms.
- For `swift build`, this brings the time taken for a null build down from ~600ms to ~450ms (the larger delta is presumably due to the fact that there's much more Swift code in `swift-package`).