### PR TITLE
[sil] Add flexibility to SILPrinter to allow for full SIL types to printed out in the debugger and programatically without touching the global flag.

### DIFF
--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -176,10 +176,8 @@ public:
   /// Print the coverage map.
   void print(llvm::raw_ostream &OS, bool Verbose = false,
              bool ShouldSort = false) const {
-    SILPrintContext Ctx(OS,
-                        SILPrintContext::OptionSet(
-                            {{Verbose, SILPrintContext::Flag::Verbose},
-                             {ShouldSort, SILPrintContext::Flag::SortedSIL}}));
+    SILPrintContext Ctx(OS, {{Verbose, SILPrintContext::Flag::Verbose},
+                             {ShouldSort, SILPrintContext::Flag::SortedSIL}});
     print(Ctx);
   }
 

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -176,7 +176,10 @@ public:
   /// Print the coverage map.
   void print(llvm::raw_ostream &OS, bool Verbose = false,
              bool ShouldSort = false) const {
-    SILPrintContext Ctx(OS, Verbose, ShouldSort);
+    SILPrintContext Ctx(OS,
+                        SILPrintContext::OptionSet(
+                            {{Verbose, SILPrintContext::Flag::Verbose},
+                             {ShouldSort, SILPrintContext::Flag::SortedSIL}}));
     print(Ctx);
   }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1711,9 +1711,7 @@ public:
   ///
   /// \param Verbose Dump SIL location information in verbose mode.
   void print(raw_ostream &OS, bool Verbose = false) const {
-    SILPrintContext PrintCtx(OS,
-                             SILPrintContext::OptionSet(
-                                 {{Verbose, SILPrintContext::Flag::Verbose}}));
+    SILPrintContext PrintCtx(OS, {{Verbose, SILPrintContext::Flag::Verbose}});
     print(PrintCtx);
   }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1711,7 +1711,9 @@ public:
   ///
   /// \param Verbose Dump SIL location information in verbose mode.
   void print(raw_ostream &OS, bool Verbose = false) const {
-    SILPrintContext PrintCtx(OS, Verbose);
+    SILPrintContext PrintCtx(OS,
+                             SILPrintContext::OptionSet(
+                                 {{Verbose, SILPrintContext::Flag::Verbose}}));
     print(PrintCtx);
   }
 

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -43,6 +43,9 @@ public:
 
     /// See \ref FrontendOptions.PrintFullConvention.
     PrintFullConvention = 0x8,
+
+    /// Print out all types that normally would be surpressed.
+    PrintAllTypes = 0x10,
   };
 
   using OptionSet = OptionSet<Flag>;
@@ -122,6 +125,10 @@ public:
   bool printFullConvention() const {
     return Options.contains(Flag::PrintFullConvention);
   }
