### PR TITLE
[6.1] LargeLoadable types: propagate large type property along projections

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3500,6 +3500,8 @@ public:
    bool isLargeLoadableType(SILType ty);
    bool isPotentiallyCArray(SILType ty);
 
+   void propagate(PostOrderFunctionInfo &po);
+
 private:
   bool isLargeLoadableTypeOld(SILType ty);
 
@@ -3539,6 +3541,32 @@ private:
     return 0;
   }
 };
+}
+
+void LargeLoadableHeuristic::propagate(PostOrderFunctionInfo &po) {
+  if (!UseAggressiveHeuristic)
+    return;
+
+  for (auto *BB : po.getPostOrder()) {
+    for (auto &I : llvm::reverse(*BB)) {
+      switch (I.getKind()) {
+      case SILInstructionKind::TupleExtractInst:
+      case SILInstructionKind::StructExtractInst: {
+        auto &proj = cast<SingleValueInstruction>(I);
+        if (isLargeLoadableType(proj.getType())) {
+          auto opdTy = proj.getOperand(0)->getType();
+          auto entry = largeTypeProperties[opdTy];
+          entry.setNumRegisters(65535);
+          largeTypeProperties[opdTy] = entry;
+        }
+      }
+      break;
+
+      default:
+        continue;
+      }
+    }
+  }
 }
 
 void LargeLoadableHeuristic::visit(SILArgument *arg) {
@@ -4655,6 +4683,9 @@ static void runPeepholesAndReg2Mem(SILPassManager *pm, SILModule *silMod,
     // Delete replaced instructions.
     opts.deleteInstructions();
 
+    PostOrderFunctionInfo postorderInfo(&currF);
+    heuristic.propagate(postorderInfo);
+
     AddressAssignment assignment(heuristic, irgenModule, currF);
 
     // Assign addresses to basic block arguments.
@@ -4725,7 +4756,6 @@ static void runPeepholesAndReg2Mem(SILPassManager *pm, SILModule *silMod,
     }
 
     // Asign addresses to non-address SSA values.
-    PostOrderFunctionInfo postorderInfo(&currF);
     for (auto *BB : postorderInfo.getReversePostOrder()) {
       SmallVector<SILInstruction *, 32> origInsts;
       for (SILInstruction &i : *BB) {

--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -78,3 +78,19 @@ typedef union {
         unsigned char cnt;
     } out;
 } union_t;
+
+
+typedef enum {
+  TYPE1,
+  TYPE2,
+  TYPE3
+} member_type_t;
+
+typedef unsigned char uuid_t[16];
+typedef struct {
+  member_type_t member_type;
+  union {
+    uuid_t uuid;
+    unsigned x;
+  } member_value;
+} member_id_t;

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -1,5 +1,10 @@
 // RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
 
+// wasm currently disables aggressive reg2mem
+// UNSUPPORTED: wasm
+// UNSUPPORTED: OS=wasi
+// UNSUPPORTED: CPU=wasm32
+
 sil_stage canonical
 
 import Builtin
@@ -396,4 +401,26 @@ bb3(%4 : $X):
   dealloc_stack %2 : $*X
   %t = tuple ()
   return %t : $()
+}
+
+sil @usei8 : $@convention(thin) (UInt8) -> ()
+
+// CHECK: sil @test16
+// CHECK: bb0(%0 : $member_id_t):
+// CHECK:   [[T0:%.*]] = alloc_stack $member_id_t
+// CHECK:   store %0 to [[T0]] : $*member_id_t
+// CHECK:   struct_element_addr [[T0]]
+// CHECK:} // end sil function 'test16'
+
+sil @test16 : $@convention(thin) (member_id_t) -> () {
+bb0(%0 : $member_id_t):
+  %2 = alloc_stack $X
+  %44 = struct_extract %0 : $member_id_t, #member_id_t.member_value // user: %45
+  %45 = unchecked_trivial_bit_cast %44 : $member_id_t.__Unnamed_union_member_value to $(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+  %46 = tuple_extract %45 : $(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8), 0
+  %11 = function_ref @usei8 : $@convention(thin) (UInt8) -> ()
+  %12 = apply %11(%46) : $@convention(thin) (UInt8) -> ()
+  dealloc_stack %2 : $*X
+  %13 = tuple ()
+  return %13 : $()
 }


### PR DESCRIPTION
Explanation: Back propagate the isLargeType property along projections. This is neccessary because c union types can "hide" largeness. Without this change the compiler would crash because an operand of a projection (struct_extract, tuple_extract) would be deemed small but the projected element would be deemed large. The stack location for the operand would therefore be missing when lowering to addresses.

Scope: Corner case involving large c type lowering.

Risk: Medium. Should only affect c union types.

Original PR: https://github.com/swiftlang/swift/pull/78321

rdar://141775951