### PR TITLE
[cxx-interop] Diagnose ObjC APIs returning SWIFT_SHARED_REFERENCE types

### DIFF
--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
@@ -9,26 +9,40 @@ struct CxxRefType {
 __attribute__((swift_attr("retain:retainCxxRefType")))
 __attribute__((swift_attr("release:releaseCxxRefType")));
 
+struct CxxValType {};
+
 void retainCxxRefType(CxxRefType *_Nonnull b) {}
 void releaseCxxRefType(CxxRefType *_Nonnull b) {}
 
 @interface Bridge : NSObject
 
-+ (struct CxxRefType *)objCMethodReturningFRTUnannotated;
++ (struct CxxRefType *)objCMethodReturningFRTUnannotated; // expected-warning {{'objCMethodReturningFRTUnannotated' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENCE}}
 + (struct CxxRefType *)objCMethodReturningFRTUnowned
     __attribute__((swift_attr("returns_unretained")));
 + (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained")));
++ (struct CxxRefType *)objCMethodReturningFRTBothAnnotations // expected-error {{'objCMethodReturningFRTBothAnnotations' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED}}
+    __attribute__((swift_attr("returns_unretained")))
+    __attribute__((swift_attr("returns_retained")));
++ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated // expected-error {{'objCMethodReturningNonCxxFrtAnannotated' cannot be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type}}
     __attribute__((swift_attr("returns_retained")));
 
 @end
 
 @implementation Bridge
 + (struct CxxRefType *)objCMethodReturningFRTUnannotated {
-};
+}
 + (struct CxxRefType *)objCMethodReturningFRTUnowned
     __attribute__((swift_attr("returns_unretained"))) {
 }
 + (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained"))) {
+}
++ (struct CxxRefType *)objCMethodReturningFRTBothAnnotations
+    __attribute__((swift_attr("returns_unretained")))
+    __attribute__((swift_attr("returns_retained"))) {
+}
++ (struct CxxValType *)objCMethodReturningNonCxxFrtAnannotated
     __attribute__((swift_attr("returns_retained"))) {
 }
 

--- a/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt-diagnostics.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt-diagnostics.swift
@@ -1,0 +1,11 @@
+// RUN: rm -rf %t
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/cxx-frt.h -Xcc -Wno-return-type
+
+import CxxForeignRef
+
+// REQUIRES: objc_interop
+func testObjCMethods() {
+    _ = Bridge.objCMethodReturningFRTBothAnnotations()
+    _ = Bridge.objCMethodReturningNonCxxFrtAnannotated()
+    _ = Bridge.objCMethodReturningFRTUnannotated()
+}


### PR DESCRIPTION
Adding diagnostic support (related to SWIFT_RETURNS_(UN)RETAINED annotations) for ObjC APIs returning SWIFT_SHARED_REFERENCE types

rdar://142500663
