### PR TITLE
OpenedExistentials: Do not attempt to erase existential metatypes wit…

### DIFF
--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -147,7 +147,7 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
   }
 
   // Metatypes preserve variance.
-  if (auto metaTy = type->getAs<MetatypeType>()) {
+  if (auto metaTy = type->getAs<AnyMetatypeType>()) {
     return findGenericParameterReferencesRec(genericSig, origParam, openedParam,
                                              metaTy->getInstanceType(),
                                              position, canBeCovariantResult);
@@ -272,10 +272,9 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
         TypePosition::Invariant, /*canBeCovariantResult=*/false);
   }
 
-  // Specifically ignore parameterized protocols and existential
-  // metatypes because we can erase them to the upper bound.
-  if (type->is<ParameterizedProtocolType>() ||
-      type->is<ExistentialMetatypeType>()) {
+  // Specifically ignore parameterized protocols because we can erase them to
+  // the upper bound.
+  if (type->is<ParameterizedProtocolType>()) {
     return GenericParameterReferenceInfo();
   }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -485,6 +485,20 @@ do {
 }
 
 do {
+  class C<T> {}
+  protocol P {}
+
+  func f<T: P>(_: T, _: (() -> any (P & C<T>).Type)? = nil) {}
+  // expected-note@-1 {{required by local function 'f' where 'T' = 'any P'}}
+
+  let p: any P
+  // CHECK-NOT: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
+  f(p)
+  // expected-error@-1 {{type 'any P' cannot conform to 'P'}}
+  // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+}
+
+do {
   protocol P {}
 
   func foo<T: P>(_ m: inout T.Type) {}

--- a/test/decl/protocol/existential_member_access/basic.swift
+++ b/test/decl/protocol/existential_member_access/basic.swift
@@ -510,6 +510,7 @@ do {
     // expected-error@+1 {{non-protocol, non-class type 'Sequence<${type}>' cannot be used within a protocol-constrained type}}
     func invariant13() -> any P & Sequence<${type}>
     func invariant14() -> (any Sequence<${type}>).Type
+    func invariant15() -> any (P & Class<${type}>).Type
 
 
     var invariantProp1: (inout ${type}) -> Void { get }
@@ -523,6 +524,7 @@ do {
     var invariantProp9: (Struct<() -> ${type}>) -> Void { get }
     var invariantProp10: (any P & Class<${type}>) -> Void { get }
     var invariantProp11: Struct<${type}>.InnerGeneric<Void> { get }
+    var invariantProp15: any (P & Class<${type}>).Type { get }
 
     subscript(invariantSubscript1 _: Struct<${type}>) -> Void { get }
     subscript(invariantSubscript2 _: Void) -> Struct<${type}> { get }
@@ -532,6 +534,7 @@ do {
     subscript(invariantSubscript6 _: Struct<() -> ${type}>) -> Void { get }
     subscript(invariantSubscript7 _: any P & Class<${type}>) -> Void { get }
     subscript(invariantSubscript8 _: Void) -> Struct<${type}>.InnerGeneric<Void> { get }
+    subscript(invariantSubscript15 _: Void) -> any (P & Class<${type}>).Type { get }
   }
 
   let exist: any P
@@ -561,6 +564,7 @@ do {
     var types = SwiftTypePair(typeOf: exist.invariant14(), type2: SwiftType<(any Sequence).Type>.self)
     types.assertTypesAreEqual()
   }
+  exist.invariant15() // expected-error {{member 'invariant15' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
 
   exist.invariantProp1 // expected-error {{member 'invariantProp1' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist.invariantProp2 // expected-error {{member 'invariantProp2' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
@@ -573,6 +577,7 @@ do {
   exist.invariantProp9 // expected-error {{member 'invariantProp9' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist.invariantProp10 // expected-error {{member 'invariantProp10' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist.invariantProp11 // expected-error {{member 'invariantProp11' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
+  exist.invariantProp15 // expected-error {{member 'invariantProp15' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
 
   exist[invariantSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist[invariantSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
@@ -582,4 +587,5 @@ do {
   exist[invariantSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist[invariantSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
   exist[invariantSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
+  exist[invariantSubscript15: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
 }


### PR DESCRIPTION
…h invariant `Self`

The non-metatype case was never supported. The same should hold for the existential metatype case, which used to miscompile and now crashes because the invariant reference is deemed OK but the erasure expectedly fails to handle it:

```swift
class C<T> {}
protocol P {
  associatedtype A

  func f() -> any P & C<A>
  func fMeta() -> any (P & C<A>).Type
}

do {
  let p: any P
  let _ = p.f() // error
  let _ = p.fMeta() // crash
}
```