### PR TITLE
[cxx-interop] Skip type metadata for C++ types that are only used in private C++ fields

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -931,6 +931,15 @@ private:
 
     B.addInt32(getNumFields(NTD));
     forEachField(IGM, NTD, [&](Field field) {
+      // Skip private C++ fields that were imported as private Swift fields.
+      // The type of a private field might not have all the type witness
+      // operations that Swift requires, for instance,
+      // `std::unique_ptr<IncompleteType>` would not have a destructor.
+      if (field.getKind() == Field::Kind::Var &&
+          field.getVarDecl()->getClangDecl() &&
+          field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
+        return;
+
       addField(field);
     });
   }

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -151,3 +151,9 @@ module Closure {
   header "closure.h"
   requires cplusplus
 }
+
+module PIMPL {
+  header "pimpl.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/class/Inputs/pimpl.h
+++ b/test/Interop/Cxx/class/Inputs/pimpl.h
@@ -1,0 +1,24 @@
+#include <memory>
+
+// C++ types that use pointer-to-implementation idiom.
+
+struct HasPIMPL {
+private:
+  struct I;
+  I *ptr;
+};
+
+HasPIMPL createHasPIMPL();
+
+struct HasSmartPIMPL {
+private:
+  struct I;
+  std::unique_ptr<I> smart_ptr;
+
+public:
+  HasSmartPIMPL();
+  HasSmartPIMPL(const HasSmartPIMPL &other);
+  ~HasSmartPIMPL();
+};
+
+HasSmartPIMPL createHasSmartPIMPL();

--- a/test/Interop/Cxx/class/pimpl-irgen.swift
+++ b/test/Interop/Cxx/class/pimpl-irgen.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swiftxx-frontend -emit-irgen %s -I %S/Inputs | %FileCheck %s
+
+// Make sure Swift handles the C++ pointer-to-implementation idiom properly.
+
+import PIMPL
+
+// Trigger type metadata to be emitted by conforming C++ types to a Swift protocol.
+protocol MyProto {}
+extension HasPIMPL : MyProto {}
+extension HasSmartPIMPL : MyProto {}
+
+let _ = createHasPIMPL()
+let _ = createHasSmartPIMPL()
+
+// CHECK-NOT: @"get_type_metadata {{.*}}default_delete{{.*}}

--- a/test/Interop/Cxx/class/pimpl-module-interface.swift
+++ b/test/Interop/Cxx/class/pimpl-module-interface.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=PIMPL -print-access -I %S/Inputs -cxx-interoperability-mode=default -source-filename=x | %FileCheck %s
+
+// FIXME: We can't import std::unique_ptr properly on Windows (https://github.com/apple/swift/issues/70226)
+// XFAIL: OS=windows-msvc
+
+// CHECK:      public struct HasPIMPL {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private var ptr: OpaquePointer!
+// CHECK-NEXT: }
+
+// CHECK:      public struct HasSmartPIMPL {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private var smart_ptr: std.
+// CHECK-NEXT: }


### PR DESCRIPTION
This fixes compiler errors for C++ types that use pimpl idiom:
```
invalid application of 'sizeof' to an incomplete type
```

rdar://141960396

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
