### PR TITLE
[AVR] Fix broken IRGen emission due to not respecting LLVM program address space in the Datalayout

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6086,7 +6086,7 @@ Signature irgen::emitCastOfFunctionPointer(IRGenFunction &IGF,
                             : IGF.IGM.getSignature(fnType);
 
   // Emit the cast.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, sig.getType()->getPointerTo());
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, sig.getType()->getPointerTo(IGF.IGM.DataLayout.getProgramAddressSpace()));
 
   // Return the information.
   return sig;
@@ -6219,7 +6219,7 @@ FunctionPointer FunctionPointer::forExplosionValue(IRGenFunction &IGF,
                                                    llvm::Value *fnPtr,
                                                    CanSILFunctionType fnType) {
   // Bitcast out of an opaque pointer type.
-  assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
+  assert(fnPtr->getType() == IGF.IGM.Int8ProgramSpacePtrTy);
   auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
   auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
 
@@ -6238,7 +6238,7 @@ FunctionPointer::getExplosionValue(IRGenFunction &IGF,
   }
 
   // Bitcast to an opaque pointer type.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8ProgramSpacePtrTy);
 
   return fnPtr;
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2410,7 +2410,8 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM, LinkInfo &linkInfo,
   }
 
   llvm::Function *fn =
-    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(), name);
+    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(),
+     /*addrspace*/IGM.DataLayout.getProgramAddressSpace(), name);
   fn->setCallingConv(signature.getCallingConv());
 
   if (insertBefore) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -246,6 +246,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
   Int8PtrTy = PtrTy;
+  FunctionPtrTy = llvm::Type::getInt8Ty(getLLVMContext())->getPointerTo(DataLayout.getProgramAddressSpace());
   Int8PtrPtrTy = Int8PtrTy->getPointerTo(0);
   SizeTy = DataLayout.getIntPtrType(getLLVMContext(), /*addrspace*/ 0);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -723,8 +723,11 @@ public:
     llvm::PointerType *Int8PtrTy;      /// i8*
     llvm::PointerType *WitnessTableTy;
     llvm::PointerType *ObjCSELTy;
-    llvm::PointerType *FunctionPtrTy;
     llvm::PointerType *CaptureDescriptorPtrTy;
+  };
+  union {
+    llvm::PointerType *FunctionPtrTy;
+    llvm::PointerType *Int8ProgramSpacePtrTy; /// i8* in same address space as programs
   };
   union {
     llvm::PointerType *Int8PtrPtrTy;   /// i8**

--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -1,0 +1,42 @@
+// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+// RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
+// REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: CODEGENERATOR=AVR
+// REQUIRES: swift_feature_Embedded
+
+// IRGen needs various patches to work with program address space 1 on AVR.
+// Even the most basic stub program will fail to lower to IR without them.
+// We test IR rather than object code for now, to avoid any issues with an
+// out of date LLVM AVR back end throwing off the tests.
+// We are focusing on getting the front end functioning.
+
+import Swift
+
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
+let i: Int = 1
+
+var firstCallback: ((Int) -> Void)?
+
+var secondCallback: (@convention(c) (UInt8) -> UInt8)?
+
+#endif
+
+var j = i
+
+firstCallback = {
+	j += $0
+}
+
+secondCallback = {
+	return $0 * 2 - UInt8(j)
+}
+
+
+// CHECK: target triple = "avr-none-none-elf"
+// CHECK-DAG: 20testIRGenFunctioning1iSivp
+// CHECK-DAG: @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
+// CHECK-DAG: @"$e20testIRGenFunctioning14secondCallbacks5UInt8VADXCSgvp"
+// CHECK-DAG: 20testIRGenFunctioning1jSivp
+// CHECK: define protected i32 @main(i32 %0, ptr %1) addrspace(1)
+// CHECK: store i16 ptrtoint (ptr addrspace(1) @"$e20testIRGenFunctioningySicfU_" to i16), ptr @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
+// CHECK: define protected void @"$e20testIRGenFunctioningySicfU_"(i16 %0) addrspace(1)


### PR DESCRIPTION
[AVR] Fix IRGen function emission to respect LLVM DataLayout program address space.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

IRGen crashes when attempting to lower even the most basic Swift programs on AVR. I have encountered many problems similar to this over the years and it's always to do with program address space. (See forum discussion: https://forums.swift.org/t/avr-irgen-traps-on-lowering-invalid-cast-assertion-thrown-by-llvm/76883).

This seems to work for at least basic IRGen functionality on AVR. We may need more PRs in future for AVR but this is a start at least.

This is the approach I took on my fork, changing the structure of IRGenModule a bit to separate out `FunctionPtrTy`, if this is too intrusive for other platforms, I'm happy to use another approach, whatever seems sensible. I'm not attached to any one approach.

---

Note: AVR uses pointers with a different address space for program (flash) memory on the microcontrollers to distinguish RAM from Flash memory. Because AVR uses 16-bit pointers, there are not enough addresses to keep the two types of memory separate otherwise. This is well established in LLVM now (it has been in mainstream LLVM for years now) and all other AVR front ends (Rust, C, TinyGo) depend on it.

Resolves https://github.com/swiftlang/swift/issues/78380

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
