### PR TITLE
Add an `@_addressableForDependencies` type attribute.

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -524,18 +524,22 @@ DECL_ATTR(lifetime, Lifetime,
   161)
 
 SIMPLE_DECL_ATTR(_addressableSelf, AddressableSelf,
-  OnAccessor | OnConstructor | OnFunc | OnSubscript | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | UserInaccessible,
+  OnAccessor | OnConstructor | OnFunc | OnSubscript | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UserInaccessible,
   162)
+
+SIMPLE_DECL_ATTR(_addressableForDependencies, AddressableForDependencies,
+  OnNominalType | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UserInaccessible,
+  163)
 
 DECL_ATTR(safe, Safe,
   OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
   OnExtension | OnTypeAlias | OnImport | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
-  163)
+  164)
 
 DECL_ATTR(abi, ABI,
   OnAbstractFunction | OnVar /* will eventually add types */ | LongAttribute | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
-  164)
+  165)
 DECL_ATTR_FEATURE_REQUIREMENT(ABI, ABIAttribute)
 
 LAST_DECL_ATTR(ABI)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -313,6 +313,10 @@ ERROR(addressable_not_enabled,none,
       "@_addressable is an experimental feature", ())
 ERROR(addressableSelf_not_on_method,none,
       "@_addressableSelf cannot be applied to non-member declarations", ())
+ERROR(addressable_types_not_enabled,none,
+      "@_addressableForDependencies is an experimental feature", ())
+ERROR(class_cannot_be_addressable_for_dependencies,none,
+      "a class cannot be @_addressableForDependencies", ())
 
 ERROR(unsupported_closure_attr,none,
       "%select{attribute |}0 '%1' is not supported on a closure",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -434,6 +434,7 @@ EXPERIMENTAL_FEATURE(CoroutineAccessorsAllocateInCallee, false)
 EXPERIMENTAL_FEATURE(GenerateForceToMainActorThunks, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)
+EXPERIMENTAL_FEATURE(AddressableTypes, true)
 
 /// Allow the @abi attribute.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1558,6 +1558,16 @@ public:
   /// for one of its parameters.
   ParameterTypeFlags getFunctionParamFlags(unsigned index) const;
 
+  /// Given that the value being abstracted is a function type, return whether
+  /// the indicated parameter should be treated as addressable, meaning
+  /// calls should preserve the in-memory address of the argument for as
+  /// long as any dependencies may live.
+  ///
+  /// This may be true either because the type is structurally addressable for
+  /// dependencies, or because it was explicitly marked as `@_addressable`
+  /// in its declaration.
+  bool isFunctionParamAddressable(TypeConverter &TC, unsigned index) const;
+
   /// Given that the value being abstracted is a function type, and that
   /// this is not an opaque abstraction pattern, return the number of
   /// parameters in the pattern.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3760,6 +3760,7 @@ public:
 
   TRIVIAL_ATTR_PRINTER(Actor, actor)
   TRIVIAL_ATTR_PRINTER(AddressableSelf, _addressableSelf)
+  TRIVIAL_ATTR_PRINTER(AddressableForDependencies, _addressableForDependencies)
   TRIVIAL_ATTR_PRINTER(AlwaysEmitConformanceMetadata,
                        always_emit_conformance_metadata)
   TRIVIAL_ATTR_PRINTER(AlwaysEmitIntoClient, always_emit_into_client)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -308,6 +308,14 @@ static bool usesFeatureAddressableParameters(Decl *d) {
   return false;
 }
 
+static bool usesFeatureAddressableTypes(Decl *d) {
+  if (d->getAttrs().hasAttribute<AddressableForDependenciesAttr>()) {
+    return true;
+  }
+  
+  return false;
+}
+
 UNINTERESTING_FEATURE(IsolatedAny2)
 UNINTERESTING_FEATURE(GlobalActorIsolatedTypesUsability)
 UNINTERESTING_FEATURE(ObjCImplementation)

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -191,6 +191,7 @@ extension ASTGenVisitor {
 
       // Simple attributes.
       case .addressableSelf,
+        .addressableForDependencies,
         .alwaysEmitConformanceMetadata,
         .alwaysEmitIntoClient,
         .atReasync,

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -314,6 +314,12 @@ namespace {
     }
 
     RecursiveProperties
+    getTrivialOpaqueRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
+      return mergeIsTypeExpansionSensitive(isSensitive,
+                                           RecursiveProperties::forTrivial());
+    }
+
+    RecursiveProperties
     getReferenceRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
                                            RecursiveProperties::forReference());
