### PR TITLE
Tests: Use a local cache for many tests importing AppKit

### DIFF
--- a/test/Interpreter/SDK/Cocoa_transitive.swift
+++ b/test/Interpreter/SDK/Cocoa_transitive.swift
@@ -1,4 +1,5 @@
-// RUN: %target-build-swift %s
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift %s -module-cache-path %t/cache
 // REQUIRES: executable_test
 
 // FIXME: iOS does not have Cocoa.framework

--- a/test/Interpreter/SDK/GLKit_parse.swift
+++ b/test/Interpreter/SDK/GLKit_parse.swift
@@ -1,4 +1,5 @@
-// RUN: %target-build-swift -typecheck %s -Xfrontend -verify
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -typecheck %s -Xfrontend -verify -module-cache-path %t/cache
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/Interpreter/SDK/NSApplicationMain.swift
+++ b/test/Interpreter/SDK/NSApplicationMain.swift
@@ -1,4 +1,5 @@
-// RUN: %target-build-swift -typecheck %s
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -typecheck %s -module-cache-path %t/cache
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 

--- a/test/Interpreter/SDK/c_pointers.swift
+++ b/test/Interpreter/SDK/c_pointers.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift %s -o %t/a.out -module-cache-path %t/cache
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/objc_factory_method.swift
+++ b/test/Interpreter/SDK/objc_factory_method.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name FactoryTest %s -o %t/a.out
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -module-name FactoryTest %s -o %t/a.out -module-cache-path %t/cache
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/object_literals.swift
+++ b/test/Interpreter/SDK/object_literals.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
 // RUN: %empty-directory(%t/Test.app/Contents/MacOS)
 // RUN: cp -r %S/Inputs/object_literals-Resources %t/Test.app/Contents/Resources
-// RUN: %target-build-swift %s -o %t/Test.app/Contents/MacOS/main
+// RUN: %target-build-swift %s -o %t/Test.app/Contents/MacOS/main -module-cache-path %t/cache
 // RUN: %target-codesign %t/Test.app/Contents/MacOS/main
 // RUN: %target-run %t/Test.app/Contents/MacOS/main %t/Test.app/Contents/Resources/*
 

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -1,5 +1,6 @@
-// RUN: %target-build-swift -typecheck %s -Xfrontend -verify -Xfrontend -verify-ignore-unknown
-// RUN: %target-build-swift -emit-ir -g %s -DNO_ERROR > /dev/null
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -typecheck %s -Xfrontend -verify -Xfrontend -verify-ignore-unknown -module-cache-path %t/cache
+// RUN: %target-build-swift -emit-ir -g %s -DNO_ERROR -module-cache-path %t/cache > /dev/null
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/Migrator/remove_override.swift
+++ b/test/Migrator/remove_override.swift
@@ -1,6 +1,7 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir -module-cache-path %t/cache
 // RUN: diff -u %S/remove_override.swift.expected %t/remove_override.result.swift
 
 import AppKit

--- a/test/Migrator/remove_override.swift.expected
+++ b/test/Migrator/remove_override.swift.expected
@@ -1,6 +1,7 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir -module-cache-path %t/cache
 // RUN: diff -u %S/remove_override.swift.expected %t/remove_override.result.swift
 
 import AppKit

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
 //
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
 // Note: explicitly link the CoreGraphics overlay because does not get autolinked
 // and it is needed for conformances on macOS < 15.
-// RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o -o %t/a.out -lswiftCoreGraphics
+// RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o -o %t/a.out -lswiftCoreGraphics -module-cache-path %t/cache
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out %S/Inputs/shuffle.jpg | %FileCheck %s
 


### PR DESCRIPTION
Tests importing AppKit have a tendency to be flaky when they share a module cache with other builds using a different set of framework search flags. Make sure they use a local cache, otherwise the compiler can reuse incompatible cached modules.

Alternatively, we could align all builds using the same cache to have exactly the same framework search paths or enable explicit module builds. I picked the module cache as it's the most reliable solution in the short and long term.

The 5 tests below import AppKit and have been known to be flaky. Adapting them to use a custom cache with require more care. For now, let's use them as control group to validate that the fix works. If these 5 fail without the fixed ones, we should extend the same corresponding fix to them.

- Interpreter/SDK/GLKit.swift
- Interpreter/SDK/cf_extensions.swift
- Interpreter/SDK/cf_type_bridging.swift
- Interpreter/SDK/mapkit_header_static.swift
- Interpreter/SDK/objc_ns_enum.swift

rdar://142296731