### PR TITLE
🍒[cxx-interop] Skip type metadata for C++ types that are only used in private C++ fields

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -931,6 +931,15 @@ private:
 
     B.addInt32(getNumFields(NTD));
     forEachField(IGM, NTD, [&](Field field) {
+      // Skip private C++ fields that were imported as private Swift fields.
+      // The type of a private field might not have all the type witness
+      // operations that Swift requires, for instance,
+      // `std::unique_ptr<IncompleteType>` would not have a destructor.
+      if (field.getKind() == Field::Kind::Var &&
+          field.getVarDecl()->getClangDecl() &&
+          field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
+        return;
+
       addField(field);
     });
   }

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -151,3 +151,9 @@ module Closure {
   header "closure.h"
   requires cplusplus
 }
+
+module PIMPL {
+  header "pimpl.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/class/Inputs/pimpl.h
+++ b/test/Interop/Cxx/class/Inputs/pimpl.h
@@ -1,0 +1,24 @@
+#include <memory>
+
+// C++ types that use pointer-to-implementation idiom.
+
+struct HasPIMPL {
+private:
+  struct I;
+  I *ptr;
+};
+
+HasPIMPL createHasPIMPL();
+
+struct HasSmartPIMPL {
+private:
+  struct I;
+  std::unique_ptr<I> smart_ptr;
+
+public:
+  HasSmartPIMPL();
+  HasSmartPIMPL(const HasSmartPIMPL &other);
+  ~HasSmartPIMPL();
+};
+
+HasSmartPIMPL createHasSmartPIMPL();

--- a/test/Interop/Cxx/class/pimpl-irgen.swift
+++ b/test/Interop/Cxx/class/pimpl-irgen.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swiftxx-frontend -emit-irgen %s -I %S/Inputs | %FileCheck %s
+
+// Make sure Swift handles the C++ pointer-to-implementation idiom properly.
+
+import PIMPL
+
+// Trigger type metadata to be emitted by conforming C++ types to a Swift protocol.
+protocol MyProto {}
+extension HasPIMPL : MyProto {}
+extension HasSmartPIMPL : MyProto {}
+
+let _ = createHasPIMPL()
+let _ = createHasSmartPIMPL()
+
+// CHECK-NOT: @"get_type_metadata {{.*}}default_delete{{.*}}

--- a/test/Interop/Cxx/class/pimpl-module-interface.swift
+++ b/test/Interop/Cxx/class/pimpl-module-interface.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=PIMPL -print-access -I %S/Inputs -cxx-interoperability-mode=default -source-filename=x | %FileCheck %s
+
+// FIXME: We can't import std::unique_ptr properly on Windows (https://github.com/apple/swift/issues/70226)
+// XFAIL: OS=windows-msvc
+
+// CHECK:      public struct HasPIMPL {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private var ptr: OpaquePointer!
+// CHECK-NEXT: }
+
+// CHECK:      public struct HasSmartPIMPL {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private var smart_ptr: std.
+// CHECK-NEXT: }


### PR DESCRIPTION
**Explanation**: When importing C++ types that use pointer-to-implementation idiom, when the implementation type is forward-declared, the compiler would previously emit an error:
```
invalid application of 'sizeof' to an incomplete type
```
This was happening because Swift was trying to emit the value witness table for `std::unique_ptr<IncompleteType>`, which isn't possible, because the destructor cannot be instantiated for an incomplete pointee type. 
**Scope**: This changes IRGen logic that emits Swift metadata for private fields. It now ignores private fields imported from Clang, since there is no way to use those from Swift.
**Risk**: Low, this only affects type metadata of private fields. Swift started importing C++ private fields very recently. Non-C++ imported types don't get private fields in Swift.
**Testing**: Added new compiler tests.
**Issue**: rdar://141960396
**Reviewer**: @Xazax-hun @rjmccall 

Original PR: https://github.com/swiftlang/swift/pull/78467