### PR TITLE
[Gardening] Include Runtime/Config.h directly

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -30,6 +30,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/IRGen/IRGenPublic.h"
+#include "swift/Runtime/Config.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/SmallString.h"


### PR DESCRIPTION
This file was relying on Runtime/Config.h for SWIFT_CC() but didn't include it directly.

I found this when some local experiments went awry in confusing ways.
