### PR TITLE
Don't look through ownership instructions during CSE

### DIFF
--- a/test/SILOptimizer/cse_apply_ossa.sil
+++ b/test/SILOptimizer/cse_apply_ossa.sil
@@ -148,8 +148,8 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @apply_nontrivial_test1 :
-// CHECK: apply
-// CHECK-NOT: apply
+// TODO-CHECK: apply
+// TODO-CHECK-NOT: apply
 // CHECK-LABEL:} // end sil function 'apply_nontrivial_test1'
 sil [ossa] @apply_nontrivial_test1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -185,8 +185,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @apply_nontrivial_test3 :
-// CHECK: apply
-// CHECK-NOT: apply
+// TODO-CHECK: apply
+// TODO-CHECK-NOT: apply
 // CHECK-LABEL:} // end sil function 'apply_nontrivial_test3'
 sil [ossa] @apply_nontrivial_test3 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):

--- a/test/SILOptimizer/cse_forwarding_ossa.sil
+++ b/test/SILOptimizer/cse_forwarding_ossa.sil
@@ -12,8 +12,8 @@ struct NonTrivialStruct {
 }
 
 // CHECK-LABEL: sil [ossa] @cse_copy_upcast1 :
-// CHECK: upcast
-// CHECK-NOT: upcast 
+// TODO-CHECK: upcast
+// TODO-CHECK-NOT: upcast 
 // CHECK-LABEL: } // end sil function 'cse_copy_upcast1'
 sil [ossa] @cse_copy_upcast1 : $@convention(thin) (@owned Klass) -> @owned (SuperKlass, SuperKlass) {
 bb0(%0 : @owned $Klass):
@@ -25,8 +25,8 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_copy_upcast2 :
-// CHECK: upcast
-// CHECK-NOT: upcast 
+// TODO-CHECK: upcast
+// TODO-CHECK-NOT: upcast 
 // CHECK-LABEL: } // end sil function 'cse_copy_upcast2'
 sil [ossa] @cse_copy_upcast2 : $@convention(thin) (@owned Klass) -> @owned (SuperKlass, SuperKlass) {
 bb0(%0 : @owned $Klass):
@@ -38,8 +38,8 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_copy_upcast3 :
-// CHECK: upcast
-// CHECK-NOT: upcast 
+// TODO-CHECK: upcast
+// TODO-CHECK-NOT: upcast 
 // CHECK-LABEL: } // end sil function 'cse_copy_upcast3'
 sil [ossa] @cse_copy_upcast3 : $@convention(thin) (@owned Klass) -> @owned (SuperKlass, SuperKlass) {
 bb0(%0 : @owned $Klass):
@@ -140,8 +140,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_copy_unchecked_ref_cast : 
-// CHECK: unchecked_ref_cast
-// CHECK-NOT: unchecked_ref_cast 
+// TODO-CHECK: unchecked_ref_cast
+// TODO-CHECK-NOT: unchecked_ref_cast 
 // CHECK-LABEL: } // end sil function 'cse_copy_unchecked_ref_cast'
 sil [ossa] @cse_copy_unchecked_ref_cast : $@convention(thin) (@owned Klass) -> @owned (SuperKlass, SuperKlass) {
 bb0(%0 : @owned $Klass):
@@ -205,8 +205,8 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_borrow_upcast : 
-// CHECK: upcast
-// CHECK-NOT: upcast 
+// TODO-CHECK: upcast
+// TODO-CHECK-NOT: upcast 
 // CHECK-LABEL: } // end sil function 'cse_borrow_upcast'
 sil [ossa] @cse_borrow_upcast : $@convention(thin) (@owned Klass) -> @owned (SuperKlass, SuperKlass) {
 bb0(%0 : @owned $Klass):

--- a/test/SILOptimizer/cse_objc_ossa.sil
+++ b/test/SILOptimizer/cse_objc_ossa.sil
@@ -327,10 +327,10 @@ sil_vtable Bar {
 }
 
 // CHECK-LABEL: sil [ossa] @cse_value_metatype2 :
-// CHECK: value_metatype $@objc_metatype
-// CHECK: objc_metatype_to_object
-// CHECK-NOT: value_metatype $@objc_metatype
-// CHECK: destroy_value 
+// TODO-CHECK: value_metatype $@objc_metatype
+// TODO-CHECK: objc_metatype_to_object
+// TODO-CHECK-NOT: value_metatype $@objc_metatype
+// TODO-CHECK: destroy_value 
 // CHECK-LABEL: } // end sil function 'cse_value_metatype2'
 sil [ossa] @cse_value_metatype2 : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned (AnyObject, AnyObject) {
 bb0(%0 : @owned $T):
@@ -346,10 +346,10 @@ bb0(%0 : @owned $T):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_existential_metatype2 :
-// CHECK: existential_metatype $@objc_metatype
-// CHECK: objc_existential_metatype_to_object
-// CHECK-NOT: existential_metatype $@objc_metatype
-// CHECK: destroy_value 
+// TODO-CHECK: existential_metatype $@objc_metatype
+// TODO-CHECK: objc_existential_metatype_to_object
+// TODO-CHECK-NOT: existential_metatype $@objc_metatype
+// TODO-CHECK: destroy_value 
 // CHECK-LABEL: } // end sil function 'cse_existential_metatype2'
 sil [ossa] @cse_existential_metatype2 : $@convention(thin) (@owned XX) -> @owned (AnyObject, AnyObject) {
 bb0(%0 : @owned $XX):

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1275,8 +1275,8 @@ bb0(%0 : $LazyKlass):
 }
 
 // CHECK-LABEL: sil [ossa] @test_end_lifetime :
-// CHECK:       upcast
-// CHECK-NOT:   upcast
+// TODO:       upcast
+// TODO-NOT:   upcast
 // CHECK: } // end sil function 'test_end_lifetime'
 sil [ossa] @test_end_lifetime : $@convention(method) (@owned E) -> () {
 bb0(%0 : @owned $E):

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -59,8 +59,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @structliteral2 :
-// CHECK: struct $NonTrivialStruct
-// CHECK-NOT: struct $NonTrivialStruct
+// TODO-CHECK: struct $NonTrivialStruct
+// TODO-CHECK-NOT: struct $NonTrivialStruct
 // CHECK-LABEL: } // end sil function 'structliteral2'
 sil [ossa] @structliteral2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -126,8 +126,8 @@ sil [ossa] @tuple_function1 : $@convention(thin) (@owned (Klass, Klass), @owned 
 sil [ossa] @tuple_function2 : $@convention(thin) (@guaranteed (Klass, Klass), @guaranteed (Klass, Klass)) -> @owned (Klass)
 
 // CHECK-LABEL: sil [ossa] @tuple_test1 :
-// CHECK: tuple ({{%[0-9]+}} : $Klass, {{%[0-9]+}} : $Klass)
-// CHECK-NOT: tuple ({{%[0-9]+}} : $Klass, {{%[0-9]+}} : $Klass)
+// TODO-CHECK: tuple ({{%[0-9]+}} : $Klass, {{%[0-9]+}} : $Klass)
+// TODO-CHECK-NOT: tuple ({{%[0-9]+}} : $Klass, {{%[0-9]+}} : $Klass)
 // CHECK-LABEL: } // end sil function 'tuple_test1'
 sil [ossa] @tuple_test1 : $@convention(thin) (@owned Klass, @owned Klass) -> @owned (Klass) {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
@@ -436,8 +436,8 @@ bb0(%0 : @guaranteed $(Klass, Klass)):
 
 
 // CHECK-LABEL: sil [ossa] @struct_test2 :
-// CHECK: struct $NonTrivialStruct
-// CHECK-NOT: struct $NonTrivialStruct
+// TODO-CHECK: struct $NonTrivialStruct
+// TODO-CHECK-NOT: struct $NonTrivialStruct
 // CHECK-LABEL: } // end sil function 'struct_test2'
 sil [ossa] @struct_test2 : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
 bb0(%0 : @guaranteed $Klass):
@@ -451,8 +451,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @struct_test3 :
-// CHECK: struct $NonTrivialStruct
-// CHECK-NOT: struct $NonTrivialStruct
+// TODO-CHECK: struct $NonTrivialStruct
+// TODO-CHECK-NOT: struct $NonTrivialStruct
 // CHECK-LABEL: } // end sil function 'struct_test3'
 sil [ossa] @struct_test3 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
@@ -486,8 +486,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @struct_test5 :
-// CHECK: struct $NonTrivialStruct
-// CHECK-NOT: struct $NonTrivialStruct
+// TODO-CHECK: struct $NonTrivialStruct
+// TODO-CHECK-NOT: struct $NonTrivialStruct
 // CHECK-LABEL: } // end sil function 'struct_test5'
 sil [ossa] @struct_test5 : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
 bb0(%0 : @guaranteed $Klass):
@@ -501,8 +501,8 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @struct_extract_test1 :
-// CHECK:       struct_extract
-// CHECK-NOT:   struct_extract
+// TODO-CHECK:       struct_extract
+// TODO-CHECK-NOT:   struct_extract
 // CHECK-LABEL: } // end sil function 'struct_extract_test1'
 sil [ossa] @struct_extract_test1 : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
 bb0(%0 : @owned $NonTrivialStruct):
@@ -641,10 +641,10 @@ bb3(%borrow : @guaranteed $Klass):
 // Test to make sure we clear the context if we fail while checking if ownership rauw is possible
 // CHECK-LABEL: sil [ossa] @test_rauwfailsandthensucceeds :
 // CHECK: bb0
-// CHECK: struct_extract
-// CHECK: struct_extract
-// CHECK: struct $_SliceBuffer
-// CHECK-NOT: struct $_SliceBuffer
+// TODO-CHECK: struct_extract
+// TODO-CHECK: struct_extract
+// TODO-CHECK: struct $_SliceBuffer
+// TODO-CHECK-NOT: struct $_SliceBuffer
 // CHECK-LABEL: } // end sil function 'test_rauwfailsandthensucceeds'
 sil [ossa] @test_rauwfailsandthensucceeds : $@convention(method) <Element> (UnsafeMutablePointer<Element>, @guaranteed _ContiguousArrayBuffer<Element>, Int, UInt) -> @owned _SliceBuffer<Element> {
 bb0(%0 : $UnsafeMutablePointer<Element>, %1 : @guaranteed $_ContiguousArrayBuffer<Element>, %2 : $Int, %3 : $UInt):
@@ -705,8 +705,8 @@ sil [ossa] @use_object : $@convention(thin) (@inout Builtin.NativeObject) -> ()
 
 // CHECK-LABEL: sil [ossa] @test_refelementaddr :
 // CHECK: bb0
-// CHECK: ref_element_addr
-// CHECK-NOT: ref_element_addr
+// TODO-CHECK: ref_element_addr
+// TODO-CHECK-NOT: ref_element_addr
 // CHECK-LABEL: } // end sil function 'test_refelementaddr'
 sil [ossa] @test_refelementaddr : $@convention(thin) (@guaranteed WrapperKlass) -> () {
 bb0(%0 : @guaranteed $WrapperKlass):
@@ -799,8 +799,8 @@ bb0(%0 : @guaranteed $WrapperKlass):
 }
 
 // CHECK-LABEL: sil [ossa] @cse_upcast_loop :
-// CHECK: upcast
-// CHECK-NOT: upcast
+// TODO-CHECK: upcast
+// TODO-CHECK-NOT: upcast
 // CHECK-LABEL: } // end sil function 'cse_upcast_loop'
 sil [ossa] @cse_upcast_loop : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -826,9 +826,9 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @cse_select_enum2 :
-// CHECK: select_enum
-// CHECK-NOT: select_enum
-// CHECK: tuple
+// TODO-CHECK: select_enum
+// TODO-CHECK-NOT: select_enum
+// TODO-CHECK: tuple
 // CHECK-LABEL: } // end sil function 'cse_select_enum2'
 sil [ossa] @cse_select_enum2 : $@convention(thin) (@guaranteed FakeOptional) -> (Builtin.Int1, Builtin.Int1) {
 bb0(%0 : @guaranteed $FakeOptional):
@@ -843,8 +843,8 @@ bb0(%0 : @guaranteed $FakeOptional):
 }
 
 // CHECK-LABEL: sil [ossa] @enum_cse2 :
-// CHECK: enum $FakeOptional, #FakeOptional.some!enumelt
-// CHECK-NOT: enum $FakeOptional, #FakeOptional.some!enumelt
+// TODO-CHECK: enum $FakeOptional, #FakeOptional.some!enumelt
+// TODO-CHECK-NOT: enum $FakeOptional, #FakeOptional.some!enumelt
 // CHECK-LABEL: } // end sil function 'enum_cse2'
 sil [ossa] @enum_cse2 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
@@ -1033,3 +1033,50 @@ bb0(%0 : @owned $_NativeDictionary<Int, Klass>):
   destroy_value %49
   unreachable
 }
+
+// Both CopyPropagation and CopyToBorrow cannot eliminate the copy generated by
+// OSSA RAUW if we look through ownership instructions while CSE'ing
+// CHECK-LABEL: sil [ossa] @struct_copy_test1 :
+// CHECK: struct_extract
+// CHECK: struct_extract
+// CHECK-LABEL: } // end sil function 'struct_copy_test1'
+sil [ossa] @struct_copy_test1 : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %f = function_ref @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+  %b1 = begin_borrow %0
+  %ex1 = struct_extract %b1, #NonTrivialStruct.val
+  apply %f(%ex1) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b1
+  %b2 = begin_borrow %0
+  %ex2 = struct_extract %b2, #NonTrivialStruct.val
+  apply %f(%ex2) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b2
+  destroy_value %0 : $NonTrivialStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// Both CopyPropagation and CopyToBorrow cannot eliminate the copy generated by
+// OSSA RAUW if we look through ownership instructions while CSE'ing
+// CHECK-LABEL: sil [ossa] @struct_copy_test2 :
+// CHECK: struct_extract
+// CHECK: struct_extract
+// CHECK-LABEL: } // end sil function 'struct_copy_test2'
+sil [ossa] @struct_copy_test2 : $@convention(thin) () -> () {
+bb0:
+  %f1 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %0 = apply %f1() : $@convention(thin) () -> @owned NonTrivialStruct
+  %f2 = function_ref @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+  %b1 = begin_borrow %0
+  %ex1 = struct_extract %b1, #NonTrivialStruct.val
+  apply %f2(%ex1) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b1
+  %b2 = begin_borrow %0
+  %ex2 = struct_extract %b2, #NonTrivialStruct.val
+  apply %f2(%ex2) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b2
+  destroy_value %0 : $NonTrivialStruct
+  %res = tuple ()
+  return %res : $()
+}
+


### PR DESCRIPTION
OSSA rauw creates copies in a lot of cases. Several of these copies cannot be eliminated due to escapes, unimplemeneted optimization edge cases etc.

This can be an issue for performance parity with non-ossa

Disable looking through ownership instructions to avoid copies created by OSSA rauw.

This can be revisited if we rewrite OSSA rauw to not create copies.

This has no -ve effect on microbenchmarks with -enable-ossa-modules on by default.

rdar://139773406

