### PR TITLE
LifetimeDependenceDiagnostics; remove a bootstrapping hack.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -199,21 +199,6 @@ private struct DiagnoseDependence {
     if function.hasUnsafeNonEscapableResult {
       return .continueWalk
     }
-    // FIXME: remove this condition once we have a Builtin.dependence,
-    // which developers should use to model the unsafe
-    // dependence. Builtin.lifetime_dependence will be lowered to
-    // mark_dependence [unresolved], which will be checked
-    // independently. Instead, of this function result check, allow
-    // isUnsafeApplyResult to be used be mark_dependence [unresolved]
-    // without checking its dependents.
-    //
-    // Allow returning an apply result (@_unsafeNonescapableResult) if
-    // the calling function has a dependence. This implicitly makes
-    // the unsafe nonescapable result dependent on the calling
-    // function's lifetime dependence arguments.
-    if dependence.isUnsafeApplyResult, function.hasResultDependence {
-      return .continueWalk
-    }
     // Check that the parameter dependence for this result is the same
     // as the current dependence scope.
     if let arg = dependence.scope.parentValue as? FunctionArgument,

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -225,16 +225,6 @@ extension LifetimeDependence {
     self.dependentValue = value
   }
 
-  var isUnsafeApplyResult: Bool {
-    if case let .owned(value) = scope {
-      if let apply = value.definingInstruction as? FullApplySite {
-        assert(!apply.hasResultDependence)
-        return true
-      }
-    }
-    return false
-  }
-
   /// Construct LifetimeDependence from mark_dependence [unresolved] or mark_dependence [nonescaping].
   ///
   /// For any LifetimeDependence constructed from a mark_dependence, its `dependentValue` will be the result of the

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -6,10 +6,26 @@
 // REQUIRES: swift_feature_LifetimeDependence
 
 @_unsafeNonescapableResult
+@lifetime(borrow source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, borrowing source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}
+
+@_unsafeNonescapableResult
 @lifetime(source)
-func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
-  dependent: consuming T, dependsOn source: borrowing U)
-  -> T {
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, copying source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
 
@@ -21,7 +37,7 @@ struct BufferView : ~Escapable {
     self.ptr = ptr
     self.c = c
   }
-  @_unsafeNonescapableResult
+  @lifetime(borrow ptr)
   init(independent ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
@@ -74,7 +90,8 @@ func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0)  @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
-  return BufferView(independent: x.ptr, x.c)
+  let bv = BufferView(independent: x.ptr, x.c)
+  return _overrideLifetime(bv, copying: x)
 }
 
 func use(_ x: borrowing BufferView) {}
@@ -175,7 +192,7 @@ struct GenericBufferView<Element> : ~Escapable {
         count: bounds.upperBound.distance(to:bounds.lowerBound) / MemoryLayout<Element>.stride
       )
       // assuming that bounds is within self
-      return unsafeLifetime(dependent: result, dependsOn: self)
+      return _overrideLifetime(result, copying: self)
     }
   }
 }

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -21,12 +21,12 @@ extension P {
 }
 
 public struct View: ~Escapable {
-  // TODO: dependsOn(immortal)
-  @_unsafeNonescapableResult
+  @lifetime(immortal)
   init() { }
 }
 
 public struct PView: P {
+  @lifetime(immortal)
   borrowing func getE() -> View { return View() }
 }
 
