### PR TITLE
[6.1] Look through forwarding instructions while querying ownership root

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -638,6 +638,13 @@ public:
     return findOwnershipReferenceRoot(getReference());
   }
 
+  /// Return the OSSA root of the reference being accessed
+  /// looking through struct_extract, tuple_extract, etc.
+  /// Precondition: isReference() is true.
+  SILValue getOwnershipReferenceAggregate() const {
+    return findOwnershipReferenceAggregate(getReference());
+  }
+  
   /// Return the storage root of the reference being accessed.
   ///
   /// Precondition: isReference() is true.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1093,7 +1093,7 @@ bool AddressOwnership::areUsesWithinLifetime(
   if (!base.hasLocalOwnershipLifetime())
     return true;
 
-  SILValue root = base.getOwnershipReferenceRoot();
+  SILValue root = base.getOwnershipReferenceAggregate();
   BorrowedValue borrow(root);
   if (borrow)
     return borrow.areUsesWithinExtendedScope(uses, &deadEndBlocks);

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -1010,3 +1010,26 @@ bb0:
  return %t : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_aggreate_tail_addr :
+// CHECK: ref_tail_addr
+// CHECK: ref_tail_addr
+// CHECK-LABEL: } // end sil function 'test_aggreate_tail_addr'
+sil [ossa] @test_aggreate_tail_addr : $@convention(thin) (@owned _NativeDictionary<Int, Klass>) -> () {
+bb0(%0 : @owned $_NativeDictionary<Int, Klass>):
+  %1 = move_value [lexical] %0 : $_NativeDictionary<Int, Klass>
+  %2 = begin_borrow %1 : $_NativeDictionary<Int, Klass>
+  %3 = struct_extract %2 : $_NativeDictionary<Int, Klass>, #_NativeDictionary._storage
+  %4 = copy_value %3 : $__RawDictionaryStorage
+  %5 = ref_tail_addr %3 : $__RawDictionaryStorage, $_UnsafeBitset.Word
+  %6 = load [trivial] %5 : $*_UnsafeBitset.Word
+  end_borrow %2 : $_NativeDictionary<Int, Klass>
+  %8 = begin_borrow %4 : $__RawDictionaryStorage
+  %9 = ref_tail_addr %8 : $__RawDictionaryStorage, $_UnsafeBitset.Word
+  %10 = struct_element_addr %9 : $*_UnsafeBitset.Word, #_UnsafeBitset.Word.value
+  %11 = struct_element_addr %10 : $*UInt, #UInt._value
+  %12 = load [trivial] %11 : $*Builtin.Int64
+  end_borrow %8 : $__RawDictionaryStorage
+  destroy_value %4 : $__RawDictionaryStorage
+  destroy_value %1 : $_NativeDictionary<Int, Klass>
+  unreachable
+}


### PR DESCRIPTION
Explanation: While looking for ownership reference root to determine if address uses are within it's lifetime, skip through struct_extract/tuple_extract and other forwarding operations.
Scope: CSE on functions in OSSA 
Issues: rdar://142507746
Original PRs: https://github.com/swiftlang/swift/pull/78557 
Risk: Low.
Testing: Smoke test.
Reviewers: @nate-chandler 
