### PR TITLE
[Compile Time Constant Extraction] Extract Partial Keypath Expressions

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -487,6 +487,11 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
       }
       break;
     }
+
+    case ExprKind::DerivedToBase: {
+      auto derivedExpr = cast<DerivedToBaseExpr>(expr);
+      return extractCompileTimeValue(derivedExpr->getSubExpr());
+    }
     default: {
       break;
     }

--- a/test/ConstExtraction/ExtractKeyPaths.swift
+++ b/test/ConstExtraction/ExtractKeyPaths.swift
@@ -22,8 +22,18 @@ public struct MyType {
     }
 }
 
+struct Item {
+    var foo: String
+    let bar: String
+}
+
 public struct KeyPaths: MyProto {
-    static let nestedVariable = \MyType.nested.foo.bar.baz
+    static let keyPath1: PartialKeyPath<Item> = \Item.foo
+    static var keyPath2: KeyPath<Item, String> = \Item.foo
+    static var keyPath3: WritableKeyPath<Item, String> = \Item.foo
+    static var keyPath4: PartialKeyPath<Item> = \Item.bar
+    static var keyPath5: KeyPath<Item, String> = \Item.bar
+    static let nestedKeyPath = \MyType.nested.foo.bar.baz
 }
 
 // CHECK: [
@@ -32,8 +42,7 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:     "mangledTypeName": "15ExtractKeyPaths0bC0V",
 // CHECK-NEXT:     "kind": "struct",
 // CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:    "line": 25,
-// CHECK-NEXT:    "conformances": [
+// CHECK:          "conformances": [
 // CHECK-NEXT:      "ExtractKeyPaths.MyProto"
 // CHECK-NEXT:     ],
 // CHECK-NEXT:    "allConformances": [
@@ -42,16 +51,115 @@ public struct KeyPaths: MyProto {
 // CHECK-NEXT:        "conformanceDefiningModule": "ExtractKeyPaths"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [],
-// CHECK-NEXT:    "properties": [
+// CHECK:         "properties": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:        "label": "keyPath1",
+// CHECK-NEXT:        "type": "Swift.PartialKeyPath<ExtractKeyPaths.Item>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
+// CHECK-NEXT:       "line": 31,
+// CHECK-NEXT:        "valueKind": "KeyPath",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "path": "foo",
+// CHECK-NEXT:          "rootType": "ExtractKeyPaths.Item",
+// CHECK-NEXT:          "components": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:              "label": "foo",
+// CHECK-NEXT:              "type": "Swift.String"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyPath2",
+// CHECK-NEXT:        "type": "Swift.KeyPath<ExtractKeyPaths.Item, Swift.String>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
+// CHECK-NEXT:        "line": 32,
+// CHECK-NEXT:        "valueKind": "KeyPath",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "path": "foo",
+// CHECK-NEXT:          "rootType": "ExtractKeyPaths.Item",
+// CHECK-NEXT:          "components": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "foo",
+// CHECK-NEXT:              "type": "Swift.String"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyPath3",
+// CHECK-NEXT:        "type": "Swift.WritableKeyPath<ExtractKeyPaths.Item, Swift.String>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
+// CHECK-NEXT:        "line": 33,
+// CHECK-NEXT:        "valueKind": "KeyPath",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "path": "foo",
+// CHECK-NEXT:          "rootType": "ExtractKeyPaths.Item",
+// CHECK-NEXT:          "components": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "foo",
+// CHECK-NEXT:              "type": "Swift.String"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyPath4",
+// CHECK-NEXT:        "type": "Swift.PartialKeyPath<ExtractKeyPaths.Item>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
+// CHECK-NEXT:        "line": 34,
+// CHECK-NEXT:        "valueKind": "KeyPath",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "path": "bar",
+// CHECK-NEXT:          "rootType": "ExtractKeyPaths.Item",
+// CHECK-NEXT:          "components": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:             "label": "bar",
+// CHECK-NEXT:             "type": "Swift.String"
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyPath5",
+// CHECK-NEXT:        "type": "Swift.KeyPath<ExtractKeyPaths.Item, Swift.String>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
+// CHECK-NEXT:        "line": 35,
+// CHECK-NEXT:        "valueKind": "KeyPath",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "path": "bar",
+// CHECK-NEXT:          "rootType": "ExtractKeyPaths.Item",
+// CHECK-NEXT:          "components": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "bar",
+// CHECK-NEXT:              "type": "Swift.String"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
 // CHECK-NEXT:       {
-// CHECK-NEXT:        "label": "nestedVariable",
+// CHECK-NEXT:        "label": "nestedKeyPath",
 // CHECK-NEXT:        "type": "Swift.WritableKeyPath<ExtractKeyPaths.MyType, Swift.String>",
 // CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractKeyPaths.swift",
-// CHECK-NEXT:        "line": 26,
+// CHECK-NEXT:        "line": 36,
 // CHECK-NEXT:        "valueKind": "KeyPath",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:         "path": "nested.foo.bar.baz",


### PR DESCRIPTION
Add support for extracting partial KeyPath expressions

Example:

```
struct Item: Sendable {
    var foo: String
    let bar: String
}

var keyPath1: PartialKeyPath<Item> = \Item.foo                       
var keyPath2: PartialKeyPath<Item> = \Item.bar                      
```

Resolves rdar://141772235