### PR TITLE
Fix SILGenFunction::emitBasicProlog for @lifetime with default args.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1643,9 +1643,12 @@ uint16_t SILGenFunction::emitBasicProlog(
     emitIndirectErrorParameter(*this, *errorType, *origErrorType, DC);
   }
   
-  // Parameters with scoped dependencies may lower differently.
+  // Parameters with scoped dependencies may lower differently. Parameters are
+  // relative to the current SILGenFunction, not the passed in DeclContext. For
+  // example, the an argument initializer's DeclContext is the enclosing
+  // function definition rather that the initializer's generator function.
   llvm::SmallPtrSet<ParamDecl *, 2> scopedDependencyParams;
-  if (auto afd = dyn_cast<AbstractFunctionDecl>(DC)) {
+  if (auto afd = dyn_cast<AbstractFunctionDecl>(FunctionDC)) {
     if (auto deps = afd->getLifetimeDependencies()) {
       for (auto &dep : *deps) {
         auto scoped = dep.getScopeIndices();

--- a/test/SILGen/addressable_for_dependencies.swift
+++ b/test/SILGen/addressable_for_dependencies.swift
@@ -9,7 +9,7 @@ struct Foo { var x: String }
 struct Bar { var foo: Foo }
 
 struct Dep: ~Escapable {
-    var x: Int
+    var x: Int = 0
 
     @lifetime(immortal)
     init() { }
@@ -98,3 +98,11 @@ extension Bar {
         return bar.dependencyOnSelf()
     }
 }
+
+// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iySi_tFfA_ :
+// CHECK-SAME: $@convention(thin) () -> Int {
+
+// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iySi_tF :
+// CHECK-SAME: $@convention(thin) (Int) -> @lifetime(borrow 0) () {
+@lifetime(borrow i)
+func defaulArgument(i: Int = 0) {}


### PR DESCRIPTION
LifetimeDependencies were being read from the wrong DeclContext.

Fixes rdar://142451893 (Crash during AST -> SIL lowering)
