### PR TITLE
[SILCombine] Fix apply(convert_function(@guaranteed)) with an @owned operand.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -149,6 +149,13 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   if (SubstCalleeTy->hasArchetype() || ConvertCalleeTy->hasArchetype())
     return nullptr;
 
+  // If we converted from a non-throwing to a throwing function which is
+  // try_apply'd, rewriting would require changing the CFG.  Bail for now.
+  if (!ConvertCalleeTy->hasErrorResult() && isa<TryApplyInst>(AI)) {
+    assert(SubstCalleeTy->hasErrorResult());
+    return nullptr;
+  }
+
   // Ok, we can now perform our transformation. Grab AI's operands and the
   // relevant types from the ConvertFunction function type and AI.
   Builder.setCurrentDebugScope(AI.getDebugScope());
@@ -240,7 +247,8 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
       
       Builder.createBranch(AI.getLoc(), TAI->getNormalBB(), branchArgs);
     }
-    
+
+    Builder.setInsertionPoint(AI.getInstruction());
     return Builder.createTryApply(AI.getLoc(), funcOper, SubstitutionMap(), Args,
                                   normalBB, TAI->getErrorBB(),
                                   TAI->getApplyOptions());
@@ -1626,6 +1634,10 @@ SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
   // from visitPartialApplyInst(), so bail here.
   if (isa<PartialApplyInst>(AI->getCallee()))
     return nullptr;
+
+  if (auto *CFI = dyn_cast<ConvertFunctionInst>(AI->getCallee())) {
+    return optimizeApplyOfConvertFunctionInst(AI, CFI);
+  }
 
   // Optimize readonly functions with no meaningful users.
   SILFunction *Fn = AI->getReferencedFunctionOrNull();

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1420,7 +1420,9 @@ bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
 
 sil @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
 
-// TODO
+// CHECK-LABEL: sil @peephole_convert_function_result_change_with_error : {{.*}} {
+// CHECK-NOT:     convert_function
+// CHECK-LABEL: } // end sil function 'peephole_convert_function_result_change_with_error'
 sil @peephole_convert_function_result_change_with_error : $@convention(thin) () -> () {
 entry:
   %f = function_ref @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)

--- a/test/SILOptimizer/sil_combine_apply_unit.sil
+++ b/test/SILOptimizer/sil_combine_apply_unit.sil
@@ -1,11 +1,28 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -test-runner | %FileCheck %s
+// RUN: %target-sil-opt \
+// RUN:     -test-runner %s \
+// RUN:     -module-name Swift \
+// RUN:     -enable-sil-verify-all \
+// RUN: | %FileCheck %s
 
 import Builtin
+
+enum Optional<T> {
+  case some(T)
+  case none
+}
+
+protocol Error {}
+
+class C {}
 
 struct Input {}
 struct Output {}
 enum Nunca {}
 
+sil @borrowMaybeC : $@convention(thin) (@guaranteed Optional<C>) -> ()
+sil @borrowMaybeC2 : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> ()
+sil @borrowMaybeCThrowing : $@convention(thin) (@guaranteed Optional<C>) -> (@error Error)
+sil @borrowMaybeC2Throwing : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> (@error Error)
 sil @rdar127452206_callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
 
 // CHECK-LABEL: sil @rdar127452206 : {{.*}} {
@@ -31,4 +48,131 @@ entry(%input : $*Input):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @convert_function__to_optional__owned_as_guaranteed__1 : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+// CHECK:         [[BORROW_MAYBE_C:%[^,]+]] = function_ref @borrowMaybeC
+// CHECK:         [[B:%[^,]+]] = begin_borrow [[C]]
+// CHECK:         [[MAYBE_B:%[^,]+]] = unchecked_ref_cast [[B]] to $Optional<C>
+// CHECK:         apply [[BORROW_MAYBE_C]]([[MAYBE_B]])
+// CHECK:         end_borrow [[B]]
+// CHECK:         destroy_value [[C]]
+// CHECK-LABEL: } // end sil function 'convert_function__to_optional__owned_as_guaranteed__1'
+sil [ossa] @convert_function__to_optional__owned_as_guaranteed__1 : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  %borrowMaybeC = function_ref @borrowMaybeC : $@convention(thin) (@guaranteed Optional<C>) -> ()
+  %borrowC = convert_function %borrowMaybeC to $@convention(thin) (@guaranteed C) -> ()
+  %void = apply %borrowC(%c) : $@convention(thin) (@guaranteed C) -> ()
+  specify_test "sil_combine_instruction %void"
+  destroy_value %c
+  %retval = tuple ()
+  return %retval
+}
 
