### PR TITLE
TypeCheckType: Make `ExistentialAny` warn rather than error until Swift 7

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5542,12 +5542,6 @@ public:
   ///   value requirement.
   bool hasSelfOrAssociatedTypeRequirements() const;
 
-  /// Determine whether an existential type constrained by this protocol must
-  /// be written using `any` syntax.
-  ///
-  /// \Note This method takes language feature state into account.
-  bool existentialRequiresAny() const;
-
   /// Returns a list of protocol requirements that must be assessed to
   /// determine a concrete's conformance effect polymorphism kind.
   PolymorphicEffectRequirementList getPolymorphicEffectRequirements(

--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -26,6 +26,7 @@ GROUP(DeprecatedDeclaration, "DeprecatedDeclaration.md")
 GROUP(Unsafe, "Unsafe.md")
 GROUP(UnknownWarningGroup, "UnknownWarningGroup.md")
 GROUP(PreconcurrencyImport, "PreconcurrencyImport.md")
+GROUP(ExistentialAny, "ExistentialAny.md")
 
 #define UNDEFINE_DIAGNOSTIC_GROUPS_MACROS
 #include "swift/AST/DefineDiagnosticGroupsMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5825,11 +5825,12 @@ ERROR(any_not_existential,none,
 ERROR(incorrect_optional_any,none,
       "optional 'any' type must be written %0",
       (Type))
-ERROR(existential_requires_any,none,
-      "use of %select{protocol |}2%0 as a type must be written %1",
-      (Type, Type, bool))
-ERROR(inverse_requires_any,none,
-      "constraint that suppresses conformance requires 'any'", ())
+
+GROUPED_ERROR(existential_requires_any,ExistentialAny,none,
+              "use of %select{protocol |}2%0 as a type must be written %1",
+              (Type, Type, bool))
+GROUPED_ERROR(inverse_requires_any,ExistentialAny,none,
+              "constraint that suppresses conformance requires 'any'", ())
 
 ERROR(nonisolated_mutable_storage,none,
       "'nonisolated' cannot be applied to mutable stored properties",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6884,13 +6884,6 @@ bool ProtocolDecl::hasSelfOrAssociatedTypeRequirements() const {
                            resultForCycle);
 }
 
-bool ProtocolDecl::existentialRequiresAny() const {
-  if (getASTContext().LangOpts.hasFeature(Feature::ExistentialAny))
-    return true;
-
-  return hasSelfOrAssociatedTypeRequirements();
-}
-
 ArrayRef<AssociatedTypeDecl *>
 ProtocolDecl::getPrimaryAssociatedTypes() const {
   return evaluateOrDefault(getASTContext().evaluator,

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -112,9 +112,9 @@ struct DoesNotConform : Up {
 // Circular protocols
 
 protocol CircleMiddle : CircleStart { func circle_middle() }
-// expected-note@-1 3 {{protocol 'CircleMiddle' declared here}}
-protocol CircleStart : CircleEnd { func circle_start() } // expected-error 3 {{protocol 'CircleStart' refines itself}}
-protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note 3 {{protocol 'CircleEnd' declared here}}
+// expected-note@-1 2 {{protocol 'CircleMiddle' declared here}}
+protocol CircleStart : CircleEnd { func circle_start() } // expected-error 2 {{protocol 'CircleStart' refines itself}}
+protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note 2 {{protocol 'CircleEnd' declared here}}
 
 protocol CircleEntry : CircleTrivial { }
 protocol CircleTrivial : CircleTrivial { } // expected-error {{protocol 'CircleTrivial' refines itself}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -18,8 +18,10 @@ protocol Bar {
 }
 
 class Bistro {
-  convenience init(_: Bar){ self.init()} // expected-explicit-any-error{{use of protocol 'Bar' as a type must be written 'any Bar'}}{{23-26=any Bar}}
-  class func returnBar() -> Bar {} // expected-explicit-any-error {{use of protocol 'Bar' as a type must be written 'any Bar'}}{{29-32=any Bar}}
+  convenience init(_: Bar){ self.init()}
+  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode}}{{23-26=any Bar}}
+  class func returnBar() -> Bar {}
+  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode}}{{29-32=any Bar}}
 }
 
 func useBarAsType(_ x: any Bar) {}
