### PR TITLE
[6.1] [rbi] Fix demangling of sending results when demangling impl-function-type

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -836,7 +836,7 @@ mangled in to disambiguate.
   impl-function-type ::= type* 'I' FUNC-ATTRIBUTES '_'
   impl-function-type ::= type* generic-signature 'I' FUNC-ATTRIBUTES '_'
 
-  FUNC-ATTRIBUTES ::= PATTERN-SUBS? INVOCATION-SUBS? PSEUDO-GENERIC? CALLEE-ESCAPE? ISOLATION? DIFFERENTIABILITY-KIND? CALLEE-CONVENTION FUNC-REPRESENTATION? COROUTINE-KIND? SENDABLE? ASYNC? (PARAM-CONVENTION PARAM-DIFFERENTIABILITY?)* RESULT-CONVENTION* ('Y' PARAM-CONVENTION)* ('z' RESULT-CONVENTION RESULT-DIFFERENTIABILITY?)?
+  FUNC-ATTRIBUTES ::= PATTERN-SUBS? INVOCATION-SUBS? PSEUDO-GENERIC? CALLEE-ESCAPE? ISOLATION? DIFFERENTIABILITY-KIND? CALLEE-CONVENTION FUNC-REPRESENTATION? COROUTINE-KIND? SENDABLE? ASYNC? SENDING-RESULT? (PARAM-CONVENTION PARAM-DIFFERENTIABILITY?)* RESULT-CONVENTION* ('Y' PARAM-CONVENTION)* ('z' RESULT-CONVENTION RESULT-DIFFERENTIABILITY?)?
 
   PATTERN-SUBS ::= 's'                       // has pattern substitutions
   INVOCATION-SUB ::= 'I'                     // has invocation substitutions
@@ -870,8 +870,9 @@ mangled in to disambiguate.
   COROUTINE-KIND ::= 'G'                     // yield-many coroutine
 
   #if SWIFT_RUNTIME_VERSION >= 5.5
-    SENDABLE ::= 'h'                           // @Sendable
-    ASYNC ::= 'H'                              // @async
+    SENDABLE ::= 'h'                         // @Sendable
+    ASYNC ::= 'H'                            // @async
+    SENDING-RESULT ::= 'T'                   // sending result
   #endif
 
   PARAM-CONVENTION ::= 'i'                   // indirect in

--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -872,6 +872,9 @@ mangled in to disambiguate.
   #if SWIFT_RUNTIME_VERSION >= 5.5
     SENDABLE ::= 'h'                         // @Sendable
     ASYNC ::= 'H'                            // @async
+  #endif
+
+  #if SWIFT_RUNTIME_VERSION >= 6.0
     SENDING-RESULT ::= 'T'                   // sending result
   #endif
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4789,12 +4789,12 @@ public:
   SILType getSILStorageInterfaceType() const;
   /// Return a version of this result info with the type replaced.
   SILResultInfo getWithInterfaceType(CanType type) const {
-    return SILResultInfo(type, getConvention());
+    return SILResultInfo(type, getConvention(), getOptions());
   }
 
   /// Return a version of this result info with the convention replaced.
   SILResultInfo getWithConvention(ResultConvention c) const {
-    return SILResultInfo(getInterfaceType(), c);
+    return SILResultInfo(getInterfaceType(), c, getOptions());
   }
 
   // Does this result convention require indirect storage? This reflects a

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1093,7 +1093,14 @@ protected:
             flags = flags.withSendable();
           } else if (child->getText() == "@async") {
             flags = flags.withAsync();
+          } else if (child->getText() == "sending-result") {
+            flags = flags.withSendingResult();
           }
