### PR TITLE
[cxx-interop] Use fully-qualified type names of C++ template parameters

### DIFF
--- a/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
+++ b/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
@@ -7,7 +7,7 @@ import CxxStdlib
 
 // CHECK: @"\01L_selector(UTF8String)"
 // CHECK: @objc_msgSend
-// CHECK: call swiftcc void @"$sSo3stdO3__1O0071basic_stringCCharchar_traitsCCharallocatorCChar_mHGHsqaGJcraCCfsaqChraaV9CxxStdlibEyAFSPys4Int8VGSgcfC"
+// CHECK: call swiftcc void @"$sSo3stdO3__1O0088basic_stringCCharstd__1char_traitsCCharstd__1allocatorCChar_cyHBywaEDexaCidvdFCgAayGjzaaV9CxxStdlibEyAFSPys4Int8VGSgcfC"
 
 let ObjCStr: NSString = "hello"
 let CxxStr = std.string(ObjCStr.utf8String) // Should not crash here

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -20,14 +20,14 @@
 
 // CHECK-IOSFWD: enum std {
 // CHECK-IOSFWD:   enum __1 {
-// CHECK-IOSFWD:     struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxMutableRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> : CxxMutableRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxMutableRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<CWideChar, std.__1.char_traits<CWideChar>, std.__1.allocator<CWideChar>> : CxxMutableRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CWideChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     typealias string = std.__1.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
-// CHECK-IOSFWD:     typealias wstring = std.__1.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
+// CHECK-IOSFWD:     typealias string = std.__1.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>>
+// CHECK-IOSFWD:     typealias wstring = std.__1.basic_string<CWideChar, std.__1.char_traits<CWideChar>, std.__1.allocator<CWideChar>>
 // CHECK-IOSFWD:   }
 // CHECK-IOSFWD: }
 // CHECK-IOSFWD-NOT: enum std

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -11,10 +11,10 @@
 // REQUIRES: OS=linux-gnu
 
 // CHECK-STD: enum std {
-// CHECK-STRING:   struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxMutableRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = std.char_traits<CChar>.char_type
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxMutableRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CWideChar, std{{(.__cxx11)?}}.char_traits<CWideChar>, std{{(.__cxx11)?}}.allocator<CWideChar>> : CxxMutableRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = std.char_traits<CWideChar>.char_type
 // CHECK-STRING:   }
 
@@ -23,6 +23,6 @@
 
 // CHECK-SIZE-T:   typealias size_t = Int
 
-// CHECK-STRING:   typealias string =  std{{(.__cxx11)?}}.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
-// CHECK-STRING:   typealias wstring =  std{{(.__cxx11)?}}.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
+// CHECK-STRING:   typealias string =  std{{(.__cxx11)?}}.basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>>
+// CHECK-STRING:   typealias wstring =  std{{(.__cxx11)?}}.basic_string<CWideChar, std{{(.__cxx11)?}}.char_traits<CWideChar>, std{{(.__cxx11)?}}.allocator<CWideChar>>
 // CHECK-STD: }

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -12,13 +12,13 @@
 // CHECK-STRING:   typealias size_t = size_t
 // CHECK-STRING:   static func to_string(_ _Val: Int32) -> std.string
 // CHECK-STRING:   static func to_wstring(_ _Val: Int32) -> std.wstring
-// CHECK-STRING:   struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CWideChar, std.char_traits<CWideChar>, std.allocator<CWideChar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CWideChar
 // CHECK-STRING:   }
-// CHECK-STRING:   typealias string = std.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
-// CHECK-STRING:   typealias wstring = std.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
+// CHECK-STRING:   typealias string = std.basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>>
+// CHECK-STRING:   typealias wstring = std.basic_string<CWideChar, std.char_traits<CWideChar>, std.allocator<CWideChar>>
 // CHECK-STRING: }
 

--- a/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
@@ -40,7 +40,7 @@ public:
     std::vector<SimplePOD * _Nullable> getMutPODPtrItems() const;
 };
 
-// CHECK: func getPODItems() -> std{{\.__(ndk)?1\.|\.}}vector<SimplePOD, allocator<SimplePOD>>
-// CHECK: func getFRTItems() -> std{{\.__(ndk)?1\.|\.}}vector<FRTType, allocator<FRTType>>
-// CHECK: func getPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafePointer<SimplePOD>, allocator<UnsafePointer<SimplePOD>>>
-// CHECK: func getMutPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, allocator<UnsafeMutablePointer<SimplePOD>>>
+// CHECK: func getPODItems() -> std{{\.__(ndk)?1\.|\.}}vector<SimplePOD, std{{\.__(ndk)?1\.|\.}}allocator<SimplePOD>>
+// CHECK: func getFRTItems() -> std{{\.__(ndk)?1\.|\.}}vector<FRTType, std{{\.__(ndk)?1\.|\.}}allocator<FRTType>>
+// CHECK: func getPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafePointer<SimplePOD>, std{{\.__(ndk)?1\.|\.}}allocator<UnsafePointer<SimplePOD>>>
+// CHECK: func getMutPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, std{{\.__(ndk)?1\.|\.}}allocator<UnsafeMutablePointer<SimplePOD>>>