@@ -217,7 +219,8 @@ protocol RawRepresentable {
 enum E1: RawRepresentable {
   typealias RawValue = P1
 
-  var rawValue: P1 { // expected-explicit-any-error {{use of protocol 'P1' as a type must be written 'any P1'}}{{17-19=any P1}}
+  var rawValue: P1 {
+    // expected-explicit-any-warning@-1 {{use of protocol 'P1' as a type must be written 'any P1'; this will be an error in a future Swift language mode}}{{17-19=any P1}}
     return ConcreteComposition()
   }
 }
@@ -315,9 +318,9 @@ enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not
 
 // Protocols from a serialized module (the standard library).
 do {
-  // expected-explicit-any-error@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'}}
+  // expected-explicit-any-warning@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'; this will be an error in a future Swift language mode}}
   let _: Decodable
-  // expected-explicit-any-error@+1 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable')}}
+  // expected-explicit-any-warning@+1 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable'); this will be an error in a future Swift language mode}}
   let _: Codable
 }
 
@@ -543,7 +546,7 @@ func testEnumAssociatedValue() {
     case c1((any HasAssoc) -> Void)
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
     case c2((HasAssoc) -> Void)
-    // expected-explicit-any-error@+1 {{use of protocol 'P' as a type must be written 'any P'}}
+    // expected-explicit-any-warning@+1 {{use of protocol 'P' as a type must be written 'any P'; this will be an error in a future Swift language mode}}
     case c3((P) -> Void)
   }
 }
@@ -568,5 +571,7 @@ typealias Objectlike = AnyObject
 func f(_ x: Objectlike) {}
 
 typealias Copy = Copyable
-func h(_ z1: Copy, // expected-explicit-any-error {{use of 'Copy' (aka 'Copyable') as a type must be written 'any Copy' (aka 'any Copyable')}}
-       _ z2: Copyable) {} // expected-explicit-any-error {{use of protocol 'Copyable' as a type must be written 'any Copyable'}}
+func h(_ z1: Copy,
+       // expected-explicit-any-warning@-1 {{use of 'Copy' (aka 'Copyable') as a type must be written 'any Copy' (aka 'any Copyable'); this will be an error in a future Swift language mode}}
+       _ z2: Copyable) {}
+       // expected-explicit-any-warning@-1 {{use of protocol 'Copyable' as a type must be written 'any Copyable'; this will be an error in a future Swift language mode}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-additional-prefix default-swift-mode-
 // RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift-6-
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups -enable-upcoming-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
+// RUN: %target-typecheck-verify-swift -print-diagnostic-groups -enable-experimental-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
 
 // REQUIRES: swift_feature_ExistentialAny
 
@@ -19,9 +19,9 @@ protocol Bar {
 
 class Bistro {
   convenience init(_: Bar){ self.init()}
-  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode}}{{23-26=any Bar}}
+  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode [ExistentialAny]}}{{23-26=any Bar}}
   class func returnBar() -> Bar {}
-  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode}}{{29-32=any Bar}}
+  // expected-explicit-any-warning@-1 {{use of protocol 'Bar' as a type must be written 'any Bar'; this will be an error in a future Swift language mode [ExistentialAny]}}{{29-32=any Bar}}
 }
 
 func useBarAsType(_ x: any Bar) {}
@@ -220,7 +220,7 @@ enum E1: RawRepresentable {
   typealias RawValue = P1
 
   var rawValue: P1 {
-    // expected-explicit-any-warning@-1 {{use of protocol 'P1' as a type must be written 'any P1'; this will be an error in a future Swift language mode}}{{17-19=any P1}}
+    // expected-explicit-any-warning@-1 {{use of protocol 'P1' as a type must be written 'any P1'; this will be an error in a future Swift language mode [ExistentialAny]}}{{17-19=any P1}}
     return ConcreteComposition()
   }
 }
@@ -318,9 +318,9 @@ enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not
 
 // Protocols from a serialized module (the standard library).
 do {
-  // expected-explicit-any-warning@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'; this will be an error in a future Swift language mode}}
+  // expected-explicit-any-warning@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'; this will be an error in a future Swift language mode [ExistentialAny]}}
   let _: Decodable
-  // expected-explicit-any-warning@+1 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable'); this will be an error in a future Swift language mode}}
+  // expected-explicit-any-warning@+1 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable'); this will be an error in a future Swift language mode [ExistentialAny]}}
   let _: Codable
 }
 
@@ -546,7 +546,7 @@ func testEnumAssociatedValue() {
     case c1((any HasAssoc) -> Void)
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
     case c2((HasAssoc) -> Void)
-    // expected-explicit-any-warning@+1 {{use of protocol 'P' as a type must be written 'any P'; this will be an error in a future Swift language mode}}
+    // expected-explicit-any-warning@+1 {{use of protocol 'P' as a type must be written 'any P'; this will be an error in a future Swift language mode [ExistentialAny]}}
     case c3((P) -> Void)
   }
 }
