### PR TITLE
Disable this test on anything but macOS

### DIFF
--- a/test/embedded/wrong-linkage.swift
+++ b/test/embedded/wrong-linkage.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -verify -wmo
 
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
 
 @_cdecl("posix_memalign")
 func posix_memalign(_ resultPtr:UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ :Int, _ :Int) -> Int32 { // expected-error {{function has wrong linkage to be called from}}


### PR DESCRIPTION
Attempting to unblock bots

Specifically, this also seems to fail on PR tests:

```
Failed Tests (1):
  Swift(iphonesimulator-x86_64) :: embedded/wrong-linkage.swift
```

rdar://142601111