### PR TITLE
SwiftifyImport: Fix warnings

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -314,7 +314,7 @@ struct CxxSpanThunkBuilder: BoundsCheckedThunkBuilder {
         "unable to desugar type with name '\(typeName)'", node: node)
     }
 
-    let parsedDesugaredType = try TypeSyntax("\(raw: desugaredType)")
+    let parsedDesugaredType = TypeSyntax("\(raw: desugaredType)")
     types[index] = TypeSyntax(IdentifierTypeSyntax(name: "Span",
       genericArgumentClause: parsedDesugaredType.as(IdentifierTypeSyntax.self)!.genericArgumentClause))
     return try base.buildFunctionSignature(types, variant)
@@ -679,7 +679,7 @@ public struct SwiftifyImportMacro: PeerMacro {
           }
           dict[key.representedLiteralValue!] = value.representedLiteralValue!
         }
-      default:
+      @unknown default:
         throw DiagnosticError("unknown dictionary literal", node: dictExpr)
     }
     return dict


### PR DESCRIPTION
Fixes the following warnings:

```
warning: no calls to throwing functions occur within 'try' expression
warning: default will never be executed
```
