### PR TITLE
[Sema]Skip Sendable conformance check when `sending` are added to parameters or return types of an actor-isolated function

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1168,34 +1168,58 @@ bool swift::diagnoseNonSendableTypesInReference(
       return true;
   }
 
-  // For functions, check the parameter and result types.
+  // For functions or subscripts, check the parameter and result types.
   SubstitutionMap subs = declRef.getSubstitutions();
-  if (auto function = dyn_cast<AbstractFunctionDecl>(declRef.getDecl())) {
+  auto decl = declRef.getDecl();
+  if (isa<AbstractFunctionDecl>(decl) || isa<SubscriptDecl>(decl)) {
     if (funcCheckOptions.contains(FunctionCheckKind::Params)) {
       // only check params if funcCheckKind specifies so
-      for (auto param : *function->getParameters()) {
+      ParameterList *paramList = nullptr;
+      if (auto function = dyn_cast<AbstractFunctionDecl>(decl)) {
+        paramList = function->getParameters();
+      } else if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
+        paramList = subscript->getIndices();
+      }
+
+      // Check params of this function or subscript override for sendability
+      for (auto param : *paramList) {
         Type paramType = param->getInterfaceType().subst(subs);
+        if (param->isSending() && !paramType->hasError()) {
+          continue;
+        }
         if (diagnoseNonSendableTypes(
-                paramType, fromDC, derivedConformanceType,
-                refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
-                getSendableParamDiag(refKind),
-                function, getActorIsolation()))
+                paramType, fromDC, derivedConformanceType, refLoc,
+                diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
+                getSendableParamDiag(refKind), decl, getActorIsolation()))
           return true;
       }
     }
 
-    // Check the result type of a function.
-    if (auto func = dyn_cast<FuncDecl>(function)) {
-      if (funcCheckOptions.contains(FunctionCheckKind::Results)) {
-        // only check results if funcCheckKind specifies so
-        Type resultType = func->getResultInterfaceType().subst(subs);
-        if (diagnoseNonSendableTypes(
-            resultType, fromDC, derivedConformanceType,
-            refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
-            getSendableResultDiag(refKind),
-            func, getActorIsolation()))
-          return true;
+    // Check the result type of a function or subscript.
+    if (funcCheckOptions.contains(FunctionCheckKind::Results)) {
+      Type resultType;
+      bool hasSendingResult;
+      if (auto func = dyn_cast<FuncDecl>(decl)) {
+        resultType = func->getResultInterfaceType().subst(subs);
+        hasSendingResult = func->hasSendingResult();
+        decl = func;
+      } else if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
+        resultType = subscript->getElementInterfaceType().subst(subs);
+        hasSendingResult = isa<SendingTypeRepr>(subscript->getResultTypeRepr());
       }
+      if (!resultType) {
+        return false;
+      }
+      auto diag = getSendableResultDiag(refKind);
+      if (diag.ID == diag::non_sendable_result_in_witness.ID &&
+          hasSendingResult && !resultType->hasError()) {
+        return false;
+      }
+      if (diagnoseNonSendableTypes(
+              resultType, fromDC, derivedConformanceType, refLoc,
+              diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc, diag, decl,
+              getActorIsolation()))
+        return true;
     }
 
     return false;
@@ -1211,34 +1235,6 @@ bool swift::diagnoseNonSendableTypesInReference(
             getSendablePropertyDiag(refKind),
             var, getActorIsolation()))
       return true;
-  }
-
-  if (auto subscript = dyn_cast<SubscriptDecl>(declRef.getDecl())) {
-    for (auto param : *subscript->getIndices()) {
-      if (funcCheckOptions.contains(FunctionCheckKind::Params)) {
-        // Check params of this subscript override for sendability
-        Type paramType = param->getInterfaceType().subst(subs);
-        if (diagnoseNonSendableTypes(
-                paramType, fromDC, derivedConformanceType,
-                refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
-                getSendableParamDiag(refKind),
-                subscript, getActorIsolation()))
-          return true;
-      }
-    }
-
-    if (funcCheckOptions.contains(FunctionCheckKind::Results)) {
-      // Check the element type of a subscript.
-      Type resultType = subscript->getElementInterfaceType().subst(subs);
-      if (diagnoseNonSendableTypes(
-              resultType, fromDC, derivedConformanceType,
-              refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
-              getSendableResultDiag(refKind),
-              subscript, getActorIsolation()))
-        return true;
-    }
-
-    return false;
   }
 
   return false;

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -459,8 +459,9 @@ bool diagnoseNonSendableTypesWithSendingCheck(
       return false;
   }
   if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
