### PR TITLE
[demangler] Add a getRemainingText() method to the demangler only for use in the debugger.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -23,6 +23,16 @@
 #include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Demangling/NamespaceMacros.h"
 
+#ifndef NDEBUG
+
+// NOTE: We can include swift/Basic/Debug.h here since
+// swift/Demangling/Demangle.h already includes the one dependency of Debug.h:
+// llvm/Support/Compiler.h... so we are not introducing a new dependency on
+// LLVM.
+#include "swift/Basic/Debug.h"
+
+#endif
+
 //#define NODE_FACTORY_DEBUGGING
 
 using namespace swift::Demangle;
@@ -416,6 +426,12 @@ protected:
   int NumWords = 0;
   
   std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver;
+
+#ifndef NDEBUG
+  /// Only for use in the debugger when attempting to see the remaining string
+  /// left to be demangled.
+  SWIFT_DEBUG_HELPER(StringRef getRemainingText() const);
+#endif
 
   bool nextIf(StringRef str) {
     if (!Text.substr(Pos).starts_with(str)) return false;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4472,3 +4472,11 @@ NodePointer Demangler::demangleIntegerType() {
 
   return createType(integer);
 }
+
+#ifndef NDEBUG
+
+StringRef Demangler::getRemainingText() const {
+  return Text.drop_front(Pos);
+}
+
+#endif


### PR DESCRIPTION
Without this one cannot easily in the debugger see what is left to be parsed when working in a release+debuginfo build. To be careful, I only included the method in NDEBUG builds and used SWIFT_DEBUG_HELPER so that even then, people do not attempt to use it outside of the debugger. Finally I validated that I am not including any additional parts of LLVM into the demangler header I am changing (since I know the demangler is sensitive to this). The only LLVM header I am including (llvm/Support/Compiler.h) is already included into the file by Demangler.h... so there isnt a risk of expanding the world of LLVM being included.
