### PR TITLE
Define placeholder availability for Swift 6.2

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -155,6 +155,11 @@ RUNTIME_VERSION(
   FUTURE
 )
 
+RUNTIME_VERSION(
+  (6, 2),
+  FUTURE
+)
+
 END_MAJOR_VERSION(6)
 
 // .......................................................................... //

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -230,9 +230,11 @@ extension _SwiftStdlibVersion {
   public static var v6_0_0: Self { Self(_value: 0x060000) }
   @_alwaysEmitIntoClient
   public static var v6_1_0: Self { Self(_value: 0x060100) }
+  @_alwaysEmitIntoClient
+  public static var v6_2_0: Self { Self(_value: 0x060200) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v6_1_0 }
+  public static var current: Self { .v6_2_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -769,6 +769,7 @@ Added: _$ss7UnicodeO5ASCIIO27encodedReplacementCharacters15CollectionOfOneVys5UI
 Added: _$ss7UnicodeO5UTF16O27encodedReplacementCharacters11_UIntBufferVys6UInt16VGvpZMV
 Added: _$ss7UnicodeO5UTF32O27encodedReplacementCharacters15CollectionOfOneVys6UInt32VGvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_1_0ABvpZMV
+Added: _$sSo19_SwiftStdlibVersionasE6v6_2_0ABvpZMV
 
 // SE-0445 Improving printed descriptions of String.Index
 Added: _$sSS5IndexV16debugDescriptionSSvpMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -750,6 +750,7 @@ Added: _$ss8SIMDMaskVss6SIMD64Vys5Int16VGRszrlE7allTrueAByAGGvpZMV
 Added: _$ss8SIMDMaskVss6SIMD64Vys5Int32VGRszrlE7allTrueAByAGGvpZMV
 Added: _$ss8SIMDMaskVss6SIMD64Vys5Int64VGRszrlE7allTrueAByAGGvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_1_0ABvpZMV
+Added: _$sSo19_SwiftStdlibVersionasE6v6_2_0ABvpZMV
 Added: _$ss7Float80V12signalingNaNABvpZMV
 Added: _$ss7Float80V13_exponentBiasSuvpZMV
 Added: _$ss7Float80V13_quietNaNMasks6UInt64VvpZMV

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -37,6 +37,7 @@ SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
This PR defines `SwiftStdlib 6.2` to track availability of features introduced on the current main branch.

```
SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
```

It also updates `RuntimeVersions.def` to define placeholder availability for the 6.2 runtime within the compiler.

Additionally, `_SwiftStdlibVersion` gains a new `.v6_2_0` case, and `_SwiftStdlibVersion.current` is updated to report that.