### PR TITLE
Reland "[windows][toolchain] Enable builtins and sanitizers"

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -51,11 +51,11 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS YES CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
   # Sanitizers will be configured, but not built. We have separate build
   # steps for that, because we need a different shell for each target.

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -27,24 +27,22 @@ set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
 
-set(DEFAULT_BUILTIN_TARGETS
-      x86_64-unknown-windows-msvc
-      aarch64-unknown-windows-msvc)
-# Build the android builtins if NDK path is provided.
-if(NOT "$ENV{NDKPATH}" STREQUAL "")
-  list(APPEND DEFAULT_BUILTIN_TARGETS
-       aarch64-unknown-linux-android
-       x86_64-unknown-linux-android)
-endif()
-
-# The builtin targets are used to build the compiler-rt builtins.
-set(LLVM_BUILTIN_TARGETS ${DEFAULT_BUILTIN_TARGETS} CACHE STRING "")
-
-# The runtime targets are used to build the compiler-rt profile library.
-set(LLVM_RUNTIME_TARGETS
+set(default_targets
       x86_64-unknown-windows-msvc
       aarch64-unknown-windows-msvc
-    CACHE STRING "")
+      i686-unknown-windows-msvc)
+set(LLVM_RUNTIME_TARGETS ${default_targets} CACHE STRING "")
+
+# Build the android builtins if NDK path is provided.
+if(NOT "$ENV{NDKPATH}" STREQUAL "")
+  list(APPEND default_targets
+       aarch64-unknown-linux-android
+       x86_64-unknown-linux-android
+       i686-unknown-linux-android
+       armv7-unknown-linux-androideabi)
+endif()
+
+set(LLVM_BUILTIN_TARGETS ${default_targets} CACHE STRING "")
 
 foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
@@ -53,13 +51,15 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS YES CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
+  # Sanitizers will be configured, but not built. We have separate build
+  # steps for that, because we need a different shell for each target.
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
 endforeach()
 
 foreach(target ${LLVM_BUILTIN_TARGETS})
@@ -72,6 +72,10 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
     set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
     if(${target} MATCHES aarch64)
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "")
+    elseif(${target} MATCHES armv7)
+      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI armeabi-v7a CACHE STRING "")
+    elseif(${target} MATCHES i686)
+      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86 CACHE STRING "")
     else()
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86_64 CACHE STRING "")
     endif()

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -27,49 +27,52 @@ set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
 
-set(default_targets
-      x86_64-unknown-windows-msvc
-      aarch64-unknown-windows-msvc
-      i686-unknown-windows-msvc)
-set(LLVM_RUNTIME_TARGETS ${default_targets} CACHE STRING "")
-
-# Build the android builtins if NDK path is provided.
-if(NOT "$ENV{NDKPATH}" STREQUAL "")
-  list(APPEND default_targets
-       aarch64-unknown-linux-android
-       x86_64-unknown-linux-android
-       i686-unknown-linux-android
-       armv7-unknown-linux-androideabi)
+if("$ENV{NDKPATH}" STREQUAL "")
+  set(LLVM_RUNTIME_TARGETS
+        x86_64-unknown-windows-msvc
+        aarch64-unknown-windows-msvc
+        i686-unknown-windows-msvc
+      CACHE STRING "")
+else()
+  # Keep API level in sync with build.ps1
+  set(CMAKE_ANDROID_API 28 CACHE BOOL "")
+  set(LLVM_RUNTIME_TARGETS
+        x86_64-unknown-windows-msvc
+        aarch64-unknown-windows-msvc
+        i686-unknown-windows-msvc
+        x86_64-unknown-linux-android
+        aarch64-unknown-linux-android
+        i686-unknown-linux-android
+        armv7-unknown-linux-androideabi
+      CACHE STRING "")
 endif()
 
-set(LLVM_BUILTIN_TARGETS ${default_targets} CACHE STRING "")
-
 foreach(target ${LLVM_RUNTIME_TARGETS})
-  set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
-        compiler-rt
-      CACHE STRING "")
+  # We configure all runtimes, but don't build them yet. build.ps1 has a
+  # separate step for it, because we need a different shell for each target.
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
-  # Sanitizers will be configured, but not built. We have separate build
-  # steps for that, because we need a different shell for each target.
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
-endforeach()
 
-foreach(target ${LLVM_BUILTIN_TARGETS})
+  # Configure and build builtins for all targets
   set(BUILTINS_${target}_CMAKE_MT mt CACHE STRING "")
+  set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
   if(${target} MATCHES windows-msvc)
     set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   elseif(${target} MATCHES linux-android)
+    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
+    set(BUILTINS_${target}_CMAKE_ANDROID_API ${CMAKE_ANDROID_API} CACHE STRING "")
+    set(BUILTINS_${target}_CMAKE_C_COMPILER_TARGET "${target}${CMAKE_ANDROID_API}" CACHE STRING "")
+    set(BUILTINS_${target}_CMAKE_CXX_COMPILER_TARGET "${target}${CMAKE_ANDROID_API}" CACHE STRING "")
+    set(BUILTINS_${target}_CMAKE_ANDROID_NDK $ENV{NDKPATH} CACHE PATH "")
     # Use a single 'linux' directory and arch-based lib names on Android.
     set(BUILTINS_${target}_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR NO CACHE BOOL "")
