### PR TITLE
[NFC] cleanup test/SILOptimizer/addressable_dependencies.swift

### DIFF
--- a/test/SILOptimizer/addressable_dependencies.swift
+++ b/test/SILOptimizer/addressable_dependencies.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -disable-access-control -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature ValueGenerics %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature ValueGenerics %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_AddressableTypes
@@ -6,6 +6,14 @@
 // REQUIRES: swift_feature_ValueGenerics
 
 import Builtin
+
+// Copied from the stdlib until we have Builtin.overrideLifetime.
+@_unsafeNonescapableResult
+@lifetime(borrow source)
+internal func _overrideLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  _ dependent: consuming T, borrowing source: borrowing U) -> T {
+  dependent
+}
 
 struct NodeRef: ~Escapable {
     private var parent: UnsafePointer<Node>


### PR DESCRIPTION
Don't use -disable-access-control. Just copy things over from the stdlib.
