### PR TITLE
LifetimeDependenceInsertion: fix dependence on store_borrow.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -215,6 +215,11 @@ extension AccessBase {
         return nil
       }
       baseAddr = arg
+    case let .storeBorrow(sbi):
+      guard case let .stack(allocStack) = sbi.destinationOperand.value.accessBase else {
+        return nil
+      }
+      return (initialAddress: allocStack, initializingStore: sbi)
     default:
       return nil
     }

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
@@ -1,0 +1,64 @@
+// RUN: %target-sil-opt %s \
+// RUN:   --lifetime-dependence-insertion \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+
+sil_stage raw
+
+import Swift
+
+struct NE: ~Escapable {
+  var p: UnsafeRawPointer
+
+  @lifetime(immortal)
+  init()
+}
+
+sil @getPtr : $@convention(thin) () -> @out UnsafeRawPointer
+sil @getSpan : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
+
+// Check that the inserted dependence is on the 'self' argument, not the temporary borrow.
+//
+// CHECK-LABEL: sil [available 9999] [ossa] @testSpanProp : $@convention(method) (@guaranteed AnyObject) -> @lifetime(borrow 0) @owned NE {
+// CHECK: bb0(%0 : @guaranteed $AnyObject):
+// CHECK:   [[OUT:%.*]] = alloc_stack $NE
+// CHECK:   [[TEMP:%.*]] = begin_borrow
+// CHECK:   [[MV:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[TEMP]]
+// CHECK:   [[IN:%.*]] = alloc_stack $AnyObject
+// CHECK:   [[SB:%.*]] = store_borrow [[MV]] to [[IN]]
+// CHECK:   apply %{{.*}}([[OUT]], [[SB]]) : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
+// CHECK:   [[MD:%.*]] = mark_dependence [unresolved] [[OUT]] on %0
+// CHECK:   end_borrow [[SB]]
+// CHECK:   end_borrow [[TEMP]]
+// CHECK:   [[LD:%.*]] = load [take] [[OUT]]
+// CHECK:   return [[LD]]
+// CHECK-LABEL: } // end sil function 'testSpanProp'
+sil [available 9999] [ossa] @testSpanProp : $@convention(method) (@guaranteed AnyObject) -> @lifetime(borrow 0) @owned NE {
+bb0(%0 : @guaranteed $AnyObject):
+  // setup the 'self' variable
+  %1 = copyable_to_moveonlywrapper [guaranteed] %0
+  %2 = copy_value %1
+  %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %2
+  debug_value %3, let, name "self", argno 1
+  %5 = alloc_stack $NE
+
+  // temporarily borrow 'self' but don't depend on this borrow.
+  %6 = begin_borrow %3
+  %7 = moveonlywrapper_to_copyable [guaranteed] %6
+  %8 = alloc_stack $AnyObject
+  %9 = store_borrow %7 to %8
+
+  %10 = function_ref @getSpan : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
+  %11 = apply %10(%5, %9) : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
+  end_borrow %9
+  dealloc_stack %8
+  end_borrow %6
+  %15 = load [take] %5
+  dealloc_stack %5
+  destroy_value %3
+  return %15
+}


### PR DESCRIPTION
For a lifetime dependent call that depends on a temporary store_borrow, the generated mark_dependendence should be on the stored value, not the stack location.

  %temp = alloc_stack $AnyObject
  %sb = store_borrow %arg to %temp
  apply %10(%out, %sb)
  mark_dependence [unresolved] %out on %arg
  end_borrow %sb

Fixes rdar://142847915 (Crash during lifetime checking while building new swift standard library `Span`-related features)