### PR TITLE
[AutoDiff] Fix derivative for array literal with tuple_element_addr elts

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -3284,7 +3284,7 @@ SILValue PullbackCloner::Implementation::getAdjointProjection(
     auto adjSource = getAdjointBuffer(origBB, source);
     if (!adjSource->getType().is<TupleType>())
       return adjSource;
-    auto origTupleTy = source->getType().castTo<TupleType>();
+    auto origTupleTy = remapType(source->getType()).castTo<TupleType>();
     unsigned adjIndex = 0;
     for (unsigned i : range(teai->getFieldIndex())) {
       if (getTangentSpace(

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -192,10 +192,7 @@ ArrayAutoDiffTests.test("ArrayLiteralTuple") {
       return [tuple.0, tuple.1]
     }
     let pb = pullback(at: Float(3), 4, of: { tupleElementGeneric($0, $1) })
-    // FIXME(TF-977): Fix incorrect derivative for array literal with
-    // `tuple_element_addr` elements.
-    // expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
-    expectEqual((0, 2), pb(FloatArrayTan([1, 1])))
+    expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
   }
 }
 


### PR DESCRIPTION
The `adjIndex` was not incremented due to missed `remapType`.

Fixes #54214

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
