### PR TITLE
Array access slow path shouldn't try to retain autoreleased return values

### DIFF
--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -59,7 +59,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
   @usableFromInline
   internal subscript(i: Int) -> AnyObject {
     @_effects(releasenone) get {
-      core.objectAt(i)
+      core.objectAt(i).takeUnretainedValue()
     }
   }
 
@@ -92,7 +92,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
       .assumingMemoryBound(to: AnyObject.self)
       
     for idx in 0..<boundsCount {
-      (base + idx).initialize(to: core.objectAt(idx + bounds.lowerBound))
+      (base + idx).initialize(to: core.objectAt(idx + bounds.lowerBound).takeUnretainedValue())
     }
 
     return _SliceBuffer(_buffer: result, shiftedToStartIndex: bounds.lowerBound)

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -61,7 +61,7 @@ internal protocol _NSCopying: _ShadowProtocol {
 internal protocol _NSArrayCore: _NSCopying, _NSFastEnumeration {
 
   @objc(objectAtIndex:)
-  func objectAt(_ index: Int) -> AnyObject
+  func objectAt(_ index: Int) -> Unmanaged<AnyObject>
 
   func getObjects(_: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange)
 


### PR DESCRIPTION
Fixes rdar://142438689