### PR TITLE
Add formerly-slow expressions found by building projects from the Swift package index

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000
+// REQUIRES: tools-release,no_asan
+
+public class Cookie {
+    public var url: String!
+    public var port: Int16?
+    public var name: String!
+    public var path: String!
+    public var value: String!
+    public var comment: String?
+    public var commentURL: String?
+
+    private let fixedByteSize: Int32 = 56
+
+    var totalByteCount: Int32 {
+        return fixedByteSize + 
+               (port != nil ? 2 : 0) +
+               Int32(comment?.utf8.count ?? 0) +
+               Int32(commentURL?.utf8.count ?? 0) +
+               Int32(url.utf8.count) +
+               Int32(name.utf8.count) +
+               Int32(path.utf8.count) +
+               Int32(value.utf8.count)
+    }
+}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_2.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_2.swift.gyb
@@ -1,0 +1,13 @@
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumConstraintScopes %s
+// REQUIRES: tools-release,no_asan,asserts
+
+var v: [String] = []
+var vv: [String]? = nil
+
+func f() -> [String] {
+  return (
+%for i in range(0, N):
+    v +
+%end
+    v + (vv ?? []))
+}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_3.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_3.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=50000
+// REQUIRES: tools-release,no_asan
+
+extension String {
+  func replacingOccurrences(of: String, with: String) -> String { return "" }
+  func components(separatedBy: String) -> [String] { return [] }
+}
+
+func getProperties(
+    from ics: String
+) -> [(name: String, value: String)] {
+    return ics
+        .replacingOccurrences(of: "\r\n ", with: "")
+        .components(separatedBy: "\r\n")
+        .map { $0.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true) }
+        .filter { $0.count > 1 }
+        .map { (String($0[0]), String($0[1])) }
+}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_4.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=60000
+// REQUIRES: tools-release,no_asan
+
+protocol ArgumentProtocol {}
+
+extension String: ArgumentProtocol {}
+extension Bool: ArgumentProtocol {}
+
+struct ConcreteError: Error {}
+
+struct Option<T> {
+  init(key: String, defaultValue: T, usage: String) {}
+}
+
+struct Argument<T> {
+  init(defaultValue: T? = nil, usage: String, usageParameter: String? = nil) {}
+}
+
+struct Switch {
+  init(flag: Character? = nil, key: String, usage: String) {}
+}
+
+infix operator <*> : LogicalDisjunctionPrecedence
+infix operator <| : MultiplicationPrecedence
+
+func <*> <T, U>(f: (T) -> U, value: Result<T, ConcreteError>) -> Result<U, ConcreteError> { fatalError() }
+func <*> <T, U>(f: Result<((T) -> U), ConcreteError>, value: Result<T, ConcreteError>) -> Result<U, ConcreteError> { fatalError() }
+
+struct CommandMode {
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, option: Option<T>) -> Result<T, ConcreteError> { fatalError() }
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, option: Option<T?>) -> Result<T?, ConcreteError> { fatalError() }
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, option: Option<[T]>) -> Result<[T], ConcreteError> { fatalError() }
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, ConcreteError> { fatalError() }
+  static func <| (mode: CommandMode, option: Option<Bool>) -> Result<Bool, ConcreteError> { fatalError() }
+  static func <| (mode: CommandMode, option: Switch) -> Result<Bool, ConcreteError> { fatalError() }
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, argument: Argument<T>) -> Result<T, ConcreteError> { fatalError() }
+  static func <| <T: ArgumentProtocol>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], ConcreteError> { fatalError() }
+}
+
+struct FileManager {
+  static var `default`: FileManager = FileManager()
+  var currentDirectoryPath: String = ""
+}
+
+struct Options {
+  static func create(_ project: String?) -> (String?) -> (String) -> (String) -> (String?) -> (String?) -> (String?) -> (String?) -> (Bool) -> ([String]) -> Options { fatalError() }
+
+  static func evaluate(_ mode: CommandMode) -> Result<Options, ConcreteError> {
+    let defaultBuildDirectory = ""
+    return create
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Option(key: "", defaultValue: FileManager.default.currentDirectoryPath, usage: "")
+      <*> mode <| Option(key: "", defaultValue: FileManager.default.currentDirectoryPath, usage: "")
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Option(key: "", defaultValue: nil, usage: "")
+      <*> mode <| Switch(key: "", usage: "")
+      <*> mode <| Argument(defaultValue: [], usage: "")
+  }
+}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_5.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_5.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000 -swift-version 5
+// REQUIRES: tools-release,no_asan
+
+func g<T>(_: T) throws {
+    let _: T? =
+        (try? f() as? T) ??
+        (try? f() as? T) ??
+        (try? f() as? T) ??
+        (try? f() as? T) ??
+        (try? f() as? T)
+}
+
+func f() throws -> Int { return 0 }


### PR DESCRIPTION
These were slow in 6.0 and are now fast(er).