### PR TITLE
[AST] Walk into LocatableType in TypeWalker

### DIFF
--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -50,7 +50,11 @@ class Traversal : public TypeVisitor<Traversal, bool>
     return false;
 
   }
-  bool visitLocatableType(LocatableType *ty) { return false; }
+
+  bool visitLocatableType(LocatableType *ty) {
+    return doIt(ty->getSinglyDesugaredType());
+  }
+
   bool visitSILTokenType(SILTokenType *ty) { return false; }
 
   bool visitPackType(PackType *ty) {

--- a/validation-test/IDE/stress_tester_issues_fixed/issue-78397.swift
+++ b/validation-test/IDE/stress_tester_issues_fixed/issue-78397.swift
@@ -1,0 +1,21 @@
+// RUN: %batch-code-completion
+
+// https://github.com/apple/swift/issues/78397
+
+struct TabView<Content> {
+  public init(@ViewBuilder content: () -> Content)
+}
+
+protocol View {}
+func tabItem() -> some View
+
+@resultBuilder struct ViewBuilder {
+  static func buildBlock<T>(_ content: T) -> T
+}
+
+func test() -> some View {
+  TabView {
+    tabItem
+  }#^COMPLETE^#
+  // COMPLETE: Begin completions
+}


### PR DESCRIPTION
Make sure we walk into the underlying type for LocatableType.

Resolves #78397