### PR TITLE
Handle delete_pending error code

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -458,7 +458,7 @@ isFileUpToDateForOutputFile(StringRef filePath, StringRef timeCompareFilePath) {
   };
   llvm::sys::fs::file_status unitStat;
   if (std::error_code ec = llvm::sys::fs::status(filePath, unitStat)) {
-    if (ec != std::errc::no_such_file_or_directory)
+    if (ec != std::errc::no_such_file_or_directory && ec != llvm::errc::delete_pending)
       return makeError(filePath, ec);
     return false;
   }
@@ -469,7 +469,7 @@ isFileUpToDateForOutputFile(StringRef filePath, StringRef timeCompareFilePath) {
   llvm::sys::fs::file_status compareStat;
   if (std::error_code ec =
           llvm::sys::fs::status(timeCompareFilePath, compareStat)) {
-    if (ec != std::errc::no_such_file_or_directory)
+    if (ec != std::errc::no_such_file_or_directory && ec != llvm::errc::delete_pending)
       return makeError(timeCompareFilePath, ec);
     return true;
   }


### PR DESCRIPTION
Apply the same fix as
https://github.com/swiftlang/llvm-project/pull/8838 to the index writer in swift/lib/Index/IndexRecord.cpp noting it is meant to be merged with the IndexUnitWriter in LLVM.

This should fix intermittent permission denied errors during builds that https://github.com/swiftlang/llvm-project/pull/8838 fixes (but missed this one).
