### PR TITLE
[6.1] IRGen: OutliningCollector's bindPolymorphicParameters needs to disambiguate between Formal and Representational metadata types

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -246,10 +246,14 @@ void OutliningMetadataCollector::bindPolymorphicParameters(
       auto key = pair.first;
       assert(key.Kind.isAnyTypeMetadata());
       setTypeMetadataName(IGF.IGM, arg, key.Type);
-      IGF.bindLocalTypeDataFromTypeMetadata(key.Type,
-                                            IsExact,
-                                            arg,
-                                            MetadataState::Complete);
+      if (key.Kind == LocalTypeDataKind::forRepresentationTypeMetadata()) {
+        IGF.setUnscopedLocalTypeData(key, MetadataResponse::forComplete(arg));
+      } else {
+        IGF.bindLocalTypeDataFromTypeMetadata(key.Type,
+                                              IsExact,
+                                              arg,
+                                              MetadataState::Complete);
+      }
     }
     return;
   }

--- a/test/IRGen/outlined_copy_addr.sil
+++ b/test/IRGen/outlined_copy_addr.sil
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-ir %s -I %t | %FileCheck %s
+
+import Swift
+import resilient_struct
+
+indirect enum E<A, B> {
+    case a(A, B)
+    case b(B)
+    case c(A)
+    case d
+}
+
+// This used to crash when generating the outlined copy function.
+// CHECK: s18outlined_copy_addr1EOyxq_G_S2i16resilient_struct12ResilientIntVIeg_tSgr0_lWOb
+
+sil @test : $@convention(thin) <ItemA, ItemB> () -> () {
+bb0:
+  %1 = alloc_stack $Optional<(E<ItemA, ItemB>, Int, Int, ResilientInt, @callee_guaranteed () -> ())>
+  %2 = alloc_stack $Optional<(E<ItemA, ItemB>, Int, Int, ResilientInt, @callee_guaranteed () -> ())>
+  copy_addr [take] %1 to [init] %2 : $*Optional<(E<ItemA, ItemB>, Int, Int, ResilientInt, @callee_guaranteed () -> ())>
+  dealloc_stack %2 : $*Optional<(E<ItemA, ItemB>, Int, Int, ResilientInt, @callee_guaranteed () -> ())>
+  dealloc_stack %1 : $*Optional<(E<ItemA, ItemB>, Int, Int, ResilientInt, @callee_guaranteed () -> ())>
+  %t = tuple ()
+  return %t: $()
+}


### PR DESCRIPTION


Explaination: A recent change removed the usage of LocalTypeDataKind when populating the local type metadata cache. This change reintroduces it.

Scope: Whenever representational metadat types are called for a compiler crash could be the result.

Risk: Low. Should restore previous behavior when representational types are called for.

Original PR: https://github.com/swiftlang/swift/pull/78423

rdar://141961121