### PR TITLE
[stdlib] fix getting eager-lazy-bridged Array buffer

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -586,9 +586,8 @@ extension _ArrayBuffer {
       _storage.objCInstance,
       _ArrayBuffer.associationKey
     ) {
-      let buffer = assocPtr.load(
-        as: _ContiguousArrayStorage<Element>.self
-      )
+      let buffer: _ContiguousArrayStorage<Element>
+      buffer = Unmanaged.fromOpaque(assocPtr).takeUnretainedValue()
       return _ContiguousArrayBuffer(buffer)
     }
     return nil

--- a/test/stdlib/BridgedArrayNonContiguous.swift
+++ b/test/stdlib/BridgedArrayNonContiguous.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-run-stdlib-swift(-enable-experimental-feature Span) -enable-experimental-feature Span
+// RUN: %target-run-stdlib-swift -enable-experimental-feature LifetimeDependence -enable-experimental-feature Span
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/stdlib/BridgedArrayNonContiguous.swift
+++ b/test/stdlib/BridgedArrayNonContiguous.swift
@@ -1,0 +1,42 @@
+//===--- BridgedArrayNonContiguous.swift ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift(-enable-experimental-feature Span) -enable-experimental-feature Span
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Span
+
+import StdlibUnittest
+
+import Foundation
+
+var suite = TestSuite("EagerLazyBridgingTests")
+defer { runAllTests() }
+
+var x: NSObject? = nil
+
+suite.test("Bridged NSArray without direct memory sharing") {
+
+  var arr = Array(repeating: NSObject(), count: 100) as [AnyObject]
+  let nsArray:NSArray = NSArray(objects: &arr, count: 100)
+  for _ in 0 ..< 5 {
+    let tmp = nsArray as! [NSObject]
+    x = tmp.withContiguousStorageIfAvailable {
+      $0[0]
+    }
+    expectNotNil(x)
+  }
+
+  x = nil
+}


### PR DESCRIPTION
Retain the appropriate reference. Fixes rdar://142867382

This will unblock swift-ci benchmarking for the x86-64 macOS target.