-    if (isa<SendingTypeRepr>(subscript->getResultTypeRepr()))
-      return false;
+    if (auto resultTypeRepr = subscript->getResultTypeRepr())
+      if (isa<SendingTypeRepr>(resultTypeRepr))
+        return false;
   }
 
   return diagnoseNonSendableTypes(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -459,9 +459,8 @@ bool diagnoseNonSendableTypesWithSendingCheck(
       return false;
   }
   if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
-    if (auto resultTypeRepr = subscript->getResultTypeRepr())
-      if (isa<SendingTypeRepr>(resultTypeRepr))
-        return false;
+    if (isa_and_nonnull<SendingTypeRepr>(subscript->getResultTypeRepr()))
+      return false;
   }
 
   return diagnoseNonSendableTypes(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Sema/Concurrency.h"
 
 #include <cassert>
@@ -434,6 +435,37 @@ namespace detail {
   struct Identity {
     typedef T type;
   };
+}
+
+/// Diagnose any non-Sendable types that occur within the given type, using
+/// the given diagnostic.
+///
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced or if a decl contains a sending
+/// parameter or result
+template <typename... DiagArgs>
+bool diagnoseNonSendableTypesWithSendingCheck(
+    ValueDecl *decl, Type type, SendableCheckContext fromContext,
+    Type derivedConformance, SourceLoc typeLoc, SourceLoc diagnoseLoc,
+    Diag<Type, DiagArgs...> diag,
+    typename detail::Identity<DiagArgs>::type... diagArgs) {
+  if (auto param = dyn_cast<ParamDecl>(decl)) {
+    if (param->isSending()) {
+      return false;
+    }
+  }
+  if (auto *func = dyn_cast<FuncDecl>(decl)) {
+    if (func->hasSendingResult())
+      return false;
+  }
+  if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
+    if (isa<SendingTypeRepr>(subscript->getResultTypeRepr()))
+      return false;
+  }
+
+  return diagnoseNonSendableTypes(
+      type, fromContext, derivedConformance, typeLoc, diagnoseLoc, diag,
+      std::forward<decltype(diagArgs)>(diagArgs)...);
 }
 
 /// Diagnose any non-Sendable types that occur within the given type, using

