### PR TITLE
[stdlib] loading a reference can’t use `loadUnaligned`

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -586,7 +586,7 @@ extension _ArrayBuffer {
       _storage.objCInstance,
       _ArrayBuffer.associationKey
     ) {
-      let buffer = assocPtr.loadUnaligned(
+      let buffer = assocPtr.load(
         as: _ContiguousArrayStorage<Element>.self
       )
       return _ContiguousArrayBuffer(buffer)


### PR DESCRIPTION
Change a mistaken use of `loadUnaligned` to just `load`. The source pointer must be aligned for a reference, since it's either typed as an `Any` or an `AnyObject` in the Objective-C runtime interface.

This is a fix for the issue mentioned in https://github.com/swiftlang/swift/pull/78452#issuecomment-2583099073