@@ -740,11 +746,11 @@ namespace {
       if (LayoutInfo) {
         if (LayoutInfo->isFixedSizeTrivial()) {
           return asImpl().handleTrivial(
-              type, getTrivialRecursiveProperties(isSensitive));
+              type, getTrivialOpaqueRecursiveProperties(isSensitive));
         }
 
         if (LayoutInfo->isAddressOnlyTrivial()) {
-          auto properties = getTrivialRecursiveProperties(isSensitive);
+          auto properties = getTrivialOpaqueRecursiveProperties(isSensitive);
           properties.setAddressOnly();
           return asImpl().handleAddressOnly(type, properties);
         }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1424,6 +1424,16 @@ public:
   ManagedValue manageBufferForExprResult(SILValue buffer,
                                          const TypeLowering &bufferTL,
                                          SGFContext C);
+                                         
+  /// Tries to emit an argument referring to an addressable parameter as the
+  /// stable address of the parameter.
+  ///
+  /// Returns a null ManagedValue if the argument is not a parameter reference,
+  /// the referenced parameter is not addressable, or the requested
+  /// \c ownership is not compatible with the parameter's ownership. \c arg
+  /// is consumed only if the operation succeeds.
+  ManagedValue tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
+                                                    ValueOwnership ownership);
   
   //===--------------------------------------------------------------------===//
   // Type conversions for expr emission and thunks

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -465,11 +465,17 @@ public:
     /// It may be invalid if no box was made for the value (e.g., because it was
     /// an inout value, or constant emitted to an alloc_stack).
     SILValue box;
+    
+    /// True if the `value` represents the memory location of a value that is
+    /// stable for the lifetimes of any dependencies on that value.
+    bool addressable;
 
-    static VarLoc get(SILValue value, SILValue box = SILValue()) {
+    static VarLoc get(SILValue value, SILValue box = SILValue(),
+                      bool addressable = false) {
       VarLoc Result;
       Result.value = value;
       Result.box = box;
+      Result.addressable = addressable;
       return Result;
     }
   };

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -204,14 +204,17 @@ public:
   }
 
   ManagedValue handleParam(AbstractionPattern origType, CanType substType,
-                           ParamDecl *pd) {
+                           ParamDecl *pd, bool isAddressable) {
     // Note: inouts of tuples are not exploded, so we bypass visit().
     if (pd->isInOut()) {
       return handleInOut(origType, substType, pd->isAddressable());
     }
-    // `@_addressable` also suppresses exploding the parameter.
-    if (pd->isAddressable()) {
-      return handleScalar(claimNextParameter(), origType, substType,
+    // Addressability also suppresses exploding the parameter.
+    if ((SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableTypes)
+         || SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableParameters))
+        && isAddressable) {
+      return handleScalar(claimNextParameter(),
+                          AbstractionPattern::getOpaque(), substType,
                           /*emitInto*/ nullptr,
                           /*inout*/ false, /*addressable*/ true);
     }
@@ -629,10 +632,15 @@ class ArgumentInitHelper {
 
   std::optional<FunctionInputGenerator> FormalParamTypes;
 
+  SmallPtrSet<ParamDecl *, 2> ScopedDependencies;
+  SmallPtrSet<ParamDecl *, 2> AddressableParams;
+
 public:
   ArgumentInitHelper(SILGenFunction &SGF,
-                     unsigned numIgnoredTrailingParameters)
-      : SGF(SGF), loweredParams(SGF, numIgnoredTrailingParameters) {}
+                     unsigned numIgnoredTrailingParameters,
+                     llvm::SmallPtrSet<ParamDecl*, 2> &&scopedDependencies)
+      : SGF(SGF), loweredParams(SGF, numIgnoredTrailingParameters),
+        ScopedDependencies(std::move(scopedDependencies)) {}
 
   /// Emit the given list of parameters.
   unsigned emitParams(std::optional<AbstractionPattern> origFnType,
@@ -691,6 +699,11 @@ public:
 
     if (FormalParamTypes) FormalParamTypes->finish();
     loweredParams.finish();
+    
+    for (auto addressableParam : AddressableParams) {
+      assert(SGF.VarLocs.contains(addressableParam));
+      SGF.VarLocs[addressableParam].addressable = true;
+    }
 
     return ArgNo;
   }
@@ -723,7 +736,22 @@ private:
       auto origType = (FormalParamTypes ? FormalParamTypes->getOrigType()
                                         : AbstractionPattern(substType));
 
-      paramValue = argEmitter.handleParam(origType, substType, pd);
+      // A parameter can be directly marked as addressable, or its
+      // addressability can be implied by a scoped dependency.
+      bool isAddressable = false;
+      
+      if (SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableTypes)
+          || SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableParameters)) {
+        isAddressable = pd->isAddressable()
+          || (ScopedDependencies.contains(pd)
+              && SGF.getTypeLowering(origType, substType)
+                    .getRecursiveProperties().isAddressableForDependencies());
+        if (isAddressable) {
+          AddressableParams.insert(pd);
+        }
+      }
+      paramValue = argEmitter.handleParam(origType, substType, pd,
+                                          isAddressable);
     }
 
     // Reset the parameter data on the lowered parameter generator.
