### PR TITLE
[ScanDependency] Swift source module should not have build args for modules

### DIFF
--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -9,10 +9,13 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd
 
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
 // RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph1 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
 
@@ -22,6 +25,7 @@
 // RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph2 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
@@ -35,6 +39,7 @@
 // RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job > %t/key.casid
 
@@ -42,6 +47,7 @@
 // RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -5,6 +5,10 @@
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s
 
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json deps | %FileCheck --check-prefix CHECK-NO-MODULES %s --allow-empty
+// CHECK-NO-MODULES-NOT: -swift-module-file
+// CHECK-NO-MODULES-NOT: -fmodule-file
+
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix CHECK-NO-SEARCH-PATHS
 


### PR DESCRIPTION
When planning for a swift source module, it should not get build commands for its module dependencies. Those dependencies should be planned and added by swift-driver.

This is another regression from #76700 that causes unnecessary increase of build command-line size.

rdar://141843125

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
