### PR TITLE
6.1: [OSSACanonicalizeGuaranteed] Don't rewrite consuming uses of move-only values.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -394,7 +394,7 @@ protected:
 
 } // namespace
 
-/// Erase users from \p outerUseInsts that are not within the borrow scope.
+/// Erase users from \p outerUseInsts that are actually within the borrow scope.
 void CanonicalizeBorrowScope::filterOuterBorrowUseInsts(
     OuterUsers &outerUseInsts) {
   auto *beginBorrow = cast<BeginBorrowInst>(borrowedValue.value);

--- a/test/SILOptimizer/canonicalize_function_argument_unit.sil
+++ b/test/SILOptimizer/canonicalize_function_argument_unit.sil
@@ -1,0 +1,79 @@
+// RUN: %target-sil-opt \
+// RUN:     -test-runner \
+// RUN:     -module-name Swift \
+// RUN:     %s \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck %s
+
+import Builtin
+
+@_marker protocol Copyable {}
+
+class C {}
+struct NC : ~Copyable {
+  var c: C
+}
+
+// CHECK-LABEL: begin running test {{.*}} on consume_move_only
+// CHECK-LABEL: sil [ossa] @consume_move_only : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+//                Necessary copy.
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[C]]
+// CHECK:         [[NC:%[^,]+]] = struct $NC ([[COPY]]
+// CHECK:         apply undef([[NC]])
+// CHECK-LABEL: } // end sil function 'consume_move_only'
+// CHECK-LABEL: end running test {{.*}} on consume_move_only
+sil [ossa] @consume_move_only : $@convention(thin) (@guaranteed C) -> () {
+bb0(%c : @guaranteed $C):
+  specify_test "canonicalize_function_argument @argument"
+  %copy = copy_value %c
+  %nc = struct $NC (%copy)
+  apply undef(%nc) : $@convention(thin) (@owned NC) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: begin running test {{.*}} on borrow_move_only
+// CHECK-LABEL: sil [ossa] @borrow_move_only : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+//                No copy!
+// CHECK:         [[NC:%[^,]+]] = struct $NC ([[C]]
+// CHECK:         apply undef([[NC]])
+// CHECK-LABEL: } // end sil function 'borrow_move_only'
+// CHECK-LABEL: end running test {{.*}} on borrow_move_only
+sil [ossa] @borrow_move_only : $@convention(thin) (@guaranteed C) -> () {
+bb0(%c : @guaranteed $C):
+  specify_test "canonicalize_function_argument @argument"
+  %copy = copy_value %c
+  %nc = struct $NC (%copy)
+  apply undef(%nc) : $@convention(thin) (@guaranteed NC) -> ()
+  destroy_value %nc
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: begin running test {{.*}} on consume_and_borrow_move_only
+// CHECK-LABEL: sil [ossa] @consume_and_borrow_move_only : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+//                No copy!
+// CHECK:         [[NC1:%[^,]+]] = struct $NC ([[C]]
+// CHECK:         apply undef([[NC1]])
+//                Necessary copy.
+// CHECK:         [[COPY2:%[^,]+]] = copy_value [[C]]
+// CHECK:         [[NC2:%[^,]+]] = struct $NC ([[COPY2]]
+// CHECK:         apply undef([[NC2]])
+// CHECK-LABEL: } // end sil function 'consume_and_borrow_move_only'
+// CHECK-LABEL: end running test {{.*}} on consume_and_borrow_move_only
+sil [ossa] @consume_and_borrow_move_only : $@convention(thin) (@guaranteed C) -> () {
+bb0(%c : @guaranteed $C):
+  specify_test "canonicalize_function_argument @argument"
+  %copy1 = copy_value %c
+  %nc1 = struct $NC (%copy1)
+  apply undef(%nc1) : $@convention(thin) (@guaranteed NC) -> ()
+  destroy_value %nc1
+  %copy2 = copy_value %c
+  %nc2 = struct $NC (%copy2)
+  apply undef(%nc2) : $@convention(thin) (@owned NC) -> ()
+  %retval = tuple ()
+  return %retval
+}

--- a/test/SILOptimizer/canonicalize_function_argument_unit.sil
+++ b/test/SILOptimizer/canonicalize_function_argument_unit.sil
@@ -26,11 +26,11 @@ struct NC : ~Copyable {
 sil [ossa] @consume_move_only : $@convention(thin) (@guaranteed C) -> () {
 bb0(%c : @guaranteed $C):
   specify_test "canonicalize_function_argument @argument"
-  %copy = copy_value %c
-  %nc = struct $NC (%copy)
+  %copy = copy_value %c : $C
+  %nc = struct $NC (%copy : $C)
   apply undef(%nc) : $@convention(thin) (@owned NC) -> ()
   %retval = tuple ()
-  return %retval
+  return %retval : $()
 }
 
 // CHECK-LABEL: begin running test {{.*}} on borrow_move_only
@@ -44,12 +44,12 @@ bb0(%c : @guaranteed $C):
 sil [ossa] @borrow_move_only : $@convention(thin) (@guaranteed C) -> () {
 bb0(%c : @guaranteed $C):
   specify_test "canonicalize_function_argument @argument"
-  %copy = copy_value %c
-  %nc = struct $NC (%copy)
+  %copy = copy_value %c : $C
+  %nc = struct $NC (%copy : $C)
   apply undef(%nc) : $@convention(thin) (@guaranteed NC) -> ()
-  destroy_value %nc
+  destroy_value %nc : $NC
   %retval = tuple ()
-  return %retval
+  return %retval : $()
 }
 
 // CHECK-LABEL: begin running test {{.*}} on consume_and_borrow_move_only
@@ -67,13 +67,13 @@ bb0(%c : @guaranteed $C):
 sil [ossa] @consume_and_borrow_move_only : $@convention(thin) (@guaranteed C) -> () {
 bb0(%c : @guaranteed $C):
   specify_test "canonicalize_function_argument @argument"
-  %copy1 = copy_value %c
-  %nc1 = struct $NC (%copy1)
+  %copy1 = copy_value %c : $C
+  %nc1 = struct $NC (%copy1 : $C)
   apply undef(%nc1) : $@convention(thin) (@guaranteed NC) -> ()
-  destroy_value %nc1
-  %copy2 = copy_value %c
-  %nc2 = struct $NC (%copy2)
+  destroy_value %nc1 : $NC
+  %copy2 = copy_value %c : $C
+  %nc2 = struct $NC (%copy2 : $C)
   apply undef(%nc2) : $@convention(thin) (@owned NC) -> ()
   %retval = tuple ()
-  return %retval
+  return %retval : $()
 }


### PR DESCRIPTION
**Explanation**: Fix a miscompile which introduced a copy of a noncopyable value.

SILCombine uses the `CanonicalizeBorrowScope` utility to eliminate copies of guaranteed function arguments.  The utility walks the def-use tree of the argument, walking through copies and moves, walking into the uses of forwarding operations, producing copies as needed for any consuming uses for the value produced by a chain of forwarding operations.  These days, some forwarding operations produce noncopyable values such as `struct $Noncopyable`, however.  If the tree included a chain like `consume(struct $Noncopyable(copy(%arg)))`, it was previously rewritten as `consume(copy(struct $Noncopyable(%arg)))`.  This is invalid (copies of noncopyable values are invalid).  Here, this is fixed by bailing out of rewriting uses of a particular def in the tree (e.g. `struct $Noncopyable(copy(%arg))`) if one of the uses is a consuming use of a noncopyable value.  This bailout (two lines) required a bit of tweaking to the utility because it was written not to bailout when processing arguments--at the time, there were no cases in which it ought to.
**Scope**: Affects optimized code.
**Issue**: rdar://142520491
**Original PR**: https://github.com/swiftlang/swift/pull/78552
**Risk**: Low.  
**Testing**: Added tests.
**Reviewer**: Meghana Gupta ( @meg-gupta )
