### PR TITLE
[cxx-interop] Fix compiling stdlib 6.2 with Swift compiler 6.1

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -413,6 +413,11 @@ EXPERIMENTAL_FEATURE(SafeInterop, true)
 // generate Swift wrappers with safe pointer types.
 EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
 
+/// Enables converting a C++ span to Swift's span.
+/// We need this for maintaining compatibility between the Swift 6.1 compiler
+/// and the 6.2 stdlib implementation.
+EXPERIMENTAL_FEATURE(SpanConversions, false)
+
 /// Ignore resilience errors due to C++ types.
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -349,6 +349,7 @@ static bool usesFeatureABIAttribute(Decl *decl) {
 UNINTERESTING_FEATURE(WarnUnsafe)
 UNINTERESTING_FEATURE(SafeInterop)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
+UNINTERESTING_FEATURE(SpanConversions)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(CoroutineAccessorsAllocateInCallee)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -657,6 +657,8 @@ static void diagnoseCxxInteropCompatMode(Arg *verArg, ArgList &Args,
 
 void LangOptions::setCxxInteropFromArgs(ArgList &Args,
                                         swift::DiagnosticEngine &Diags) {
+  enableFeature(Feature::SpanConversions);
+
   if (Arg *A = Args.getLastArg(options::OPT_cxx_interoperability_mode)) {
     if (Args.hasArg(options::OPT_enable_experimental_cxx_interop)) {
       Diags.diagnose(SourceLoc(), diag::dont_enable_interop_and_compat);

--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -77,6 +77,7 @@ extension CxxSpan {
   }
 }
 
+#if $SpanConversions
 @available(SwiftStdlib 6.1, *)
 extension Span {
   @_alwaysEmitIntoClient
@@ -91,6 +92,7 @@ extension Span {
     self = _overrideLifetime(newSpan, borrowing: span)
   }
 }
+#endif
 
 public protocol CxxMutableSpan<Element> {
   associatedtype Element

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -660,6 +660,7 @@ StdSpanTestSuite.test("Convert between Swift and C++ span types") {
   guard #available(SwiftStdlib 6.1, *) else {
     return
   }
+  #if $SpanConversions
   do {
     var arr: [Int32] = [1, 2, 3]
     arr.withUnsafeMutableBufferPointer{ ubpointer in
@@ -672,6 +673,7 @@ StdSpanTestSuite.test("Convert between Swift and C++ span types") {
       expectEqual(swiftSpan[2], 3)
     }
   }
+  #endif
   do {
     var arr: [Int32] = [1, 2, 3]
     arr.withUnsafeMutableBufferPointer{ ubpointer in


### PR DESCRIPTION
Apparently, one of the implementations depends on features that did not land in 6.1. Adding some safe guards to avoid error in this scenario.

rdar://142634994
