### PR TITLE
AccessEnforcementOpts: fix a SIL verifier error caused by a wrong bail-out condition

### DIFF
--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1082,7 +1082,7 @@ mergeAccesses(SILFunction *F, PostDominanceInfo *postDomTree,
       continue;
 
     if (!extendOwnership(parentIns, childIns, deleter, deBlocks))
-      return false;
+      continue;
 
     LLVM_DEBUG(llvm::dbgs()
                << "Merging " << *childIns << " into " << *parentIns << "\n");

--- a/test/SILOptimizer/access_enforcement_opts_ossa.sil
+++ b/test/SILOptimizer/access_enforcement_opts_ossa.sil
@@ -1905,3 +1905,28 @@ bb0(%0 : $UnsafeRawPointer):
   return %9 : $()
 }
 
+
+// CHECK-LABEL: sil [ossa] @merge_3_pairs_and_escaping_pointer :
+// CHECK:         ref_element_addr
+// CHECK-NEXT:    begin_access
+// CHECK-NEXT:    end_access
+// CHECK-NEXT:    ref_element_addr
+// CHECK-NEXT:    begin_access
+// CHECK-NEXT:    address_to_pointer
+// CHECK-NEXT:    end_access
+// CHECK-NEXT:    tuple
+// CHECK-LABEL: } // end sil function 'merge_3_pairs_and_escaping_pointer'
+sil [ossa] @merge_3_pairs_and_escaping_pointer : $@convention(thin) (@guaranteed RefElemClass) -> () {
+bb0(%1 : @guaranteed $RefElemClass):
+  %2 = ref_element_addr %1, #RefElemClass.x
+  %3 = begin_access [modify] [dynamic] %2
+  end_access %3
+  %5 = begin_access [modify] [dynamic] %2
+  end_access %5
+  %7 = ref_element_addr %1, #RefElemClass.x
+  %8 = begin_access [modify] [dynamic] %7
+  %9 = address_to_pointer %8 to $Builtin.RawPointer
+  end_access %8
+  %11 = tuple ()
+  return %11
+}


### PR DESCRIPTION
In case of a bail-out on failed ownership extension the optimization didn't remove old instructions from previously merged access pairs.

This is part of fixing regressions when enabling OSSA modules:
rdar://141490629