### PR TITLE
Build swift-testing as part of the compat-suite toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2947,6 +2947,8 @@ build-ninja
 llbuild
 swiftpm
 swift-driver
+swift-testing
+swift-testing-macros
 install-llbuild
 install-llvm
 install-static-linux-config
@@ -2954,6 +2956,8 @@ install-swift
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 reconfigure
 verbose-build
 skip-build-benchmarks


### PR DESCRIPTION
Various projects (vapor in particular) now depend on swift-testing. The current Xcode installation doesn't contain it and we're not building it, so they're failing. Update the base compat suite preset to also build swift-testing (and its macros).