### PR TITLE
Respect "getBypassResilience" on "isResilient"

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -857,7 +857,7 @@ public:
   ModuleDecl *getTopLevelModule(bool overlay = false);
 
   bool isResilient() const {
-    return getResilienceStrategy() != ResilienceStrategy::Default;
+    return getResilienceStrategy() != ResilienceStrategy::Default && !getBypassResilience();
   }
 
   /// True if this module is resilient AND also does _not_ allow


### PR DESCRIPTION
LLDB sets BypassResilience to have direct access to private properties of modules built with resilience. This setting is ignored in many paths that check resiliency though, which causes LLDB to fail to evaluate certain expressions.

This commit simply makes sure that `isResilient` checks whether resiliency should be bypassed or not.

rdar://137876089

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
