### PR TITLE
[build-script] Add an option to build the Foundation tests in another mode

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -913,6 +913,7 @@ indexstore-db
 sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
+foundation-tests-build-type=Debug
 
 # rdar://problem/31454823
 lldb-test-swift-only
@@ -937,6 +938,11 @@ skip-test-swiftdocc
 
 # to allow to build under aarch64
 llvm-build-compiler-rt-with-use-runtime=0
+
+[preset: buildbot_linux,release_foundation_tests]
+mixin-preset=buildbot_linux
+
+foundation-tests-build-type=Release
 
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
@@ -1098,6 +1104,7 @@ reconfigure
 test-optimized
 skip-test-swiftdocc
 lldb-test-swift-only
+foundation-tests-build-type=Debug
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
@@ -1206,6 +1213,7 @@ swiftsyntax
 swiftformat
 indexstore-db
 sourcekit-lsp
+foundation-tests-build-type=Debug
 
 install-llvm
 install-static-linux-config

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -94,6 +94,9 @@ def _apply_default_arguments(args):
     if args.foundation_build_variant is None:
         args.foundation_build_variant = args.build_variant
 
+    if args.foundation_tests_build_variant is None:
+        args.foundation_tests_build_variant = args.build_variant
+
     if args.libdispatch_build_variant is None:
         args.libdispatch_build_variant = args.build_variant
 
@@ -954,6 +957,12 @@ def create_argument_parser():
     option('--debug-foundation', store('foundation_build_variant'),
            const='Debug',
            help='build the Debug variant of Foundation')
+
+    option('--foundation-tests-build-type', store('foundation_tests_build_variant'),
+           choices=['Debug', 'Release'],
+           default=None,
+           help='build the Foundation tests in a certain variant '
+                '(Debug builds much faster)')
 
     option('--debug-libdispatch', store('libdispatch_build_variant'),
            const='Debug',

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -542,6 +542,7 @@ class TestDriverArgumentParser(
 
         self.assertEqual(namespace.cmark_build_variant, 'Debug')
         self.assertEqual(namespace.foundation_build_variant, 'Debug')
+        self.assertEqual(namespace.foundation_tests_build_variant, 'Debug')
         self.assertEqual(namespace.libdispatch_build_variant, 'Debug')
         self.assertEqual(namespace.lldb_build_variant, 'Debug')
         self.assertEqual(namespace.llvm_build_variant, 'Debug')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -201,6 +201,7 @@ EXPECTED_DEFAULTS = {
     'swift_debuginfo_non_lto_args': None,
     'force_optimized_typechecker': False,
     'foundation_build_variant': 'Debug',
+    'foundation_tests_build_variant': 'Debug',
     'host_cc': None,
     'host_cxx': None,
     'host_libtool': None,
@@ -783,6 +784,8 @@ EXPECTED_OPTIONS = [
                   choices=['false', 'not-merged', 'merged']),
     ChoicesOption('--android-arch',
                   choices=['armv7', 'aarch64', 'x86_64']),
+    ChoicesOption('--foundation-tests-build-type',
+                  dest='foundation_tests_build_variant', choices=['Debug', 'Release']),
 
     StrOption('--android-api-level'),
     StrOption('--build-args'),

--- a/utils/swift_build_support/swift_build_support/products/foundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/foundationtests.py
@@ -53,7 +53,10 @@ class FoundationTests(product.Product):
         return self.args.test_foundation
 
     def configuration(self):
-        return 'release' if self.is_release() else 'debug'
+        if self.args.foundation_tests_build_variant in ['Release', 'RelWithDebInfo']:
+            return 'release'
+        else:
+            return 'debug'
 
     def test(self, host_target):
         swift_exec = os.path.join(

--- a/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
@@ -53,7 +53,10 @@ class SwiftFoundationTests(product.Product):
         return self.args.test_foundation
 
     def configuration(self):
-        return 'release' if self.is_release() else 'debug'
+        if self.args.foundation_tests_build_variant in ['Release', 'RelWithDebInfo']:
+            return 'release'
+        else:
+            return 'debug'
 
     def test(self, host_target):
         swift_exec = os.path.join(


### PR DESCRIPTION
Use it in the linux CI presets to set them to Debug mode and speed up the linux CI, plus add a new preset which keeps building them in Release mode.

I was looking at a passing linux CI run and saw the log timings at the end: it takes [longer to build and test the swift-foundation repos than to compile all 7k+ mostly C++ files in LLVM](https://ci.swift.org/job/swift-PR-Linux/18996/console)!
```
--- Build Script Analyzer ---
Build Script Log: /home/build-user/build/.build_script_log
Build Percentage 	 Build Duration (sec) 	 Build Phase
================ 	 ==================== 	 ===========
9.2%              	 1132.94               	 Running tests for foundationtests
9.1%              	 1120.57               	 linux-x86_64-swift-build
9.0%              	 1104.2                	 Building llvm
7.2%              	 878.84                	 Running tests for swiftfoundationtests
6.5%              	 796.81                	 Running tests for swiftpm
5.6%              	 684.7                 	 Building swiftpm
5.5%              	 667.92                	 linux-x86_64-swift-test
4.9%              	 597.64
```
Looking at the log, building swift-foundation in release mode takes a long time, so let's see if changing it to debug mode helps. Some background - the Foundation repos are built twice on the linux CI: once by CMake, which is the version installed in the toolchain, then a second time by SwiftPM purely for testing.

This pull only affects that second SwiftPM build for testing, which is not shipped in the final toolchain but thrown away. @jmschonfeld and @shahmishal, let me know what you think.