### PR TITLE
Fix SILGenFunction::emitValueConstructor for library evolution.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -773,15 +773,14 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     
     auto cleanupLoc = CleanupLocation(ctor);
 
+    if (selfLV.getType().isMoveOnly()) {
+      selfLV = B.createMarkUnresolvedNonCopyableValueInst(
+        cleanupLoc, selfLV,
+        MarkUnresolvedNonCopyableValueInst::CheckKind::
+        AssignableButNotConsumable);
+    }
     if (!F.getConventions().hasIndirectSILResults()) {
       // Otherwise, load and return the final 'self' value.
-      if (selfLV.getType().isMoveOnly()) {
-        selfLV = B.createMarkUnresolvedNonCopyableValueInst(
-            cleanupLoc, selfLV,
-            MarkUnresolvedNonCopyableValueInst::CheckKind::
-                AssignableButNotConsumable);
-      }
-
       selfValue = lowering.emitLoad(B, cleanupLoc, selfLV.getValue(),
                                     LoadOwnershipQualifier::Copy);
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -106,3 +106,16 @@ func useUsableFromInlineTestKlass() {
     let k = UsableFromInlineTestKlass()
     k.e = E()
 }
+
+// rdar://142690658 (In ~Copyable public struct, an init with COW type param causes compiler error)
+//
+// CHECK-LABEL: sil hidden [ossa] @$s26moveonly_library_evolution19NonCopyableWithInitV1sACSS_tcfC :
+// CHECK-SAME: $@convention(method) (@owned String, @thin NonCopyableWithInit.Type) -> @out NonCopyableWithInit {
+// CHECK: bb0(%0 : $*NonCopyableWithInit, %1 : @owned $String, %2 : $@thin NonCopyableWithInit.Type):
+// CHECK:   [[BOX:%.*]] = project_box %{{.*}}, 0
+// CHECK:   store %{{.*}} to [init] [[BOX]]
+// CHECK:   [[MD:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[BOX]]
+// CHECK:   copy_addr [[MD]] to [init] %0
+public struct NonCopyableWithInit: ~Copyable {
+  init(s: String) {}
+}


### PR DESCRIPTION
Always call createMarkUnresolvedNonCopyableValueInst for a constructor with move-only 'self'. Handle 'self' that is either returned by value or as an indirect result

Fixes rdar://142690658 (In ~Copyable public struct, an init with COW type param causes compiler error)
