### PR TITLE
LargeLoadable types: propagate large type property along projections

### DIFF
--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -78,3 +78,19 @@ typedef union {
         unsigned char cnt;
     } out;
 } union_t;
+
+
+typedef enum {
+  TYPE1,
+  TYPE2,
+  TYPE3
+} member_type_t;
+
+typedef unsigned char uuid_t[16];
+typedef struct {
+  member_type_t member_type;
+  union {
+    uuid_t uuid;
+    unsigned x;
+  } member_value;
+} member_id_t;

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -1,5 +1,10 @@
 // RUN: %target-swift-frontend %s  -Xllvm -sil-print-types -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
 
+// wasm currently disables aggressive reg2mem
+// UNSUPPORTED: wasm
+// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
+
 sil_stage canonical
 
 import Builtin

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -397,3 +397,25 @@ bb3(%4 : $X):
   %t = tuple ()
   return %t : $()
 }
+
+sil @usei8 : $@convention(thin) (UInt8) -> ()
+
+// CHECK: sil @test16
+// CHECK: bb0(%0 : $member_id_t):
+// CHECK:   [[T0:%.*]] = alloc_stack $member_id_t
+// CHECK:   store %0 to [[T0]] : $*member_id_t
+// CHECK:   struct_element_addr [[T0]]
+// CHECK:} // end sil function 'test16'
+
+sil @test16 : $@convention(thin) (member_id_t) -> () {
+bb0(%0 : $member_id_t):
+  %2 = alloc_stack $X
+  %44 = struct_extract %0 : $member_id_t, #member_id_t.member_value // user: %45
+  %45 = unchecked_trivial_bit_cast %44 : $member_id_t.__Unnamed_union_member_value to $(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+  %46 = tuple_extract %45 : $(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8), 0
+  %11 = function_ref @usei8 : $@convention(thin) (UInt8) -> ()
+  %12 = apply %11(%46) : $@convention(thin) (UInt8) -> ()
+  dealloc_stack %2 : $*X
+  %13 = tuple ()
+  return %13 : $()
+}


### PR DESCRIPTION
Back propagate the isLargeType property along projections. This is neccessary because c union types can "hide" largeness.

rdar://141775951