### PR TITLE
`AddressableTypes` should be a SUPPRESSIBLE_LANGUAGE_FEATURE.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -434,7 +434,7 @@ EXPERIMENTAL_FEATURE(CoroutineAccessorsAllocateInCallee, false)
 EXPERIMENTAL_FEATURE(GenerateForceToMainActorThunks, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)
-EXPERIMENTAL_FEATURE(AddressableTypes, true)
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
 
 /// Allow the @abi attribute.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3160,13 +3160,30 @@ suppressingFeatureIsolatedDeinit(PrintOptions &options,
   action();
 }
 
+namespace {
+struct ExcludeAttrRAII {
+  std::vector<AnyAttrKind> &ExcludeAttrList;
+  unsigned OriginalExcludeAttrCount;
+  
+  ExcludeAttrRAII(std::vector<AnyAttrKind> &ExcludeAttrList,
+                  DeclAttrKind excluded)
+    : ExcludeAttrList(ExcludeAttrList),
+      OriginalExcludeAttrCount(ExcludeAttrList.size())
+  {
+    ExcludeAttrList.push_back(excluded);
+  }
+  
+  ~ExcludeAttrRAII() {
+    ExcludeAttrList.resize(OriginalExcludeAttrCount);
+  }
+};
+}
+
 static void
 suppressingFeatureAllowUnsafeAttribute(PrintOptions &options,
                                        llvm::function_ref<void()> action) {
-  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
-  options.ExcludeAttrList.push_back(DeclAttrKind::Unsafe);
+  ExcludeAttrRAII scope(options.ExcludeAttrList, DeclAttrKind::Unsafe);
   action();
-  options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
 static void
@@ -3179,11 +3196,17 @@ suppressingFeatureCoroutineAccessors(PrintOptions &options,
 static void
 suppressingFeatureABIAttribute(PrintOptions &options,
                                llvm::function_ref<void()> action) {
-  llvm::SaveAndRestore<bool> scope(options.PrintSyntheticSILGenName, true);
-  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
-  options.ExcludeAttrList.push_back(DeclAttrKind::ABI);
+  llvm::SaveAndRestore<bool> scope1(options.PrintSyntheticSILGenName, true);
+  ExcludeAttrRAII scope2(options.ExcludeAttrList, DeclAttrKind::ABI);
   action();
-  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
+static void
+suppressingFeatureAddressableTypes(PrintOptions &options,
+                                   llvm::function_ref<void()> action) {
+  ExcludeAttrRAII scope(options.ExcludeAttrList,
+                        DeclAttrKind::AddressableForDependencies);
+  action();
 }
 
 /// Suppress the printing of a particular feature.

--- a/test/ModuleInterface/addressable_attrs.swift
+++ b/test/ModuleInterface/addressable_attrs.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs -enable-experimental-feature AddressableTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
+// RUN: %FileCheck %s --input-file %t.swiftinterface
+
+// REQUIRES: swift_feature_AddressableTypes
+
+@_addressableForDependencies
+public struct Foo {}
+// CHECK: #if {{.*}} $AddressableTypes
+// CHECK: @_addressableForDependencies public struct Foo
+// CHECK: #else
+// CHECK: {{^}}public struct Foo {
+// CHECK: #endif


### PR DESCRIPTION
Types annotated as `@_addressableForDependencies` are still usable by older compilers that don't know about nonescapable types or lifetime dependencies, since it only affects the behavior of the type when it's the source of a dependency.