### PR TITLE
AST: Introduce new conveniences for synthesizing AvailabilityAttrs

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -813,14 +813,36 @@ public:
         Bits.AvailableAttr.PlatformAgnostic);
   }
 
-  /// Create an AvailableAttr that indicates specific availability
-  /// for all platforms.
-  static AvailableAttr *
-  createPlatformAgnostic(ASTContext &C, StringRef Message, StringRef Rename = "",
-                      PlatformAgnosticAvailabilityKind Reason
-                         = PlatformAgnosticAvailabilityKind::Unavailable,
-                         llvm::VersionTuple Obsoleted
-                         = llvm::VersionTuple());
+  /// Create an `AvailableAttr` that specifies universal unavailability, e.g.
+  /// `@available(*, unavailable)`.
+  static AvailableAttr *createUniversallyUnavailable(ASTContext &C,
+                                                     StringRef Message,
+                                                     StringRef Rename = "");
+
+  /// Create an `AvailableAttr` that specifies universal deprecation, e.g.
+  /// `@available(*, deprecated)`.
+  static AvailableAttr *createUniversallyDeprecated(ASTContext &C,
+                                                    StringRef Message,
+                                                    StringRef Rename = "");
+
+  /// Create an `AvailableAttr` that specifies unavailability in Swift, e.g.
+  /// `@available(swift, unavailable)`.
+  static AvailableAttr *createUnavailableInSwift(ASTContext &C,
+                                                 StringRef Message,
+                                                 StringRef Rename = "");
+
+  /// Create an `AvailableAttr` that specifies availability associated with
+  /// Swift language modes, e.g. `@available(swift, obsoleted: 6)`.
+  static AvailableAttr *createSwiftLanguageModeVersioned(
+      ASTContext &C, StringRef Message, StringRef Rename,
+      llvm::VersionTuple Introduced, llvm::VersionTuple Obsoleted);
+
+  /// Create an `AvailableAttr` that specifies versioned availability for a
+  /// particular platform, e.g. `@available(macOS, introduced: 13)`.
+  static AvailableAttr *createPlatformVersioned(
+      ASTContext &C, PlatformKind Platform, StringRef Message, StringRef Rename,
+      llvm::VersionTuple Introduced, llvm::VersionTuple Deprecated,
+      llvm::VersionTuple Obsoleted);
 
   AvailableAttr *clone(ASTContext &C, bool implicit) const;
   AvailableAttr *clone(ASTContext &C) const {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2134,22 +2134,60 @@ AvailableAttr::AvailableAttr(
 
 #undef INIT_VER_TUPLE
 
-AvailableAttr *
-AvailableAttr::createPlatformAgnostic(ASTContext &C,
-                                   StringRef Message,
-                                   StringRef Rename,
-                                   PlatformAgnosticAvailabilityKind Kind,
-                                   llvm::VersionTuple Obsoleted) {
-  assert(Kind != PlatformAgnosticAvailabilityKind::None);
-  llvm::VersionTuple NoVersion;
-  if (Kind == PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
-    assert(!Obsoleted.empty());
-  }
+AvailableAttr *AvailableAttr::createUniversallyUnavailable(ASTContext &C,
+                                                           StringRef Message,
+                                                           StringRef Rename) {
   return new (C) AvailableAttr(
       SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
-      /*Introduced=*/NoVersion, SourceRange(), /*Deprecated=*/NoVersion,
-      SourceRange(), Obsoleted, SourceRange(), Kind, /*Implicit=*/false,
+      /*Introduced=*/{}, SourceRange(), /*Deprecated=*/{}, SourceRange(),
+      /*Obsoleted=*/{}, SourceRange(),
+      PlatformAgnosticAvailabilityKind::Unavailable, /*Implicit=*/false,
       /*SPI=*/false);
+}
+
+AvailableAttr *AvailableAttr::createUniversallyDeprecated(ASTContext &C,
+                                                          StringRef Message,
+                                                          StringRef Rename) {
+  return new (C) AvailableAttr(
+      SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
+      /*Introduced=*/{}, SourceRange(), /*Deprecated=*/{}, SourceRange(),
+      /*Obsoleted=*/{}, SourceRange(),
+      PlatformAgnosticAvailabilityKind::Deprecated, /*Implicit=*/false,
+      /*SPI=*/false);
+}
+
+AvailableAttr *AvailableAttr::createUnavailableInSwift(ASTContext &C,
+                                                       StringRef Message,
+                                                       StringRef Rename) {
+  return new (C) AvailableAttr(
+      SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
+      /*Introduced=*/{}, SourceRange(), /*Deprecated=*/{}, SourceRange(),
+      /*Obsoleted=*/{}, SourceRange(),
+      PlatformAgnosticAvailabilityKind::UnavailableInSwift, /*Implicit=*/false,
+      /*SPI=*/false);
+}
+
+AvailableAttr *AvailableAttr::createSwiftLanguageModeVersioned(
+    ASTContext &C, StringRef Message, StringRef Rename,
+    llvm::VersionTuple Introduced, llvm::VersionTuple Obsoleted) {
+  return new (C) AvailableAttr(
+      SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
+      Introduced, SourceRange(), /*Deprecated=*/{}, SourceRange(), Obsoleted,
+      SourceRange(), PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
+      /*Implicit=*/false,
+      /*SPI=*/false);
+}
+
+AvailableAttr *AvailableAttr::createPlatformVersioned(
+    ASTContext &C, PlatformKind Platform, StringRef Message, StringRef Rename,
+    llvm::VersionTuple Introduced, llvm::VersionTuple Deprecated,
+    llvm::VersionTuple Obsoleted) {
+  return new (C) AvailableAttr(SourceLoc(), SourceRange(), Platform, Message,
+                               Rename, Introduced, SourceRange(), Deprecated,
+                               SourceRange(), Obsoleted, SourceRange(),
+                               PlatformAgnosticAvailabilityKind::None,
+                               /*Implicit=*/false,
+                               /*SPI=*/false);
 }
 
 bool BackDeployedAttr::isActivePlatform(const ASTContext &ctx,

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1269,7 +1269,8 @@ void swift::conformToCxxSpanIfNeeded(ClangImporter::Implementation &impl,
   if (!importedConstructor)
     return;
 
-  auto attr = AvailableAttr::createPlatformAgnostic(importedConstructor->getASTContext(), "use 'init(_:)' instead.", "", PlatformAgnosticAvailabilityKind::Deprecated);
+  auto attr = AvailableAttr::createUniversallyDeprecated(
+      importedConstructor->getASTContext(), "use 'init(_:)' instead.", "");
   importedConstructor->getAttrs().add(attr);
 
   decl->addMember(importedConstructor);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -554,18 +554,9 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityRange &info,
   if (info.isAlwaysAvailable())
     return;
 
-  llvm::VersionTuple noVersion;
-  auto AvAttr = new (C) AvailableAttr(
-      SourceLoc(), SourceRange(), targetPlatform(C.LangOpts),
-      /*Message=*/StringRef(),
-      /*Rename=*/StringRef(), info.getRawMinimumVersion(),
-      /*IntroducedRange=*/SourceRange(),
-      /*Deprecated=*/noVersion,
-      /*DeprecatedRange=*/SourceRange(),
-      /*Obsoleted=*/noVersion,
-      /*ObsoletedRange=*/SourceRange(), PlatformAgnosticAvailabilityKind::None,
-      /*Implicit=*/false,
-      /*SPI=*/false);
+  auto AvAttr = AvailableAttr::createPlatformVersioned(
+      C, targetPlatform(C.LangOpts), /*Message=*/"", /*Rename=*/"",
+      info.getRawMinimumVersion(), /*Deprecated=*/{}, /*Obsoleted=*/{});
 
   decl->getAttrs().add(AvAttr);
 }
@@ -1304,9 +1295,8 @@ namespace {
         // "Raw" is the Objective-C name, which was never available in Swift.
         // Variants within the active version are usually declarations that
         // have been superseded, like the accessors of a property.
-        attr = AvailableAttr::createPlatformAgnostic(
-            ctx, /*Message*/StringRef(), ctx.AllocateCopy(renamed.str()),
-            PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+        attr = AvailableAttr::createUnavailableInSwift(
+            ctx, /*Message*/ StringRef(), ctx.AllocateCopy(renamed.str()));
       } else {
         unsigned majorVersion = getVersion().majorVersionNumber();
         unsigned minorVersion = getVersion().minorVersionNumber();
@@ -1319,10 +1309,9 @@ namespace {
             (majorVersion == 4 && minorVersion < 2)
                 ? llvm::VersionTuple(4, 2)
                 : llvm::VersionTuple(majorVersion + 1);
-          attr = AvailableAttr::createPlatformAgnostic(
-              ctx, /*Message*/StringRef(), ctx.AllocateCopy(renamed.str()),
-              PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
-              obsoletedVersion);
+          attr = AvailableAttr::createSwiftLanguageModeVersioned(
+              ctx, /*Message=*/"", ctx.AllocateCopy(renamed.str()),
+              /*Introduced=*/{}, obsoletedVersion);
         } else {
           // Future names are introduced in their future version.
           assert(getVersion() > getActiveSwiftVersion());
@@ -1330,15 +1319,9 @@ namespace {
             (majorVersion == 4 && minorVersion == 2)
                 ? llvm::VersionTuple(4, 2)
                 : llvm::VersionTuple(majorVersion);
-          attr = new (ctx) AvailableAttr(
-              SourceLoc(), SourceRange(), PlatformKind::none,
-              /*Message=*/StringRef(), ctx.AllocateCopy(renamed.str()),
-              /*Introduced=*/introducedVersion, SourceRange(),
-              /*Deprecated=*/llvm::VersionTuple(), SourceRange(),
-              /*Obsoleted=*/llvm::VersionTuple(), SourceRange(),
-              PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
-              /*Implicit=*/false,
-              /*SPI=*/false);
+          attr = AvailableAttr::createSwiftLanguageModeVersioned(
+              ctx, /*Message=*/"", ctx.AllocateCopy(renamed.str()),
+              introducedVersion, /*Obsoleted=*/{});
         }
       }
 
@@ -1525,10 +1508,8 @@ namespace {
 
       // Make Objective-C's 'id' unavailable.
       if (Impl.SwiftContext.LangOpts.EnableObjCInterop && isObjCId(Decl)) {
-        auto attr = AvailableAttr::createPlatformAgnostic(
-                      Impl.SwiftContext,
-                      "'id' is not available in Swift; use 'Any'", "",
-                      PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+        auto attr = AvailableAttr::createUnavailableInSwift(
+            Impl.SwiftContext, "'id' is not available in Swift; use 'Any'", "");
         Result->getAttrs().add(attr);
       }
 
@@ -2391,12 +2372,12 @@ namespace {
             synthesizer.createDefaultConstructor(result);
         ctors.push_back(defaultCtor);
         if (cxxRecordDecl) {
-          auto attr = AvailableAttr::createPlatformAgnostic(
+          auto attr = AvailableAttr::createUniversallyDeprecated(
               defaultCtor->getASTContext(),
               "This zero-initializes the backing memory of the struct, which "
               "is unsafe for some C++ structs. Consider adding an explicit "
               "default initializer for this C++ struct.",
-              "", PlatformAgnosticAvailabilityKind::Deprecated);
+              "");
           defaultCtor->getAttrs().add(attr);
         }
       }
@@ -2910,16 +2891,11 @@ namespace {
         auto availability = Impl.SwiftContext.getSwift58Availability();
         if (!availability.isAlwaysAvailable()) {
           assert(availability.hasMinimumVersion());
-          auto AvAttr = new (Impl.SwiftContext)
-              AvailableAttr(SourceLoc(), SourceRange(),
-                            targetPlatform(Impl.SwiftContext.LangOpts),
-                            /*Message=*/"", /*Rename=*/"",
-                            availability.getRawMinimumVersion(),
-                            /*IntroducedRange=*/SourceRange(), {},
-                            /*DeprecatedRange=*/SourceRange(), {},
-                            /*ObsoletedRange=*/SourceRange(),
-                            PlatformAgnosticAvailabilityKind::None,
-                            /*Implicit=*/false, false);
+          auto AvAttr = AvailableAttr::createPlatformVersioned(
+              Impl.SwiftContext, targetPlatform(Impl.SwiftContext.LangOpts),
+              /*Message=*/"", /*Rename=*/"",
+              availability.getRawMinimumVersion(), /*Deprecated=*/{},
+              /*Obsoleted=*/{});
           classDecl->getAttrs().add(AvAttr);
         }
       }
@@ -4419,7 +4395,7 @@ namespace {
           decl, AccessLevel::Public, loc, name, loc, std::nullopt,
           genericParamList, dc);
 
-      auto attr = AvailableAttr::createPlatformAgnostic(
+      auto attr = AvailableAttr::createUniversallyUnavailable(
           Impl.SwiftContext, "Un-specialized class templates are not currently "
                              "supported. Please use a specialization of this "
                              "type.");
@@ -5389,8 +5365,8 @@ namespace {
         message = "cannot find Swift declaration for this protocol";
       else
         llvm_unreachable("unknown bridged decl kind");
-      auto attr = AvailableAttr::createPlatformAgnostic(Impl.SwiftContext,
-                                                        message);
+      auto attr = AvailableAttr::createUniversallyUnavailable(Impl.SwiftContext,
+                                                              message);
       VD->getAttrs().add(attr);
     }
 
@@ -5443,7 +5419,7 @@ namespace {
             addObjCAttribute(result,
                             Impl.importIdentifier(decl->getIdentifier()));
             result->setImplicit();
-            auto attr = AvailableAttr::createPlatformAgnostic(
+            auto attr = AvailableAttr::createUniversallyUnavailable(
                 Impl.SwiftContext,
                 "This Objective-C protocol has only been forward-declared; "
                 "import its owning module to use it");
@@ -5598,7 +5574,8 @@ namespace {
             auto result = createFakeClass(name, /* cacheResult */ true,
                                               /* inheritFromNSObject */ true);
             result->setImplicit();
-            auto attr = AvailableAttr::createPlatformAgnostic(Impl.SwiftContext,
+            auto attr = AvailableAttr::createUniversallyUnavailable(
+                Impl.SwiftContext,
                 "This Objective-C class has only been forward-declared; "
                 "import its owning module to use it");
             result->getAttrs().add(attr);
@@ -6490,7 +6467,7 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
       !CD->isUnavailable()) {
     /// Create an AvailableAttr that indicates specific availability
     /// for all platforms.
-    auto attr = AvailableAttr::createPlatformAgnostic(
+    auto attr = AvailableAttr::createUniversallyUnavailable(
         Impl.SwiftContext, "use [] to construct an empty option set");
     CD->getAttrs().add(attr);
   }
@@ -7127,7 +7104,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       errorStr += objcMethod->getSelector().getAsString();
       errorStr += ']';
 
-      auto attr = AvailableAttr::createPlatformAgnostic(
+      auto attr = AvailableAttr::createUniversallyUnavailable(
           Impl.SwiftContext, Impl.SwiftContext.AllocateCopy(errorStr.str()));
       ctor->getAttrs().add(attr);
       continue;
@@ -8808,7 +8785,7 @@ void ClangImporter::Implementation::importAttributes(
     //
     if (auto unavailable = dyn_cast<clang::UnavailableAttr>(*AI)) {
       auto Message = unavailable->getMessage();
-      auto attr = AvailableAttr::createPlatformAgnostic(C, Message);
+      auto attr = AvailableAttr::createUniversallyUnavailable(C, Message);
       MappedDecl->getAttrs().add(attr);
       AnyUnavailable = true;
       continue;
@@ -8821,8 +8798,7 @@ void ClangImporter::Implementation::importAttributes(
     //
     if (auto unavailable_annot = dyn_cast<clang::AnnotateAttr>(*AI))
       if (unavailable_annot->getAnnotation() == "swift1_unavailable") {
-        auto attr = AvailableAttr::createPlatformAgnostic(
-            C, "", "", PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+        auto attr = AvailableAttr::createUnavailableInSwift(C, "", "");
         MappedDecl->getAttrs().add(attr);
         AnyUnavailable = true;
         continue;
@@ -8835,8 +8811,7 @@ void ClangImporter::Implementation::importAttributes(
     //
     if (auto deprecated = dyn_cast<clang::DeprecatedAttr>(*AI)) {
       auto Message = deprecated->getMessage();
-      auto attr = AvailableAttr::createPlatformAgnostic(C, Message, "",
-                    PlatformAgnosticAvailabilityKind::Deprecated);
+      auto attr = AvailableAttr::createUniversallyDeprecated(C, Message, "");
       MappedDecl->getAttrs().add(attr);
       continue;
     }
@@ -8858,9 +8833,8 @@ void ClangImporter::Implementation::importAttributes(
         if (!replacement.empty())
           swiftReplacement = getSwiftNameFromClangName(replacement);
 
-        auto attr = AvailableAttr::createPlatformAgnostic(
-            C, avail->getMessage(), swiftReplacement,
-            PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+        auto attr = AvailableAttr::createUnavailableInSwift(
+            C, avail->getMessage(), swiftReplacement);
         MappedDecl->getAttrs().add(attr);
         AnyUnavailable = true;
         continue;
@@ -8968,7 +8942,7 @@ void ClangImporter::Implementation::importAttributes(
   if (auto ID = dyn_cast<clang::ObjCInterfaceDecl>(ClangDecl)) {
     // Ban NSInvocation.
     if (ID->getName() == "NSInvocation") {
-      auto attr = AvailableAttr::createPlatformAgnostic(C, "");
+      auto attr = AvailableAttr::createUniversallyUnavailable(C, "");
       MappedDecl->getAttrs().add(attr);
       return;
     }
@@ -9001,8 +8975,8 @@ void ClangImporter::Implementation::importAttributes(
         !FD->getAttr<clang::SwiftNameAttr>()) {
       if (auto t = FD->getParamDecl(0)->getType()->getAs<clang::TypedefType>()){
         if (isCFTypeDecl(t->getDecl())) {
-          auto attr = AvailableAttr::createPlatformAgnostic(C,
-            "Core Foundation objects are automatically memory managed");
+          auto attr = AvailableAttr::createUniversallyUnavailable(
+              C, "Core Foundation objects are automatically memory managed");
           MappedDecl->getAttrs().add(attr);
           return;
         }
@@ -9690,8 +9664,8 @@ void ClangImporter::Implementation::
 markUnavailable(ValueDecl *decl, StringRef unavailabilityMsgRef) {
 
   unavailabilityMsgRef = SwiftContext.AllocateCopy(unavailabilityMsgRef);
-  auto ua = AvailableAttr::createPlatformAgnostic(SwiftContext,
-                                                  unavailabilityMsgRef);
+  auto ua = AvailableAttr::createUniversallyUnavailable(SwiftContext,
+                                                        unavailabilityMsgRef);
   decl->getAttrs().add(ua);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6672,13 +6672,8 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
 
   // Add the blanket "unavailable".
 
-  auto attr = new (ctx) AvailableAttr(
-      SourceLoc(), SourceRange(), PlatformKind::none, /*Message*/ "",
-      /*Rename=*/"", /*Introduced=*/noVersion, SourceRange(),
-      /*Deprecated=*/noVersion, SourceRange(), /*Obsoleted=*/noVersion,
-      SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
-      /*Implicit=*/false, /*SPI=*/false);
-  ext->getAttrs().add(attr);
+  ext->getAttrs().add(
+      AvailableAttr::createUniversallyUnavailable(ctx, /*Message=*/""));
 }
 
 ProtocolConformance *swift::deriveImplicitSendableConformance(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2150,8 +2150,8 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     // usable from Swift, even though it is imported.
     if (!decl->isUnavailable()) {
       StringRef unavailabilityMsgRef = "return type is unavailable in Swift";
-      auto ua =
-          AvailableAttr::createPlatformAgnostic(ctx, unavailabilityMsgRef);
+      auto ua = AvailableAttr::createUniversallyUnavailable(
+          ctx, unavailabilityMsgRef);
       decl->getAttrs().add(ua);
     }
 


### PR DESCRIPTION
This makes intent clearer at the call site and removes a lot of explicit uses of `PlatformAgnosticAvailabilityKind`, which is going away.
