### PR TITLE
[Swiftify] Add return pointer support

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8702,7 +8702,9 @@ public:
 
   void printNonEscaping(int idx) {
     printSeparator();
-    out << ".nonescaping(pointer: " << idx << ")";
+    out << ".nonescaping(pointer: ";
+    printParamOrReturn(idx);
+    out << ")";
   }
 
   void printTypeMapping(const llvm::StringMap<std::string> &mapping) {
@@ -8759,7 +8761,7 @@ void ClangImporter::Implementation::importSpanAttributes(FuncDecl *MappedDecl) {
       if (decl->getName() != "span")
         continue;
       if (param->hasAttr<clang::NoEscapeAttr>()) {
-        printer.printNonEscaping(index + 1);
+        printer.printNonEscaping(index);
         clang::PrintingPolicy policy(param->getASTContext().getLangOpts());
         policy.SuppressTagKeyword = true;
         auto param = MappedDecl->getParameters()->get(index);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8678,7 +8678,7 @@ public:
   ~SwiftifyInfoPrinter() { out << ")"; }
 
   void printCountedBy(const clang::CountAttributedType *CAT,
-                      size_t pointerIndex) {
+                      ssize_t pointerIndex) {
     printSeparator();
     clang::Expr *countExpr = CAT->getCountExpr();
     bool isSizedBy = CAT->isCountInBytes();
@@ -8687,7 +8687,9 @@ public:
       out << "sizedBy";
     else
       out << "countedBy";
-    out << "(pointer: " << pointerIndex + 1 << ", ";
+    out << "(pointer: ";
+    printParamOrReturn(pointerIndex);
+    out << ", ";
     if (isSizedBy)
       out << "size";
     else
@@ -8723,6 +8725,13 @@ private:
     } else {
       firstParam = false;
     }
+  }
+
+  void printParamOrReturn(ssize_t pointerIndex) {
+    if (pointerIndex == -1)
+      out << ".return";
+    else
+      out << ".param(" << pointerIndex + 1 << ")";
   }
 };
 } // namespace
@@ -8786,6 +8795,10 @@ void ClangImporter::Implementation::importBoundsAttributes(
       if (auto CAT = param->getType()->getAs<clang::CountAttributedType>()) {
         printer.printCountedBy(CAT, index);
       }
+    }
+    if (auto CAT =
+            ClangDecl->getReturnType()->getAs<clang::CountAttributedType>()) {
+      printer.printCountedBy(CAT, -1);
     }
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2329,7 +2329,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
                        : ImportTypeKind::Result),
       ImportDiagnosticAdder(*this, clangDecl, clangDecl->getLocation()),
       allowNSUIntegerAsInt, Bridgeability::Full, getImportTypeAttrs(clangDecl),
