### PR TITLE
[AutoDiff] Delete wrong FIXMEs (TF-284) from tests

### DIFF
--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -290,7 +290,6 @@ public struct PublicDiffAttrConformance: ProtocolRequirements {
   var x: Float
   var y: Float
 
-  // FIXME(TF-284): Fix unexpected diagnostic.
   // expected-note @+2 {{candidate is missing explicit '@differentiable(reverse)' attribute to satisfy requirement}} {{10-10=@differentiable(reverse) }}
   // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Float)'}}
   public init(x: Float, y: Float) {
@@ -298,7 +297,6 @@ public struct PublicDiffAttrConformance: ProtocolRequirements {
     self.y = y
   }
 
-  // FIXME(TF-284): Fix unexpected diagnostic.
   // expected-note @+2 {{candidate is missing explicit '@differentiable(reverse)' attribute to satisfy requirement}} {{10-10=@differentiable(reverse) }}
   // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Int)'}}
   public init(x: Float, y: Int) {


### PR DESCRIPTION
In AutoDiff/Sema/differentiable_attr_type_checking.swift, we have a couple of following FIXMEs:

```
// FIXME(TF-284): Fix unexpected diagnostic.
```

However, the diagnostic is expected for the case of public protocol requirements: see description https://github.com/swiftlang/swift/pull/30629. This PR removed the diagnostic for less-than-public-visible requirements, and the FIXME was initially related to them.

It looks like that the FIXMEs present now are a result of copy-paste and have no meaning, and the diagnostic is expected and should be present and does not need to be removed.

Fixes #78609

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
