### PR TITLE
Tighten up `unsafe` effects checking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8093,6 +8093,9 @@ NOTE(note_reference_to_unsafe_typed_decl,none,
 NOTE(note_reference_to_unsafe_through_typealias,none,
      "reference to %kind0 whose underlying type involves unsafe type %1",
      (const ValueDecl *, Type))
+NOTE(note_reference_to_unsafe_type,none,
+     "reference to unsafe type %0",
+     (Type))
 NOTE(note_reference_to_nonisolated_unsafe,none,
      "reference to nonisolated(unsafe) %kind0 is unsafe in concurrently-executing code",
      (const ValueDecl *))

--- a/include/swift/AST/UnsafeUse.h
+++ b/include/swift/AST/UnsafeUse.h
@@ -225,6 +225,33 @@ public:
     }
   }
 
+  /// Replace the location, if possible.
+  void replaceLocation(SourceLoc loc) {
+    switch (getKind()) {
+    case Override:
+    case Witness:
+    case PreconcurrencyImport:
+      // Cannot replace location.
+      return;
+
+    case UnsafeConformance:
+      storage.conformance.location = loc.getOpaquePointerValue();
+      break;
+
+    case TypeWitness:
+      storage.typeWitness.location = loc.getOpaquePointerValue();
+      break;
+
+    case UnownedUnsafe:
+    case ExclusivityUnchecked:
+    case NonisolatedUnsafe:
+    case ReferenceToUnsafe:
+    case ReferenceToUnsafeThroughTypealias:
+    case CallToUnsafe:
+      storage.entity.location = loc.getOpaquePointerValue();
+    }
+  }
+
   /// Get the main declaration, when there is one.
   const Decl *getDecl() const {
     switch (getKind()) {

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -53,18 +53,6 @@ DeclContext *ConformanceLookupTable::ConformanceSource::getDeclContext() const {
   llvm_unreachable("Unhandled ConformanceEntryKind in switch.");
 }
 
-bool ConformanceLookupTable::ConformanceSource::isUnsafeContext(DeclContext *dc) {
-  if (auto enclosingNominal = dc->getSelfNominalTypeDecl())
-    if (enclosingNominal->isUnsafe())
-      return true;
-
-  if (auto ext = dyn_cast<ExtensionDecl>(dc))
-    if (ext->getAttrs().hasAttribute<UnsafeAttr>())
-      return true;
-
-  return false;
-}
-
 ProtocolDecl *ConformanceLookupTable::ConformanceEntry::getProtocol() const {
   if (auto protocol = Conformance.dyn_cast<ProtocolDecl *>())
     return protocol;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -166,13 +166,17 @@ namespace {
     /// The location of the "preconcurrency" attribute if present.
     const SourceLoc preconcurrencyLoc;
 
+    /// The location of the "unsafe" attribute if present.
+    const SourceLoc unsafeLoc;
+
     ConformanceConstructionInfo() { }
 
     ConformanceConstructionInfo(ProtocolDecl *item, SourceLoc loc,
                                 SourceLoc uncheckedLoc,
-                                SourceLoc preconcurrencyLoc)
+                                SourceLoc preconcurrencyLoc,
+                                SourceLoc unsafeLoc)
         : Located(item, loc), uncheckedLoc(uncheckedLoc),
-          preconcurrencyLoc(preconcurrencyLoc) {}
+          preconcurrencyLoc(preconcurrencyLoc), unsafeLoc(unsafeLoc) {}
   };
 }
 
@@ -228,7 +232,7 @@ void ConformanceLookupTable::forEachInStage(ConformanceStage stage,
       registerProtocolConformances(next, conformances);
       for (auto conf : conformances) {
         protocols.push_back(
-            {conf->getProtocol(), SourceLoc(), SourceLoc(), SourceLoc()});
+            {conf->getProtocol(), SourceLoc(), SourceLoc(), SourceLoc(), SourceLoc()});
       }
     } else if (next->getParentSourceFile() ||
                next->getParentModule()->isBuiltinModule()) {
@@ -238,7 +242,8 @@ void ConformanceLookupTable::forEachInStage(ConformanceStage stage,
                getDirectlyInheritedNominalTypeDecls(next, inverses, anyObject)) {
         if (auto proto = dyn_cast<ProtocolDecl>(found.Item))
           protocols.push_back(
-              {proto, found.Loc, found.uncheckedLoc, found.preconcurrencyLoc});
+              {proto, found.Loc, found.uncheckedLoc,
+               found.preconcurrencyLoc, found.unsafeLoc});
       }
     }
 
