### PR TITLE
[NFC] Fix new warnings in the headers

### DIFF
--- a/include/swift/Basic/HeaderFooterLayout.h
+++ b/include/swift/Basic/HeaderFooterLayout.h
@@ -22,7 +22,10 @@ class size_without_trailing_padding {
   struct ExtraByte { char _size_without_trailing_padding_probe; };
   struct Probe: T, ExtraByte {};
 public:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
   enum { value = offsetof(Probe, _size_without_trailing_padding_probe) };
+#pragma clang diagnostic pop
 };
 
 namespace detail {

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -60,7 +60,7 @@ struct LoadOperation {
   /// TODO: Rather than use an optional here, we should include an invalid
   /// representation in LoadOwnershipQualifier.
   std::optional<LoadOwnershipQualifier> getOwnershipQualifier() const {
-    if (auto *lbi = value.dyn_cast<LoadBorrowInst *>()) {
+    if (value.dyn_cast<LoadBorrowInst *>()) {
       return std::nullopt;
     }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1195,9 +1195,12 @@ public:
 };
 
 struct SILNodeOffsetChecker {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
   static_assert(offsetof(SingleValueInstruction, kind) ==
                 offsetof(NonSingleValueInstruction, kind),
                 "wrong SILNode layout in SILInstruction");
+#pragma clang diagnostic pop
 };
 
 inline SILNodePointer::SILNodePointer(const SingleValueInstruction *svi) :


### PR DESCRIPTION
The newer version of clang will issue warnings in more cases, specifically, -Winvalid-offsetof and -Wunused-but-set-variable. This cleans up the new warnings issued from header, which shows up for every TU that includes them. Fixing them should make the remaining warnings easier to read.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
