### PR TITLE
SILLinker: convert an assert to a compiler error message

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -408,6 +408,8 @@ ERROR(embedded_swift_allocating,none,
       "cannot use allocating operation in -no-allocations mode", ())
 ERROR(embedded_capture_of_generic_value_with_deinit,none,
       "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
+ERROR(wrong_linkage_for_serialized_function,none,
+      "function has wrong linkage to be called from %0", (StringRef))
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -91,6 +91,8 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, void> {
   /// Whether any functions were deserialized.
   bool Changed;
 
+  bool hasError = false;
+
 public:
   SILLinkerVisitor(SILModule &M, SILModule::LinkingMode LinkingMode)
       : Mod(M), Worklist(), Mode(LinkingMode), Changed(false) {}
@@ -143,7 +145,8 @@ private:
   /// If `callerSerializedKind` is IsSerialized, then all shared
   /// functions which are referenced from `F` are set to be serialized.
   void maybeAddFunctionToWorklist(SILFunction *F,
-                                  SerializedKind_t callerSerializedKind);
+                                  SerializedKind_t callerSerializedKind,
+                                  SILFunction *caller = nullptr);
 
   /// Is the current mode link all? Link all implies we should try and link
   /// everything, not just transparent/shared functions.

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -51,7 +51,9 @@ public:
     using namespace RuntimeConstants;
 #define FUNCTION(ID, NAME, CC, AVAILABILITY, RETURNS, ARGS, ATTRS, EFFECT,     \
                  MEMORY_EFFECTS)                                               \
-  linkEmbeddedRuntimeFunctionByName(#NAME, EFFECT);
+  linkEmbeddedRuntimeFunctionByName(#NAME, EFFECT);                            \
+  if (getModule()->getASTContext().hadError())                                  \
+    return;
 
 #define RETURNS(...)
 #define ARGS(...)

--- a/test/embedded/wrong-linkage.swift
+++ b/test/embedded/wrong-linkage.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -verify -wmo
+
+// REQUIRES: swift_feature_Embedded
+
+@_cdecl("posix_memalign")
+func posix_memalign(_ resultPtr:UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ :Int, _ :Int) -> Int32 { // expected-error {{function has wrong linkage to be called from}}
+  return 0
+}


### PR DESCRIPTION
Having a wrong linkage can happen if the user "re-defines" an existing function with a wrong linkage, e.g. using `@_cdecl`.