@@ -343,7 +348,8 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
             addProtocol(
                 locAndProto.Item, locAndProto.Loc,
                 source.withUncheckedLoc(locAndProto.uncheckedLoc)
-                      .withPreconcurrencyLoc(locAndProto.preconcurrencyLoc));
+                      .withPreconcurrencyLoc(locAndProto.preconcurrencyLoc)
+                      .withUnsafeLoc(locAndProto.unsafeLoc));
         });
     break;
 

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -171,7 +171,7 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
         options |= ProtocolConformanceFlags::Unchecked;
       if (getPreconcurrencyLoc().isValid())
         options |= ProtocolConformanceFlags::Preconcurrency;
-      if (getUnsafeLoc().isValid() || isUnsafeContext(getDeclContext()))
+      if (getUnsafeLoc().isValid())
         options |= ProtocolConformanceFlags::Unsafe;
       return options;
     }
@@ -264,10 +264,6 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
     /// Get the declaration context that this conformance will be
     /// associated with.
     DeclContext *getDeclContext() const;
-
-  private:
-    /// Whether this declaration context is @unsafe.
-    static bool isUnsafeContext(DeclContext *dc);
   };
 
   /// An entry in the conformance table.

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3277,7 +3277,8 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // the autoclosure expression itself, and the autoclosure must be
       // 'async'.
 
-      // FIXME: 'unsafe' should do what with autoclosures?
+      OldFlags.mergeFrom(ContextFlags::HasAnyUnsafe, Self.Flags);
+      OldFlags.mergeFrom(ContextFlags::HasAnyUnsafeSite, Self.Flags);
     }
 
     void setCoverageForSingleValueStmtExpr() {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -613,6 +613,31 @@ public:
       if (!TE->isImplicit()) {
         recurse = asImpl().checkType(TE, TE->getTypeRepr(), TE->getInstanceType());
       }
+    } else if (auto KPE = dyn_cast<KeyPathExpr>(E)) {
+      for (auto &component : KPE->getComponents()) {
+        switch (component.getKind()) {
+        case KeyPathExpr::Component::Kind::Property:
+        case KeyPathExpr::Component::Kind::Subscript: {
+          (void)asImpl().checkDeclRef(KPE, component.getDeclRef(),
+                                      component.getLoc(),
+                                      /*isImplicitlyAsync=*/false,
+                                      /*isImplicitlyThrows=*/false);
+          break;
+        }
+
+        case KeyPathExpr::Component::Kind::TupleElement:
+        case KeyPathExpr::Component::Kind::Invalid:
+        case KeyPathExpr::Component::Kind::UnresolvedProperty:
+        case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+        case KeyPathExpr::Component::Kind::OptionalChain:
+        case KeyPathExpr::Component::Kind::OptionalWrap:
+        case KeyPathExpr::Component::Kind::OptionalForce:
+        case KeyPathExpr::Component::Kind::Identity:
+        case KeyPathExpr::Component::Kind::DictionaryKey:
+        case KeyPathExpr::Component::Kind::CodeCompletion:
+          break;
+        }
+      }
     }
     // Error handling validation (via checkTopLevelEffects) happens after
     // type checking. If an unchecked expression is still around, the code was

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6672,27 +6672,3 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
   llvm_unreachable("Unhandled catch node");
 }
-
-void swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
-                               llvm::function_ref<void(Type)> diagnose) {
-  if (!ctx.LangOpts.hasFeature(Feature::WarnUnsafe))
-    return;
-
-  if (!type->isUnsafe() && !type->getCanonicalType()->isUnsafe())
-    return;
-
-  // Look for a specific @unsafe nominal type.
-  Type specificType;
-  type.findIf([&specificType](Type type) {
-    if (auto typeDecl = type->getAnyNominal()) {
-      if (typeDecl->isUnsafe()) {
-        specificType = type;
-        return false;
-      }
-    }
-
-    return false;
-  });
-
-  diagnose(specificType ? specificType : type);
-}

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -748,11 +748,6 @@ bool diagnoseMissingOwnership(ParamSpecifier ownership,
                               TypeRepr *repr, Type ty,
                               const TypeResolution &resolution);
 
-/// If the given type involves an unsafe type, diagnose it by calling the
-/// diagnose function with the most specific unsafe type that can be provided.
-void diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
-                        llvm::function_ref<void(Type)> diagnose);
-
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPE_CHECK_TYPE_H */

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -273,11 +273,10 @@ static bool forEachUnsafeConformance(
   return false;
 }
 
