### PR TITLE
Use Response file for SwiftFoundation

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1928,6 +1928,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -UseBuiltCompilers ASM,C,CXX,Swift `
         -SwiftSDK:$SDKRoot `
         -Defines (@{
+          CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
           ENABLE_TESTING = "NO";
           FOUNDATION_BUILD_TOOLS = if ($Platform -eq "Windows") { "YES" } else { "NO" };
           CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";


### PR DESCRIPTION
The command-line length to compile SwiftFoundation for arm64 exceeds the maximum command-line length on Windows. Force CMake to use a response file to get around this limitation.