### PR TITLE
`@_addressableForDependencies` fixes

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -222,7 +222,7 @@ public:
             IsNotTypeExpansionSensitive,
         HasRawPointer_t hasRawPointer = DoesNotHaveRawPointer,
         IsLexical_t isLexical = IsNotLexical, HasPack_t hasPack = HasNoPack,
-        IsAddressableForDependencies_t isAFD = IsAddressableForDependencies)
+        IsAddressableForDependencies_t isAFD = IsNotAddressableForDependencies)
         : Flags((isTrivial ? 0U : NonTrivialFlag) |
                 (isFixedABI ? 0U : NonFixedABIFlag) |
                 (isAddressOnly ? AddressOnlyFlag : 0U) |

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1779,20 +1779,17 @@ private:
              ParameterTypeFlags origFlags) {
     assert(!isa<InOutType>(substType));
 
-    if (TC.Context.LangOpts.hasFeature(Feature::AddressableTypes)
-        || TC.Context.LangOpts.hasFeature(Feature::AddressableParameters)) {
-      // If the parameter is marked addressable, lower it with maximal
-      // abstraction.
-      if (origFlags.isAddressable()) {
+    // If the parameter is marked addressable, lower it with maximal
+    // abstraction.
+    if (origFlags.isAddressable()) {
+      origType = AbstractionPattern::getOpaque();
+    } else if (hasScopedDependency) {
+      // If there is a scoped dependency on this parameter, and the parameter
+      // is addressable-for-dependencies, then lower it with maximal abstraction
+      // as well.
+      auto &initialSubstTL = TC.getTypeLowering(origType, substType, expansion);
+      if (initialSubstTL.getRecursiveProperties().isAddressableForDependencies()) {
         origType = AbstractionPattern::getOpaque();
-      } else if (hasScopedDependency) {
-        // If there is a scoped dependency on this parameter, and the parameter
-        // is addressable-for-dependencies, then lower it with maximal abstraction
-        // as well.
-        auto &initialSubstTL = TC.getTypeLowering(origType, substType, expansion);
-        if (initialSubstTL.getRecursiveProperties().isAddressableForDependencies()) {
-          origType = AbstractionPattern::getOpaque();
-        }
       }
     }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2510,6 +2510,7 @@ namespace {
       }
 
       if (D->isCxxNonTrivial()) {
+        properties.setAddressableForDependencies();
         properties.setAddressOnly();
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
@@ -2549,6 +2550,10 @@ namespace {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         return handleAddressOnly(structType, properties);
+      }
+      
+      if (D->getAttrs().hasAttribute<AddressableForDependenciesAttr>()) {
+        properties.setAddressableForDependencies();
       }
 
       auto subMap = structType->getContextSubstitutionMap();
@@ -2619,6 +2624,10 @@ namespace {
 
       if (handleResilience(enumType, D, properties))
         return handleAddressOnly(enumType, properties);
+
+      if (D->getAttrs().hasAttribute<AddressableForDependenciesAttr>()) {
+        properties.setAddressableForDependencies();
+      }
 
       // [is_or_contains_pack_unsubstituted] Visit the elements of the
       // unsubstituted type to find pack types which would be substituted away.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -210,9 +210,7 @@ public:
       return handleInOut(origType, substType, pd->isAddressable());
     }
     // Addressability also suppresses exploding the parameter.
-    if ((SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableTypes)
-         || SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableParameters))
-        && isAddressable) {
+    if (isAddressable) {
       return handleScalar(claimNextParameter(),
                           AbstractionPattern::getOpaque(), substType,
                           /*emitInto*/ nullptr,
@@ -740,15 +738,12 @@ private:
       // addressability can be implied by a scoped dependency.
       bool isAddressable = false;
       
-      if (SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableTypes)
-          || SGF.getASTContext().LangOpts.hasFeature(Feature::AddressableParameters)) {
-        isAddressable = pd->isAddressable()
-          || (ScopedDependencies.contains(pd)
-              && SGF.getTypeLowering(origType, substType)
-                    .getRecursiveProperties().isAddressableForDependencies());
-        if (isAddressable) {
-          AddressableParams.insert(pd);
-        }
+      isAddressable = pd->isAddressable()
+        || (ScopedDependencies.contains(pd)
+            && SGF.getTypeLowering(origType, substType)
+                  .getRecursiveProperties().isAddressableForDependencies());
+      if (isAddressable) {
+        AddressableParams.insert(pd);
       }
       paramValue = argEmitter.handleParam(origType, substType, pd,
                                           isAddressable);

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -50,20 +50,20 @@ func testConsumingError(_ x: consuming Klass) async {
   print(x)
 }
 
-func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
+func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' used after consume}}
   await consumeTransferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
-  // expected-note @-1 {{consumed again here}}
+  // expected-note @-1 {{used here}}
 }
 
-@CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
+@CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' used after consume}}
   await consumeTransferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
-  // expected-note @-1 {{consumed again here}}
+  // expected-note @-1 {{used here}}
 }
 
 func testBorrowing(_ x: borrowing Klass) async {

--- a/test/SILOptimizer/addressable_move_only_checking.swift
+++ b/test/SILOptimizer/addressable_move_only_checking.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -verify %s
+
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_AddressableParameters
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_LifetimeDependence
+
+@_addressableForDependencies
+struct Node {
+    var id: AnyObject
+
+    func grungle() {}
+}
+
+struct NodeRef: ~Escapable {
+    private var parent: UnsafePointer<Node>
+
+    @lifetime(borrow node)
+    init(node: borrowing Node) { fatalError() }
+}
+
+// Ensure there aren't spurious errors about consumption when an addressable
+// parameter is passed as a normal loadable parameter to another function
+// or method.
+@lifetime(borrow node)
+func test(node: borrowing Node) -> NodeRef {
+    node.grungle()
+    return NodeRef(node: node)
+}
+


### PR DESCRIPTION
- Only lower nominal types marked with `@_addressableForDependencies` as such.
- Change codegen for loading from no-implicit-copy lvalues to avoid spurious consumption errors.