### PR TITLE
[Diagnostics] A self argument implicitly passed as an inout parameter is diagnosed as used before initialized

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1733,8 +1733,13 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
       return;
     }
 
-    auto diagID = diag::variable_inout_before_initialized;
-    
+    // A self argument implicitly passed as an inout parameter is diagnosed as
+    // "used before initialized", because "passed by reference" might be a
+    // confusing diagnostic in this context.
+    auto diagID = (Use.Kind == DIUseKind::InOutSelfArgument)
+                      ? diag::variable_used_before_initialized
+                      : diag::variable_inout_before_initialized;
+
     if (isa<AddressToPointerInst>(Use.Inst))
       diagID = diag::variable_addrtaken_before_initialized;
 

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -29,3 +29,13 @@ func bas<T>(a: Bool, t: T) {
 
   x = t
 }
+
+func quz<T>(a: Bool, t: T) {
+  let closure: (inout T) -> Void = { _ in }
+  var x: T // expected-note {{defined here}}
+  defer { closure(&x) } // expected-error{{variable 'x' passed by reference before being initialized}}
+  if a {
+    x = t
+    return
+  }
+}

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -125,6 +125,18 @@ func test2() {
   // expected-note@+1 {{'u2' declared here}}
   unowned let u2 = SomeClass()
   _ = u2                // ok
+
+  // Array
+  var arr1: [String] // expected-note {{variable defined here}}
+  arr1.append("item") // expected-error {{variable 'arr1' used before being initialized}}
+  var arr2: [String] = []
+  arr2.append("item") // ok
+
+  // Dictionary
+  var d1: [String: Int] // expected-note {{variable defined here}}
+  d1["key"] = 1 // expected-error {{variable 'd1' used before being initialized}}
+  var d2: [String: Int] = [:]
+  d2["key"] = 1 // ok
 }
 
 
@@ -1483,8 +1495,7 @@ func testOptionalChainingWithGenerics<T: DIOptionalTestProtocol>(p: T) -> T? {
             // expected-note@-2 {{constant defined here}}
 
   // note that here assignment to 'f' is a call to the setter.
-  x?.f = 0  // expected-error {{constant 'x' used before being initialized}}
-            // expected-error@-1 {{constant 'x' passed by reference before being initialized}}
+  x?.f = 0  // expected-error 2 {{constant 'x' used before being initialized}}
   return x  // expected-error {{constant 'x' used before being initialized}}
 }
 


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:


For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

  Resolves #55825 

When using the `self` argument that is implicitly passed as an inout parameter without initialization, the compiler generates a "passed by reference before being initialized" diagnostic message.

```swift
var test : [String: String]
test["1"] = "1" // variable 'test' passed by reference before being initialized
```

This error message may be confusing since the "passed by reference" is not explicitly visible in the code.

In this specific case, just "used before being initialized" would be a more understandable diagnostic message.


```swift
var test : [String: String]
test["1"] = "1" // variable 'test' used before being initialized
```

For other uses of inout parameters, the current diagnostic message should remain unchanged, as the additional information about "passed by reference" provides helpful context for developers.

```swift
func takes_inout(_ a: inout Int) {}
var a1 : Int
takes_inout(&a1)    //  variable 'a1' passed by reference before being initialized
```


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
