### PR TITLE
[stdlib] Fix doc comment refs to subranges(where:), now called indices(where:)

### DIFF
--- a/stdlib/public/core/DiscontiguousSlice.swift
+++ b/stdlib/public/core/DiscontiguousSlice.swift
@@ -393,7 +393,7 @@ extension Collection {
   ///
   ///     let str = "The rain in Spain stays mainly in the plain."
   ///     let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
-  ///     let vowelIndices = str.subranges(where: { vowels.contains($0) })
+  ///     let vowelIndices = str.indices(where: { vowels.contains($0) })
   ///
   ///     let disemvoweled = str.removingSubranges(vowelIndices)
   ///     print(String(disemvoweled))

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -377,7 +377,7 @@ extension MutableCollection {
   /// moves them to between `"i"` and `"j"`.
   ///
   ///     var letters = Array("ABCdeFGhijkLMNOp")
-  ///     let uppercaseRanges = letters.subranges(where: { $0.isUppercase })
+  ///     let uppercaseRanges = letters.indices(where: { $0.isUppercase })
   ///     let rangeOfUppercase = letters.moveSubranges(uppercaseRanges, to: 10)
   ///     // String(letters) == "dehiABCFGLMNOjkp"
   ///     // rangeOfUppercase == 4..<13

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1185,7 +1185,7 @@ extension RangeReplaceableCollection {
   ///
   ///     var str = "The rain in Spain stays mainly in the plain."
   ///     let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
-  ///     let vowelIndices = str.subranges(where: { vowels.contains($0) })
+  ///     let vowelIndices = str.indices(where: { vowels.contains($0) })
   ///
   ///     str.removeSubranges(vowelIndices)
   ///     // str == "Th rn n Spn stys mnly n th pln."
@@ -1216,7 +1216,7 @@ extension MutableCollection where Self: RangeReplaceableCollection {
   /// numbers in the array, and then removes those values.
   ///
   ///     var numbers = [5, 7, -3, -8, 11, 2, -1, 6]
-  ///     let negativeIndices = numbers.subranges(where: { $0 < 0 })
+  ///     let negativeIndices = numbers.indices(where: { $0 < 0 })
   ///
   ///     numbers.removeSubranges(negativeIndices)
   ///     // numbers == [5, 7, 11, 2, 6]

--- a/stdlib/public/core/RangeSet.swift
+++ b/stdlib/public/core/RangeSet.swift
@@ -21,7 +21,7 @@
 /// locations of all the negative values in `numbers`:
 ///
 ///     var numbers = [10, 12, -5, 14, -3, -9, 15]
-///     let negativeSubranges = numbers.subranges(where: { $0 < 0 })
+///     let negativeSubranges = numbers.indices(where: { $0 < 0 })
 ///     // numbers[negativeSubranges].count == 3
 ///
 ///     numbers.moveSubranges(negativeSubranges, to: 0)


### PR DESCRIPTION
Doc comments for DiscontiguousSlice, MutableCollection, RangeSet, and RangeReplaceableCollection all refer to a Collection method subranges(where:) that is intended to return a RangeSet of matching ranges. I believe this is likely an old or formerly-contemplated spelling of the method now known as indices(where:). This commit changes "subranges" to "indices" in those comments.