### PR TITLE
[6.1] Sema: Allow opening existential with a warning for rdar://141962317

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8107,5 +8107,11 @@ ERROR(availability_value_generic_type_only_version_newer, none,
 ERROR(invalid_value_for_type_same_type,none,
       "cannot constrain type parameter %0 to be integer %1", (Type, Type))
 
+
+WARNING(rdar141962317,none,
+        "calling %base0 with an existential value is not supported; call it "
+        "with a generic value instead; this will be an error in a future Swift "
+        "release", (const ValueDecl *))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -489,6 +489,8 @@ enum class FixKind : uint8_t {
   /// sending result, but is passed a function typed parameter without a sending
   /// result.
   AllowSendingMismatch,
+
+  Rdar141962317,
 };
 
 class ConstraintFix {
@@ -3868,6 +3870,20 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::IgnoreKeyPathSubscriptIndexMismatch;
   }
+};
+
+class Rdar141962317_Fix final : public ConstraintFix {
+  Rdar141962317_Fix(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::Rdar141962317, locator,
+                      FixBehavior::AlwaysWarning) {}
+
+public:
+  std::string getName() const override { return "rdar://141962317"; }
+
+  static Rdar141962317_Fix *create(ConstraintSystem &cs,
+                                   ConstraintLocator *locator);
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9525,3 +9525,10 @@ bool InvalidTypeAsKeyPathSubscriptIndex::diagnoseAsError() {
   emitDiagnostic(diag::cannot_convert_type_to_keypath_subscript_index, ArgType);
   return true;
 }
+
+bool Rdar141962317_Warning::diagnoseAsError() {
+  auto overload = *getCalleeOverloadChoiceIfAvailable(getLocator());
+
+  emitDiagnostic(diag::rdar141962317, overload.choice.getDecl());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3239,6 +3239,13 @@ public:
   bool diagnoseAsError() override;
 };
 
+struct Rdar141962317_Warning final : public FailureDiagnostic {
+  Rdar141962317_Warning(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator, FixBehavior::AlwaysWarning) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2727,3 +2727,13 @@ IgnoreKeyPathSubscriptIndexMismatch::create(ConstraintSystem &cs, Type argType,
   return new (cs.getAllocator())
       IgnoreKeyPathSubscriptIndexMismatch(cs, argType, locator);
 }
+
+bool Rdar141962317_Fix::diagnose(const Solution &solution, bool asNote) const {
+  Rdar141962317_Warning warning(solution, getLocator());
+  return warning.diagnose(asNote);
+}
+
+Rdar141962317_Fix *Rdar141962317_Fix::create(ConstraintSystem &cs,
+                                             ConstraintLocator *locator) {
+  return new (cs.getAllocator()) Rdar141962317_Fix(cs, locator);
+}

--- a/lib/Sema/OpenedExistentials.h
+++ b/lib/Sema/OpenedExistentials.h
@@ -34,8 +34,15 @@ public:
   /// example, "func foo(x: Int) -> () -> Self?" has a covariant 'Self' result.
   bool hasCovariantSelfResult;
 
+  bool is_rdar141962317;
+
   OptionalTypePosition selfRef;
   OptionalTypePosition assocTypeRef;
+
+  static GenericParameterReferenceInfo for_rdar141962317() {
+    return GenericParameterReferenceInfo(false, std::nullopt, std::nullopt,
+                                         true);
+  }
 
   /// A reference to 'Self'.
   static GenericParameterReferenceInfo forSelfRef(TypePosition position) {
@@ -64,9 +71,12 @@ public:
         assocTypeRef(std::nullopt) {}
 
 private:
-  GenericParameterReferenceInfo(bool hasCovariantSelfResult, OptionalTypePosition selfRef,
-                    OptionalTypePosition assocTypeRef)
-      : hasCovariantSelfResult(hasCovariantSelfResult), selfRef(selfRef),
+  GenericParameterReferenceInfo(bool hasCovariantSelfResult,
+                                OptionalTypePosition selfRef,
+                                OptionalTypePosition assocTypeRef,
+                                bool is_rdar141962317 = false)
+      : hasCovariantSelfResult(hasCovariantSelfResult),
+        is_rdar141962317(is_rdar141962317), selfRef(selfRef),
         assocTypeRef(assocTypeRef) {}
 };
 
@@ -117,8 +127,8 @@ using OpenedExistentialAdjustments =
 /// variable (from the opened parameter type) the existential type that needs
 /// to be opened (from the argument type), and the adjustments that need to be
 /// applied to the existential type after it is opened.
-std::optional<std::tuple<GenericTypeParamType *, TypeVariableType *,
-                                Type, OpenedExistentialAdjustments>>
+std::optional<std::tuple<GenericTypeParamType *, TypeVariableType *, Type,
+                         OpenedExistentialAdjustments, bool>>
 canOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
                                Type paramTy, Type argTy);
 

--- a/validation-test/Sema/rdar141962317.swift
+++ b/validation-test/Sema/rdar141962317.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+struct S<each T> {}
+protocol P {}
+func open<T: P>(_: Int, _: T.Type, _: S<T>? = nil) {}
+let meta: any P.Type
+open(0, meta)
+// expected-warning@-1:9 {{calling 'open' with an existential value is not supported; call it with a generic value instead; this will be an error in a future Swift release}}


### PR DESCRIPTION
- **Explanation**:
  We now correctly refuse to open the existential in the following case due to the invariant `T` in the second parameter, which broke some code internally. Opening the existential in this precise case happens to be safe, so this patch adds a temporary exception to the rules and pairs it with a warning so folks can spot and fix the problem.
  
  ```swift
  struct S<each T> {}
  protocol P {}
  func open<T: P>(_: T.Type, _: S<T>? = nil) {}
  let meta: any P.Type
  open(meta)
  ```
- **Scope**: Existential opening for call arguments.
- **Issues**: rdar://141962317
- **Original PRs**: #78658
- **Risk**: Low
- **Testing**: Smoke test
- **Reviewers**: TBD
