### PR TITLE
Sema: Relax primary associated type matching in matchExistentialTypes() [6.1]

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4207,7 +4207,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
   // Finally, check parameterized protocol requirements.
   if (!layout.getParameterizedProtocols().empty()) {
-    SmallVector<std::pair<AssociatedTypeDecl *, Type>, 4> fromReqs;
+    SmallVector<std::pair<Identifier, Type>, 4> fromReqs;
 
     if (type1->isExistentialType()) {
       auto fromLayout = type1->getExistentialLayout();
@@ -4218,8 +4218,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
         for (unsigned i : indices(argTypes)) {
           auto argType = argTypes[i];
-          auto *assocType = assocTypes[i]->getAssociatedTypeAnchor();
-          fromReqs.push_back(std::make_pair(assocType, argType));
+          fromReqs.push_back(std::make_pair(assocTypes[i]->getName(), argType));
         }
       }
     }
@@ -4234,10 +4233,9 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
         for (unsigned i : indices(argTypes)) {
           auto argType = argTypes[i];
-          auto *assocType = assocTypes[i]->getAssociatedTypeAnchor();
           bool found = false;
           for (auto fromReq : fromReqs) {
-            if (fromReq.first == assocType) {
+            if (fromReq.first == assocTypes[i]->getName()) {
               // FIXME: Extend the locator path to point to the argument
               // inducing the requirement.
               auto result = matchTypes(fromReq.second, argType,

--- a/test/Constraints/parameterized_existential_unrelated_args.swift
+++ b/test/Constraints/parameterized_existential_unrelated_args.swift
@@ -31,4 +31,25 @@ var q: any Q<String> = p // expected-error {{cannot convert value of type 'any P
 // Previously we accepted the above conversion, and then getB()
 // would return something that was dynamically Array<String>
 // and not String as expected.
-print(q.getB())
+// print(q.getB())
+
+
+// However, this is OK -- the two A's have the same name, so by the
+// semantics of the generics system they must be equivalent as type
+// parameters.
+
+protocol P1<A> {
+  associatedtype A
+}
+
+protocol P2<A> {
+  associatedtype A
+}
+
+protocol P3<A>: P1, P2 {
+  associatedtype A
+}
+
+func f<T>(_ value: any P3<T>) -> (any P1<T>, any P2<T>) {
+  return (value, value)
+}


### PR DESCRIPTION
6.1 cherry-pick of https://github.com/swiftlang/swift/pull/78559

* **Description:** A fix for a soundness hole was too strict and broke source compatibility with existing valid code.

* **Origination:** Regression first appeared in 6.1

* **Risk:** Low.

* **Radar:** rdar://141968103.

* **Reviewed by:** @AnthonyLatsis and @xedin 
