### PR TITLE
Fix the demangling of sending result types when combined with isolation

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -733,10 +733,12 @@ Types
   FUNCTION-KIND ::= 'A'                      // @auto_closure function type (escaping)
   FUNCTION-KIND ::= 'E'                      // function type (noescape)
 
-  C-TYPE is mangled according to the Itanium ABI, and prefixed with the length.
-  Non-ASCII identifiers are preserved as-is; we do not use Punycode.
+  C-TYPE ::= NATURAL CHAR*                   // raw Itanium mangling
 
-  function-signature ::= params-type params-type async? sendable? throws? differentiable? function-isolation? // results and parameters
+  function-signature ::= result-type params-type async? sendable? throws? differentiable? function-isolation? sending-result? // results and parameters
+
+  result-type ::= type
+  result-type ::= empty-list                 // shortcut for ()
 
   params-type ::= type 'z'? 'h'?             // tuple in case of multiple parameters or a single parameter with a single tuple type
                                              // with optional inout convention, shared convention. parameters don't have labels,
@@ -752,6 +754,7 @@ Types
   #if SWIFT_RUNTIME_VERSION >= 6.0
     throws ::= type 'YK'                     // 'throws(type)' annotation on function types
     function-isolation ::= type 'YA'         // @isolated(any) on function type
+    sending-result ::= 'YT'                  // -> sending T
   #endif
   differentiable ::= 'Yjf'                   // @differentiable(_forward) on function type
   differentiable ::= 'Yjr'                   // @differentiable(reverse) on function type
@@ -762,6 +765,12 @@ Types
 
                                                   // FIXME: Consider replacing 'h' with a two-char code
   list-type ::= type identifier? 'Yk'? 'z'? 'h'? 'n'? 'Yi'? 'd'? 'Yt'?  // type with optional label, '@noDerivative', inout convention, shared convention, owned convention, actor 'isolated', variadic specifier, and compile-time constant
+
+In the mangling of C function types,``C-TYPE`` is mangled according to the Itanium ABI, prefixed with its length. This resembles the mangling of ``identifier``, but it does not honor substitutions or Punycode.
+
+The 6.0 Swift runtime supports demangling ``sending-result``, but has a bug when it's combined with ``function-isolation``.
+
+::
 
   METATYPE-REPR ::= 't'                      // Thin metatype representation
   METATYPE-REPR ::= 'T'                      // Thick metatype representation

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -915,6 +915,12 @@ protected:
         ++firstChildIdx;
       }
 
+      if (Node->getChild(firstChildIdx)->getKind() ==
+          NodeKind::SendingResultFunctionType) {
+        extFlags = extFlags.withSendingResult();
+        ++firstChildIdx;
+      }
+
       BuiltType globalActorType = BuiltType();
       if (Node->getChild(firstChildIdx)->getKind() ==
           NodeKind::GlobalActorFunctionType) {
@@ -934,12 +940,6 @@ protected:
       } else if (Node->getChild(firstChildIdx)->getKind() ==
                  NodeKind::IsolatedAnyFunctionType) {
         extFlags = extFlags.withIsolatedAny();
-        ++firstChildIdx;
-      }
-
-      if (Node->getChild(firstChildIdx)->getKind() ==
-          NodeKind::SendingResultFunctionType) {
-        extFlags = extFlags.withSendingResult();
         ++firstChildIdx;
       }
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -898,6 +898,18 @@ private:
       // handled earlier
       ++startIndex;
     }
+
+    // Be sure to check for function signature components in the same
+    // order that they're added by the demangler, which is the reverse
+    // of the order that they appear in the mangling grammar.
+
+    if (node->getChild(startIndex)->getKind() ==
+        Node::Kind::SendingResultFunctionType) {
+      ++startIndex;
+      hasSendingResult = true;
+    }
+
+    // function-isolation; note that these can't actually both appear.
     if (node->getChild(startIndex)->getKind()
             == Node::Kind::IsolatedAnyFunctionType) {
       print(node->getChild(startIndex), depth + 1);
@@ -908,6 +920,7 @@ private:
       print(node->getChild(startIndex), depth + 1);
       ++startIndex;
     }
