### PR TITLE
[DebugInfo] Fix debug info round tripping of types inside functions

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2591,15 +2591,9 @@ void ASTMangler::appendModule(const ModuleDecl *module,
   StringRef ModName = module->getRealName().str();
 
   // If RespectOriginallyDefinedIn is not set, ignore the ABI name only for
-  // _Concurrency and swift-syntax (which adds "Compiler" as a prefix when
-  // building swift-syntax as part of the compiler).
-  // TODO: Mangling for the debugger should respect originally defined in, but
-  // as of right now there is not enough information in the mangled name to
-  // reconstruct AST types from mangled names when using that attribute.
+  // _Concurrency.
   if ((RespectOriginallyDefinedIn ||
-       (module->getName().str() != SWIFT_CONCURRENCY_NAME &&
-        !module->getABIName().str().starts_with(
-            SWIFT_MODULE_ABI_NAME_PREFIX))) &&
+       module->getName().str() != SWIFT_CONCURRENCY_NAME) &&
       module->getABIName() != module->getName())
     ModName = module->getABIName().str();
 

--- a/test/DebugInfo/local_type_originally_defined_in.swift
+++ b/test/DebugInfo/local_type_originally_defined_in.swift
@@ -21,6 +21,19 @@ public func localTypeAliasTest(horse: Horse) {
   // CHECK: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest5horsey4Barn5HorseV_tF1AL_aD"
 }
 
+
+public func localTypeTest(horse: Horse) {
+  // The local type mangling for 'A' mentions 'Horse', which must
+  // be mangled using it's current module name, and not the
+  // original module name, for consistency with the debug info
+  // mangling.
+  struct LocalStruct {}
+
+  let info = UnsafeMutablePointer<LocalStruct>.allocate(capacity: 1)
+  _ = info
+  // CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "$s32local_type_originally_defined_in0A8TypeTest5horsey4Barn5HorseV_tF11LocalStructL_VD"
+}
+
 public func localTypeAliasTest() -> Horse {
   typealias B = Int
 


### PR DESCRIPTION
Types with @_originallyDefinedIn cannot be round tripped,

Types declared inside functions have their mangling affected by the function signature. If the generic signature mentions an @_originallyDefinedIn type, the type inside the function cannot be round tripped either.

This commit disables round tripping for this scenario.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
