### PR TITLE
[cherry-pick][DebugInfo] Fix debug info round tripping of types inside functions

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2575,15 +2575,9 @@ void ASTMangler::appendModule(const ModuleDecl *module,
   StringRef ModName = module->getRealName().str();
 
   // If RespectOriginallyDefinedIn is not set, ignore the ABI name only for
-  // _Concurrency and swift-syntax (which adds "Compiler" as a prefix when
-  // building swift-syntax as part of the compiler).
-  // TODO: Mangling for the debugger should respect originally defined in, but
-  // as of right now there is not enough information in the mangled name to
-  // reconstruct AST types from mangled names when using that attribute.
+  // _Concurrency.
   if ((RespectOriginallyDefinedIn ||
-       (module->getName().str() != SWIFT_CONCURRENCY_NAME &&
-        !module->getABIName().str().starts_with(
-            SWIFT_MODULE_ABI_NAME_PREFIX))) &&
+       module->getName().str() != SWIFT_CONCURRENCY_NAME) &&
       module->getABIName() != module->getName())
     ModName = module->getABIName().str();
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DeclContext.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
@@ -34,6 +35,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/TypeDifferenceVisitor.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
@@ -65,6 +67,7 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -2336,18 +2339,21 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       if (visitedOriginallyDefinedIn)
         return TypeWalker::Action::Stop;
 
-      // A typealias inside a function used that function's signature as part of
+      DeclContext *D = nullptr;
+      if (auto *TAT = llvm::dyn_cast<TypeAliasType>(T))
+        D = TAT->getDecl()->getDeclContext();
+      else if (auto *NT = llvm::dyn_cast<NominalOrBoundGenericNominalType>(T))
+        D = NT->getDecl()->getDeclContext();
+
+      // A type inside a function uses that function's signature as part of
       // its mangling, so check if any types in the generic signature are
       // annotated with @_originallyDefinedIn.
-      if (auto *TAT = llvm::dyn_cast<TypeAliasType>(T)) {
-        auto D = TAT->getDecl()->getDeclContext();
-        if (auto AFD = llvm::dyn_cast<AbstractFunctionDecl>(D)) {
-          OriginallyDefinedInFinder InnerWalker;
-          AFD->getInterfaceType().walk(InnerWalker);
-          if (InnerWalker.visitedOriginallyDefinedIn) {
-            visitedOriginallyDefinedIn = true;
-            return TypeWalker::Action::Stop;
-          }
+      if (auto AFD = llvm::dyn_cast_or_null<AbstractFunctionDecl>(D)) {
+        OriginallyDefinedInFinder InnerWalker;
+        AFD->getInterfaceType().walk(InnerWalker);
+        if (InnerWalker.visitedOriginallyDefinedIn) {
+          visitedOriginallyDefinedIn = true;
+          return TypeWalker::Action::Stop;
         }
       }
 

--- a/test/DebugInfo/local_type_originally_defined_in.swift
+++ b/test/DebugInfo/local_type_originally_defined_in.swift
@@ -21,6 +21,19 @@ public func localTypeAliasTest(horse: Horse) {
   // CHECK: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest5horsey4Barn5HorseV_tF1AL_aD"
 }
 
+
+public func localTypeTest(horse: Horse) {
+  // The local type mangling for 'A' mentions 'Horse', which must
+  // be mangled using it's current module name, and not the
+  // original module name, for consistency with the debug info
+  // mangling.
+  struct LocalStruct {}
+
+  let info = UnsafeMutablePointer<LocalStruct>.allocate(capacity: 1)
+  _ = info
+  // CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "$s32local_type_originally_defined_in0A8TypeTest5horsey4Barn5HorseV_tF11LocalStructL_VD"
+}
+
 public func localTypeAliasTest() -> Horse {
   typealias B = Int
 


### PR DESCRIPTION
Types with @_originallyDefinedIn cannot be round tripped,

Types declared inside functions have their mangling affected by the function signature. If the generic signature mentions an @_originallyDefinedIn type, the type inside the function cannot be round tripped either.

This commit disables round tripping for this scenario.

(cherry picked from commit 3bb29ca8f35ccca1dc3745999a29e78f2b943dab)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