+
     if (node->getChild(startIndex)->getKind() ==
         Node::Kind::DifferentiableFunctionType) {
       diffKind =
@@ -931,11 +944,6 @@ private:
     if (node->getChild(startIndex)->getKind() == Node::Kind::AsyncAnnotation) {
       ++startIndex;
       isAsync = true;
-    }
-    if (node->getChild(startIndex)->getKind() ==
-        Node::Kind::SendingResultFunctionType) {
-      ++startIndex;
-      hasSendingResult = true;
     }
 
     switch (diffKind) {

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -766,6 +766,15 @@ public:
 
     auto funcNode = Dem.createNode(kind);
 
+    // This needs to use the same order as the demangler.
+
+    // TODO: the C function type would go here
+
+    if (F->getExtFlags().hasSendingResult()) {
+      auto node = Dem.createNode(Node::Kind::SendingResultFunctionType);
+      funcNode->addChild(node, Dem);
+    }
+
     if (auto globalActor = F->getGlobalActor()) {
       auto node = Dem.createNode(Node::Kind::GlobalActorFunctionType);
       auto globalActorNode = visit(globalActor);
@@ -773,9 +782,6 @@ public:
       funcNode->addChild(node, Dem);
     } else if (F->getExtFlags().isIsolatedAny()) {
       auto node = Dem.createNode(Node::Kind::IsolatedAnyFunctionType);
-      funcNode->addChild(node, Dem);
-    } else if (F->getExtFlags().hasSendingResult()) {
-      auto node = Dem.createNode(Node::Kind::SendingResultFunctionType);
       funcNode->addChild(node, Dem);
     }
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -741,8 +741,14 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
 
     NodePointer result = Dem.createNode(Node::Kind::ReturnType);
     result->addChild(resultTy, Dem);
-    
+
     auto funcNode = Dem.createNode(kind);
+    // Add the components of the function-signature production in the same
+    // order that the demangler would.
+    // TODO: C function type would go here
+    if (func->getExtendedFlags().hasSendingResult())
+      funcNode->addChild(Dem.createNode(Node::Kind::SendingResultFunctionType),
+                         Dem);
     if (func->hasGlobalActor()) {
       auto globalActorTypeNode =
           _swift_buildDemanglingForMetadata(func->getGlobalActor(), Dem);
@@ -797,10 +803,6 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     }
     if (func->isAsync())
       funcNode->addChild(Dem.createNode(Node::Kind::AsyncAnnotation), Dem);
-
-    if (func->getExtendedFlags().hasSendingResult())
-      funcNode->addChild(Dem.createNode(Node::Kind::SendingResultFunctionType),
-                         Dem);
 
     funcNode->addChild(parameters, Dem);
     funcNode->addChild(result, Dem);

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -465,7 +465,7 @@ $sS3fIedgyywTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swi
 $sS3fIedgyyTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned sending Swift.Float) -> (@unowned Swift.Float)
 $s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass
 $s4main5KlassCACYTcMD ---> demangling cache variable for type metadata for (main.Klass) -> sending main.Klass
-$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() -> sending null.NonSendableKlass
+$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass
 $s4null16NonSendableKlassCIegHo_ACs5Error_pIegHTrzo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed @async () -> (@owned null.NonSendableKlass) to @escaping @callee_guaranteed @async () -> sending (@out null.NonSendableKlass, @error @owned Swift.Error)
 $sSRyxG15Synchronization19AtomicRepresentableABRi_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Copyable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi0_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Escapable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
@@ -483,3 +483,5 @@ $s4mainAAyyycAA1CCFTTH ---> hop to main actor thunk of main.main(main.C) -> () -
 
 $s4main6VectorVy$1_SiG ---> main.Vector<2, Swift.Int>
 $s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
+$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A
+$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A


### PR DESCRIPTION
Fixes the immediate problem, but the presence of demangling code in the runtime means that we'll need a follow-up to fix the compiler so that it doesn't try to use the demangler to materialize metadata for function types that have both isolation and a sending result.

rdar://142443925