### PR TITLE
[6.1][IRGen] Fix SignatureExpansion::expandAsyncReturnType()

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2142,9 +2142,9 @@ void SignatureExpansion::expandAsyncReturnType() {
       } else {
         ParamIRTypes.push_back(combined.combinedTy);
       }
+      addErrorResult();
+      return;
     }
-    addErrorResult();
-    return;
   }
 
   if (native.requiresIndirect() || native.empty()) {

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -285,3 +285,13 @@ func callClosureAsync<T>(t: T) async {
     return t
   }
 }
+
+enum LargeError: Error {
+  case x
+  case y(Int64, Int64, Int64, Int64, Int64)
+}
+
+// Used to crash the compiler because
+func callClosureAsyncIndirectError(f: () async throws(LargeError) -> Int) async throws(LargeError) -> Int {
+  return try await f()
+}


### PR DESCRIPTION
  - **Explanation**: This fixes an issue that caused parameters to be dropped when a typed error in an async closure was too big to be returned directly.
  - **Scope**: Only affects IR generation for asynchronous returns in functions using typed throws, where the error type is too large to be returned in registers.
  - **Issues**: rdar://141962253
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78446
  - **Risk**: Low. Small localized fix, which is just falling back to previous behavior.
  - **Testing**: Added regression test and all old tests are still passing.
  - **Reviewers**: @aschwaighofer 