### PR TITLE
[cxx-interop] Workaround compiler error when importing CoreGraphics with C++ interop

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2202,7 +2202,9 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
 
   // FIXME: Hack for Darwin.swiftmodule, which cannot be rebuilt with C++
   // interop enabled by the Swift CI because it uses an old host SDK.
-  if (moduleName == "Darwin") {
+  // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
+  // of a CF_OPTIONS bug (rdar://142762174).
+  if (moduleName == "Darwin" || moduleName == "CoreGraphics") {
     subInvocation.getLangOptions().EnableCXXInterop = false;
     subInvocation.getLangOptions().cxxInteropCompatVersion = {};
     BuildArgs.erase(llvm::remove_if(BuildArgs,

--- a/test/Interop/Cxx/objc-correctness/coregraphics.swift
+++ b/test/Interop/Cxx/objc-correctness/coregraphics.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+
+ // REQUIRES: objc_interop
+ // REQUIRES: VENDOR=apple
+
+ import CoreGraphics
+
+ var _: CGBitmapInfo! = nil
+ 


### PR DESCRIPTION
The CoreGraphics overlay refers to symbols declared via `CF_OPTIONS` macro, which is causing issues in C++ language mode due to the macro definition being different.

This teaches the module interface loader to drop the C++ interop flag when rebuilding the CoreGraphics overlay from its interface.

rdar://142762174

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