-    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
     if(${target} MATCHES aarch64)
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "")
     elseif(${target} MATCHES armv7)
@@ -79,12 +82,7 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
     else()
       set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86_64 CACHE STRING "")
     endif()
-    set(BUILTINS_${target}_CMAKE_ANDROID_NDK $ENV{NDKPATH} CACHE PATH "")
-    set(BUILTINS_${target}_CMAKE_ANDROID_API 21 CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_C_COMPILER_TARGET "${target}21" CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_CXX_COMPILER_TARGET "${target}21" CACHE STRING "")
   endif()
-  set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
 endforeach()
 
 set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -51,11 +51,11 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS YES CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
+  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
   # Sanitizers will be configured, but not built. We have separate build
   # steps for that, because we need a different shell for each target.

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -51,7 +51,6 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   # We configure all runtimes, but don't build them yet. build.ps1 has a
   # separate step for it, because we need a different shell for each target.
   set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
@@ -59,6 +58,11 @@ foreach(target ${LLVM_RUNTIME_TARGETS})
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE NO CACHE BOOL "")
   set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
+  if(${target} MATCHES windows-msvc)
+    set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
+  elseif(${target} MATCHES linux-android)
+    set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
+  endif()
 
   # Configure and build builtins for all targets
   set(BUILTINS_${target}_CMAKE_MT mt CACHE STRING "")

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: OS=windows-msvc
+
 // Different sanitizer coverage types
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=func -sanitize=address %s | %FileCheck -check-prefix=SANCOV_FUNC %s
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=bb -sanitize=address %s | %FileCheck -check-prefix=SANCOV_BB %s

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 // Different sanitizer coverage types
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=func -sanitize=address %s | %FileCheck -check-prefix=SANCOV_FUNC %s

--- a/test/IRGen/address_sanitizer_use_odr_indicator.swift
+++ b/test/IRGen/address_sanitizer_use_odr_indicator.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: asan_runtime
 
 // Default instrumentation that does not use ODR indicators

--- a/test/IRGen/address_sanitizer_use_odr_indicator.swift
+++ b/test/IRGen/address_sanitizer_use_odr_indicator.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 // REQUIRES: asan_runtime
 
 // Default instrumentation that does not use ODR indicators

--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env ASAN_OPTIONS=detect_leaks=0 %target-run %t_asan-binary

--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,4 +1,5 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// UNSUPPORTED: OS=windows-msvc
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,5 +1,5 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run %t_asan-binary 2>&1 | %FileCheck %s

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -9,6 +9,7 @@
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
 // UNSUPPORTED: remote_run
+// UNSUPPORTED: OS=windows-msvc
 
 func sayHello() {
   print("Hello")

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -9,7 +9,7 @@
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
 // UNSUPPORTED: remote_run
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 func sayHello() {
   print("Hello")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1794,6 +1794,21 @@ function Build-CURL([Platform]$Platform, $Arch) {
     })
 }
 
+function Build-Sanitizers([Platform]$Platform, $Arch, $InstallTo) {
+  Isolate-EnvVars {
+    # Use configured compilers
+    Build-CMakeProject `
+      -Src $SourceCache\llvm-project\runtimes `
+      -Bin "$(Get-HostProjectBinaryCache Compilers)\runtimes\runtimes-$($Arch.LLVMTarget)-bins" `
+      -InstallTo $InstallTo `
+      -Arch $Arch `
+      -Platform $Platform `
+      -Defines (@{
+        COMPILER_RT_BUILD_SANITIZERS = "YES"
+      })
+  }
+}
+
 function Build-Runtime([Platform]$Platform, $Arch) {
   $PlatformDefines = @{}
   if ($Platform -eq "Android") {
@@ -2799,6 +2814,11 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-CMark $HostArch
   Invoke-BuildStep Build-XML2 Windows $HostArch
   Invoke-BuildStep Build-Compilers $HostArch
+
+  $InstallTo = "$($HostArch.ToolchainInstallRoot)\usr"
+  foreach ($Arch in $WindowsSDKArchs) {
+    Invoke-BuildStep Build-Sanitizers Windows $Arch $InstallTo
+  }
 }
 
 if ($Clean) {


### PR DESCRIPTION
Profile and builtin libraries from compiler-rt are static and do not require a link step. We can enable them in our CMake caches and we can build and install them in the unified LLVM build step.

Sanitizers contain dynamic libraries. We need the target-specific Visual Studio shell to perform the link step. This patch adds extra build steps in build.ps1 that reconfigure, build and install the target-specific nested build-trees in the LLVM runtimes directory through their respective Visual Studio shells.

My previous attempt in https://github.com/swiftlang/swift/pull/77770 failed, because it didn't handle cross-compile cases properly. Since the just-built compiler cannot be executed in a cross-build, the LLVM build step was falling back to the host compiler. On Windows this resolves to MSVC, which doesn't work.

This PR aims to fix that and reland the feature. We have to override the compiler in each nested build-tree manually, to select the stage-1 Clang compiler that we use for the LLVM build step itself.