### PR TITLE
[6.1][ScanDependency] Swift source module should not have build args for modules

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -309,11 +309,13 @@ private:
   llvm::Error handleSwiftInterfaceModuleDependency(
       ModuleDependencyID depModuleID,
       const SwiftInterfaceModuleDependenciesStorage &interfaceDepDetails) {
-    auto &path = interfaceDepDetails.moduleCacheKey.empty()
-                     ? interfaceDepDetails.moduleOutputPath
-                     : interfaceDepDetails.moduleCacheKey;
-    commandline.push_back("-swift-module-file=" + depModuleID.ModuleName + "=" +
-                          path);
+    if (!resolvingDepInfo.isSwiftSourceModule()) {
+      auto &path = interfaceDepDetails.moduleCacheKey.empty()
+                       ? interfaceDepDetails.moduleOutputPath
+                       : interfaceDepDetails.moduleCacheKey;
+      commandline.push_back("-swift-module-file=" + depModuleID.ModuleName +
+                            "=" + path);
+    }
     addMacroDependencies(depModuleID, interfaceDepDetails);
     return llvm::Error::success();
   }
@@ -321,24 +323,27 @@ private:
   llvm::Error handleSwiftBinaryModuleDependency(
       ModuleDependencyID depModuleID,
       const SwiftBinaryModuleDependencyStorage &binaryDepDetails) {
-    auto &path = binaryDepDetails.moduleCacheKey.empty()
-                     ? binaryDepDetails.compiledModulePath
-                     : binaryDepDetails.moduleCacheKey;
-    commandline.push_back("-swift-module-file=" + depModuleID.ModuleName + "=" +
-                          path);
-    // If this binary module was built with a header, the header's module
-    // dependencies must also specify a .modulemap to the compilation, in
-    // order to resolve the header's own header include directives.
-    for (const auto &bridgingHeaderDepID :
-         binaryDepDetails.headerModuleDependencies) {
-      auto optionalBridgingHeaderDepModuleInfo = cache.findKnownDependency(
-          bridgingHeaderDepID);
-      const auto bridgingHeaderDepModuleDetails =
-          optionalBridgingHeaderDepModuleInfo.getAsClangModule();
-      commandline.push_back("-Xcc");
-      commandline.push_back("-fmodule-map-file=" +
-                            cache.getScanService().remapPath(
-                                bridgingHeaderDepModuleDetails->moduleMapFile));
+    if (!resolvingDepInfo.isSwiftSourceModule()) {
+      auto &path = binaryDepDetails.moduleCacheKey.empty()
+                       ? binaryDepDetails.compiledModulePath
+                       : binaryDepDetails.moduleCacheKey;
+      commandline.push_back("-swift-module-file=" + depModuleID.ModuleName +
+                            "=" + path);
+      // If this binary module was built with a header, the header's module
+      // dependencies must also specify a .modulemap to the compilation, in
+      // order to resolve the header's own header include directives.
+      for (const auto &bridgingHeaderDepID :
+           binaryDepDetails.headerModuleDependencies) {
+        auto optionalBridgingHeaderDepModuleInfo =
+            cache.findKnownDependency(bridgingHeaderDepID);
+        const auto bridgingHeaderDepModuleDetails =
+            optionalBridgingHeaderDepModuleInfo.getAsClangModule();
+        commandline.push_back("-Xcc");
+        commandline.push_back(
+            "-fmodule-map-file=" +
+            cache.getScanService().remapPath(
+                bridgingHeaderDepModuleDetails->moduleMapFile));
+      }
     }
     addMacroDependencies(depModuleID, binaryDepDetails);
     return llvm::Error::success();
@@ -347,26 +352,29 @@ private:
   llvm::Error handleSwiftPlaceholderModuleDependency(
       ModuleDependencyID depModuleID,
       const SwiftPlaceholderModuleDependencyStorage &placeholderDetails) {
-    commandline.push_back("-swift-module-file=" + depModuleID.ModuleName + "=" +
-                          placeholderDetails.compiledModulePath);
+    if (!resolvingDepInfo.isSwiftSourceModule())
+      commandline.push_back("-swift-module-file=" + depModuleID.ModuleName +
+                            "=" + placeholderDetails.compiledModulePath);
     return llvm::Error::success();
   }
 
   llvm::Error handleClangModuleDependency(
       ModuleDependencyID depModuleID,
       const ClangModuleDependencyStorage &clangDepDetails) {
-    if (!resolvingDepInfo.isClangModule()) {
-      commandline.push_back("-Xcc");
-      commandline.push_back("-fmodule-file=" + depModuleID.ModuleName + "=" +
-                            clangDepDetails.mappedPCMPath);
-    }
-    if (!clangDepDetails.moduleCacheKey.empty()) {
-      commandline.push_back("-Xcc");
-      commandline.push_back("-fmodule-file-cache-key");
-      commandline.push_back("-Xcc");
-      commandline.push_back(clangDepDetails.mappedPCMPath);
-      commandline.push_back("-Xcc");
-      commandline.push_back(clangDepDetails.moduleCacheKey);
+    if (!resolvingDepInfo.isSwiftSourceModule()) {
+      if (!resolvingDepInfo.isClangModule()) {
+        commandline.push_back("-Xcc");
+        commandline.push_back("-fmodule-file=" + depModuleID.ModuleName + "=" +
+                              clangDepDetails.mappedPCMPath);
+      }
+      if (!clangDepDetails.moduleCacheKey.empty()) {
+        commandline.push_back("-Xcc");
+        commandline.push_back("-fmodule-file-cache-key");
+        commandline.push_back("-Xcc");
+        commandline.push_back(clangDepDetails.mappedPCMPath);
+        commandline.push_back("-Xcc");
+        commandline.push_back(clangDepDetails.moduleCacheKey);
+      }
     }
 
     // Collect CAS deppendencies from clang modules.
@@ -1389,7 +1397,7 @@ bool swift::dependencies::batchScanDependencies(
     return true;
 
   auto batchScanResults = performBatchModuleScan(
-      instance, /*DependencyScanDiagnosticCollector*/ nullptr, 
+      instance, /*DependencyScanDiagnosticCollector*/ nullptr,
       cache, /*versionedPCMInstanceCache*/ nullptr, saver,
       *batchInput);
 
@@ -1650,7 +1658,7 @@ swift::dependencies::performBatchModuleScan(
           }
           allDependencies = scanner.performDependencyScan(moduleID, cache);
         }
-        
+
         batchScanResult.push_back(
             generateFullDependencyGraph(instance, diagnosticCollector, cache,
                                         allDependencies));

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -9,10 +9,13 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd
 
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/Test.cmd
 // RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph1 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
 
@@ -22,6 +25,7 @@
 // RUN: %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph2 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
@@ -35,6 +39,7 @@
 // RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job > %t/key.casid
 
@@ -42,6 +47,7 @@
 // RUN:   %target-swift-frontend -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -parse-stdlib -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/Test.swiftmodule -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph3 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -5,6 +5,10 @@
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s
 
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json deps | %FileCheck --check-prefix CHECK-NO-MODULES %s --allow-empty
+// CHECK-NO-MODULES-NOT: -swift-module-file
+// CHECK-NO-MODULES-NOT: -fmodule-file
+
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix CHECK-NO-SEARCH-PATHS
 


### PR DESCRIPTION
  - **Explanation**: When planning for a swift source module, it should not get build commands for its module dependencies. Those dependencies should be planned and added by swift-driver.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: This makes build command for the main module unnecessarily long. 
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://141843125
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78331
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Not appending certain flags to source module.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Added unit tests.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @artemcm 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->


