### PR TITLE
Strict safety more cases

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -589,9 +589,9 @@ ERROR(experimental_not_supported_in_production,none,
       "experimental feature '%0' cannot be enabled in production compiler",
       (StringRef))
 
-GROUPED_WARNING(Ounchecked_with_strict_safety,Unsafe,none,
-      "'-Ounchecked' is not memory-safe and should not be combined with "
-      "strict memory safety checking", ())
+GROUPED_WARNING(command_line_conflicts_with_strict_safety,Unsafe,none,
+      "'%0' is not memory-safe and should not be combined with "
+      "strict memory safety checking", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8097,6 +8097,8 @@ NOTE(note_reference_to_nonisolated_unsafe,none,
      (const ValueDecl *))
 NOTE(note_reference_unowned_unsafe,none,
      "reference to unowned(unsafe) %kind0 is unsafe", (const ValueDecl *))
+NOTE(note_reference_exclusivity_unchecked,none,
+     "reference to @exclusivity(unchecked) %kind0 is unsafe", (const ValueDecl *))
 NOTE(note_use_of_unsafe_conformance_is_unsafe,none,
      "@unsafe conformance of %0 to %kind1 involves unsafe code",
      (Type, const ValueDecl *))
@@ -8118,6 +8120,9 @@ GROUPED_WARNING(use_of_unsafe_conformance_is_unsafe,Unsafe,none,
        (Type, const ValueDecl *))
 GROUPED_WARNING(reference_unowned_unsafe,Unsafe,none,
       "reference to unowned(unsafe) %kind0 is unsafe", (const ValueDecl *))
+GROUPED_WARNING(reference_exclusivity_unchecked,Unsafe,none,
+      "reference to @exclusivity(unchecked) %kind0 is unsafe", (const ValueDecl *))
+
 GROUPED_WARNING(reference_to_nonisolated_unsafe,Unsafe,none,
       "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
        (const ValueDecl *))

--- a/include/swift/AST/UnsafeUse.h
+++ b/include/swift/AST/UnsafeUse.h
@@ -39,6 +39,8 @@ public:
     UnsafeConformance,
     /// A reference to an unowned(unsafe) entity.
     UnownedUnsafe,
+    /// A reference to an @exclusivity(unchecked) entity.
+    ExclusivityUnchecked,
     /// A reference to a nonisolated(unsafe) entity.
     NonisolatedUnsafe,
     /// A reference to an unsafe declaration.
@@ -111,6 +113,7 @@ private:
       SourceLoc location
   ) {
     assert(kind == UnownedUnsafe ||
+           kind == ExclusivityUnchecked ||
            kind == NonisolatedUnsafe ||
            kind == ReferenceToUnsafe ||
            kind == ReferenceToUnsafeThroughTypealias ||
@@ -166,6 +169,12 @@ public:
     return forReference(UnownedUnsafe, dc, decl, Type(), location);
   }
 
+  static UnsafeUse forExclusivityUnchecked(const Decl *decl,
+                                           SourceLoc location,
+                                           DeclContext *dc) {
+    return forReference(ExclusivityUnchecked, dc, decl, Type(), location);
+  }
+
   static UnsafeUse forNonisolatedUnsafe(const Decl *decl,
                                         SourceLoc location,
                                         DeclContext *dc) {
@@ -215,6 +224,7 @@ public:
             (const char *)storage.typeWitness.location));
 
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:
@@ -238,6 +248,7 @@ public:
       return storage.typeWitness.assocType;
 
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:
@@ -262,6 +273,7 @@ public:
   DeclContext *getDeclContext() const {
     switch (getKind()) {
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:
@@ -294,6 +306,7 @@ public:
 
     case TypeWitness:
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:
@@ -319,6 +332,7 @@ public:
       return storage.typeWitness.type;
 
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:
@@ -342,6 +356,7 @@ public:
 
     case Override:
     case UnownedUnsafe:
+    case ExclusivityUnchecked:
     case NonisolatedUnsafe:
     case ReferenceToUnsafe:
     case ReferenceToUnsafeThroughTypealias:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3840,7 +3840,15 @@ bool CompilerInvocation::parseArgs(
   if (LangOpts.hasFeature(Feature::WarnUnsafe)) {
     if (SILOpts.RemoveRuntimeAsserts ||
         SILOpts.AssertConfig == SILOptions::Unchecked) {
-      Diags.diagnose(SourceLoc(), diag::Ounchecked_with_strict_safety);
+      Diags.diagnose(SourceLoc(),
+                     diag::command_line_conflicts_with_strict_safety,
+                     "-Ounchecked");
+    }
+
+    if (!LangOpts.EnableAccessControl) {
+      Diags.diagnose(SourceLoc(),
+                     diag::command_line_conflicts_with_strict_safety,
+                     "-disable-access-control");
     }
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4258,6 +4258,17 @@ diagnoseDeclUnsafe(const ValueDecl *D, SourceRange R,
           return;
         }
       }
+
+      // @exclusivity(unchecked) is unsafe.
+      if (auto exclusivityAttr =
+              var->getAttrs().getAttribute<ExclusivityAttr>()) {
+        if (exclusivityAttr->getMode() == ExclusivityAttr::Unchecked) {
+          diagnoseUnsafeUse(
+              UnsafeUse::forExclusivityUnchecked(var, R.Start,
+                                                 Where.getDeclContext()));
+          return;
+        }
+      }
     }
   }
 }

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -97,6 +97,19 @@ struct SuperHolder {
 }
 
 // -----------------------------------------------------------------------
+// Dynamic exclusivity check suppression
+// -----------------------------------------------------------------------
+class ExclusivityChecking {
+  @exclusivity(unchecked) var value: Int = 0
+
+  // expected-warning@+1{{instance method 'next' involves unsafe code; use '@safe(unchecked)' to assert that the code is memory-safe}}
+  func next() -> Int {
+    value += 1 // expected-note{{reference to @exclusivity(unchecked) property 'value' is unsafe}}
+    return value  // expected-note{{reference to @exclusivity(unchecked) property 'value' is unsafe}}
+  }
+}
+
+// -----------------------------------------------------------------------
 // Inheritance of @unsafe
 // -----------------------------------------------------------------------
 @unsafe class UnsafeSuper {

--- a/test/Unsafe/unsafe_Ounchecked.swift
+++ b/test/Unsafe/unsafe_Ounchecked.swift
@@ -1,5 +1,0 @@
-// RUN: %target-swift-frontend -typecheck -enable-experimental-feature WarnUnsafe -Ounchecked %s 2>&1 | %FileCheck %s
-
-// REQUIRES: swift_feature_WarnUnsafe
-
-// CHECK: warning: '-Ounchecked' is not memory-safe

--- a/test/Unsafe/unsafe_command_line.swift
+++ b/test/Unsafe/unsafe_command_line.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature WarnUnsafe -Ounchecked -disable-access-control %s 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_WarnUnsafe
+
+// CHECK: warning: '-Ounchecked' is not memory-safe
+// CHECK: warning: '-disable-access-control' is not memory-safe


### PR DESCRIPTION
Handle two more cases where we need to diagnose things under the strict safety mode, both of which came up in the pitch thread:
* Uses of `@exclusivity(unchecked)` variables
* Use of `-disable-access-control`