@@ -1619,10 +1647,32 @@ uint16_t SILGenFunction::emitBasicProlog(
       F.getConventions().hasIndirectSILErrorResults()) {
     emitIndirectErrorParameter(*this, *errorType, *origErrorType, DC);
   }
+  
+  // Parameters with scoped dependencies may lower differently.
+  llvm::SmallPtrSet<ParamDecl *, 2> scopedDependencyParams;
+  if (auto afd = dyn_cast<AbstractFunctionDecl>(DC)) {
+    if (auto deps = afd->getLifetimeDependencies()) {
+      for (auto &dep : *deps) {
+        auto scoped = dep.getScopeIndices();
+        if (!scoped) {
+          continue;
+        }
+        for (unsigned i = 0, e = paramList->size(); i < e; ++i) {
+          if (scoped->contains(i)) {
+            scopedDependencyParams.insert((*paramList)[i]);
+          }
+        }
+        if (scoped->contains(paramList->size())) {
+          scopedDependencyParams.insert(selfParam);
+        }
+      }
+    }
+  }
 
   // Emit the argument variables in calling convention order.
   unsigned ArgNo =
-    ArgumentInitHelper(*this, numIgnoredTrailingParameters)
+    ArgumentInitHelper(*this, numIgnoredTrailingParameters,
+                       std::move(scopedDependencyParams))
       .emitParams(origClosureType, paramList, selfParam);
 
   // Record the ArgNo of the artificial $error inout argument. 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -529,6 +529,7 @@ public:
   void visitSafeAttr(SafeAttr *attr);
   void visitLifetimeAttr(LifetimeAttr *attr);
   void visitAddressableSelfAttr(AddressableSelfAttr *attr);
+  void visitAddressableForDependenciesAttr(AddressableForDependenciesAttr *attr);
 };
 
 } // end anonymous namespace
