### PR TITLE
add %SDKROOT%\usr\include as -isystem for non-Windows non-Darwin

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -701,16 +701,17 @@ void importer::getNormalInvocationArguments(
         invocationArgStrs.push_back("-isysroot");
         invocationArgStrs.push_back(searchPathOpts.getSDKPath().str());
       } else {
-        llvm::SmallString<256> path;
-        path = searchPathOpts.getSDKPath();
-        llvm::sys::path::append(path, "usr", "include");
-
-        invocationArgStrs.push_back("-isystem");
-        invocationArgStrs.push_back(path.str().str());
-
         if (auto sysroot = searchPathOpts.getSysRoot()) {
+          // Both the sdk path and sysroot are provided. Pass along the sysroot
+          // to Clang but also ensure the SDK include path is provided.
           invocationArgStrs.push_back("--sysroot");
           invocationArgStrs.push_back(sysroot->str());
+
+          llvm::SmallString<256> path;
+          path = searchPathOpts.getSDKPath();
+          llvm::sys::path::append(path, "usr", "include");
+          invocationArgStrs.push_back("-isystem");
+          invocationArgStrs.push_back(path.str().str());
         } else {
           invocationArgStrs.push_back("--sysroot");
           invocationArgStrs.push_back(searchPathOpts.getSDKPath().str());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -701,6 +701,13 @@ void importer::getNormalInvocationArguments(
         invocationArgStrs.push_back("-isysroot");
         invocationArgStrs.push_back(searchPathOpts.getSDKPath().str());
       } else {
+        llvm::SmallString<256> path;
+        path = searchPathOpts.getSDKPath();
+        llvm::sys::path::append(path, "usr", "include");
+
+        invocationArgStrs.push_back("-isystem");
+        invocationArgStrs.push_back(path.str().str());
+
         if (auto sysroot = searchPathOpts.getSysRoot()) {
           invocationArgStrs.push_back("--sysroot");
           invocationArgStrs.push_back(sysroot->str());


### PR DESCRIPTION
## Purpose
Automatically add `%SDKROOT%\usr\include` as the `-isystem` argument to `clang` when both SDK and sysroot are provided.

## Background
Without this change, cross-compiling a Swift program for Android requires explicitly adding `-Xswiftc -I -Xswiftc %SDKROOT%\usr\include` to `swift build` or `-Xcc -I%SDKROOT%\usr\include` to `CMAKE_Swift_FLAGS` for `cmake` builds.

## Validation
Built `swift-argument-parser` for Android on Windows without manually specifying `%SDKROOT%\usr\include`.

Using Swift build:
```cmd
swift build --target ArgumentParser ^
    --triple aarch64-unknown-linux-android29 ^
    --sdk %ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\sysroot ^
    -Xswiftc -sdk -Xswiftc %SDKROOT%\..\..\..\..\Android.platform\Developer\SDKs\Android.sdk\ ^
    -Xswiftc -sysroot -Xswiftc %ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\sysroot ^
    -Xswiftc -Xclang-linker -Xswiftc -resource-dir -Xswiftc -Xclang-linker -Xswiftc %ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\lib\clang\17.0.2
```

Using CMake
```cmd
cmake -B build -S . -G Ninja ^
    -D CMAKE_BUILD_WITH_INSTALL_RPATH=YES ^
    -D CMAKE_SYSTEM_NAME=Android ^
    -D CMAKE_ANDROID_ARCH_ABI=arm64-v8a ^
    -D CMAKE_SYSTEM_VERSION=29 ^
    -D CMAKE_Swift_COMPILER_TARGET=aarch64-unknown-linux-android29 ^
    -D CMAKE_Swift_FLAGS="-sdk %SDKROOT%..\..\..\..\Android.platform\Developer\SDKs\Android.sdk  -Xclang-linker -resource-dir -Xclang-linker %ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\lib\clang\17.0.2"
cmake --build build --target ArgumentParser
```