### PR TITLE
[6.1] Fix build option for Synchronization and Distributed

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -3169,9 +3169,12 @@ static AllocationInst *getOptimizableAllocation(SILInstruction *i) {
 }
 
 bool swift::optimizeMemoryAccesses(SILFunction *fn) {
+  if (!fn->hasOwnership()) {
+    return false;
+  }
+
   bool changed = false;
   DeadEndBlocks deadEndBlocks(fn);
-
   InstructionDeleter deleter;
   for (auto &bb : *fn) {
     for (SILInstruction &inst : bb.deletableInstructions()) {
@@ -3209,6 +3212,9 @@ bool swift::optimizeMemoryAccesses(SILFunction *fn) {
 }
 
 bool swift::eliminateDeadAllocations(SILFunction *fn, DominanceInfo *domInfo) {
+  if (!fn->hasOwnership()) {
+    return false;
+  }
   bool changed = false;
   DeadEndBlocks deadEndBlocks(fn);
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2064,7 +2064,7 @@ function(add_swift_target_library name)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
   endif()
 
-  if (NOT DEFINED IMPORTS_NON_OSSA)
+  if (NOT SWIFTLIB_IMPORTS_NON_OSSA)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
   endif()
 

--- a/test/SILOptimizer/stdlib/Atomics.swift
+++ b/test/SILOptimizer/stdlib/Atomics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-ossa-modules -O -emit-sil -disable-availability-checking %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s | %IRGenFileCheck %s
 
 // REQUIRES: synchronization
 


### PR DESCRIPTION
Explanation: https://github.com/swiftlang/swift/pull/77314 incorrectly named the parameter name which resulted in the -enable-ossa-modules being present in the swift interfaces of Synchronization and Distributed. This PR fixes the cmake function parameter name while querying for IMPORTS_NON_OSSA by using the right prefix used in cmake_parse_arguments

Scope: Removes -enable-ossa-modules from swiftinterfaces of Synchronization and Distributed 

Original PRs: https://github.com/swiftlang/swift/pull/78460

Issue: rdar://138407068

Risk: Low

Testing: swift ci testing and manually verified the absence of the flag in the swiftinterfaces of Synchronization and Distributed 

Reviewed by: @tshortli 