### PR TITLE
AST: Remove most platform queries from `AvailableAttr`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -817,11 +817,6 @@ public:
   /// platform.
   bool hasPlatform() const { return getPlatform() != PlatformKind::none; }
 
-  /// Returns the string for the platform of the attribute.
-  StringRef platformString() const {
-    return swift::platformString(getPlatform());
-  }
-
   /// Returns the human-readable string for the platform of the attribute.
   StringRef prettyPlatformString() const {
     return swift::prettyPlatformString(getPlatform());

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -827,9 +827,6 @@ public:
     return swift::prettyPlatformString(getPlatform());
   }
 
-  /// Returns true if this attribute is active given the current platform.
-  bool isActivePlatform(const ASTContext &ctx) const;
-
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
   static AvailableAttr *

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3313,6 +3313,9 @@ public:
   /// compilation context.
   bool isActive(ASTContext &ctx) const;
 
+  /// Whether this attribute was spelled `@_spi_available`.
+  bool isSPI() const { return attr->isSPI(); }
+
   bool operator==(const SemanticAvailableAttr &other) const {
     return other.attr == attr;
   }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -813,10 +813,6 @@ public:
         Bits.AvailableAttr.PlatformAgnostic);
   }
 
-  /// Returns true if the availability applies to a specific
-  /// platform.
-  bool hasPlatform() const { return getPlatform() != PlatformKind::none; }
-
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
   static AvailableAttr *

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3222,7 +3222,7 @@ public:
 
   /// Returns the effective range in which the declaration with this attribute
   /// was introduced.
-  AvailabilityRange getIntroducedRange(ASTContext &Ctx) const;
+  AvailabilityRange getIntroducedRange(const ASTContext &Ctx) const;
 
   /// The version tuple written in source for the `deprecated:` component.
   std::optional<llvm::VersionTuple> getDeprecated() const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -817,11 +817,6 @@ public:
   /// platform.
   bool hasPlatform() const { return getPlatform() != PlatformKind::none; }
 
-  /// Returns the human-readable string for the platform of the attribute.
-  StringRef prettyPlatformString() const {
-    return swift::prettyPlatformString(getPlatform());
-  }
-
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
   static AvailableAttr *

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -88,7 +88,7 @@ public:
 
   /// Returns true if this domain is considered active in the current
   /// compilation context.
