### PR TITLE
[SIL] Only visit final partial_apply [on_stack] lifetime ends.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -15,14 +15,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/SILInstruction.h"
-#include "swift/Basic/Assertions.h"
 #include "swift/Basic/AssertImplements.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/Basic/Unicode.h"
 #include "swift/Basic/type_traits.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/InstWrappers.h"
 #include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILDebugScope.h"
@@ -1869,6 +1872,38 @@ visitRecursivelyLifetimeEndingUses(
   return true;
 }
 
+static SILValue lookThroughOwnershipAndForwardingInsts(SILValue value) {
+  auto current = value;
+  while (true) {
+    if (auto *inst = current->getDefiningInstruction()) {
+      switch (inst->getKind()) {
+      case SILInstructionKind::MoveValueInst:
+      case SILInstructionKind::CopyValueInst:
+      case SILInstructionKind::BeginBorrowInst:
+        current = inst->getOperand(0);
+        continue;
+      default:
+        break;
+      }
+      auto forward = ForwardingOperation(inst);
+      Operand *op = nullptr;
+      if (forward && (op = forward.getSingleForwardingOperand())) {
+        current = op->get();
+        continue;
+      }
+    } else if (auto *result = SILArgument::isTerminatorResult(current)) {
+      auto *op = result->forwardedTerminatorResultOperand();
+      if (!op) {
+        break;
+      }
+      current = op->get();
+      continue;
+    }
+    break;
+  }
+  return current;
+}
+
 bool
 PartialApplyInst::visitOnStackLifetimeEnds(
                              llvm::function_ref<bool (Operand *)> func) const {
@@ -1877,29 +1912,74 @@ PartialApplyInst::visitOnStackLifetimeEnds(
          && "only meaningful for OSSA stack closures");
   bool noUsers = true;
 
-  auto visitUnknownUse = [](Operand *unknownUse) {
-    // There shouldn't be any dead-end consumptions of a nonescaping
-    // partial_apply that don't forward it along, aside from destroy_value.
-    //
-    // On-stack partial_apply cannot be cloned, so it should never be used by a
-    // BranchInst.
-    //
-    // This is a fatal error because it performs SIL verification that is not
-    // separately checked in the verifier. It is the only check that verifies
-    // the structural requirements of on-stack partial_apply uses.
-    llvm::errs() << "partial_apply [on_stack] use:\n";
-    auto *user = unknownUse->getUser();
-    user->printInContext(llvm::errs());
-    if (isa<BranchInst>(user)) {
-      llvm::report_fatal_error("partial_apply [on_stack] cannot be cloned");
+  auto *function = getFunction();
+
+  SmallVector<SILBasicBlock *, 32> discoveredBlocks;
+  SSAPrunedLiveness liveness(function, &discoveredBlocks);
+  liveness.initializeDef(this);
+
+  StackList<SILValue> values(function);
+  values.push_back(this);
+
+  while (!values.empty()) {
+    auto value = values.pop_back_val();
+    for (auto *use : value->getUses()) {
+      if (!use->isConsuming()) {
+        if (auto *cvi = dyn_cast<CopyValueInst>(use->getUser())) {
+          values.push_back(cvi);
+        }
+        continue;
+      }
+      noUsers = false;
+      if (isa<DestroyValueInst>(use->getUser())) {
+        liveness.updateForUse(use->getUser(), /*lifetimeEnding=*/true);
+        continue;
+      }
+      auto forward = ForwardingOperand(use);
+      if (!forward) {
+        // There shouldn't be any non-forwarding consumptions of a nonescaping
+        // partial_apply that don't forward it along, aside from destroy_value.
+        //
+        // On-stack partial_apply cannot be cloned, so it should never be used
+        // by a BranchInst.
+        //
+        // This is a fatal error because it performs SIL verification that is
+        // not separately checked in the verifier. It is the only check that
+        // verifies the structural requirements of on-stack partial_apply uses.
+        if (lookThroughOwnershipAndForwardingInsts(use->get()) !=
+            SILValue(this)) {
+          // Consumes of values which aren't "essentially" the
+          //   partial_apply [on_stack]
+          // are okay.  For example, a not-on_stack partial_apply that captures
+          // it.
+          continue;
+        }
+        llvm::errs() << "partial_apply [on_stack] use:\n";
+        auto *user = use->getUser();
+        user->printInContext(llvm::errs());
+        if (isa<BranchInst>(user)) {
+          llvm::report_fatal_error("partial_apply [on_stack] cannot be cloned");
+        }
+        llvm::report_fatal_error("partial_apply [on_stack] must be directly "
+                                 "forwarded to a destroy_value");
+      }
+      forward.visitForwardedValues([&values](auto value) {
+        values.push_back(value);
+        return true;
+      });
     }
-    llvm::report_fatal_error("partial_apply [on_stack] must be directly "
-                             "forwarded to a destroy_value");
-    return false;
-  };
-  if (!visitRecursivelyLifetimeEndingUses(this, noUsers, func,
-                                          visitUnknownUse)) {
-    return false;
+  }
+  PrunedLivenessBoundary boundary;
+  liveness.computeBoundary(boundary);
+
+  for (auto *inst : boundary.lastUsers) {
+    // Only destroy_values were added to liveness, so only destroy_values can be
+    // the last users.
+    auto *dvi = cast<DestroyValueInst>(inst);
+    auto keepGoing = func(&dvi->getOperandRef());
+    if (!keepGoing) {
+      return false;
+    }
   }
   return !noUsers;
 }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1904,6 +1904,22 @@ PartialApplyInst::visitOnStackLifetimeEnds(
   return !noUsers;
 }
 
+namespace swift::test {
+FunctionTest PartialApplyPrintOnStackLifetimeEnds(
+    "partial_apply_print_on_stack_lifetime_ends",
+    [](auto &function, auto &arguments, auto &test) {
+      auto *inst = arguments.takeInstruction();
+      auto *pai = cast<PartialApplyInst>(inst);
+      function.print(llvm::outs());
+      auto result = pai->visitOnStackLifetimeEnds([](auto *operand) {
+        operand->print(llvm::outs());
+        return true;
+      });
+      const char *resultString = result ? "true" : "false";
+      llvm::outs() << "returned: " << resultString << "\n";
+    });
+} // end namespace swift::test
+
 // FIXME: Rather than recursing through all results, this should only recurse
 // through ForwardingInstruction and OwnershipTransitionInstruction and the
 // client should prove that any other uses cannot be upstream from a consume of

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -414,7 +414,7 @@ static FunctionTest LinearLivenessTest("linear_liveness", [](auto &function,
 // - the computed pruned liveness
 // - the liveness boundary
 static FunctionTest
-    InteriorLivenessTest("interior-liveness",
+    InteriorLivenessTest("interior_liveness",
                          [](auto &function, auto &arguments, auto &test) {
                            SILValue value = arguments.takeValue();
                            function.print(llvm::outs());

--- a/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
+++ b/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
@@ -1,0 +1,40 @@
+// RUN: %target-sil-opt \
+// RUN:     -test-runner \
+// RUN:     %s \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+class C {}
+
+sil @borrowC : $@convention(thin) (@guaranteed C) -> ()
+
+// CHECK-LABEL: begin running test {{.*}} on copied_partial_apply
+// CHECK-LABEL: sil [ossa] @copied_partial_apply : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+// CHECK:         [[BORROW_C:%[^,]+]] = function_ref @borrowC
+// CHECK:         [[PA:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[BORROW_C]]([[C]])
+// CHECK:         [[PA2:%[^,]+]] = copy_value [[PA]]
+// CHECK:         destroy_value [[PA]]
+// CHECK:         destroy_value [[PA2]]
+// CHECK:         destroy_value [[C]]
+// CHECK-LABEL: } // end sil function 'copied_partial_apply'
+// CHECK:       Operand.
+// CHECK:       Owner:   destroy_value [[PA]]
+// CHECK:       returned: true
+// CHECK-LABEL: end running test {{.*}} on copied_partial_apply
+sil [ossa] @copied_partial_apply : $@convention(thin) (@owned C) -> () {
+entry(%c: @owned $C):
+  specify_test "partial_apply_print_on_stack_lifetime_ends %pa"
+
+  %callee = function_ref @borrowC : $@convention(thin) (@guaranteed C) -> ()
+  %pa = partial_apply [callee_guaranteed] [on_stack] %callee(%c) : $@convention(thin) (@guaranteed C) -> ()
+  %pa2 = copy_value %pa
+  destroy_value %pa
+
+  destroy_value %pa2
+  destroy_value %c
+  %retval = tuple ()
+  return %retval
+}

--- a/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
+++ b/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
@@ -21,7 +21,7 @@ sil @borrowC : $@convention(thin) (@guaranteed C) -> ()
 // CHECK:         destroy_value [[C]]
 // CHECK-LABEL: } // end sil function 'copied_partial_apply'
 // CHECK:       Operand.
-// CHECK:       Owner:   destroy_value [[PA]]
+// CHECK:       Owner:   destroy_value [[PA2]]
 // CHECK:       returned: true
 // CHECK-LABEL: end running test {{.*}} on copied_partial_apply
 sil [ossa] @copied_partial_apply : $@convention(thin) (@owned C) -> () {

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -162,9 +162,9 @@ exit(%phi : @owned $C, %typhi : $S):
 sil @empty : $@convention(thin) () -> () {
 [global: ]
 bb0:
-  %0 = tuple ()                                   
-  return %0 : $()                                 
-} 
+  %0 = tuple ()
+  return %0 : $()
+}
 
 // Even though the apply of %empty is not a deinit barrier, verify that the
 // destroy is not hoisted, because MoS is move-only.
@@ -568,16 +568,16 @@ entry(%c1 : @owned $C):
 // CHECK:       bb0([[C1:%[^,]+]] : @owned $C):
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
-// CHECK:         cond_br undef, [[LEFT]], [[RIGHT]]                         
-// CHECK:       [[LEFT]]:                                              
+// CHECK:         cond_br undef, [[LEFT]], [[RIGHT]]
+// CHECK:       [[LEFT]]:
 // CHECK:         [[M:%[^,]+]] = move_value [[C1]]
 // CHECK:         apply [[TAKE_C]]([[M]])
-// CHECK:         br [[EXIT]]                                          
-// CHECK:       [[RIGHT]]:                                              
+// CHECK:         br [[EXIT]]
+// CHECK:       [[RIGHT]]:
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
-// CHECK:         br [[EXIT]]                                          
-// CHECK:       [[EXIT]]:                                              
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
 // CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
@@ -883,4 +883,38 @@ die:
   %reload = load_borrow %token
   apply undef(%reload) : $@convention(thin) (@guaranteed C) -> ()
   unreachable
+}
+
+// The destroy of a value must not be hoisted over a destroy of a copy of a
+// partial_apply [on_stack] which captures the value.
+// CHECK-LABEL: begin running test {{.*}} on destroy_after_pa_copy_destroy
+// CHECK-LABEL: sil [ossa] @destroy_after_pa_copy_destroy : {{.*}} {
+// CHECK:       bb0([[A:%[^,]+]] :
+// CHECK:         [[C:%[^,]+]] = move_value [[A]]
+// CHECK:         [[BORROW_C:%[^,]+]] = function_ref @borrowC
+// CHECK:         [[PA:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[BORROW_C]]([[C]])
+// CHECK:         [[PA2:%[^,]+]] = copy_value [[PA]]
+// CHECK:         destroy_value [[PA]]
+// CHECK:         destroy_value [[PA2]]
+// CHECK:         destroy_value [[C]]
+// CHECK:         apply undef()
+// CHECK-LABEL: } // end sil function 'destroy_after_pa_copy_destroy'
+// CHECK-LABEL: end running test {{.*}} on destroy_after_pa_copy_destroy
+sil [ossa] @destroy_after_pa_copy_destroy : $@convention(thin) (@owned C) -> () {
+entry(%a: @owned $C):
+  // To defeat deinit barriers (apply undef).
+  %c = move_value %a
+  specify_test "canonicalize_ossa_lifetime true false true %c"
+
+  %callee = function_ref @borrowC : $@convention(thin) (@guaranteed C) -> ()
+  %pa = partial_apply [callee_guaranteed] [on_stack] %callee(%c) : $@convention(thin) (@guaranteed C) -> ()
+  %pa2 = copy_value %pa
+  destroy_value %pa
+
+  destroy_value %pa2
+  // To defeat ignoredByDestroyHoisting.
+  apply undef() : $@convention(thin) () -> ()
+  destroy_value %c
+  %retval = tuple ()
+  return %retval
 }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -355,7 +355,7 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // InteriorLiveness
 // =============================================================================
 
-// CHECK-LABEL: testInteriorRefElementEscape: interior-liveness with: %0
+// CHECK-LABEL: testInteriorRefElementEscape: interior_liveness with: %0
 // CHECK: Incomplete liveness: Escaping address
 // CHECK: last user:   %{{.*}} = address_to_pointer
 // CHECK-NEXT: testInteriorRefElementEscape:
@@ -374,7 +374,7 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: testInteriorRefElementEscape:
 sil [ossa] @testInteriorRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "interior-liveness %0"
+  specify_test "interior_liveness %0"
   specify_test "interior_liveness_swift %0"
   %d = unchecked_ref_cast %0 : $C to $D
   %f1 = ref_element_addr %d : $D, #D.object  
@@ -383,7 +383,7 @@ bb0(%0 : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorUnconditionalAddrCast: interior-liveness with: %1
+// CHECK-LABEL: testInteriorUnconditionalAddrCast: interior_liveness with: %1
 // CHECK: Interior liveness: %1 = argument of bb0 : $D
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   [[FIELD:%.*]] = ref_element_addr %1 : $D, #D.object
@@ -394,7 +394,7 @@ bb0(%0 : @guaranteed $C):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
-// CHECK-NEXT: testInteriorUnconditionalAddrCast: interior-liveness with: %1
+// CHECK-NEXT: testInteriorUnconditionalAddrCast: interior_liveness with: %1
 
 // CHECK-LABEL: testInteriorUnconditionalAddrCast: interior_liveness_swift with: %1
 // CHECK: Interior liveness: %1 = argument of bb0 : $D
@@ -410,7 +410,7 @@ bb0(%0 : @guaranteed $C):
 // CHECK-NEXT: testInteriorUnconditionalAddrCast: interior_liveness_swift with: %1
 sil [ossa] @testInteriorUnconditionalAddrCast : $@convention(thin) (@guaranteed D) -> @out D {
 bb0(%0 : $*D, %1 : @guaranteed $D):
-  specify_test "interior-liveness %1"
+  specify_test "interior_liveness %1"
   specify_test "interior_liveness_swift %1"
   %c1 = ref_element_addr %1 : $D, #D.object
   unconditional_checked_cast_addr C in %c1 : $*C to D in %0 : $*D
@@ -421,7 +421,7 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 2 on testInteriorDropDeinit: interior-liveness with: %0
+// CHECK-LABEL: begin running test 1 of 2 on testInteriorDropDeinit: interior_liveness with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $NCInt
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: lifetime-ending user:   [[DD:%.*]] = drop_deinit %0 : $NCInt
@@ -429,7 +429,7 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   [[DD]] = drop_deinit %0 : $NCInt
-// CHECK-LABEL: end running test 1 of 2 on testInteriorDropDeinit: interior-liveness with: %0
+// CHECK-LABEL: end running test 1 of 2 on testInteriorDropDeinit: interior_liveness with: %0
 
 // CHECK-LABEL: begin running test 2 of 2 on testInteriorDropDeinit: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $NCInt
@@ -443,7 +443,7 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
 // CHECK-LABEL: end running test 2 of 2 on testInteriorDropDeinit: interior_liveness_swift with: %0
 sil [ossa] @testInteriorDropDeinit : $@convention(thin) (@owned NCInt) -> () {
 bb0(%0 : @owned $NCInt):
-  specify_test "interior-liveness %0"
+  specify_test "interior_liveness %0"
   specify_test "interior_liveness_swift %0"
   %nd = drop_deinit %0 : $NCInt
   destroy_value %nd : $NCInt
@@ -451,7 +451,7 @@ bb0(%0 : @owned $NCInt):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_interior: interior-liveness
+// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness
 // CHECK-LABEL: sil [ossa] @testLoopConditional_incomplete_interior : {{.*}} {
 // CHECK:       [[ENTRY:bb[0-9]+]]([[C:%[^,]+]] :
 // CHECK:         cond_br undef, [[HEADER:bb[0-9]+]], [[EXIT:bb[0-9]+]]
@@ -476,7 +476,7 @@ bb0(%0 : @owned $NCInt):
 // CHECK:       Unenclosed phis {
 // CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
-// CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_interior: interior-liveness
+// CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness
 // CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness_swift
 // CHECK:       Interior liveness: [[C]]
 // CHECK:       begin:      cond_br undef, [[HEADER]], [[EXIT]]
@@ -489,7 +489,7 @@ bb0(%0 : @owned $NCInt):
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness_swift
 sil [ossa] @testLoopConditional_incomplete_interior : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):
-  specify_test "interior-liveness %c"
+  specify_test "interior_liveness %c"
   specify_test "interior_liveness_swift %c"
   cond_br undef, header, exit
 
@@ -507,7 +507,7 @@ exit:
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_interior: interior-liveness
+// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_interior: interior_liveness
 // CHECK-LABEL: sil [ossa] @testLoopConditional_complete_interior : {{.*}} {
 // CHECK:     [[ENTRY:bb[0-9]+]]([[C:%[^,]+]] :
 // CHECK:       cond_br undef, [[HEADER:bb[0-9]+]], [[EXIT:bb[0-9]+]]
@@ -534,7 +534,7 @@ exit:
 // CHECK:       Unenclosed phis {
 // CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
-// CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_interior: interior-liveness
+// CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_interior: interior_liveness
 
 // CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_interior: interior_liveness_swift
 // CHECK:       Interior liveness: [[C]]
@@ -549,7 +549,7 @@ exit:
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_interior: interior_liveness_swift
 sil [ossa] @testLoopConditional_complete_interior : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):
-  specify_test "interior-liveness %c"
+  specify_test "interior_liveness %c"
   specify_test "interior_liveness_swift %c"
   cond_br undef, header, exit
 
@@ -572,12 +572,12 @@ exit:
 // InteriorLiveness and visitAdjacentPhis
 // =============================================================================
 
-// CHECK-LABEL: testInteriorReborrow: interior-liveness with: %borrow
+// CHECK-LABEL: testInteriorReborrow: interior_liveness with: %borrow
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1
-// CHECK-NEXT: testInteriorReborrow: interior-liveness with: %borrow
+// CHECK-NEXT: testInteriorReborrow: interior_liveness with: %borrow
 
 // CHECK-LABEL: testInteriorReborrow: interior_liveness_swift with: %borrow
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
@@ -592,7 +592,7 @@ exit:
 sil [ossa] @testInteriorReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
-  specify_test "interior-liveness %borrow"
+  specify_test "interior_liveness %borrow"
   specify_test "interior_liveness_swift %borrow"
   br bb1(%borrow : $C)
 
@@ -602,7 +602,7 @@ bb1(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorNondominatedReborrow: interior-liveness with: %borrow1
+// CHECK-LABEL: testInteriorNondominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveWithin
@@ -612,7 +612,7 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
-// CHECK-NEXT: testInteriorNondominatedReborrow: interior-liveness with: %borrow1
+// CHECK-NEXT: testInteriorNondominatedReborrow: interior_liveness with: %borrow1
 
 // CHECK-LABEL: testInteriorNondominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
@@ -627,7 +627,7 @@ bb1(%reborrow : @guaranteed $C):
 sil [ossa] @testInteriorNondominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow1 = begin_borrow %0 : $C
-  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness %borrow1"
   specify_test "interior_liveness_swift %borrow1"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   %borrow2 = begin_borrow %d1 : $D
@@ -640,7 +640,7 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorDominatedReborrow: interior-liveness with: %borrow1
+// CHECK-LABEL: testInteriorDominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
@@ -654,7 +654,7 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %1 : $C
-// CHECK-NEXT: testInteriorDominatedReborrow: interior-liveness with: %borrow1
+// CHECK-NEXT: testInteriorDominatedReborrow: interior_liveness with: %borrow1
 
 // CHECK-LABEL: testInteriorDominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
@@ -672,7 +672,7 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 sil [ossa] @testInteriorDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow1 = begin_borrow %0 : $C
-  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness %borrow1"
   specify_test "interior_liveness_swift %borrow1"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   %borrow2 = begin_borrow %d1 : $D
@@ -687,7 +687,7 @@ bb3(%reborrow2 : @guaranteed $D):
 
 // Test mark_dependence of an address value. Walk down.
 
-// CHECK-LABEL: testInteriorMarkDepAddressValue: interior-liveness with: %0
+// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
@@ -696,7 +696,7 @@ bb3(%reborrow2 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
-// CHECK-NEXT: testInteriorMarkDepAddressValue: interior-liveness with: %0
+// CHECK-NEXT: testInteriorMarkDepAddressValue: interior_liveness with: %0
 
 // CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
@@ -712,7 +712,7 @@ bb3(%reborrow2 : @guaranteed $D):
 // CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressValue : $@convention(thin) (@guaranteed D, @guaranteed C) -> () {
 bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
-  specify_test "interior-liveness %0"
+  specify_test "interior_liveness %0"
   specify_test "interior_liveness_swift %0"
   %f = ref_element_addr %0 : $D, #D.object
   %dependence = mark_dependence %f: $*C on %1: $C
@@ -724,7 +724,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 
 // Test mark_dependence on a base address value. Walk down.
 
-// CHECK-LABEL: testInteriorMarkDepAddressBase: interior-liveness with: %0
+// CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
@@ -733,7 +733,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = mark_dependence %{{.*}} : $*C on %{{.*}} : $*C
-// CHECK-NEXT: testInteriorMarkDepAddressBase: interior-liveness with: %0
+// CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness with: %0
 
 // CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
@@ -749,7 +749,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 // CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressBase : $@convention(thin) (@guaranteed D, @guaranteed D) -> () {
 bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
-  specify_test "interior-liveness %0"
+  specify_test "interior_liveness %0"
   specify_test "interior_liveness_swift %0"
   %f0 = ref_element_addr %0 : $D, #D.object
   %f1 = ref_element_addr %1 : $D, #D.object
@@ -760,7 +760,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior-liveness with: %0
+// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
@@ -770,7 +770,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access %{{.*}} : $*C
-// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior-liveness with: %0
+// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness with: %0
 
 // CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
@@ -785,7 +785,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
 // CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressDependent : $@convention(thin) (@guaranteed D, @owned C) -> () {
 bb0(%0 : @guaranteed $D, %1 : @owned $C):
-  specify_test "interior-liveness %0"
+  specify_test "interior_liveness %0"
   specify_test "interior_liveness_swift %0"
   %f = ref_element_addr %0 : $D, #D.object
   %access = begin_access [read] [static] %f : $*C
@@ -800,7 +800,7 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior-liveness with: @argument[0]
+// CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior_liveness with: @argument[0]
 // CHECK: Complete liveness
 // CHECK: last user: %{{.*}} load [copy]
 // CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
@@ -822,7 +822,7 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
 // CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
 sil [ossa] @testInteriorDominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness @argument[0]"
   specify_test "interior_liveness_swift @argument[0]"
   cond_br undef, bb1, bb2
 
@@ -842,12 +842,12 @@ bb3(%phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: %borrow1
+// CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness with: %borrow1
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(
-// CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: %borrow1
+// CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness with: %borrow1
 
 // CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
@@ -865,7 +865,7 @@ bb0(%0 : @guaranteed $C):
 
 bb1:
   %borrow1 = begin_borrow %0 : $C
-  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness %borrow1"
   specify_test "interior_liveness_swift %borrow1"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   br bb3(%borrow1 : $C, %d1 : $D)
@@ -884,14 +884,14 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInnerDominatedReborrow: interior-liveness with: @argument[0]
+// CHECK-LABEL: testInnerDominatedReborrow: interior_liveness with: @argument[0]
 // CHECK: Interior liveness:
 // CHECK: Inner scope:   %{{.*}} = begin_borrow %0 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:  %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
-// CHECK-NEXT: testInnerDominatedReborrow: interior-liveness with: @argument[0]
+// CHECK-NEXT: testInnerDominatedReborrow: interior_liveness with: @argument[0]
 
 // CHECK-LABEL: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
@@ -906,7 +906,7 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness @argument[0]"
   specify_test "interior_liveness_swift @argument[0]"
   %borrow = begin_borrow %0 : $C
   br bb1(%borrow : $C)
@@ -917,14 +917,14 @@ bb1(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInnerDominatedReborrow2: interior-liveness with: %copy0a
+// CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness with: %copy0a
 // CHECK: Inner scope:   %{{.*}} = begin_borrow %1 : $C
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value
-// CHECK-NEXT: testInnerDominatedReborrow2: interior-liveness with: %copy0a
+// CHECK-NEXT: testInnerDominatedReborrow2: interior_liveness with: %copy0a
 
 // CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
 // CHECK: Interior liveness:   %{{.*}} = copy_value %0 : $C
@@ -942,7 +942,7 @@ sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> 
 bb0(%0 : @guaranteed $C):
   %copy0a = copy_value %0 : $C
   %copy0b = copy_value %0 : $C
-  specify_test "interior-liveness %copy0a"
+  specify_test "interior_liveness %copy0a"
   specify_test "interior_liveness_swift %copy0a"
   cond_br undef, bb1, bb2
 
@@ -962,13 +962,13 @@ bb3(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInnerNonDominatedReborrow: interior-liveness with: %borrow1
+// CHECK-LABEL: testInnerNonDominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF:%.*]] : $D
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3([[DEF]] : $D, [[BORROW]] : $D)
-// CHECK-NEXT: testInnerNonDominatedReborrow: interior-liveness with: %borrow1
+// CHECK-NEXT: testInnerNonDominatedReborrow: interior_liveness with: %borrow1
 
 // CHECK-LABEL: testInnerNonDominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $D
@@ -986,7 +986,7 @@ bb0(%0 : @guaranteed $D):
 
 bb1:
   %borrow1 = begin_borrow %0 : $D
-  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness %borrow1"
   specify_test "interior_liveness_swift %borrow1"
   %inner1 = begin_borrow %borrow1 : $D
   br bb3(%borrow1 : $D, %inner1 : $D)
@@ -1006,7 +1006,7 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testInnerAdjacentReborrow1: interior-liveness with: %outer3
+// CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
@@ -1017,7 +1017,7 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user: %{{.*}} = borrowed %{{.*}} : $D from
-// CHECK-NEXT: testInnerAdjacentReborrow1: interior-liveness with: %outer3
+// CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness with: %outer3
 
 // CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
@@ -1046,7 +1046,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness %outer3"
   specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
@@ -1058,7 +1058,7 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testInnerAdjacentReborrow2: interior-liveness with: %outer3
+// CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
@@ -1069,7 +1069,7 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user: {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: testInnerAdjacentReborrow2: interior-liveness with: %outer3
+// CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness with: %outer3
 
 // CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
@@ -1098,7 +1098,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness %outer3"
   specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
@@ -1110,7 +1110,7 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testInnerNonAdjacentReborrow: interior-liveness with: %outer3
+// CHECK-LABEL: testInnerNonAdjacentReborrow: interior_liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK-NOT:  Inner scope
 // CHECK-NOT:  lifetime-ending user
@@ -1118,7 +1118,7 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $D
-// CHECK-NEXT: testInnerNonAdjacentReborrow: interior-liveness with: %outer3
+// CHECK-NEXT: testInnerNonAdjacentReborrow: interior_liveness with: %outer3
 
 // CHECK-LABEL: testInnerNonAdjacentReborrow: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
@@ -1145,7 +1145,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness %outer3"
   specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
@@ -1157,13 +1157,13 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testInnerAdjacentPhi1: interior-liveness with: %inner3
+// CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy]
-// CHECK-NEXT: testInnerAdjacentPhi1: interior-liveness with: %inner3
+// CHECK-NEXT: testInnerAdjacentPhi1: interior_liveness with: %inner3
 
 // CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness_swift with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
@@ -1196,7 +1196,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @reborrow $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness %inner3"
   specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
@@ -1207,13 +1207,13 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testInnerAdjacentPhi2: interior-liveness with: %inner3
+// CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy]
-// CHECK-NEXT: testInnerAdjacentPhi2: interior-liveness with: %inner3
+// CHECK-NEXT: testInnerAdjacentPhi2: interior_liveness with: %inner3
 
 // CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness_swift with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
@@ -1246,7 +1246,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @reborrow $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness %inner3"
   specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
@@ -1257,13 +1257,13 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testInnerNonAdjacentPhi: interior-liveness with: %inner3
+// CHECK-LABEL: testInnerNonAdjacentPhi: interior_liveness with: %inner3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: testInnerNonAdjacentPhi: interior-liveness with: %inner3
+// CHECK-NEXT: testInnerNonAdjacentPhi: interior_liveness with: %inner3
 
 // CHECK-LABEL: testInnerNonAdjacentPhi: interior_liveness_swift with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
@@ -1292,7 +1292,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness %inner3"
   specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
@@ -1303,12 +1303,12 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: testScopedAddress: interior-liveness with: @argument[0]
+// CHECK-LABEL: testScopedAddress: interior_liveness with: @argument[0]
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access
-// CHECK-NEXT: testScopedAddress: interior-liveness with: @argument[0]
+// CHECK-NEXT: testScopedAddress: interior_liveness with: @argument[0]
 
 // CHECK-LABEL: testScopedAddress: interior_liveness_swift with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
@@ -1323,7 +1323,7 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-NEXT: testScopedAddress: interior_liveness_swift with: @argument[0]
 sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
-  specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness @argument[0]"
   specify_test "interior_liveness_swift @argument[0]"
   %f = ref_element_addr %0 : $D, #D.object
   %access = begin_access [read] [static] %f : $*C


### PR DESCRIPTION
In OSSA, the `partial_apply [on_stack]` instruction produces a value with odd characteristics that correspond to the fact that it is lowered to a stack-allocating instruction.  Among these characteristics is the fact that copies of such values aren't load bearing.

When visiting the lifetime-ending uses of a `partial_apply [on_stack]` the lifetime ending uses of (transitive) copies of the partial_apply must be considered as well.  Otherwise, the borrow scope it defines may be incorrectly short:

```
%closure = partial_apply %fn(%value) // borrows %value
%closure2 = copy_value %closure
destroy_value %closure // does _not_ end borrow of %value!
...
destroy_value %closure2 // ends borrow of %value
...
destroy_value %value
```

Furthermore, _only_ the final such destroys actually count as the real lifetime ends.  At least one client (OME) relies on `visitOnStackLifetimeEnds` visiting at most a single lifetime end on any path.

Rewrite the utility to use `PrunedLiveness`, tracking only destroys of copies and forwards.  The final destroys are the destroys on the boundary.

Also, add here a couple other changes: 
- Made it a bit easier to debug `CopyPropagation`, where the original problem showed up, by adding subpass bailouts.
- Did the same for `DestroyAddrHoisting`, where a different issue (a missing `!`) introduced by a previous version of this patch appeared to show up.
- Invalidated instructions in `TempRValueOpt` when lifetime completion had an effect.  This lack of invalidation resulted in not verifying or printing the SIL after the pass with `sil-print-function` despite the fact that it had indeed been changed (without using more exotic flags like `sil-verify-force-analysis`), obscuring the actual source of the issue introduced by a previous version of this patch.

rdar://142636711

