### PR TITLE
[AutoDiff] Do not require no optimizations for control_flow test

### DIFF
--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -5,9 +5,6 @@
 // iphonesimulator-i386-specific failures.
 // REQUIRES: CPU=x86_64
 
-// rdar://71642726 this test is crashing with optimizations.
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Differentiation
 import StdlibUnittest
 


### PR DESCRIPTION
The test used to crash with optimizations enabled previously, but currently it passes with `swift_test_mode_optimize` and `swift_test_mode_optimize_size`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
