### PR TITLE
[Test] Fix a typo in the test util python script

### DIFF
--- a/test/CAS/Inputs/GenerateExplicitModuleMap.py
+++ b/test/CAS/Inputs/GenerateExplicitModuleMap.py
@@ -9,11 +9,11 @@ input_json = sys.argv[1]
 
 modules = []
 
-with open(input_json, 'r') as file:
+with open(input_json, "r") as file:
     deps = json.load(file)
-    main_module_name = deps['mainModuleName']
-    module_names = deps['modules'][::2]
-    module_details = deps['modules'][1::2]
+    main_module_name = deps["mainModuleName"]
+    module_names = deps["modules"][::2]
+    module_details = deps["modules"][1::2]
     # add all modules other than the main module into the module map.
     for name, detail in zip(module_names, module_details):
         kind, name = list(name.items())[0]
@@ -24,11 +24,15 @@ with open(input_json, 'r') as file:
         module["moduleName"] = name
         module["isFramework"] = False
         if kind == "clang":
-            module["clangModulePath"] = name + ".pcm"
-            module["clangModuleCacheKey"] = detail['details'][kind]["moduleCacheKey"]
+            module["clangModulePath"] = detail["modulePath"]
+            if "moduleCacheKey" in detail["details"][kind]:
+                module["clangModuleCacheKey"] = detail["details"][kind][
+                    "moduleCacheKey"
+                ]
         else:
-            module["modulePath"] = name + ".swiftmdoule"
-            module["moduleCacheKey"] = detail['details'][kind]["moduleCacheKey"]
+            module["modulePath"] = detail["modulePath"]
+            if "moduleCacheKey" in detail["details"][kind]:
+                module["moduleCacheKey"] = detail["details"][kind]["moduleCacheKey"]
 
         modules.append(module)
 

--- a/test/CAS/module_trace.swift
+++ b/test/CAS/module_trace.swift
@@ -44,7 +44,7 @@
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/test.swiftdeps > %t/test-processed.swiftdeps
 // RUN: %FileCheck %s --check-prefix=SWIFTDEPS --input-file=%t/test-processed.swiftdeps
 // SWIFTDEPS: A.swiftinterface
-// SWIFTDEPS: B.swiftmdoule
+// SWIFTDEPS: B.swiftmodule
 
 
 //--- main.swift


### PR DESCRIPTION
Fix the typo in GenerateExplicitModuleMap.py where the modulePath is mis-spelled. Use the module path from the dependency output json file directly instead, which means the script can be used to generate non-caching build module map as well since the module path actually matters for those builds.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