+// CHECK-LABEL: sil [ossa] @convert_function__to_optional__owned_as_guaranteed__2 : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[C:%[^,]+]] :
+// CHECK-SAME:      [[C2:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:       [[BORROW_MAYBE_C2:%[^,]+]] = function_ref @borrowMaybeC2
+// CHECK:       [[B:%[^,]+]] = begin_borrow [[C]]
+// CHECK:       [[MAYBE_B:%[^,]+]] = unchecked_ref_cast [[B]] to $Optional<C>
+// CHECK:       [[B2:%[^,]+]] = begin_borrow [[C2]]
+// CHECK:       [[MAYBE_B2:%[^,]+]] = unchecked_ref_cast [[B2]] to $Optional<C>
+// CHECK:       apply [[BORROW_MAYBE_C2]]([[MAYBE_B]], [[MAYBE_B2]])
+// CHECK:       end_borrow [[B]]
+// CHECK:       end_borrow [[B2]]
+// CHECK:       destroy_value [[C]]
+// CHECK:       destroy_value [[C2]]
+// CHECK-LABEL: } // end sil function 'convert_function__to_optional__owned_as_guaranteed__2'
+sil [ossa] @convert_function__to_optional__owned_as_guaranteed__2 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%c : @owned $C, %c2 : @owned $C):
+  %borrowMaybeC2 = function_ref @borrowMaybeC2 : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> ()
+  %borrowC2 = convert_function %borrowMaybeC2 to $@convention(thin) (@guaranteed C, @guaranteed C) -> ()
+  %void = apply %borrowC2(%c, %c2) : $@convention(thin) (@guaranteed C, @guaranteed C) -> ()
+  specify_test "sil_combine_instruction %void"
+  destroy_value %c
+  destroy_value %c2
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @convert_function__to_optional__owned_as_guaranteed__3 : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+// CHECK:         [[BORROW_MAYBE_C:%[^,]+]] = function_ref @borrowMaybeCThrowing
+// CHECK:         [[B:%[^,]+]] = begin_borrow [[C]]
+// CHECK:         [[MAYBE_B:%[^,]+]] = unchecked_ref_cast [[B]] to $Optional<C>
+// CHECK:         try_apply [[BORROW_MAYBE_C]]([[MAYBE_B]])
+// CHECK:             normal [[SUCCESS:bb[0-9]+]]
+// CHECK:             error [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]
+// CHECK:         end_borrow [[B]]
+// CHECK:         destroy_value [[C]]
+// CHECK:       [[FAILURE]]([[ERROR:%[^,]+]] :
+// CHECK:         end_borrow [[B]]
+// CHECK:         destroy_value [[C]]
+// CHECK:         throw [[ERROR]]
+// CHECK-LABEL: } // end sil function 'convert_function__to_optional__owned_as_guaranteed__3'
+sil [ossa] @convert_function__to_optional__owned_as_guaranteed__3 : $@convention(thin) (@owned C) -> (@error Error) {
+entry(%c : @owned $C):
+  %borrowMaybeC = function_ref @borrowMaybeCThrowing : $@convention(thin) (@guaranteed Optional<C>) -> (@error Error)
+  %borrowC = convert_function %borrowMaybeC to $@convention(thin) (@guaranteed C) -> (@error Error)
+  specify_test "sil_combine_instruction @instruction"
+  try_apply %borrowC(%c) : $@convention(thin) (@guaranteed C) -> (@error Error),
+    normal success,
+    error failure
+
+success(%void : $()):
+  destroy_value %c
+  %retval = tuple ()
+  return %retval
+
+failure(%error : @owned $Error):
+  destroy_value %c
+  throw %error
+}
+
+// CHECK-LABEL: sil [ossa] @convert_function__to_optional__owned_as_guaranteed__4 : {{.*}} {
+// CHECK:       bb0(
+// CHECK-SAME:      [[C:%[^,]+]] :
+// CHECK-SAME:      [[C2:%[^,]+]] :
+// CHECK-SAME:  ):
+// CHECK:         [[BORROW_MAYBE_C2:%[^,]+]] = function_ref @borrowMaybeC2Throwing
+// CHECK:         [[B:%[^,]+]] = begin_borrow [[C]]
+// CHECK:         [[MAYBE_B:%[^,]+]] = unchecked_ref_cast [[B]] to $Optional<C>
+// CHECK:         [[B2:%[^,]+]] = begin_borrow [[C2]]
+// CHECK:         [[MAYBE_B2:%[^,]+]] = unchecked_ref_cast [[B2]] to $Optional<C>
+// CHECK:         try_apply [[BORROW_MAYBE_C2]]([[MAYBE_B]], [[MAYBE_B2]])
+// CHECK:             normal [[SUCCESS:bb[0-9]+]]
+// CHECK:             error [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]
+// CHECK:         end_borrow [[B]]
+// CHECK:         end_borrow [[B2]]
+// CHECK:         destroy_value [[C]]
+// CHECK:         destroy_value [[C2]]
+// CHECK:       [[FAILURE]]([[ERROR:%[^,]+]] :
+// CHECK:         end_borrow [[B]]
+// CHECK:         end_borrow [[B2]]
+// CHECK:         destroy_value [[C]]
+// CHECK:         destroy_value [[C2]]
+// CHECK:         throw [[ERROR]]
+// CHECK-LABEL: } // end sil function 'convert_function__to_optional__owned_as_guaranteed__4'
+sil [ossa] @convert_function__to_optional__owned_as_guaranteed__4 : $@convention(thin) (@owned C, @owned C) -> (@error Error) {
+entry(%c : @owned $C, %c2 : @owned $C):
+  %borrowMaybeC2 = function_ref @borrowMaybeC2Throwing : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> (@error Error)
+  %borrowC2 = convert_function %borrowMaybeC2 to $@convention(thin) (@guaranteed C, @guaranteed C) -> (@error Error)
+  specify_test "sil_combine_instruction @instruction"
+  try_apply %borrowC2(%c, %c2) : $@convention(thin) (@guaranteed C, @guaranteed C) -> (@error Error),
+    normal success,
+    error failure
+
+success(%void : $()):
+  destroy_value %c
+  destroy_value %c2
+  %retval = tuple ()
+  return %retval
+
+failure(%error : @owned $Error):
+  destroy_value %c
+  destroy_value %c2
+  throw %error
+}

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1747,7 +1747,9 @@ bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
 
 sil @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
 