+
+  /// Returns true if we should print out all SIL types that normally would be
+  /// suppressed.
+  bool printAllTypes() const { return Options.contains(Flag::PrintAllTypes); }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -29,6 +29,24 @@ class SILBasicBlock;
 /// Used as context for the SIL print functions.
 class SILPrintContext {
 public:
+  enum class Flag {
+    None,
+
+    /// Dump more information in the SIL output.
+    Verbose = 0x1,
+
+    /// Sort all kind of tables to ease diffing.
+    SortedSIL = 0x2,
+
+    /// Print debug locations and scopes.
+    DebugInfo = 0x4,
+
+    /// See \ref FrontendOptions.PrintFullConvention.
+    PrintFullConvention = 0x8,
+  };
+
+  using OptionSet = OptionSet<Flag>;
+
   struct ID {
     enum ID_Kind { SILBasicBlock, SILUndef, SSAValue, Null } Kind;
     unsigned Number;
@@ -57,33 +75,29 @@ protected:
 
   llvm::DenseMap<const SILDebugScope *, unsigned> ScopeToIDMap;
 
-  /// Dump more information in the SIL output.
-  bool Verbose;
-  
-  /// Sort all kind of tables to ease diffing.
-  bool SortedSIL;
-
-  /// Print debug locations and scopes.
-  bool DebugInfo;
-
-  /// See \ref FrontendOptions.PrintFullConvention.
-  bool PrintFullConvention;
+  OptionSet Options;
 
 public:
   /// Constructor with default values for options.
   ///
   /// DebugInfo will be set according to the -sil-print-debuginfo option.
-  SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
-                  bool SortedSIL = false, bool PrintFullConvention = false);
+  SILPrintContext(llvm::raw_ostream &OS, OptionSet options = {})
+      : OutStream(OS), Options(options) {}
+
+  /// Helper constructor that enables one to pass through direct (bool, Flag)
+  /// pairs to initialize the option set.
+  ///
+  /// Intended to be used to "re-core" older APIs that rely on passing many
+  /// boolean parameters.
+  SILPrintContext(llvm::raw_ostream &OS,
+                  std::initializer_list<std::pair<bool, Flag>> &&options)
+      : SILPrintContext(OS, OptionSet(std::move(options))) {}
 
   /// Constructor based on SILOptions.
   ///
   /// DebugInfo will be set according to SILOptions::PrintDebugInfo or
   /// the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts);
-
-  SILPrintContext(llvm::raw_ostream &OS, bool Verbose, bool SortedSIL,
-                  bool DebugInfo, bool PrintFullConvention);
 
   virtual ~SILPrintContext();
 
@@ -96,16 +110,18 @@ public:
   llvm::raw_ostream &OS() const { return OutStream; }
 
   /// Returns true if the SIL output should be sorted.
-  bool sortSIL() const { return SortedSIL; }
-  
+  bool sortSIL() const { return Options.contains(Flag::SortedSIL); }
+
   /// Returns true if verbose SIL should be printed.
-  bool printVerbose() const { return Verbose; }
+  bool printVerbose() const { return Options.contains(Flag::Verbose); }
 
   /// Returns true if debug locations and scopes should be printed.
-  bool printDebugInfo() const { return DebugInfo; }
+  bool printDebugInfo() const { return Options.contains(Flag::DebugInfo); }
 
   /// Returns true if the entire @convention(c, cType: ..) should be printed.
-  bool printFullConvention() const { return PrintFullConvention; }
+  bool printFullConvention() const {
+    return Options.contains(Flag::PrintFullConvention);
+  }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -27,7 +27,7 @@ using namespace swift;
 
 static void disableExpensiveSILOptions(SILOptions &Opts) {
   // Disable the sanitizers.
-  Opts.Sanitizers = {};
+  Opts.Sanitizers = OptionSet<SanitizerKind>();
 
   // Disable PGO and code coverage.
   Opts.GenerateProfile = false;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -739,6 +739,9 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
     if (SILPrintTypes)
       return true;
 
+    if (Ctx.printAllTypes())
+      return true;
+
     if (!V)
       return false;
 
@@ -3377,9 +3380,8 @@ void SILBasicBlock::printID(SILPrintContext &Ctx, bool newline) const {
 
 /// Pretty-print the SILFunction to errs.
 void SILFunction::dump(bool Verbose) const {
-  SILPrintContext Ctx(
-      llvm::errs(),
-      SILPrintContext::OptionSet({{Verbose, SILPrintContext::Flag::Verbose}}));
+  SILPrintContext Ctx(llvm::errs(),
+                      {{Verbose, SILPrintContext::Flag::Verbose}});
   print(Ctx);
 }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -735,7 +735,7 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
     return *this;
   }
 
-  bool needPrintTypeFor(SILValue V) {
+  bool shouldPrintType(SILValue V) {
     if (SILPrintTypes)
       return true;
 
@@ -776,7 +776,7 @@ public:
   }
 
   SILValuePrinterInfo getIDAndType(SILValue V) {
-    return {Ctx.getID(V), V ? V->getType() : SILType(), needPrintTypeFor(V)};
+    return {Ctx.getID(V), V ? V->getType() : SILType(), shouldPrintType(V)};
   }
   SILValuePrinterInfo getIDAndForcedPrintedType(SILValue V) {
     return {Ctx.getID(V), V ? V->getType() : SILType(), /*needPrintType=*/true};

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3377,7 +3377,9 @@ void SILBasicBlock::printID(SILPrintContext &Ctx, bool newline) const {
 
 /// Pretty-print the SILFunction to errs.
 void SILFunction::dump(bool Verbose) const {
-  SILPrintContext Ctx(llvm::errs(), Verbose);
+  SILPrintContext Ctx(
+      llvm::errs(),
+      SILPrintContext::OptionSet({{Verbose, SILPrintContext::Flag::Verbose}}));
   print(Ctx);
 }
 
@@ -3706,7 +3708,8 @@ void SILGlobalVariable::printName(raw_ostream &OS) const {
       
 /// Pretty-print the SILModule to errs.
 void SILModule::dump(bool Verbose) const {
-  SILPrintContext Ctx(llvm::errs(), Verbose);
+  SILPrintContext Ctx(llvm::errs(),
+                      {{Verbose, SILPrintContext::Flag::Verbose}});
   print(Ctx);
 }
 
@@ -3714,7 +3717,7 @@ void SILModule::dump(const char *FileName, bool Verbose,
                      bool PrintASTDecls) const {
   std::error_code EC;
   llvm::raw_fd_ostream os(FileName, EC, llvm::sys::fs::OpenFlags::OF_None);
-  SILPrintContext Ctx(os, Verbose);
+  SILPrintContext Ctx(os, {{Verbose, SILPrintContext::Flag::Verbose}});
   print(Ctx, getSwiftModule(), PrintASTDecls);
 }
 
@@ -4563,22 +4566,12 @@ void KeyPathPatternComponent::print(SILPrintContext &ctxt) const {
 // SILPrintContext members
 //===----------------------------------------------------------------------===//
 
-SILPrintContext::SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
-                                 bool SortedSIL, bool PrintFullConvention)
-    : OutStream(OS), Verbose(Verbose), SortedSIL(SortedSIL),
-      DebugInfo(SILPrintDebugInfo), PrintFullConvention(PrintFullConvention) {}
-
 SILPrintContext::SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts)
-    : OutStream(OS), Verbose(Opts.EmitVerboseSIL),
-      SortedSIL(Opts.EmitSortedSIL),
-      DebugInfo(Opts.PrintDebugInfo || SILPrintDebugInfo),
-      PrintFullConvention(Opts.PrintFullConvention) {}
-
-SILPrintContext::SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
-                                 bool SortedSIL, bool DebugInfo,
-                                 bool PrintFullConvention)
-    : OutStream(OS), Verbose(Verbose), SortedSIL(SortedSIL),
-      DebugInfo(DebugInfo), PrintFullConvention(PrintFullConvention) {}
+    : OutStream(OS),
+      Options({{Opts.EmitVerboseSIL, Flag::Verbose},
+               {Opts.EmitSortedSIL, Flag::SortedSIL},
+               {Opts.PrintDebugInfo || SILPrintDebugInfo, Flag::DebugInfo},
+               {Opts.PrintFullConvention, Flag::PrintFullConvention}}) {}
 
 void SILPrintContext::setContext(const void *FunctionOrBlock) {
   if (FunctionOrBlock != ContextFunctionOrBlock) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1779,7 +1779,9 @@ public:
                    Demangle::DemangleOptions::SimplifiedUIDemangleOptions())
             << '\n'
             << PER_FUNCTION_SEP_STR << "Dump:\n";
-        function->print(llvm::dbgs()));
+        SILPrintContext printCtx(llvm::dbgs(),
+                                 {SILPrintContext::Flag::PrintAllTypes});
+        function->print(printCtx));
 
     gatherFlowInsensitiveInformationBeforeDataflow();
 

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -596,7 +596,7 @@ void RetainCodeMotionContext::convergeCodeMotionDataFlow() {
 
 void RetainCodeMotionContext::computeCodeMotionInsertPoints() {
 #ifndef NDEBUG
-  printCtx.emplace(llvm::dbgs(), /*Verbose=*/false, /*Sorted=*/true);
+  printCtx.emplace(llvm::dbgs(), SILPrintContext::Flag::SortedSIL);
 #endif
   // The BBSetOuts have converged, run last iteration and figure out
   // insertion point for each refcounted root.
@@ -1020,7 +1020,7 @@ void ReleaseCodeMotionContext::convergeCodeMotionDataFlow() {
 
 void ReleaseCodeMotionContext::computeCodeMotionInsertPoints() {
 #ifndef NDEBUG
-  printCtx.emplace(llvm::dbgs(), /*Verbose=*/false, /*Sorted=*/true);
+  printCtx.emplace(llvm::dbgs(), SILPrintContext::Flag::SortedSIL);
 #endif
 
   // The BBSetIns have converged, run last iteration and figure out insertion

--- a/lib/SILOptimizer/UtilityPasses/ModulePrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ModulePrinter.cpp
@@ -27,8 +27,10 @@ class SILModulePrinter : public SILModuleTransform {
   /// The entry point.
   void run() override {
     auto *module = getModule();
-    SILPrintContext context(llvm::outs(), /*Verbose*/ true, /*SortedSIL*/ true,
-                            /*PrintFullConvention*/ true);
+    SILPrintContext context(llvm::outs(),
+                            {SILPrintContext::Flag::Verbose,
+                             SILPrintContext::Flag::SortedSIL,
+                             SILPrintContext::Flag::PrintFullConvention});
     module->print(context);
   }
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1129,7 +1129,7 @@ CloseClangModuleFiles::~CloseClangModuleFiles() {
 
 void SourceKit::disableExpensiveSILOptions(SILOptions &Opts) {
   // Disable the sanitizers.
-  Opts.Sanitizers = {};
+  Opts.Sanitizers = OptionSet<SanitizerKind>();
 
   // Disable PGO and code coverage.
   Opts.GenerateProfile = false;


### PR DESCRIPTION
This PR adds flexibility to the SIL printer API such that users can emit full SIL types without touching the global flag. This is implemented by changing SILPrinterContext to take an OptionSet instead of boolean flags and adding a flag to SILPrinterContext that forces the behavior. The default behavior is left alone and is controlled via the global flag.

By doing this, without changing any normal path behavior, we allow for:

1. Compiler developers in the debugger to dump the full types without needing to restart the compilation session to set the global flag.
2. In certain cases when emitting logging specific to an optimization pass, it is useful to emit full types to enable quick triaging. This occurs in RegionAnalysis where we do a quick dump of the entire function before we emit logging to give the user a more global look at the function. It is not intended to be used to get actual output (that is a job for -sil-print-function) but rather just for quick scanning to get a sense of what types/etc are being used. This is especially useful when looking at a large piece of code where types are defined very early in the function (several pages up).