### PR TITLE
[6.1] Cherry-pick various windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -950,12 +950,6 @@ if (NOT BOOTSTRAPPING_MODE)
   message(FATAL_ERROR "turning off bootstrapping is not supported anymore")
 endif()
 
-# As a temporary workaround, disable SwiftCompilerSources on
-# Windows/ARM64 because the compiler segfaults
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
-  set(BOOTSTRAPPING_MODE "OFF")
-endif()
-
 set(SWIFT_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -279,6 +279,7 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
   // optimization pipeline.
   SerializationOptions SerializationOpts;
   std::string OutPathStr = OutputPath.str();
+  SerializationOpts.StaticLibrary = FEOpts.Static;
   SerializationOpts.OutputPath = OutPathStr.c_str();
   SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
   SerializationOpts.AutolinkForceLoad =

--- a/test/ModuleInterface/Inputs/SR77756/dynamic.swiftinterface
+++ b/test/ModuleInterface/Inputs/SR77756/dynamic.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name dynamic
+
+import Swift
+
+public func f() {}
+

--- a/test/ModuleInterface/Inputs/SR77756/static.swiftinterface
+++ b/test/ModuleInterface/Inputs/SR77756/static.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -static -module-name static
+
+import Swift
+
+public func f() {}

--- a/test/ModuleInterface/swift-interface-compile.swift
+++ b/test/ModuleInterface/swift-interface-compile.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t/mcp -I %S/Inputs/SR77756 -c %s -o /dev/null -D STATIC
+// RUN: llvm-bcanalyzer -dump %t/mcp/static-*.swiftmodule | %FileCheck %s -check-prefix CHECK-STATIC
+// RUN: %target-swift-frontend -module-cache-path %t/mcp -I %S/Inputs/SR77756 -c %s -o /dev/null
+// RUN: llvm-bcanalyzer -dump %t/mcp/dynamic-*.swiftmodule | %FileCheck %s -check-prefix CHECK-DYNAMIC
+
+#if STATIC
+import `static`
+#else
+import `dynamic`
+#endif
+
+// CHECK-STATIC: IS_STATIC
+// CHECK-DYNAMIC-NOT: IS_STATIC

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.28)
+
+project(swift-inspect
+  LANGUAGES CXX Swift)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+find_package(ArgumentParser CONFIG REQUIRED)
+
+add_library(SymbolicationShims INTERFACE)
+target_include_directories(SymbolicationShims INTERFACE
+  Sources/SymbolicationShims)
+
+if(WIN32)
+  add_library(SwiftInspectClientInterface INTERFACE)
+  target_include_directories(SwiftInspectClientInterface INTERFACE
+    Sources/SwiftInspectClientInterface)
+
+  add_library(SwiftInspectClient SHARED
+    Sources/SwiftInspectClient/SwiftInspectClient.cpp)
+  target_link_libraries(SwiftInspectClient PRIVATE
+    SwiftInspectClientInterface)
+endif()
+
+add_executable(swift-inspect
+  Sources/swift-inspect/Operations/DumpArray.swift
+  Sources/swift-inspect/Operations/DumpCacheNodes.swift
+  Sources/swift-inspect/Operations/DumpConcurrency.swift
+  Sources/swift-inspect/Operations/DumpConformanceCache.swift
+  Sources/swift-inspect/Operations/DumpGenericMetadata.swift
+  Sources/swift-inspect/Operations/DumpRawMetadata.swift
+  Sources/swift-inspect/Backtrace.swift
+  Sources/swift-inspect/DarwinRemoteProcess.swift
+  Sources/swift-inspect/main.swift
+  Sources/swift-inspect/Process.swift
+  Sources/swift-inspect/RemoteMirror+Extensions.swift
+  Sources/swift-inspect/RemoteProcess.swift
+  Sources/swift-inspect/String+Extensions.swift
+  Sources/swift-inspect/Symbolication+Extensions.swift
+  Sources/swift-inspect/WindowsRemoteProcess.swift
+  Sources/swift-inspect/WinSDK+Extentions.swift)
+target_compile_options(swift-inspect PRIVATE
+  -parse-as-library)
+target_link_libraries(swift-inspect PRIVATE
+  ArgumentParser
+  swiftRemoteMirror)
+if(WIN32)
+  target_link_libraries(swift-inspect PRIVATE
+    SwiftInspectClientInterface)
+endif()
+
+install(TARGETS swift-inspect
+  DESTINATION bin)
+if(WIN32)
+  install(TARGETS SwiftInspectClient
+    RUNTIME DESTINATION bin)
+endif()

