### PR TITLE
[AST] Link ASTGen

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -171,4 +171,9 @@ target_link_libraries(swiftAST
   PUBLIC swiftBasic
   PRIVATE swiftMarkup)
 
+if (SWIFT_BUILD_SWIFT_SYNTAX)
+  target_link_libraries(swiftAST
+    PRIVATE swiftASTGen)
+endif()
+
 set_swift_llvm_is_available(swiftAST)


### PR DESCRIPTION
swiftAST uses several `swift_ASTGen_*` functions. It does depend on swiftASTGen, so there's cyclic references. Not ideal though.
