### PR TITLE
[cxx-interop] Check the safety of C++ template arguments

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2194,6 +2194,39 @@ namespace {
             dc);
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
+      // We have to do this after populating ImportedDecls to avoid importing
+      // the same multiple times.
+      if (Impl.SwiftContext.LangOpts.hasFeature(Feature::SafeInterop) &&
+          Impl.SwiftContext.LangOpts.hasFeature(
+              Feature::AllowUnsafeAttribute)) {
+        if (const auto *ctsd =
+                dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
+          for (auto arg : ctsd->getTemplateArgs().asArray()) {
+            llvm::SmallVector<clang::TemplateArgument, 1> nonPackArgs;
+            if (arg.getKind() == clang::TemplateArgument::Pack) {
+              auto pack = arg.getPackAsArray();
+              nonPackArgs.assign(pack.begin(), pack.end());
+            } else {
+              nonPackArgs.push_back(arg);
+            }
+            for (auto realArg : nonPackArgs) {
+              if (realArg.getKind() != clang::TemplateArgument::Type)
+                continue;
+              auto SwiftType = Impl.importTypeIgnoreIUO(
+                  realArg.getAsType(), ImportTypeKind::Abstract,
+                  [](Diagnostic &&diag) {}, false, Bridgeability::None,
+                  ImportTypeAttrs());
+              if (SwiftType && SwiftType->isUnsafe()) {
+                auto attr =
+                    new (Impl.SwiftContext) UnsafeAttr(/*implicit=*/true);
+                result->getAttrs().add(attr);
+                break;
+              }
+            }
+          }
+        }
+      }
+
       if (recordHasMoveOnlySemantics(decl)) {
         if (decl->isInStdNamespace() && decl->getName() == "promise") {
           // Do not import std::promise.
@@ -8402,6 +8435,13 @@ static bool importAsUnsafe(ClangImporter::Implementation &impl,
     return true;
 
   if (isa<ClassDecl>(MappedDecl))
+    return false;
+
+  // Most STL containers have std::allocator as their default allocator. We need
+  // to consider std::allocator safe for the STL containers to be ever
+  // considered safe.
+  if (decl->isInStdNamespace() && decl->getIdentifier() &&
+      decl->getName() == "allocator")
     return false;
 
   if (const auto *record = dyn_cast<clang::RecordDecl>(decl))

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -18,6 +18,8 @@ module Test {
 //--- Inputs/nonescapable.h
 #include "swift/bridging"
 #include <span>
+#include <vector>
+#include <tuple>
 
 struct SWIFT_NONESCAPABLE View {
     __attribute__((swift_attr("@lifetime(immortal)")))
@@ -54,6 +56,10 @@ struct MyContainer {
 
 using SpanOfInt = std::span<int>;
 using SpanOfIntAlias = SpanOfInt;
+using VecOfPtr = std::vector<int*>;
+using VecOfInt = std::vector<int>;
+using SafeTuple = std::tuple<int, int, int>;
+using UnsafeTuple = std::tuple<int, int*, int>;
 
 //--- test.swift
 
@@ -85,7 +91,21 @@ func useCfType(x: CFArray) {
 func useString(x: std.string) {
 }
 
-// expected-warning@+1{{global function 'useCppSpan' has an interface that is not memory-safe}}
+// expected-warning@+1{{global function 'useVecOfPtr' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+func useVecOfPtr(x: VecOfPtr) { // expected-note{{reference to unsafe type alias 'VecOfPtr'}}
+}
+
+func useVecOfInt(x: VecOfInt) {
+}
+
+func useSafeTuple(x: SafeTuple) {
+}
+
+// expected-warning@+1{{global function 'useUnsafeTuple' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+func useUnsafeTuple(x: UnsafeTuple) { // expected-note{{reference to unsafe type alias 'UnsafeTuple'}}
+}
+
+// expected-warning@+1{{global function 'useCppSpan' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
 func useCppSpan(x: SpanOfInt) { // expected-note{{reference to unsafe type alias 'SpanOfInt'}}
 }
 


### PR DESCRIPTION
Swift imports template specializations as a standalone type (not as an instantiation of a generic) so unsafety is not propagated from the template arguments to the specialization. This PR propagates this information explicitly.