-// TODO
+// CHECK-LABEL: sil [ossa] @peephole_convert_function_result_change_with_error : {{.*}} {
+// CHECK-NOT:     convert_function
+// CHECK-LABEL: } // end sil function 'peephole_convert_function_result_change_with_error'
 sil [ossa] @peephole_convert_function_result_change_with_error : $@convention(thin) () -> () {
 entry:
   %f = function_ref @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)


### PR DESCRIPTION
The operands to the original apply are cast via an ownership forwarding instruction to the appropriate type for the rewritten apply.

```
%converted = convert_function %original to $(NewTy) -> ()
apply %converted(%operand)
```
->
```
%cast = cast %operand to $OriginalTy
apply %original(%cast)
```

Previously, when an original operand is owned but the new apply does not consume that operand, the newly added cast would consume the original operand (an owned value)--something the original code being replaced did not do.

```
%converted = convert_function %original to $(NewTy) -> ()
apply %converted(%operand : @guaranteed)
// %operand remains available
```
->
```
%cast = cast %operand to $OriginalTy // consumes %operand!
apply %original(%cast : @guaranteed)
// %operand is not available!
```

This is incorrect for the complementary reasons that the result of the cast is leaked and any uses of the original operand subsequent to the new apply are uses-after-consume.

Here, this is fixed by borrowing the original operand before casting in this case.

Took the opportunity to reenable this peephole for `try_apply`s when doing so doesn't require changing the CFG.

rdar://142570727

