### PR TITLE
🍒[6.1][cxx-interop] Avoid spurious type aliases in reverse interop

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -257,6 +257,9 @@ private:
       for (const Decl *member : members) {
         if (member->getModuleContext()->isStdlibModule())
           break;
+        auto VD = dyn_cast<ValueDecl>(member);
+        if (!VD || !shouldInclude(VD))
+          continue;
         // TODO: support nested classes.
         if (isa<ClassDecl>(member))
           continue;

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -60,3 +60,9 @@ public func makeRecordConfig() -> RecordConfig {
 public func makeAudioFileType() -> AudioFileType {
     return AudioFileType.CAF(AudioFileType.SubType(id: 42))
 }
+
+public class TestObject {
+    enum CustomError: Swift.Error {
+        case invalid
+    }
+}


### PR DESCRIPTION
**Explanation**: Due to a missing check we emitted using declarations for types we did not emit into the reverse interop header resulted in compilation errors.
**Scope**: C++ reverse interop
**Risk**: Low. The fix is straightforward calling a function to do the check if the entity should be included in the reverse interop header. It does not affect other code paths.
**Testing**: Added compiler tests.
**Issue**: rdar://141688074
**Reviewers**: @egorzhdan

Original PR: #78287