@@ -572,6 +572,6 @@ func f(_ x: Objectlike) {}
 
 typealias Copy = Copyable
 func h(_ z1: Copy,
-       // expected-explicit-any-warning@-1 {{use of 'Copy' (aka 'Copyable') as a type must be written 'any Copy' (aka 'any Copyable'); this will be an error in a future Swift language mode}}
+       // expected-explicit-any-warning@-1 {{use of 'Copy' (aka 'Copyable') as a type must be written 'any Copy' (aka 'any Copyable'); this will be an error in a future Swift language mode [ExistentialAny]}}
        _ z2: Copyable) {}
-       // expected-explicit-any-warning@-1 {{use of protocol 'Copyable' as a type must be written 'any Copyable'; this will be an error in a future Swift language mode}}
+       // expected-explicit-any-warning@-1 {{use of protocol 'Copyable' as a type must be written 'any Copyable'; this will be an error in a future Swift language mode [ExistentialAny]}}

--- a/test/type/explicit_existential_cyclic_protocol.swift
+++ b/test/type/explicit_existential_cyclic_protocol.swift
@@ -10,24 +10,24 @@ do {
   do {
     protocol P1 : P2 {}
     // expected-no-explicit-any-note@-1 2 {{protocol 'P1' declared here}}
-    // expected-explicit-any-note@-2 1 {{protocol 'P1' declared here}}
+    // expected-explicit-any-note@-2 2 {{protocol 'P1' declared here}}
     protocol P2 : P1 {}
     // expected-no-explicit-any-error@-1 2 {{protocol 'P2' refines itself}}
-    // expected-explicit-any-error@-2 1 {{protocol 'P2' refines itself}}
+    // expected-explicit-any-error@-2 2 {{protocol 'P2' refines itself}}
 
     // Diagnosed only with the feature enabled, as a protocol without
     // "HasSelfOrAssociatedTypeRequirements" should.
     let _: P2
-    // expected-explicit-any-error@-1 {{use of protocol 'P2' as a type must be written 'any P2'}}
+    // expected-explicit-any-warning@-1 {{use of protocol 'P2' as a type must be written 'any P2'}}
   }
   do {
     protocol P0 { associatedtype A }
     protocol P1 : P2, P0 {}
     // expected-no-explicit-any-note@-1 2 {{protocol 'P1' declared here}}
-    // expected-explicit-any-note@-2 1 {{protocol 'P1' declared here}}
+    // expected-explicit-any-note@-2 2 {{protocol 'P1' declared here}}
     protocol P2 : P1 {}
     // expected-no-explicit-any-error@-1 2 {{protocol 'P2' refines itself}}
-    // expected-explicit-any-error@-2 1 {{protocol 'P2' refines itself}}
+    // expected-explicit-any-error@-2 2 {{protocol 'P2' refines itself}}
 
     let _: P2
     // expected-error@-1 {{use of protocol 'P2' as a type must be written 'any P2'}}

--- a/test/type/explicit_existential_multimodule2.swift
+++ b/test/type/explicit_existential_multimodule2.swift
@@ -4,8 +4,9 @@
 
 // REQUIRES: swift_feature_ExistentialAny
 
-// Test that a protocol that requires 'any' *only* when the feature is enabled
-// is diagnosed as expected when said protocol originates in a different module.
+// Test that a protocol that requires 'any' *only* under ExistentialAny
+// is diagnosed as expected with the feature enabled when said protocol
+// originates in a different module.
 // In other words, test that deserialization does not affect 'any' migration
 // diagnostics.
 
@@ -13,5 +14,6 @@
 public protocol P {}
 #else
 import M
-func test(_: P) {} // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
+func test(_: P) {}
+// expected-warning@-1 {{use of protocol 'P' as a type must be written 'any P'}}
 #endif

--- a/userdocs/diagnostic_groups/ExistentialAny.md
+++ b/userdocs/diagnostic_groups/ExistentialAny.md
@@ -1,0 +1,18 @@
+# `ExistentialAny`
+
+This diagnostic group includes type syntax errors and warnings that may arise on
+occurrences of protocol or protocol composition types without an `any` or `some`
+qualifier in type position (vs. constraint position).
+For example:
+
+```swift
+struct AnyJoinedSequence<Element> {
+  private let sequences: [Sequence<Element>] // error.
+}
+
+extension AnyJoinedSequence: Sequence, IteratorProtocol {
+  func next() -> Element? {
+    fatalError("Not implemented")
+  }
+}
+```


### PR DESCRIPTION
This enables programmers to opt in to assisted adoption of the new syntax without breaking code and, thus, migrate in increments, whilst retaining the option to unconditionally escalate warnings with `-Werror`.