-bool swift::enumerateUnsafeUses(SubstitutionMap subs,
+bool swift::enumerateUnsafeUses(ArrayRef<ProtocolConformanceRef> conformances,
                                 SourceLoc loc,
                                 llvm::function_ref<bool(UnsafeUse)> fn) {
-  // FIXME: Check replacement types?
-  for (auto conformance : subs.getConformances()) {
+  for (auto conformance : conformances) {
     if (!conformance.hasEffect(EffectKind::Unsafe))
       continue;
 
@@ -291,6 +290,18 @@ bool swift::enumerateUnsafeUses(SubstitutionMap subs,
       return true;
     }
   }
+
+  return false;
+}
+
+bool swift::enumerateUnsafeUses(SubstitutionMap subs,
+                                SourceLoc loc,
+                                llvm::function_ref<bool(UnsafeUse)> fn) {
+  // FIXME: Check replacement types?
+
+  // Check conformances.
+  if (enumerateUnsafeUses(subs.getConformances(), loc, fn))
+    return true;
 
   return false;
 }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -123,11 +123,11 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
   case UnsafeUse::ReferenceToUnsafe:
   case UnsafeUse::CallToUnsafe: {
     bool isCall = use.getKind() == UnsafeUse::CallToUnsafe;
-    auto decl = cast<ValueDecl>(use.getDecl());
+    auto decl = cast_or_null<ValueDecl>(use.getDecl());
     auto loc = use.getLocation();
     Type type = use.getType();
-    ASTContext &ctx = decl->getASTContext();
-    if (type) {
+    ASTContext &ctx = decl ? decl->getASTContext() : type->getASTContext();
+    if (type && decl) {
       diagnoseUnsafeType(
           ctx, loc, type,
           [&](Type specificType) {
@@ -136,6 +136,11 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
                 diag::note_reference_to_unsafe_typed_decl,
                 isCall, decl, specificType);
           });
+    } else if (type) {
+      ctx.Diags.diagnose(
+          loc,
+          diag::note_reference_to_unsafe_type,
+          type);
     } else {
       ctx.Diags.diagnose(
           loc,
@@ -335,4 +340,28 @@ bool swift::isUnsafeInConformance(const ValueDecl *requirement,
     hasUnsafeType = true;
   });
   return hasUnsafeType;
+}
+
+void swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+                               llvm::function_ref<void(Type)> diagnose) {
+  if (!ctx.LangOpts.hasFeature(Feature::WarnUnsafe))
+    return;
+
+  if (!type->isUnsafe() && !type->getCanonicalType()->isUnsafe())
+    return;
+
+  // Look for a specific @unsafe nominal type.
+  Type specificType;
+  type.findIf([&specificType](Type type) {
+    if (auto typeDecl = type->getAnyNominal()) {
+      if (typeDecl->isUnsafe()) {
+        specificType = type;
+        return false;
+      }
+    }
+
+    return false;
+  });
+
+  diagnose(specificType ? specificType : type);
 }

--- a/lib/Sema/TypeCheckUnsafe.h
+++ b/lib/Sema/TypeCheckUnsafe.h
@@ -64,6 +64,12 @@ bool isUnsafe(ConcreteDeclRef declRef);
 bool isUnsafeInConformance(const ValueDecl *requirement,
                            const Witness &witness,
                            NormalProtocolConformance *conformance);
+
+/// If the given type involves an unsafe type, diagnose it by calling the
+/// diagnose function with the most specific unsafe type that can be provided.
+void diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+                        llvm::function_ref<void(Type)> diagnose);
+
 }
 
 #endif // SWIFT_SEMA_TYPE_CHECK_UNSAFE_H

--- a/lib/Sema/TypeCheckUnsafe.h
+++ b/lib/Sema/TypeCheckUnsafe.h
@@ -36,8 +36,17 @@ bool enumerateUnsafeUses(ConcreteDeclRef declRef,
                          bool isCall,
                          llvm::function_ref<bool(UnsafeUse)> fn);
 
+/// Enumerate all of the unsafe uses that occur within this array of protocol
+/// conformances.
+///
+/// The given `fn` will be called with each unsafe use. If it returns `true`
+/// for any use, this function will return `true` immediately. Otherwise,
+/// it will return `false` once all unsafe uses have been emitted.
+bool enumerateUnsafeUses(ArrayRef<ProtocolConformanceRef> conformances,
+                         SourceLoc loc,
+                         llvm::function_ref<bool(UnsafeUse)> fn);
+
 /// Enumerate all of the unsafe uses that occur within this substitution map.
