### PR TITLE
[Sema] Emit dynamic actor isolation checks for derived protocol witnesses

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -21,6 +21,7 @@
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
+#include "DerivedConformances.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/AvailabilityInference.h"
@@ -1726,6 +1727,15 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   return llvm::any_of(nominal->getStoredProperties(), [&](VarDecl *v) {
     return v->isLet() && v->hasInitialValue();
   });
+}
+
+bool swift::addNonIsolatedToSynthesized(DerivedConformance &derived,
+                                        ValueDecl *value) {
+  if (auto *conformance = derived.Conformance) {
+    if (conformance && conformance->isPreconcurrency())
+      return false;
+  }
+  return addNonIsolatedToSynthesized(derived.Nominal, value);
 }
 
 bool swift::addNonIsolatedToSynthesized(NominalTypeDecl *nominal,

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -41,6 +41,7 @@ class ParamDecl;
 class Type;
 class ValueDecl;
 class VarDecl;
+class DerivedConformance;
 
 enum class SelfAccessorKind {
   /// We're building a derived accessor on top of whatever this
@@ -84,6 +85,11 @@ ValueDecl *getProtocolRequirement(ProtocolDecl *protocol, Identifier name);
 // Returns true if given nominal type declaration has a `let` stored property
 // with an initial value.
 bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal);
+
+/// Add 'nonisolated' to the synthesized declaration for a derived
+/// conformance when needed. Returns true if an attribute was added.
+bool addNonIsolatedToSynthesized(DerivedConformance &conformance,
+                                 ValueDecl *value);
 
 /// Add 'nonisolated' to the synthesized declaration when needed. Returns true
 /// if an attribute was added.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1254,7 +1254,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
     encodeDecl->getAttrs().add(attr);
   }
 
-  addNonIsolatedToSynthesized(derived.Nominal, encodeDecl);
+  addNonIsolatedToSynthesized(derived, encodeDecl);
 
   encodeDecl->copyFormalAccessFrom(derived.Nominal,
                                    /*sourceIsParentContext*/ true);
@@ -1906,7 +1906,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
     initDecl->getAttrs().add(reqAttr);
   }
 
-  addNonIsolatedToSynthesized(derived.Nominal, initDecl);
+  addNonIsolatedToSynthesized(derived, initDecl);
 
   initDecl->copyFormalAccessFrom(derived.Nominal,
                                  /*sourceIsParentContext*/ true);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -428,7 +428,7 @@ deriveEquatable_eq(
     return nullptr;
   }
 
-  addNonIsolatedToSynthesized(derived.Nominal, eqDecl);
+  addNonIsolatedToSynthesized(derived, eqDecl);
 
   eqDecl->setBodySynthesizer(bodySynthesizer);
 
@@ -553,7 +553,7 @@ deriveHashable_hashInto(
                                  /*sourceIsParentContext=*/true);
 
   // The derived hash(into:) for an actor must be non-isolated.
