### PR TITLE
[6.1][CAS] Allow empty filename for diagnostics location

### DIFF
--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -330,7 +330,7 @@ unsigned DiagnosticSerializer::getFileIDFromBufferID(SourceManager &SM,
 
   auto &Buf = SM.getLLVMSourceMgr().getBufferInfo(Idx);
   auto Filename = Buf.Buffer->getBufferIdentifier();
-  bool IsFileBacked = SM.getFileSystem()->exists(Filename);
+  bool IsFileBacked = !Filename.empty() && SM.getFileSystem()->exists(Filename);
 
   // Construct and add to files. If there is an IncludeLoc, the file from
   // IncludeLoc is added before current file.

--- a/test/CAS/cached_diagnostics_empty_filename.swift
+++ b/test/CAS/cached_diagnostics_empty_filename.swift
@@ -1,0 +1,68 @@
+// REQUIRES: swift_feature_RegionBasedIsolation
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -I %t \
+// RUN:   -disable-implicit-string-processing-module-import \
+// RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -module-load-mode prefer-serialized
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:_SwiftConcurrencyShims > %t/cshim.cmd
+// RUN: %swift_frontend_plain @%t/cshim.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-MISS
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: cache miss for input
+// CHECK: <module-includes>:1
+// CHECK-SAME: note: in file included from <module-includes>:1:
+// CHECK: warning: warning a.h
+// CACHE-HIT: remark: replay output file
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
+// RUN:   -emit-module -o %t/test.swiftmodule -require-explicit-sendable -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+
+//--- module.modulemap
+module A {
+  header "a.h"
+  export *
+}
+
+//--- a.h
+#warning warning a.h
+
+#pragma clang attribute push(__attribute__((swift_attr("@_nonSendable(_assumed)"))), apply_to = any(objc_interface, record, enum))
+@protocol P
+@end
+
+@interface C
+@end
+#pragma clang attribute pop
+
+//--- test.swift
+import A
+import _Concurrency
+
+func acceptSendable<T: Sendable>(_: T) {
+}
+
+func testMe(c: C) {
+  acceptSendable(c)
+}
+


### PR DESCRIPTION
   - **Explanation**: Fix a bug that an empty filename for diagnostics can trigger an error in the cached diagnostics. The empty filename can be a virtual file synthesized, for example, to hold an implicit attribute from clang importer.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: The cached diagnostics can correctly handle such filename now and cached/replay those diagnostics.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://141961161
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78406
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Swift caching only and a very safe fix to handle empty file names.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Added unit test.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @benlangmuir 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->