--- a/test/Interop/Cxx/templates/Inputs/class-template-in-namespace.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-in-namespace.h
@@ -8,6 +8,24 @@ template <class T, class... Args> struct Ship<T(Args...)> {};
 
 using Orbiter = Ship<void(bool)>;
 
+template <class T>
+struct Box {
+  T value;
+};
+
+using IntBoxWithinNS = Box<int>;
+using BoxOfIntBoxWithinNS = Box<Box<int>>;
+
+namespace NestedNS1 {
+struct Impl {};
+using ImplBox1 = Box<Impl>;
+}
+
+namespace NestedNS2 {
+struct Impl {};
+using ImplBox2 = Box<Impl>;
+}
+
 } // namespace Space
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_IN_NAMESPACE_H

--- a/test/Interop/Cxx/templates/Inputs/member-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/member-templates.h
@@ -50,6 +50,22 @@ struct HasTemplatedField {
   MyTemplatedStruct<int> x;
 };
 
+struct HasNestedInstantiation {
+  template <typename T>
+  struct MyNestedTemplatedStruct {};
+
+  using NestedInst = MyTemplatedStruct<MyNestedTemplatedStruct<int>>;
+};
+
+namespace NS {
+struct HasNestedInstantiation {
+  template <typename T>
+  struct MyNestedTemplatedStruct {};
+
+  using NestedInst = MyTemplatedStruct<MyNestedTemplatedStruct<int>>;
+};
+}
+
 template <typename A, typename R = TemplateClassWithMemberTemplates<A>>
 struct HasUninstantiatableTemplateMember {
   R *pointer; // R cannot be instantiated here, because R is an incomplete type,

--- a/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
@@ -5,4 +5,16 @@
 // CHECK:   struct Ship<> {
 // CHECK:   }
 // CHECK:   typealias Orbiter = Space.Ship<((CBool) -> Void)>
+
+// CHECK:   typealias IntBoxWithinNS = Space.Box<CInt>
+// CHECK:   typealias BoxOfIntBoxWithinNS = Space.Box<Space.Box<CInt>>
+
+// CHECK:   enum NestedNS1 {
+// CHECK:     typealias ImplBox1 = Space.Box<Space.NestedNS1.Impl>
+// CHECK:   }
+
+// CHECK:   enum NestedNS2 {
+// CHECK:     typealias ImplBox2 = Space.Box<Space.NestedNS2.Impl>
+// CHECK:   }
+
 // CHECK: }

--- a/test/Interop/Cxx/templates/class-template-in-namespace-typechecker.swift
+++ b/test/Interop/Cxx/templates/class-template-in-namespace-typechecker.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -I %S/Inputs
+
+import ClassTemplateInNamespace
+
+let _ = Space.NestedNS1.ImplBox1(value: Space.NestedNS1.Impl())
+let _ = Space.NestedNS2.ImplBox2(value: Space.NestedNS2.Impl())
+
+let _ = Space.NestedNS1.ImplBox1(value: Space.NestedNS2.Impl()) // expected-error {{cannot convert value of type 'Space.NestedNS2.Impl' to expected argument type 'Space.NestedNS1.Impl'}}
+let _ = Space.NestedNS2.ImplBox2(value: Space.NestedNS1.Impl()) // expected-error {{cannot convert value of type 'Space.NestedNS1.Impl' to expected argument type 'Space.NestedNS2.Impl'}}

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -12,4 +12,4 @@
 
 // TODO: we should not be importing functions that use this type in their
 // signature (such as the function below).
-// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<CInt>, _CInt_1>, _CInt_1>>
+// CHECK: mutating func test1() -> RegressionTest.ValExpr<RegressionTest.SliceExpr<RegressionTest.SliceExpr<RegressionTest.Array<CInt>, _CInt_1>, _CInt_1>>

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -36,12 +36,27 @@
 // CHECK:   var x: MyTemplatedStruct<CInt>
 // CHECK: }
 
-// CHECK: struct HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>> {
+// CHECK: struct HasNestedInstantiation {
+// CHECK:   struct MyNestedTemplatedStruct<T> {
+// CHECK:   }
+// CHECK:   typealias NestedInst = MyTemplatedStruct<HasNestedInstantiation.MyNestedTemplatedStruct<CInt>>
+// CHECK: }
+
+// CHECK: enum NS {
+// CHECK:   struct HasNestedInstantiation {
+// CHECK:     struct MyNestedTemplatedStruct<T> {
+// CHECK:     }
+// CHECK:     typealias NestedInst = MyTemplatedStruct<NS.HasNestedInstantiation.MyNestedTemplatedStruct<CInt>>
+// CHECK:   }
+// CHECK: }
+
+
+// CHECK: struct HasUninstantiatableTemplateMember<HasTemplateInstantiationWithForwardDecl.NoDefinition, TemplateClassWithMemberTemplates<HasTemplateInstantiationWithForwardDecl.NoDefinition>> {
 // CHECK:   init(pointer: OpaquePointer!)
 // CHECK:   var pointer: OpaquePointer!
 // CHECK: }
 
 // CHECK: struct HasTemplateInstantiationWithForwardDecl {
-// CHECK:   init(noDefMember: HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>>)
-// CHECK:   var noDefMember: HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>>
+// CHECK:   init(noDefMember: HasUninstantiatableTemplateMember<HasTemplateInstantiationWithForwardDecl.NoDefinition, TemplateClassWithMemberTemplates<HasTemplateInstantiationWithForwardDecl.NoDefinition>>)
+// CHECK:   var noDefMember: HasUninstantiatableTemplateMember<HasTemplateInstantiationWithForwardDecl.NoDefinition, TemplateClassWithMemberTemplates<HasTemplateInstantiationWithForwardDecl.NoDefinition>>
 // CHECK: }

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -246,7 +246,7 @@ public struct Strct {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateTrivial
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
@@ -258,7 +258,7 @@ public struct Strct {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateTrivial> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVMa(0)._0;
+// CHECK-NEXT:     return _impl::$sSo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
@@ -273,7 +273,7 @@ public struct Strct {
 // CHECK-NEXT: SWIFT_INLINE_THUNK ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
-// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVyF(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVyF(storage);
 // CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(static_cast<ns::NonTrivialTemplate<ns::TrivialinNS> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
@@ -312,7 +312,7 @@ public struct Strct {
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVF(swift::_impl::getOpaquePointer(x));
+// CHECK-NEXT:   _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeSimpleScopedEnum(const SimpleScopedEnum& x) noexcept SWIFT_SYMBOL({{.*}}) {

--- a/test/SILGen/opaque_values_cxx.swift
+++ b/test/SILGen/opaque_values_cxx.swift
@@ -7,14 +7,14 @@
 
 import Cxx
 
-// CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO3__1O0055vectorCUnsignedIntallocatorCUnsignedInt_iqGBpboaivxaEhaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW : {{.*}} {
+// CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO3__1O0065vectorCUnsignedIntstd__1allocatorCUnsignedInt_dDGIrdqahddCJdFaAjaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW : {{.*}} {
 // CHECK:       bb0([[VECTOR_ADDR:%[^,]+]] :
 // CHECK:         [[VECTOR:%[^,]+]] = load_borrow [[VECTOR_ADDR]]
 // CHECK:         [[BEGIN_FN:%[^,]+]] = function_ref
 // CHECK:         [[BEGIN:%[^,]+]] = apply [[BEGIN_FN]]([[VECTOR]])
 // CHECK:         end_borrow [[VECTOR]]
 // CHECK:         return [[BEGIN]]
-// CHECK-LABEL: } // end sil function '$sSo3stdO3__1O0055vectorCUnsignedIntallocatorCUnsignedInt_iqGBpboaivxaEhaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW'
+// CHECK-LABEL: } // end sil function '$sSo3stdO3__1O0065vectorCUnsignedIntstd__1allocatorCUnsignedInt_dDGIrdqahddCJdFaAjaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW'
 // CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO{{(3__1O)?}}0047___wrap_iterUnsafePointerCUnsignedInt_heCInnaEgaVSQSCSQ2eeoiySbx_xtFZTW : {{.*}} {
 // CHECK:       bb0([[LHS:%[^,]+]] : $std.__1.__wrap_iter<UnsafePointer<CUnsignedInt>>, [[RHS:%[^,]+]] :
 // CHECK:         [[CALLEE:%[^,]+]] = function_ref @$sSo2eeoiySbSo3stdO{{(3__1O)?}}0047___wrap_iterUnsafePointerCUnsignedInt_heCInnaEgaV_AGtFTO

--- a/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
@@ -3,4 +3,4 @@
 // REQUIRES: OS=macosx
 
 // CHECK: import {{CxxStdlib.vector|std_vector}}
-// CHECK: extension std.basic_string<CChar, char_traits<CChar>, allocator<CChar>> {
+// CHECK: extension std.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> {


### PR DESCRIPTION
When importing C++ class template instantiations, Swift generates a type name for each instantiation. The generated names must be unique, since they are used for mangling.

If multiple different C++ types declare nested types with the same name, which are then used as template arguments, Swift was generating the same name for those template instantiations (e.g. `shared_ptr<Impl>` for different `Impl` types).

This change makes sure we use fully-qualified type names of template parameters when generating Swift type names for class template instantiations (e.g. `shared_ptr<MyNamespace.MyClass.Impl>`).

This fixes an assertion failure coming out of IRGen:
```
Assertion failed: (Buffer.empty() && "didn't claim all values out of buffer"), function ~ConstantInitBuilderBase, file ConstantInitBuilder.h, line 75.
```

rdar://141962480

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