@@ -36,7 +36,7 @@ public func test(pview: borrowing PView) -> View {
 
 // CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @lifetime(borrow 0)  @out Self.E {
 
-// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyF : $@convention(method) (PView) -> @lifetime(borrow 0)  @owned View {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyF : $@convention(method) (PView) -> @lifetime(immortal) @owned View {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzyFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> @lifetime(borrow 0)  @out View {
 

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -5,6 +5,30 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
 
+@_unsafeNonescapableResult
+@lifetime(borrow source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, borrowing source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}
+
+@_unsafeNonescapableResult
+@lifetime(source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, copying source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}
+
 // TODO: Use real Range
 public struct FakeRange<Bound> {
   public let lowerBound: Bound
@@ -128,10 +152,11 @@ extension Span {
   public subscript(bounds: FakeRange<SpanIndex<Element>>) -> Self {
   @lifetime(self)
     get {
-      Span(
+      let span = Span(
         start: bounds.lowerBound,
         count: bounds.upperBound.distance(to:bounds.lowerBound) / MemoryLayout<Element>.stride
       )
+      return _overrideLifetime(span, copying: self)
     }
   }
 

--- a/test/SILOptimizer/addressable_dependencies.swift
+++ b/test/SILOptimizer/addressable_dependencies.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature ValueGenerics %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -disable-access-control -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature ValueGenerics %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_AddressableTypes
@@ -69,12 +69,14 @@ struct Schmector {
         // CHECK-SAME:    (@in_guaranteed Schmector) ->
         @lifetime(borrow self)
         borrowing get {
-            return Spam(base: UnsafePointer(Builtin.addressOfBorrow(self)), count: 10)
+            let pointer = UnsafePointer<Int>(Builtin.addressOfBorrow(self))
+            let spam = Spam(base: pointer, count: 10)
+            return _overrideLifetime(spam, borrowing: self)
         }
     }
 }
 
 struct Spam: ~Escapable {
-    @_unsafeNonescapableResult
+    @lifetime(borrow base)
     init(base: UnsafePointer<Int>, count: Int) {}
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -31,13 +31,17 @@ struct NC : ~Copyable {
     BV(p, i)
   }
 
+  // @lifetime(borrow self)
   borrowing func getEmpty() -> Empty {
     Empty()
   }
 }
 
 // Test dependencies on an empty struct.
-public struct Empty: ~Escapable {}
+public struct Empty: ~Escapable {
+  @lifetime(immortal)
+  init() {}
+}
 
 func use(e: Empty) {}
 

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -74,7 +74,17 @@ extension Array {
   }
 }
 
-struct Inner {
+struct InnerTrivial {
+  var p: UnsafePointer<Int>
+
+  @lifetime(borrow self)
+  borrowing func span() -> Span<Int> {
+    Span(base: p, count: 1)
+  }
+}
+
+struct InnerObject {
+  let object: AnyObject
   var p: UnsafePointer<Int>
 
   @lifetime(borrow self)
@@ -84,14 +94,31 @@ struct Inner {
 }
 
 struct Outer {
-  let inner: Inner
-  let fakePointer: UnsafePointer<Inner>
+  var _innerTrivial: InnerTrivial
+  var _innerObject: InnerObject
+  let trivialPointer: UnsafePointer<InnerTrivial>
+  let objectPointer: UnsafePointer<InnerObject>
 
-  var innerAddress: Inner {
+  var innerTrivialAddress: InnerTrivial {
     unsafeAddress {
-      fakePointer
+      trivialPointer
     }
   }
+
+  var innerObjectAddress: InnerObject {
+    unsafeAddress {
+      objectPointer
+    }
+  }
+
+  var innerTrivialTemp: InnerTrivial {
+    get { _innerTrivial }
+  }
+
+  var innerObjectTemp: InnerObject {
+    get { _innerObject }
+  }
+
   /* TODO: rdar://137608270 Add Builtin.addressof() support for @addressable arguments
   @addressableSelf
   var innerAddress: Inner {
@@ -206,11 +233,63 @@ func testTrivialScope<T>(a: Array<T>) -> Span<T> {
 // =============================================================================
 
 @lifetime(borrow outer)
-func testBorrowComponent(outer: Outer) -> Span<Int> {
-  outer.inner.span()
+func testBorrowStoredTrivial(outer: Outer) -> Span<Int> {
+  outer._innerTrivial.span()
 }
 
 @lifetime(borrow outer)
-func testBorrowAddressComponent(outer: Outer) -> Span<Int> {
-  outer.innerAddress.span()
+func testBorrowStoredObject(outer: Outer) -> Span<Int> {
+  outer._innerObject.span()
 }
+
+@lifetime(borrow outer)
+func testBorrowTrivialAddressProjection(outer: Outer) -> Span<Int> {
+  outer.innerTrivialAddress.span()
+}
+
+@lifetime(borrow outer)
+func testBorrowObjectAddressProjection(outer: Outer) -> Span<Int> {
+  outer.innerObjectAddress.span()
+}
+
+func testExprExtendTrivialTemp(outer: Outer) {
+  parse(outer.innerTrivialTemp.span())
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+  // expected-note  @-3{{this use of the lifetime-dependent value is out of scope}}
+}
+
+func testExprExtendObjectTemp(outer: Outer) {
+  parse(outer.innerObjectTemp.span())
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+  // expected-note  @-3{{this use of the lifetime-dependent value is out of scope}}
+}
+
+func testLocalExtendTrivialTemp(outer: Outer) {
+  let span = outer.innerTrivialTemp.span()
+  // expected-error @-1{{lifetime-dependent variable 'span' escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+  parse(span) // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+func testLocalExtendObjectTemp(outer: Outer) {
+  let span = outer.innerObjectTemp.span()
+  // expected-error @-1{{lifetime-dependent variable 'span' escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+  parse(span) // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+@lifetime(borrow outer)
+func testReturnTrivialTemp(outer: Outer) -> Span<Int> {
+  outer.innerTrivialTemp.span()
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+} // expected-note {{this use causes the lifetime-dependent value to escape}}
+
+@lifetime(borrow outer)
+func testReturnObjectTemp(outer: Outer) -> Span<Int> {
+  outer.innerObjectTemp.span()
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
+} // expected-note  {{this use causes the lifetime-dependent value to escape}}

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -1,4 +1,8 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -predictable-deadalloc-elim | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -predictable-deadalloc-elim \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
 
 sil_stage canonical
 
@@ -23,6 +27,8 @@ case some(T)
 
 protocol P {}
 struct S: P {}
+
+struct NE: ~Escapable {}
 
 ///////////
 // Tests //
@@ -761,4 +767,21 @@ bb0(%0 : $S):
   %4 = init_existential_addr %1 : $*any P, $S
   store %0 to [trivial] %4 : $*S
   unreachable
+}
+
+// Preserve ownership for empty ~Escapable structs.
+//
+// CHECK-LABEL: sil hidden [ossa] @testEmptyNonEscapable : $@convention(method) (@guaranteed NE) -> @lifetime(copy 0) @owned NE {
+// CHECK: bb0(%0 : @guaranteed $NE):
+// CHECK-NEXT:   %1 = copy_value %0 : $NE
+// CHECK-NEXT:   return %1 : $NE
+// CHECK-LABEL: } // end sil function 'testEmptyNonEscapable'
+sil hidden [ossa] @testEmptyNonEscapable : $@convention(method) (@guaranteed NE) -> @lifetime(copy 0) @owned NE {
+bb0(%0 : @guaranteed $NE):
+  %1 = copy_value %0
+  %13 = alloc_stack $NE
+  store %1 to [init] %13
+  %22 = load [take] %13
+  dealloc_stack %13
+  return %22
 }


### PR DESCRIPTION
This temporary hack was preventing diagnostics from kicking in. This could even result in invalid SIL after the diagnostic failed to trigger.

Add unit tests for lifetime dependence property access semantics.

