### PR TITLE
build: enable the Android SDKs to be built, packaged, and tested

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -75,6 +75,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^
+  -AndroidSDKs aarch64 ^
   %SkipPackagingArg% ^
   %TestArg% ^
   -Stage %PackageRoot% ^


### PR DESCRIPTION
Build and package the Android SDKs on Windows as part of the toolchain distribution. This requires further fine tuning to improve the DevEx, however, this ensures that we do not backslide on the ability to build and package the SDK as a starting point.