### PR TITLE
Frontend: Fix `-target-variant` subarch normalization

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -573,8 +573,7 @@ public:
 bool extractCompilerFlagsFromInterface(
     StringRef interfacePath, StringRef buffer, llvm::StringSaver &ArgSaver,
     SmallVectorImpl<const char *> &SubArgs,
-    std::optional<llvm::Triple> PreferredTarget = std::nullopt,
-    std::optional<llvm::Triple> PreferredTargetVariant = std::nullopt);
+    std::optional<llvm::Triple> PreferredTarget = std::nullopt);
 
 /// Extract the user module version number from an interface file.
 llvm::VersionTuple extractUserModuleVersionFromInterface(StringRef moduleInterfacePath);

--- a/test/ScanDependencies/Inputs/target-normalization/iOSSupport/Unzippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface
+++ b/test/ScanDependencies/Inputs/target-normalization/iOSSupport/Unzippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Unzippered -target arm64e-apple-ios15.0-macabi
+import Swift
+public func unzipperedFunc() { }

--- a/test/ScanDependencies/Inputs/target-normalization/macOS/Unzippered.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/target-normalization/macOS/Unzippered.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Unzippered -target arm64e-apple-macosx12.0
+import Swift
+public func unzipperedFunc() { }

--- a/test/ScanDependencies/Inputs/target-normalization/macOS/Zippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface
+++ b/test/ScanDependencies/Inputs/target-normalization/macOS/Zippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Zippered -target arm64e-apple-ios15.0-macabi
+import Swift
+public func zipperedFunc() { }

--- a/test/ScanDependencies/Inputs/target-normalization/macOS/Zippered.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/target-normalization/macOS/Zippered.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Zippered -target arm64e-apple-macosx12.0 -target-variant arm64e-apple-ios15.0-macabi
+import Swift
+public func zipperedFunc() { }

--- a/test/ScanDependencies/target_normalization.swift
+++ b/test/ScanDependencies/target_normalization.swift
@@ -1,0 +1,56 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64-apple-macosx14.0 \
+// RUN:   -o %t/deps-arm64-apple-macosx.json
+
+// RUN: %validate-json %t/deps-arm64-apple-macosx.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64-apple-macosx.json \
+// RUN:   -DORIG_ARCH=arm64 \
+// RUN:   -DNORM_ARCH=aarch64
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64e-apple-macosx14.0 \
+// RUN:   -o %t/deps-arm64e-apple-macosx.json
+
+// RUN: %validate-json %t/deps-arm64e-apple-macosx.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64e-apple-macosx.json \
+// RUN:   -DORIG_ARCH=arm64e \
+// RUN:   -DNORM_ARCH=arm64e
+
+import Zippered
+import Unzippered
+
+// CHECK:        "modulePath": "{{.*}}Unzippered-[[UNZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/macOS/Unzippered.swiftmodule/arm64e-apple-macos.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-macosx14.0"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-macosx12.0"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "contextHash": "[[UNZIPPERED_HASH]]",
+
+// CHECK:        "modulePath": "{{.*}}Zippered-[[ZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/macOS/Zippered.swiftmodule/arm64e-apple-macos.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-macosx14.0"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-macosx12.0"
+// CHECK:        "-target-variant"
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-ios15.0-macabi",
+// CHECK:        "contextHash": "[[ZIPPERED_HASH]]",