-      OptionalityOfReturn, isBoundsAnnotated);
+      OptionalityOfReturn, true, std::nullopt, isBoundsAnnotated);
 }
 
 static Type

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -68,11 +68,12 @@ struct CxxSpan: ParamInfo {
   ) -> BoundsCheckedThunkBuilder {
     switch pointerIndex {
     case .param(let i):
-    CxxSpanThunkBuilder(base: base, index: i - 1, signature: funcDecl.signature,
-      typeMappings: typeMappings, node: original, nonescaping: nonescaping)
+      return CxxSpanThunkBuilder(base: base, index: i - 1, signature: funcDecl.signature,
+        typeMappings: typeMappings, node: original, nonescaping: nonescaping)
     case .return:
-    CxxSpanThunkBuilder(base: base, index: -1, signature: funcDecl.signature,
-      typeMappings: typeMappings, node: original, nonescaping: nonescaping)
+      // TODO: actually implement std::span in return position
+      return CxxSpanThunkBuilder(base: base, index: -1, signature: funcDecl.signature,
+        typeMappings: typeMappings, node: original, nonescaping: nonescaping)
     }
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -4,10 +4,27 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
+// avoids depending on SwiftifyImport.swift
+// all instances are reparsed and reinstantiated by the macro anyways,
+// so linking is irrelevant
+enum SwiftifyExpr {
+  case param(_ index: Int)
+  case `return`
+}
+
+extension SwiftifyExpr: CustomStringConvertible {
+  var description: String {
+    switch self {
+    case .param(let index): return ".param(\(index))"
+    case .return: return ".return"
+    }
+  }
+}
+
 protocol ParamInfo: CustomStringConvertible {
   var description: String { get }
   var original: SyntaxProtocol { get }
-  var pointerIndex: Int { get }
+  var pointerIndex: SwiftifyExpr { get }
   var nonescaping: Bool { get set }
 
   func getBoundsCheckedThunkBuilder(
@@ -16,8 +33,27 @@ protocol ParamInfo: CustomStringConvertible {
   ) -> BoundsCheckedThunkBuilder
 }
 
+func tryGetParamName(_ funcDecl: FunctionDeclSyntax, _ expr: SwiftifyExpr) -> TokenSyntax? {
+  switch expr {
+  case .param(let i):
+    let funcParam = getParam(funcDecl, i - 1)
+    return funcParam.secondName ?? funcParam.firstName
+  default: return nil
+  }
+}
+
+func getSwiftifyExprType(_ funcDecl: FunctionDeclSyntax, _ expr: SwiftifyExpr) -> TypeSyntax {
+  switch expr {
+  case .param(let i):
+    let funcParam = getParam(funcDecl, i - 1)
+    return funcParam.type
+  case .return:
+    return funcDecl.signature.returnClause!.type
+  }
+}
+
 struct CxxSpan: ParamInfo {
-  var pointerIndex: Int
+  var pointerIndex: SwiftifyExpr
   var nonescaping: Bool
   var original: SyntaxProtocol
   var typeMappings: [String: String]
@@ -30,13 +66,19 @@ struct CxxSpan: ParamInfo {
     _ base: BoundsCheckedThunkBuilder, _ funcDecl: FunctionDeclSyntax,
     _ variant: Variant
   ) -> BoundsCheckedThunkBuilder {
-    CxxSpanThunkBuilder(base: base, index: pointerIndex - 1, signature: funcDecl.signature, 
+    switch pointerIndex {
+    case .param(let i):
+    CxxSpanThunkBuilder(base: base, index: i - 1, signature: funcDecl.signature,
       typeMappings: typeMappings, node: original)
+    case .return:
+    CxxSpanThunkBuilder(base: base, index: -1, signature: funcDecl.signature,
+      typeMappings: typeMappings, node: original)
+    }
   }
 }
 
 struct CountedBy: ParamInfo {
-  var pointerIndex: Int
+  var pointerIndex: SwiftifyExpr
   var count: ExprSyntax
   var sizedBy: Bool
   var nonescaping: Bool
@@ -53,37 +95,18 @@ struct CountedBy: ParamInfo {
     _ base: BoundsCheckedThunkBuilder, _ funcDecl: FunctionDeclSyntax,
     _ variant: Variant
   ) -> BoundsCheckedThunkBuilder {
-    let funcParam = getParam(funcDecl, pointerIndex - 1)
-    let paramName = funcParam.secondName ?? funcParam.firstName
-    let isNullable = funcParam.type.is(OptionalTypeSyntax.self)
-    return CountedOrSizedPointerThunkBuilder(
-      base: base, index: pointerIndex - 1, countExpr: count,
-      name: paramName, nullable: isNullable, signature: funcDecl.signature,
-      nonescaping: nonescaping, isSizedBy: sizedBy)
-  }
-}
-
-struct EndedBy: ParamInfo {
-  var pointerIndex: Int
-  var endIndex: Int
-  var nonescaping: Bool
-  var original: SyntaxProtocol
-
-  var description: String {
-    return ".endedBy(start: \(pointerIndex), end: \(endIndex), nonescaping: \(nonescaping))"
-  }
-
-  func getBoundsCheckedThunkBuilder(
-    _ base: BoundsCheckedThunkBuilder, _ funcDecl: FunctionDeclSyntax,
-    _ variant: Variant
-  ) -> BoundsCheckedThunkBuilder {
-    let funcParam = getParam(funcDecl, pointerIndex - 1)
-    let paramName = funcParam.secondName ?? funcParam.firstName
-    let isNullable = funcParam.type.is(OptionalTypeSyntax.self)
-    return EndedByPointerThunkBuilder(
-      base: base, startIndex: pointerIndex - 1, endIndex: endIndex - 1,
-      name: paramName, nullable: isNullable, signature: funcDecl.signature, nonescaping: nonescaping
-    )
+    switch pointerIndex {
+    case .param(let i):
+      return CountedOrSizedPointerThunkBuilder(
+        base: base, index: i-1, countExpr: count,
+        signature: funcDecl.signature,
+        nonescaping: nonescaping, isSizedBy: sizedBy, variant: variant)
+    case .return:
+      return CountedOrSizedReturnPointerThunkBuilder(
+        base: base, countExpr: count,
+        signature: funcDecl.signature,
+        nonescaping: nonescaping, isSizedBy: sizedBy, variant: variant)
+    }
   }
 }
 
@@ -229,9 +252,9 @@ struct Variant {
 }
 
 protocol BoundsCheckedThunkBuilder {
-  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax], _ variant: Variant) throws -> ExprSyntax
-  func buildBoundsChecks(_ variant: Variant) throws -> [CodeBlockItemSyntax.Item]
-  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ variant: Variant) throws
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item]
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> FunctionSignatureSyntax
 }
 
@@ -254,11 +277,11 @@ struct FunctionCallBuilder: BoundsCheckedThunkBuilder {
     base = function
   }
 
-  func buildBoundsChecks(_ variant: Variant) throws -> [CodeBlockItemSyntax.Item] {
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
     return []
   }
 