@@ -7929,6 +7930,18 @@ void AttributeChecker::visitAddressableSelfAttr(AddressableSelfAttr *attr) {
   
   if (!D->getDeclContext()->isTypeContext()) {
     Ctx.Diags.diagnose(attr->getLocation(), diag::addressableSelf_not_on_method);
+  }
+}
+
+void
+AttributeChecker::visitAddressableForDependenciesAttr(
+                                         AddressableForDependenciesAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::AddressableTypes)) {
+    Ctx.Diags.diagnose(attr->getLocation(), diag::addressable_types_not_enabled);
+  }
+  
+  if (isa<ClassDecl>(D)) {
+    Ctx.Diags.diagnose(attr->getLocation(), diag::class_cannot_be_addressable_for_dependencies);
   }
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1740,6 +1740,7 @@ namespace  {
     UNINTERESTING_ATTR(AddressableSelf)
     UNINTERESTING_ATTR(Unsafe)
     UNINTERESTING_ATTR(Safe)
+    UNINTERESTING_ATTR(AddressableForDependencies)
 #undef UNINTERESTING_ATTR
 
     void visitABIAttr(ABIAttr *attr) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 911; // caller inheriting isolation
+const uint16_t SWIFTMODULE_VERSION_MINOR = 912; // @_addressableForDependencies
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/SILGen/addressable_for_dependencies.swift
+++ b/test/SILGen/addressable_for_dependencies.swift
@@ -1,0 +1,100 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableTypes -enable-experimental-feature LifetimeDependence %s | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_LifetimeDependence
+
+@_addressableForDependencies
+struct Foo { var x: String }
+
+struct Bar { var foo: Foo }
+
+struct Dep: ~Escapable {
+    var x: Int
+
+    @lifetime(immortal)
+    init() { }
+}
+
+// CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3foo{{.*}} :
+// CHECK-SAME:    (@in_guaranteed Foo) -> 
+@lifetime(borrow foo)
+func dependencyOn(foo: Foo) -> Dep {
+    // CHECK-NOT: load_borrow
+}
+// CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3bar{{.*}} :
+// CHECK-SAME:    (@in_guaranteed Bar) -> 
+@lifetime(borrow bar)
+func dependencyOn(bar: Bar) -> Dep {
+    // CHECK-NOT: load_borrow
+}
+
+// CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3foo6butNot{{.*}} :
+// CHECK-SAME:    (@in_guaranteed Foo, @guaranteed Foo) -> 
+@lifetime(borrow foo)
+func dependencyOn(foo: Foo, butNot _: Foo) -> Dep {
+    // CHECK: bb0(%0 : $*Foo,
+    // CHECK:   apply {{.*}}(%0)
+    return dependencyOn(foo: foo)
+}
+
+// CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3bar6butNot{{.*}} :
+// CHECK-SAME:    (@in_guaranteed Bar, @guaranteed Bar) -> 
+@lifetime(borrow bar)
+func dependencyOn(bar: Bar, butNot _: Bar) -> Dep {
+    // CHECK: bb0(%0 : $*Bar,
+    // CHECK:   apply {{.*}}(%0)
+    return dependencyOn(bar: bar)
+}
+
+extension Foo {
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV16dependencyOnSelf{{.*}} :
+    // CHECK-SAME:    (@in_guaranteed Foo) -> 
+    @lifetime(borrow self)
+    func dependencyOnSelf() -> Dep {
+        // CHECK-NOT: load_borrow
+    }
+
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV16dependencyOnSelf6butNot{{.*}} :
+    // CHECK-SAME:    (@guaranteed Foo, @in_guaranteed Foo) -> 
+    @lifetime(borrow self)
+    func dependencyOnSelf(butNot _: Foo) -> Dep {
+        // CHECK: bb0({{.*}}, %1 : $*Foo)
+        // CHECK:   apply {{.*}}(%1)
+        return dependencyOnSelf()
+    }
+
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV19dependencyNotOnSelf{{.*}} :
+    // CHECK-SAME:    (@in_guaranteed Foo, @guaranteed Foo) -> 
+    @lifetime(borrow foo)
+    func dependencyNotOnSelf(butOn foo: Foo) -> Dep {
+        // CHECK: bb0(%0 : $*Foo,
+        // CHECK:   apply {{.*}}(%0)
+        return foo.dependencyOnSelf()
+    }
+}
+
+extension Bar {
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV16dependencyOnSelf{{.*}} :
+    // CHECK-SAME:    (@in_guaranteed Bar) -> 
+    @lifetime(borrow self)
+    func dependencyOnSelf() -> Dep {
+    }
+
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV16dependencyOnSelf6butNot{{.*}} :
+    // CHECK-SAME:    (@guaranteed Bar, @in_guaranteed Bar) -> 
+    @lifetime(borrow self)
+    func dependencyOnSelf(butNot _: Bar) -> Dep {
+        // CHECK: bb0({{.*}}, %1 : $*Bar)
+        // CHECK:   apply {{.*}}(%1)
+        return dependencyOnSelf()
+    }
+
+    // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV19dependencyNotOnSelf{{.*}} :
+    // CHECK-SAME:    (@in_guaranteed Bar, @guaranteed Bar) -> 
+    @lifetime(borrow bar)
+    func dependencyNotOnSelf(butOn bar: Bar) -> Dep {
+        // CHECK: bb0(%0 : $*Bar,
+        // CHECK:   apply {{.*}}(%0)
+        return bar.dependencyOnSelf()
+    }
+}

--- a/test/SILOptimizer/addressable_dependencies.swift
+++ b/test/SILOptimizer/addressable_dependencies.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes %s | %FileCheck %s
+
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_LifetimeDependence
+
+import Builtin
+
+@_addressableForDependencies
+struct Node {
+    var id: String
+
+    var ref: NodeRef {
+      // CHECK-LABEL: sil {{.*}}@${{.*}}4NodeV3ref{{.*}}Vvg :
+      // CHECK-SAME:    (@in_guaranteed Node) ->
+      @lifetime(borrow self)
+      borrowing get {
+        // CHECK: bb0(%0 : @noImplicitCopy $*Node):
+        // CHECK: [[REF:%.*]] = apply {{.*}}(%0,
+        // CHECK: mark_dependence [nonescaping] [[REF]] on %0
+        return NodeRef(node: self)
+      }
+    }
+}
+
+struct NodeRef: ~Escapable {
+    private var parent: UnsafePointer<Node>
+
+    // CHECK-LABEL: sil {{.*}}@${{.*}}7NodeRefV4node{{.*}}fC :
+    // CHECK-SAME:    (@in_guaranteed Node,
+    @lifetime(borrow node)
+    init(node: borrowing Node) {
+        // CHECK: bb0(%0 : @noImplicitCopy $*Node,
+        // CHECK:   [[RAW_PTR:%.*]] = address_to_pointer {{.*}}%0
+        // CHECK:   struct $UnsafePointer<Node> ([[RAW_PTR]])
+        self.parent = UnsafePointer(Builtin.addressOfBorrow(node))
+    }
+}


### PR DESCRIPTION
This attribute makes it so that a parameter of the annotated type, as well as any type structurally containing that type as a field, becomes passed as if `@_addressable` if the return value of the function has a dependency on the parameter. This allows nonescapable values to take interior pointers into such types.