### PR TITLE
[rbi] Ensure that we infer isolation correctly for direct sending results

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -358,6 +358,15 @@ inferIsolationInfoForTempAllocStack(AllocStackInst *asi) {
 
 SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto fas = FullApplySite::isa(inst)) {
+    // Before we do anything, see if we have a sending result. In such a case,
+    // our full apply site result must be disconnected.
+    //
+    // NOTE: This handles the direct case of a sending result. The indirect case
+    // is handled above.
+    if (fas.getSubstCalleeType()->hasSendingResult())
+      return SILIsolationInfo::getDisconnected(
+          false /*is unsafe non isolated*/);
+
     // Check if we have SIL based "faked" isolation crossings that we use for
     // testing purposes.
     //

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -21,16 +21,21 @@ import _Concurrency
 
 class Klass {}
 
-class NonSendableKlass { // expected-note 2{{}}
+class NonSendableKlass { // expected-note 4{{}}
   var klass: Klass
 
   func asyncCall() async
+
+  @MainActor static func getValue() -> sending NonSendableKlass
 }
 
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+sil @useNonSendableKlassAsync : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
 sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
+sil @constructNonSendableKlassAsync : $@convention(thin) @async () -> @owned NonSendableKlass
+sil @constructNonSendableKlassAsyncSending : $@convention(thin) @async () -> @sil_sending @owned NonSendableKlass
 
 final class SendableKlass : Sendable {}
 
@@ -376,11 +381,60 @@ bb0(%0 : @guaranteed $Self):
   return %9999 : $()
 }
 
+sil [ossa] @sending_direct_result_from_callee : $@convention(thin) @async () -> () {
+bb0:
+  %0 = function_ref @constructNonSendableKlassAsyncSending : $@convention(thin) @async () -> @sil_sending @owned NonSendableKlass
+  %1 = apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %0() : $@convention(thin) @async () -> @sil_sending @owned NonSendableKlass
+
+  %useValue = function_ref @useNonSendableKlassAsync : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %useValue(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  destroy_value %1
+
+  // Double check we actually error without @sil_sending
+  %2 = function_ref @constructNonSendableKlassAsync : $@convention(thin) @async () -> @owned NonSendableKlass
+  %3 = apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2() : $@convention(thin) @async () -> @owned NonSendableKlass
+  // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from global actor '<null>'-isolated function to nonisolated context}}
+
+  apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %useValue(%3) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-2 {{}}
+
+  destroy_value %3
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @sending_direct_result_from_callee_2 : $@convention(thin) @async () -> () {
+bb0:
+  %0 = function_ref @constructNonSendableKlassAsyncSending : $@convention(thin) @async () -> @sil_sending @owned NonSendableKlass
+  %1 = apply [caller_isolation=global_actor] [callee_isolation=global_actor] %0() : $@convention(thin) @async () -> @sil_sending @owned NonSendableKlass
+
+  %useValue = function_ref @useNonSendableKlassAsync : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=global_actor] [callee_isolation=actor_instance] %useValue(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  destroy_value %1
+
+  // Double check we actually error without @sil_sending
+  %2 = function_ref @constructNonSendableKlassAsync : $@convention(thin) @async () -> @owned NonSendableKlass
+  %3 = apply [caller_isolation=global_actor] [callee_isolation=global_actor] %2() : $@convention(thin) @async () -> @owned NonSendableKlass
+  // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from global actor '<null>'-isolated function to global actor '<null>'-isolated context}}
+
+  apply [caller_isolation=global_actor] [callee_isolation=actor_instance] %useValue(%3) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-2 {{}}
+
+  destroy_value %3
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+
 sil @closureForCheckedContinuation : $@convention(thin) <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()
 sil @withCheckedContinuation : $@convention(thin) @async <τ_0_0> (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @callee_guaranteed <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()) -> @sil_sending @out τ_0_0
 
 // We shouldn't emit any error here due to sil_sending.
-sil [ossa] @sending_result_from_callee : $@convention(thin) @async () -> () {
+sil [ossa] @sending_indirect_result_from_callee : $@convention(thin) @async () -> () {
 bb0:
   %0 = alloc_stack $NonSendableKlass
   %1 = function_ref @closureForCheckedContinuation : $@convention(thin) <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1906,3 +1906,30 @@ func offByOneWithImplicitPartialApply() {
       }
   }
 }
+
+// We should not error in either of the cases below due to sending.
+func testIndirectAndDirectSendingResultsWithGlobalActor() async {
+  @MainActor
+  struct S {
+    let ns = NonSendableKlass()
+
+    func getNonSendableKlassIndirect<T>() -> sending T {
+      fatalError()
+    }
+    func getNonSendableKlassDirect() -> sending NonSendableKlass {
+      fatalError()
+    }
+  }
+
+  let s = await S()
+  let ns: NonSendableKlass = await s.getNonSendableKlassDirect()
+
+  Task.detached {
+    _ = ns
+  }
+
+  let ns2: NonSendableKlass = await s.getNonSendableKlassIndirect()
+  Task.detached {
+    _ = ns2
+  }
+}


### PR DESCRIPTION
I did the correct thing for indirect parameters, but did not do the correct thing for direct parameters. This is now fixed with some tests to boot.

rdar://141631655
