### PR TITLE
Runtimes: disable ObjC interop if not enabled

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -127,6 +127,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
   $<$<COMPILE_LANGUAGE:CXX>:-funwind-tables>
+  "$<$<AND:$<COMPILE_LANGUAGE:Swift>,$<NOT:$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>>>:SHELL:-Xfrontend -disable-objc-interop>"
   "$<$<AND:$<COMPILE_LANGUAGE:Swift>,$<PLATFORM_ID:Windows>>:SHELL:-Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules>"
   $<$<AND:$<COMPILE_LANGUAGE:Swift>,$<BOOL:${SwiftCore_ENABLE_LIBRARY_EVOLUTION}>>:-enable-library-evolution>)
 


### PR DESCRIPTION
Disable the objc interop support explicitly if objc interop is disabled in the toolchain build.