-  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ variant: Variant) throws
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> FunctionSignatureSyntax
   {
     var newParams = base.signature.parameterClause.parameters.enumerated().filter {
@@ -271,10 +294,14 @@ struct FunctionCallBuilder: BoundsCheckedThunkBuilder {
     let last = newParams.popLast()!
     newParams.append(last.with(\.trailingComma, nil))
 
-    return base.signature.with(\.parameterClause.parameters, FunctionParameterListSyntax(newParams))
+    var sig = base.signature.with(\.parameterClause.parameters, FunctionParameterListSyntax(newParams))
+    if returnType != nil {
+      sig = sig.with(\.returnClause!.type, returnType!)
+    }
+    return sig
   }
 
-  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax], _: Variant) throws -> ExprSyntax {
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     let functionRef = DeclReferenceExprSyntax(baseName: base.name)
     let args: [ExprSyntax] = base.signature.parameterClause.parameters.enumerated()
       .map { (i: Int, param: FunctionParameterSyntax) in
@@ -312,11 +339,11 @@ struct CxxSpanThunkBuilder: BoundsCheckedThunkBuilder {
   public let typeMappings: [String: String] 
   public let node: SyntaxProtocol
 
-  func buildBoundsChecks(_ variant: Variant) throws -> [CodeBlockItemSyntax.Item] {
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
     return []
   }
 
-  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ variant: Variant) throws
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> FunctionSignatureSyntax {
     var types = argTypes
     let param = getParam(signature, index)
@@ -330,53 +357,105 @@ struct CxxSpanThunkBuilder: BoundsCheckedThunkBuilder {
     let genericArg = TypeSyntax(parsedDesugaredType.as(IdentifierTypeSyntax.self)!
       .genericArgumentClause!.arguments.first!.argument)!
     types[index] = TypeSyntax("Span<\(raw: try getTypeName(genericArg).text)>")
-    return try base.buildFunctionSignature(types, variant)
+    return try base.buildFunctionSignature(types, returnType)
   }
 
-  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax], _ variant: Variant) throws -> ExprSyntax {
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     var args = pointerArgs
     let param = getParam(signature, index)
     let typeName = try getTypeName(param.type).text;
     assert(args[index] == nil)
     args[index] = ExprSyntax("\(raw: typeName)(\(raw: param.secondName ?? param.firstName))")
-    return try base.buildFunctionCall(args, variant)
+    return try base.buildFunctionCall(args)
   }
 }
 
 protocol PointerBoundsThunkBuilder: BoundsCheckedThunkBuilder {
-  var name: TokenSyntax { get }
+  var oldType: TypeSyntax { get }
+  var newType: TypeSyntax { get throws }
   var nullable: Bool { get }
   var signature: FunctionSignatureSyntax { get }
   var nonescaping: Bool { get }
+  var variant: Variant { get }
+  var isSizedBy: Bool { get }
+}
+
+extension PointerBoundsThunkBuilder {
+  var nullable: Bool { return oldType.is(OptionalTypeSyntax.self) }
+
+  var newType: TypeSyntax { get throws {
+    return try transformType(oldType, variant, isSizedBy) }
+  }
+}
+
+struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
+  public let base: BoundsCheckedThunkBuilder
+  public let countExpr: ExprSyntax
+  public let signature: FunctionSignatureSyntax
+  public let nonescaping: Bool
+  public let isSizedBy: Bool
+  public let variant: Variant
+
+  var oldType: TypeSyntax {
+    return signature.returnClause!.type
+  }
+
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
+    -> FunctionSignatureSyntax {
+    assert(returnType == nil)
+    return try base.buildFunctionSignature(argTypes, newType)
+  }
+
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
+    return []
+  }
+
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
+    let call = try base.buildFunctionCall(pointerArgs)
+    return
+      """
+      \(raw: try newType)(start: \(call), count: Int(\(countExpr)))
+      """
+  }
 }
 
 struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
   public let base: BoundsCheckedThunkBuilder
   public let index: Int
   public let countExpr: ExprSyntax
-  public let name: TokenSyntax
-  public let nullable: Bool
   public let signature: FunctionSignatureSyntax
   public let nonescaping: Bool
   public let isSizedBy: Bool
+  public let variant: Variant
+  
+  var param: FunctionParameterSyntax {
+    return getParam(signature, index)
+  }
 
-  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ variant: Variant) throws
+  var oldType: TypeSyntax {
+    return param.type
+  }
+
+  var name: TokenSyntax {
+    return param.secondName ?? param.firstName
+  }
+
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> FunctionSignatureSyntax
   {
     var types = argTypes
-    let param = getParam(signature, index)
-    types[index] = try transformType(param.type, variant, isSizedBy)
+    types[index] = try newType
     if variant.skipTrivialCount {
       if let countVar = countExpr.as(DeclReferenceExprSyntax.self) {
         let i = try getParameterIndexForDeclRef(signature.parameterClause.parameters, countVar)
         types[i] = nil as TypeSyntax?
       }
     }
-    return try base.buildFunctionSignature(types, variant)
+    return try base.buildFunctionSignature(types, returnType)
   }
 
-  func buildBoundsChecks(_ variant: Variant) throws -> [CodeBlockItemSyntax.Item] {
-    var res = try base.buildBoundsChecks(variant)
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
+    var res = try base.buildBoundsChecks()
     let countName: TokenSyntax = "_\(raw: name)Count"
     let count: VariableDeclSyntax = try VariableDeclSyntax(
       "let \(countName): some BinaryInteger = \(countExpr)")
@@ -384,7 +463,7 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
 
     let countCheck = ExprSyntax(
       """
-        if \(getCount(variant)) < \(countName) || \(countName) < 0 {
+        if \(getCount()) < \(countName) || \(countName) < 0 {
           fatalError("bounds check failure when calling unsafe function")
         }
       """)
@@ -413,13 +492,13 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
     return ExprSyntax("\(type)(exactly: \(expr))!")
   }
 
