### PR TITLE
Re-land using associated objects to attach bridged Array buffers

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources
   LibcOverlayShims.h
   LibcShims.h
   MetadataSections.h
+  ObjCShims.h
   Random.h
   RefCount.h
   Reflection.h

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -30,9 +30,11 @@ extern "C" {
 #if __LLP64__
 typedef unsigned long long _swift_shims_CFHashCode;
 typedef signed long long _swift_shims_CFIndex;
+
 #else
 typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
+
 #endif
 
 // Consider creating SwiftMacTypes.h for these
@@ -74,7 +76,7 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void * _Nonnull addr);
-  
+
 #endif // __OBJC2__
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -30,11 +30,9 @@ extern "C" {
 #if __LLP64__
 typedef unsigned long long _swift_shims_CFHashCode;
 typedef signed long long _swift_shims_CFIndex;
-
 #else
 typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
-
 #endif
 
 // Consider creating SwiftMacTypes.h for these
@@ -76,7 +74,7 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void * _Nonnull addr);
-
+  
 #endif // __OBJC2__
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
@@ -1,0 +1,51 @@
+//===--- ObjCShims.h - Access to libobjc for the core stdlib ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Using the ObjectiveC module in the core stdlib would create a
+//  circular dependency, so instead we import these declarations as
+//  part of SwiftShims.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_OBJCSHIMS_H
+#define SWIFT_STDLIB_SHIMS_OBJCSHIMS_H
+
+#include "SwiftStdint.h"
+#include "Visibility.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __OBJC2__
+
+extern void objc_setAssociatedObject(void);
+extern void objc_getAssociatedObject(void);
+int objc_sync_enter(id _Nonnull object);
+int objc_sync_exit(id _Nonnull object);
+
+static void * _Nonnull getSetAssociatedObjectPtr() {
+  return (void *)&objc_setAssociatedObject;
+}
+
+static void * _Nonnull getGetAssociatedObjectPtr() {
+  return (void *)&objc_getAssociatedObject;
+}
+
+#endif // __OBJC2__
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_COREFOUNDATIONSHIMS_H
+

--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -1,6 +1,7 @@
 module SwiftShims {
   header "AssertionReporting.h"
   header "CoreFoundationShims.h"
+  header "ObjCShims.h"
   header "EmbeddedShims.h"
   header "FoundationShims.h"
   header "GlobalObjects.h"

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -807,3 +807,5 @@ Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON
 
+// Eager-lazy Array bridging
+Added: _$ss12_ArrayBufferV14associationKeySVvpZMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -808,3 +808,5 @@ Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON
 
+// Eager-lazy Array bridging
+Added: _$ss12_ArrayBufferV14associationKeySVvpZMV


### PR DESCRIPTION
This broke the internal branch tests before. Now that that's been fixed, re-landing it publicly for convenience.