### PR TITLE
Statically emit ELF notes for Swift's metadata sections.

### DIFF
--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -70,7 +70,7 @@ struct SectionNote {
   /// The size of this array must be a multiple of `sizeof(void *)` plus `4` to
   /// ensure correct alignment on 64-bit archs (because `ElfW(Nhdr)` is 12 bytes
   /// long and only 4-byte aligned.)
-  char name[28];
+  char n_name[28];
 
   /// The "payload" of the note.
   struct Bounds {
@@ -85,17 +85,17 @@ struct SectionNote {
   Bounds bounds;
 };
 
-#define DECLARE_NOTE(name)                             \
-  __attribute__((section(".note.swift5.section")))     \
-  static const SectionNote note##name = {              \
-    {                                                  \
-      sizeof(SectionNote::name), /* n_namesz */        \
-      sizeof(Section::Bounds), /* n_descsz */          \
-      0 /* n_type (unused) */                          \
-    },                                                 \
-    #name,                                             \
-    &__start_##name,                                   \
-    &__stop_##name                                     \
+#define DECLARE_NOTE(name)                                   \
+  __attribute__((section(".note.swift5.section"), used))     \
+  static const SectionNote note_##name = {                   \
+    {                                                        \
+      sizeof(SectionNote::n_name), /* n_namesz */            \
+      sizeof(SectionNote::Bounds), /* n_descsz */            \
+      0 /* n_type (unused) */                                \
+    },                                                       \
+    #name,                                                   \
+    &__start_##name,                                         \
+    &__stop_##name                                           \
   };
 #else
 #define DECLARE_NOTE(name)

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -70,7 +70,7 @@ struct SectionNote {
   /// The size of this array must be a multiple of `sizeof(void *)` plus `4` to
   /// ensure correct alignment on 64-bit archs (because `ElfW(Nhdr)` is 12 bytes
   /// long and only 4-byte aligned.)
-  char n_name[28];
+  char n_name[36];
 
   /// The "payload" of the note.
   struct Bounds {

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -17,9 +17,9 @@
 #include <cstddef>
 #include <new>
 
-#if defined(__ELF__) && __has_include(<elf.h>)
+#if defined(__ELF__) && __has_include(<link.h>)
 #define EMIT_NOTES 1
-#include <elf.h>
+#include <link.h>
 #else
 #define EMIT_NOTES 0
 #endif


### PR DESCRIPTION
ELF does not preserve section information like Mach-O and COFF do. This PR adds additional exported symbols on platforms that use ELF to help us find Swift's metadata sections at runtime. These symbols are emitted as [ELF notes](https://man7.org/linux/man-pages/man5/elf.5.html), which are a kind of optional metadata that can be iterated at runtime using the [`dl_iterate_phdr()`](https://man7.org/linux/man-pages/man3/dl_iterate_phdr.3.html) function.

Although the ELF standard says that notes can be stripped without affecting a program's behavior, in practice they are used widely for similar purposes e.g. by GCC/ld and various OS vendors.

A more permanent solution may involve teaching llvm and lld about some new section name or attribute that translates to a specific custom ELF program header in the `PT_LOUSER`–`PT_HIUSER` range, then emitting that information for all of Swift's standard sections as well as anything marked `@_section`.

Resolves #76698.