### PR TITLE
Further adoption of `SemanticAvailableAttr`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3221,7 +3221,7 @@ public:
 /// informaton, like its corresponding `AvailabilityDomain`.
 class SemanticAvailableAttr final {
   const AvailableAttr *attr;
-  const AvailabilityDomain domain;
+  AvailabilityDomain domain;
 
 public:
   SemanticAvailableAttr(const AvailableAttr *attr, AvailabilityDomain domain)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -21,6 +21,7 @@
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/AvailabilityDomain.h"
+#include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/Identifier.h"
@@ -3231,14 +3232,21 @@ public:
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const { return domain; }
 
+  /// The version tuple written in source for the `introduced:` component.
   std::optional<llvm::VersionTuple> getIntroduced() const {
     return attr->Introduced;
   }
 
+  /// Returns the effective range in which the declaration with this attribute
+  /// was introduced.
+  AvailabilityRange getIntroducedRange(ASTContext &Ctx) const;
+
+  /// The version tuple written in source for the `deprecated:` component.
   std::optional<llvm::VersionTuple> getDeprecated() const {
     return attr->Deprecated;
   }
 
+  /// The version tuple written in source for the `obsoleted:` component.
   std::optional<llvm::VersionTuple> getObsoleted() const {
     return attr->Obsoleted;
   }

--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -60,32 +60,32 @@ public:
 
 private:
   Kind kind;
-  const AvailableAttr *attr;
+  SemanticAvailableAttr attr;
 
-  AvailabilityConstraint(Kind kind, const AvailableAttr *attr)
+  AvailabilityConstraint(Kind kind, SemanticAvailableAttr attr)
       : kind(kind), attr(attr) {};
 
 public:
   static AvailabilityConstraint
-  forAlwaysUnavailable(const AvailableAttr *attr) {
+  forAlwaysUnavailable(SemanticAvailableAttr attr) {
     return AvailabilityConstraint(Kind::AlwaysUnavailable, attr);
   }
 
-  static AvailabilityConstraint forObsoleted(const AvailableAttr *attr) {
+  static AvailabilityConstraint forObsoleted(SemanticAvailableAttr attr) {
     return AvailabilityConstraint(Kind::Obsoleted, attr);
   }
 
-  static AvailabilityConstraint forRequiresVersion(const AvailableAttr *attr) {
+  static AvailabilityConstraint forRequiresVersion(SemanticAvailableAttr attr) {
     return AvailabilityConstraint(Kind::RequiresVersion, attr);
   }
 
   static AvailabilityConstraint
-  forIntroducedInNewerVersion(const AvailableAttr *attr) {
+  forIntroducedInNewerVersion(SemanticAvailableAttr attr) {
     return AvailabilityConstraint(Kind::IntroducedInNewerVersion, attr);
   }
 
   Kind getKind() const { return kind; }
-  const AvailableAttr *getAttr() const { return attr; }
+  SemanticAvailableAttr getAttr() const { return attr; }
 
   /// Returns the platform that this constraint applies to, or
   /// `PlatformKind::none` if it is not platform specific.

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -62,10 +62,6 @@ public:
   static AvailabilityRange availableRange(const AvailableAttr *attr,
                                           ASTContext &C);
 
-  /// Returns the attribute that should be used to determine the availability
-  /// range of the given declaration, or nullptr if there is none.
-  static const AvailableAttr *attrForAnnotatedAvailableRange(const Decl *D);
-
   /// Returns the context for which the declaration
   /// is annotated as available, or None if the declaration
   /// has no availability annotation.

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -46,12 +46,6 @@ public:
   /// Returns the range of platform versions in which the decl is available.
   static AvailabilityRange availableRange(const Decl *D);
 
-  /// Returns the range of platform versions in which the decl is available and
-  /// the attribute which determined this range (which may be `nullptr` if the
-  /// declaration is always available.
-  static std::pair<AvailabilityRange, const AvailableAttr *>
-  availableRangeAndAttr(const Decl *D);
-
   /// Returns true is the declaration is `@_spi_available`.
   static bool isAvailableAsSPI(const Decl *D);
 

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -55,13 +55,6 @@ public:
   /// Returns true is the declaration is `@_spi_available`.
   static bool isAvailableAsSPI(const Decl *D);
 
-  /// Returns the range of platform versions in which a declaration with the
-  /// given `@available` attribute is available.
-  ///
-  /// NOTE: The attribute must be active on the current platform.
-  static AvailabilityRange availableRange(const AvailableAttr *attr,
-                                          ASTContext &C);
-
   /// Returns the context for which the declaration
   /// is annotated as available, or None if the declaration
   /// has no availability annotation.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1430,6 +1430,11 @@ public:
   std::optional<SemanticAvailableAttr> getActiveAvailableAttrForCurrentPlatform(
       bool ignoreAppExtensions = false) const;
 
+  /// Returns the active platform-specific `@available` attribute that should be
+  /// used to determine the platform introduction version of the decl.
+  std::optional<SemanticAvailableAttr>
+  getAvailableAttrForPlatformIntroduction() const;
+
   /// Returns true if the declaration is deprecated at the current deployment
   /// target.
   bool isDeprecated() const { return getDeprecatedAttr().has_value(); }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -68,7 +68,7 @@ AvailabilityRange AvailabilityRange::forRuntimeTarget(const ASTContext &Ctx) {
 }
 
 PlatformKind AvailabilityConstraint::getPlatform() const {
-  return attr->getPlatform();
+  return attr.getPlatform();
 }
 
 std::optional<AvailabilityRange>
@@ -80,7 +80,7 @@ AvailabilityConstraint::getRequiredNewerAvailabilityRange(
   case Kind::Obsoleted:
     return std::nullopt;
   case Kind::IntroducedInNewerVersion:
-    return AvailabilityInference::availableRange(attr, ctx);
+    return AvailabilityInference::availableRange(attr.getParsedAttr(), ctx);
   }
 }
 
@@ -96,10 +96,10 @@ bool AvailabilityConstraint::isConditionallySatisfiable() const {
 }
 
 bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
-  if (attr->getPlatform() == PlatformKind::none)
+  if (attr.getPlatform() == PlatformKind::none)
     return true;
 
-  return swift::isPlatformActive(attr->getPlatform(), ctx.LangOpts,
+  return swift::isPlatformActive(attr.getPlatform(), ctx.LangOpts,
                                  /*forTargetVariant=*/false,
                                  /*forRuntimeQuery=*/true);
 }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -357,8 +357,7 @@ AvailabilityScope::getExplicitAvailabilityRange() const {
   case Reason::Decl: {
     auto decl = Node.getAsDecl();
     if (auto attr = decl->getAvailableAttrForPlatformIntroduction())
-      return AvailabilityInference::availableRange(attr->getParsedAttr(),
-                                                   decl->getASTContext());
+      return attr->getIntroducedRange(decl->getASTContext());
 
     return std::nullopt;
   }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -356,8 +356,9 @@ AvailabilityScope::getExplicitAvailabilityRange() const {
 
   case Reason::Decl: {
     auto decl = Node.getAsDecl();
-    if (auto attr = AvailabilityInference::attrForAnnotatedAvailableRange(decl))
-      return AvailabilityInference::availableRange(attr, decl->getASTContext());
+    if (auto attr = decl->getAvailableAttrForPlatformIntroduction())
+      return AvailabilityInference::availableRange(attr->getParsedAttr(),
+                                                   decl->getASTContext());
 
     return std::nullopt;
   }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1243,38 +1243,37 @@ extractBuilderValueIfExists(const swift::NominalTypeDecl *TypeDecl,
 }
 
 void writeAvailabilityAttributes(llvm::json::OStream &JSON, const Decl &decl) {
-  auto semanticAttrs = decl.getSemanticAvailableAttrs();
-  if (semanticAttrs.empty())
+  auto attrs = decl.getSemanticAvailableAttrs();
+  if (attrs.empty())
     return;
 
   JSON.attributeArray("availabilityAttributes", [&] {
-    for (auto semanticAttr : semanticAttrs) {
-      auto attr = semanticAttr.getParsedAttr();
-
+    for (auto attr : attrs) {
       JSON.object([&] {
-        if (!attr->platformString().empty())
-          JSON.attribute("platform", attr->platformString());
+        auto domainName = attr.getDomain().getNameForAttributePrinting();
+        if (!domainName.empty())
+          JSON.attribute("platform", domainName);
 
-        if (!attr->Message.empty())
-          JSON.attribute("message", attr->Message);
+        if (!attr.getMessage().empty())
+          JSON.attribute("message", attr.getMessage());
 
-        if (!attr->Rename.empty())
-          JSON.attribute("rename", attr->Rename);
+        if (!attr.getRename().empty())
+          JSON.attribute("rename", attr.getRename());
 
-        if (attr->Introduced.has_value())
+        if (attr.getIntroduced().has_value())
           JSON.attribute("introducedVersion",
-                         attr->Introduced.value().getAsString());
+                         attr.getIntroduced().value().getAsString());
 
-        if (attr->Deprecated.has_value())
+        if (attr.getDeprecated().has_value())
           JSON.attribute("deprecatedVersion",
-                         attr->Deprecated.value().getAsString());
+                         attr.getDeprecated().value().getAsString());
 
-        if (attr->Obsoleted.has_value())
+        if (attr.getObsoleted().has_value())
           JSON.attribute("obsoletedVersion",
-                         attr->Obsoleted.value().getAsString());
+                         attr.getObsoleted().value().getAsString());
 
-        JSON.attribute("isUnavailable", attr->isUnconditionallyUnavailable());
-        JSON.attribute("isDeprecated", attr->isUnconditionallyDeprecated());
+        JSON.attribute("isUnavailable", attr.isUnconditionallyUnavailable());
+        JSON.attribute("isDeprecated", attr.isUnconditionallyDeprecated());
       });
     }
   });

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2378,16 +2378,17 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   // is fully contained within that declaration's range. If there is no such
   // enclosing declaration, then there is nothing to check.
   std::optional<AvailabilityRange> EnclosingAnnotatedRange;
-  AvailabilityRange AttrRange =
-      AvailabilityInference::availableRange(attr, Ctx);
+  AvailabilityRange AttrRange = semanticAttr->getIntroducedRange(Ctx);
 
   if (auto *parent = getEnclosingDeclForDecl(D)) {
     if (auto enclosingAvailable =
             getSemanticAvailableRangeDeclAndAttr(parent)) {
-      const AvailableAttr *enclosingAttr = enclosingAvailable.value().first;
       const Decl *enclosingDecl = enclosingAvailable.value().second;
-      EnclosingAnnotatedRange.emplace(
-          AvailabilityInference::availableRange(enclosingAttr, Ctx));
+      SemanticAvailableAttr enclosingAttr =
+          enclosingDecl
+              ->getSemanticAvailableAttr(enclosingAvailable.value().first)
+              .value();
+      EnclosingAnnotatedRange.emplace(enclosingAttr.getIntroducedRange(Ctx));
       if (!AttrRange.isContainedIn(*EnclosingAnnotatedRange)) {
         auto limit = DiagnosticBehavior::Unspecified;
         if (D->isImplicit()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2266,8 +2266,8 @@ static Decl *getEnclosingDeclForDecl(Decl *D) {
 
 static std::optional<std::pair<const AvailableAttr *, const Decl *>>
 getSemanticAvailableRangeDeclAndAttr(const Decl *decl) {
-  if (auto attr = AvailabilityInference::attrForAnnotatedAvailableRange(decl))
-    return std::make_pair(attr, decl);
+  if (auto attr = decl->getAvailableAttrForPlatformIntroduction())
+    return std::make_pair(attr->getParsedAttr(), decl);
 
   if (auto *parent =
           AvailabilityInference::parentDeclForInferredAvailability(decl))

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3182,10 +3182,11 @@ swift::getUnsatisfiedAvailabilityConstraint(
   }
 
   // Check whether the declaration is available in a newer platform version.
-  auto rangeAndAttr = AvailabilityInference::availableRangeAndAttr(decl);
-  if (!availabilityContext.getPlatformRange().isContainedIn(rangeAndAttr.first))
-    return AvailabilityConstraint::forIntroducedInNewerVersion(
-        decl->getSemanticAvailableAttr(rangeAndAttr.second).value());
+  if (auto rangeAttr = decl->getAvailableAttrForPlatformIntroduction()) {
+    auto range = rangeAttr->getIntroducedRange(ctx);
+    if (!availabilityContext.getPlatformRange().isContainedIn(range))
+      return AvailabilityConstraint::forIntroducedInNewerVersion(*rangeAttr);
+  }
 
   return std::nullopt;
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3163,7 +3163,6 @@ swift::getUnsatisfiedAvailabilityConstraint(
                                                  *attr))
       return std::nullopt;
 
-    auto parsedAttr = attr->getParsedAttr();
     switch (attr->getVersionAvailability(ctx)) {
     case AvailableVersionComparison::Available:
     case AvailableVersionComparison::PotentiallyUnavailable:
@@ -3173,12 +3172,12 @@ swift::getUnsatisfiedAvailabilityConstraint(
       if ((attr->isSwiftLanguageModeSpecific() ||
            attr->isPackageDescriptionVersionSpecific()) &&
           attr->getIntroduced().has_value())
-        return AvailabilityConstraint::forRequiresVersion(parsedAttr);
+        return AvailabilityConstraint::forRequiresVersion(*attr);
 
-      return AvailabilityConstraint::forAlwaysUnavailable(parsedAttr);
+      return AvailabilityConstraint::forAlwaysUnavailable(*attr);
 
     case AvailableVersionComparison::Obsoleted:
-      return AvailabilityConstraint::forObsoleted(parsedAttr);
+      return AvailabilityConstraint::forObsoleted(*attr);
     }
   }
 
@@ -3186,7 +3185,7 @@ swift::getUnsatisfiedAvailabilityConstraint(
   auto rangeAndAttr = AvailabilityInference::availableRangeAndAttr(decl);
   if (!availabilityContext.getPlatformRange().isContainedIn(rangeAndAttr.first))
     return AvailabilityConstraint::forIntroducedInNewerVersion(
-        rangeAndAttr.second);
+        decl->getSemanticAvailableAttr(rangeAndAttr.second).value());
 
   return std::nullopt;
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2954,11 +2954,11 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
 
 void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
                                               const ValueDecl *base,
-                                              const AvailableAttr *attr) {
+                                              SemanticAvailableAttr attr) {
   ASTContext &ctx = override->getASTContext();
   auto &diags = ctx.Diags;
-  if (attr->Rename.empty()) {
-    EncodedDiagnosticMessage EncodedMessage(attr->Message);
+  if (attr.getRename().empty()) {
+    EncodedDiagnosticMessage EncodedMessage(attr.getMessage());
     diags.diagnose(override, diag::override_unavailable,
                    override->getBaseName(), EncodedMessage.Message);
 
@@ -2970,7 +2970,7 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
   diagnoseExplicitUnavailability(
       base, override->getLoc(), where,
       /*Flags*/ std::nullopt, [&](InFlightDiagnostic &diag) {
-        ParsedDeclName parsedName = parseDeclName(attr->Rename);
+        ParsedDeclName parsedName = parseDeclName(attr.getRename());
         if (!parsedName || parsedName.isPropertyAccessor() ||
             parsedName.isMember() || parsedName.isOperator()) {
           return;

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -240,7 +240,7 @@ bool diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
 /// unavailable declaration.
 void diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
                                        const ValueDecl *base,
-                                       const AvailableAttr *attr);
+                                       SemanticAvailableAttr attr);
 
 /// Checks whether a declaration should be considered unavailable when referred
 /// to in the given declaration context and availability context and, if so,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6648,20 +6648,19 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
            ? enclosing->getDeclContext()->getAsDecl()
            : nullptr) {
     bool anyPlatformSpecificAttrs = false;
-    for (auto semanticAttr : enclosing->getSemanticAvailableAttrs()) {
-      auto available = semanticAttr.getParsedAttr();
-
-      if (available->getPlatform() == PlatformKind::none)
+    for (auto available : enclosing->getSemanticAvailableAttrs()) {
+      // FIXME: [availability] Generalize to AvailabilityDomain.
+      if (available.getPlatform() == PlatformKind::none)
         continue;
 
       auto attr = new (ctx) AvailableAttr(
-          SourceLoc(), SourceRange(), available->getPlatform(),
-          available->Message,
-          /*Rename=*/"", available->Introduced.value_or(noVersion),
-          SourceRange(), available->Deprecated.value_or(noVersion),
-          SourceRange(), available->Obsoleted.value_or(noVersion),
+          SourceLoc(), SourceRange(), available.getPlatform(),
+          available.getMessage(),
+          /*Rename=*/"", available.getIntroduced().value_or(noVersion),
+          SourceRange(), available.getDeprecated().value_or(noVersion),
+          SourceRange(), available.getObsoleted().value_or(noVersion),
           SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
-          /*Implicit=*/true, available->isSPI());
+          /*Implicit=*/true, available.getParsedAttr()->isSPI());
       ext->getAttrs().add(attr);
       anyPlatformSpecificAttrs = true;
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4408,8 +4408,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
 
     case CheckKind::Unavailable: {
-      auto *attr = requirement->getUnavailableAttr()->getParsedAttr();
-      diagnoseOverrideOfUnavailableDecl(witness, requirement, attr);
+      diagnoseOverrideOfUnavailableDecl(
+          witness, requirement, requirement->getUnavailableAttr().value());
       break;
     }
 

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -18,23 +18,15 @@ using namespace swift;
 using namespace symbolgraphgen;
 
 namespace {
-StringRef getDomain(const AvailableAttr &AvAttr) {
-  switch (AvAttr.getPlatformAgnosticAvailability()) {
-    // SPM- and Swift-specific availability.
-    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-      return { "SwiftPM" };
-    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-      return { "Swift" };
-    // Although these are in the agnostic kinds, they are actually a signal
-    // that there is either platform-specific or completely platform-agnostic.
-    // They'll be handled below.
-    case PlatformAgnosticAvailabilityKind::Deprecated:
-    case PlatformAgnosticAvailabilityKind::Unavailable:
-    case PlatformAgnosticAvailabilityKind::None:
-    case PlatformAgnosticAvailabilityKind::NoAsync:
-      break;
-  }
+StringRef getDomain(const SemanticAvailableAttr &AvAttr) {
+  // FIXME: [avalailability] Move the definition of these strings into
+  // AvailabilityDomain so that new domains are handled automatically.
+
+  if (AvAttr.getDomain().isPackageDescription())
+    return { "SwiftPM" };
+
+  if (AvAttr.getDomain().isSwiftLanguage())
+    return { "Swift" };
 
   // Platform-specific availability.
   switch (AvAttr.getPlatform()) {
@@ -73,16 +65,13 @@ StringRef getDomain(const AvailableAttr &AvAttr) {
 }
 } // end anonymous namespace
 
-Availability::Availability(const AvailableAttr &AvAttr)
-  : Domain(getDomain(AvAttr)),
-    Introduced(AvAttr.Introduced),
-    Deprecated(AvAttr.Deprecated),
-    Obsoleted(AvAttr.Obsoleted),
-    Message(AvAttr.Message),
-    Renamed(AvAttr.Rename),
-    IsUnconditionallyDeprecated(AvAttr.isUnconditionallyDeprecated()),
-    IsUnconditionallyUnavailable(AvAttr.isUnconditionallyUnavailable()) {
-      assert(!Domain.empty());
+Availability::Availability(const SemanticAvailableAttr &AvAttr)
+    : Domain(getDomain(AvAttr)), Introduced(AvAttr.getIntroduced()),
+      Deprecated(AvAttr.getDeprecated()), Obsoleted(AvAttr.getObsoleted()),
+      Message(AvAttr.getMessage()), Renamed(AvAttr.getRename()),
+      IsUnconditionallyDeprecated(AvAttr.isUnconditionallyDeprecated()),
+      IsUnconditionallyUnavailable(AvAttr.isUnconditionallyUnavailable()) {
+  assert(!Domain.empty());
 }
 
 void

--- a/lib/SymbolGraphGen/AvailabilityMixin.h
+++ b/lib/SymbolGraphGen/AvailabilityMixin.h
@@ -49,7 +49,7 @@ struct Availability {
   /// If \c true, is unconditionally unavailable in this \c Domain.
   bool IsUnconditionallyUnavailable;
 
-  Availability(const AvailableAttr &AvAttr);
+  Availability(const SemanticAvailableAttr &AvAttr);
 
   /// Update this availability from a duplicate @available
   /// attribute with the same platform on the same declaration.

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -637,17 +637,15 @@ void getAvailabilities(const Decl *D,
                        bool IsParent) {
   // DeclAttributes is a linked list in reverse order from where they
   // appeared in the source. Let's re-reverse them.
-  SmallVector<const AvailableAttr *, 4> AvAttrs;
-  for (const auto *Attr : D->getAttrs()) {
-    if (const auto *AvAttr = dyn_cast<AvailableAttr>(Attr)) {
-      AvAttrs.push_back(AvAttr);
-    }
+  SmallVector<SemanticAvailableAttr, 4> AvAttrs;
+  for (auto Attr : D->getSemanticAvailableAttrs(/*includeInactive=*/true)) {
+    AvAttrs.push_back(Attr);
   }
   std::reverse(AvAttrs.begin(), AvAttrs.end());
 
   // Now go through them in source order.
-  for (auto *AvAttr : AvAttrs) {
-    Availability NewAvailability(*AvAttr);
+  for (auto AvAttr : AvAttrs) {
+    Availability NewAvailability(AvAttr);
     if (NewAvailability.empty()) {
       continue;
     }


### PR DESCRIPTION
Adopt `SemanticAvailableAttr` as a replacement for `AvailableAttr` more thoroughly in much of the compiler. Builds on https://github.com/swiftlang/swift/pull/78308.

NFC.