### PR TITLE
Fix the doc formatting for FloatingPoint comparison methods

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1048,6 +1048,9 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// - Every value except for NaN and `+infinity` compares less than
   ///   `+infinity`.
   ///
+  /// The following example shows the behavior of the `isLess(than:)` method
+  /// with different kinds of values:
+  ///
   ///     let x = 15.0
   ///     x.isLess(than: 20.0)
   ///     // true
@@ -1077,6 +1080,9 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///   when called on NaN or when NaN is passed as `other`.
   /// - `-infinity` compares less than or equal to all values except NaN.
   /// - Every value except NaN compares less than or equal to `+infinity`.
+  ///
+  /// The following example shows the behavior of the `isLessThanOrEqualTo(_:)`
+  /// method with different kinds of values:
   ///
   ///     let x = 15.0
   ///     x.isLessThanOrEqualTo(20.0)


### PR DESCRIPTION
In the documentation for the `isLess(than:)` and `isLessThanOrEqualTo(_:)` methods, a code sample isn't being formatted correctly due to it directly following an unordered list. This change adds an additional message that introduces the code sample, separating it from the list and allowing the correct formatting to be applied.

For example, see the discussion section here: https://developer.apple.com/documentation/swift/floatingpoint/isless(than:)