### PR TITLE
Frontend: Honor warning suppression when parsing arguments from swiftinterfaces

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -654,9 +654,11 @@ private:
                                      bool suppressRemarks,
                                      RequireOSSAModules_t requireOSSAModules);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
+                                           DiagnosticEngine &subInstanceDiags,
                                            SwiftInterfaceInfo &interfaceInfo,
                                            StringRef interfacePath,
                                            SourceLoc diagnosticLoc);
+
 public:
   InterfaceSubContextDelegateImpl(
       SourceManager &SM, DiagnosticEngine *Diags,

--- a/test/ModuleInterface/Inputs/suppress-warnings/SuppressWarnings.swiftinterface
+++ b/test/ModuleInterface/Inputs/suppress-warnings/SuppressWarnings.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SuppressWarnings -swift-version 6 -enable-upcoming-feature ConciseMagicFile
+
+import Swift
+
+@inlinable public func neverMutated() {
+  var x = 1
+}

--- a/test/ModuleInterface/suppress-warnings.swift
+++ b/test/ModuleInterface/suppress-warnings.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -compile-module-from-interface %S/Inputs/suppress-warnings/SuppressWarnings.swiftinterface -o /dev/null -module-name SuppressWarnings 2>&1 | %FileCheck %s --allow-empty
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/suppress-warnings/ 2>&1 | %FileCheck %s --allow-empty
+
+// Warnings should not be emitted when compiling SuppressWarnings from its interface
+// CHECK-NOT: warning
+
+import SuppressWarnings


### PR DESCRIPTION
Diagnostics are suppressed when parsing swiftinterface files, since the warnings emitted from compiling the swiftinterface of a dependency would just be a nuisance. It follows that warnings generated when parsing the arguments in a swiftinterface file should also be suppressed, but that wasn't happening because the diagnostic engine of the main compile was used for parsing. Pass the diagnostic engine of the compiler subinstance instead, and proactively suppress warnings before parsing begins.

Resolves rdar://142814164.
