### PR TITLE
[6.1][Embedded] Do not produce `cannot_specialize_class` for live issues

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -46,6 +46,14 @@ extension Context {
 
   var moduleIsSerialized: Bool { _bridged.moduleIsSerialized() }
 
+  /// Enable diagnostics requiring WMO (for @noLocks, @noAllocation
+  /// annotations, Embedded Swift, and class specialization). SourceKit is the
+  /// only consumer that has this disabled today (as it disables WMO
+  /// explicitly).
+  var enableWMORequiredDiagnostics: Bool {
+    _bridged.enableWMORequiredDiagnostics()
+  }
+
   func canMakeStaticObjectReadOnly(objectType: Type) -> Bool {
     _bridged.canMakeStaticObjectReadOnly(objectType.bridged)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -49,7 +49,9 @@ private struct VTableSpecializer {
 
     let classDecl = classType.nominal! as! ClassDecl
     guard let origVTable = context.lookupVTable(for: classDecl) else {
-      context.diagnosticEngine.diagnose(errorLocation.sourceLoc, .cannot_specialize_class, classType)
+      if context.enableWMORequiredDiagnostics {
+        context.diagnosticEngine.diagnose(errorLocation.sourceLoc, .cannot_specialize_class, classType)
+      }
       return
     }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -153,9 +153,11 @@ public:
   /// Enables SIL-level diagnostics for NonescapableTypes.
   bool EnableLifetimeDependenceDiagnostics = true;
 
-  /// Enables SIL-level performance diagnostics (for @noLocks, @noAllocation
-  /// annotations and for Embedded Swift).
-  bool EnablePerformanceDiagnostics = true;
+  /// Enable diagnostics requiring WMO (for @noLocks, @noAllocation
+  /// annotations, Embedded Swift, and class specialization). SourceKit is the
+  /// only consumer that has this disabled today (as it disables WMO
+  /// explicitly).
+  bool EnableWMORequiredDiagnostics = true;
 
   /// Controls whether or not paranoid verification checks are run.
   bool VerifyAll = false;

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -380,6 +380,7 @@ struct BridgedPassContext {
   BRIDGED_INLINE bool enableMoveInoutStackProtection() const;
   BRIDGED_INLINE AssertConfiguration getAssertConfiguration() const;
   bool enableSimplificationFor(BridgedInstruction inst) const;
+  BRIDGED_INLINE bool enableWMORequiredDiagnostics() const;
 
   // Closure specializer
   SWIFT_IMPORT_UNSAFE BridgedFunction ClosureSpecializer_createEmptyFunctionWithSpecializedSignature(BridgedStringRef specializedName,

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -571,6 +571,11 @@ bool BridgedPassContext::shouldExpand(BridgedType ty) const {
   return swift::shouldExpand(mod, ty.unbridged());
 }
 
+bool BridgedPassContext::enableWMORequiredDiagnostics() const {
+  swift::SILModule *mod = invocation->getPassManager()->getModule();
+  return mod->getOptions().EnableWMORequiredDiagnostics;
+}
+
 static_assert((int)BridgedPassContext::SILStage::Raw == (int)swift::SILStage::Raw);
 static_assert((int)BridgedPassContext::SILStage::Canonical == (int)swift::SILStage::Canonical);
 static_assert((int)BridgedPassContext::SILStage::Lowered == (int)swift::SILStage::Lowered);

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -811,7 +811,7 @@ private:
     // Skip all performance/embedded diagnostics if asked. This is used from
     // SourceKit to avoid reporting false positives when WMO is turned off for
     // indexing purposes.
-    if (!module->getOptions().EnablePerformanceDiagnostics) return;
+    if (!module->getOptions().EnableWMORequiredDiagnostics) return;
 
     PerformanceDiagnostics diagnoser(*module, getAnalysis<BasicCalleeAnalysis>());
 

--- a/test/SourceKit/Diagnostics/embedded_non_wmo.swift
+++ b/test/SourceKit/Diagnostics/embedded_non_wmo.swift
@@ -18,6 +18,8 @@ func foo() {
 
 @main
 struct Main {
+    var someClass = SomeClass()
+
     static func main() {
         foo()
     }
@@ -25,9 +27,9 @@ struct Main {
 
 //--- file2.swift
 
-func bar<T>(_ T: T.Type) {
-    
-}
+final class SomeClass {}
+
+func bar<T>(_ T: T.Type) {}
 
 // CHECK:      {
 // CHECK-NEXT:   key.diagnostics: [

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1215,9 +1215,8 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
       llvm::SaveAndRestore<std::shared_ptr<std::atomic<bool>>> DisableCancellationDuringSILGen(CompIns.getASTContext().CancellationFlag, nullptr);
       SILOptions SILOpts = Invocation.getSILOptions();
 
-      // Disable PerformanceDiagnostics SIL pass, which in some cases requires
-      // WMO (e.g. for Embedded Swift diags) but SourceKit compiles without WMO.
-      SILOpts.EnablePerformanceDiagnostics = false;
+      // Disable diagnostics that require WMO (as SourceKit disables it).
+      SILOpts.EnableWMORequiredDiagnostics = false;
 
       auto &TC = CompIns.getSILTypes();
       std::unique_ptr<SILModule> SILMod = performASTLowering(*SF, TC, SILOpts);


### PR DESCRIPTION
  - **Explanation**: SourceKit explicitly disables WMO, silence the diagnostic in this case (but leave it enabled for explicit non-WMO builds otherwise).
  - **Scope**: SourceKit
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78262
  - **Risk**: Very low, just disabling a diagnostic
  - **Testing**: Added test that this diagnostic is in fact disabled
  - **Reviewers**: @eeckstein @kubamracek 