### PR TITLE
SILGen: Coordinate access strategy determination with actual codegen in `findStorageReferenceExprForMoveOnly`.

### DIFF
--- a/test/SILOptimizer/moveonly_checking_class_method.swift
+++ b/test/SILOptimizer/moveonly_checking_class_method.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// rdar://142509673
+
+struct Foo: ~Copyable {
+    var storage: UnsafeRawPointer
+}
+
+class Bar {
+    class var foo: Foo { fatalError() }
+}
+
+func test(foo: borrowing Foo) -> Bool {
+    fatalError()
+}
+
+func test2(bar: Bar.Type) -> Bool {
+    guard test(foo: bar.foo) else {
+        return false
+    }
+    return true
+}


### PR DESCRIPTION
Looking at the AST-level `getReadImpl` doesn't always correspond to what accessor SILGen prefers to use, due to resilience, ABI rules, and other concerns. In findStorageReferenceExprForMoveOnly, when determining whether a storage reference is borrowable, use the same logic as SILGenLValue actually uses to determine what storage or accessor access strategy to use.

Fixes rdar://142509673