### PR TITLE
Sema: Allow opening existential with a warning for rdar://141962317

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -731,6 +731,15 @@ namespace swift {
     /// until the next major language version.
     InFlightDiagnostic &warnUntilSwiftVersion(unsigned majorVersion);
 
+    /// Limit the behavior of this diagnostic to a warning and append a fragment
+    /// to the message stating that it will become an error in a future Swift
+    /// compiler.
+    /// The diagnostic represented by the receiver must be defined as an error.
+    ///
+    /// This helps to stage in source-breaking fixes for potentially harmful
+    /// miscompilations.
+    InFlightDiagnostic &warnUntilFutureSwiftCompiler();
+
     /// Limit the diagnostic behavior to warning if the context is a
     /// swiftinterface.
     ///

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -47,15 +47,15 @@ ERROR(error_no_group_info,none,
 NOTE(brace_stmt_suggest_do,none,
      "did you mean to use a 'do' statement?", ())
 
-// `error_in_future_swift_version` does not have a group because warnings of this kind
-// inherit the group from the wrapped error.
-WARNING(error_in_future_swift_version,none,
+// This does not have a group because warnings of this kind inherit the group
+// from the wrapped error.
+WARNING(error_in_swift_lang_mode,none,
         "%0; this is an error in the Swift %1 language mode",
         (DiagnosticInfo *, unsigned))
 
-// `error_in_a_future_swift_version` does not have a group because warnings of this kind
-// inherit the group from the wrapped error.
-WARNING(error_in_a_future_swift_version,none,
+// This does not have a group because warnings of this kind inherit the group
+// from the wrapped error.
+WARNING(error_in_a_future_swift_lang_mode,none,
         "%0; this will be an error in a future Swift language mode",
         (DiagnosticInfo *))
 

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -59,6 +59,12 @@ WARNING(error_in_a_future_swift_lang_mode,none,
         "%0; this will be an error in a future Swift language mode",
         (DiagnosticInfo *))
 
+// This does not have a group because warnings of this kind inherit the group
+// from the wrapped error.
+WARNING(error_in_a_future_swift_compiler,none,
+        "%0; this will be an error in a future Swift compiler",
+        (DiagnosticInfo *))
+
 // Generic disambiguation
 NOTE(while_parsing_as_left_angle_bracket,none,
      "while parsing this '<' as a type parameter bracket", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -155,6 +155,11 @@ ERROR(could_not_use_member_on_existential,none,
 FIXIT(replace_with_type,"%0",(Type))
 FIXIT(insert_type_qualification,"%0.",(Type))
 
+ERROR(cannot_open_existential_for_call_arg,none,
+      "calling %base0 with an existential value is not supported; call it "
+      "with a generic value instead; this will be an error in a future Swift "
+      "release", (const ValueDecl *))
+
 ERROR(candidate_inaccessible,none,
       "%base0 is inaccessible due to "
       "'%select{private|fileprivate|internal|package|@_spi|@_spi}1' protection level",

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -86,7 +86,7 @@ EDUCATIONAL_NOTES(result_builder_missing_build_array,
 EDUCATIONAL_NOTES(multiple_inheritance,
                   "multiple-inheritance.md")
 
-EDUCATIONAL_NOTES(error_in_future_swift_version,
+EDUCATIONAL_NOTES(error_in_swift_lang_mode,
                   "error-in-future-swift-version.md")
 
 #undef EDUCATIONAL_NOTES

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -431,9 +431,9 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
     // wrapIn will result in the behavior of the wrapping diagnostic.
     if (limit >= DiagnosticBehavior::Warning) {
       if (majorVersion > 6) {
-        wrapIn(diag::error_in_a_future_swift_version);
+        wrapIn(diag::error_in_a_future_swift_lang_mode);
       } else {
-        wrapIn(diag::error_in_future_swift_version, majorVersion);
+        wrapIn(diag::error_in_swift_lang_mode, majorVersion);
       }
     }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -455,6 +455,21 @@ InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
                                         majorVersion);
 }
 
+InFlightDiagnostic &InFlightDiagnostic::warnUntilFutureSwiftCompiler() {
+  // Calling this method on something that is not an error by definition is
+  // not a good practice.
+  {
+    auto diagID = Engine->getActiveDiagnostic().getID();
+    auto diagInfo = storedDiagnosticInfos[(unsigned)diagID];
+
+    ASSERT(diagInfo.kind == DiagnosticKind::Error);
+  }
+
+  wrapIn(diag::error_in_a_future_swift_compiler);
+
+  return limitBehavior(DiagnosticBehavior::Warning);
+}
+
 InFlightDiagnostic &
 InFlightDiagnostic::warnInSwiftInterface(const DeclContext *context) {
   auto sourceFile = context->getParentSourceFile();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9576,3 +9576,13 @@ bool IncorrectSlabLiteralCount::diagnoseAsError() {
   emitDiagnostic(diag::slab_literal_incorrect_count, lhsCount, rhsCount);
   return true;
 }
+
+bool WarnAboutExistentialOpenedForCallArgumentUntilFutureRelease::
+    diagnoseAsError() {
+  auto overload = *getCalleeOverloadChoiceIfAvailable(getLocator());
+
+  emitDiagnostic(diag::cannot_open_existential_for_call_arg,
+                 overload.choice.getDecl())
+      .warnUntilFutureSwiftCompiler();
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3252,6 +3252,27 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// A stopgap warning for the following case, where the invariant reference to
+/// `T` is temporarily ignored for compatibility:
+///
+/// \code
+/// struct S<each T> {}
+/// protocol P {}
+/// func open<T: P>(_: T.Type, _: S<T>? = nil) {}
+/// //                              ^
+/// let meta: any P.Type
+/// open(meta) // OK for now.
+/// \endcode
+///
+struct WarnAboutExistentialOpenedForCallArgumentUntilFutureRelease final
+    : public FailureDiagnostic {
+  WarnAboutExistentialOpenedForCallArgumentUntilFutureRelease(
+      const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator, FixBehavior::AlwaysWarning) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2736,3 +2736,17 @@ bool AllowSlabLiteralCountMismatch::diagnose(const Solution &solution,
   IncorrectSlabLiteralCount failure(solution, lhsCount, rhsCount, getLocator());
   return failure.diagnose(asNote);
 }
+
+bool AllowOpeningExistentialForCallArgumentUntilFutureRelease::diagnose(
+    const Solution &solution, bool asNote) const {
+  WarnAboutExistentialOpenedForCallArgumentUntilFutureRelease warning(
+      solution, getLocator());
+  return warning.diagnose(asNote);
+}
+
+AllowOpeningExistentialForCallArgumentUntilFutureRelease *
+AllowOpeningExistentialForCallArgumentUntilFutureRelease::create(
+    ConstraintSystem &cs, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowOpeningExistentialForCallArgumentUntilFutureRelease(cs, locator);
+}

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_unittest(SwiftASTTests
   ASTDumperTests.cpp
   ASTWalkerTests.cpp
   IndexSubsetTests.cpp
+  DiagnosticBehaviorTests.cpp
   DiagnosticConsumerTests.cpp
   DiagnosticGroupsTests.cpp
   SourceLocTests.cpp

--- a/unittests/AST/DiagnosticBehaviorTests.cpp
+++ b/unittests/AST/DiagnosticBehaviorTests.cpp
@@ -1,0 +1,134 @@
+//===--- DiagnosticBehaviorTests.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/SourceManager.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+class TestDiagnosticConsumer : public DiagnosticConsumer {
+  llvm::function_ref<void(const DiagnosticInfo &)> callback;
+
+public:
+  TestDiagnosticConsumer(decltype(callback) callback) : callback(callback) {}
+
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    this->callback(Info);
+  }
+};
+} // end anonymous namespace
+
+static void diagnosticBehaviorTestCase(
+    llvm::function_ref<void(DiagnosticEngine &)> diagnose,
+    llvm::function_ref<void(DiagnosticEngine &, const DiagnosticInfo &)>
+        callback,
+    unsigned expectedNumCallbackCalls) {
+  SourceManager sourceMgr;
+  DiagnosticEngine diags(sourceMgr);
+
+  unsigned count = 0;
+
+  const auto countingCallback = [&](const DiagnosticInfo &info) {
+    ++count;
+    callback(diags, info);
+  };
+
+  TestDiagnosticConsumer consumer(countingCallback);
+  diags.addConsumer(consumer);
+  diagnose(diags);
+  diags.removeConsumer(consumer);
+
+  EXPECT_EQ(count, expectedNumCallbackCalls);
+}
+
+TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
+  diagnosticBehaviorTestCase(
+      [](DiagnosticEngine &diags) {
+        diags.setLanguageVersion(version::Version({5}));
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .warnUntilSwiftVersion(4);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.Kind, DiagnosticKind::Error);
+        EXPECT_EQ(info.FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/1);
+
+  diagnosticBehaviorTestCase(
+      [](DiagnosticEngine &diags) {
+        diags.setLanguageVersion(version::Version({4}));
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .warnUntilSwiftVersion(5);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
+        EXPECT_EQ(info.FormatString,
+                  diags.diagnosticStringFor(diag::error_in_swift_lang_mode.ID));
+
+        auto wrappedDiagInfo = info.FormatArgs.front().getAsDiagnostic();
+        EXPECT_EQ(wrappedDiagInfo->FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/1);
+
+  diagnosticBehaviorTestCase(
+      [](DiagnosticEngine &diags) {
+        diags.setLanguageVersion(version::Version({4}));
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .warnUntilSwiftVersion(99);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
+        EXPECT_EQ(info.FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_in_a_future_swift_lang_mode.ID));
+
+        auto wrappedDiagInfo = info.FormatArgs.front().getAsDiagnostic();
+        EXPECT_EQ(wrappedDiagInfo->FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticBehavior, WarnUntilFutureCompiler) {
+  diagnosticBehaviorTestCase(
+      [](DiagnosticEngine &diags) {
+        diags.setLanguageVersion(version::Version({4}));
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .warnUntilFutureSwiftCompiler();
+
+        diags.setLanguageVersion(version::Version({99}));
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .warnUntilFutureSwiftCompiler();
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
+        EXPECT_EQ(info.FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_in_a_future_swift_compiler.ID));
+
+        auto wrappedDiagInfo = info.FormatArgs.front().getAsDiagnostic();
+
+        EXPECT_EQ(wrappedDiagInfo->FormatString,
+                  diags.diagnosticStringFor(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/2);
+}

--- a/unittests/AST/DiagnosticGroupsTests.cpp
+++ b/unittests/AST/DiagnosticGroupsTests.cpp
@@ -105,7 +105,7 @@ TEST(DiagnosticGroups, DiagnosticsWrappersInheritGroups) {
             .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
       },
       [](const DiagnosticInfo &info) {
-        EXPECT_EQ(info.ID, diag::error_in_a_future_swift_version.ID);
+        EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
         EXPECT_TRUE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
       },
       /*expectedNumCallbackCalls=*/1);

--- a/validation-test/Sema/rdar141962317.swift
+++ b/validation-test/Sema/rdar141962317.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+struct S<each T> {}
+protocol P {}
+func open<T: P>(_: Int, _: T.Type, _: S<T>? = nil) {}
+let meta: any P.Type
+open(0, meta)
+// expected-warning@-1:9 {{calling 'open' with an existential value is not supported; call it with a generic value instead; this will be an error in a future Swift release}}


### PR DESCRIPTION
We now correctly refuse to open the existential in the following case due to the invariant `T` in the second parameter, which broke some code internally. Opening the existential in this precise case happens to be safe, so this patch adds a temporary exception to the rules and pairs it with a warning so folks can spot and fix the problem.

```swift
struct S<each T> {}
protocol P {}
func open<T: P>(_: T.Type, _: S<T>? = nil) {}
let meta: any P.Type
open(meta)
```
