### PR TITLE
AST: Refactor `AvailableAttr` representation to use `AvailabilityDomain`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -836,6 +836,23 @@ public:
         Bits.AvailableAttr.PlatformAgnostic);
   }
 
+  /// Returns the kind of availability the attribute specifies.
+  Kind getKind() const {
+    switch (getPlatformAgnosticAvailability()) {
+    case PlatformAgnosticAvailabilityKind::None:
+    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
+      return Kind::Default;
+    case PlatformAgnosticAvailabilityKind::Deprecated:
+      return Kind::Deprecated;
+    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+    case PlatformAgnosticAvailabilityKind::Unavailable:
+      return Kind::Unavailable;
+    case PlatformAgnosticAvailabilityKind::NoAsync:
+      return Kind::NoAsync;
+    }
+  }
+
   /// Create an `AvailableAttr` that specifies universal unavailability, e.g.
   /// `@available(*, unavailable)`.
   static AvailableAttr *createUniversallyUnavailable(ASTContext &C,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -743,6 +743,20 @@ enum class PlatformAgnosticAvailabilityKind : uint8_t {
 /// Defines the @available attribute.
 class AvailableAttr : public DeclAttribute {
 public:
+  enum class Kind : uint8_t {
+    /// The attribute does not specify `deprecated`, `unavailable`,
+    /// or `noasync`. Instead, it may specify `introduced:`, `deprecated:`, or
+    /// `obsoleted:` versions or it may simply have a `rename:` field.
+    Default,
+    /// The attribute specifies unconditional deprecation.
+    Deprecated,
+    /// The attribute specifies unconditional unavailability.
+    Unavailable,
+    /// The attribute specifies unavailability in asynchronous contexts.
+    NoAsync,
+  };
+
+public:
   AvailableAttr(SourceLoc AtLoc, SourceRange Range, PlatformKind Platform,
                 StringRef Message, StringRef Rename,
                 const llvm::VersionTuple &Introduced,
@@ -751,6 +765,15 @@ public:
                 SourceRange DeprecatedRange,
                 const llvm::VersionTuple &Obsoleted, SourceRange ObsoletedRange,
                 PlatformAgnosticAvailabilityKind PlatformAgnostic,
+                bool Implicit, bool IsSPI, bool IsForEmbedded = false);
+
+  AvailableAttr(SourceLoc AtLoc, SourceRange Range,
+                const AvailabilityDomain &Domain, Kind Kind, StringRef Message,
+                StringRef Rename, const llvm::VersionTuple &Introduced,
+                SourceRange IntroducedRange,
+                const llvm::VersionTuple &Deprecated,
+                SourceRange DeprecatedRange,
+                const llvm::VersionTuple &Obsoleted, SourceRange ObsoletedRange,
                 bool Implicit, bool IsSPI, bool IsForEmbedded = false);
 
   /// The optional message.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -716,27 +716,6 @@ enum class AvailableVersionComparison {
   Obsoleted,
 };
 
-/// Describes the platform-agnostic availability of a declaration.
-enum class PlatformAgnosticAvailabilityKind : uint8_t {
-  /// The associated availability attribute is not platform-agnostic.
-  None,
-  /// The declaration is deprecated, but can still be used.
-  Deprecated,
-  /// The declaration is unavailable in Swift, specifically
-  UnavailableInSwift,
-  /// The declaration is available in some but not all versions
-  /// of Swift, as specified by the VersionTuple members.
-  SwiftVersionSpecific,
-  /// The declaration is available in some but not all versions
-  /// of SwiftPM's PackageDescription library, as specified by
-  /// the VersionTuple members.
-  PackageDescriptionVersionSpecific,
-  /// The declaration is unavailable for other reasons.
-  Unavailable,
-  /// The declaration is unavailable from asynchronous contexts
-  NoAsync,
-};
-
 /// Defines the @available attribute.
 class AvailableAttr : public DeclAttribute {
   AvailabilityDomain Domain;
@@ -823,39 +802,6 @@ public:
 
   /// Returns the kind of availability the attribute specifies.
   Kind getKind() const { return static_cast<Kind>(Bits.AvailableAttr.Kind); }
-
-  /// Returns the platform-agnostic availability.
-  PlatformAgnosticAvailabilityKind getPlatformAgnosticAvailability() const {
-    // FIXME: [availability] Remove this method entirely.
-    switch (getKind()) {
-    case Kind::Default:
-      if (Domain.isSwiftLanguage())
-        return PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
-      else if (Domain.isPackageDescription())
-        return PlatformAgnosticAvailabilityKind::
-            PackageDescriptionVersionSpecific;
-      else if (Domain.isUniversal() || Domain.isPlatform())
-        return PlatformAgnosticAvailabilityKind::None;
-
-      break;
-
-    case Kind::Deprecated:
-      return PlatformAgnosticAvailabilityKind::Deprecated;
-
-    case Kind::Unavailable:
-      if (Domain.isSwiftLanguage())
-        return PlatformAgnosticAvailabilityKind::UnavailableInSwift;
-      else if (Domain.isUniversal() || Domain.isPlatform())
-        return PlatformAgnosticAvailabilityKind::Unavailable;
-
-      break;
-
-    case Kind::NoAsync:
-      return PlatformAgnosticAvailabilityKind::NoAsync;
-    }
-
-    llvm_unreachable("unsupported AvailabilityDomain and Kind");
-  }
 
   /// Create an `AvailableAttr` that specifies universal unavailability, e.g.
   /// `@available(*, unavailable)`.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -792,9 +792,6 @@ public:
   /// Whether this attribute was spelled `@_unavailableInEmbedded`.
   bool isForEmbedded() const { return Bits.AvailableAttr.IsForEmbedded; }
 
-  /// Returns the platform that the attribute applies to (may be `none`).
-  PlatformKind getPlatform() const { return Domain.getPlatformKind(); }
-
   /// Returns the `AvailabilityDomain` associated with the attribute, or
   /// `std::nullopt` if it has either not yet been resolved or could not be
   /// resolved successfully.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -33,14 +33,14 @@ public:
     /// universally unavailable or deprecated, for example.
     Universal,
 
-    /// Represents availability for a specific operating system platform.
-    Platform,
-
     /// Represents availability with respect to Swift language mode.
     SwiftLanguage,
 
     /// Represents PackageDescription availability.
     PackageDescription,
+
+    /// Represents availability for a specific operating system platform.
+    Platform,
   };
 
 private:
@@ -98,6 +98,40 @@ public:
 
   /// Returns the string to use when printing an `@available` attribute.
   llvm::StringRef getNameForAttributePrinting() const;
+
+  bool operator==(const AvailabilityDomain &other) const {
+    if (getKind() != other.getKind())
+      return false;
+
+    switch (getKind()) {
+    case Kind::Universal:
+    case Kind::SwiftLanguage:
+    case Kind::PackageDescription:
+      // These availability domains are singletons.
+      return true;
+    case Kind::Platform:
+      return getPlatformKind() == other.getPlatformKind();
+    }
+  }
+
+  bool operator!=(const AvailabilityDomain &other) const {
+    return !(*this == other);
+  }
+
+  bool operator<(const AvailabilityDomain &other) const {
+    if (getKind() != other.getKind())
+      return getKind() < other.getKind();
+
+    switch (getKind()) {
+    case Kind::Universal:
+    case Kind::SwiftLanguage:
+    case Kind::PackageDescription:
+      // These availability domains are singletons.
+      return false;
+    case Kind::Platform:
+      return getPlatformKind() < other.getPlatformKind();
+    }
+  }
 };
 
 } // end namespace swift

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -57,6 +57,8 @@ private:
   };
 
 public:
+  AvailabilityDomain() {}
+
   static AvailabilityDomain forUniversal() {
     return AvailabilityDomain(Kind::Universal);
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3892,35 +3892,21 @@ public:
   }
   void visitAvailableAttr(AvailableAttr *Attr, StringRef label) {
     printCommon(Attr, "available_attr", label);
-    switch (Attr->getPlatformAgnosticAvailability()) {
-    case PlatformAgnosticAvailabilityKind::None:
-    case PlatformAgnosticAvailabilityKind::Deprecated:
-    case PlatformAgnosticAvailabilityKind::Unavailable:
-    case PlatformAgnosticAvailabilityKind::NoAsync:
-      printField(Attr->getPlatform(), "platform");
+
+    if (auto domain = Attr->getCachedDomain())
+      printField(domain->getNameForAttributePrinting(), "platform");
+
+    switch (Attr->getKind()) {
+    case swift::AvailableAttr::Kind::Default:
       break;
-    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-      printFieldQuoted("swift", "platform");
-      break;
-    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-      printFieldQuoted("_PackageDescription", "platform");
-      break;
-    }
-    switch (Attr->getPlatformAgnosticAvailability()) {
-    case PlatformAgnosticAvailabilityKind::Deprecated:
+    case swift::AvailableAttr::Kind::Deprecated:
       printFlag("deprecated");
       break;
-    case PlatformAgnosticAvailabilityKind::Unavailable:
-    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+    case swift::AvailableAttr::Kind::Unavailable:
       printFlag("unavailable");
       break;
-    case PlatformAgnosticAvailabilityKind::NoAsync:
+    case swift::AvailableAttr::Kind::NoAsync:
       printFlag("noasync");
-      break;
-    case PlatformAgnosticAvailabilityKind::None:
-    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
       break;
     }
     if (Attr->Introduced.has_value())

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -439,15 +439,12 @@ static bool isShortAvailable(const SemanticAvailableAttr &attr) {
   if (!attr.getRename().empty())
     return false;
 
-  switch (parsedAttr->getPlatformAgnosticAvailability()) {
-  case PlatformAgnosticAvailabilityKind::Deprecated:
-  case PlatformAgnosticAvailabilityKind::Unavailable:
-  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-  case PlatformAgnosticAvailabilityKind::NoAsync:
+  switch (parsedAttr->getKind()) {
+  case AvailableAttr::Kind::NoAsync:
+  case AvailableAttr::Kind::Deprecated:
+  case AvailableAttr::Kind::Unavailable:
     return false;
-  case PlatformAgnosticAvailabilityKind::None:
-  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
+  case AvailableAttr::Kind::Default:
     return true;
   }
 
@@ -2238,42 +2235,42 @@ OriginallyDefinedInAttr *OriginallyDefinedInAttr::clone(ASTContext &C,
 }
 
 bool AvailableAttr::isUnconditionallyUnavailable() const {
-  switch (getPlatformAgnosticAvailability()) {
-  case PlatformAgnosticAvailabilityKind::None:
-  case PlatformAgnosticAvailabilityKind::Deprecated:
-  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-  case PlatformAgnosticAvailabilityKind::NoAsync:
+  switch (getKind()) {
+  case Kind::Default:
+  case Kind::Deprecated:
+  case Kind::NoAsync:
     return false;
-
-  case PlatformAgnosticAvailabilityKind::Unavailable:
-  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+  case Kind::Unavailable:
     return true;
   }
 
-  llvm_unreachable("Unhandled PlatformAgnosticAvailabilityKind in switch.");
+  llvm_unreachable("Unhandled AvailableAttr::Kind in switch.");
 }
 
 bool AvailableAttr::isUnconditionallyDeprecated() const {
-  switch (getPlatformAgnosticAvailability()) {
-  case PlatformAgnosticAvailabilityKind::None:
-  case PlatformAgnosticAvailabilityKind::Unavailable:
-  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-  case PlatformAgnosticAvailabilityKind::NoAsync:
+  switch (getKind()) {
+  case Kind::Default:
+  case Kind::Unavailable:
+  case Kind::NoAsync:
     return false;
-
-  case PlatformAgnosticAvailabilityKind::Deprecated:
+  case Kind::Deprecated:
     return true;
   }
 
-  llvm_unreachable("Unhandled PlatformAgnosticAvailabilityKind in switch.");
+  llvm_unreachable("Unhandled AvailableAttr::Kind in switch.");
 }
 
 bool AvailableAttr::isNoAsync() const {
-  return getPlatformAgnosticAvailability() ==
-         PlatformAgnosticAvailabilityKind::NoAsync;
+  switch (getKind()) {
+  case Kind::Default:
+  case Kind::Deprecated:
+  case Kind::Unavailable:
+    return false;
+  case Kind::NoAsync:
+    return true;
+  }
+
+  llvm_unreachable("Unhandled AvailableAttr::Kind in switch.");
 }
 
 llvm::VersionTuple

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -109,12 +109,14 @@ namespace {
 /// The inferred availability required to access a group of declarations
 /// on a single platform.
 struct InferredAvailability {
-  PlatformAgnosticAvailabilityKind PlatformAgnostic
-    = PlatformAgnosticAvailabilityKind::None;
+  AvailableAttr::Kind Kind = AvailableAttr::Kind::Default;
 
   std::optional<llvm::VersionTuple> Introduced;
   std::optional<llvm::VersionTuple> Deprecated;
   std::optional<llvm::VersionTuple> Obsoleted;
+
+  StringRef Message;
+  StringRef Rename;
   bool IsSPI = false;
 };
 
@@ -148,10 +150,9 @@ mergeIntoInferredVersion(const std::optional<llvm::VersionTuple> &Version,
 static void mergeWithInferredAvailability(SemanticAvailableAttr Attr,
                                           InferredAvailability &Inferred) {
   auto *ParsedAttr = Attr.getParsedAttr();
-  Inferred.PlatformAgnostic = static_cast<PlatformAgnosticAvailabilityKind>(
-      std::max(static_cast<unsigned>(Inferred.PlatformAgnostic),
-               static_cast<unsigned>(
-                   ParsedAttr->getPlatformAgnosticAvailability())));
+  Inferred.Kind = static_cast<AvailableAttr::Kind>(
+      std::max(static_cast<unsigned>(Inferred.Kind),
+               static_cast<unsigned>(ParsedAttr->getKind())));
 
   // The merge of two introduction versions is the maximum of the two versions.
   if (mergeIntoInferredVersion(Attr.getIntroduced(), Inferred.Introduced,
@@ -162,21 +163,24 @@ static void mergeWithInferredAvailability(SemanticAvailableAttr Attr,
   // The merge of deprecated and obsoleted versions takes the minimum.
   mergeIntoInferredVersion(Attr.getDeprecated(), Inferred.Deprecated, std::min);
   mergeIntoInferredVersion(Attr.getObsoleted(), Inferred.Obsoleted, std::min);
+
+  if (Inferred.Message.empty() && !Attr.getMessage().empty())
+    Inferred.Message = Attr.getMessage();
+
+  if (Inferred.Rename.empty() && !Attr.getRename().empty())
+    Inferred.Rename = Attr.getRename();
 }
 
-/// Create an implicit availability attribute for the given platform
+/// Create an implicit availability attribute for the given domain
 /// and with the inferred availability.
-static AvailableAttr *createAvailableAttr(PlatformKind Platform,
+static AvailableAttr *createAvailableAttr(AvailabilityDomain Domain,
                                           const InferredAvailability &Inferred,
-                                          StringRef Message, 
-                                          StringRef Rename,
-                                          ValueDecl *RenameDecl,
                                           ASTContext &Context) {
   // If there is no information that would go into the availability attribute,
   // don't create one.
-  if (Inferred.PlatformAgnostic == PlatformAgnosticAvailabilityKind::None &&
-      !Inferred.Introduced && !Inferred.Deprecated && !Inferred.Obsoleted &&
-      Message.empty() && Rename.empty() && !RenameDecl)
+  if (Inferred.Kind == AvailableAttr::Kind::Default && !Inferred.Introduced &&
+      !Inferred.Deprecated && !Inferred.Obsoleted && Inferred.Message.empty() &&
+      Inferred.Rename.empty())
     return nullptr;
 
   llvm::VersionTuple Introduced =
@@ -186,36 +190,26 @@ static AvailableAttr *createAvailableAttr(PlatformKind Platform,
   llvm::VersionTuple Obsoleted =
       Inferred.Obsoleted.value_or(llvm::VersionTuple());
 
-  return new (Context)
-      AvailableAttr(SourceLoc(), SourceRange(), Platform, Message, Rename,
-                    Introduced, SourceRange(), Deprecated, SourceRange(),
-                    Obsoleted, SourceRange(), Inferred.PlatformAgnostic,
-                    /*Implicit=*/true, Inferred.IsSPI);
+  return new (Context) AvailableAttr(
+      SourceLoc(), SourceRange(), Domain, Inferred.Kind, Inferred.Message,
+      Inferred.Rename, Introduced, SourceRange(), Deprecated, SourceRange(),
+      Obsoleted, SourceRange(), /*Implicit=*/true, Inferred.IsSPI);
 }
 
 void AvailabilityInference::applyInferredAvailableAttrs(
     Decl *ToDecl, ArrayRef<const Decl *> InferredFromDecls) {
   auto &Context = ToDecl->getASTContext();
 
-  // Let the new AvailabilityAttr inherit the message and rename.
-  // The first encountered message / rename will win; this matches the 
-  // behaviour of diagnostics for 'non-inherited' AvailabilityAttrs.
-  StringRef Message;
-  StringRef Rename;
-  ValueDecl *RenameDecl = nullptr;
-
   // Iterate over the declarations and infer required availability on
   // a per-platform basis.
-  // FIXME: [availability] Generalize to AvailabilityDomain.
-  std::map<PlatformKind, InferredAvailability> Inferred;
+  std::map<AvailabilityDomain, InferredAvailability> Inferred;
   for (const Decl *D : InferredFromDecls) {
     llvm::SmallVector<SemanticAvailableAttr, 8> MergedAttrs;
 
     do {
       llvm::SmallVector<SemanticAvailableAttr, 8> PendingAttrs;
 
-      for (auto AvAttr :
-           D->getSemanticAvailableAttrs()) {
+      for (auto AvAttr : D->getSemanticAvailableAttrs()) {
         // Skip an attribute from an outer declaration if it is for a platform
         // that was already handled implicitly by an attribute from an inner
         // declaration.
@@ -226,14 +220,8 @@ void AvailabilityInference::applyInferredAvailableAttrs(
                          }))
           continue;
 
-        mergeWithInferredAvailability(AvAttr, Inferred[AvAttr.getPlatform()]);
+        mergeWithInferredAvailability(AvAttr, Inferred[AvAttr.getDomain()]);
         PendingAttrs.push_back(AvAttr);
-
-        if (Message.empty() && !AvAttr.getMessage().empty())
-          Message = AvAttr.getMessage();
-
-        if (Rename.empty() && !AvAttr.getRename().empty())
-          Rename = AvAttr.getRename();
       }
 
       MergedAttrs.append(PendingAttrs);
@@ -245,20 +233,12 @@ void AvailabilityInference::applyInferredAvailableAttrs(
   }
 
   DeclAttributes &Attrs = ToDecl->getAttrs();
-  auto *ToValueDecl = dyn_cast<ValueDecl>(ToDecl);
 
   // Create an availability attribute for each observed platform and add
   // to ToDecl.
   for (auto &Pair : Inferred) {
-    auto *Attr = createAvailableAttr(Pair.first, Pair.second, Message,
-                                     Rename, RenameDecl, Context);
-
-    if (Attr) {
-      if (RenameDecl && ToValueDecl)
-        ToValueDecl->setRenamedDecl(Attr, RenameDecl);
-
+    if (auto Attr = createAvailableAttr(Pair.first, Pair.second, Context))
       Attrs.add(Attr);
-    }
   }
 }
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -447,27 +447,9 @@ Decl::getSemanticAvailableAttrs(bool includeInactive) const {
 
 std::optional<SemanticAvailableAttr>
 Decl::getSemanticAvailableAttr(const AvailableAttr *attr) const {
-  auto domainForAvailableAttr = [](const AvailableAttr *attr) {
-    auto platform = attr->getPlatform();
-    if (platform != PlatformKind::none)
-      return AvailabilityDomain::forPlatform(platform);
-
-    switch (attr->getPlatformAgnosticAvailability()) {
-    case PlatformAgnosticAvailabilityKind::Deprecated:
-    case PlatformAgnosticAvailabilityKind::Unavailable:
-    case PlatformAgnosticAvailabilityKind::NoAsync:
-    case PlatformAgnosticAvailabilityKind::None:
-      return AvailabilityDomain::forUniversal();
-
-    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-      return AvailabilityDomain::forSwiftLanguage();
-
-    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-      return AvailabilityDomain::forPackageDescription();
-    }
-  };
-  return SemanticAvailableAttr(attr, domainForAvailableAttr(attr));
+  if (auto domain = attr->getCachedDomain())
+    return SemanticAvailableAttr(attr, *domain);
+  return std::nullopt;
 }
 
 std::optional<SemanticAvailableAttr>

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -31,12 +31,12 @@ llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
   switch (kind) {
   case Kind::Universal:
     return "";
-  case Kind::Platform:
-    return swift::prettyPlatformString(getPlatformKind());
   case Kind::SwiftLanguage:
     return "Swift";
   case Kind::PackageDescription:
     return "PackageDescription";
+  case Kind::Platform:
+    return swift::prettyPlatformString(getPlatformKind());
   }
 }
 
@@ -44,11 +44,11 @@ llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
   switch (kind) {
   case Kind::Universal:
     return "*";
-  case Kind::Platform:
-    return swift::platformString(getPlatformKind());
   case Kind::SwiftLanguage:
     return "swift";
   case Kind::PackageDescription:
     return "_PackageDescription";
+  case Kind::Platform:
+    return swift::platformString(getPlatformKind());
   }
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7997,13 +7997,14 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
       continue;
 
     llvm::VersionTuple NoVersion;
-    auto *attr = new (SwiftContext)
-        AvailableAttr(SourceLoc(), SourceRange(), PlatformKind::none,
-                      /*Message=*/"", /*Rename=*/"", /*Introduced=*/NoVersion,
-                      SourceRange(), /*Deprecated=*/NoVersion, SourceRange(),
-                      /*Obsoleted=*/NoVersion, SourceRange(),
-                      PlatformAgnosticAvailabilityKind::None, /*Implicit=*/true,
-                      /*SPI=*/false);
+    auto *attr = new (SwiftContext) AvailableAttr(
+        SourceLoc(), SourceRange(), AvailabilityDomain::forUniversal(),
+        AvailableAttr::Kind::Default,
+        /*Message=*/"", /*Rename=*/"", /*Introduced=*/NoVersion, SourceRange(),
+        /*Deprecated=*/NoVersion, SourceRange(),
+        /*Obsoleted=*/NoVersion, SourceRange(),
+        /*Implicit=*/true,
+        /*SPI=*/false);
 
     afd->setRenamedDecl(attr, asyncFunc);
     afd->getAttrs().add(attr);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -333,8 +333,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
 
   StringRef Message, Renamed;
   VersionArg Introduced, Deprecated, Obsoleted;
-  auto PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
-
+  auto AttrKind = AvailableAttr::Kind::Default;
   bool HasUpcomingEntry = false;
 
   {
@@ -377,24 +376,16 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
                          .Default(IsInvalid);
     }
 
-    auto platformAgnosticKindToStr = [](PlatformAgnosticAvailabilityKind kind) {
+    auto attrKindToStr = [](AvailableAttr::Kind kind) {
       switch (kind) {
-      case PlatformAgnosticAvailabilityKind::None:
-        return "none";
-      case PlatformAgnosticAvailabilityKind::Deprecated:
+      case AvailableAttr::Kind::Default:
+        return "default";
+      case AvailableAttr::Kind::Deprecated:
         return "deprecated";
-      case PlatformAgnosticAvailabilityKind::Unavailable:
+      case AvailableAttr::Kind::Unavailable:
         return "unavailable";
-      case PlatformAgnosticAvailabilityKind::NoAsync:
+      case AvailableAttr::Kind::NoAsync:
         return "noasync";
-
-      // These are possible platform agnostic availability kinds.
-      // I'm not sure what their spellings are at the moment, so I'm
-      // crashing instead of handling them.
-      case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
-      case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-      case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
-        llvm_unreachable("Unknown availability kind for parser");
       }
     };
 
@@ -471,12 +462,12 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
 
     case IsDeprecated:
       if (!findAttrValueDelimiter()) {
-        if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
+        if (AttrKind != AvailableAttr::Kind::Default) {
           diagnose(Tok, diag::attr_availability_multiple_kinds, AttrName,
-                   "deprecated", platformAgnosticKindToStr(PlatformAgnostic));
+                   "deprecated", attrKindToStr(AttrKind));
         }
 
-        PlatformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
+        AttrKind = AvailableAttr::Kind::Deprecated;
         break;
       }
       LLVM_FALLTHROUGH;
@@ -517,20 +508,21 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     }
 
     case IsUnavailable:
-      if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
+      if (AttrKind != AvailableAttr::Kind::Default) {
         diagnose(Tok, diag::attr_availability_multiple_kinds, AttrName,
-                 "unavailable", platformAgnosticKindToStr(PlatformAgnostic));
+                 "unavailable", attrKindToStr(AttrKind));
       }
 
-      PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
+      AttrKind = AvailableAttr::Kind::Unavailable;
       break;
 
     case IsNoAsync:
-      if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
+      if (AttrKind != AvailableAttr::Kind::Default) {
         diagnose(Tok, diag::attr_availability_multiple_kinds, AttrName,
-                 "noasync", platformAgnosticKindToStr(PlatformAgnostic));
+                 "noasync", attrKindToStr(AttrKind));
       }
-      PlatformAgnostic = PlatformAgnosticAvailabilityKind::NoAsync;
+
+      AttrKind = AvailableAttr::Kind::NoAsync;
       break;
 
     case IsInvalid:
@@ -551,6 +543,9 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   }
 
   auto PlatformKind = platformFromString(Platform);
+  auto Domain = (PlatformKind && *PlatformKind != PlatformKind::none)
+                    ? AvailabilityDomain::forPlatform(*PlatformKind)
+                    : AvailabilityDomain::forUniversal();
 
   // Treat 'swift' as a valid version-qualifying token, when
   // at least some versions were mentioned and no other
@@ -561,18 +556,18 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   if (!PlatformKind.has_value() &&
       (Platform == "swift" || Platform == "_PackageDescription")) {
 
-    if (PlatformAgnostic == PlatformAgnosticAvailabilityKind::Deprecated) {
+    if (AttrKind == AvailableAttr::Kind::Deprecated) {
       diagnose(AttrLoc,
                diag::attr_availability_platform_agnostic_expected_deprecated_version,
                AttrName, Platform);
       return nullptr;
     }
-    if (PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
+    if (AttrKind == AvailableAttr::Kind::Unavailable) {
       diagnose(AttrLoc, diag::attr_availability_platform_agnostic_infeasible_option,
                "unavailable", AttrName, Platform);
       return nullptr;
     }
-    assert(PlatformAgnostic == PlatformAgnosticAvailabilityKind::None);
+    assert(AttrKind == AvailableAttr::Kind::Default);
 
     if (!SomeVersion) {
       diagnose(AttrLoc, diag::attr_availability_platform_agnostic_expected_option,
@@ -581,9 +576,9 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     }
 
     PlatformKind = PlatformKind::none;
-    PlatformAgnostic = (Platform == "swift") ?
-                         PlatformAgnosticAvailabilityKind::SwiftVersionSpecific :
-                         PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific;
+    Domain = (Platform == "swift")
+                 ? AvailabilityDomain::forSwiftLanguage()
+                 : AvailabilityDomain::forPackageDescription();
   }
 
 
@@ -602,7 +597,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   }
 
   // Warn if any version is specified for non-specific platform '*'.
-  if (Platform == "*" && SomeVersion) {
+  if (Domain.isUniversal() && SomeVersion) {
     auto diag = diagnose(AttrLoc,
         diag::attr_availability_nonspecific_platform_unexpected_version,
         AttrName);
@@ -633,9 +628,9 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   }
 
   auto Attr = new (Context) AvailableAttr(
-      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), PlatformKind.value(), Message,
+      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Domain, AttrKind, Message,
       Renamed, Introduced.Version, Introduced.Range, Deprecated.Version,
-      Deprecated.Range, Obsoleted.Version, Obsoleted.Range, PlatformAgnostic,
+      Deprecated.Range, Obsoleted.Version, Obsoleted.Range,
       /*Implicit=*/false, AttrName == SPI_AVAILABLE_ATTRNAME);
   return makeParserResult(Attr);
 
@@ -875,37 +870,36 @@ bool Parser::parseAvailability(
     //   @available(_PackageDescription, introduced: 4.2)
 
     for (auto *Spec : Specs) {
-      PlatformKind Platform;
+      AvailabilityDomain Domain;
       llvm::VersionTuple Version;
       SourceRange VersionRange;
-      PlatformAgnosticAvailabilityKind PlatformAgnostic;
 
+      // FIXME: [availability] Allow arbitrary availability domains.
       if (auto *PlatformVersionSpec =
               dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec)) {
-        Platform = PlatformVersionSpec->getPlatform();
+        Domain =
+            AvailabilityDomain::forPlatform(PlatformVersionSpec->getPlatform());
         Version = PlatformVersionSpec->getVersion();
         VersionRange = PlatformVersionSpec->getVersionSrcRange();
-        PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
 
       } else if (auto *PlatformAgnosticVersionSpec = dyn_cast<
                      PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
-        Platform = PlatformKind::none;
+        Domain = PlatformAgnosticVersionSpec->isLanguageVersionSpecific()
+                     ? AvailabilityDomain::forSwiftLanguage()
+                     : AvailabilityDomain::forPackageDescription();
         Version = PlatformAgnosticVersionSpec->getVersion();
         VersionRange = PlatformAgnosticVersionSpec->getVersionSrcRange();
-        PlatformAgnostic =
-            PlatformAgnosticVersionSpec->isLanguageVersionSpecific()
-                ? PlatformAgnosticAvailabilityKind::SwiftVersionSpecific
-                : PlatformAgnosticAvailabilityKind::
-                      PackageDescriptionVersionSpecific;
 
       } else {
         continue;
       }
 
-      Version = canonicalizePlatformVersion(Platform, Version);
+      if (Domain.isPlatform())
+        Version =
+            canonicalizePlatformVersion(Domain.getPlatformKind(), Version);
 
       addAttribute(new (Context) AvailableAttr(
-          AtLoc, attrRange, Platform,
+          AtLoc, attrRange, Domain, AvailableAttr::Kind::Default,
           /*Message=*/StringRef(),
           /*Rename=*/StringRef(),
           /*Introduced=*/Version,
@@ -913,9 +907,8 @@ bool Parser::parseAvailability(
           /*Deprecated=*/llvm::VersionTuple(),
           /*DeprecatedRange=*/SourceRange(),
           /*Obsoleted=*/llvm::VersionTuple(),
-          /*ObsoletedRange=*/SourceRange(), PlatformAgnostic,
-          /*Implicit=*/false,
-          AttrName == SPI_AVAILABLE_ATTRNAME));
+          /*ObsoletedRange=*/SourceRange(),
+          /*Implicit=*/false, AttrName == SPI_AVAILABLE_ATTRNAME));
     }
 
     return true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4462,10 +4462,11 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
     if (Context.LangOpts.hasFeature(Feature::Embedded)) {
       StringRef Message = "unavailable in embedded Swift", Renamed;
       auto attr = new (Context) AvailableAttr(
-          AtLoc, SourceRange(AtLoc, attrLoc), PlatformKind::none, Message,
-          Renamed, llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
-          SourceRange(), llvm::VersionTuple(), SourceRange(),
-          PlatformAgnosticAvailabilityKind::Unavailable,
+          AtLoc, SourceRange(AtLoc, attrLoc),
+          AvailabilityDomain::forUniversal(), AvailableAttr::Kind::Unavailable,
+          Message, Renamed, llvm::VersionTuple(), SourceRange(),
+          llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
+          SourceRange(),
           /*Implicit=*/false, /*IsSPI=*/false, /*IsForEmbedded=*/true);
       Attributes.add(attr);
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6654,12 +6654,13 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
         continue;
 
       auto attr = new (ctx) AvailableAttr(
-          SourceLoc(), SourceRange(), available.getPlatform(),
-          available.getMessage(),
+          SourceLoc(), SourceRange(),
+          AvailabilityDomain::forPlatform(available.getPlatform()),
+          AvailableAttr::Kind::Unavailable, available.getMessage(),
           /*Rename=*/"", available.getIntroduced().value_or(noVersion),
           SourceRange(), available.getDeprecated().value_or(noVersion),
           SourceRange(), available.getObsoleted().value_or(noVersion),
-          SourceRange(), PlatformAgnosticAvailabilityKind::Unavailable,
+          SourceRange(),
           /*Implicit=*/true, available.getParsedAttr()->isSPI());
       ext->getAttrs().add(attr);
       anyPlatformSpecificAttrs = true;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3078,7 +3078,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           LIST_VER_TUPLE_PIECES(Introduced),
           LIST_VER_TUPLE_PIECES(Deprecated),
           LIST_VER_TUPLE_PIECES(Obsoleted),
-          static_cast<unsigned>(theAttr->getPlatform()),
+          static_cast<unsigned>(domain->getPlatformKind()),
           theAttr->Message.size(),
           theAttr->Rename.size(),
           blob);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3058,10 +3058,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       assert(theAttr->Rename.empty() || !theAttr->hasCachedRenamedDecl());
 
-      bool isPackageDescriptionVersionSpecific =
-          theAttr->getPlatformAgnosticAvailability() ==
-          PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific;
+      auto domain = theAttr->getCachedDomain();
+      assert(domain);
 
+      // FIXME: [availability] Serialize domain and kind directly.
       llvm::SmallString<32> blob;
       blob.append(theAttr->Message);
       blob.append(theAttr->Rename);
@@ -3072,7 +3072,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isUnconditionallyUnavailable(),
           theAttr->isUnconditionallyDeprecated(),
           theAttr->isNoAsync(),
-          isPackageDescriptionVersionSpecific,
+          domain->isPackageDescription(),
           theAttr->isSPI(),
           theAttr->isForEmbedded(),
           LIST_VER_TUPLE_PIECES(Introduced),

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -39,6 +39,20 @@ public actor UnavailableActor {
   // CHECK-NEXT: }
 }
 
+// CHECK:      @_hasMissingDesignatedInitializers @available(*, deprecated, message: "Will be unavailable Swift 6")
+// CHECK-NEXT: @available(swift, obsoleted: 6)
+// CHECK-NEXT: public actor DeprecatedAndObsoleteInSwift6Actor {
+@available(*, deprecated, message: "Will be unavailable Swift 6")
+@available(swift, obsoleted: 6)
+public actor DeprecatedAndObsoleteInSwift6Actor {
+  // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  // CHECK-NEXT: @available(*, deprecated, message: "Will be unavailable Swift 6")
+  // CHECK-NEXT: @available(swift, obsoleted: 6)
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+}
+
 // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
 // CHECK-NEXT: public enum Enum {
 @available(SwiftStdlib 5.2, *)


### PR DESCRIPTION
Replace the `PlatformKind` and `PlatformAgnosticAvailabilityKind` properties of `AvailableAttr` with `AvailabilityDomain` and `AvailableAttr::Kind`. This will allow `@available` attributes to model availability for arbitrary domains, instead of just a predefined set of platforms plus the `swift` and `_PackageDescription` domains. Since resolving the domain specified by an attribute may require performing a name lookup in the future, `getCachedDomain()` returns an optional even though currently the domain is always fully resolved during parsing.

This PR is mostly NFC, with two notable exceptions:
- The `ASTDumper` output for `AvailableAttr` has been corrected and expanded.
- Availability attribute inference has been improved to handle non-platform-specific availability more gracefully because it was more difficult to preserve the existing, buggy behavior. A new test covers a case that was previously poorly tested and generated bad implicit `@available` attributes but now generates correct ones. 