### PR TITLE
🍒[6.1] FineModuleTracing/CAS: move the computation of whether fine module trace will be emitted to an early stage.

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -563,9 +563,6 @@ public:
   /// All block list configuration files to be honored in this compilation.
   std::vector<std::string> BlocklistConfigFilePaths;
 
-  /// Whether explicitly disble fine-grained module tracing in this compiler
-  /// invocation.
-  bool DisableFineModuleTracing = false;
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -386,7 +386,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   }
 
   Opts.DisableSandbox = Args.hasArg(OPT_disable_sandbox);
-  Opts.DisableFineModuleTracing = Args.hasArg(OPT_disable_fine_module_tracing);
   return false;
 }
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -411,6 +411,51 @@ SupplementaryOutputPathsComputer::getSupplementaryFilenamesFromArguments(
   return std::nullopt;
 }
 
+static bool shouldEmitFineModuleTrace(FrontendOptions::ActionType action) {
+  // Only full compilation jobs should emit fine module tracing file.
+  // Other partial compilation jobs, such as emitting modules, only typecheck partially
+  // so walking into every function bodies may be risky.
+  switch(action) {
+  case swift::FrontendOptions::ActionType::Typecheck:
+  case swift::FrontendOptions::ActionType::EmitSILGen:
+  case swift::FrontendOptions::ActionType::EmitSIL:
+  case swift::FrontendOptions::ActionType::EmitAssembly:
+  case swift::FrontendOptions::ActionType::EmitLoweredSIL:
+  case swift::FrontendOptions::ActionType::EmitIRGen:
+  case swift::FrontendOptions::ActionType::EmitIR:
+  case swift::FrontendOptions::ActionType::EmitBC:
+  case swift::FrontendOptions::ActionType::EmitObject:
+    return true;
+  case swift::FrontendOptions::ActionType::NoneAction:
+  case swift::FrontendOptions::ActionType::Parse:
+  case swift::FrontendOptions::ActionType::ResolveImports:
+  case swift::FrontendOptions::ActionType::DumpParse:
+  case swift::FrontendOptions::ActionType::DumpInterfaceHash:
+  case swift::FrontendOptions::ActionType::DumpAST:
+  case swift::FrontendOptions::ActionType::PrintAST:
+  case swift::FrontendOptions::ActionType::PrintASTDecl:
+  case swift::FrontendOptions::ActionType::DumpScopeMaps:
+  case swift::FrontendOptions::ActionType::DumpAvailabilityScopes:
+  case swift::FrontendOptions::ActionType::EmitImportedModules:
+  case swift::FrontendOptions::ActionType::EmitPCH:
+  case swift::FrontendOptions::ActionType::EmitModuleOnly:
+  case swift::FrontendOptions::ActionType::MergeModules:
+  case swift::FrontendOptions::ActionType::CompileModuleFromInterface:
+  case swift::FrontendOptions::ActionType::TypecheckModuleFromInterface:
+  case swift::FrontendOptions::ActionType::EmitSIBGen:
+  case swift::FrontendOptions::ActionType::EmitSIB:
+  case swift::FrontendOptions::ActionType::Immediate:
+  case swift::FrontendOptions::ActionType::REPL:
+  case swift::FrontendOptions::ActionType::DumpTypeInfo:
+  case swift::FrontendOptions::ActionType::EmitPCM:
+  case swift::FrontendOptions::ActionType::DumpPCM:
+  case swift::FrontendOptions::ActionType::ScanDependencies:
+  case swift::FrontendOptions::ActionType::PrintVersion:
+  case swift::FrontendOptions::ActionType::PrintFeature:
+    return false;
+  }
+}
+
 std::optional<SupplementaryOutputPaths>
 SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
     StringRef outputFile, const SupplementaryOutputPaths &pathsFromArguments,
@@ -461,7 +506,9 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   // SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH.
   // FIXME: we probably need to move this to a frontend argument.
   llvm::SmallString<128> FineModuleTracePath;
