### PR TITLE
Allow recompilation of modules in the resource directory when importing non-ossa module to ossa module

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -936,8 +936,17 @@ class ModuleInterfaceLoaderImpl {
         } else if (isInResourceDir(adjacentMod) &&
                    loadMode == ModuleLoadingMode::PreferSerialized &&
                    !version::isCurrentCompilerTagged() &&
-                   rebuildInfo.getOrInsertCandidateModule(adjacentMod).serializationStatus !=
-                     serialization::Status::SDKMismatch) {
+                   rebuildInfo.getOrInsertCandidateModule(adjacentMod)
+                           .serializationStatus !=
+                       serialization::Status::SDKMismatch &&
+                   // FIXME (meg-gupta): We need to support recompilation of
+                   // modules in the resource directory if the mismatch is due
+                   // to importing a non-ossa module to an ossa module. This is
+                   // needed during ossa bringup, once -enable-ossa-modules is
+                   // on by default, this can be deleted.
+                   rebuildInfo.getOrInsertCandidateModule(adjacentMod)
+                           .serializationStatus !=
+                       serialization::Status::NotInOSSA) {
           // Special-case here: If we're loading a .swiftmodule from the resource
           // dir adjacent to the compiler, defer to the serialized loader instead
           // of falling back. This is to support local development of Swift,

--- a/test/SILOptimizer/stdlib/Atomics.swift
+++ b/test/SILOptimizer/stdlib/Atomics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -emit-sil -disable-availability-checking %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -emit-sil -disable-availability-checking -enable-ossa-modules %s | %IRGenFileCheck %s
 
 // REQUIRES: synchronization
 


### PR DESCRIPTION
Currently recompilation of modules in the resource dir is allowed only when serialization status is `serialization::Status::SDKMismatch`. We however need to allow recompilation when it is `serialization::Status::NotInOSSA` as well. This seems to be an issue with implicit build modules only and not explicit build modules.

This change affects local swift development only and is needed to use `-enable-ossa-modules` in tests that import Synchronization and Distributed which are non-ossa.

