### PR TITLE
Continue adoption of `SemanticAvailableAttr`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3189,6 +3189,18 @@ public:
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const { return domain; }
 
+  std::optional<llvm::VersionTuple> getIntroduced() const {
+    return attr->Introduced;
+  }
+
+  std::optional<llvm::VersionTuple> getDeprecated() const {
+    return attr->Deprecated;
+  }
+
+  std::optional<llvm::VersionTuple> getObsoleted() const {
+    return attr->Obsoleted;
+  }
+
   /// Returns the `message:` field of the attribute, or an empty string.
   StringRef getMessage() const { return attr->Message; }
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3197,6 +3197,9 @@ public:
   /// `PlatformKind::none` if the attribute is not platform specific.
   PlatformKind getPlatformKind() const { return getDomain().getPlatformKind(); }
 
+  /// Whether this is a `noasync` attribute.
+  bool isNoAsync() const { return attr->isNoAsync(); }
+
   /// Whether this attribute has an introduced, deprecated, or obsoleted
   /// version.
   bool isVersionSpecific() const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3215,6 +3215,16 @@ public:
   /// `PlatformKind::none` if the attribute is not platform specific.
   PlatformKind getPlatform() const { return getDomain().getPlatformKind(); }
 
+  /// Whether this is attribute indicates unavailability in all versions.
+  bool isUnconditionallyUnavailable() const {
+    return attr->isUnconditionallyUnavailable();
+  }
+
+  /// Whether this is attribute indicates deprecation in all versions.
+  bool isUnconditionallyDeprecated() const {
+    return attr->isUnconditionallyDeprecated();
+  }
+
   /// Whether this is a `noasync` attribute.
   bool isNoAsync() const { return attr->isNoAsync(); }
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3244,6 +3244,9 @@ public:
     return getDomain().isPackageDescription() && isVersionSpecific();
   }
 
+  /// Whether this attribute was spelled `@_unavailableInEmbedded`.
+  bool isEmbeddedSpecific() const { return attr->isForEmbedded(); }
+
   /// Returns the active version from the AST context corresponding to
   /// the available kind. For example, this will return the effective language
   /// version for swift version-specific availability kind, PackageDescription

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3191,11 +3191,11 @@ public:
 
   /// Returns the platform kind that the attribute applies to, or
   /// `PlatformKind::none` if the attribute is not platform specific.
-  bool isPlatformSpecific() const { return domain.isPlatform(); }
+  bool isPlatformSpecific() const { return getDomain().isPlatform(); }
 
   /// Returns the platform kind that the attribute applies to, or
   /// `PlatformKind::none` if the attribute is not platform specific.
-  PlatformKind getPlatformKind() const { return domain.getPlatformKind(); }
+  PlatformKind getPlatformKind() const { return getDomain().getPlatformKind(); }
 
   /// Whether this attribute has an introduced, deprecated, or obsoleted
   /// version.
@@ -3205,12 +3205,12 @@ public:
 
   /// Whether this is a language mode specific attribute.
   bool isSwiftLanguageModeSpecific() const {
-    return domain.isSwiftLanguage() && isVersionSpecific();
+    return getDomain().isSwiftLanguage() && isVersionSpecific();
   }
 
   /// Whether this is a PackageDescription version specific attribute.
   bool isPackageDescriptionVersionSpecific() const {
-    return domain.isPackageDescription() && isVersionSpecific();
+    return getDomain().isPackageDescription() && isVersionSpecific();
   }
 
   /// Returns the active version from the AST context corresponding to

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3237,6 +3237,14 @@ public:
   /// Returns true if this attribute is considered active in the current
   /// compilation context.
   bool isActive(ASTContext &ctx) const;
+
+  bool operator==(const SemanticAvailableAttr &other) const {
+    return other.attr == attr;
+  }
+
+  bool operator!=(const SemanticAvailableAttr &other) const {
+    return other.attr != attr;
+  }
 };
 
 /// An iterable range of `SemanticAvailableAttr`s.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3189,13 +3189,19 @@ public:
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const { return domain; }
 
+  /// Returns the `message:` field of the attribute, or an empty string.
+  StringRef getMessage() const { return attr->Message; }
+
+  /// Returns the `rename:` field of the attribute, or an empty string.
+  StringRef getRename() const { return attr->Rename; }
+
   /// Returns the platform kind that the attribute applies to, or
   /// `PlatformKind::none` if the attribute is not platform specific.
   bool isPlatformSpecific() const { return getDomain().isPlatform(); }
 
   /// Returns the platform kind that the attribute applies to, or
   /// `PlatformKind::none` if the attribute is not platform specific.
