### PR TITLE
[ASTGen/MacroEvaluation] Fix and adjust FixIt application

### DIFF
--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -21,7 +21,7 @@ func testEditorPlaceholder() -> Int {
 
 _ = [(Int) -> async throws Int]()
 // expected-error@-1{{'async throws' must precede '->'}}
-// expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}
+// expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{12-12=async }} {{12-12=throws }}
 
 @freestanding // expected-error {{expected arguments for 'freestanding' attribute}}
 func dummy() {}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -161,12 +161,7 @@ public enum AddBlocker: ExpressionMacro {
                   changes: [
                     FixIt.Change.replace(
                       oldNode: Syntax(binOp.operator),
-                      newNode: Syntax(
-                        TokenSyntax(
-                          .binaryOperator("-"),
-                          presence: .present
-                        )
-                      )
+                      newNode: Syntax(binOp.operator.detached.with(\.tokenKind, .binaryOperator("-"))),
                     )
                   ]
                 ),


### PR DESCRIPTION
* Fix mismatch on `FixIt.Change.replace` between several application implementations. Specifically `.replace` should includes the trivia.
* Ignore no-op `FixIt.Change.replace{Leading|Trailing}Triviia`.
