### PR TITLE
[6.1][Sema] Look through `ActorIsolationErasureExpr` when finding function…

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -468,6 +468,10 @@ public:
         // Look through optional evaluations.
       } else if (auto optionalEval = dyn_cast<OptionalEvaluationExpr>(fn)) {
         fn = optionalEval->getSubExpr()->getValueProvidingExpr();
+        // Look through actor isolation erasures.
+      } else if (auto actorIsolationErasure =
+                     dyn_cast<ActorIsolationErasureExpr>(fn)) {
+        fn = actorIsolationErasure->getSubExpr()->getValueProvidingExpr();
       } else {
         break;
       }

--- a/test/Concurrency/dynamic_actor_isolation.swift
+++ b/test/Concurrency/dynamic_actor_isolation.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature DynamicActorIsolation -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
+
+// REQUIRES: swift_feature_DynamicActorIsolation
+
+// Tests related to DynamicActorIsolation feature
+
+// rdar://142562250 - error: call can throw, but it is not marked with ‘try’ and the error is not handled
+@MainActor
+struct TestNoErrorsAboutThrows {
+  struct Column {
+    @MainActor
+    init?(_ column: Int) {}
+  }
+
+  func test(columns: [Int]) {
+    // MainActor isolation erasure shouldn't interfere with effects checking
+    _ = columns.compactMap(Column.init) // Ok
+  }
+}


### PR DESCRIPTION
… DeclRefs for `rethrows` checking.

Cherry-pick of https://github.com/swiftlang/swift/pull/78535

---

- Explanation:

  Fixes a source compatibility regression when actor isolated function values are passed to throwing parameters.

  This conversion has no effect on `rethrows` checking and should be ignored.

- Main Branch PR: https://github.com/swiftlang/swift/pull/78535

- Resolves: rdar://142562250

- Risk: Very Low (this conversion appears in a limit set of circumstances and has no effect on `rethrows` checking).

- Reviewed By: @hborla

- Testing: Added new tests to the Concurrency test suite.

(cherry picked from commit e0bfa13f8fa7d22da01952b50ad25361f010660d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
