### PR TITLE
CMake: SwiftCore: Add Locale macro

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SwiftCore_VENDOR_MODULE_DIR "${SwiftCore_CMAKE_MODULES_DIR}/vendor"
 
 include(GNUInstallDirs)
 include(CheckSymbolExists)
+include(CheckIncludeFileCXX)
 include(AvailabilityMacros)
 include(CompilerSettings)
 include(DefaultSettings)
@@ -72,6 +73,8 @@ include(Plist)
 
 check_symbol_exists("dladdr" "dlfcn.h" SwiftCore_HAS_DLADDR)
 check_symbol_exists("dlsym" "dlfcn.h" SwiftCore_HAS_DLSYM)
+
+check_include_file_cxx("clocale" SwiftCore_HAS_LOCALE)
 
 include("${SwiftCore_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
 

--- a/Runtimes/Core/stubs/CMakeLists.txt
+++ b/Runtimes/Core/stubs/CMakeLists.txt
@@ -28,7 +28,8 @@ endif()
 
 target_compile_definitions(swiftStdlibStubs PRIVATE
   $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
-  $<$<BOOL:${SwiftCore_ENABLE_UNICODE_DATA}>:-DSWIFT_STDLIB_ENABLE_UNICODE_DATA>)
+  $<$<BOOL:${SwiftCore_ENABLE_UNICODE_DATA}>:-DSWIFT_STDLIB_ENABLE_UNICODE_DATA>
+  $<$<BOOL:${SwiftCore_HAS_LOCALE}>:-DSWIFT_STDLIB_HAS_LOCALE>)
 
 target_link_libraries(swiftStdlibStubs PRIVATE
   swiftShims)


### PR DESCRIPTION
Add locale support to new build system. The locale support depends on finding the `clocale` C++ header.

rdar://142440689