### PR TITLE
Enable PACBTI on OpenBSD/arm64.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -204,6 +204,15 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back("-disable-objc-interop");
   }
 
+  if (Triple.isOSOpenBSD() && Triple.getArch() == llvm::Triple::aarch64) {
+    arguments.push_back("-Xcc");
+    arguments.push_back("-Xclang=-mbranch-target-enforce");
+    arguments.push_back("-Xcc");
+    arguments.push_back("-Xclang=-msign-return-address=non-leaf");
+    arguments.push_back("-Xcc");
+    arguments.push_back("-Xclang=-msign-return-address-key=a_key");
+  }
+
   if (inputArgs.getLastArg(options::OPT_experimental_serialize_debug_info)) {
     arguments.push_back(
         inputArgs.MakeArgString(Twine("-experimental-serialize-debug-info")));

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1425,6 +1425,9 @@ function swift_c_flags() {
         linux-static-*)
             echo -n " -D_GNU_SOURCE -DHAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME"
             ;;
+        openbsd-aarch64)
+            echo -n " -Xclang=-msign-return-address=non-leaf -Xclang=-msign-return-address-key=a_key -Xclang=-mbranch-target-enforce"
+            ;;
     esac
 }
 


### PR DESCRIPTION
BTI enforcement is mandatory here, which means if PAC and BTI instructions are not emitted, then the compiled binary gets killed with SIGILL. The default compiler achieves enabling PAC and BTI by embedding the relevant enabled Clang compilation option flags into the local platform toolchain, which affects C/C++ code generation.

For Swift however, to achieve the same effect, we would need to add the relevant LLVM module flags in the IRGen process. But, since Swift uses the Clang code generator when doing this, using the same option flag approach will work here as well, and is probably preferable to introducing operating system-dependent logic to the ClangImporter, for example.

Finally, the stdlib needs to be built with PACBTI as well, since the stdlib's global constructors get run when a compiled binary does. Since the Swift build uses the just-built Clang for the stdlib, just embed the necessary options into `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` via `build-script-impl`. This will be redundant with the host compiler, but at least it will be thorough.