### PR TITLE
Leave reminder to update RuntimeVersions

### DIFF
--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -38,6 +38,8 @@ SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+# TODO: When you add a new version, remember to tell the compiler about it
+# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
Leave a reminder to update the runtime versions macro file after updating availability-macros.def.