### PR TITLE
[DebugInfo] Add PrettyStackTrace when creating DI types and processing globals

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3705,7 +3705,8 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
   if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::LineTables)
     return;
 
-  PrettyStackTraceStringAction trace("emitting global", Var->getName());
+  PrettyStackTraceStringAction trace("emitting global",
+                                     Var ? Var->getName() : Name);
 
   llvm::DIType *DITy = getOrCreateType(DbgTy);
   VarDecl *VD = nullptr;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -38,6 +38,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -1766,6 +1767,8 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
 
   llvm::DIType *createType(DebugTypeInfo DbgTy, StringRef MangledName,
                            llvm::DIScope *Scope, llvm::DIFile *File) {
+    PrettyStackTraceStringAction trace("creating debug info type", MangledName);
+
     // FIXME: For SizeInBits, clang uses the actual size of the type on
     // the target machine instead of the storage size that is alloca'd
     // in the LLVM IR. For all types that are boxed in a struct, we are
@@ -3701,6 +3704,8 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
     DebugTypeInfo DbgTy, bool IsLocalToUnit, std::optional<SILLocation> Loc) {
   if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::LineTables)
     return;
+
+  PrettyStackTraceStringAction trace("emitting global", Var->getName());
 
   llvm::DIType *DITy = getOrCreateType(DbgTy);
   VarDecl *VD = nullptr;


### PR DESCRIPTION
I have recently hit a crasher in IRGenDebugInfo.cpp and the crash stack trace didn't really suggest which variable or type is problematic. Let's add some PrettyStackTrace entries.