### PR TITLE
[android] Use emulated thread-local storage for API 28 and earlier

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -142,6 +142,11 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // Set UseInitArray appropriately.
   TargetOpts.UseInitArray = Clang->getCodeGenOpts().UseInitArray;
 
+  // Set emulated TLS in inlined C/C++ functions based on what clang is doing,
+  // ie either setting the default based on the OS or -Xcc -f{no-,}emulated-tls
+  // command-line flags.
+  TargetOpts.EmulatedTLS = Clang->getCodeGenOpts().EmulatedTLS;
+
   // WebAssembly doesn't support atomics yet, see
   // https://github.com/apple/swift/issues/54533 for more details.
   if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm())

--- a/test/IRGen/Inputs/tls.h
+++ b/test/IRGen/Inputs/tls.h
@@ -1,0 +1,7 @@
+#include "shims/SwiftStdint.h"
+
+static inline __swift_uint32_t _swift_stdlib_gettid() {
+  static __thread __swift_uint32_t tid = 0;
+
+  return tid;
+}

--- a/test/IRGen/emulated-tls.swift
+++ b/test/IRGen/emulated-tls.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -Xcc -femulated-tls %s -S -import-objc-header %S/Inputs/tls.h | %FileCheck %s --check-prefix=EMUTLS --check-prefix=EMUTLS-%target-os
+// RUN: %target-swift-frontend -Xcc -fno-emulated-tls %s -S -import-objc-header %S/Inputs/tls.h | %FileCheck %s --check-prefix=NOEMUTLS
+
+_swift_stdlib_gettid()
+
+// EMUTLS: __emutls_v._swift_stdlib_gettid.tid
+// EMUTLS-linux-android: __emutls_get_address
+// EMUTLS-linux-gnu: __emutls_get_address
+// EMUTLS-macosx: __emutls_get_address
+// EMUTLS-openbsd: __emutls_get_address
+// EMUTLS-windows-msvc: __emutls_get_address
+// EMUTLS-wasi-NOT: __emutls_get_address
+
+// NOEMUTLS-NOT: __emutls_v._swift_stdlib_gettid.tid
+// NOEMUTLS-NOT: __emutls_get_address


### PR DESCRIPTION
__Explanation:__ [Android before API 29](https://android.googlesource.com/platform/bionic/+/HEAD/android-changes-for-ndk-developers.md#elf-tls-available-for-api-level-29) and a few other platforms don't support native TLS, so fall back to LLVM's emulated TLS there, just like clang does. Also, make sure `-Xcc -f{no-,}emulated-tls` flags passed in are applied to control what the Swift compiler does.

__Scope:__ Has no effect by default, except on [Android API 28 or older, OpenBSD, and a couple other platforms Swift doesn't support](https://github.com/llvm/llvm-project/blob/7672216ed7f480c8d461a2d046a74453307f6298/llvm/include/llvm/TargetParser/Triple.h#L1094)

__Issue:__ None

__Original PR:__ #77883

__Risk:__ very low

__Testing:__ Passed all CI on trunk and [now on my Android CI running at API 24](https://github.com/finagolfin/swift-android-sdk/actions/runs/12726288059/job/35486443831?pr=201), when built with the latest Jan. 10 trunk snapshot tag containing this commit

__Reviewer:__ @compnerd

This will allow Foundation in my Android SDK bundle and native toolchain for Android to support APIs 24-28 again, finagolfin/swift-android-sdk#175.