### PR TITLE
[OSSACompleteLifetime] Skip mark_dependence [unresolved].

### DIFF
--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -461,6 +461,12 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(
         liveness.updateForUse(user, /*lifetimeEnding=*/true);
         return true;
       }
+      auto *mdi = dyn_cast<MarkDependenceInst>(user);
+      if (mdi && mdi->hasUnresolvedEscape()) {
+        // mark_dependence [unresolved] instructions can appear outside the
+        // lifetime of an access scope.
+        return true;
+      }
       liveness.updateForUse(user, /*lifetimeEnding=*/false);
       for (auto result : user->getResults()) {
         auto shouldComplete =

--- a/validation-test/SILOptimizer/rdar142424000.swift
+++ b/validation-test/SILOptimizer/rdar142424000.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -c %s
+
+struct NC<Element>: ~Copyable {
+  var count: Int = 0
+}
+func playback_handler2() {
+  var iou_ptr: UnsafePointer<Bool>? = nil
+  var noncopyable = NC<Int>()
+  _ = noncopyable.count
+  _ = iou_ptr!.pointee
+}


### PR DESCRIPTION
Such instructions can appear outside the lifetime of the `begin_access` which they use.  They are eventually rewritten not to have that flag and not to appear outside the access scope they refer to.

rdar://142424000