-  PlatformKind getPlatformKind() const { return getDomain().getPlatformKind(); }
+  PlatformKind getPlatform() const { return getDomain().getPlatformKind(); }
 
   /// Whether this is a `noasync` attribute.
   bool isNoAsync() const { return attr->isNoAsync(); }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1443,12 +1443,12 @@ public:
   ///
   /// Note that this query only considers the attributes that are attached
   /// directly to this decl (or the extension it is declared in, if applicable).
-  bool isUnavailable() const { return getUnavailableAttr() != nullptr; }
+  bool isUnavailable() const { return getUnavailableAttr().has_value(); }
 
   /// If the decl is always unavailable in the current compilation
   /// context, returns the attribute attached to the decl (or its parent
   /// extension) that makes it unavailable.
-  const AvailableAttr *
+  std::optional<SemanticAvailableAttr>
   getUnavailableAttr(bool ignoreAppExtensions = false) const;
 
   /// Returns true if the decl is effectively always unavailable in the current

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1428,7 +1428,7 @@ public:
 
   /// Returns the first @available attribute that indicates this decl is
   /// unavailable from asynchronous contexts, or `nullptr` otherwise.
-  const AvailableAttr *getNoAsyncAttr() const;
+  std::optional<SemanticAvailableAttr> getNoAsyncAttr() const;
 
   /// Returns true if the decl has been marked unavailable in the Swift language
   /// version that is currently active.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1416,15 +1416,15 @@ public:
 
   /// Returns true if the declaration is deprecated at the current deployment
   /// target.
-  bool isDeprecated() const { return getDeprecatedAttr() != nullptr; }
+  bool isDeprecated() const { return getDeprecatedAttr().has_value(); }
 
   /// Returns the first `@available` attribute that indicates that this decl
   /// is deprecated on current deployment target, or `nullptr` otherwise.
-  const AvailableAttr *getDeprecatedAttr() const;
+  std::optional<SemanticAvailableAttr> getDeprecatedAttr() const;
 
   /// Returns the first `@available` attribute that indicates that this decl
   /// will be deprecated in the future, or `nullptr` otherwise.
-  const AvailableAttr *getSoftDeprecatedAttr() const;
+  std::optional<SemanticAvailableAttr> getSoftDeprecatedAttr() const;
 
   /// Returns the first @available attribute that indicates this decl is
   /// unavailable from asynchronous contexts, or `nullptr` otherwise.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1411,7 +1411,7 @@ public:
   /// Returns the active platform-specific `@available` attribute for this decl.
   /// There may be multiple `@available` attributes that are relevant to the
   /// current platform, but the returned one has the highest priority.
