### PR TITLE
[6.1] Disable warning about `@preconcurrency` having no effect on an import

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -942,24 +942,8 @@ bool swift::diagnoseSendabilityErrorBasedOn(
 }
 
 void swift::diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf) {
-  if (!shouldDiagnosePreconcurrencyImports(sf))
-    return;
-
-  ASTContext &ctx = sf.getASTContext();
-
-  if (ctx.TypeCheckerOpts.SkipFunctionBodies != FunctionBodySkipping::None)
-    return;
-
-  for (const auto &import : sf.getImports()) {
-    if (import.options.contains(ImportFlags::Preconcurrency) &&
-        import.importLoc.isValid() &&
-        !sf.hasImportUsedPreconcurrency(import)) {
-      ctx.Diags.diagnose(
-          import.importLoc, diag::remove_predates_concurrency_import,
-          import.module.importedModule->getName())
-        .fixItRemove(import.preconcurrencyRange);
-    }
-  }
+  // NOTE: Disabled in Swift 6.0.
+  return;
 }
 
 /// Produce a diagnostic for a single instance of a non-Sendable type where

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -13,7 +13,6 @@
 @preconcurrency import NonStrictModule
 @_predatesConcurrency import StrictModule // expected-warning{{'@_predatesConcurrency' has been renamed to '@preconcurrency'}}
 @preconcurrency import OtherActors
-// expected-warning@-1{{'@preconcurrency' attribute on module 'OtherActors' has no effect}}{{1-17=}}
 
 @preconcurrency
 class MyPredatesConcurrencyClass { }


### PR DESCRIPTION
* Explanation: We have a couple of persistent issues where the warning about `@preconcurrency` having no effect on import declarations is emitted but is wrong, because removing the `@preconcurrency` will cause warnings or errors to appear. Disable this warning until we can make it reliable.
* Scope: Disables a bit of code that generates the warning in concurrency type checking.
* Original PRs: https://github.com/swiftlang/swift/pull/75365, from the 6.0 branch
* Issue: rdar://142559966
* Risk: Very very low. We're just disabling a warning.
* Testing: Updated tests.