### PR TITLE
Restrict Weak-Re-Exports To @_exported Modules

### DIFF
--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -428,7 +428,17 @@ ImportCache::getWeakImports(const ModuleDecl *mod) {
       ModuleDecl *importedModule = import.module.importedModule;
       result.insert(importedModule);
 
-      auto reexportedModules = getImportSet(importedModule).getAllImports();
+      // Only explicit re-exports of a weak-linked module are themselves
+      // weak-linked.
+      //
+      // // Module A
+      // @_weakLinked import B
+      //
+      // // Module B
+      // @_exported import C
+      SmallVector<ImportedModule, 4> reexportedModules;
+      importedModule->getImportedModules(
+          reexportedModules, ModuleDecl::ImportFilterKind::Exported);
       for (auto reexportedModule : reexportedModules) {
         result.insert(reexportedModule.importedModule);
       }

--- a/test/IRGen/weaklinked_import_peer_transitive_objc.swift
+++ b/test/IRGen/weaklinked_import_peer_transitive_objc.swift
@@ -1,0 +1,20 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weaklinked_import_helper.swiftmodule -parse-as-library %S/Inputs/weaklinked_import_helper.swift -enable-library-evolution
+//
+// RUN: echo 'import Foundation' > %t/intermediate_foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-path %t/intermediate_foundation.swiftmodule -parse-as-library %t/intermediate_foundation.swift -I %t -enable-library-evolution
+//
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -primary-file %s -I %t -emit-ir -Xcc -fmodule-map-file=%S/Inputs/weaklinked_import_helper_clang.modulemap | %FileCheck %s
+
+@_weakLinked import intermediate_foundation
+import Foundation
+
+// ThisModule -weak imports-> intermediate_foundation -imports-> Foundation
+// Because Foundation is _not_ re-exported, make sure any symbols from it are strongly referenced.
+// CAUTION: Suppose you _want_ Foundation to be weak-linked. It's not enough to just `@_exported import Foundation`
+//          in the intermediate_foundation module. That only gets you the Swift half of the Foundation overlay.
+
+// CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = external global %objc_class
+_ = NSNotification()


### PR DESCRIPTION
This code got refactored and it accidentally widened the applicable structures for this check. The idea is that you have the following structure

```
// Module A
@_weakLinked import B

// Module B
@_exported import C
```

And the compiler conspires to make it so the modules B AND C wind up weak-linked from module A.

The broadened check accidentally allowed the following:

```
// Module A
@_weakLinked import B

// Module B
import C // Oops!
```

Which caused quite a few more modules than were intended to be weak-linked. Restore the `Exported` filter to cut back on the amount of weak re-exports the compiler processes.

Resolves rdar://142706779