-  if (!loadedModuleTracePath.empty()) {
+  if (!loadedModuleTracePath.empty() &&
+      shouldEmitFineModuleTrace(RequestedAction) &&
+      !Args.hasArg(OPT_disable_fine_module_tracing)) {
     if (const char *P = ::getenv("SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH")) {
       StringRef FilePath = P;
       llvm::sys::path::append(FineModuleTracePath, FilePath);

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -899,59 +899,8 @@ static void createFineModuleTraceFile(CompilerInstance &instance,
   }
 }
 
-static bool shouldActionTypeEmitFineModuleTrace(FrontendOptions::ActionType action) {
-  // Only full compilation jobs should emit fine module tracing file.
-  // Other partial compilation jobs, such as emitting modules, only typecheck partially
-  // so walking into every function bodies may be risky.
-  switch(action) {
-  case swift::FrontendOptions::ActionType::Typecheck:
-  case swift::FrontendOptions::ActionType::EmitSILGen:
-  case swift::FrontendOptions::ActionType::EmitSIL:
-  case swift::FrontendOptions::ActionType::EmitAssembly:
-  case swift::FrontendOptions::ActionType::EmitLoweredSIL:
-  case swift::FrontendOptions::ActionType::EmitIRGen:
-  case swift::FrontendOptions::ActionType::EmitIR:
-  case swift::FrontendOptions::ActionType::EmitBC:
-  case swift::FrontendOptions::ActionType::EmitObject:
-    return true;
-  case swift::FrontendOptions::ActionType::NoneAction:
-  case swift::FrontendOptions::ActionType::Parse:
-  case swift::FrontendOptions::ActionType::ResolveImports:
-  case swift::FrontendOptions::ActionType::DumpParse:
-  case swift::FrontendOptions::ActionType::DumpInterfaceHash:
-  case swift::FrontendOptions::ActionType::DumpAST:
-  case swift::FrontendOptions::ActionType::PrintAST:
-  case swift::FrontendOptions::ActionType::PrintASTDecl:
-  case swift::FrontendOptions::ActionType::DumpScopeMaps:
-  case swift::FrontendOptions::ActionType::DumpAvailabilityScopes:
-  case swift::FrontendOptions::ActionType::EmitImportedModules:
-  case swift::FrontendOptions::ActionType::EmitPCH:
-  case swift::FrontendOptions::ActionType::EmitModuleOnly:
-  case swift::FrontendOptions::ActionType::MergeModules:
-  case swift::FrontendOptions::ActionType::CompileModuleFromInterface:
-  case swift::FrontendOptions::ActionType::TypecheckModuleFromInterface:
-  case swift::FrontendOptions::ActionType::EmitSIBGen:
-  case swift::FrontendOptions::ActionType::EmitSIB:
-  case swift::FrontendOptions::ActionType::Immediate:
-  case swift::FrontendOptions::ActionType::REPL:
-  case swift::FrontendOptions::ActionType::DumpTypeInfo:
-  case swift::FrontendOptions::ActionType::EmitPCM:
-  case swift::FrontendOptions::ActionType::DumpPCM:
-  case swift::FrontendOptions::ActionType::ScanDependencies:
-  case swift::FrontendOptions::ActionType::PrintVersion:
-  case swift::FrontendOptions::ActionType::PrintFeature:
-    return false;
-  }
-}
-
 bool swift::emitFineModuleTraceIfNeeded(CompilerInstance &Instance,
                                         const FrontendOptions &opts) {
-  if (opts.DisableFineModuleTracing) {
-    return false;
-  }
-  if (!shouldActionTypeEmitFineModuleTrace(opts.RequestedAction)) {
-    return false;
-  }
   ModuleDecl *mainModule = Instance.getMainModule();
   ASTContext &ctxt = mainModule->getASTContext();
   if (ctxt.blockListConfig.hasBlockListAction(mainModule->getNameStr(),

--- a/test/IDE/objc_send_collector_1.swift
+++ b/test/IDE/objc_send_collector_1.swift
@@ -17,7 +17,7 @@
 // RUN: echo "    - FooBar" >> %t/blocklist.yml
 
 // RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_3.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name FooBar -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -blocklist-file %t/blocklist.yml
-// RUN: not ls %t/given_trace_3.json
+// RUN: cat %t/given_trace_3.json | %{python} -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | %FileCheck %s  --check-prefix=CHECK-BLOCKED
 
 // RUN: SWIFT_COMPILER_FINE_GRAINED_TRACE_PATH=%t/given_trace_4.json %target-swift-frontend  -I %t/lib/swift -typecheck %s %S/Inputs/objc_send_collector_2.swift -module-name FooBar -swift-version 5 -F %S/Inputs/mock-sdk -emit-loaded-module-trace-path %t/.MODULE_TRACE -disable-fine-module-tracing
 // RUN: not ls %t/given_trace_4.json
@@ -45,3 +45,5 @@ public func testProperties(_ x: FooClassBase, _ y: FooProtocolBase) {
 // CHECK-DAG: "file_path": "SOURCE_DIR/test/IDE/objc_send_collector_1.swift"
 // CHECK-DAG: "file_path": "SOURCE_DIR/test/IDE/Inputs/objc_send_collector_2.swift"
 // CHECK-DAG: "swift-compiler-version":
+
+// CHECK-BLOCKED-NOT: "FooClassBase"


### PR DESCRIPTION
- Explanation: CAS needs to determine if an output is needed very early (when computing supplementary outputs) in the pipeline so we can do caching and replays.
- Scope: this change only affects when emitting fine-grained module trace.
- Issues: rdar://141850408
- Original PRs: https://github.com/swiftlang/swift/pull/78337
- Risk: Very Low. For CAS-disabled build, this is a no-op change.
- Testing: Added unit tests.
- Reviewers: @cachemeifyoucan 