-/// reference.
 ///
 /// The given `fn` will be called with each unsafe use. If it returns `true`
 /// for any use, this function will return `true` immediately. Otherwise,

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -104,6 +104,26 @@ class MyRange {
   }
 }
 
+func casting(value: Any, i: Int) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = value as? UnsafeType // expected-note{{reference to unsafe type 'UnsafeType'}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = value as! UnsafeType // expected-note{{reference to unsafe type 'UnsafeType'}}
+
+  _ = unsafe value as? UnsafeType
+  _ = unsafe value as! UnsafeType
+
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = i as any P // expected-note{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
+}
+
+func metatypes() {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let _: Any.Type = UnsafeType.self // expected-note{{reference to unsafe type 'UnsafeType'}}
+
+  let _: Any.Type = unsafe UnsafeType.self
+}
+
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -131,8 +131,18 @@ func testKeyPath() {
   _ = unsafe \HasProperties.computedUnsafe
 }
 
+func takesAutoclosure<T>(_ body: @autoclosure () -> T) { }
+
+func testAutoclosure() {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{20-20=unsafe }}
+  takesAutoclosure(unsafeFunction()) // expected-note{{reference to unsafe global function 'unsafeFunction()'}}
+
+  unsafe takesAutoclosure(unsafeFunction())
+
+  takesAutoclosure(unsafe unsafeFunction())
+}
+
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}
 }
-

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -124,6 +124,13 @@ func metatypes() {
   let _: Any.Type = unsafe UnsafeType.self
 }
 
+func testKeyPath() {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = \HasProperties.computedUnsafe // expected-note{{reference to unsafe property 'computedUnsafe'}}
+
+  _ = unsafe \HasProperties.computedUnsafe
+}
+
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -60,6 +60,18 @@ struct HasProperties {
   }()
 }
 
+protocol P { }
+
+extension Int: @unsafe P { }
+
+func acceptP(_: some P) { }
+
+func testConformance(i: Int) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  acceptP(i) // expected-note{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
+}
+
+
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -81,6 +81,16 @@ func returnsExistentialP() -> any P {
   // expected-note@-1{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
 }
 
+class MyRange {
+  @unsafe init(unchecked bounds: Range<Int>) { }
+
+  convenience init(_ bounds: Range<Int>) {
+    // bounds check
+    self.init(unchecked: bounds) // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+    // expected-note@-1{{reference to unsafe initializer 'init(unchecked:)'}}
+  }
+}
+
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -81,6 +81,19 @@ func returnsExistentialP() -> any P {
   // expected-note@-1{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
 }
 
+struct UnsafeAsSequence: @unsafe Sequence, IteratorProtocol {
+  mutating func next() -> Int? { nil }
+}
+
+func testUnsafeAsSequenceForEach() {
+  let uas = UnsafeAsSequence()
+
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{12-12=unsafe }}
+  for _ in uas { } // expected-note{{conformance}}
+
+  for _ in unsafe uas { } // okay
+}
+
 class MyRange {
   @unsafe init(unchecked bounds: Range<Int>) { }
 

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -71,6 +71,15 @@ func testConformance(i: Int) {
   acceptP(i) // expected-note{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
 }
 
+func returnsOpaqueP() -> some P {
+  5 // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
+}
+
+func returnsExistentialP() -> any P {
+  5 // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1{{@unsafe conformance of 'Int' to protocol 'P' involves unsafe code}}
+}
 
 // Parsing of `unsafe` expressions.
 func testUnsafePositionError() -> Int {

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -60,10 +60,19 @@ extension S3: P {
 
 struct S4 { }
 
-@unsafe
-extension S4: P {
+extension S4: @unsafe P {
   @unsafe
   func protoMethod() { } // okay
+}
+
+protocol P2 {
+  func proto2Method()
+}
+
+@unsafe
+extension S4: P2 { // expected-warning{{conformance of 'S4' to protocol 'P2' involves unsafe code; use '@unsafe' to indicate that the conformance is not memory-safe}}
+  @unsafe
+  func proto2Method() { } // expected-note{{unsafe instance method}}
 }
 
 


### PR DESCRIPTION
Improve `unsafe` effects checking to capture more potential uses of unsafe constructs:
* References to unsafe declarations in constructors, literal conversions, and key paths
* References to unsafe conformances in existential conversions, opaque result type conversions
* References to unsafe types in casts and metatype references
* References to unsafe conformances in the for..in loop
* Properly handle `unsafe` with auto closures

While here, fix some issues with `@unsafe` conformances: they weren't being recorded as unsafe when placed on an extension (!), and we were inferring that all conformances of an unsafe type are unsafe. We don't need that, because the type being unsafe is enough.