-  bool isActive(ASTContext &ctx) const;
+  bool isActive(const ASTContext &ctx) const;
 
   /// Returns the string to use in diagnostics to identify the domain. May
   /// return an empty string.

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -24,9 +24,9 @@
 
 namespace swift {
 class ASTContext;
-class AvailableAttr;
 class BackDeployedAttr;
 class Decl;
+class SemanticAvailableAttr;
 
 class AvailabilityInference {
 public:
@@ -63,26 +63,26 @@ public:
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
   static bool updateIntroducedPlatformForFallback(
-      const AvailableAttr *attr, const ASTContext &Ctx,
+      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
       llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
 
   /// For the attribute's deprecation version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
   static bool updateDeprecatedPlatformForFallback(
-      const AvailableAttr *attr, const ASTContext &Ctx,
+      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
       llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
 
   /// For the attribute's obsoletion version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
   static bool updateObsoletedPlatformForFallback(
-      const AvailableAttr *attr, const ASTContext &Ctx,
+      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
       llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
 
-  static void updatePlatformStringForFallback(
-      const AvailableAttr *attr, const ASTContext &Ctx,
-      llvm::StringRef &Platform);
+  static void updatePlatformStringForFallback(const SemanticAvailableAttr &attr,
+                                              const ASTContext &Ctx,
+                                              llvm::StringRef &Platform);
 
   /// For the attribute's before version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1339,16 +1339,14 @@ std::optional<uint8_t> SDKContext::getFixedBinaryOrder(ValueDecl *VD) const {
 // check for if it has @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 static bool isABIPlaceHolder(Decl *D) {
   llvm::SmallSet<PlatformKind, 4> Platforms;
-  for (auto semanticAttr : D->getSemanticAvailableAttrs()) {
-    auto attr = semanticAttr.getParsedAttr();
-    auto domain = semanticAttr.getDomain();
-    if (domain.isPlatform() && attr->Introduced &&
-        attr->Introduced->getMajor() == 9999) {
-      Platforms.insert(attr->getPlatform());
+  for (auto attr : D->getSemanticAvailableAttrs()) {
+    if (attr.isPlatformSpecific() && attr.getIntroduced().has_value() &&
+        attr.getIntroduced()->getMajor() == 9999) {
+      Platforms.insert(attr.getPlatform());
     }
   }
 
-  // FIXME: This probably isn't correct anymore, now that visionOS exists
+  // FIXME: [availability] This probably isn't correct now that visionOS exists
   return Platforms.size() == 4;
 }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2148,10 +2148,6 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
       /*SPI=*/false);
 }
 
-bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
-  return isPlatformActive(getPlatform(), ctx.LangOpts);
-}
-
 bool BackDeployedAttr::isActivePlatform(const ASTContext &ctx,
                                         bool forTargetVariant) const {
   return isPlatformActive(Platform, ctx.LangOpts, forTargetVariant);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2261,7 +2261,7 @@ SemanticAvailableAttr::getVersionAvailability(const ASTContext &ctx) const {
   StringRef ObsoletedPlatform;
   llvm::VersionTuple RemappedObsoletedVersion;
   if (AvailabilityInference::updateObsoletedPlatformForFallback(
-          attr, ctx, ObsoletedPlatform, RemappedObsoletedVersion))
+          *this, ctx, ObsoletedPlatform, RemappedObsoletedVersion))
     ObsoletedVersion = RemappedObsoletedVersion;
 
   // If this entity was obsoleted before or at the query platform version,
@@ -2273,7 +2273,7 @@ SemanticAvailableAttr::getVersionAvailability(const ASTContext &ctx) const {
   StringRef IntroducedPlatform;
   llvm::VersionTuple RemappedIntroducedVersion;
   if (AvailabilityInference::updateIntroducedPlatformForFallback(
-          attr, ctx, IntroducedPlatform, RemappedIntroducedVersion))
+          *this, ctx, IntroducedPlatform, RemappedIntroducedVersion))
     IntroducedVersion = RemappedIntroducedVersion;
 
   // If this entity was introduced after the query version and we're doing a

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -421,7 +421,7 @@ void DeclAttributes::dump(const Decl *D) const {
 LLVM_READONLY
 static bool isShortAvailable(const SemanticAvailableAttr &attr) {
   auto parsedAttr = attr.getParsedAttr();
-  if (parsedAttr->isSPI())
+  if (attr.isSPI())
     return false;
 
   if (!attr.getIntroduced().has_value())

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1172,21 +1172,20 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   }
 
   case DeclAttrKind::Available: {
-    auto Attr = cast<AvailableAttr>(this);
-    auto SemanticAttr = D->getSemanticAvailableAttr(Attr);
-    if (!SemanticAttr)
+    auto Attr = D->getSemanticAvailableAttr(cast<AvailableAttr>(this));
+    if (!Attr)
       return false;
 
     if (Options.printPublicInterface() && Attr->isSPI()) {
-      assert(Attr->hasPlatform());
-      assert(Attr->Introduced.has_value());
+      assert(Attr->isPlatformSpecific());
+      assert(Attr->getIntroduced().has_value());
       Printer.printAttrName("@available");
       Printer << "(";
-      Printer << Attr->platformString();
+      Printer << Attr->getDomain().getNameForAttributePrinting();
       Printer << ", unavailable)";
       break;
     }
-    if (Attr->isForEmbedded()) {
+    if (Attr->getParsedAttr()->isForEmbedded()) {
       std::string atUnavailableInEmbedded =
           (llvm::Twine("@") + UNAVAILABLE_IN_EMBEDDED_ATTRNAME).str();
       Printer.printAttrName(atUnavailableInEmbedded);
@@ -1200,7 +1199,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       Printer.printAttrName("@available");
     }
     Printer << "(";
-    printAvailableAttr(D, *SemanticAttr, Printer, Options);
+    printAvailableAttr(D, *Attr, Printer, Options);
     Printer << ")";
     break;
   }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -829,7 +829,7 @@ bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
 AvailabilityRange
 SemanticAvailableAttr::getIntroducedRange(ASTContext &Ctx) const {
   auto *attr = getParsedAttr();
-  assert(attr->isActivePlatform(Ctx));
+  assert(domain.isActive(Ctx));
 
   llvm::VersionTuple IntroducedVersion = attr->Introduced.value();
   StringRef Platform = attr->prettyPlatformString();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -156,7 +156,7 @@ static void mergeWithInferredAvailability(SemanticAvailableAttr Attr,
   // The merge of two introduction versions is the maximum of the two versions.
   if (mergeIntoInferredVersion(Attr.getIntroduced(), Inferred.Introduced,
                                std::max)) {
-    Inferred.IsSPI = ParsedAttr->isSPI();
+    Inferred.IsSPI = Attr.isSPI();
   }
 
   // The merge of deprecated and obsoleted versions takes the minimum.
@@ -821,7 +821,7 @@ AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
 
 bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
   if (auto attr = D->getAvailableAttrForPlatformIntroduction())
-    return attr->getParsedAttr()->isSPI();
+    return attr->isSPI();
 
   return false;
 }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -832,7 +832,7 @@ SemanticAvailableAttr::getIntroducedRange(ASTContext &Ctx) const {
   assert(domain.isActive(Ctx));
 
   llvm::VersionTuple IntroducedVersion = attr->Introduced.value();
-  StringRef Platform = attr->prettyPlatformString();
+  StringRef Platform;
   llvm::VersionTuple RemappedIntroducedVersion;
   if (AvailabilityInference::updateIntroducedPlatformForFallback(
       attr, Ctx, Platform, RemappedIntroducedVersion))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -468,8 +468,9 @@ Decl::getSemanticAvailableAttrs(bool includeInactive) const {
 std::optional<SemanticAvailableAttr>
 Decl::getSemanticAvailableAttr(const AvailableAttr *attr) const {
   auto domainForAvailableAttr = [](const AvailableAttr *attr) {
-    if (attr->hasPlatform())
-      return AvailabilityDomain::forPlatform(attr->getPlatform());
+    auto platform = attr->getPlatform();
+    if (platform != PlatformKind::none)
+      return AvailabilityDomain::forPlatform(platform);
 
     switch (attr->getPlatformAgnosticAvailability()) {
     case PlatformAgnosticAvailabilityKind::Deprecated:

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -828,9 +828,12 @@ bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
 }
 
 AvailabilityRange
-SemanticAvailableAttr::getIntroducedRange(ASTContext &Ctx) const {
-  auto *attr = getParsedAttr();
+SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
   assert(domain.isActive(Ctx));
+
+  auto *attr = getParsedAttr();
+  if (!attr->Introduced.has_value())
+    return AvailabilityRange::alwaysAvailable();
 
   llvm::VersionTuple IntroducedVersion = attr->Introduced.value();
   StringRef Platform;

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -16,7 +16,7 @@
 
 using namespace swift;
 
-bool AvailabilityDomain::isActive(ASTContext &ctx) const {
+bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   switch (kind) {
   case Kind::Universal:
   case Kind::SwiftLanguage:

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -295,21 +295,19 @@ static SourceRange getAvailabilityConditionVersionSourceRange(
 }
 
 static SourceRange
-getAvailabilityConditionVersionSourceRange(const DeclAttributes &DeclAttrs,
-                                           PlatformKind Platform,
+getAvailabilityConditionVersionSourceRange(const Decl *D, PlatformKind Platform,
                                            const llvm::VersionTuple &Version) {
   SourceRange Range;
-  for (auto *Attr : DeclAttrs) {
-    if (auto *AA = dyn_cast<AvailableAttr>(Attr)) {
-      if (AA->Introduced.has_value() && AA->Introduced.value() == Version &&
-          AA->getPlatform() == Platform) {
+  for (auto Attr : D->getSemanticAvailableAttrs()) {
+    if (Attr.getIntroduced().has_value() &&
+        Attr.getIntroduced().value() == Version &&
+        Attr.getPlatform() == Platform) {
 
-        // More than one: return invalid range.
-        if (Range.isValid())
-          return SourceRange();
-        else
-          Range = AA->IntroducedRange;
-      }
+      // More than one: return invalid range.
+      if (Range.isValid())
+        return SourceRange();
+      else
+        Range = Attr.getParsedAttr()->IntroducedRange;
     }
   }
   return Range;
@@ -319,8 +317,8 @@ SourceRange AvailabilityScope::getAvailabilityConditionVersionSourceRange(
     PlatformKind Platform, const llvm::VersionTuple &Version) const {
   switch (getReason()) {
   case Reason::Decl:
-    return ::getAvailabilityConditionVersionSourceRange(
-        Node.getAsDecl()->getAttrs(), Platform, Version);
+    return ::getAvailabilityConditionVersionSourceRange(Node.getAsDecl(),
+                                                        Platform, Version);
 
   case Reason::IfStmtThenBranch:
   case Reason::IfStmtElseBranch:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -571,12 +571,9 @@ const Decl *Decl::getInnermostDeclWithAvailability() const {
 
 std::optional<llvm::VersionTuple>
 Decl::getIntroducedOSVersion(PlatformKind Kind) const {
-  for (auto *attr: getAttrs()) {
-    if (auto *ava = dyn_cast<AvailableAttr>(attr)) {
-      if (ava->getPlatform() == Kind && ava->Introduced) {
-        return ava->Introduced;
-      }
-    }
+  for (auto attr : getSemanticAvailableAttrs()) {
+    if (attr.getPlatform() == Kind && attr.getIntroduced().has_value())
+      return attr.getIntroduced();
   }
   return std::nullopt;
 }

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -94,7 +94,7 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 
   llvm::VersionTuple RemappedDeprecatedVersion;
   if (AvailabilityInference::updateDeprecatedPlatformForFallback(
-          Attr.getParsedAttr(), Ctx, Platform, RemappedDeprecatedVersion))
+          Attr, Ctx, Platform, RemappedDeprecatedVersion))
     DeprecatedVersion = RemappedDeprecatedVersion;
 
   auto Message = Attr.getMessage();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5018,21 +5018,24 @@ void AttributeChecker::checkBackDeployedAttrs(
             getSemanticAvailableRangeDeclAndAttr(VD)) {
       auto beforePlatformString = prettyPlatformString(Attr->Platform);
       auto beforeVersion = Attr->Version;
-      auto availableAttr = availableRangeAttrPair.value().first.getParsedAttr();
-      auto introVersion = availableAttr->Introduced.value();
-      StringRef introPlatformString = availableAttr->prettyPlatformString();
+      auto availableAttr = availableRangeAttrPair.value().first;
+      auto introVersion = availableAttr.getIntroduced().value();
+      StringRef introPlatformString =
+          availableAttr.getDomain().getNameForDiagnostics();
 
       AvailabilityInference::updateBeforePlatformForFallback(
           Attr, Ctx, beforePlatformString, beforeVersion);
       AvailabilityInference::updateIntroducedPlatformForFallback(
-          availableAttr, Ctx, introPlatformString, introVersion);
+          availableAttr.getParsedAttr(), Ctx, introPlatformString,
+          introVersion);
 
       if (Attr->Version <= introVersion) {
         diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,
                  Attr, VD, beforePlatformString, beforeVersion);
-        diagnose(availableAttr->AtLoc, diag::availability_introduced_in_version,
-                 VD, introPlatformString, introVersion)
-            .highlight(availableAttr->getRange());
+        diagnose(availableAttr.getParsedAttr()->AtLoc,
+                 diag::availability_introduced_in_version, VD,
+                 introPlatformString, introVersion)
+            .highlight(availableAttr.getParsedAttr()->getRange());
         continue;
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5025,8 +5025,7 @@ void AttributeChecker::checkBackDeployedAttrs(
       AvailabilityInference::updateBeforePlatformForFallback(
           Attr, Ctx, beforePlatformString, beforeVersion);
       AvailabilityInference::updateIntroducedPlatformForFallback(
-          availableAttr.getParsedAttr(), Ctx, introPlatformString,
-          introVersion);
+          availableAttr, Ctx, introPlatformString, introVersion);
 
       if (Attr->Version <= introVersion) {
         diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2845,7 +2845,7 @@ static void diagnoseIfDeprecated(SourceRange ReferenceRange,
   // FIXME: [availability] Remap before emitting diagnostic above.
   llvm::VersionTuple RemappedDeprecatedVersion;
   if (AvailabilityInference::updateDeprecatedPlatformForFallback(
-          Attr->getParsedAttr(), Context, Platform, RemappedDeprecatedVersion))
+          *Attr, Context, Platform, RemappedDeprecatedVersion))
     DeprecatedVersion = RemappedDeprecatedVersion;
 
   SmallString<32> newNameBuf;
@@ -2920,7 +2920,7 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
 
   llvm::VersionTuple remappedDeprecatedVersion;
   if (AvailabilityInference::updateDeprecatedPlatformForFallback(
-          attr->getParsedAttr(), ctx, platform, remappedDeprecatedVersion))
+          *attr, ctx, platform, remappedDeprecatedVersion))
     deprecatedVersion = remappedDeprecatedVersion;
 
   auto message = attr->getMessage();
@@ -3575,7 +3575,7 @@ bool diagnoseExplicitUnavailability(
   } else {
     auto unavailableDiagnosticPlatform = platform;
     AvailabilityInference::updatePlatformStringForFallback(
-        Attr.getParsedAttr(), ctx, unavailableDiagnosticPlatform);
+        Attr, ctx, unavailableDiagnosticPlatform);
     EncodedDiagnosticMessage EncodedMessage(message);
     diags
         .diagnose(Loc, diag::availability_decl_unavailable, D, platform.empty(),

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -839,16 +839,14 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
   return false;
 }
 
-/// FIXME: This should use Decl::getUnavailableAttr() or similar.
+/// FIXME: [availability] This should use Decl::getUnavailableAttr() or similar.
 bool SymbolGraph::isUnconditionallyUnavailableOnAllPlatforms(const Decl *D) const {
-  return llvm::any_of(D->getAttrs(), [](const auto *Attr) { 
-    if (const auto *AvAttr = dyn_cast<AvailableAttr>(Attr)) {
-      return !AvAttr->hasPlatform()
-        && AvAttr->isUnconditionallyUnavailable();
-    }
+  for (auto Attr : D->getSemanticAvailableAttrs()) {
+    if (!Attr.isPlatformSpecific() && Attr.isUnconditionallyUnavailable())
+      return true;
+  }
 
-    return false;
-  });
+  return false;
 }
 
 /// Returns `true` if the symbol should be included as a node in the graph.


### PR DESCRIPTION
Remove most of the queries from `AvailableAttr` that related to the platform specified by the attribute. Migrate the clients of those queries to `SemanticAvailableAttr` instead, where the `AvailabilityDomain` is the source of this information.

NFC.