### PR TITLE
🍒[6.1] Frontend: add an ABI checker flag to avoid downgrading detected ABI breakages into warnings.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1785,6 +1785,10 @@ def compiler_style_diags: Flag<["-", "--"], "compiler-style-diags">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   HelpText<"Print compiler style diagnostics to stderr.">;
 
+def error_on_abi_breakage: Flag<["-", "--"], "error-on-abi-breakage">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Always treat ABI checker issues as errors">;
+
 def json: Flag<["-", "--"], "json">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   HelpText<"Print output in JSON format.">;


### PR DESCRIPTION
- Explanation: By default in certain build environments, we downgrade ABI checker issues to warnings to prevent blocking the build process. Several existing users raised concerns about this for escaping significant ABI breakages. Therefore, an ABI checker flag is introduced in this PR to allow users to opt-in a mode where ABI breakages are considered fatal.

- Scope: ABI checker
 
- Risk: Very Low. No existing behaviors are altered except adding an argument
 
- Original PR: https://github.com/swiftlang/swift/pull/78418
 
- Resolves: rdar://122325279

- Reviewer: @tshortli 