+        } else if (child->getKind() == NodeKind::ImplSendingResult) {
+          // NOTE: This flag needs to be set both at the function level and on
+          // each of the parameters. The flag on the function just means that
+          // all parameters are sending (which is always true today).
+          flags = flags.withSendingResult();
         } else if (child->getKind() == NodeKind::ImplCoroutineKind) {
           if (!child->hasText())
             return MAKE_NODE_TYPE_ERROR0(child, "expected text");

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -677,6 +677,10 @@ Type ASTBuilder::createImplFunctionType(
     auto type = result.getType()->getCanonicalType();
     auto conv = getResultConvention(result.getConvention());
     auto options = *getResultOptions(result.getOptions());
+    // We currently set sending result at the function level, but we set sending
+    // result on each result.
+    if (flags.hasSendingResult())
+      options |= SILResultInfo::IsSending;
     funcResults.emplace_back(type, conv, options);
   }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2202,9 +2202,9 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
 
   // Mangle if we have a sending result and we are in a recursive position.
   //
-  // DISCUSSION: We only want sending results to change ABI if it is using in a
-  // function value passed to a parameter or generic position... but not if it
-  // is just added to a return type.
+  // DISCUSSION: We only want sending results to be in the mangling if it is
+  // being used in a function value passed to a parameter or generic
+  // position... but not if it is just added to a return type.
   //
   // E.x.:
   //

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2200,6 +2200,19 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
     OpArgs.push_back('H');
   }
 
+  // Mangle if we have a sending result and we are in a recursive position.
+  //
+  // DISCUSSION: We only want sending results to change ABI if it is using in a
+  // function value passed to a parameter or generic position... but not if it
+  // is just added to a return type.
+  //
+  // E.x.:
+  //
+  //   func foo() -> sending X // No mangling
+  //   func bar(_ x: () -> sending X) {} // Add to mangling for x
+  if (isInRecursion && fn->hasSendingResult())
+    OpArgs.push_back('T');
+
   GenericSignature sig = fn->getSubstGenericSignature();
   
   // Mangle the parameters.
@@ -2211,10 +2224,6 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
       OpArgs.push_back(*diffKind);
     appendType(param.getInterfaceType(), sig, forDecl);
   }
-
-  // Mangle if we have a sending result.
-  if (isInRecursion && fn->hasSendingResult())
-    OpArgs.push_back('T');
 
   // Mangle the results.
   for (auto result : fn->getResults()) {

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2412,6 +2412,10 @@ NodePointer Demangler::demangleImplFunctionType() {
                    *this);
   }
 
+  if (nextIf('T')) {
+    type->addChild(createNode(Node::Kind::ImplSendingResult), *this);
+  }
+
   addChild(type, GenSig);
 
   int NumTypesToAdd = 0;
