### PR TITLE
embedded: make sure to generate witness tables which are imported from other modules

### DIFF
--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -92,7 +92,7 @@ class IRGenPrepare : public SILFunctionTransform {
       // Even de-serialized functions must be code-gen'd.
       SILLinkage linkage = F->getLinkage();
       if (isAvailableExternally(linkage)) {
-        F->setLinkage(stripExternalFromLinkage(linkage));
+        F->setLinkage(SILLinkage::Hidden);
       }
     }
 

--- a/test/embedded/modules-class-bound-existential.swift
+++ b/test/embedded/modules-class-bound-existential.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+public protocol Foo: AnyObject {
+  func run()
+}
+
+public class Hello: Foo {
+  public init() {}
+  public func run() {
+    print("Hello from MyLibrary!")
+  }
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+@main
+struct MyApp {
+  static func main() {
+    let ex: Foo = Hello()
+    print("Hello from main!")
+    ex.run()
+  }
+}
+
+// CHECK: Hello from main!


### PR DESCRIPTION
In embedded swift all the code is generated in the top-level module. De-serialized tables must be code-gen'd and therefore made non-external.

This also requires another change: in IRGen, don't force generate code for functions which are imported from other modules.

Only generate code lazily for such functions, i.e. only if such a function is referenced from already generated code.
This is achieved by converting the SILLinkage for `public_external` functions to `internal` instead of `public` in IRGenPrepare.

Fixes an unresolved symbol linker error.
rdar://142561676