--- a/test/ScanDependencies/target_normalization_maccatalyst.swift
+++ b/test/ScanDependencies/target_normalization_maccatalyst.swift
@@ -1,0 +1,55 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64-apple-ios15.0-macabi \
+// RUN:   -o %t/deps-arm64-apple-ios-macabi.json
+
+// RUN: %validate-json %t/deps-arm64-apple-ios-macabi.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64-apple-ios-macabi.json \
+// RUN:   -DORIG_ARCH=arm64 \
+// RUN:   -DNORM_ARCH=aarch64
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64e-apple-ios15.0-macabi \
+// RUN:   -o %t/deps-arm64e-apple-ios-macabi.json
+
+// RUN: %validate-json %t/deps-arm64e-apple-ios-macabi.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64e-apple-ios-macabi.json \
+// RUN:   -DORIG_ARCH=arm64e \
+// RUN:   -DNORM_ARCH=arm64e
+
+import Zippered
+import Unzippered
+
+// CHECK:        "modulePath": "{{.*}}Unzippered-[[UNZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/iOSSupport/Unzippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-ios15.0-macabi"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-ios15.0-macabi"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "contextHash": "[[UNZIPPERED_HASH]]",
+
+// CHECK:        "modulePath": "{{.*}}Zippered-[[ZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/macOS/Zippered.swiftmodule/arm64e-apple-ios-macabi.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-ios15.0-macabi"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-ios15.0-macabi"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "contextHash": "[[ZIPPERED_HASH]]",

--- a/test/ScanDependencies/target_normalization_maccatalyst_zippered.swift
+++ b/test/ScanDependencies/target_normalization_maccatalyst_zippered.swift
@@ -1,0 +1,57 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64-apple-macosx14.0 \
+// RUN:   -target-variant arm64-apple-ios15.0-macabi \
+// RUN:   -o %t/deps-arm64-apple-macosx.json
+
+// RUN: %validate-json %t/deps-arm64-apple-macosx.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64-apple-macosx.json \
+// RUN:   -DORIG_ARCH=arm64 \
+// RUN:   -DNORM_ARCH=aarch64
+
+// RUN: %target-swift-frontend -parse-stdlib -scan-dependencies %s \
+// RUN:   -module-cache-path %t/module-cache \
+// RUN:   -I %S/Inputs/target-normalization/iOSSupport \
+// RUN:   -I %S/Inputs/target-normalization/macOS \
+// RUN:   -target arm64e-apple-macosx14.0 \
+// RUN:   -target-variant arm64e-apple-ios15.0-macabi \
+// RUN:   -o %t/deps-arm64e-apple-macosx.json
+
+// RUN: %validate-json %t/deps-arm64e-apple-macosx.json
+// RUN: %FileCheck %s --input-file %t/deps-arm64e-apple-macosx.json \
+// RUN:   -DORIG_ARCH=arm64e \
+// RUN:   -DNORM_ARCH=arm64e
+
+import Zippered
+import Unzippered
+
+// CHECK:        "modulePath": "{{.*}}Unzippered-[[UNZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/macOS/Unzippered.swiftmodule/arm64e-apple-macos.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-macosx14.0"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-macosx12.0"
+// CHECK-NOT:    "-target-variant"
+// CHECK:        "contextHash": "[[UNZIPPERED_HASH]]",
+
+// CHECK:        "modulePath": "{{.*}}Zippered-[[ZIPPERED_HASH:[A-Z0-9]+]].swiftmodule",
+// CHECK:        "moduleInterfacePath": "{{.*}}/macOS/Zippered.swiftmodule/arm64e-apple-macos.swiftinterface",
+// CHECK:        "commandLine"
+// CHECK:        "-compile-module-from-interface",
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[ORIG_ARCH]]-apple-macosx14.0"
+// CHECK:        "-target",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-macosx12.0"
+// CHECK:        "-target-variant",
+// CHECK-NEXT:   "[[NORM_ARCH]]-apple-ios15.0-macabi",
+// CHECK:        "contextHash": "[[ZIPPERED_HASH]]",


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/77156, normalization was introduced for `-target-variant` triples. That PR also caused `-target-variant` arguments to be inherited from the main compilation options whenever building dependency modules from their interfaces, which is incorrect. The `-target-variant` option must only be specified when compiling a "zippered" module, but the dependencies of zippered modules are not necessarily zippered themselves and indiscriminately propagating the option can cause miscompilation.

The new, more targeted approach to normalizing arm64e triples simply uses the arch and subarch of the `-target` argument of the main compile to decide whether the subarch of both the `-target` and `-target-variant` arguments of a dependency need adjustment.

Resolves rdar://135322077 and rdar://141640919.
