### PR TITLE
Improve and collate diagnostics for uses of unsafe constructs in declarations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8084,6 +8084,9 @@ NOTE(note_reference_to_unsafe_decl,none,
 NOTE(note_reference_to_unsafe_typed_decl,none,
      "%select{reference|call}0 to %kind1 involves unsafe type %2",
      (bool, const ValueDecl *, Type))
+NOTE(note_reference_to_nonisolated_unsafe,none,
+     "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
+     (const ValueDecl *))
 
 GROUPED_WARNING(override_safe_withunsafe,Unsafe,none,
       "override of safe %0 with unsafe %0", (DescriptiveDeclKind))
@@ -8097,8 +8100,9 @@ GROUPED_WARNING(unchecked_conformance_is_unsafe,Unsafe,none,
       "@unchecked conformance involves unsafe code", ())
 GROUPED_WARNING(unowned_unsafe_is_unsafe,Unsafe,none,
       "unowned(unsafe) involves unsafe code", ())
-GROUPED_WARNING(nonisolated_unsafe_is_unsafe,Unsafe,none,
-      "nonisolated(unsafe) involves unsafe code", ())
+GROUPED_WARNING(reference_to_nonisolated_unsafe,Unsafe,none,
+      "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
+       (const ValueDecl *))
 GROUPED_WARNING(reference_to_unsafe_decl,Unsafe,none,
       "%select{reference|call}0 to unsafe %kindbase1",
       (bool, const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8087,6 +8087,8 @@ NOTE(note_reference_to_unsafe_typed_decl,none,
 NOTE(note_reference_to_nonisolated_unsafe,none,
      "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
      (const ValueDecl *))
+NOTE(note_reference_unowned_unsafe,none,
+     "reference to unowned(unsafe) %kind0 is unsafe", (const ValueDecl *))
 
 GROUPED_WARNING(override_safe_withunsafe,Unsafe,none,
       "override of safe %0 with unsafe %0", (DescriptiveDeclKind))
@@ -8098,8 +8100,8 @@ GROUPED_WARNING(type_witness_unsafe,Unsafe,none,
       (Type, DeclName))
 GROUPED_WARNING(unchecked_conformance_is_unsafe,Unsafe,none,
       "@unchecked conformance involves unsafe code", ())
-GROUPED_WARNING(unowned_unsafe_is_unsafe,Unsafe,none,
-      "unowned(unsafe) involves unsafe code", ())
+GROUPED_WARNING(reference_unowned_unsafe,Unsafe,none,
+      "reference to unowned(unsafe) %kind0 is unsafe", (const ValueDecl *))
 GROUPED_WARNING(reference_to_nonisolated_unsafe,Unsafe,none,
       "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
        (const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8072,6 +8072,19 @@ NOTE(sending_function_result_with_sending_param_note, none,
 //------------------------------------------------------------------------------
 ERROR(unsafe_attr_disabled,none,
       "attribute requires '-enable-experimental-feature AllowUnsafeAttribute'", ())
+
+GROUPED_WARNING(decl_involves_unsafe,Unsafe,none,
+      "%kindbase0 involves unsafe code; "
+      "use %select{'@unsafe' to indicate that its use is not memory-safe|"
+      "'@safe(unchecked)' to assert that the code is memory-safe}1",
+      (const Decl *, bool))
+NOTE(note_reference_to_unsafe_decl,none,
+      "%select{reference|call}0 to unsafe %kind1",
+      (bool, const ValueDecl *))
+NOTE(note_reference_to_unsafe_typed_decl,none,
+     "%select{reference|call}0 to %kind1 involves unsafe type %2",
+     (bool, const ValueDecl *, Type))
+
 GROUPED_WARNING(override_safe_withunsafe,Unsafe,none,
       "override of safe %0 with unsafe %0", (DescriptiveDeclKind))
 GROUPED_WARNING(witness_unsafe,Unsafe,none,

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -27,6 +27,7 @@
 namespace swift {
 
 class PersistentParserState;
+struct SourceFileExtras;
 
 /// Kind of import affecting how a decl can be reexported.
 ///
@@ -243,6 +244,9 @@ private:
   /// Storage for \c HasImportsMatchingFlagRequest.
   ImportOptions cachedImportOptions;
 
+  /// Extra information for the source file, allocated as needed.
+  SourceFileExtras *extras = nullptr;
+
   friend ASTContext;
 
 public:
@@ -367,6 +371,11 @@ public:
   /// identifiers in this source file, including virtual filenames introduced by
   /// \c #sourceLocation(file:) declarations.
   llvm::StringMap<SourceFilePathInfo> getInfoForUsedFilePaths() const;
+
+  /// Retrieve "extra" information associated with this source file, which is
+  /// lazily and separately constructed. Use this for scratch information
+  /// that isn't needed for all source files.
+  SourceFileExtras &getExtras() const;
 
   SourceFile(ModuleDecl &M, SourceFileKind K, unsigned bufferID,
              ParsingOptions parsingOpts = {}, bool isPrimary = false);

--- a/include/swift/AST/SourceFileExtras.h
+++ b/include/swift/AST/SourceFileExtras.h
@@ -1,0 +1,36 @@
+//===--- SourceFileExtras.h - Extra data for a source file ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SOURCEFILEEXTRAS_H
+#define SWIFT_AST_SOURCEFILEEXTRAS_H
+
+#include "swift/AST/UnsafeUse.h"
+#include "llvm/ADT/DenseMap.h"
+#include <vector>
+
+namespace swift {
+
+class Decl;
+
+/// Extra information associated with a source file that is lazily created and
+/// stored in a separately-allocated side structure.
+struct SourceFileExtras {
+  /// Captures all of the unsafe uses associated with a given declaration.
+  ///
+  /// The declaration is the entity that can be annotated (e.g., with @unsafe)
+  /// to suppress all of the unsafe-related diagnostics listed here.
+  llvm::DenseMap<const Decl *, std::vector<UnsafeUse>> unsafeUses;
+};
+  
+}
+
+#endif // SWIFT_AST_SOURCEFILEEXTRAS_H

--- a/include/swift/AST/UnsafeUse.h
+++ b/include/swift/AST/UnsafeUse.h
@@ -1,0 +1,302 @@
+//===--- UnsafeUse.h - A use of an unsafe construct -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_UNSAFEUSE_H
+#define SWIFT_AST_UNSAFEUSE_H
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Type.h"
+#include "swift/Basic/SourceLoc.h"
+#include "swift/Basic/Unreachable.h"
+
+namespace swift {
+
+class NormalProtocolConformance;
+
+/// Describes a use of an unsafe construct.
+///
+/// Every use of an unsafe construct that should be diagnosed will be captured
+/// in an instance of this type.
+class UnsafeUse {
+public:
+  enum Kind {
+    /// An unsafe declaration overriding a safe one.
+    Override,
+    /// An unsafe declaration witnessing a safe one.
+    Witness,
+    /// An unsafe type witnesses a safe associated type.
+    TypeWitness,
+    /// An @unsafe or @unchecked conformance (e.g., Sendable).
+    UnsafeConformance,
+    /// A reference to an unowned(unsafe) entity.
+    UnownedUnsafe,
+    /// A reference to a nonisolated(unsafe) entity.
+    NonisolatedUnsafe,
+    /// A reference to an unsafe declaration.
+    ReferenceToUnsafe,
+    /// A call to an unsafe declaration.
+    CallToUnsafe,
+  };
+
+private:
+  Kind kind;
+
+  union {
+    struct {
+      const Decl *decl;
+      const Decl *original;
+      NormalProtocolConformance *conformance;
+    } polymorphic;
+
+    struct {
+      const AssociatedTypeDecl *assocType;
+      TypeBase *type;
+      NormalProtocolConformance *conformance;
+      const void *location;
+    } typeWitness;
+
+    struct {
+      NormalProtocolConformance *conformance;
+      const void *location;
+    } conformance;
+
+    struct {
+      const Decl *decl;
+      DeclContext *declContext;
+      TypeBase *type;
+      const void *location;
+    } entity;
+  } storage;
+
+  UnsafeUse(Kind kind) : kind(kind) { }
+
+  static UnsafeUse forPolymorphic(
+      Kind kind,
+      const Decl *decl,
+      const Decl *original,
+      NormalProtocolConformance *conformance
+  ) {
+    assert(kind == Override || kind == Witness);
+
+    UnsafeUse result(kind);
+    result.storage.polymorphic.decl = decl;
+    result.storage.polymorphic.original = original;
+    result.storage.polymorphic.conformance = conformance;
+    return result;
+  }
+
+  static UnsafeUse forReference(
+      Kind kind,
+      DeclContext *dc,
+      const Decl *decl,
+      Type type,
+      SourceLoc location
+  ) {
+    assert(kind == UnownedUnsafe ||
+           kind == NonisolatedUnsafe ||
+           kind == ReferenceToUnsafe ||
+           kind == CallToUnsafe);
+
+    UnsafeUse result(kind);
+    result.storage.entity.decl = decl;
+    result.storage.entity.declContext = dc;
+    result.storage.entity.type = type.getPointer();
+    result.storage.entity.location = location.getOpaquePointerValue();
+    return result;
+
+  }
+
+public:
+  static UnsafeUse forOverride(const Decl *decl, const Decl *overridden) {
+    return forPolymorphic(Override, decl, overridden, nullptr);
+  }
+
+  static UnsafeUse forWitness(const Decl *witness, const Decl *requirement,
+                              NormalProtocolConformance *conformance) {
+    return forPolymorphic(Witness, witness, requirement, conformance);
+  }
+
+  static UnsafeUse forTypeWitness(const AssociatedTypeDecl *assocType,
+                                  Type typeWitness,
+                                  NormalProtocolConformance *conformance,
+                                  SourceLoc location) {
+    UnsafeUse result(TypeWitness);
+    result.storage.typeWitness.assocType = assocType;
+    result.storage.typeWitness.type = typeWitness.getPointer();
+    result.storage.typeWitness.conformance = conformance;
+    result.storage.typeWitness.location = location.getOpaquePointerValue();
+    return result;
+  }
+
+  static UnsafeUse forConformance(NormalProtocolConformance *conformance,
+                                  SourceLoc location) {
+    UnsafeUse result(UnsafeConformance);
+    result.storage.conformance.conformance = conformance;
+    result.storage.conformance.location = location.getOpaquePointerValue();
+    return result;
+  }
+
+  static UnsafeUse forUnownedUnsafe(const Decl *decl,
+                                    SourceLoc location,
+                                    DeclContext *dc) {
+    return forReference(UnownedUnsafe, dc, decl, Type(), location);
+  }
+
+  static UnsafeUse forNonisolatedUnsafe(const Decl *decl,
+                                        SourceLoc location,
+                                        DeclContext *dc) {
+    return forReference(NonisolatedUnsafe, dc, decl, Type(), location);
+  }
+
+  static UnsafeUse forReferenceToUnsafe(const Decl *decl,
+                                        bool isCall,
+                                        DeclContext *dc,
+                                        Type type,
+                                        SourceLoc location) {
+    return forReference(isCall ? CallToUnsafe: ReferenceToUnsafe, dc,
+                        decl, type, location);
+  }
+
+  Kind getKind() const { return kind; }
+
+  /// The location at which this use will be diagnosed.
+  SourceLoc getLocation() const {
+    switch (getKind()) {
+    case Override:
+    case Witness:
+      return getDecl()->getLoc();
+
+    case UnsafeConformance:
+      return getConformance()->getLoc();
+
+    case TypeWitness:
+      return SourceLoc(
+          llvm::SMLoc::getFromPointer(
+            (const char *)storage.typeWitness.location));
+
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+      return SourceLoc(
+          llvm::SMLoc::getFromPointer((const char *)storage.entity.location));
+    }
+  }
+
+  /// Get the main declaration, when there is one.
+  const Decl *getDecl() const {
+    switch (getKind()) {
+    case Override:
+    case Witness:
+      return storage.polymorphic.decl;
+
+    case TypeWitness:
+      return storage.typeWitness.assocType;
+
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+      return storage.entity.decl;
+
+    case UnsafeConformance:
+      return nullptr;
+    }
+  }
+
+  /// Get the associated type declaration for a type witness.
+  const AssociatedTypeDecl *getAssociatedType() const {
+    assert(getKind() == TypeWitness);
+    return storage.typeWitness.assocType;
+  }
+
+  /// Retrieve the declaration context in which the reference occurs.
+  DeclContext *getDeclContext() const {
+    switch (getKind()) {
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+      return storage.entity.declContext;
+
+    case Override:
+    case Witness:
+    case TypeWitness:
+    case UnsafeConformance:
+      return nullptr;
+    }
+  }
+
+  /// Get the original declaration for an issue with a polymorphic
+  /// implementation, e.g., an overridden declaration or a protocol
+  /// requirement.
+  const Decl *getOriginalDecl() const {
+    switch (getKind()) {
+    case Override:
+    case Witness:
+      return storage.polymorphic.original;
+
+    case TypeWitness:
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+    case UnsafeConformance:
+      return nullptr;
+    }
+  }
+
+  /// Get the type of the reference, if there is one.
+  Type getType() const {
+    switch (getKind()) {
+    case Override:
+    case Witness:
+    case UnsafeConformance:
+      return nullptr;
+
+    case TypeWitness:
+      return storage.typeWitness.type;
+
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+      return storage.entity.type;
+    }
+  }
+
+  /// Get the protocol conformance, if there is one.
+  NormalProtocolConformance *getConformance() const {
+    switch (getKind()) {
+    case UnsafeConformance:
+      return storage.conformance.conformance;
+
+    case Witness:
+      return storage.polymorphic.conformance;
+
+    case TypeWitness:
+      return storage.typeWitness.conformance;
+
+    case Override:
+    case UnownedUnsafe:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case CallToUnsafe:
+      return nullptr;
+    }
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_AST_UNSAFEUSE_H

--- a/include/swift/AST/UnsafeUse.h
+++ b/include/swift/AST/UnsafeUse.h
@@ -67,6 +67,7 @@ private:
 
     struct {
       NormalProtocolConformance *conformance;
+      DeclContext *declContext;
       const void *location;
     } conformance;
 
@@ -139,9 +140,11 @@ public:
   }
 
   static UnsafeUse forConformance(NormalProtocolConformance *conformance,
-                                  SourceLoc location) {
+                                  SourceLoc location,
+                                  DeclContext *dc) {
     UnsafeUse result(UnsafeConformance);
     result.storage.conformance.conformance = conformance;
+    result.storage.conformance.declContext = dc;
     result.storage.conformance.location = location.getOpaquePointerValue();
     return result;
   }
@@ -230,10 +233,14 @@ public:
       return storage.entity.declContext;
 
     case Override:
+      return getDecl()->getDeclContext();
+
     case Witness:
     case TypeWitness:
+      return getConformance()->getDeclContext();
+
     case UnsafeConformance:
-      return nullptr;
+      return storage.conformance.declContext;
     }
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/SourceFileExtras.h"
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -1173,6 +1174,17 @@ ASTNode SourceFile::getNodeInEnclosingSourceFile() const {
     return nullptr;
 
   return ASTNode::getFromOpaqueValue(getGeneratedSourceFileInfo()->astNode);
+}
+
+SourceFileExtras &SourceFile::getExtras() const {
+  if (!extras) {
+    const_cast<SourceFile *>(this)->extras = new SourceFileExtras();
+    getASTContext().addCleanup([extras=this->extras] {
+      delete extras;
+    });
+  }
+
+  return *extras;
 }
 
 void ModuleDecl::lookupClassMember(ImportPath::Access accessPath,

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -34,6 +34,7 @@
 #include "DerivedConformances.h"
 #include "TypeAccessScopeChecker.h"
 #include "TypeChecker.h"
+#include "TypeCheckAvailability.h"
 #include "TypeCheckType.h"
 
 #include "swift/AST/ConformanceLookup.h"
@@ -47,6 +48,7 @@
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/UnsafeUse.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
@@ -363,16 +365,8 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
     SourceLoc loc = typeDecl->getLoc();
     if (loc.isInvalid())
       loc = conformance->getLoc();
-    diagnoseUnsafeType(ctx,
-                       loc,
-                       type,
-                       conformance->getDeclContext(),
-                       [&](Type specificType) {
-      ctx.Diags.diagnose(
-          loc, diag::type_witness_unsafe, specificType, assocType->getName());
-      suggestUnsafeMarkerOnConformance(conformance);
-      assocType->diagnose(diag::decl_declared_here, assocType);
-    });
+    diagnoseUnsafeUse(
+        UnsafeUse::forTypeWitness(assocType, type, conformance, loc));
   }
 
   // Record the type witness.

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -78,6 +78,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckStorage.cpp
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
+  TypeCheckUnsafe.cpp
   TypeChecker.cpp
   IDETypeCheckingRequests.cpp)
 if(SWIFT_FORCE_OPTIMIZED_TYPECHECKER)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7201,15 +7201,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   // that do not have storage.
   auto dc = D->getDeclContext();
 
-  // nonisolated(unsafe) is unsafe, but only under strict concurrency.
-  if (attr->isUnsafe() &&
-      Ctx.LangOpts.hasFeature(Feature::WarnUnsafe) &&
-      Ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete &&
-      !D->allowsUnsafe()) {
-    diagnoseUnsafeUse(
-        UnsafeUse::forNonisolatedUnsafe(D, attr->getLocation(), dc));
-  }
-
   if (auto var = dyn_cast<VarDecl>(D)) {
     // stored properties have limitations as to when they can be nonisolated.
     auto type = var->getTypeInContext();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -42,7 +42,6 @@
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/UnsafeUse.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParseDeclName.h"
@@ -4976,15 +4975,6 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
                ownershipKind);
       attr->setInvalid();
     }
-  }
-
-  // unowned(unsafe) is unsafe (duh).
-  if (ownershipKind == ReferenceOwnership::Unmanaged &&
-      ctx.LangOpts.hasFeature(Feature::WarnUnsafe) &&
-      !var->allowsUnsafe()) {
-    diagnoseUnsafeUse(
-        UnsafeUse::forUnownedUnsafe(var, attr->getLocation(),
-                                    var->getDeclContext()));
   }
 
   if (attr->isInvalid())

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1684,8 +1684,10 @@ public:
     // is contained in the range we are looking for.
     FoundTarget = SM.rangeContains(TargetRange, Range);
 
-    if (FoundTarget)
+    if (FoundTarget) {
+      walkToNodePost(Node);
       return Action::SkipNode(Node);
+    }
 
     // Search the subtree if the target range is inside its range.
     if (!SM.rangeContains(Range, TargetRange))

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4228,6 +4228,19 @@ diagnoseDeclUnsafe(const ValueDecl *D, SourceRange R,
           valueDecl, R.Start, Where.getDeclContext()));
       return;
     }
+
+    if (auto var = dyn_cast<VarDecl>(valueDecl)) {
+      // unowned(unsafe) is unsafe (duh).
+      if (auto ownershipAttr =
+              var->getAttrs().getAttribute<ReferenceOwnershipAttr>()) {
+        if (ownershipAttr->get() == ReferenceOwnership::Unmanaged) {
+          diagnoseUnsafeUse(
+              UnsafeUse::forUnownedUnsafe(var, R.Start,
+                                          Where.getDeclContext()));
+          return;
+        }
+      }
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -34,6 +34,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeDeclFinder.h"
+#include "swift/AST/UnsafeUse.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
@@ -4071,36 +4072,6 @@ private:
 };
 } // end anonymous namespace
 
-static void suggestUnsafeOnEnclosingDecl(
-    SourceRange referenceRange, const DeclContext *referenceDC) {
-  if (referenceRange.isInvalid())
-    return;
-
-  ASTContext &ctx = referenceDC->getASTContext();
-  std::optional<ASTNode> versionCheckNode;
-  const Decl *memberLevelDecl = nullptr;
-  const Decl *typeLevelDecl = nullptr;
-  findAvailabilityFixItNodes(
-                             referenceRange, referenceDC, ctx.SourceMgr,
-      versionCheckNode, memberLevelDecl, typeLevelDecl);
-
-  auto decl = memberLevelDecl ? memberLevelDecl : typeLevelDecl;
-  if (!decl)
-    return;
-
-  if (versionCheckNode.has_value()) {
-    // The unsafe construct is inside the body of the entity, so suggest
-    // @safe(unchecked) on the declaration.
-    decl->diagnose(diag::encapsulate_unsafe_in_enclosing_context, decl)
-      .fixItInsert(decl->getAttributeInsertionLoc(false),
-                   "@safe(unchecked) ");
-  } else {
-    // The unsafe construct is not part of the body, so
-    decl->diagnose(diag::make_enclosing_context_unsafe, decl)
-      .fixItInsert(decl->getAttributeInsertionLoc(false), "@unsafe ");
-  }
-}
-
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
 bool ExprAvailabilityWalker::diagnoseDeclRefAvailability(
@@ -4140,18 +4111,11 @@ bool ExprAvailabilityWalker::diagnoseDeclRefAvailability(
     auto type = D->getInterfaceType();
     if (auto subs = declRef.getSubstitutions())
       type = type.subst(subs);
-    if (type->isUnsafe()) {
-      diagnoseUnsafeType(
-          ctx, R.Start, type,
-          Where.getAvailability(),
-          [&](Type specificType) {
-            ctx.Diags.diagnose(
-                R.Start, diag::reference_to_unsafe_typed_decl,
-                call != nullptr && !isa<ParamDecl>(D), D,
-                specificType);
-            suggestUnsafeOnEnclosingDecl(R, Where.getDeclContext());
-            D->diagnose(diag::unsafe_decl_here, D);
-          });
+    if (type->isUnsafe() && !Where.getAvailability().allowsUnsafe()) {
+      diagnoseUnsafeUse(
+          UnsafeUse::forReferenceToUnsafe(
+            D, call != nullptr && !isa<ParamDecl>(D), Where.getDeclContext(),
+            type, R.Start));
     }
   }
 
@@ -4235,10 +4199,9 @@ diagnoseDeclUnsafe(const ValueDecl *D, SourceRange R,
     return;
 
   SourceLoc diagLoc = call ? call->getLoc() : R.Start;
-  ctx.Diags
-    .diagnose(diagLoc, diag::reference_to_unsafe_decl, call != nullptr, D);
-  suggestUnsafeOnEnclosingDecl(R, Where.getDeclContext());
-  D->diagnose(diag::unsafe_decl_here, D);
+  diagnoseUnsafeUse(
+      UnsafeUse::forReferenceToUnsafe(
+        D, call != nullptr, Where.getDeclContext(), Type(), diagLoc));
 }
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
@@ -4965,4 +4928,25 @@ void swift::checkExplicitAvailability(Decl *decl) {
       diag.fixItInsert(InsertLoc, AttrText);
     }
   }
+}
+
+std::pair<const Decl *, bool /*inDefinition*/>
+swift::enclosingContextForUnsafe(
+    SourceLoc referenceLoc, const DeclContext *referenceDC) {
+  if (referenceLoc.isInvalid())
+    return { nullptr, false };
+
+  ASTContext &ctx = referenceDC->getASTContext();
+  std::optional<ASTNode> versionCheckNode;
+  const Decl *memberLevelDecl = nullptr;
+  const Decl *typeLevelDecl = nullptr;
+  findAvailabilityFixItNodes(
+      referenceLoc, referenceDC, ctx.SourceMgr,
+      versionCheckNode, memberLevelDecl, typeLevelDecl);
+
+  auto decl = memberLevelDecl ? memberLevelDecl : typeLevelDecl;
+  if (!decl)
+    return { nullptr, false };
+
+  return { decl, versionCheckNode.has_value() };
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -36,6 +36,7 @@ namespace swift {
   class SubstitutionMap;
   class Type;
   class TypeRepr;
+  class UnsafeUse;
   class ValueDecl;
 
 enum class DeclAvailabilityFlag : uint8_t {
@@ -265,6 +266,15 @@ bool checkTypeMetadataAvailability(Type type, SourceRange loc,
 
 /// Check if \p decl has a introduction version required by -require-explicit-availability
 void checkExplicitAvailability(Decl *decl);
+
+/// Determine the enclosing context that allows for some use of an unsafe
+/// construct, and whether that reference is in the definition (true) vs.
+/// in the interface (false) of that context.
+std::pair<const Decl *, bool /*inDefinition*/>
+enclosingContextForUnsafe(SourceLoc referenceLoc, const DeclContext *referenceDC);
+
+/// Diagnose the given unsafe use right now.
+void diagnoseUnsafeUse(const UnsafeUse &use);
 
 } // namespace swift
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -280,7 +280,6 @@ void diagnoseUnsafeUse(const UnsafeUse &use, bool asNote = false);
 /// declaration, if there are any.
 void diagnoseUnsafeUsesIn(const Decl *decl);
 
-
 } // namespace swift
 
 #endif // SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -274,7 +274,12 @@ std::pair<const Decl *, bool /*inDefinition*/>
 enclosingContextForUnsafe(SourceLoc referenceLoc, const DeclContext *referenceDC);
 
 /// Diagnose the given unsafe use right now.
-void diagnoseUnsafeUse(const UnsafeUse &use);
+void diagnoseUnsafeUse(const UnsafeUse &use, bool asNote = false);
+
+/// Diagnose any unsafe uses within the signature or definition of the given
+/// declaration, if there are any.
+void diagnoseUnsafeUsesIn(const Decl *decl);
+
 
 } // namespace swift
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1645,9 +1645,6 @@ ReferencedActor ReferencedActor::forGlobalActor(VarDecl *actor,
   return ReferencedActor(actor, isPotentiallyIsolated, kind, globalActor);
 }
 
-static ActorIsolation getActorIsolationForReference(
-    ValueDecl *decl, const DeclContext *fromDC);
-
 bool ReferencedActor::isKnownToBeLocal() const {
   switch (kind) {
   case GlobalActor:
@@ -7161,7 +7158,7 @@ bool swift::isPotentiallyIsolatedActor(
 
 /// Determine the actor isolation used when we are referencing the given
 /// declaration.
-static ActorIsolation getActorIsolationForReference(ValueDecl *decl,
+ActorIsolation swift::getActorIsolationForReference(ValueDecl *decl,
                                                     const DeclContext *fromDC) {
   auto declIsolation = getActorIsolation(decl);
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -564,6 +564,11 @@ checkGlobalActorAttributes(SourceLoc loc, DeclContext *dc,
 /// Get the explicit global actor specified for a closure.
 Type getExplicitGlobalActor(ClosureExpr *closure);
 
+/// Determine the actor isolation used when we are referencing the given
+/// declaration.
+ActorIsolation getActorIsolationForReference(ValueDecl *decl,
+                                             const DeclContext *fromDC);
+
 /// Adjust the type of the variable for concurrency.
 Type adjustVarTypeForConcurrency(
     Type type, VarDecl *var, DeclContext *dc,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/UnsafeUse.h"
 #include "swift/Basic/Assertions.h"
 using namespace swift;
 
@@ -2251,16 +2252,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     bool shouldDiagnose = !overridingClass || !overridingClass->allowsUnsafe();
 
     if (shouldDiagnose) {
-      override->diagnose(diag::override_safe_withunsafe,
-                         base->getDescriptiveKind());
-      if (overridingClass) {
-        overridingClass->diagnose(
-            diag::make_subclass_unsafe, overridingClass->getName()
-        ).fixItInsert(
-            overridingClass->getAttributeInsertionLoc(false), "@unsafe ");
-      }
-
-      base->diagnose(diag::overridden_here);
+      diagnoseUnsafeUse(UnsafeUse::forOverride(override, base));
     }
   }
   /// Check attributes associated with the base; some may need to merged with

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2348,8 +2348,21 @@ public:
             { });
       }
     }
+
+    // Diagnose any uses of unsafe constructs within this declaration.
+    if (!hasUnsafeCheckingOutsideOfPrimary(decl))
+      diagnoseUnsafeUsesIn(decl);
   }
 
+  /// Determine whether @unsafe checking for this declaration occurs outside
+  /// of "primary" declaration checking, e.g., with the request that
+  /// type-checks a function body.
+  static bool hasUnsafeCheckingOutsideOfPrimary(const Decl *decl) {
+    if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
+      return func->hasBody();
+
+    return false;
+  }
 
   //===--------------------------------------------------------------------===//
   // Visit Methods.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2469,7 +2469,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
     if (!conformance->getDeclContext()->allowsUnsafe()) {
       diagnoseUnsafeUse(
-          UnsafeUse::forConformance(conformance, ComplainLoc));
+          UnsafeUse::forConformance(conformance, ComplainLoc,
+                                    conformance->getDeclContext()));
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -240,10 +240,6 @@ bool witnessHasImplementsAttrForRequiredName(ValueDecl *witness,
 bool witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
                                                  ValueDecl *requirement);
 
-/// Suggest that the context of the given conformance be marked to suppress
-/// warnings about uses of unsafe constructs.
-void suggestUnsafeMarkerOnConformance(NormalProtocolConformance *conformance);
-
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2949,6 +2949,8 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
     TypeChecker::checkFunctionEffects(AFD);
   }
 
+  diagnoseUnsafeUsesIn(AFD);
+
   return hadError ? errorBody() : body;
 }
 

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -87,16 +87,6 @@ static void suggestUnsafeMarkerOnConformance(
   ).fixItInsert(decl->getAttributeInsertionLoc(false), "@unsafe ");
 }
 
-static bool shouldDeferUnsafeUseIn(const Decl *decl) {
-  if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(decl)) {
-    if (func->hasBody()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 /// Retrieve the extra information
 static SourceFileExtras &getSourceFileExtrasFor(const Decl *decl) {
   auto dc = decl->getDeclContext();
@@ -112,7 +102,7 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use, bool asNote) {
         use.getKind() == UnsafeUse::CallToUnsafe) {
       auto [enclosingDecl, _] = enclosingContextForUnsafe(
           use.getLocation(), use.getDeclContext());
-      if (enclosingDecl && shouldDeferUnsafeUseIn(enclosingDecl)) {
+      if (enclosingDecl) {
         getSourceFileExtrasFor(enclosingDecl).unsafeUses[enclosingDecl]
           .push_back(use);
         return;

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -1,0 +1,159 @@
+//===--- TypeCheckUnsafe.cpp - Unsafe Diagnostics -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements unsafe diagnostics.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/UnsafeUse.h"
+#include "swift/AST/DiagnosticsSema.h"
+#include "TypeCheckAvailability.h"
+#include "TypeCheckType.h"
+
+using namespace swift;
+
+static void suggestUnsafeOnEnclosingDecl(
+    SourceLoc referenceLoc, const DeclContext *referenceDC) {
+  const Decl *decl = nullptr;
+  bool inDefinition = false;
+  std::tie(decl, inDefinition) = enclosingContextForUnsafe(
+      referenceLoc, referenceDC);
+  if (!decl)
+    return;
+
+  if (inDefinition) {
+    // The unsafe construct is inside the body of the entity, so suggest
+    // @safe(unchecked) on the declaration.
+    decl->diagnose(diag::encapsulate_unsafe_in_enclosing_context, decl)
+      .fixItInsert(decl->getAttributeInsertionLoc(false),
+                   "@safe(unchecked) ");
+  } else {
+    // The unsafe construct is not part of the body, so
+    decl->diagnose(diag::make_enclosing_context_unsafe, decl)
+      .fixItInsert(decl->getAttributeInsertionLoc(false), "@unsafe ");
+  }
+}
+
+static void suggestUnsafeMarkerOnConformance(
+    NormalProtocolConformance *conformance) {
+  auto dc = conformance->getDeclContext();
+  auto decl = dc->getAsDecl();
+  if (!decl)
+    return;
+
+  decl->diagnose(
+      diag::make_conforming_context_unsafe,
+      decl->getDescriptiveKind(),
+      conformance->getProtocol()->getName()
+  ).fixItInsert(decl->getAttributeInsertionLoc(false), "@unsafe ");
+}
+
+void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
+  switch (use.getKind()) {
+  case UnsafeUse::Override: {
+    auto override = use.getDecl();
+    override->diagnose(
+        diag::override_safe_withunsafe, override->getDescriptiveKind());
+    if (auto overridingClass = override->getDeclContext()->getSelfClassDecl()) {
+      overridingClass->diagnose(
+          diag::make_subclass_unsafe, overridingClass->getName()
+      ).fixItInsert(
+          overridingClass->getAttributeInsertionLoc(false), "@unsafe ");
+    }
+    use.getOriginalDecl()->diagnose(diag::overridden_here);
+    return;
+  }
+
+  case UnsafeUse::Witness: {
+    auto witness = cast<ValueDecl>(use.getDecl());
+    witness->diagnose(diag::witness_unsafe,
+                      witness->getDescriptiveKind(),
+                      witness->getName());
+    suggestUnsafeMarkerOnConformance(use.getConformance());
+    return;
+  }
+
+  case UnsafeUse::TypeWitness: {
+    auto assocType = use.getAssociatedType();
+    auto loc = use.getLocation();
+    auto type = use.getType();
+    auto conformance = use.getConformance();
+    ASTContext &ctx = assocType->getASTContext();
+
+    diagnoseUnsafeType(ctx, loc, type, conformance->getDeclContext(),
+                       [&](Type specificType) {
+      ctx.Diags.diagnose(
+          loc, diag::type_witness_unsafe, specificType, assocType->getName());
+    });
+    suggestUnsafeMarkerOnConformance(conformance);
+    assocType->diagnose(diag::decl_declared_here, assocType);
+
+    return;
+  }
+
+  case UnsafeUse::UnsafeConformance: {
+    auto conformance = use.getConformance();
+    ASTContext &ctx = conformance->getProtocol()->getASTContext();
+    ctx.Diags.diagnose(
+        use.getLocation(), diag::unchecked_conformance_is_unsafe);
+    suggestUnsafeMarkerOnConformance(conformance);
+    return;
+  }
+
+  case UnsafeUse::UnownedUnsafe: {
+    auto var = cast<VarDecl>(use.getDecl());
+    var->diagnose(diag::unowned_unsafe_is_unsafe);
+    var->diagnose(diag::make_enclosing_context_unsafe, var)
+      .fixItInsert(var->getAttributeInsertionLoc(false), "@unsafe ");
+    return;
+  }
+
+  case UnsafeUse::NonisolatedUnsafe: {
+    auto decl = use.getDecl();
+    ASTContext &ctx = decl->getASTContext();
+    ctx.Diags.diagnose(use.getLocation(), diag::nonisolated_unsafe_is_unsafe);
+    if (auto var = dyn_cast<VarDecl>(decl)) {
+      var->diagnose(diag::make_enclosing_context_unsafe, var)
+        .fixItInsert(var->getAttributeInsertionLoc(false), "@unsafe ");
+    }
+    return;
+  }
+
+  case UnsafeUse::ReferenceToUnsafe:
+  case UnsafeUse::CallToUnsafe: {
+    bool isCall = use.getKind() == UnsafeUse::CallToUnsafe;
+    auto decl = cast<ValueDecl>(use.getDecl());
+    auto loc = use.getLocation();
+    Type type = use.getType();
+    ASTContext &ctx = decl->getASTContext();
+    if (type) {
+      diagnoseUnsafeType(
+          ctx, loc, type,
+          use.getDeclContext(),
+          [&](Type specificType) {
+            ctx.Diags.diagnose(
+                loc, diag::reference_to_unsafe_typed_decl, isCall, decl,
+                specificType);
+          });
+      suggestUnsafeOnEnclosingDecl(loc, use.getDeclContext());
+      decl->diagnose(diag::unsafe_decl_here, decl);
+    } else {
+      ctx.Diags
+        .diagnose(loc, diag::reference_to_unsafe_decl, isCall, decl);
+      suggestUnsafeOnEnclosingDecl(loc, use.getDeclContext());
+      decl->diagnose(diag::unsafe_decl_here, decl);
+    }
+    return;
+  }
+  }
+}

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -317,6 +317,7 @@ extension SerialExecutor {
 /// different objects, the executor must be referenced strongly by the
 /// actor.
 @available(SwiftStdlib 5.1, *)
+@unsafe
 @frozen
 public struct UnownedSerialExecutor: Sendable {
   @usableFromInline

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -81,10 +81,10 @@ func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer)
 func useCfType(x: CFArray) {
 }
 
-// expected-note@+1{{make global function 'useCppSpan' @unsafe to indicate that its use is not memory-safe}}
-func useCppSpan(x: SpanOfInt) { // expected-warning{{reference to unsafe type alias 'SpanOfInt'}}
+// expected-warning@+1{{global function 'useCppSpan' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}
+func useCppSpan(x: SpanOfInt) { // expected-note{{reference to unsafe type alias 'SpanOfInt'}}
 }
 
-// expected-note@+1{{make global function 'useCppSpan2' @unsafe to indicate that its use is not memory-safe}}
-func useCppSpan2(x: SpanOfIntAlias) { // expected-warning{{reference to unsafe type alias 'SpanOfIntAlias'}}
+// expected-warning@+1{{global function 'useCppSpan2' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}
+func useCppSpan2(x: SpanOfIntAlias) { // expected-note{{reference to unsafe type alias 'SpanOfIntAlias'}}
 }

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -60,22 +60,22 @@ using SpanOfIntAlias = SpanOfInt;
 import Test
 import CoreFoundation
 
-// expected-note@+1{{make global function 'useUnsafeParam' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
-func useUnsafeParam(x: Unannotated) { // expected-warning{{reference to unsafe struct 'Unannotated'}}
+// expected-warning@+1{{global function 'useUnsafeParam' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+func useUnsafeParam(x: Unannotated) { // expected-note{{reference to unsafe struct 'Unannotated'}}
 }
 
-// expected-note@+2{{make global function 'useUnsafeParam2' @unsafe to indicate that its use is not memory-safe}}{{10:1-1=@unsafe }}
+// expected-warning@+2{{global function 'useUnsafeParam2' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{10:1-1=@unsafe }}
 @available(SwiftStdlib 5.8, *)
-func useUnsafeParam2(x: UnsafeReference) { // expected-warning{{reference to unsafe class 'UnsafeReference'}}
+func useUnsafeParam2(x: UnsafeReference) { // expected-note{{reference to unsafe class 'UnsafeReference'}}
 }
 
-// expected-note@+1{{make global function 'useUnsafeParam3' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
-func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-warning{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
+// expected-warning@+1{{global function 'useUnsafeParam3' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-note{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
 }
 
-// expected-note@+1{{make global function 'useSafeParams' @safe(unchecked) to allow it to use unsafe constructs in its definition}}{{1-1=@safe(unchecked) }}
+// expected-warning@+1{{global function 'useSafeParams' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe}}{{1-1=@safe(unchecked) }}
 func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer) {
-    let _ = c.__beginUnsafe() // expected-warning{{call to unsafe instance method '__beginUnsafe'}}
+    let _ = c.__beginUnsafe() // expected-note{{call to unsafe instance method '__beginUnsafe()'}}
 }
 
 func useCfType(x: CFArray) {

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -7,7 +7,7 @@
 func unsafeFunction() { }
 
 @unsafe
-struct UnsafeType { } // expected-note 3{{unsafe struct 'UnsafeType' declared here}}
+struct UnsafeType { }
 
 @safe(unchecked)
 func f() {
@@ -19,18 +19,18 @@ func g() {
   unsafeFunction()
 }
 
-// expected-note@+2{{make global function 'h' @unsafe to indicate that its use is not memory-safe}}
+// expected-warning@+2{{global function 'h' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe [Unsafe]}}
 @safe(unchecked, message: "I was careful")
-func h(_: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+func h(_: UnsafeType) { // expected-note{{reference to unsafe struct 'UnsafeType'}}
   unsafeFunction()
 }
 
-// expected-note@+1 {{make global function 'rethrowing' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
-func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+// expected-warning@+1 {{global function 'rethrowing' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-note{{reference to unsafe struct 'UnsafeType'}}
 
 class HasStatics {
-  // expected-note@+1{{make static method 'f' @unsafe to indicate that its use is not memory-safe}}{{3-3=@unsafe }}
-  static internal func f(_: UnsafeType) { } // expected-warning{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+  // expected-warning@+1{{static method 'f' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe [Unsafe]}}{{3-3=@unsafe }}
+  static internal func f(_: UnsafeType) { } // expected-note{{reference to unsafe struct 'UnsafeType'}}
 
   
 }

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -91,7 +91,7 @@ class NonSendable { }
 
 
 @unsafe
-struct UnsafeOuter { // expected-note{{unsafe struct 'UnsafeOuter' declared here}}
+struct UnsafeOuter {
   func f(_: UnsafeType) { } // okay
 
   @unsafe func g(_ y: UnsafeType) {
@@ -100,8 +100,8 @@ struct UnsafeOuter { // expected-note{{unsafe struct 'UnsafeOuter' declared here
   }
 }
 
-// expected-note@+1{{make extension of struct 'UnsafeOuter' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
-extension UnsafeOuter { // expected-warning{{reference to unsafe struct 'UnsafeOuter' [Unsafe]}}
+// expected-warning@+1{{extension of struct 'UnsafeOuter' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+extension UnsafeOuter { // expected-note{{reference to unsafe struct 'UnsafeOuter'}}
   func h(_: UnsafeType) { }
 }
 

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -10,11 +10,11 @@
 func iAmUnsafe() { }
 
 @unsafe
-struct UnsafeType { } // expected-note{{unsafe struct 'UnsafeType' declared here}}
+struct UnsafeType { }
 
-// expected-warning@+1{{reference to unsafe struct 'UnsafeType' [Unsafe]}}
+// expected-note@+1{{reference to unsafe struct 'UnsafeType'}}
 func iAmImpliedUnsafe() -> UnsafeType? { nil }
-// expected-note@-1{{make global function 'iAmImpliedUnsafe' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+// expected-warning@-1{{global function 'iAmImpliedUnsafe' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe [Unsafe]}}{{1-1=@unsafe }}
 
 @unsafe
 func labeledUnsafe(_: UnsafeType) {

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -61,8 +61,8 @@ struct SuperHolder {
 // -----------------------------------------------------------------------
 // Inheritance of @unsafe
 // -----------------------------------------------------------------------
-@unsafe class UnsafeSuper { // expected-note 5{{'UnsafeSuper' declared here}}
-  func f() { } // expected-note{{unsafe instance method 'f' declared here}}
+@unsafe class UnsafeSuper { // expected-note 4{{'UnsafeSuper' declared here}}
+  func f() { }
 };
 
 class UnsafeSub: UnsafeSuper { } // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
@@ -71,22 +71,20 @@ class UnsafeSub: UnsafeSuper { } // expected-warning{{reference to unsafe class 
 // -----------------------------------------------------------------------
 // Declaration references
 // -----------------------------------------------------------------------
-@unsafe func unsafeF() { } // expected-note{{unsafe global function 'unsafeF' declared here}}
-@unsafe var unsafeVar: Int = 0 // expected-note{{'unsafeVar' declared here}}
+@unsafe func unsafeF() { }
+@unsafe var unsafeVar: Int = 0
 
-// expected-note@+2 5{{make global function 'testMe' @safe(unchecked) to allow it to use unsafe constructs in its definition}}{{1-1=@safe(unchecked) }}
-// expected-note@+1 2{{make global function 'testMe' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+// expected-warning@+1{{global function 'testMe' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe [Unsafe]}}{{1-1=@unsafe }}
 func testMe(
-  _ pointer: PointerType, // expected-warning{{reference to unsafe struct 'PointerType'}}
-  _ unsafeSuper: UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
-  // expected-note@-1{{'unsafeSuper' declared here}}
+  _ pointer: PointerType, // expected-note{{reference to unsafe struct 'PointerType'}}
+  _ unsafeSuper: UnsafeSuper // expected-note{{reference to unsafe class 'UnsafeSuper'}}
 ) { 
-  unsafeF() // expected-warning{{call to unsafe global function 'unsafeF'}}
-  _ = unsafeVar // expected-warning{{reference to unsafe var 'unsafeVar'}}
-  unsafeSuper.f() // expected-warning{{call to unsafe instance method 'f'}}
-  // expected-warning@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
+  unsafeF() // expected-note{{call to unsafe global function 'unsafeF()'}}
+  _ = unsafeVar // expected-note{{reference to unsafe var 'unsafeVar'}}
+  unsafeSuper.f() // expected-note{{call to unsafe instance method 'f()'}}
+  // expected-note@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
 
-  _ = getPointers() // expected-warning{{call to global function 'getPointers' involves unsafe type 'PointerType'}}
+  _ = getPointers() // expected-note{{call to global function 'getPointers()' involves unsafe type 'PointerType'}}
 }
 
 // -----------------------------------------------------------------------

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -61,8 +61,7 @@ struct SuperHolder {
     return s2 // expected-note{{reference to unowned(unsafe) property 's2' is unsafe}}
   }
 
-  // FIXME: We should be able to identify this as being inside the function
-  // expected-warning@+1{{instance method 'getSuper2b' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}
+  // expected-warning@+1{{instance method 'getSuper2b' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe}}
   func getSuper2b() -> Super {
     s2 // expected-note{{reference to unowned(unsafe) property 's2' is unsafe}}
   }

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -54,8 +54,18 @@ class Sub: Super { // expected-note{{make class 'Sub' @unsafe to allow unsafe ov
 // -----------------------------------------------------------------------
 struct SuperHolder {
   unowned var s1: Super
-  unowned(unsafe) var s2: Super // expected-warning{{unowned(unsafe) involves unsafe code}}
-  // expected-note@-1{{make property 's2' @unsafe to indicate that its use is not memory-safe}}{{3-3=@unsafe }}
+  unowned(unsafe) var s2: Super
+
+  // expected-warning@+1{{instance method 'getSuper2' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe}}
+  func getSuper2() -> Super {
+    return s2 // expected-note{{reference to unowned(unsafe) property 's2' is unsafe}}
+  }
+
+  // FIXME: We should be able to identify this as being inside the function
+  // expected-warning@+1{{instance method 'getSuper2b' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}
+  func getSuper2b() -> Super {
+    s2 // expected-note{{reference to unowned(unsafe) property 's2' is unsafe}}
+  }
 }
 
 // -----------------------------------------------------------------------

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -61,12 +61,12 @@ struct SuperHolder {
 // -----------------------------------------------------------------------
 // Inheritance of @unsafe
 // -----------------------------------------------------------------------
-@unsafe class UnsafeSuper { // expected-note 4{{'UnsafeSuper' declared here}}
+@unsafe class UnsafeSuper { // expected-note{{'UnsafeSuper' declared here}}
   func f() { }
 };
 
-class UnsafeSub: UnsafeSuper { } // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
-// expected-note@-1{{make class 'UnsafeSub' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+class UnsafeSub: UnsafeSuper { } // expected-warning{{class 'UnsafeSub' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+// expected-note@-1{{reference to unsafe class 'UnsafeSuper'}}
 
 // -----------------------------------------------------------------------
 // Declaration references
@@ -90,13 +90,13 @@ func testMe(
 // -----------------------------------------------------------------------
 // Various declaration kinds
 // -----------------------------------------------------------------------
-// expected-note@+1{{make type alias 'SuperUnsafe' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
-typealias SuperUnsafe = UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper' [Unsafe]}}
+// expected-warning@+1{{type alias 'SuperUnsafe' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+typealias SuperUnsafe = UnsafeSuper // expected-note{{reference to unsafe class 'UnsafeSuper'}}
 @unsafe typealias SuperUnsafe2 = UnsafeSuper
 
 enum HasUnsafeThings {
-// expected-note@+1{{make enum case 'one' @unsafe to indicate that its use is not memory-safe}}
-case one(UnsafeSuper) // expected-warning{{reference to unsafe class 'UnsafeSuper' [Unsafe]}}
+// expected-warning@+1{{enum case 'one' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+case one(UnsafeSuper) // expected-note{{reference to unsafe class 'UnsafeSuper'}}
 
 @unsafe case two(UnsafeSuper)
 }

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature WarnUnsafe -enable-experimental-feature StrictConcurrency
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_AllowUnsafeAttribute
 // REQUIRES: swift_feature_StrictConcurrency
 // REQUIRES: swift_feature_WarnUnsafe
 

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -enable-experimental-feature StrictConcurrency
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature WarnUnsafe -enable-experimental-feature StrictConcurrency
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_AllowUnsafeAttribute
@@ -11,15 +11,15 @@ class C: @unchecked Sendable {
   var counter: Int = 0
 }
 
+nonisolated(unsafe) var globalCounter = 0
+
 @available(SwiftStdlib 5.1, *)
-func f() async {
-  // expected-warning@+2{{nonisolated(unsafe) involves unsafe code}}
-  // expected-note@+1{{make var 'counter' @unsafe to indicate that its use is not memory-safe}}
+func f() async { // expected-warning{{global function 'f' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe}}
   nonisolated(unsafe) var counter = 0
   Task.detached {
-    counter += 1
+    counter += 1 // expected-note{{reference to nonisolated(unsafe) var 'counter' is unsafe in concurrently-executing code}}
   }
-  counter += 1
-  print(counter)
+  counter += 1 // expected-note{{reference to nonisolated(unsafe) var 'counter' is unsafe in concurrently-executing code}}
+  print(counter) // expected-note{{reference to nonisolated(unsafe) var 'counter' is unsafe in concurrently-executing code}}
+  print(globalCounter) // expected-note{{reference to nonisolated(unsafe) var 'globalCounter' is unsafe in concurrently-executing code}}
 }
-

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -5,12 +5,11 @@
 
 import unsafe_decls
 
-// expected-note@+2 2{{make global function 'testUnsafe' @safe(unchecked) to allow it to use unsafe constructs in its definition}}
-// expected-note@+1{{make global function 'testUnsafe' @unsafe to indicate that its use is not memory-safe}}
-func testUnsafe(_ ut: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType'}}
-  unsafe_c_function() // expected-warning{{call to unsafe global function 'unsafe_c_function'}}
+// expected-warning@+1{{global function 'testUnsafe' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+func testUnsafe(_ ut: UnsafeType) { // expected-note{{reference to unsafe struct 'UnsafeType'}}
+  unsafe_c_function() // expected-note{{call to unsafe global function 'unsafe_c_function()'}}
 
   var array: [CInt] = [1, 2, 3, 4, 5]
   print_ints(&array, CInt(array.count))
-  // expected-warning@-1{{call to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}
+  // expected-note@-1{{call to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}
 }

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -6,16 +6,15 @@
 // REQUIRES: swift_feature_AllowUnsafeAttribute
 // REQUIRES: swift_feature_WarnUnsafe
 
-// expected-note@+2 2{{make global function 'test' @safe(unchecked) to allow it to use unsafe constructs in its definition}}{{1-1=@safe(unchecked) }}
-// expected-note@+1 2{{make global function 'test' @unsafe to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
+// expected-warning@+1{{global function 'test' involves unsafe code; use '@unsafe' to indicate that its use is not memory-safe}}{{1-1=@unsafe }}
 func test(
-  x: OpaquePointer, // expected-warning{{reference to unsafe struct 'OpaquePointer'}}
-  other: UnsafeMutablePointer<Int> // expected-warning{{reference to unsafe generic struct 'UnsafeMutablePointer'}}
+  x: OpaquePointer, // expected-note{{reference to unsafe struct 'OpaquePointer'}}
+  other: UnsafeMutablePointer<Int> // expected-note{{reference to unsafe generic struct 'UnsafeMutablePointer'}}
 ) {
   var array = [1, 2, 3]
-  // expected-warning@+1{{call to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
-  array.withUnsafeBufferPointer{ buffer in // expected-note{{'buffer' declared here}}
-    print(buffer) // expected-warning{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  // expected-note@+1{{call to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  array.withUnsafeBufferPointer{ buffer in
+    print(buffer) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
   }
   array.append(4)
   _ = array


### PR DESCRIPTION
Instead of producing a warning for each use of an unsafe entity, collect all of the uses of unsafe constructs within a given function and batch them together in a single diagnostic at the enclosing declaration that tells you what you can do (add `@unsafe` or `@safe(unchecked)`, depending on whether all unsafe uses were in the definition), plus notes identifying every unsafe use within that declaration. The new diagnostic renderer nicely collects together in a single snippet, so it's easier to reason about.

Here's an example from the embedded runtime that previously would have been 6 separate warnings, each with 1-2 notes:

```
swift/stdlib/public/core/EmbeddedRuntime.swift:397:13: warning: global function 'swift_retainCount' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe
395 |
396 | @_cdecl("swift_retainCount")
397 | public func swift_retainCount(object: Builtin.RawPointer) -> Int {
    |             `- warning: global function 'swift_retainCount' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe
398 |   if !isValidPointerForNativeRetain(object: object) { return 0 }
399 |   let o = UnsafeMutablePointer<HeapObject>(object)
    |           |                              `- note: call to unsafe initializer 'init(_:)'
    |           `- note: reference to unsafe generic struct 'UnsafeMutablePointer'
400 |   let refcount = refcountPointer(for: o)
    |                  |                    `- note: reference to let 'o' involves unsafe type 'UnsafeMutablePointer<HeapObject>'
    |                  `- note: call to global function 'refcountPointer(for:)' involves unsafe type 'UnsafeMutablePointer<Int>'
401 |   return loadAcquire(refcount) & HeapObject.refcountMask
    |          |           `- note: reference to let 'refcount' involves unsafe type 'UnsafeMutablePointer<Int>'
    |          `- note: call to global function 'loadAcquire' involves unsafe type 'UnsafeMutablePointer<Int>'
402 | }
403 |
```

Note that we have lost a little bit of information, because we no longer produce "unsafe declaration was here" notes pointing back at things like `UnsafeMutablePointer` or `recountPointer(for:)`. However, strict memory safety tends to be noisy to turn on, so it's worth losing a little bit of easily-recovered information to gain some brevity.

While here, also fix a few issues with the checking:
* Diagnose uses of `nonisolated(unsafe)` declarations, not the declaration itself
* Diagnose uses of `unowned(unsafe)` declarations, not the declaration itself
