### PR TITLE
Sema: Don't remove nonisolated attribute when we diagnose it as invalid on 'lazy'

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7449,7 +7449,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     }
 
     if (var->getAttrs().hasAttribute<LazyAttr>()) {
-      diagnoseAndRemoveAttr(attr, diag::nonisolated_lazy)
+      diagnose(attr->getLocation(), diag::nonisolated_lazy)
         .warnUntilSwiftVersion(6);
       return;
     }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -838,11 +838,13 @@ actor LazyActor {
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
     // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l33: Int = { self.v }()
     // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
     // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
     // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -64,3 +64,8 @@ actor Dril: NSObject {
 
 // makes sure the synthesized init's delegation kind is determined correctly.
 actor Pumpkin: NSObject {}
+
+actor Bad {
+  @objc nonisolated lazy var invalid = 0
+  // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+}


### PR DESCRIPTION
Fixes rdar://141967932.