-  const AvailableAttr *getActiveAvailableAttrForCurrentPlatform(
+  std::optional<SemanticAvailableAttr> getActiveAvailableAttrForCurrentPlatform(
       bool ignoreAppExtensions = false) const;
 
   /// Returns true if the declaration is deprecated at the current deployment

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -588,8 +588,7 @@ const AvailableAttr *Decl::getNoAsyncAttr() const {
        getSemanticAvailableAttrs(/*includingInactive=*/false)) {
     auto attr = semanticAttr.getParsedAttr();
 
-    if (attr->getPlatformAgnosticAvailability() !=
-        PlatformAgnosticAvailabilityKind::NoAsync)
+    if (!semanticAttr.isNoAsync())
       continue;
 
     if (!bestAttr) {

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -57,10 +57,10 @@ bool AvailabilityContext::PlatformInfo::constrainWith(const Decl *decl) {
   if (auto range = AvailabilityInference::annotatedAvailableRange(decl))
     isConstrained |= constrainRange(Range, *range);
 
-  if (auto *attr = decl->getUnavailableAttr()) {
+  if (auto attr = decl->getUnavailableAttr()) {
     isConstrained |= constrainUnavailability(attr->getPlatform());
     isConstrained |=
-        CONSTRAIN_BOOL(IsUnavailableInEmbedded, attr->isForEmbedded());
+        CONSTRAIN_BOOL(IsUnavailableInEmbedded, attr->isEmbeddedSpecific());
   }
 
   isConstrained |= CONSTRAIN_BOOL(IsDeprecated, decl->isDeprecated());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9278,16 +9278,14 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
   // `getAttrs` is in reverse source order, so the last attribute is the
   // first in source.
   AbstractFunctionDecl *alternative = nullptr;
-  for (auto semanticAttr : getSemanticAvailableAttrs()) {
-    auto attr = semanticAttr.getParsedAttr();
-
-    if (attr->isNoAsync())
+  for (auto attr : getSemanticAvailableAttrs()) {
+    if (attr.isNoAsync())
       continue;
 
-    if (attr->getPlatform() != PlatformKind::none && alternative != nullptr)
+    if (attr.isPlatformSpecific() && alternative != nullptr)
       continue;
 
-    if (auto *renamedDecl = getRenamedDecl(attr)) {
+    if (auto *renamedDecl = getRenamedDecl(attr.getParsedAttr())) {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(renamedDecl)) {
         if (afd->hasAsync())
           alternative = afd;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4833,10 +4833,10 @@ void AttributeChecker::checkBackDeployedAttrs(
         // Find the attribute that makes the declaration unavailable.
         const Decl *attrDecl = D;
         do {
-          if (auto *unavailableAttr = attrDecl->getUnavailableAttr()) {
-            diagnose(unavailableAttr->AtLoc,
+          if (auto unavailableAttr = attrDecl->getUnavailableAttr()) {
+            diagnose(unavailableAttr->getParsedAttr()->AtLoc,
                      diag::availability_marked_unavailable, VD)
-                .highlight(unavailableAttr->getRange());
+                .highlight(unavailableAttr->getParsedAttr()->getRange());
             break;
           }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2184,14 +2184,14 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   // we're checking an iOS attribute while building for macCatalyst.
   if (attr->getPlatform() == PlatformKind::iOS &&
       isPlatformActive(PlatformKind::macCatalyst, Ctx.LangOpts)) {
-    if (attr != D->getActiveAvailableAttrForCurrentPlatform()) {
+    if (semanticAttr != D->getActiveAvailableAttrForCurrentPlatform()) {
       return;
     }
   }
 
   if (attr->getPlatform() == PlatformKind::iOS &&
       isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
-    if (attr != D->getActiveAvailableAttrForCurrentPlatform()) {
+    if (semanticAttr != D->getActiveAvailableAttrForCurrentPlatform()) {
       return;
     }
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2373,14 +2373,14 @@ diagnosePotentialUnavailability(const RootProtocolConformance *rootConf,
 /// declaration is deprecated or null otherwise.
 static const AvailableAttr *getDeprecated(const Decl *D) {
   auto &Ctx = D->getASTContext();
-  if (auto *Attr = D->getDeprecatedAttr())
-    return Attr;
+  if (auto Attr = D->getDeprecatedAttr())
+    return Attr->getParsedAttr();
 
   if (Ctx.LangOpts.WarnSoftDeprecated) {
     // When -warn-soft-deprecated is specified, treat any declaration that is
     // deprecated in the future as deprecated.
-    if (auto *Attr = D->getSoftDeprecatedAttr())
-      return Attr;
+    if (auto Attr = D->getSoftDeprecatedAttr())
+      return Attr->getParsedAttr();
   }
 
   // Treat extensions methods as deprecated if their extension

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4201,14 +4201,14 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
   }
 
   // @available(noasync) spelling
-  if (const AvailableAttr *attr = D->getNoAsyncAttr()) {
+  if (auto attr = D->getNoAsyncAttr()) {
     SourceLoc diagLoc = call ? call->getLoc() : R.Start;
-    auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl,
-                                   D, attr->Message);
+    auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl, D,
+                                   attr->getMessage());
     diag.warnUntilSwiftVersion(6);
 
-    if (!attr->Rename.empty()) {
-      fixItAvailableAttrRename(diag, R, D, attr, call);
+    if (!attr->getRename().empty()) {
+      fixItAvailableAttrRename(diag, R, D, attr->getParsedAttr(), call);
     }
     return true;
   }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -13,7 +13,7 @@
 #ifndef SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H
 #define SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H
 
-#include "swift/AST/AttrKind.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/DeclContext.h"
@@ -26,7 +26,6 @@
 
 namespace swift {
   class ApplyExpr;
-  class AvailableAttr;
   class Expr;
   class ClosureExpr;
   class InFlightDiagnostic;
@@ -198,7 +197,8 @@ public:
   /// is not also unavailable in the same way, then this returns the specific
   /// `@available` attribute that makes the decl unavailable. Otherwise, returns
   /// nullptr.
-  const AvailableAttr *shouldDiagnoseDeclAsUnavailable(const Decl *decl) const;
+  std::optional<SemanticAvailableAttr>
+  shouldDiagnoseDeclAsUnavailable(const Decl *decl) const;
 };
 
 /// Check if a declaration is exported as part of a module's external interface.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -242,18 +242,14 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
 
 static bool isUnavailableInAllVersions(ValueDecl *decl) {
   ASTContext &ctx = decl->getASTContext();
-  auto *attr = decl->getUnavailableAttr();
+  auto attr = decl->getUnavailableAttr();
   if (!attr)
-    return false;
-
-  auto semanticAttr = decl->getSemanticAvailableAttr(attr);
-  if (!semanticAttr)
     return false;
 
   if (attr->isUnconditionallyUnavailable())
     return true;
 
-  return semanticAttr->getVersionAvailability(ctx) ==
+  return attr->getVersionAvailability(ctx) ==
          AvailableVersionComparison::Unavailable;
 }
 
@@ -1942,11 +1938,12 @@ checkOverrideUnavailability(ValueDecl *override, ValueDecl *base) {
     }
   }
 
-  auto *baseUnavailableAttr = base->getUnavailableAttr();
-  auto *overrideUnavailableAttr = override->getUnavailableAttr();
+  auto baseUnavailableAttr = base->getUnavailableAttr();
+  auto overrideUnavailableAttr = override->getUnavailableAttr();
 
   if (baseUnavailableAttr && !overrideUnavailableAttr)
-    return {OverrideUnavailabilityStatus::BaseUnavailable, baseUnavailableAttr};
+    return {OverrideUnavailabilityStatus::BaseUnavailable,
+            baseUnavailableAttr->getParsedAttr()};
 
   return {OverrideUnavailabilityStatus::Compatible, nullptr};
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4452,8 +4452,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
             auto &ctx = witness->getASTContext();
             auto &diags = ctx.Diags;
             SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
-            auto *attr = witness->getDeprecatedAttr();
-            EncodedDiagnosticMessage EncodedMessage(attr->Message);
+            auto attr = witness->getDeprecatedAttr();
+            EncodedDiagnosticMessage EncodedMessage(attr->getMessage());
             diags.diagnose(diagLoc, diag::witness_deprecated,
                            witness, conformance->getProtocol()->getName(),
                            EncodedMessage.Message);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4376,7 +4376,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
 
     case CheckKind::Unavailable: {
-      auto *attr = requirement->getUnavailableAttr();
+      auto *attr = requirement->getUnavailableAttr()->getParsedAttr();
       diagnoseOverrideOfUnavailableDecl(witness, requirement, attr);
       break;
     }
@@ -4434,8 +4434,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         [witness, requirement](NormalProtocolConformance *conformance) {
           auto &diags = witness->getASTContext().Diags;
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
-          auto *attr = witness->getUnavailableAttr();
-          EncodedDiagnosticMessage EncodedMessage(attr->Message);
+          auto attr = witness->getUnavailableAttr();
+          EncodedDiagnosticMessage EncodedMessage(attr->getMessage());
           diags.diagnose(diagLoc, diag::witness_unavailable, witness,
                          conformance->getProtocol(), EncodedMessage.Message);
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
@@ -4854,7 +4854,7 @@ static bool diagnoseTypeWitnessAvailability(
         conformance, shouldError,
         [witness, assocType, attr](NormalProtocolConformance *conformance) {
           SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
-          EncodedDiagnosticMessage encodedMessage(attr->Message);
+          EncodedDiagnosticMessage encodedMessage(attr->getMessage());
           auto &ctx = conformance->getDeclContext()->getASTContext();
           ctx.Diags
               .diagnose(loc, diag::witness_unavailable, witness,

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -111,7 +111,7 @@ SymbolGraph *SymbolGraphASTWalker::getModuleSymbolGraph(const Decl *D) {
 }
 
 static bool isUnavailableOrObsoletedOnPlatform(const Decl *D) {
-  if (const auto *Avail = D->getUnavailableAttr()) {
+  if (const auto Avail = D->getUnavailableAttr()) {
     if (Avail->getPlatform() != PlatformKind::none)
       return true;
   }


### PR DESCRIPTION
Build on https://github.com/swiftlang/swift/pull/78284 by adopting `SemanticAvailableAttr` in more places. Many of the availability query methods on `Decl` now return `SemanticAvailableAttr` instead of `AvailableAttr *`.