### PR TITLE
[SILOptimizer] Prevent crash in SendNonSendable by using function’s Type Lowering

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1647,7 +1647,7 @@ bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
   for (auto capture : ce->getCaptureInfo().getCaptures()) {
     auto *decl = capture.getDecl();
     auto type = decl->getInterfaceType()->getCanonicalType();
-    auto silType = SILType::getPrimitiveObjectType(type);
+    auto silType = pai->getFunction()->getTypeLowering(type).getLoweredType();
     if (!SILIsolationInfo::isNonSendableType(silType, pai->getFunction()))
       continue;
 


### PR DESCRIPTION
Previously, the SendNonSendable diagnostic pass called `SILType::getPrimitiveObjectType(...)` directly on a closure capture’s `CanType`. If that type hadn’t been fully lowered yet, it triggered the assertion in `SILType` and caused a compiler crash.

This patch switches to retrieving the lowered to prevent the crash.

Resolves https://github.com/swiftlang/swift/issues/78439