### PR TITLE
[AVR] Fix broken IRGen emission due to not respecting LLVM program address space in the Datalayout

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5451,7 +5451,7 @@ llvm::Value* IRGenFunction::coerceValue(llvm::Value *value, llvm::Type *toTy,
   // Use the pointer/pointer and pointer/int casts if we can.
   if (toTy->isPointerTy()) {
     if (fromTy->isPointerTy())
-      return Builder.CreateBitCast(value, toTy);
+      return Builder.CreatePointerBitCastOrAddrSpaceCast(value, toTy);
     if (fromTy == IGM.IntPtrTy)
       return Builder.CreateIntToPtr(value, toTy);
   } else if (fromTy->isPointerTy()) {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6093,7 +6093,7 @@ Signature irgen::emitCastOfFunctionPointer(IRGenFunction &IGF,
                             : IGF.IGM.getSignature(fnType);
 
   // Emit the cast.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, sig.getType()->getPointerTo());
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, sig.getType()->getPointerTo(IGF.IGM.DataLayout.getProgramAddressSpace()));
 
   // Return the information.
   return sig;
@@ -6226,7 +6226,7 @@ FunctionPointer FunctionPointer::forExplosionValue(IRGenFunction &IGF,
                                                    llvm::Value *fnPtr,
                                                    CanSILFunctionType fnType) {
   // Bitcast out of an opaque pointer type.
-  assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
+  assert(fnPtr->getType() == IGF.IGM.Int8ProgramSpacePtrTy);
   auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
   auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
 
@@ -6245,7 +6245,7 @@ FunctionPointer::getExplosionValue(IRGenFunction &IGF,
   }
 
   // Bitcast to an opaque pointer type.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8ProgramSpacePtrTy);
 
   return fnPtr;
 }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -599,7 +599,14 @@ namespace {
 
     /// Add a pointer to the given type as the next parameter.
     void addPointerParameter(llvm::Type *storageType) {
-      ParamIRTypes.push_back(storageType->getPointerTo());
+      if (isa<llvm::FunctionType>(storageType)) {
+        // read the program data space from the target data layout
+        ParamIRTypes.push_back(storageType->getPointerTo(IGM.DataLayout.getProgramAddressSpace()));
+      } else {
+        ParamIRTypes.push_back(storageType->getPointerTo());
+      }
+
+      // ParamIRTypes.push_back(storageType->getPointerTo());
     }
 
     void addCoroutineContextParameter();

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2410,7 +2410,8 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM, LinkInfo &linkInfo,
   }
 
   llvm::Function *fn =
-    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(), name);
+    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(),
+     /*addrspace*/IGM.DataLayout.getProgramAddressSpace(), name);
   fn->setCallingConv(signature.getCallingConv());
 
   if (insertBefore) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -246,6 +246,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
   Int8PtrTy = PtrTy;
+  FunctionPtrTy = llvm::Type::getInt8Ty(getLLVMContext())->getPointerTo(DataLayout.getProgramAddressSpace());
   Int8PtrPtrTy = Int8PtrTy->getPointerTo(0);
   SizeTy = DataLayout.getIntPtrType(getLLVMContext(), /*addrspace*/ 0);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -723,8 +723,11 @@ public:
     llvm::PointerType *Int8PtrTy;      /// i8*
     llvm::PointerType *WitnessTableTy;
     llvm::PointerType *ObjCSELTy;
-    llvm::PointerType *FunctionPtrTy;
     llvm::PointerType *CaptureDescriptorPtrTy;
+  };
+  union {
+    llvm::PointerType *FunctionPtrTy;
+    llvm::PointerType *Int8ProgramSpacePtrTy; /// i8* in same address space as programs
   };
   union {
     llvm::PointerType *Int8PtrPtrTy;   /// i8**

--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -1,0 +1,21 @@
+// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+// RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
+// REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: CODEGENERATOR=AVR
+// REQUIRES: swift_feature_Embedded
+
+// IRGen needs various patches to work with program address space 1 on AVR.
+// Even the most basic stub program will fail to lower to IR without them.
+// We test IR rather than object code for now, to avoid any issues with an
+// out of date LLVM AVR back end throwing off the tests.
+// We are focusing on getting the front end functioning.
+
+import Swift
+
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
+let i: Int = 1
+#endif
+
+var j = i
+
+// CHECK: define protected i32 @main(i32 %0, ptr %1) addrspace(1)


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

-->

IRGen crashes when attempting to lower even the most basic Swift programs on AVR. I have encountered many problems similar to this over the years and it's always to do with program address space. (See forum discussion: https://forums.swift.org/t/avr-irgen-traps-on-lowering-invalid-cast-assertion-thrown-by-llvm/76883).

I attempted to cherry pick over a few of the changes on my fork of Swift (https://github.com/carlos4242/swift avr-mods-6) until I resolved the problem, then added a basic unit test.

It does work but I am not confident at all that this is the minimum change required. Arguably, the changes might end up being needed anyway later in the development of the Swift frontend for AVR, but I would feel more comfortable if we didn't apply them until we understood what was required, why and where.

Resolves https://github.com/swiftlang/swift/issues/78380

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
