### PR TITLE
🍒[cxx-interop] Workaround name lookup issues with `namespace os`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1147,6 +1147,14 @@ namespace {
       // Do not import namespace declarations marked as 'swift_private'.
       if (decl->hasAttr<clang::SwiftPrivateAttr>())
         return nullptr;
+      // Workaround for os module declaring `namespace os` on Darwin, causing
+      // name lookup issues. That namespace only declares utility functions that
+      // are not supposed to be used from Swift, so let's just not import the
+      // namespace (rdar://119044493).
+      if (decl->getIdentifier() && decl->getName() == "os" &&
+          decl->getOwningModule() &&
+          decl->getOwningModule()->getTopLevelModuleName() == "os")
+        return nullptr;
       // If this is a top-level namespace, don't put it in the module we're
       // importing, put it in the "__ObjC" module that is implicitly imported.
       if (!decl->getParent()->isNamespace())

--- a/test/Interop/Cxx/objc-correctness/os-logger.swift
+++ b/test/Interop/Cxx/objc-correctness/os-logger.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+import os
+
+var _: os.Logger! = nil

--- a/test/Interop/Cxx/objc-correctness/os-logger.swift
+++ b/test/Interop/Cxx/objc-correctness/os-logger.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
 
 // REQUIRES: objc_interop
-// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 import os
 


### PR DESCRIPTION
**Explanation**: On Apple platforms, a system module `os` declares a `namespace os` under `#if defined(__cplusplus)`. This causes ClangImporter to import it as `enum os` when C++ interop is enabled. This causes name lookup ambiguity (module os vs namespace os) which is resolved in namespace's favor, breaking existing usages.
**Scope**: This changes ClangImporter to not import a particular C++ namespace into Swift.
**Risk**: Low, this only affects the import of C++ namespace named `os` in a module named `os`.
**Testing**: Added a new compiler test.
**Issue**: rdar://119044493
**Reviewer**: @Xazax-hun

Original PR: https://github.com/swiftlang/swift/pull/78634

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
