### PR TITLE
[cxx-interop] NFC: Fix a warning

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -165,7 +165,7 @@ extension CxxDictionary {
   @inlinable
   @discardableResult
   public mutating func removeValue(forKey key: Key) -> Value? {
-    var iter = self.__findMutatingUnsafe(key)
+    let iter = self.__findMutatingUnsafe(key)
     guard iter != self.__endMutatingUnsafe() else { return nil }
 
     let value = iter.pointee.second


### PR DESCRIPTION
This fixes a build warning:
```
swift/stdlib/public/Cxx/CxxDictionary.swift:168:9: warning: variable 'iter' was never mutated; consider changing to 'let' constant
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