@@ -2423,10 +2427,6 @@ NodePointer Demangler::demangleImplFunctionType() {
     if (auto Sending = demangleImplParameterSending())
       Param = addChild(Param, Sending);
     ++NumTypesToAdd;
-  }
-
-  if (nextIf('T')) {
-    type->addChild(createNode(Node::Kind::ImplSendingResult), *this);
   }
 
   while (NodePointer Result = demangleImplResultConvention(
@@ -2461,7 +2461,7 @@ NodePointer Demangler::demangleImplFunctionType() {
       return nullptr;
     type->getChild(type->getNumChildren() - Idx - 1)->addChild(ConvTy, *this);
   }
-  
+
   return createType(type);
 }
 

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2252,6 +2252,9 @@ private:
     if (Mangled.nextIf('H'))
       addImplFunctionAttribute(type, "@async");
 
+    if (Mangled.nextIf('T'))
+      addImplFunctionAttribute(type, "sending-result");
+
     // Enter a new generic context if this type is generic.
     // FIXME: replace with std::optional, when we have it.
     bool isPseudogeneric = false;

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2252,9 +2252,6 @@ private:
     if (Mangled.nextIf('H'))
       addImplFunctionAttribute(type, "@async");
 
-    if (Mangled.nextIf('T'))
-      addImplFunctionAttribute(type, "sending-result");
-
     // Enter a new generic context if this type is generic.
     // FIXME: replace with std::optional, when we have it.
     bool isPseudogeneric = false;

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2111,9 +2111,10 @@ ManglingError Remangler::mangleImplFunctionType(Node *node, unsigned depth) {
       }
       case Node::Kind::ImplFunctionAttribute: {
         char FuncAttr = llvm::StringSwitch<char>(Child->getText())
-                        .Case("@Sendable", 'h')
-                        .Case("@async", 'H')
-                        .Default(0);
+                            .Case("@Sendable", 'h')
+                            .Case("@async", 'H')
+                            .Case("sending-result", 'T')
+                            .Default(0);
         if (!FuncAttr) {
           return MANGLING_ERROR(ManglingError::InvalidImplFunctionAttribute,
                                Child);

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2113,7 +2113,6 @@ ManglingError Remangler::mangleImplFunctionType(Node *node, unsigned depth) {
         char FuncAttr = llvm::StringSwitch<char>(Child->getText())
                             .Case("@Sendable", 'h')
                             .Case("@async", 'H')
-                            .Case("sending-result", 'T')
                             .Default(0);
         if (!FuncAttr) {
           return MANGLING_ERROR(ManglingError::InvalidImplFunctionAttribute,

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -485,3 +485,5 @@ $s4main6VectorVy$1_SiG ---> main.Vector<2, Swift.Int>
 $s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
 $s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A
 $s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A
+$s7ToolKit10TypedValueOACs5Error_pIgHTnTrzo_A2CsAD_pIegHiTrzr_TR ---> {T:} reabstraction thunk helper from @callee_guaranteed @async (@in_guaranteed sending ToolKit.TypedValue) -> sending (@out ToolKit.TypedValue, @error @owned Swift.Error) to @escaping @callee_guaranteed @async (@in sending ToolKit.TypedValue) -> (@out ToolKit.TypedValue, @error @out Swift.Error)
+$s16sending_mangling16NonSendableKlassCACIegTiTr_A2CIegTxTo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed (@in sending sending_mangling.NonSendableKlass) -> sending (@out sending_mangling.NonSendableKlass) to @escaping @callee_guaranteed (@owned sending sending_mangling.NonSendableKlass) -> sending (@owned sending_mangling.NonSendableKlass)


### PR DESCRIPTION
This change fixes the demangling of sending results in the non-ABI impl-function-type part of the mangling that is used during reabstraction thunk generation.

Swift's mangling is a postfix mangling. We treat impl-function-type's mangling character 'I' as an operator that takes the types for parameters, results, yields, error result as parameters to the operator. The implementation of the demangler assumed that as it parsed nodes that all nodes that it demangled from impl-function-type (e.x.: flags on the function, information about params/results) would always have nodes that needed to be paired with the typed arguments to the operator were always at the end in the same order as the arguments. The demangler would after parsing the actual impl-function-type walk backwards along the child node list and add the typed argument information to the child node.

With that information in hand, the bug that occurred here is that the flag for sending results was originally placed in between the parameter and result information in impl-function-type. This would cause the nodes that were supposed to become children of the result nodes to instead be placed on the sending result flag node. The fix was to take advantage of this not being ABI to just move the bit to before the param part of the mangling so this can no longer happen.

While doing this, I also discovered a few other places where we were missing support for sending results in the old demangler/remangler so I added some quick support there as well just in case.

Scope: Affects demangle paths where a reabstraction thunk is used to reabstract in some way a function with a sending result. We produce a correct mangling, but the actual demangling will produce a bogus demangling tree, so anything that relies on being able to demangle the reabstraction thunk will cause issues. Luckily reabstraction thunks are not exported symbols so nothing can rely in the wild on linking against such a demangled symbol.
Risk: Low
Testing: Added new demangling tests and also added the specific swift example that exposed the code 
Issue: rdar://141962865
Reviewer: @rjmccall 
Original PRs:
https://github.com/swiftlang/swift/pull/78612
https://github.com/swiftlang/swift/pull/78660
https://github.com/swiftlang/swift/pull/78889