### PR TITLE
[CSOptimizer] Few tweaks to make unapplied disjunction and literal array arguments faster

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/array_count_property_vs_method.swift
+++ b/validation-test/Sema/type_checker_perf/fast/array_count_property_vs_method.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=5
+// REQUIRES: tools-release,no_asan
+
+func f(n: Int, a: [Int]) {
+  let _ = [(0 ..< n + a.count).map { Int8($0) }] +
+          [(0 ..< n + a.count).map { Int8($0) }.reversed()] // Ok
+}

--- a/validation-test/Sema/type_checker_perf/fast/array_count_property_vs_method.swift
+++ b/validation-test/Sema/type_checker_perf/fast/array_count_property_vs_method.swift
@@ -1,5 +1,6 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=5
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=11000
 // REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
 
 func f(n: Int, a: [Int]) {
   let _ = [(0 ..< n + a.count).map { Int8($0) }] +

--- a/validation-test/Sema/type_checker_perf/fast/leading_dot_syntax_in_literal_array.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/leading_dot_syntax_in_literal_array.swift.gyb
@@ -1,0 +1,23 @@
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s --expected-exit-code 0
+// REQUIRES: asserts,no_asan
+
+enum E {
+    case a
+    case b
+    case c(Int32)
+}
+
+struct Tester {
+  mutating func test(arr: [E], cond: Bool = false) {}
+  mutating func test(arr: E..., cond: Bool = false) {}
+}
+
+func test() {
+  var tester = Tester()
+  tester.test(arr: [
+    .c(1), .a,
+%for i in range(N):
+    .c(1 << 4 | 8), .c(0),
+%end
+    .c(1), .b])
+}


### PR DESCRIPTION
- When disjunction is not applied, don't only bump its score but also favor all of the choices that don't require application because selection algorithm uses that for comparison.

  This is important for situation when property is overload with a method i.e. `Array.count`.

- Extend candidate/parameter matching to support array literals

  Match `[...]` to Array<...> and/or `ExpressibleByArrayLiteral`
  conforming types. This is very helpful for expressions like:
  `[...] + [...]`.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