-  if (!addNonIsolatedToSynthesized(derived.Nominal, hashDecl) &&
+  if (!addNonIsolatedToSynthesized(derived, hashDecl) &&
       derived.Nominal->isActor())
     hashDecl->getAttrs().add(
         new (C) NonisolatedAttr(/*unsafe*/ false, /*implicit*/ true));
@@ -913,7 +913,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   hashValueDecl->setAccessors(SourceLoc(), {getterDecl}, SourceLoc());
 
   // The derived hashValue of an actor must be nonisolated.
-  if (!addNonIsolatedToSynthesized(derived.Nominal, hashValueDecl) &&
+  if (!addNonIsolatedToSynthesized(derived, hashValueDecl) &&
       derived.Nominal->isActor())
     hashValueDecl->getAttrs().add(
         new (C) NonisolatedAttr(/*unsafe*/ false, /*implicit*/ true));

--- a/test/SILGen/preconcurrency_conformances.swift
+++ b/test/SILGen/preconcurrency_conformances.swift
@@ -309,6 +309,51 @@ struct PreconcurrencyAppliesToParentToo : @preconcurrency Child {
 // CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
 // CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
 
+@available(*, unavailable)
+extension NotSendable: Sendable {}
+
+struct NotSendable: Equatable, Hashable {
+}
+
+@MainActor
+struct TestDerivedEquatable : @preconcurrency Equatable {
+  var x: NotSendable
+}
+
+// protocol witness for static Equatable.== infix(_:_:) in conformance TestDerivedEquatable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances20TestDerivedEquatableVSQAASQ2eeoiySbx_xtFZTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+@MainActor
+struct TestDerivedHashable : @preconcurrency Hashable {
+  var x: NotSendable
+}
+
+// protocol witness for Hashable.hashValue.getter in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSHAASH9hashValueSivgTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+// protocol witness for Hashable.hash(into:) in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSHAASH4hash4intoys6HasherVz_tFTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+// protocol witness for static Equatable.== infix(_:_:) in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSQAASQ2eeoiySbx_xtFZTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+
 //--- checks_disabled.swift
 protocol P {
   associatedtype T
@@ -497,4 +542,36 @@ struct PreconcurrencyAppliesToParentToo : @preconcurrency Child {
 
 // protocol witness for Parent.a() in conformance PreconcurrencyAppliesToParentToo
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances32PreconcurrencyAppliesToParentTooVAA0F0A2aDP1ayyFTW : $@convention(witness_method: Parent) (@in_guaranteed PreconcurrencyAppliesToParentToo) -> ()
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+@available(*, unavailable)
+extension NotSendable: Sendable {}
+
+struct NotSendable: Equatable, Hashable {
+}
+
+@MainActor
+struct TestDerivedEquatable : @preconcurrency Equatable {
+  var x: NotSendable
+}
+
+// protocol witness for static Equatable.== infix(_:_:) in conformance TestDerivedEquatable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances20TestDerivedEquatableVSQAASQ2eeoiySbx_xtFZTW
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+@MainActor
+struct TestDerivedHashable : @preconcurrency Hashable {
+  var x: NotSendable
+}
+
+// protocol witness for Hashable.hashValue.getter in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSHAASH9hashValueSivgTW
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+// protocol witness for Hashable.hash(into:) in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSHAASH4hash4intoys6HasherVz_tFTW
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+// protocol witness for static Equatable.== infix(_:_:) in conformance TestDerivedHashable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSQAASQ2eeoiySbx_xtFZTW
 // CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF

--- a/test/SILGen/preconcurrency_conformances.swift
+++ b/test/SILGen/preconcurrency_conformances.swift
@@ -353,6 +353,26 @@ struct TestDerivedHashable : @preconcurrency Hashable {
 // CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
 // CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
 
+extension NotSendable : Codable {}
+
+@MainActor
+struct TestDerivedCodable : @preconcurrency Codable {
+  var x: NotSendable
+}
+
+// protocol witness for Decodable.init(from:) in conformance TestDerivedCodable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances18TestDerivedCodableVSeAASe4fromxs7Decoder_p_tKcfCTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+// protocol witness for Encodable.encode(to:) in conformance TestDerivedCodable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances18TestDerivedCodableVSEAASE6encode2toys7Encoder_p_tKFTW
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
 
 //--- checks_disabled.swift
 protocol P {
@@ -574,4 +594,19 @@ struct TestDerivedHashable : @preconcurrency Hashable {
 
 // protocol witness for static Equatable.== infix(_:_:) in conformance TestDerivedHashable
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances19TestDerivedHashableVSQAASQ2eeoiySbx_xtFZTW
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+extension NotSendable : Codable {}
+
+@MainActor
+struct TestDerivedCodable : @preconcurrency Codable {
+  var x: NotSendable
+}
+
+// protocol witness for Decodable.init(from:) in conformance TestDerivedCodable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances18TestDerivedCodableVSeAASe4fromxs7Decoder_p_tKcfCTW
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+// protocol witness for Encodable.encode(to:) in conformance TestDerivedCodable
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances18TestDerivedCodableVSEAASE6encode2toys7Encoder_p_tKFTW
 // CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF


### PR DESCRIPTION
Covers Equatable, Hashable, and Codable derivations. RawRepresentable, Comparable are not applicable here because derivation is limited to enums.

The main chance here is to not inject `nonisolated` attribute when synthesizing witnesses for `@preconcurrency` conformances during derivation, the compiler would make sure that they are used in correct isolation context by injecting dynamic action isolation checks.

Resolves: rdar://142567811
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
