### PR TITLE
Fix two bugs which cause SIL verification errors

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
@@ -164,7 +164,11 @@ private struct MutatingUsesWalker : AddressDefUseWalker {
 
       for use in startInst.uses {
         if let phi = Phi(using: use) {
-          linearLiveranges.pushIfNotVisited(phi.borrowedFrom!)
+          if let bf = phi.borrowedFrom {
+            linearLiveranges.pushIfNotVisited(bf)
+          } else {
+            require(false, "missing borrowed-from for \(phi.value)")
+          }
         }
       }
     }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1184,6 +1184,16 @@ static bool sinkArgument(EnumCaseDataflowContext &Context, SILBasicBlock *BB, un
   if (hasOwnershipOperandsOrResults(FSI))
     return false;
 
+  // Even if the incoming instruction has no ownership, the argument may have.
+  // This can happen with enums which are constructed with a non-payload case:
+  //
+  //   %1 = enum $Optional<C>, #Optional.none!enumelt
+  //   br bb3(%1)
+  // bb1(%3 : @owned $Optional<C>):
+  //
+  if (BB->getArgument(ArgNum)->getOwnershipKind() != OwnershipKind::None)
+    return false;
+
   // The list of identical instructions.
   SmallVector<SingleValueInstruction *, 8> Clones;
   Clones.push_back(FSI);

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -552,6 +552,28 @@ bb3(%12 : $Bool):
   return %12 : $Bool
 }
 
+// CHECK-LABEL: sil [ossa] @dont_sink_owned_trivial_enum :
+// CHECK:       bb1:
+// CHECK-NEXT:    enum
+// CHECK:       bb2:
+// CHECK-NEXT:    enum
+// CHECK:       bb3([[A:%.*]] : @owned $Optional<C>):
+// CHECK-NEXT:    return [[A]]
+// CHECK:       } // end sil function 'dont_sink_owned_trivial_enum'
+sil [ossa] @dont_sink_owned_trivial_enum : $@convention(thin) () -> @owned Optional<C> {
+bb0:
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = enum $Optional<C>, #Optional.none!enumelt
+  br bb3(%2)
+bb2:
+  %4 = enum $Optional<C>, #Optional.none!enumelt
+  br bb3(%4)
+bb3(%6 : @owned $Optional<C>):
+  return %6
+}
+
+
 // Sink retain down the successors so we can pair up retain with release on the
 // fast path.
 class Test {

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1939,3 +1939,35 @@ bb3:
   return %t : $()
 }
 
+// CHECK-LABEL: sil [ossa] @replace_phi_arg_with_borrowed_from_use :
+// CHECK:       bb3([[R:%.*]] : @reborrow $B):
+// CHECK:       bb6([[G:%.*]] : @guaranteed $E):
+// CHECK-NEXT:    [[X:%.*]] = borrowed [[G]] : $E from ([[R]] : $B)
+// CHECK-NEXT:    fix_lifetime [[X]]
+// CHECK:       } // end sil function 'replace_phi_arg_with_borrowed_from_use'
+sil [ossa] @replace_phi_arg_with_borrowed_from_use : $@convention(thin) (@in_guaranteed B) -> () {
+bb0(%0 : $*B):
+  cond_br undef, bb1, bb2
+bb1:
+  %4 = load_borrow %0
+  br bb3(%4)
+bb2:
+  %6 = load_borrow %0
+  br bb3(%6)
+bb3(%8 : @reborrow $B):
+  %9 = borrowed %8 from ()
+  cond_br undef, bb4, bb5
+bb4:
+  %11 = unchecked_ref_cast %9 to $E
+  br bb6(%11, %9)
+bb5:
+  %13 = unchecked_ref_cast %9 to $E
+  br bb6(%13, %9)
+bb6(%15: @guaranteed $E, %16 : @reborrow $B):
+  %17 = borrowed %15 from (%16)
+  %18 = borrowed %16 from ()
+  fix_lifetime %17
+  end_borrow %18
+  %r = tuple()
+  return %r
+}


### PR DESCRIPTION
1. CodeMotion: check the ownership of arguments when sinking arguments

So far we only checked the ownership of incoming values.
But even if the incoming instruction has no ownership, the argument may have.
This can happen with enums which are constructed with a non-payload case:
```
   %1 = enum $Optional<C>, #Optional.none!enumelt
   br bb3(%1)
 bb1(%3 : @owned $Optional<C>):
```

2. SimplifyCFG: correctly handle borrowed-from values when removing a redundant phi argument.

We need to make sure that the arguments to a borrowed-from instruction are not borrowed-from instructions, too, but their underlying phi arguments.

rdar://142506300