### PR TITLE
stdlib,Runtimes: begin preparing for a static stdlib on Windows

### DIFF
--- a/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
+++ b/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
@@ -33,5 +33,8 @@ add_library(swiftShims INTERFACE)
 target_include_directories(swiftShims INTERFACE
   $<$<COMPILE_LANGUAGE:C,CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../../>
   $<$<COMPILE_LANGUAGE:Swift>:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_compile_definitions(swiftShims INTERFACE
+  $<$<AND:$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>,$<COMPILE_LANGUAGE:C,CXX>>:SWIFT_STATIC_STDLIB>)
 target_compile_options(swiftShims INTERFACE
+  "$<$<AND:$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xcc -DSWIFT_STATIC_STDLIB>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap>")

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -152,6 +152,8 @@ if("${SwiftCore_OBJECT_FORMAT}" STREQUAL "elfx")
   install(TARGETS swiftrt DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift")
 elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
   add_library(swiftrt OBJECT SwiftRT-COFF.cpp)
+  target_compile_definitions(swiftrt PRIVATE
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:SWIFT_STATIC_STDLIB>)
   target_link_libraries(swiftrt PRIVATE swiftShims)
   install(TARGETS swiftrt DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift")
 elseif(NOT "${SwiftCore_OBJECT_FORMAT}" STREQUAL "x")

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -168,9 +168,13 @@
 // FIXME: this #else should be some sort of #elif Windows
 #else // !__MACH__ && !__ELF__
 
-// On PE/COFF, we use dllimport and dllexport.
-# define SWIFT_ATTRIBUTE_FOR_EXPORTS __declspec(dllexport)
-# define SWIFT_ATTRIBUTE_FOR_IMPORTS __declspec(dllimport)
+# if defined(SWIFT_STATIC_STDLIB)
+#   define SWIFT_ATTRIBUTE_FOR_EXPORTS /**/
+#   define SWIFT_ATTRIBUTE_FOR_IMPORTS /**/
+# else
+#   define SWIFT_ATTRIBUTE_FOR_EXPORTS __declspec(dllexport)
+#   define SWIFT_ATTRIBUTE_FOR_IMPORTS __declspec(dllimport)
+# endif
 
 #endif
 


### PR DESCRIPTION
When building the standard library statically on Windows, we should not use any `__declspec(dllimport)` or `__declspec(dllexport)` on the runtime functions or data. Furthermore, we should internalise all of the standard library functions so that they are not re-exported if used to build a shared library. The code generation changes required for this are easier to identify once a static SDK is available for Windows.