### PR TITLE
AST: Remove inline AvailabilityDomain from SemanticAvailableAttr

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -918,7 +918,7 @@ ParsedDeclAttrFilter::operator()(const DeclAttribute *Attr) const {
 }
 
 bool SemanticAvailableAttr::isActive(ASTContext &ctx) const {
-  return domain.isActive(ctx);
+  return getDomain().isActive(ctx);
 }
 
 std::optional<SemanticAvailableAttr>

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -447,9 +447,7 @@ Decl::getSemanticAvailableAttrs(bool includeInactive) const {
 
 std::optional<SemanticAvailableAttr>
 Decl::getSemanticAvailableAttr(const AvailableAttr *attr) const {
-  if (auto domain = attr->getCachedDomain())
-    return SemanticAvailableAttr(attr, *domain);
-  return std::nullopt;
+  return SemanticAvailableAttr(attr);
 }
 
 std::optional<SemanticAvailableAttr>
@@ -790,7 +788,7 @@ bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
 
 AvailabilityRange
 SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
-  assert(domain.isActive(Ctx));
+  assert(getDomain().isActive(Ctx));
 
   auto *attr = getParsedAttr();
   if (!attr->Introduced.has_value())

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3058,9 +3058,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       ENCODE_VER_TUPLE(Obsoleted, theAttr->Obsoleted)
 
       assert(theAttr->Rename.empty() || !theAttr->hasCachedRenamedDecl());
-
+      assert(theAttr->hasCachedDomain());
       auto domain = theAttr->getCachedDomain();
-      assert(domain);
 
       // FIXME: [availability] Serialize domain and kind directly.
       llvm::SmallString<32> blob;


### PR DESCRIPTION
Now that `AvailableAttr` has storage for its cached `AvailabilityDomain`, it's no longer necessary to store an `AvailabilityDomain` inline in `SemanticAvailableAttr`.

NFC.
