### PR TITLE
AST: Refactor AvailabilityDomain to prepare for external definitions

### DIFF
--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -27,7 +27,6 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceLoc.h"
-#include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/ErrorHandling.h"
 
 namespace swift {

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -17,7 +17,7 @@
 using namespace swift;
 
 bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
-  switch (kind) {
+  switch (getKind()) {
   case Kind::Universal:
   case Kind::SwiftLanguage:
   case Kind::PackageDescription:
@@ -28,7 +28,7 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
 }
 
 llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
-  switch (kind) {
+  switch (getKind()) {
   case Kind::Universal:
     return "";
   case Kind::SwiftLanguage:
@@ -41,7 +41,7 @@ llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
 }
 
 llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
-  switch (kind) {
+  switch (getKind()) {
   case Kind::Universal:
     return "*";
   case Kind::SwiftLanguage:


### PR DESCRIPTION
Represent an `AvailabilityDomain` as a pointer union where one member of the union is inline storage for built-in domains with known requirements and the other member of the union is a pointer to an externally allocated domain definition.

NFC.
