### PR TITLE
Some AST and SIL infrastructure additions and improvements

### DIFF
--- a/SwiftCompilerSources/Sources/AST/SubstitutionMap.swift
+++ b/SwiftCompilerSources/Sources/AST/SubstitutionMap.swift
@@ -56,4 +56,14 @@ public struct SubstitutionMap: CustomStringConvertible {
       return Conformance(bridged: bridgedSubs.getConformance(index))
     }
   }
+
+  public var replacementTypes: TypeArray {
+    TypeArray(bridged: bridged.getReplacementTypes())
+  }
+
+  /// The single replacement type if it's guarnateed that the substitution map has a single replacement type.
+  public var replacementType: Type {
+    assert(replacementTypes.count == 1)
+    return replacementTypes[0]
+  }
 }

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -64,3 +64,23 @@ public struct CanonicalType: CustomStringConvertible, NoReflectionChildren {
     return type.subst(with: substitutionMap).canonical
   }
 }
+
+public struct TypeArray : RandomAccessCollection, CustomReflectable {
+  public let bridged: BridgedASTTypeArray
+
+  public var startIndex: Int { return 0 }
+  public var endIndex: Int { return bridged.getCount() }
+
+  public init(bridged: BridgedASTTypeArray) {
+    self.bridged = bridged
+  }
+
+  public subscript(_ index: Int) -> Type {
+    Type(bridged: bridged.getAt(index))
+  }
+
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: nil, value: $0) }
+    return Mirror(self, children: c)
+  }
+}

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -46,6 +46,12 @@ public struct Type: CustomStringConvertible, NoReflectionChildren {
 /// A Type that is statically known to be canonical.
 /// For example, typealiases are resolved.
 public struct CanonicalType: CustomStringConvertible, NoReflectionChildren {
+  public enum TraitResult {
+    case isNot
+    case canBe
+    case `is`
+  }
+
   public let bridged: BridgedCanType
 
   public init(bridged: BridgedCanType) { self.bridged = bridged }
@@ -63,6 +69,8 @@ public struct CanonicalType: CustomStringConvertible, NoReflectionChildren {
   public func subst(with substitutionMap: SubstitutionMap) -> CanonicalType {
     return type.subst(with: substitutionMap).canonical
   }
+
+  public var canBeClass: TraitResult { bridged.canBeClass().result }
 }
 
 public struct TypeArray : RandomAccessCollection, CustomReflectable {
@@ -82,5 +90,17 @@ public struct TypeArray : RandomAccessCollection, CustomReflectable {
   public var customMirror: Mirror {
     let c: [Mirror.Child] = map { (label: nil, value: $0) }
     return Mirror(self, children: c)
+  }
+}
+
+extension BridgedCanType.TraitResult {
+  var result: CanonicalType.TraitResult {
+    switch self {
+    case .IsNot: return .isNot
+    case .CanBe: return .canBe
+    case .Is:    return .is
+    default:
+      fatalError("wrong type TraitResult enum case")
+    }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -250,8 +250,7 @@ private func createOutlinedGlobal(
   let globalAddr = builder.createGlobalAddr(global: outlinedGlobal, dependencyToken: nil)
   let rawVectorPointer = builder.createAddressToPointer(address: globalAddr, pointerType: allocVectorBuiltin.type,
                                                         needStackProtection: false)
-  allocVectorBuiltin.uses.replaceAll(with: rawVectorPointer, context)
-  context.erase(instruction: allocVectorBuiltin)
+  allocVectorBuiltin.replace(with: rawVectorPointer, context)
 }
 
 private func createStackAllocatedVector(
@@ -266,8 +265,7 @@ private func createStackAllocatedVector(
   let rawVectorPointer = builder.createAddressToPointer(address: allocVec, pointerType: allocVectorBuiltin.type,
                                                         needStackProtection: true)
 
-  allocVectorBuiltin.uses.replaceAll(with: rawVectorPointer, context)
-  context.erase(instruction: allocVectorBuiltin)
+  allocVectorBuiltin.replace(with: rawVectorPointer, context)
 
   for endInst in liverange.ends {
     let builder = Builder(after: endInst, context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -224,9 +224,10 @@ private func createOutlinedGlobal(
     return
   }
 
-  let elementType = allocVectorBuiltin.substitutionMap.replacementTypes[0]!
+  let function = allocVectorBuiltin.parentFunction
+  let elementType = allocVectorBuiltin.substitutionMap.replacementTypes[0].loweredType(in: function)
   let outlinedGlobal = context.createGlobalVariable(
-        name: context.mangleOutlinedVariable(from: allocVectorBuiltin.parentFunction),
+        name: context.mangleOutlinedVariable(from: function),
         type: elementType, linkage: .private, isLet: false)
 
   let globalBuilder = Builder(staticInitializerOf: outlinedGlobal, context)
@@ -259,7 +260,8 @@ private func createStackAllocatedVector(
   _ context: FunctionPassContext
 ) {
   let builder = Builder(before: allocVectorBuiltin, context)
-  let elementType = allocVectorBuiltin.substitutionMap.replacementTypes[0]!
+  let function = allocVectorBuiltin.parentFunction
+  let elementType = allocVectorBuiltin.substitutionMap.replacementTypes[0].loweredType(in: function)
   let allocVec = builder.createAllocVector(capacity: allocVectorBuiltin.operands[1].value, elementType: elementType)
   let rawVectorPointer = builder.createAddressToPointer(address: allocVec, pointerType: allocVectorBuiltin.type,
                                                         needStackProtection: true)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -301,8 +301,7 @@ private func rewriteApplyInstruction(using specializedCallee: Function, callSite
     }
   }
 
-  oldApply.uses.replaceAll(with: newApply, context)
-  context.erase(instruction: oldApply)
+  oldApply.replace(with: newApply, context)
 }
 
 // ===================== Utility functions and extensions ===================== //

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -260,8 +260,7 @@ private extension LoadInst {
 private func remove(copy: CopyValueInst, collectedUses: Uses, liverange: InstructionRange) {
   let context = collectedUses.context
   replaceMoveWithBorrow(of: copy, replacedBy: copy.fromValue, liverange: liverange, collectedUses: collectedUses)
-  copy.uses.replaceAll(with: copy.fromValue, context)
-  context.erase(instruction: copy)
+  copy.replace(with: copy.fromValue, context)
 
   for forwardingUse in collectedUses.forwardingUses {
     forwardingUse.changeOwnership(from: .owned, to: .guaranteed, context)
@@ -301,8 +300,7 @@ private func replaceMoveWithBorrow(
                                       isLexical: moveInst.isLexical,
                                       hasPointerEscape: moveInst.hasPointerEscape,
                                       isFromVarDecl: moveInst.isFromVarDecl)
-  moveInst.uses.replaceAll(with: bbi, context)
-  context.erase(instruction: moveInst)
+  moveInst.replace(with: bbi, context)
   createEndBorrows(for: bbi, atEndOf: liverange, collectedUses: collectedUses)
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -152,8 +152,7 @@ private func optimizeNonOptionalBridging(_ apply: ApplyInst,
     let replacement = builder.createUncheckedEnumData(enum: optionalReplacement,
                                                       caseIndex: someCase,
                                                       resultType: bridgeToObjcCall.type)
-    bridgeToObjcCall.uses.replaceAll(with: replacement, context)
-    context.erase(instruction: bridgeToObjcCall)
+    bridgeToObjcCall.replace(with: replacement, context)
     return true
   }
 
@@ -219,8 +218,7 @@ private func optimizeNonOptionalBridging(_ apply: ApplyInst,
   
   // Now replace the bridged value with the original value in the destination block.
   let replacement = s.makeAvailable(in: bridgeToObjcCall.parentBlock, context)
-  bridgeToObjcCall.uses.replaceAll(with: replacement, context)
-  context.erase(instruction: bridgeToObjcCall)
+  bridgeToObjcCall.replace(with: replacement, context)
   return true
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -454,7 +454,7 @@ private func rewriteUses(of startValue: Value, _ context: FunctionPassContext) {
 
 private extension InstructionWorklist {
   mutating func pushIfNotVisited(usersOf value: Value) {
-    pushIfNotVisited(contentsOf: value.uses.lazy.map { $0.instruction })
+    pushIfNotVisited(contentsOf: value.users)
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -413,8 +413,7 @@ private func replace(object allocRef: AllocRefInstBase,
   }
 
   rewriteUses(of: allocRef, context)
-  allocRef.uses.replaceAll(with: globalValue, context)
-  context.erase(instruction: allocRef)
+  allocRef.replace(with: globalValue, context)
   return globalValue
 }
 
@@ -431,13 +430,11 @@ private func rewriteUses(of startValue: Value, _ context: FunctionPassContext) {
       if !beginDealloc.parentFunction.hasOwnership {
         builder.createStrongRelease(operand: beginDealloc.reference)
       }
-      beginDealloc.uses.replaceAll(with: beginDealloc.reference, context)
-      context.erase(instruction: beginDealloc)
+      beginDealloc.replace(with: beginDealloc.reference, context)
     case is EndCOWMutationInst, is EndInitLetRefInst, is MoveValueInst:
       let svi = inst as! SingleValueInstruction
       worklist.pushIfNotVisited(usersOf: svi)
-      svi.uses.replaceAll(with: svi.operands[0].value, context)
-      context.erase(instruction: svi)
+      svi.replace(with: svi.operands[0].value, context)
     case let upCast as UpcastInst:
       worklist.pushIfNotVisited(usersOf: upCast)
     case let refCast as UncheckedRefCastInst:
@@ -571,8 +568,7 @@ private func replace(findStringCall: ApplyInst,
                                                 findStringCall.arguments[1],
                                                 cacheAddr])
 
-  findStringCall.uses.replaceAll(with: newCall, context)
-  context.erase(instruction: findStringCall)
+  findStringCall.replace(with: newCall, context)
 }
 
 private extension GlobalValueInst {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -279,8 +279,7 @@ private func replace(load: LoadInst, with availableValues: [AvailableValue], _ c
     //
     newValue = ssaUpdater.getValue(inMiddleOf: load.parentBlock)
   }
-  load.uses.replaceAll(with: newValue, context)
-  context.erase(instruction: load)
+  load.replace(with: newValue, context)
 }
 
 private func provideValue(

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -56,8 +56,7 @@ private func tryTransformThickToThinCallee(of apply: ApplyInst, _ context: Simpl
                                        isNonThrowing: apply.isNonThrowing,
                                        isNonAsync: apply.isNonAsync,
                                        specializationInfo: apply.specializationInfo)
-    apply.uses.replaceAll(with: newApply, context)
-    context.erase(instruction: apply)
+    apply.replace(with: newApply, context)
     return true
   }
   return false

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -86,8 +86,7 @@ private extension BeginCOWMutationInst {
 
     for use in buffer.uses.ignoreDebugUses {
       let endCOW = use.instruction as! EndCOWMutationInst
-      endCOW.uses.replaceAll(with: instance, context)
-      context.erase(instruction: endCOW)
+      endCOW.replace(with: instance, context)
     }
     context.erase(instructionIncludingDebugUses: self)
     return true

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
@@ -53,8 +53,7 @@ private extension BranchInst {
       if let phi = Phi(arg),
          let bfi = phi.borrowedFrom
       {
-        bfi.uses.replaceAll(with: op.value, context)
-        context.erase(instruction: bfi)
+        bfi.replace(with: op.value, context)
       } else {
         arg.uses.replaceAll(with: op.value, context)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -33,9 +33,8 @@ extension BuiltinInst : OnoneSimplifyable {
            .Alignof:
         optimizeTargetTypeConst(context)
       case .DestroyArray:
-        if let elementType = substitutionMap.replacementTypes[0].canonical.silType,
-           elementType.isTrivial(in: parentFunction)
-        {
+        let elementType = substitutionMap.replacementType.loweredType(in: parentFunction, maximallyAbstracted: true)
+        if elementType.isTrivial(in: parentFunction) {
           context.erase(instruction: self)
           return
         }
@@ -161,10 +160,7 @@ private extension BuiltinInst {
   }
   
   func optimizeTargetTypeConst(_ context: SimplifyContext) {
-    guard let ty = substitutionMap.replacementTypes[0].canonical.silType else {
-      return
-    }
-    
+    let ty = substitutionMap.replacementType.loweredType(in: parentFunction, maximallyAbstracted: true)
     let value: Int?
     switch id {
     case .Sizeof:

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -129,21 +129,16 @@ private extension BuiltinInst {
   }
 
   func optimizeCanBeClass(_ context: SimplifyContext) {
-    guard let ty = substitutionMap.replacementTypes[0].canonical.silType else {
-      return
-    }
     let literal: IntegerLiteralInst
-    switch ty.canBeClass {
-    case .IsNot:
+    switch substitutionMap.replacementType.canonical.canBeClass {
+    case .isNot:
       let builder = Builder(before: self, context)
       literal = builder.createIntegerLiteral(0,  type: type)
-    case .Is:
+    case .is:
       let builder = Builder(before: self, context)
       literal = builder.createIntegerLiteral(1,  type: type)
-    case .CanBe:
+    case .canBe:
       return
-    default:
-      fatalError()
     }
     self.replace(with: literal, context)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -33,7 +33,7 @@ extension BuiltinInst : OnoneSimplifyable {
            .Alignof:
         optimizeTargetTypeConst(context)
       case .DestroyArray:
-        if let elementType = substitutionMap.replacementTypes[0],
+        if let elementType = substitutionMap.replacementTypes[0].canonical.silType,
            elementType.isTrivial(in: parentFunction)
         {
           context.erase(instruction: self)
@@ -129,7 +129,7 @@ private extension BuiltinInst {
   }
 
   func optimizeCanBeClass(_ context: SimplifyContext) {
-    guard let ty = substitutionMap.replacementTypes[0] else {
+    guard let ty = substitutionMap.replacementTypes[0].canonical.silType else {
       return
     }
     let literal: IntegerLiteralInst
@@ -167,7 +167,7 @@ private extension BuiltinInst {
   }
   
   func optimizeTargetTypeConst(_ context: SimplifyContext) {
-    guard let ty = substitutionMap.replacementTypes[0] else {
+    guard let ty = substitutionMap.replacementTypes[0].canonical.silType else {
       return
     }
     

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -145,8 +145,7 @@ private extension BuiltinInst {
     default:
       fatalError()
     }
-    uses.replaceAll(with: literal, context)
-    context.erase(instruction: self)
+    self.replace(with: literal, context)
   }
 
   func optimizeAssertConfig(_ context: SimplifyContext) {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -236,7 +236,7 @@ extension Value {
   -> Bool {
     var users = InstructionSet(context)
     defer { users.deinitialize() }
-    uses.lazy.map({ $0.instruction }).forEach { users.insert($0) }
+    users.insert(contentsOf: self.users)
 
     var worklist = InstructionWorklist(context)
     defer { worklist.deinitialize() }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/PhiUpdater.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/PhiUpdater.swift
@@ -147,8 +147,7 @@ private func addEnclosingValues(
 
   let builder = Builder(before: borrowedFrom, context)
   let newBfi = builder.createBorrowedFrom(borrowedValue: borrowedFrom.borrowedValue, enclosingValues: evs)
-  borrowedFrom.uses.replaceAll(with: newBfi, context)
-  context.erase(instruction: borrowedFrom)
+  borrowedFrom.replace(with: newBfi, context)
   return true
 }
 
@@ -185,8 +184,7 @@ func replacePhiWithIncomingValue(phi: Phi, _ context: some MutatingContext) -> B
     return false
   }
   if let borrowedFrom = phi.borrowedFrom {
-    borrowedFrom.uses.replaceAll(with: uniqueIncomingValue, context)
-    context.erase(instruction: borrowedFrom)
+    borrowedFrom.replace(with: uniqueIncomingValue, context)
   } else {
     phi.value.uses.replaceAll(with: uniqueIncomingValue, context)
   }

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -13,11 +13,28 @@
 import AST
 import SILBridging
 
+extension AST.`Type` {
+  // See `CanonicalType.loweredType(in:)`.
+  public func loweredType(in function: Function, maximallyAbstracted: Bool = false) -> Type {
+    function.bridged.getLoweredType(bridged, maximallyAbstracted).type.objectType
+  }
+}
+
 extension CanonicalType {
   // This can yield nil if the AST type is not a lowered type.
   // For example, if the AST type is a `AnyFunctionType` for which the lowered type would be a `SILFunctionType`.
   public var silType: Type? {
     BridgedType.createSILType(bridged).typeOrNil
+  }
+
+  // Lowers the AST type to a SIL type - in a specific function.
+  // In contrast to `silType` this always succeeds. Still, it's not allowed to do this for certain AST types
+  // which are not present in SIL, like an `InOut` or LValue types.
+  //
+  // If `maximallyAbstracted` is true, the lowering is done with a completely opaque abstraction pattern
+  // (see AbstractionPattern for details).
+  public func loweredType(in function: Function, maximallyAbstracted: Bool = false) -> Type {
+    type.loweredType(in: function, maximallyAbstracted: maximallyAbstracted)
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -58,9 +58,4 @@ extension SubstitutionMap {
   public func getMethodSubstitutions(for method: Function) -> SubstitutionMap {
     return SubstitutionMap(bridged: method.bridged.getMethodSubstitutions(bridged))
   }
-
-  public var replacementTypes: OptionalTypeArray {
-    let types = BridgedTypeArray.fromReplacementTypes(bridged)
-    return OptionalTypeArray(bridged: types)
-  }
 }

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -14,8 +14,11 @@ import AST
 import SILBridging
 
 extension CanonicalType {
-  var objectType: Type { BridgedType.createObjectType(bridged).type }
-  var addressType: Type { BridgedType.createAddressType(bridged).type }
+  // This can yield nil if the AST type is not a lowered type.
+  // For example, if the AST type is a `AnyFunctionType` for which the lowered type would be a `SILFunctionType`.
+  public var silType: Type? {
+    BridgedType.createSILType(bridged).typeOrNil
+  }
 }
 
 extension Decl {
@@ -30,7 +33,7 @@ extension NominalTypeDecl {
 
 extension ClassDecl {
   public var superClassType: Type? {
-    self.superClass?.canonical.objectType
+    self.superClass?.canonical.silType!
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1248,6 +1248,10 @@ final public class AllocStackInst : SingleValueInstruction, Allocation, DebugVar
   public var debugVariable: DebugVariable {
     return bridged.AllocStack_getVarInfo()
   }
+
+  public var deallocations: LazyMapSequence<LazyFilterSequence<UseList>, Instruction> {
+    uses.users(ofType: DeallocStackInst.self)
+  }
 }
 
 final public class AllocVectorInst : SingleValueInstruction, Allocation, UnaryInstruction {
@@ -1317,7 +1321,7 @@ extension Instruction {
   /// Return the sequence of use points of any instruction.
   public var endInstructions: EndInstructions {
     if let scopedInst = self as? ScopedInstruction {
-      return .scoped(scopedInst.endOperands.map({ $0.instruction }))
+      return .scoped(scopedInst.endOperands.users)
     }
     return .single(self)
   }
@@ -1365,6 +1369,10 @@ final public class StoreBorrowInst : SingleValueInstruction, StoringInstruction,
       dest = mark.operand.value
     }
     return dest as! AllocStackInst
+  }
+
+  public var endBorrows: LazyMapSequence<LazyFilterSequence<UseList>, Instruction> {
+    uses.users(ofType: EndBorrowInst.self)
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -169,6 +169,20 @@ extension Sequence where Element == Operand {
   public var endingLifetime: LazyFilterSequence<Self> {
     return self.lazy.filter { $0.endsLifetime }
   }
+
+  public var users: LazyMapSequence<Self, Instruction> {
+    return self.lazy.map { $0.instruction }
+  }
+
+  // This intentinally returns a Sequence of `Instruction` and not a Sequence of `I` to be able to use
+  // it as argument to `InstructionSet.insert(contentsOf:)`.
+  public func users<I: Instruction>(ofType: I.Type) -> LazyMapSequence<LazyFilterSequence<Self>, Instruction> {
+    self.lazy.filter{ $0.instruction is I }.users
+  }
+}
+
+extension Value {
+  public var users: LazyMapSequence<UseList, Instruction> { uses.users }
 }
 
 extension Operand {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -27,7 +27,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var addressType: Type { bridged.getAddressType().type }
   public var objectType: Type { bridged.getObjectType().type }
 
-  public var canonicalASTType: CanonicalType { CanonicalType(bridged: bridged.getCanType()) }
+  public var astType: CanonicalType { CanonicalType(bridged: bridged.getCanType()) }
 
   public func isTrivial(in function: Function) -> Bool {
     return bridged.isTrivial(function.bridged)
@@ -68,7 +68,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var isThickFunction: Bool { bridged.isThickFunction() }
   public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
 
-  public var canBeClass: BridgedType.TraitResult { bridged.canBeClass() }
+  public var canBeClass: CanonicalType.TraitResult { astType.canBeClass }
 
   public var isMoveOnly: Bool { bridged.isMoveOnly() }
 

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -243,26 +243,6 @@ public struct TypeArray : RandomAccessCollection, CustomReflectable {
   }
 }
 
-public struct OptionalTypeArray : RandomAccessCollection, CustomReflectable {
-  private let bridged: BridgedTypeArray
-
-  public var startIndex: Int { return 0 }
-  public var endIndex: Int { return bridged.getCount() }
-
-  public init(bridged: BridgedTypeArray) {
-    self.bridged = bridged
-  }
-
-  public subscript(_ index: Int) -> Type? {
-    bridged.getAt(index).typeOrNil
-  }
-
-  public var customMirror: Mirror {
-    let c: [Mirror.Child] = map { (label: nil, value: $0 ?? "<invalid>") }
-    return Mirror(self, children: c)
-  }
-}
-
 public struct NominalFieldsArray : RandomAccessCollection, FormattedLikeArray {
   fileprivate let type: Type
   fileprivate let function: Function

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2288,9 +2288,16 @@ class BridgedCanType {
   swift::TypeBase * _Nullable type;
 
 public:
+  enum class TraitResult {
+    IsNot,
+    CanBe,
+    Is
+  };
+
   BRIDGED_INLINE BridgedCanType(swift::CanType ty);
   BRIDGED_INLINE swift::CanType unbridged() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getType() const;
+  BRIDGED_INLINE TraitResult canBeClass() const;
 };
 
 struct BridgedASTTypeArray {

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2293,6 +2293,15 @@ public:
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getType() const;
 };
 
+struct BridgedASTTypeArray {
+  BridgedArrayRef typeArray;
+
+  SwiftInt getCount() const { return SwiftInt(typeArray.Length); }
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedASTType getAt(SwiftInt index) const;
+};
+
 struct BridgedConformance {
   void * _Nullable opaqueValue;
 
@@ -2330,6 +2339,7 @@ struct BridgedSubstitutionMap {
   BRIDGED_INLINE bool hasAnySubstitutableParams() const;
   BRIDGED_INLINE SwiftInt getNumConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getConformance(SwiftInt index) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTTypeArray getReplacementTypes() const;
 };
 
 struct BridgedFingerprint {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -339,6 +339,15 @@ BridgedASTType BridgedCanType::getType() const {
 }
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedASTTypeArray
+//===----------------------------------------------------------------------===//
+
+BridgedASTType BridgedASTTypeArray::getAt(SwiftInt index) const {
+  return {typeArray.unbridged<swift::Type>()[index].getPointer()};
+}
+
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedConformance
 //===----------------------------------------------------------------------===//
 
@@ -460,6 +469,10 @@ SwiftInt BridgedSubstitutionMap::getNumConformances() const {
 
 BridgedConformance BridgedSubstitutionMap::getConformance(SwiftInt index) const {
   return unbridged().getConformances()[index];
+}
+
+BridgedASTTypeArray BridgedSubstitutionMap::getReplacementTypes() const {
+  return {unbridged().getReplacementTypes()};
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -327,6 +327,10 @@ BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
 // MARK: BridgedCanType
 //===----------------------------------------------------------------------===//
 
+static_assert((int)BridgedCanType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);
+static_assert((int)BridgedCanType::TraitResult::CanBe == (int)swift::TypeTraitResult::CanBe);
+static_assert((int)BridgedCanType::TraitResult::Is == (int)swift::TypeTraitResult::Is);
+
 BridgedCanType::BridgedCanType(swift::CanType ty) : type(ty.getPointer()) {
 }
 
@@ -336,6 +340,10 @@ swift::CanType BridgedCanType::unbridged() const {
 
 BridgedASTType BridgedCanType::getType() const {
   return {type};
+}
+
+BridgedCanType::TraitResult BridgedCanType::canBeClass() const {
+  return (TraitResult)unbridged()->canBeClass();
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -245,8 +245,7 @@ struct BridgedType {
   BRIDGED_INLINE swift::SILType unbridged() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getCanType() const;
 
-  static SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType createObjectType(BridgedCanType canTy);
-  static SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType createAddressType(BridgedCanType canTy);
+  static SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType createSILType(BridgedCanType canTy);
   BRIDGED_INLINE BridgedOwnedString getDebugDescription() const;
   BRIDGED_INLINE bool isNull() const;
   BRIDGED_INLINE bool isAddress() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -614,18 +614,6 @@ struct BridgedMultiValueResult {
   BRIDGED_INLINE SwiftInt getIndex() const;
 };
 
-struct BridgedTypeArray {
-  BridgedArrayRef typeArray;
-
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
-  static BridgedTypeArray fromReplacementTypes(BridgedSubstitutionMap substMap);
-
-  SwiftInt getCount() const { return SwiftInt(typeArray.Length); }
-
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
-  BridgedType getAt(SwiftInt index) const;
-};
-
 struct BridgedSILTypeArray {
   BridgedArrayRef typeArray;
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -228,12 +228,6 @@ struct BridgedType {
     ObjC
   };
 
-  enum class TraitResult {
-    IsNot,
-    CanBe,
-    Is
-  };
-
   struct EnumElementIterator {
     uint64_t storage[4];
 
@@ -277,7 +271,6 @@ struct BridgedType {
   BRIDGED_INLINE bool isAsyncFunction() const;
   BRIDGED_INLINE bool isVoid() const;
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
-  BRIDGED_INLINE TraitResult canBeClass() const;
   BRIDGED_INLINE bool isMoveOnly() const;
   BRIDGED_INLINE bool isEscapable(BridgedFunction f) const;
   BRIDGED_INLINE bool isOrContainsObjectiveCClass() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -528,7 +528,7 @@ struct BridgedFunction {
   BRIDGED_INLINE void setNeedStackProtection(bool needSP) const;
   BRIDGED_INLINE void setIsPerformanceConstraint(bool isPerfConstraint) const;
   BRIDGED_INLINE bool isResilientNominalDecl(BridgedDeclObj decl) const;
-  BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type, bool maximallyAbstracted) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getLoweredType(BridgedType type) const;
   BRIDGED_INLINE BridgedLinkage getLinkage() const;
   BRIDGED_INLINE void setLinkage(BridgedLinkage linkage) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -421,10 +421,6 @@ bool BridgedType::isEmpty(BridgedFunction f) const {
   return unbridged().isEmpty(*f.getFunction());
 }
 
-BridgedType::TraitResult BridgedType::canBeClass() const {
-  return (TraitResult)unbridged().canBeClass();
-}
-
 bool BridgedType::isMoveOnly() const {
   return unbridged().isMoveOnly();
 }

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -284,12 +284,11 @@ BridgedType::EnumElementIterator BridgedType::EnumElementIterator::getNext() con
   return bridge(std::next(unbridge(*this)));
 }
 
-BridgedType BridgedType::createObjectType(BridgedCanType canTy) {
-  return swift::SILType::getPrimitiveObjectType(canTy.unbridged());
-}
-
-BridgedType BridgedType::createAddressType(BridgedCanType canTy) {
-  return swift::SILType::getPrimitiveAddressType(canTy.unbridged());
+BridgedType BridgedType::createSILType(BridgedCanType canTy) {
+  auto ty = canTy.unbridged();
+  if (ty->isLegalSILType())
+    return swift::SILType::getPrimitiveObjectType(ty);
+  return swift::SILType();
 }
 
 BridgedOwnedString BridgedType::getDebugDescription() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -912,7 +912,10 @@ bool BridgedFunction::isResilientNominalDecl(BridgedDeclObj decl) const {
                                                            getFunction()->getResilienceExpansion());
 }
 
-BridgedType BridgedFunction::getLoweredType(BridgedASTType type) const {
+BridgedType BridgedFunction::getLoweredType(BridgedASTType type, bool maximallyAbstracted) const {
+  if (maximallyAbstracted) {
+    return BridgedType(getFunction()->getLoweredType(swift::Lowering::AbstractionPattern::getOpaque(), type.type));
+  }
   return BridgedType(getFunction()->getLoweredType(type.type));
 }
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -988,24 +988,7 @@ SwiftInt BridgedMultiValueResult::getIndex() const {
 }
 
 //===----------------------------------------------------------------------===//
-//                                BridgedTypeArray
-//===----------------------------------------------------------------------===//
-
-BridgedTypeArray 
-BridgedTypeArray::fromReplacementTypes(BridgedSubstitutionMap substMap) {
-  return {substMap.unbridged().getReplacementTypes()};
-}
-
-BridgedType BridgedTypeArray::getAt(SwiftInt index) const {
-  swift::Type origTy = typeArray.unbridged<swift::Type>()[index];
-  auto ty = origTy->getCanonicalType();
-  if (ty->isLegalSILType())
-    return swift::SILType::getPrimitiveObjectType(ty);
-  return swift::SILType();
-}
-
-//===----------------------------------------------------------------------===//
-//                                BridgedTypeArray
+//                              BridgedSILTypeArray
 //===----------------------------------------------------------------------===//
 
 BridgedType BridgedSILTypeArray::getAt(SwiftInt index) const {

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -170,11 +170,6 @@ static_assert((int)BridgedType::MetatypeRepresentation::Thin == (int)swift::Meta
 static_assert((int)BridgedType::MetatypeRepresentation::Thick == (int)swift::MetatypeRepresentation::Thick);
 static_assert((int)BridgedType::MetatypeRepresentation::ObjC == (int)swift::MetatypeRepresentation::ObjC);
 
-static_assert((int)BridgedType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);
-static_assert((int)BridgedType::TraitResult::CanBe == (int)swift::TypeTraitResult::CanBe);
-static_assert((int)BridgedType::TraitResult::Is == (int)swift::TypeTraitResult::Is);
-
-
 //===----------------------------------------------------------------------===//
 //                                SILFunction
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -615,3 +615,54 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   %3 = builtin "destroyArray"<Int>(%2 : $@thin Int.Type, %0 : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
   return %0 : $Builtin.RawPointer
 }
+
+// CHECK-LABEL: sil @remove_trivial_destroy_metatype_array :
+// CHECK-NOT:     builtin
+// CHECK:       } // end sil function 'remove_trivial_destroy_metatype_array'
+sil @remove_trivial_destroy_metatype_array : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = metatype $@thin Int.Type.Type
+  %3 = builtin "destroyArray"<Int.Type>(%2 : $@thin Int.Type.Type, %0 : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
+  return %0 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil @sizeof_concrete_type :
+// CHECK:         %0 = integer_literal $Builtin.Word, 4
+// CHECK:         return %0
+// CHECK:       } // end sil function 'sizeof_concrete_type'
+sil @sizeof_concrete_type : $@convention(thin) () -> Builtin.Word {
+bb0:
+  %0 = builtin "sizeof"<Int32>() : $Builtin.Word
+  return %0
+}
+
+// CHECK-LABEL: sil @sizeof_generic_type :
+// CHECK:         %1 = builtin
+// CHECK:         return %1
+// CHECK:       } // end sil function 'sizeof_generic_type'
+sil @sizeof_generic_type : $@convention(thin) <T> (@thick T.Type) -> Builtin.Word {
+bb0(%0 : $@thick T.Type):
+  %1 = builtin "sizeof"<T>() : $Builtin.Word
+  return %1
+}
+
+// CHECK-LABEL: sil @sizeof_metatype :
+// CHECK:         %0 = integer_literal $Builtin.Word, {{(4|8)}}
+// CHECK:         return %0
+// CHECK:       } // end sil function 'sizeof_metatype'
+sil @sizeof_metatype : $@convention(thin) () -> Builtin.Word {
+bb0:
+  %0 = builtin "sizeof"<Bool.Type>() : $Builtin.Word
+  return %0
+}
+
+// CHECK-LABEL: sil @sizeof_function_type :
+// CHECK:         %0 = integer_literal $Builtin.Word, {{(8|16)}}
+// CHECK:         return %0
+// CHECK:       } // end sil function 'sizeof_function_type'
+sil @sizeof_function_type : $@convention(thin) () -> Builtin.Word {
+bb0:
+  %0 = builtin "sizeof"<()->()>() : $Builtin.Word
+  return %0
+}
+


### PR DESCRIPTION
* replace `CanonicalType.objectType` and `CanonicalType.addressType` with `silType`
* add `AST.Type.loweredType` and `CanonicalType.loweredType`
* let `SubstitutionMap.replacementTypes` return AST types rather than optional SIL types
* add some use-list APIs
* add `SingleValueInstruction.replace(with:)` and use it throughout the optimizer
* add `CanonicalType.canBeClass` and move the implementation of `SIL.Type.canBeClass` to the AST Type
* SimplifyBuiltin: support metatype and function types when optimizing `Builtin.sizeof`/`alignof`/`strideof`/`destroyArray`

For details see the commit messages