### PR TITLE
Remove outdated warning about swift interfaces without library evolution

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -415,9 +415,6 @@ WARNING(warn_unsupported_module_interface_swift_version,none,
         "module interfaces are only supported with Swift language version 5 "
         "or later (currently using -swift-version %0)",
         (StringRef))
-WARNING(warn_unsupported_module_interface_library_evolution,none,
-        "module interfaces are only supported with -enable-library-evolution",
-        ())
 ERROR(error_extracting_version_from_module_interface,none,
       "error extracting version from module interface", ())
 ERROR(unsupported_version_of_module_interface,none,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -192,10 +192,6 @@ printModuleInterfaceIfNeeded(llvm::vfs::OutputBackend &outputBackend,
                    diag::warn_unsupported_module_interface_swift_version,
                    LangOpts.isSwiftVersionAtLeast(4, 2) ? "4.2" : "4");
   }
-  if (M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
-    diags.diagnose(SourceLoc(),
-                   diag::warn_unsupported_module_interface_library_evolution);
-  }
   return withOutputPath(diags, outputBackend, outputPath,
                         [M, Opts](raw_ostream &out) -> bool {
                           return swift::emitSwiftInterface(out, Opts, M);

--- a/test/ModuleInterface/unsupported-configurations.swift
+++ b/test/ModuleInterface/unsupported-configurations.swift
@@ -19,14 +19,12 @@
 // RUN: ls %t/empty.swiftinterface
 
 // CHECK-DAG: warning: module interfaces are only supported with Swift language version 5 or later (currently using -swift-version [[VERSION]])
-// CHECK-DAG: warning: module interfaces are only supported with -enable-library-evolution
 
 // CHECK-VERSION-ONLY-NOT: warning:
 // CHECK-VERSION-ONLY: warning: module interfaces are only supported with Swift language version 5 or later (currently using -swift-version [[VERSION]])
 // CHECK-VERSION-ONLY-NOT: warning:
 
 // CHECK-EVOLUTION-ONLY-NOT: warning:
-// CHECK-EVOLUTION-ONLY: warning: module interfaces are only supported with -enable-library-evolution
 // CHECK-EVOLUTION-ONLY-NOT: warning:
 
 // NEGATIVE-NOT: warning:


### PR DESCRIPTION
This warning was introduced over five years ago in this PR by @jrose-apple 
https://github.com/swiftlang/swift/pull/24420

It sounds like the deficiencies in the 4.X language mode were resolved in the 5.X mode, and we're on 6.X now.

> Warn when emitting an interface using -swift-version 4 or -swift-version 4.2: If the Swift project ever drops Swift 4 mode or Swift 4.2 mode, that would break modules using those modes in their interface, so put an unsilenceable warning in for using those modes to nudge interface emitters to Swift 5.
>
> Also warn when emitting without -enable-library-evolution. Module interfaces don't yet carry enough information to correctly describe the binary interface of a module compiled without -enable-library-evolution, but we don't want to make this an error because that would make it harder to work towards getting it in the future.
>
> rdar://problem/47792595

Without being able to access the radar, I'm not sure if there are any outstanding issues, but we're using Swift interfaces in Swift 6 without library evolution enabled and it seems to work fine (though it does print this warning).

Out app has hundreds of Swift modules, and enabling library or module evolution for the entire dependency graph is probably inappropriate. However, we are using the .swiftinterface files for our dependency injection system, and it would be great to remove this warning if it's no longer relevant.