### PR TITLE
[6.1] SIL: builtin willThrow does not modify memory or release

### DIFF
--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1697,3 +1697,17 @@ bb0(%0 : ${ var Int64 }):
   end_access %access : $*Int64
   return %val : $Int64
 }
+
+// CHECK-LABEL: sil @willThrow : $@convention(thin) (RefElemNoConflictClass, @guaranteed any Error) -> () {
+// CHECK:  begin_access [modify] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'willThrow'
+
+sil @willThrow : $@convention(thin) (RefElemNoConflictClass, @guaranteed any Error) -> () {
+bb0(%0 : $RefElemNoConflictClass, %1 : $any Error):
+  %x = ref_element_addr %0 : $RefElemNoConflictClass, #RefElemNoConflictClass.x
+  %b3 = begin_access [modify] [dynamic] %x : $*Int32
+  %w = builtin "willThrow"(%1 : $any Error) : $()
+  end_access %b3 : $*Int32
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -57,6 +57,9 @@ struct Ptr {
   var p: Int32
 }
 
+enum SomeErr : Error {
+    case err
+}
 
 sil_global public @global_var : $Int32
 
@@ -1242,4 +1245,15 @@ bb0(%0 : $SP):
 sil @test_consuming_in_with_unreachable : $@convention(thin) (@in X) -> () {
 bb0(%0 : $*X):
   unreachable
+}
+
+// CHECK-LABEL: sil @test_willThrow_builtin
+// CHECK: [%0: read v**.c*.v**, copy v**.c*.v**]
+// CHECK: [global: read,copy,deinit_barrier]
+
+sil @test_willThrow_builtin : $@convention(thin) (@guaranteed any Error) -> () {
+bb0(%0: $any Error):
+  %1 = builtin "willThrow"(%0 : $any Error) : $()
+  %r = tuple ()
+  return %r : $()
 }


### PR DESCRIPTION
This enables access enforcement analysis to classify a dynamic begin_access in access patterns (such as the one below) involving a throwing function as not having nested conflicts.

```
struct Stack {
  var items : [UInt8]

  mutating func pop() throws -> UInt8 {
    guard let item = items.popLast() else { throw SomeErr.err }
    return item
  }
  ...
}

class Container {
  private var ref : Stack

  @inline(never)
  internal func someMethod() throws {
     try ref.pop()
  }
  ...
}
```

Scope: Performance improvement
Risk: Medium, we are changing the side-effects of willThrow which should not matter all that match. There is a second order effect: other wrongly computed/assigned could now become visible.

Original PR: https://github.com/swiftlang/swift/pull/78091
Reviewed by: Erik Eckstein

rdar://141182074

(cherry picked from commit fa01d8d2f0642519097956fabe2e686515128a73)