### PR TITLE
[CMake] Globally set sanitizer options for Swift targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1087,6 +1087,9 @@ endif()
 #
 swift_common_cxx_warnings()
 
+# Set sanitizer options for Swift compiler.
+swift_common_sanitizer_config()
+
 # Check if we're build with MSVC or Clang-cl, as these compilers have similar command line arguments.
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
   set(SWIFT_COMPILER_IS_MSVC_LIKE TRUE)

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -69,7 +69,6 @@ function(_add_host_swift_compile_options name)
       target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-tools-directory;${tools_path};>)
     endif()
   endif()
-  _add_host_variant_swift_sanitizer_flags(${name})
 
   target_compile_options(${name} PRIVATE
     $<$<COMPILE_LANGUAGE:Swift>:-color-diagnostics>

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -82,36 +82,6 @@ function(_set_target_prefix_and_suffix target kind sdk)
   endif()
 endfunction()
 
-function(_add_host_variant_swift_sanitizer_flags target)
-  if(LLVM_USE_SANITIZER)
-    if(LLVM_USE_SANITIZER STREQUAL "Address")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=address" "-Xclang-linker" "-fsanitize=address")
-    elseif(LLVM_USE_SANITIZER STREQUAL "HWAddress")
-      # Not supported?
-    elseif(LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
-      # Not supported
-      if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
-        # Not supported
-      endif()
-    elseif(LLVM_USE_SANITIZER STREQUAL "Undefined")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=undefined" "-Xclang-linker" "-fsanitize=undefined")
-    elseif(LLVM_USE_SANITIZER STREQUAL "Thread")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=thread" "-Xclang-linker" "-fsanitize=thread")
-    elseif(LLVM_USE_SANITIZER STREQUAL "DataFlow")
-      # Not supported
-    elseif(LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
-           LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=address" "-sanitize=undefined" "-Xclang-linker" "-fsanitize=address" "-Xclang-linker" "-fsanitize=undefined")
-    elseif(LLVM_USE_SANITIZER STREQUAL "Leaks")
-      # Not supported
-    else()
-      message(SEND_ERROR "unsupported value for LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
-    endif()
-
-    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)
-  endif()
-endfunction()
-
 function(swift_get_host_triple out_var)
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
@@ -145,8 +115,6 @@ function(_add_host_variant_c_compile_link_flags name)
 
   if (CMAKE_Swift_COMPILER)
     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-target;${SWIFT_HOST_TRIPLE}>)
-
-   _add_host_variant_swift_sanitizer_flags(${name})
   endif()
 
   set(_sysroot

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -369,3 +369,35 @@ function(swift_common_llvm_config target)
     llvm_config("${target}" ${ARGN})
   endif()
 endfunction()
+
+# Set sanitizer options to all Swift compiler flags. Similar options are added to C/CXX compiler in 'HandleLLVMOptions'
+macro(swift_common_sanitizer_config)
+  if(LLVM_USE_SANITIZER)
+    if(LLVM_USE_SANITIZER STREQUAL "Address")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address -Xclang-linker -fsanitize=address")
+    elseif(LLVM_USE_SANITIZER STREQUAL "HWAddress")
+      # Not supported?
+    elseif(LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
+      # Not supported
+      if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
+        # Not supported
+      endif()
+    elseif(LLVM_USE_SANITIZER STREQUAL "Undefined")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=undefined -Xclang-linker -fsanitize=undefined")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Thread")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=thread -Xclang-linker -fsanitize=thread")
+    elseif(LLVM_USE_SANITIZER STREQUAL "DataFlow")
+      # Not supported
+    elseif(LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
+           LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address -sanitize=undefined -Xclang-linker -fsanitize=address -Xclang-linker -fsanitize=undefined")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Leaks")
+      # Not supported
+    else()
+      message(SEND_ERROR "unsupported value for LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
+    endif()
+
+    set(CMAKE_Swift_FLAGS "${CMAKE_Swift_FLAGS} ${_Swift_SANITIZER_FLAGS}")
+
+  endif()
+endmacro()


### PR DESCRIPTION
For C/CXX targets, sanitizer options are set by `CMAKE_{C|CXX}_FLAGS` in HandleLLVMComfig.cmake. However for Swift targets, they were set for each target. That caused some mismatch issues. Instead set them globally for Swift targets too.

rdar://142516855
