### PR TITLE
[gardening] move `String.withCString()` to String.swift

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -253,28 +253,6 @@ public func _withUnprotectedUnsafePointer<
   return try body(UnsafePointer<T>(Builtin.unprotectedAddressOfBorrow(value)))
 }
 
-extension String {
-  /// Calls the given closure with a pointer to the contents of the string,
-  /// represented as a null-terminated sequence of UTF-8 code units.
-  ///
-  /// The pointer passed as an argument to `body` is valid only during the
-  /// execution of `withCString(_:)`. Do not store or return the pointer for
-  /// later use.
-  ///
-  /// - Parameter body: A closure with a pointer parameter that points to a
-  ///   null-terminated sequence of UTF-8 code units. If `body` has a return
-  ///   value, that value is also used as the return value for the
-  ///   `withCString(_:)` method. The pointer argument is valid only for the
-  ///   duration of the method's execution.
-  /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable // fast-path: already C-string compatible
-  public func withCString<Result>(
-    _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
-    return try _guts.withCString(body)
-  }
-}
-
 @available(*, deprecated, message: "Use the copy operator")
 @_alwaysEmitIntoClient
 @inlinable

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -682,6 +682,26 @@ extension String {
   }
 
   /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of UTF-8 code units.
+  ///
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(_:)`. Do not store or return the pointer for
+  /// later use.
+  ///
+  /// - Parameter body: A closure with a pointer parameter that points to a
+  ///   null-terminated sequence of UTF-8 code units. If `body` has a return
+  ///   value, that value is also used as the return value for the
+  ///   `withCString(_:)` method. The pointer argument is valid only for the
+  ///   duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  @inlinable // fast-path: already C-string compatible
+  public func withCString<Result>(
+    _ body: (UnsafePointer<Int8>) throws -> Result
+  ) rethrows -> Result {
+    return try _guts.withCString(body)
+  }
+
+  /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of code units.
   ///
   /// The pointer passed as an argument to `body` is valid only during the


### PR DESCRIPTION
This function has been at an unexpected location for unremembered reasons for far too long.
Move it to the main `String` source file, alongside the other `String.withCString()` function.