--- a/tools/swift-inspect/Package.swift
+++ b/tools/swift-inspect/Package.swift
@@ -21,10 +21,7 @@ let package = Package(
                 .target(name: "SwiftInspectClientInterface", condition: .when(platforms: [.windows])),
             ],
             swiftSettings: [.unsafeFlags(["-parse-as-library"])]),
-        .target(
-            name: "SwiftInspectClient",
-            // Workaround https://github.com/llvm/llvm-project/issues/40056
-            cxxSettings: [.unsafeFlags(["-Xclang", "-fno-split-cold-code"])]),
+        .target(name: "SwiftInspectClient"),
         .systemLibrary(
             name: "SwiftInspectClientInterface"),
         .testTarget(

--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -8,12 +8,20 @@ swift-inspect uses the reflection APIs to introspect the live process.  It relie
 
 swift-inspect can be built using [swift-package-manager](https://github.com/swiftlang/swift-package-manager).
 
-##### Windows
+#### Windows
 
 In order to build on Windows, some additional parameters must be passed to the build tool to locate the necessary libraries.
 
 ~~~
 swift build -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib
+~~~
+
+#### CMake
+
+In order to build on Windows with CMake, some additional parameters must be passed to the build tool to locate the necessary Swift modules.
+
+~~~
+cmake -B out -G Ninja -S . -D ArgumentParser_DIR=... -D CMAKE_Swift_FLAGS="-Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror"
 ~~~
 
 ### Using

--- a/tools/swift-inspect/Sources/SwiftInspectClient/SwiftInspectClient.cpp
+++ b/tools/swift-inspect/Sources/SwiftInspectClient/SwiftInspectClient.cpp
@@ -12,7 +12,9 @@
 
 #if defined(_WIN32)
 
+#if SWIFT_PACKAGE
 #pragma comment(lib, "swiftCore.lib")
+#endif
 
 #include "../SwiftInspectClientInterface/SwiftInspectClientInterface.h"
 #include <assert.h>

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -166,14 +166,14 @@ if ($null -eq $BuildArchName) { $BuildArchName = $env:PROCESSOR_ARCHITECTURE }
 if ($PinnedBuild -eq "") {
   switch ($BuildArchName) {
     "AMD64" {
-      $PinnedBuild = "https://download.swift.org/swift-5.10.1-release/windows10/swift-5.10.1-RELEASE/swift-5.10.1-RELEASE-windows10.exe"
-      $PinnedSHA256 = "3027762138ACFA1BBE3050FF6613BBE754332E84C9EFA5C23984646009297286"
-      $PinnedVersion = "5.10.1"
+      $PinnedBuild = "https://download.swift.org/swift-6.0.3-release/windows10/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-windows10.exe"
+      $PinnedSHA256 = "AB205D83A38047882DB80E6A88C7D33B651F3BAC96D4515D7CBA5335F37999D3"
+      $PinnedVersion = "6.0.3"
     }
     "ARM64" {
-      $PinnedBuild = "https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a/swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a-windows10-arm64.exe"
-      $PinnedSHA256 = "037BDBF9D1A1A99D7156584948870A8A958FD27CC4FF5711691CC0A76F2E88F5"
-      $PinnedVersion = "0.0.0"
+      $PinnedBuild = "https://download.swift.org/swift-6.0.3-release/windows10-arm64/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-windows10-arm64.exe"
+      $PinnedSHA256 = "81474651E59A9955C9E6A389EF53ABD61631FFC62C63A2A02977271019E7C722"
+      $PinnedVersion = "6.0.3"
     }
     default { throw "Unsupported processor architecture" }
   }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2644,8 +2644,7 @@ function Build-Inspect() {
     -Bin (Get-HostProjectBinaryCache SwiftInspect) `
     -InstallTo "$($HostArch.ToolchainInstallRoot)\usr" `
     -Arch $HostArch `
-    -UseBuiltCompilers Swift `
-    -UseSwiftSwiftDriver `
+    -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SDKRoot `
     -Defines @{
       CMAKE_Swift_FLAGS = @("-Xcc", "-I$SDKRoot\usr\include\swift\SwiftRemoteMirror");
@@ -2845,6 +2844,7 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-Format $HostArch
   Invoke-BuildStep Build-IndexStoreDB $HostArch
   Invoke-BuildStep Build-SourceKitLSP $HostArch
+  Invoke-BuildStep Build-Inspect $HostArch
 }
 
 Install-HostToolchain
@@ -2854,7 +2854,6 @@ if (-not $SkipBuild -and $Allocator -eq "mimalloc") {
 }
 
 if (-not $SkipBuild -and -not $IsCrossCompiling) {
-  Invoke-BuildStep Build-Inspect $HostArch
   Invoke-BuildStep Build-DocC $HostArch
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1183,7 +1183,7 @@ function Build-CMakeProject {
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$(Get-CMarkBinaryCache $Arch)\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
+      $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$(Get-CMarkBinaryCache $BuildArch)\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;$(Get-PinnedToolchainRuntime);${env:Path}"
     } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
@@ -1944,7 +1944,7 @@ function Build-FoundationMacros() {
 
   $SwiftSDK = $null
   if ($Build) {
-    $SwiftSDK = $BuildArch.SDKInstallRoot
+    $SwiftSDK = $(Get-PinnedToolchainSDK)
   }
 
   $InstallDir = $null
@@ -2580,7 +2580,7 @@ function Build-TestingMacros() {
 
   $SwiftSDK = $null
   if ($Build) {
-    $SwiftSDK = $BuildArch.SDKInstallRoot
+    $SwiftSDK = $(Get-PinnedToolchainSDK)
   }
 
   $Targets = if ($Build) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2711,7 +2711,7 @@ function Build-Installer($Arch) {
   }
 
   foreach ($SDK in $WindowsSDKArchs) {
-    $Properties["INCLUDE_$($SDK.VSName.ToUpperInvariant())_SDK"] = "true"
+    $Properties["INCLUDE_WINDOWS_$($SDK.VSName.ToUpperInvariant())_SDK"] = "true"
     $Properties["PLATFORM_ROOT_$($SDK.VSName.ToUpperInvariant())"] = "$($SDK.PlatformInstallRoot)\"
     $Properties["SDK_ROOT_$($SDK.VSName.ToUpperInvariant())"] = "$($SDK.SDKInstallRoot)\"
   }
@@ -2722,11 +2722,9 @@ function Build-Installer($Arch) {
 function Stage-BuildArtifacts($Arch) {
   Copy-File "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\*.cab" "$Stage\"
   Copy-File "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\*.msi" "$Stage\"
-  Copy-File "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\rtl.cab" "$Stage\"
-  Copy-File "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\rtl.msi" "$Stage\"
   foreach ($SDK in $WindowsSDKArchs) {
-    Copy-File "$($Arch.BinaryCache)\installer\Release\$($SDK.VSName)\sdk.$($SDK.VSName).cab" "$Stage\"
-    Copy-File "$($Arch.BinaryCache)\installer\Release\$($SDK.VSName)\sdk.$($SDK.VSName).msi" "$Stage\"
+    Copy-File "$($Arch.BinaryCache)\installer\Release\$($SDK.VSName)\sdk.windows.$($SDK.VSName).cab" "$Stage\"
+    Copy-File "$($Arch.BinaryCache)\installer\Release\$($SDK.VSName)\sdk.windows.$($SDK.VSName).msi" "$Stage\"
     Copy-File "$($Arch.BinaryCache)\installer\Release\$($SDK.VSName)\rtl.$($SDK.VSName).msm" "$Stage\"
   }
   Copy-File "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\installer.exe" "$Stage\"

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -454,6 +454,7 @@ enum HostComponent {
   LMDB
   SymbolKit
   DocC
+  SwiftInspect
 }
 
 function Get-HostProjectBinaryCache([HostComponent]$Project) {
@@ -2636,18 +2637,20 @@ function Install-HostToolchain() {
 }
 
 function Build-Inspect() {
-  $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath swift-inspect
-  $SDKInstallRoot = (Get-HostSwiftSDK) `
+  $SDKRoot = Get-HostSwiftSDK
 
-  Isolate-EnvVars {
-    $env:SWIFTCI_USE_LOCAL_DEPS=1
-    Build-SPMProject `
-      -Action Build `
-      -Src $SourceCache\swift\tools\swift-inspect `
-      -Bin $OutDir `
-      -Arch $HostArch `
-      -Xcc "-I$SDKInstallRoot\usr\include\swift\SwiftRemoteMirror" -Xlinker "$SDKInstallRoot\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib"
-  }
+  Build-CMakeProject `
+    -Src $SourceCache\swift\tools\swift-inspect `
+    -Bin (Get-HostProjectBinaryCache SwiftInspect) `
+    -InstallTo "$($HostArch.ToolchainInstallRoot)\usr" `
+    -Arch $HostArch `
+    -UseBuiltCompilers Swift `
+    -UseSwiftSwiftDriver `
+    -SwiftSDK $SDKRoot `
+    -Defines @{
+      CMAKE_Swift_FLAGS = @("-Xcc", "-I$SDKRoot\usr\include\swift\SwiftRemoteMirror");
+      ArgumentParser_DIR = (Get-HostProjectCMakeModules ArgumentParser);
+    }
 }
 
 function Build-DocC() {
@@ -2686,7 +2689,6 @@ function Test-PackageManager() {
 function Build-Installer($Arch) {
   # TODO(hjyamauchi) Re-enable the swift-inspect and swift-docc builds
   # when cross-compiling https://github.com/apple/swift/issues/71655
-  $INCLUDE_SWIFT_INSPECT = if ($IsCrossCompiling) { "false" } else { "true" }
   $INCLUDE_SWIFT_DOCC = if ($IsCrossCompiling) { "false" } else { "true" }
   $ENABLE_MIMALLOC = if ($Allocator -eq "mimalloc" -and $Arch -eq $ArchX64) { "true" } else { "false" }
 
@@ -2694,10 +2696,8 @@ function Build-Installer($Arch) {
     BundleFlavor = "offline";
     DEVTOOLS_ROOT = "$($Arch.ToolchainInstallRoot)\";
     TOOLCHAIN_ROOT = "$($Arch.ToolchainInstallRoot)\";
-    INCLUDE_SWIFT_INSPECT = $INCLUDE_SWIFT_INSPECT;
-    SWIFT_INSPECT_BUILD = "$($Arch.BinaryCache)\swift-inspect\release";
-    INCLUDE_SWIFT_DOCC = $INCLUDE_SWIFT_DOCC;
     ENABLE_MIMALLOC = $ENABLE_MIMALLOC;
+    INCLUDE_SWIFT_DOCC = $INCLUDE_SWIFT_DOCC;
     SWIFT_DOCC_BUILD = "$($Arch.BinaryCache)\swift-docc\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";
   }


### PR DESCRIPTION
  - **Explanation**: Mostly this is all build system for swift-inspect + arm64, but there's also a small fix for cxx interfaces as well.
  - **Scope**: Serialization (cxx interface fix) and then build system for the rest
  - **Original PRs**: Many, see commits
  - **Risk**: Low as long as it builds!
  - **Testing**: Will run cross PR testing
  - **Reviewers**: @compnerd @hjyamauchi 