-  func buildUnwrapCall(_ argOverrides: [Int: ExprSyntax], _ variant: Variant) throws -> ExprSyntax {
+  func buildUnwrapCall(_ argOverrides: [Int: ExprSyntax]) throws -> ExprSyntax {
     let unwrappedName = TokenSyntax("_\(name)Ptr")
     var args = argOverrides
     let argExpr = ExprSyntax("\(unwrappedName).baseAddress")
     assert(args[index] == nil)
     args[index] = try castPointerToOpaquePointer(unwrapIfNonnullable(argExpr))
-    let call = try base.buildFunctionCall(args, variant)
+    let call = try base.buildFunctionCall(args)
     let ptrRef = unwrapIfNullable(ExprSyntax(DeclReferenceExprSyntax(baseName: name)))
 
     let funcName = isSizedBy ? "withUnsafeBytes" : "withUnsafeBufferPointer"
@@ -432,7 +511,7 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
     return unwrappedCall
   }
 
-  func getCount(_ variant: Variant) -> ExprSyntax {
+  func getCount() -> ExprSyntax {
     let countName = isSizedBy && variant.generateSpan ? "byteCount" : "count"
     if nullable {
       return ExprSyntax("\(name)?.\(raw: countName) ?? 0")
@@ -466,7 +545,7 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
     return ExprSyntax("\(name).baseAddress!")
   }
 
-  func buildFunctionCall(_ argOverrides: [Int: ExprSyntax], _ variant: Variant) throws -> ExprSyntax
+  func buildFunctionCall(_ argOverrides: [Int: ExprSyntax]) throws -> ExprSyntax
   {
     var args = argOverrides
     if variant.skipTrivialCount {
@@ -475,20 +554,20 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
       if let countVar = countExpr.as(DeclReferenceExprSyntax.self) {
         let i = try getParameterIndexForDeclRef(signature.parameterClause.parameters, countVar)
         assert(args[i] == nil)
-        args[i] = castIntToTargetType(expr: getCount(variant), type: getParam(signature, i).type)
+        args[i] = castIntToTargetType(expr: getCount(), type: getParam(signature, i).type)
       }
     }
     assert(args[index] == nil)
     if variant.generateSpan {
       assert(nonescaping)
-      let unwrappedCall = try buildUnwrapCall(args, variant)
+      let unwrappedCall = try buildUnwrapCall(args)
       if nullable {
         var nullArgs = args
         nullArgs[index] = ExprSyntax(NilLiteralExprSyntax(nilKeyword: .keyword(.nil)))
         return ExprSyntax(
           """
             if \(name) == nil {
-              \(try base.buildFunctionCall(nullArgs, variant))
+              \(try base.buildFunctionCall(nullArgs))
             } else {
               \(unwrappedCall)
             }
@@ -498,32 +577,7 @@ struct CountedOrSizedPointerThunkBuilder: PointerBoundsThunkBuilder {
     }
 
     args[index] = try castPointerToOpaquePointer(getPointerArg())
-    return try base.buildFunctionCall(args, variant)
-  }
-}
-
-struct EndedByPointerThunkBuilder: PointerBoundsThunkBuilder {
-  public let base: BoundsCheckedThunkBuilder
-  public let startIndex: Int
-  public let endIndex: Int
-  public let name: TokenSyntax
-  public let nullable: Bool
-  public let signature: FunctionSignatureSyntax
-  public let nonescaping: Bool
-
-  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ variant: Variant) throws
-    -> FunctionSignatureSyntax
-  {
-    throw RuntimeError("endedBy support not yet implemented")
-  }
-
-  func buildBoundsChecks(_ variant: Variant) throws -> [CodeBlockItemSyntax.Item] {
-    throw RuntimeError("endedBy support not yet implemented")
-  }
-
-  func buildFunctionCall(_ argOverrides: [Int: ExprSyntax], _ variant: Variant) throws -> ExprSyntax
-  {
-    throw RuntimeError("endedBy support not yet implemented")
+    return try base.buildFunctionCall(args)
   }
 }
 
@@ -575,14 +629,28 @@ func getParameterIndexForDeclRef(
 /// appropriately. Moreover, it can wrap C++ APIs using unsafe C++ types like
 /// std::span with APIs that use their safer Swift equivalents.
 public struct SwiftifyImportMacro: PeerMacro {
-  static func parseEnumName(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> String {
-    guard let calledExpr = enumConstructorExpr.calledExpression.as(MemberAccessExprSyntax.self)
+  static func parseEnumName(_ expr: ExprSyntax) throws -> String {
+    var exprLocal = expr
+    if let callExpr = expr.as(FunctionCallExprSyntax.self) {
+      exprLocal = callExpr.calledExpression
+    }
+    guard let dotExpr = exprLocal.as(MemberAccessExprSyntax.self)
     else {
       throw DiagnosticError(
-        "expected _SwiftifyInfo enum literal as argument, got '\(enumConstructorExpr)'",
-        node: enumConstructorExpr)
+        "expected enum literal as argument, got '\(expr)'",
+        node: expr)
     }
-    return calledExpr.declName.baseName.text
+    return dotExpr.declName.baseName.text
+  }
+
+  static func parseEnumArgs(_ expr: ExprSyntax) throws -> LabeledExprListSyntax {
+    guard let callExpr = expr.as(FunctionCallExprSyntax.self)
+    else {
+      throw DiagnosticError(
+        "expected call to enum constructor, got '\(expr)'",
+        node: expr)
+    }
+    return callExpr.arguments
   }
 
   static func getIntLiteralValue(_ expr: ExprSyntax) throws -> Int {
@@ -609,12 +677,33 @@ public struct SwiftifyImportMacro: PeerMacro {
     }
   }
 
+  static func parseSwiftifyExpr(_ expr: ExprSyntax) throws -> SwiftifyExpr {
+    let enumName = try parseEnumName(expr)
+    switch enumName {
+    case "param":
+      let argumentList = try parseEnumArgs(expr)
+      if argumentList.count != 1 {
+        throw DiagnosticError(
+          "expected single argument to _SwiftifyExpr.param, got \(argumentList.count) arguments",
+          node: expr)
+      }
+      let pointerParamIndexArg = argumentList[argumentList.startIndex]
+      let pointerParamIndex: Int = try getIntLiteralValue(pointerParamIndexArg.expression)
+      return .param(pointerParamIndex)
+    case "return": return .return
+    default:
+      throw DiagnosticError(
+        "expected 'param' or 'return', got '\(enumName)'",
+        node: expr)
+    }
+  }
+
   static func parseCountedByEnum(
     _ enumConstructorExpr: FunctionCallExprSyntax, _ signature: FunctionSignatureSyntax
   ) throws -> ParamInfo {
     let argumentList = enumConstructorExpr.arguments
-    let pointerParamIndexArg = try getArgumentByName(argumentList, "pointer")
-    let pointerParamIndex: Int = try getIntLiteralValue(pointerParamIndexArg)
+    let pointerExprArg = try getArgumentByName(argumentList, "pointer")
+    let pointerExpr: SwiftifyExpr = try parseSwiftifyExpr(pointerExprArg)
     let countExprArg = try getArgumentByName(argumentList, "count")
     guard let countExprStringLit = countExprArg.as(StringLiteralExprSyntax.self) else {
       throw DiagnosticError(
@@ -631,14 +720,14 @@ public struct SwiftifyImportMacro: PeerMacro {
       }
     }
     return CountedBy(
-      pointerIndex: pointerParamIndex, count: unwrappedCountExpr, sizedBy: false,
+      pointerIndex: pointerExpr, count: unwrappedCountExpr, sizedBy: false,
       nonescaping: false, original: ExprSyntax(enumConstructorExpr))
   }
 
   static func parseSizedByEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> ParamInfo {
     let argumentList = enumConstructorExpr.arguments
-    let pointerParamIndexArg = try getArgumentByName(argumentList, "pointer")
-    let pointerParamIndex: Int = try getIntLiteralValue(pointerParamIndexArg)
+    let pointerExprArg = try getArgumentByName(argumentList, "pointer")
+    let pointerExpr: SwiftifyExpr = try parseSwiftifyExpr(pointerExprArg)
     let sizeExprArg = try getArgumentByName(argumentList, "size")
     guard let sizeExprStringLit = sizeExprArg.as(StringLiteralExprSyntax.self) else {
       throw DiagnosticError(
@@ -646,27 +735,24 @@ public struct SwiftifyImportMacro: PeerMacro {
     }
     let unwrappedCountExpr = ExprSyntax(stringLiteral: sizeExprStringLit.representedLiteralValue!)
     return CountedBy(
-      pointerIndex: pointerParamIndex, count: unwrappedCountExpr, sizedBy: true, nonescaping: false,
+      pointerIndex: pointerExpr, count: unwrappedCountExpr, sizedBy: true, nonescaping: false,
       original: ExprSyntax(enumConstructorExpr))
   }
 
   static func parseEndedByEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> ParamInfo {
     let argumentList = enumConstructorExpr.arguments
-    let startParamIndexArg = try getArgumentByName(argumentList, "start")
-    let startParamIndex: Int = try getIntLiteralValue(startParamIndexArg)
-    let endParamIndexArg = try getArgumentByName(argumentList, "end")
-    let endParamIndex: Int = try getIntLiteralValue(endParamIndexArg)
-    let nonescapingExprArg = getOptionalArgumentByName(argumentList, "nonescaping")
-    let nonescaping = try nonescapingExprArg != nil && getBoolLiteralValue(nonescapingExprArg!)
-    return EndedBy(
-      pointerIndex: startParamIndex, endIndex: endParamIndex, nonescaping: nonescaping,
-      original: ExprSyntax(enumConstructorExpr))
+    let startPointerExprArg = try getArgumentByName(argumentList, "start")
+    let _: SwiftifyExpr = try parseSwiftifyExpr(startPointerExprArg)
+    let endPointerExprArg = try getArgumentByName(argumentList, "end")
+    let _: SwiftifyExpr = try parseSwiftifyExpr(endPointerExprArg)
+    throw RuntimeError("endedBy support not yet implemented")
   }
 
   static func parseNonEscaping(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> Int {
     let argumentList = enumConstructorExpr.arguments
-    let pointerParamIndexArg = try getArgumentByName(argumentList, "pointer")
-    let pointerParamIndex: Int = try getIntLiteralValue(pointerParamIndexArg)
+    let pointerExprArg = try getArgumentByName(argumentList, "pointer")
+    let pointerExpr: SwiftifyExpr = try parseSwiftifyExpr(pointerExprArg)
+    let pointerParamIndex: Int = paramOrReturnIndex(pointerExpr)
     return pointerParamIndex
   }
 
@@ -711,7 +797,7 @@ public struct SwiftifyImportMacro: PeerMacro {
       if let desugaredType = typeMappings[typeName] {
         if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
           if unqualifiedDesugaredType.starts(with: "span<") {
-            result.append(CxxSpan(pointerIndex: idx + 1, nonescaping: false,
+            result.append(CxxSpan(pointerIndex: .param(idx + 1), nonescaping: false,
               original: param, typeMappings: typeMappings))
           }
         }
@@ -729,7 +815,7 @@ public struct SwiftifyImportMacro: PeerMacro {
       throw DiagnosticError(
         "expected _SwiftifyInfo enum literal as argument, got '\(paramExpr)'", node: paramExpr)
     }
-    let enumName = try parseEnumName(enumConstructorExpr)
+    let enumName = try parseEnumName(paramExpr)
     switch enumName {
     case "countedBy": return try parseCountedByEnum(enumConstructorExpr, signature)
     case "sizedBy": return try parseSizedByEnum(enumConstructorExpr)
@@ -774,16 +860,18 @@ public struct SwiftifyImportMacro: PeerMacro {
 
   static func checkArgs(_ args: [ParamInfo], _ funcDecl: FunctionDeclSyntax) throws {
     var argByIndex: [Int: ParamInfo] = [:]
+    var ret: ParamInfo? = nil
     let paramCount = funcDecl.signature.parameterClause.parameters.count
-    try args.forEach { pointerArg in
-      let i = pointerArg.pointerIndex
+    try args.forEach { pointerInfo in
+      switch pointerInfo.pointerIndex {
+      case .param(let i):
       if i < 1 || i > paramCount {
         let noteMessage =
           paramCount > 0
           ? "function \(funcDecl.name) has parameter indices 1..\(paramCount)"
           : "function \(funcDecl.name) has no parameters"
         throw DiagnosticError(
-          "pointer index out of bounds", node: pointerArg.original,
+          "pointer index out of bounds", node: pointerInfo.original,
           notes: [
             Note(node: Syntax(funcDecl.name), message: MacroExpansionNoteMessage(noteMessage))
           ])
@@ -791,14 +879,28 @@ public struct SwiftifyImportMacro: PeerMacro {
       if argByIndex[i] != nil {
         throw DiagnosticError(
           "multiple _SwiftifyInfos referring to parameter with index "
-            + "\(i): \(pointerArg) and \(argByIndex[i]!)", node: pointerArg.original)
+            + "\(i): \(pointerInfo) and \(argByIndex[i]!)", node: pointerInfo.original)
       }
-      argByIndex[i] = pointerArg
+      argByIndex[i] = pointerInfo
+      case .return:
+      if ret != nil {
+        throw DiagnosticError(
+          "multiple _SwiftifyInfos referring to return value: \(pointerInfo) and \(ret!)", node: pointerInfo.original)
+      }
+      ret = pointerInfo
+      }
+    }
+  }
+
+  static func paramOrReturnIndex(_ expr: SwiftifyExpr) -> Int {
+    switch expr {
+    case .param(let i): return i
+    case .return: return -1
     }
   }
 
   static func setNonescapingPointers(_ args: inout [ParamInfo], _ nonescapingPointers: Set<Int>) {
-    for i in 0...args.count - 1 where nonescapingPointers.contains(args[i].pointerIndex) {
+    for i in 0...args.count - 1 where nonescapingPointers.contains(paramOrReturnIndex(args[i].pointerIndex)) {
       args[i].nonescaping = true
     }
   }
@@ -840,18 +942,18 @@ public struct SwiftifyImportMacro: PeerMacro {
         { (prev, parsedArg) in
           parsedArg.getBoundsCheckedThunkBuilder(prev, funcDecl, variant)
         })
-      let newSignature = try builder.buildFunctionSignature([:], variant)
+      let newSignature = try builder.buildFunctionSignature([:], nil)
       let checks =
         variant.skipTrivialCount
         ? [] as [CodeBlockItemSyntax]
-        : try builder.buildBoundsChecks(variant).map { e in
+        : try builder.buildBoundsChecks().map { e in
           CodeBlockItemSyntax(leadingTrivia: "\n", item: e)
         }
       let call = CodeBlockItemSyntax(
         item: CodeBlockItemSyntax.Item(
           ReturnStmtSyntax(
             returnKeyword: .keyword(.return, trailingTrivia: " "),
-            expression: try builder.buildFunctionCall([:], variant))))
+            expression: try builder.buildFunctionCall([:]))))
       let body = CodeBlockSyntax(statements: CodeBlockItemListSyntax(checks + [call]))
       let newFunc =
         funcDecl

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -1,3 +1,7 @@
+public enum _SwiftifyExpr {
+    case param(_ index: Int)
+    case `return`
+}
 /// Different ways to annotate pointer parameters using the `@_SwiftifyImport` macro.
 /// All indices into parameter lists start at 1. Indices __must__ be integer literals, and strings
 /// __must__ be string literals, because their contents are parsed by the `@_SwiftifyImport` macro.
@@ -13,23 +17,23 @@ public enum _SwiftifyInfo {
     /// `Unsafe[Mutable]Pointer<T>[?]`, i.e. not an `UnsafeRawPointer`.
     /// Parameter count: string containing valid Swift syntax containing the number of elements in
     /// the buffer.
-    case countedBy(pointer: Int, count: String)
+    case countedBy(pointer: _SwiftifyExpr, count: String)
     /// Corresponds to the C `__sized_by(size)` attribute.
     /// Parameter pointer: index of pointer in function parameter list. Must be of type
     /// `Unsafe[Mutable]RawPointer[?]`, i.e. not an `UnsafePointer<T>`.
     /// Parameter count: string containing valid Swift syntax containing the size of the buffer,
     /// in bytes.
-    case sizedBy(pointer: Int, size: String)
+    case sizedBy(pointer: _SwiftifyExpr, size: String)
     /// Corresponds to the C `__ended_by(end)` attribute.
     /// Parameter start: index of pointer in function parameter list.
     /// Parameter end: index of pointer in function parameter list, pointing one past the end of
     /// the same buffer as `start`.
-    case endedBy(start: Int, end: Int)
+    case endedBy(start: _SwiftifyExpr, end: Int)
     /// Corresponds to the C `noescape` attribute. Allows generated wrapper to use `Span`-types
     /// instead of `UnsafeBuffer`-types, because it is known that the function doesn't capture the
     /// object past the lifetime of the function.
     /// Parameter pointer: index of pointer in function parameter list.
-    case nonescaping(pointer: Int)
+    case nonescaping(pointer: _SwiftifyExpr)
 }
 
 /// Generates a safe wrapper for function with Unsafe[Mutable][Raw]Pointer[?] or std::span arguments.

--- a/test/Interop/C/swiftify-import/Inputs/counted-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by.h
@@ -5,7 +5,7 @@
 void simple(int len, int * __counted_by(len) p);
 
 void swiftAttr(int len, int *p) __attribute__((
-    swift_attr("@_SwiftifyImport(.countedBy(pointer: 2, count: \"len\"))")));
+    swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(2), count: \"len\"))")));
 
 void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 
@@ -16,3 +16,5 @@ void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
 void nonnull(int len, int * __counted_by(len) _Nonnull p);
 
 void nullable(int len, int * __counted_by(len) _Nullable p);
+
+int * __counted_by(len) returnPointer(int len);

--- a/test/Interop/C/swiftify-import/Inputs/sized-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by.h
@@ -4,8 +4,8 @@
 
 void simple(int len, void * __sized_by(len) p);
 
-void swiftAttr(int len, void *p) __attribute__((
-    swift_attr("@_SwiftifyImport(.sizedBy(pointer: 2, size: \"len\"))")));
+void swiftAttr(int len, void *p) __attribute__((swift_attr(
+    "@_SwiftifyImport(.sizedBy(pointer: .param(2), size: \"len\"))")));
 
 void shared(int len, void * __sized_by(len) p1, void * __sized_by(len) p2);
 

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -14,6 +14,13 @@ import CountedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: UnsafeMutableBufferPointer<Int{{.*}}>?)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func returnPointer(_  len: Int{{.*}}) -> UnsafeMutableBufferPointer<Int{{.*}}>
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+@inlinable
+public func callReturnPointer() {
+  let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
+  let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+}

--- a/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "size * count"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "size * count"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .countedBy(pointer: 3, count: "len2"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(3), count: "len2"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt, _ ptr2: UnsafePointer<CInt>, _ len2: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -4,7 +4,7 @@
 // RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span > %t.log 2>&1
 // RUN: %FileCheck --match-full-lines %s < %t.log
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
@@ -2,27 +2,27 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func ptrNamed(ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func ptrNamedOther(buf ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func lenNamed(_ ptr: UnsafePointer<CInt>, len: CInt) {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func lenNamedOther(_ ptr: UnsafePointer<CInt>, count len: CInt) {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func allNamed(ptr: UnsafePointer<CInt>, len: CInt) {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>?, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,7 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// FIXME:errors due to returning ~Escapable without lifetime dependence info
-// RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
 func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
@@ -17,7 +16,7 @@ func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: func nonEscaping(_ len: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return Span<CInt> (start: nonEscaping(len), count: Int(len))
+// CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
+// CHECK-NEXT:     return UnsafeBufferPointer<CInt> (start: nonEscaping(len), count: Int(len))
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
 func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,0 +1,23 @@
+// REQUIRES: swift_swift_parser
+
+// FIXME:errors due to returning ~Escapable without lifetime dependence info
+// RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
+func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .nonescaping(pointer: .return))
+func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
+}
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: func myFunc(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+// CHECK-NEXT:     return UnsafeMutableBufferPointer<CInt> (start: myFunc(len), count: Int(len))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: func nonEscaping(_ len: CInt) -> Span<CInt> {
+// CHECK-NEXT:     return Span<CInt> (start: nonEscaping(len), count: Int(len))
+// CHECK-NEXT: }
+

--- a/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
@@ -2,11 +2,11 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func foo(_ ptr: Swift.UnsafePointer<Swift.Int>, _ len: Swift.Int) -> Swift.Void {
 }
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func bar(_ ptr: Swift.UnsafePointer<Swift.CInt>, _ len: Swift.Int) -> () {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Return.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .countedBy(pointer: 2, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -1,0 +1,16 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_Span
+
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len1"), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(1)))
+func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CInt>, _ len2: CInt) {
+}
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     return ptr1.withUnsafeBufferPointer { _ptr1Ptr in
+// CHECK-NEXT:         return myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: ptr1.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -7,7 +7,7 @@ public struct SpanOfInt {
     init(_ x: Span<CInt>) {}
 }
 
-@_SwiftifyImport(.nonescaping(pointer: 1), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
 func myFunc(_ span: SpanOfInt, _ secondSpan: SpanOfInt) {
 }
 

--- a/test/Macros/SwiftifyImport/MacroErrors/ArrayType.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/ArrayType.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 // expected-error@+1{{expected pointer type, got [CInt] with kind arrayType}}
 func myFunc(_ ptr: [CInt], _ len: String) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/DynamicCountExpr.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/DynamicCountExpr.swift
@@ -4,6 +4,6 @@
 
 let countString = "len"
 // expected-error@+1{{expected string literal for 'count' parameter, got countString}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: countString))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: countString))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: String) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/DynamicEnum.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/DynamicEnum.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
-let countedBy = _SwiftifyInfo.countedBy(pointer: 1, count: "len")
+let countedBy = _SwiftifyInfo.countedBy(pointer: .param(1), count: "len")
 // expected-error@+1{{expected _SwiftifyInfo enum literal as argument, got 'countedBy'}}
 @_SwiftifyImport(countedBy)
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: String) {

--- a/test/Macros/SwiftifyImport/MacroErrors/DynamicPointerIndex.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/DynamicPointerIndex.swift
@@ -4,6 +4,6 @@
 
 let pointerIndex = 1
 // expected-error@+1{{expected integer literal, got 'pointerIndex'}}
-@_SwiftifyImport(.countedBy(pointer: pointerIndex, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(pointerIndex), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: String) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/InvalidCount.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/InvalidCount.swift
@@ -3,6 +3,6 @@
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
 // expected-error@+1{{no parameter with name 'foo' in '_ ptr: UnsafePointer<CInt>, _ len: CInt'}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "foo"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "foo"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/NullableSpan.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/NullableSpan.swift
@@ -5,6 +5,6 @@
 
 // XFAIL: *
 // expanded form errors with "type 'Span' does not conform to protocol 'Escapable'" because Optional doesn't support ~Escapable yet 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
 func nullableSpan(_ ptr: UnsafePointer<CInt>?, _ len: CInt) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/Pointee.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/Pointee.swift
@@ -3,17 +3,17 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
 // expected-error@+2{{SizedBy only supported for raw pointers}}
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func myFunc(_ ptr: UnsafePointer<Int>, _ size: CInt) {
 }
 
 // expected-error@+2{{raw pointers only supported for SizedBy}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "count"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "count"))
 func myFunc(_ ptr: UnsafeRawPointer, _ count: CInt) {
 }
 
 // expected-error@+2{{raw pointers only supported for SizedBy}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "count"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "count"))
 func myFunc(_ ptr: OpaquePointer, _ count: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/MacroErrors/PointerIndexOutOfBounds.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/PointerIndexOutOfBounds.swift
@@ -3,17 +3,17 @@
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
 // expected-error@+1{{pointer index out of bounds}}
-@_SwiftifyImport(.countedBy(pointer: 3, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(3), count: "len"))
 // expected-note@+1{{function myFunc has parameter indices 1..2}}
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 // expected-error@+1{{pointer index out of bounds}}
-@_SwiftifyImport(.countedBy(pointer: 0, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(0), count: "len"))
 // expected-note@+1{{function myFunc2 has parameter indices 1..2}}
 func myFunc2(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 // expected-error@+1{{pointer index out of bounds}}
-@_SwiftifyImport(.countedBy(pointer: 0, count: "1"))
+@_SwiftifyImport(.countedBy(pointer: .param(0), count: "1"))
 // expected-note@+1{{function myFunc3 has no parameters}}
 func myFunc3() {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/SamePointer.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/SamePointer.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir
 
-// expected-error@+1{{multiple _SwiftifyInfos referring to parameter with index 1: .countedBy(pointer: 1, count: "dummy", nonescaping: false) and .countedBy(pointer: 1, count: "len", nonescaping: false)}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"), .countedBy(pointer: 1, count: "dummy"))
+// expected-error@+1{{multiple _SwiftifyInfos referring to parameter with index 1: .countedBy(pointer: .param(1), count: "dummy", nonescaping: false) and .countedBy(pointer: .param(1), count: "len", nonescaping: false)}}
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(1), count: "dummy"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt, _ dummy: CInt) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/UnexpectedCountExpr.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/UnexpectedCountExpr.swift
@@ -3,6 +3,6 @@
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
 // expected-error@+1{{cannot convert value of type 'Int' to expected argument type 'String'}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: 2))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: 2))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: String) {
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/UnexpectedCountType.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/UnexpectedCountType.swift
@@ -5,7 +5,7 @@
 // RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 // RUN: %target-typecheck-verify-swift %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: UnsafePointer<CInt>, _ len: String) {
 }
 

--- a/test/Macros/SwiftifyImport/MacroErrors/UnexpectedPointerType.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/UnexpectedPointerType.swift
@@ -3,10 +3,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
 // expected-error@+2{{expected Unsafe[Mutable][Raw]Pointer type for type CInt - first type token is 'CInt'}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc(_ ptr: CInt, _ len: CInt) {
 }
 // expected-error@+2{{expected Unsafe[Mutable][Raw]Pointer type for type UnsafeBufferPointer<CInt> - first type token is 'UnsafeBufferPointer'}}
-@_SwiftifyImport(.countedBy(pointer: 1, count: "len"))
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 func myFunc2(_ ptr: UnsafeBufferPointer<CInt>, _ len: CInt) {
 }

--- a/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .sizedBy(pointer: 3, size: "size2"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .sizedBy(pointer: .param(3), size: "size2"))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ ptr2: UnsafeRawPointer, _ size2: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -4,7 +4,7 @@
 // RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span > %t.log 2>&1
 // RUN: %FileCheck --match-full-lines %s < %t.log
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func myFunc(_ ptr: UnsafeRawPointer?, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -3,29 +3,29 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span -verify 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func nonnullUnsafeRawBufferPointer(_ ptr: OpaquePointer, _ size: CInt) {
 }
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func nullableUnsafeRawBufferPointer(_ ptr: OpaquePointer?, _ size: CInt) {
 }
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func impNullableUnsafeRawBufferPointer(_ ptr: OpaquePointer!, _ size: CInt) {
 }
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func nonnullSpan(_ ptr: OpaquePointer, _ size: CInt) {
 }
 
 // expected-note@+2{{in expansion of macro '_SwiftifyImport' on global function 'nullableSpan' here}}
 // Cannot refer to source location for the error: "type 'RawSpan' does not conform to protocol 'Escapable'" (which is currently necessary for Optional)
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func nullableSpan(_ ptr: OpaquePointer?, _ size: CInt) {
 }
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Return.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .sizedBy(pointer: 2, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .sizedBy(pointer: .param(2), size: "size"))
 func myFunc(_ ptr: UnsafeRawPointer, _ ptr2: UnsafeRawPointer, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Span 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"), .nonescaping(pointer: 1))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "size * count"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size * count"))
 func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ count: CInt) {
 }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
-@_SwiftifyImport(.sizedBy(pointer: 1, size: "len"))
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "len"))
 func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 }
 

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -799,10 +799,15 @@ Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
-Added: _$ss13_SwiftifyInfoO11nonescapingyABSi_tcABmFWC
-Added: _$ss13_SwiftifyInfoO7endedByyABSi_SitcABmFWC
-Added: _$ss13_SwiftifyInfoO7sizedByyABSi_SStcABmFWC
-Added: _$ss13_SwiftifyInfoO9countedByyABSi_SStcABmFWC
+Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
+Added: _$ss13_SwiftifyExprO6returnyA2BmFWC
+Added: _$ss13_SwiftifyExprOMa
+Added: _$ss13_SwiftifyExprOMn
+Added: _$ss13_SwiftifyExprON
+Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
+Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
+Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
+Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -800,10 +800,15 @@ Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
-Added: _$ss13_SwiftifyInfoO11nonescapingyABSi_tcABmFWC
-Added: _$ss13_SwiftifyInfoO7endedByyABSi_SitcABmFWC
-Added: _$ss13_SwiftifyInfoO7sizedByyABSi_SStcABmFWC
-Added: _$ss13_SwiftifyInfoO9countedByyABSi_SStcABmFWC
+Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
+Added: _$ss13_SwiftifyExprO6returnyA2BmFWC
+Added: _$ss13_SwiftifyExprOMa
+Added: _$ss13_SwiftifyExprOMn
+Added: _$ss13_SwiftifyExprON
+Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
+Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
+Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
+Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -823,4 +823,5 @@ Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing f
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 
 Enum _SwiftifyInfo is a new API without @available attribute
+Enum _SwiftifyExpr is a new API without @available attribute
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
Instead of simply passing a parameter index to _SwiftifyInfo, the _SwiftifyExpr enum is introduced. It currently has two cases:
 - .param(index: Int), corresponding to the previous parameter index
 - .return, corresponding to the function's return value.

ClangImporter is also updated to pass this new information along to _SwiftifyImport, allowing overloads with buffer pointer return types to be generated. The swiftified return values may not yet map to Span types, because we don't currently track the lifetime information necessary to do so.

This also fixes a bug in the decision making for picking the swiftified type, where all pointers would map to [Mutable][Raw]Span when any pointer was marked nonescaping. This is incorrect both for the case where a nonescaping parameter is combined with an escaping parameter, as well as for return values, where being marked as nonescaping is not enough to soundly use Span-types.