### PR TITLE
🍒 [cxx-interop] Add support for SWIFT_RETURNS_(UN)RETAINED for ObjC APIs returning C++ FRT

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1298,6 +1298,25 @@ public:
     }
     llvm_unreachable("unhandled ownership");
   }
+
+  // Determines owned/unowned ResultConvention of the returned value based on
+  // returns_retained/returns_unretained attribute.
+  std::optional<ResultConvention>
+  getCxxRefConventionWithAttrs(const TypeLowering &tl,
+                               const clang::Decl *decl) const {
+    if (tl.getLoweredType().isForeignReferenceType() && decl->hasAttrs()) {
+      for (const auto *attr : decl->getAttrs()) {
+        if (const auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+          if (swiftAttr->getAttribute() == "returns_unretained") {
+            return ResultConvention::Unowned;
+          } else if (swiftAttr->getAttribute() == "returns_retained") {
+            return ResultConvention::Owned;
+          }
+        }
+      }
+    }
+    return std::nullopt;
+  }
 };
 
 /// A visitor for breaking down formal result types into a SILResultInfo
@@ -3335,7 +3354,8 @@ public:
       return ResultConvention::Owned;
 
     if (tl.getLoweredType().isForeignReferenceType())
-      return ResultConvention::Unowned;
+      return getCxxRefConventionWithAttrs(tl, Method)
+          .value_or(ResultConvention::Unowned);
 
     return ResultConvention::Autoreleased;
   }
@@ -3374,25 +3394,6 @@ protected:
   CFunctionTypeConventions(ConventionsKind kind,
                            const clang::FunctionType *type)
     : Conventions(kind), FnType(type) {}
-
-  // Determines owned/unowned ResultConvention of the returned value based on
-  // returns_retained/returns_unretained attribute.
-  std::optional<ResultConvention>
-  getForeignReferenceTypeResultConventionWithAttributes(
-      const TypeLowering &tl, const clang::FunctionDecl *decl) const {
-    if (tl.getLoweredType().isForeignReferenceType() && decl->hasAttrs()) {
-      for (const auto *attr : decl->getAttrs()) {
-        if (const auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-          if (swiftAttr->getAttribute() == "returns_unretained") {
-            return ResultConvention::Unowned;
-          } else if (swiftAttr->getAttribute() == "returns_retained") {
-            return ResultConvention::Owned;
-          }
-        }
-      }
-    }
-    return std::nullopt;
-  }
 
 public:
   CFunctionTypeConventions(const clang::FunctionType *type)
@@ -3511,11 +3512,7 @@ public:
       return ResultConvention::Indirect;
     }
 
-    // Explicitly setting the ownership of the returned FRT if the C++
-    // global/free function has either swift_attr("returns_retained") or
-    // ("returns_unretained") attribute.
-    if (auto resultConventionOpt =
-            getForeignReferenceTypeResultConventionWithAttributes(tl, TheDecl))
+    if (auto resultConventionOpt = getCxxRefConventionWithAttrs(tl, TheDecl))
       return *resultConventionOpt;
 
     if (isCFTypedef(tl, TheDecl->getReturnType())) {
@@ -3597,11 +3594,8 @@ public:
       return ResultConvention::Indirect;
     }
 
-    // Explicitly setting the ownership of the returned FRT if the C++ member
-    // method has either swift_attr("returns_retained") or
-    // ("returns_unretained") attribute.
     if (auto resultConventionOpt =
-            getForeignReferenceTypeResultConventionWithAttributes(resultTL, TheDecl))
+            getCxxRefConventionWithAttrs(resultTL, TheDecl))
       return *resultConventionOpt;
 
     if (TheDecl->hasAttr<clang::CFReturnsRetainedAttr>() &&

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-frt.h
@@ -1,0 +1,38 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-extension"
+#pragma clang assume_nonnull begin
+
+struct CxxRefType {
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainCxxRefType")))
+__attribute__((swift_attr("release:releaseCxxRefType")));
+
+void retainCxxRefType(CxxRefType *_Nonnull b) {}
+void releaseCxxRefType(CxxRefType *_Nonnull b) {}
+
+@interface Bridge : NSObject
+
++ (struct CxxRefType *)objCMethodReturningFRTUnannotated;
++ (struct CxxRefType *)objCMethodReturningFRTUnowned
+    __attribute__((swift_attr("returns_unretained")));
++ (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained")));
+
+@end
+
+@implementation Bridge
++ (struct CxxRefType *)objCMethodReturningFRTUnannotated {
+};
++ (struct CxxRefType *)objCMethodReturningFRTUnowned
+    __attribute__((swift_attr("returns_unretained"))) {
+}
++ (struct CxxRefType *)objCMethodReturningFRTOwned
+    __attribute__((swift_attr("returns_retained"))) {
+}
+
+@end
+
+#pragma clang diagnostic pop
+#pragma clang assume_nonnull end

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -44,3 +44,8 @@ module ID {
   requires objc
   requires cplusplus
 }
+
+module CxxForeignRef {
+  header "cxx-frt.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-returning-cxx-frt.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -disable-availability-checking -diagnostic-style llvm %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+
+import CxxForeignRef
+
+// REQUIRES: objc_interop
+
+func testObjCMethods() {
+    var frt1 = Bridge.objCMethodReturningFRTUnannotated()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTUnannotated!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> CxxRefType
+
+    var frt2 = Bridge.objCMethodReturningFRTUnowned()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTUnowned!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> CxxRefType
+
+    var frt3 = Bridge.objCMethodReturningFRTOwned()
+    // CHECK: objc_method {{.*}} #Bridge.objCMethodReturningFRTOwned!foreign : (Bridge.Type) -> () -> CxxRefType, $@convention(objc_method) (@objc_metatype Bridge.Type) -> @owned CxxRefType
+ }


### PR DESCRIPTION
Explanation: Adding support for new annotations SWIFT_RETURNS_(UN)RETAINED for ObjC APIs just like we did for C++ APIs in this PR: https://github.com/swiftlang/swift/pull/75897
Scope: Not a source breaking change. Just adding support for new annotations for ObjC APIs.
Risk: Low, this logic would trigger only when users start using new annotations.
Reviewer: @egorzhdan @Xazax-hun @j-hui

Original PR: https://github.com/swiftlang/swift/pull/78230