### PR TITLE
[6.1] Fix SILGenFunction::emitValueConstructor for library evolution.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -772,15 +772,14 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     
     auto cleanupLoc = CleanupLocation(ctor);
 
+    if (selfLV.getType().isMoveOnly()) {
+      selfLV = B.createMarkUnresolvedNonCopyableValueInst(
+        cleanupLoc, selfLV,
+        MarkUnresolvedNonCopyableValueInst::CheckKind::
+        AssignableButNotConsumable);
+    }
     if (!F.getConventions().hasIndirectSILResults()) {
       // Otherwise, load and return the final 'self' value.
-      if (selfLV.getType().isMoveOnly()) {
-        selfLV = B.createMarkUnresolvedNonCopyableValueInst(
-            cleanupLoc, selfLV,
-            MarkUnresolvedNonCopyableValueInst::CheckKind::
-                AssignableButNotConsumable);
-      }
-
       selfValue = lowering.emitLoad(B, cleanupLoc, selfLV.getValue(),
                                     LoadOwnershipQualifier::Copy);
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -106,3 +106,16 @@ func useUsableFromInlineTestKlass() {
     let k = UsableFromInlineTestKlass()
     k.e = E()
 }
+
+// rdar://142690658 (In ~Copyable public struct, an init with COW type param causes compiler error)
+//
+// CHECK-LABEL: sil hidden [ossa] @$s26moveonly_library_evolution19NonCopyableWithInitV1sACSS_tcfC :
+// CHECK-SAME: $@convention(method) (@owned String, @thin NonCopyableWithInit.Type) -> @out NonCopyableWithInit {
+// CHECK: bb0(%0 : $*NonCopyableWithInit, %1 : @owned $String, %2 : $@thin NonCopyableWithInit.Type):
+// CHECK:   [[BOX:%.*]] = project_box %{{.*}} : ${ var NonCopyableWithInit }, 0
+// CHECK:   store %{{.*}} to [init] [[BOX]]
+// CHECK:   [[MD:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[BOX]]
+// CHECK:   copy_addr [[MD]] to [init] %0
+public struct NonCopyableWithInit: ~Copyable {
+  init(s: String) {}
+}


### PR DESCRIPTION
Always call createMarkUnresolvedNonCopyableValueInst for a constructor with move-only 'self'. Handle 'self' that is either returned by value or as an indirect result

Fixes rdar://142690658 (In ~Copyable public struct, an init with COW type param causes compiler error)

(cherry picked from commit f05a8fa33b9a66e0524c05165044bbca6ae87711)

Explanation: Incorrect SIL is generated for a ~Copyable type's initializer resulting in the error: "Copy of noncopyable typed value". This appears to be an oversight in SILGen. A marker instruction needs to be emitted to trigger move checking. Otherwise, SIL contains a copy of the ~Copyable type.

Scope: In 6.1, for release compilers, with -enable-library-evolution, this error occurs for any public ~Copyable type with an initializer.

Radar/SR Issue: rdar://142690658 (In ~Copyable public struct, an init with COW type param causes compiler error)

Original PR: https://github.com/swiftlang/swift/pull/78568

Risk: Low. The affected SILGen path already generates a compiler error.

Testing: Source-level unit test.

Reviewer: @jckarter 

