### PR TITLE
[6.1] Revert some changes to CSBinding that landed after branch was created

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -486,10 +486,6 @@ public:
   /// Determine whether this type variable represents a subscript result type.
   bool isSubscriptResultType() const;
 
-  /// Determine whether this type variable represents a result type of an
-  /// application i.e. a call, an operator, or a subscript.
-  bool isApplicationResultType() const;
-
   /// Determine whether this type variable represents an opened
   /// type parameter pack.
   bool isParameterPack() const;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1208,19 +1208,7 @@ bool BindingSet::isViable(PotentialBinding &binding, bool isTransitive) {
     if (!existingNTD || NTD != existingNTD)
       continue;
 
-    // What is going on here needs to be thoroughly re-evaluated,
-    // but at least for now, let's not filter bindings of different
-    // kinds so if we have a situation like: `Array<$T0> conv $T1`
-    // and `$T1 conv Array<(String, Int)>` we can't lose `Array<$T0>`
-    // as a binding because `$T0` could be inferred to
-    // `(key: String, value: Int)` and binding `$T1` to `Array<(String, Int)>`
-    // eagerly would be incorrect.
-    if (existing->Kind != binding.Kind) {
-      // Array, Set and Dictionary allow conversions, everything else
-      // requires their generic arguments to match exactly.
-      if (existingType->isKnownStdlibCollectionType())
-        continue;
-    }
+    // FIXME: What is going on here needs to be thoroughly re-evaluated.
 
     // If new type has a type variable it shouldn't
     // be considered  viable.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1281,16 +1281,9 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
 
         return !hasConversions(binding.BindingType);
       })) {
-    bool isApplicationResultType = TypeVar->getImpl().isApplicationResultType();
-    if (llvm::none_of(Info.DelayedBy, [&isApplicationResultType](
-                                          const Constraint *constraint) {
-          // Let's not attempt to bind result type before application
-          // happens. For example because it could be discardable or
-          // l-value (subscript applications).
-          if (isApplicationResultType &&
-              constraint->getKind() == ConstraintKind::ApplicableFunction)
-            return true;
-
+    // Result type of subscript could be l-value so we can't bind it early.
+    if (!TypeVar->getImpl().isSubscriptResultType() &&
+        llvm::none_of(Info.DelayedBy, [](const Constraint *constraint) {
           return constraint->getKind() == ConstraintKind::Disjunction ||
                  constraint->getKind() == ConstraintKind::ValueMember;
         }))

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1264,8 +1264,7 @@ static bool hasConversions(Type type) {
   }
 
   return !(type->is<StructType>() || type->is<EnumType>() ||
-           type->is<BuiltinType>() || type->is<ArchetypeType>() ||
-           type->isVoid());
+           type->is<BuiltinType>() || type->is<ArchetypeType>());
 }
 
 bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -175,16 +175,6 @@ bool TypeVariableType::Implementation::isSubscriptResultType() const {
              KeyPathExpr::Component::Kind::UnresolvedSubscript;
 }
 
-bool TypeVariableType::Implementation::isApplicationResultType() const {
-  if (!(locator && locator->getAnchor()))
-    return false;
-
-  if (!locator->isLastElement<LocatorPathElt::FunctionResult>())
-    return false;
-
-  return isExpr<ApplyExpr>(locator->getAnchor()) || isSubscriptResultType();
-}
-
 bool TypeVariableType::Implementation::isParameterPack() const {
   return locator
       && locator->isForGenericParameter()

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -180,3 +180,20 @@ struct OverloadInImplicitAsyncClosure {
 
   init(int: Int) throws { }
 }
+
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) async throws {}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+func test(_: Int) -> String { "" }
+
+@available(SwiftStdlib 5.5, *)
+func compute(_: @escaping () -> Void) {}
+
+@available(SwiftStdlib 5.5, *)
+func test_sync_in_closure_context() {
+  compute {
+    test(42) // Ok (select sync overloads and discards the result)
+  }
+}

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -180,20 +180,3 @@ struct OverloadInImplicitAsyncClosure {
 
   init(int: Int) throws { }
 }
-
-@available(SwiftStdlib 5.5, *)
-func test(_: Int) async throws {}
-
-@discardableResult
-@available(SwiftStdlib 5.5, *)
-func test(_: Int) -> String { "" }
-
-@available(SwiftStdlib 5.5, *)
-func compute(_: @escaping () -> Void) {}
-
-@available(SwiftStdlib 5.5, *)
-func test_sync_in_closure_context() {
-  compute {
-    test(42) // Ok (select sync overloads and discards the result)
-  }
-}

--- a/test/Constraints/rdar139812024.swift
+++ b/test/Constraints/rdar139812024.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk
+
+// REQUIRES: objc_interop
+
+// rdar://139812024 - error: cannot convert return expression of type 'NSObject' to return type 'NSImage'
+
+import Foundation
+
+@objc
+final class Image: NSObject {
+}
+
+@available(*, unavailable)
+extension Image: Sendable {} // expected-note {{explicitly marked unavailable here}}
+
+class Lock<State> {
+  func withLock<R: Sendable>(_: @Sendable (inout State) -> R) -> R {
+    fatalError()
+  }
+}
+
+extension Lock where State == Void {
+  func withLock<R: Sendable>(_: @Sendable () -> R) -> R {
+    fatalError()
+  }
+}
+
+class Test {
+  var images: [Int: Image] = [:]
+
+  func fetchImage(lock: Lock<Void>, id: Int) -> Image? {
+    if let existingImage = lock.withLock({ return images[id] }) { // expected-warning {{unavailable}}
+      return existingImage
+    }
+    return nil
+  }
+}


### PR DESCRIPTION
Reverts https://github.com/swiftlang/swift/pull/76487, https://github.com/swiftlang/swift/pull/77153 and https://github.com/swiftlang/swift/pull/76952

---

- Explanation:
  
  Revert changes that caused performance regressions in qualification of `6.1` and are already reverted from `main`.

- Main Branch PR: https://github.com/swiftlang/swift/pull/77936, https://github.com/swiftlang/swift/pull/77653

- Risk: Very Low (Reverts of new functionality).

- Reviewed By: @hborla @slavapestov 

- Testing: Even though the comments are reverts the regression tests are preserved.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