--- a/test/Concurrency/sendable_conformance_checking_skip_sending.swift
+++ b/test/Concurrency/sendable_conformance_checking_skip_sending.swift
@@ -1,0 +1,89 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// https://github.com/swiftlang/swift/issues/76710
+
+class NonSendableKlass1 {}
+
+protocol P1 {
+  func bar(_ a: sending NonSendableKlass1) async -> sending NonSendableKlass1
+}
+
+@MainActor
+class P1Class: P1 {
+  func bar(_ a: sending NonSendableKlass1) async -> sending NonSendableKlass1 { a }
+}
+
+class NonSendableKlass2 {}
+// expected-note@-1 2{{class 'NonSendableKlass2' does not conform to the 'Sendable' protocol}}
+
+protocol P2 {
+  func bar(_ a: NonSendableKlass2) async -> NonSendableKlass2
+}
+
+@MainActor
+class P2Class: P2 {
+  func bar(_ a: NonSendableKlass2) async -> NonSendableKlass2 { a }
+  // expected-error@-1 {{non-sendable type 'NonSendableKlass2' cannot be returned from main actor-isolated implementation to caller of protocol requirement 'bar'}}
+  // expected-error@-2 {{non-sendable parameter type 'NonSendableKlass2' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
+}
+
+class NonSendableKlass3 {}
+
+protocol P3 {
+  func bar(_ a: sending NonSendableKlass3) async -> sending NonSendableKlass3
+}
+
+actor P3Actor: P3 {
+  func bar(_ a: sending NonSendableKlass3) async -> sending NonSendableKlass3 { NonSendableKlass3() }
+}
+
+class NonSendableKlass4 {}
+// expected-note@-1 2{{class 'NonSendableKlass4' does not conform to the 'Sendable' protocol}}
+
+protocol P4 {
+  func bar(_ a: NonSendableKlass4) async -> NonSendableKlass4
+}
+
+actor P4Actor: P4 {
+  func bar(_ a: NonSendableKlass4) async -> NonSendableKlass4 { NonSendableKlass4() }
+  // expected-error@-1 {{non-sendable type 'NonSendableKlass4' cannot be returned from actor-isolated implementation to caller of protocol requirement 'bar'}}
+  // expected-error@-2 {{non-sendable parameter type 'NonSendableKlass4' cannot be sent from caller of protocol requirement 'bar' into actor-isolated implementation}}
+}
+
+class NonSendableKlass5 {}
+// expected-note@-1 {{class 'NonSendableKlass5' does not conform to the 'Sendable' protocol}}
+
+
+protocol P5 {
+  func bar(_ a: sending NonSendableKlass5, _ b: NonSendableKlass5) async -> sending NonSendableKlass5
+}
+
+@MainActor
+class P5Class: P5 {
+  func bar(_ a: sending NonSendableKlass5, _ b: NonSendableKlass5) async -> sending NonSendableKlass5 { a }
+  // expected-error@-1 {{non-sendable parameter type 'NonSendableKlass5' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
+}
+
+class NonSendableKlass6 {}
+
+protocol P6 {
+  func bar(_ a: sending NonSendableKlass6, _ b: sending NonSendableKlass6) async -> sending NonSendableKlass6
+}
+
+@MainActor
+class P6Class: P6 {
+  func bar(_ a: sending NonSendableKlass6, _ b: sending NonSendableKlass6) async -> sending NonSendableKlass6 { a }
+}
+
+class NonSendableKlass7 {}
+
+protocol P7 {
+  subscript(_: sending NonSendableKlass7) -> sending NonSendableKlass7 { get async }
+}
+
+@MainActor
+struct S: P7 {
+  subscript(_: sending NonSendableKlass7) -> sending NonSendableKlass7 {
+    get async { NonSendableKlass7() }
+  }
+}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

  Resolves #76710 

Previously, we encountered errors and notes when using a non-Sendable type with `sending` for parameters or return types of an actor-isolated function, as shown below:

```swift
class NonSendable { var value = 0 } // note: class 'NonSendable' does not conform to the 'Sendable' protocol

protocol P {
    func bar(a: sending NonSendable) async -> sending NonSendable
}

@MainActor
class PImpl: P {
    // error: non-sendable type 'NonSendable' cannot be returned from main actor-isolated implementation to caller of protocol requirement 'bar(a:)'
    // error: non-sendable parameter type 'NonSendable' cannot be sent from caller of protocol requirement 'bar(a:)' into main actor-isolated implementation
    func bar(a: sending NonSendable) async -> sending NonSendable { a }
}
```

Based on the issue described, this functionality should work without any errors. To resolve the issue, we need to bypass the Sendable conformance check for non-Sendable types when `sending` keywords is added to function's parameters or return types.

--

Even if the conformance check is skipped, invalid scenarios will still be validated at the SIL stage to ensure correctness.

For example:

When running `-emit-sil -swift-version 6`, a potential data race error is still detected.

```swift
func test() async {
    var nonSendable = NonSendable()
    let p = PImpl()

    // error: sending 'nonSendable' risks causing data races
    // note: 'nonSendable' used after being passed as a 'sending' parameter; Later uses could race 
    _ = await p.bar(a: nonSendable)

    // note: access can happen concurrently 
    nonSendable.value = 1 
}
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
