### PR TITLE
6.1: [OSSACanonicalizeOwned] Fix liveness passed to completion.

### DIFF
--- a/lib/SIL/Utils/PrettyStackTrace.cpp
+++ b/lib/SIL/Utils/PrettyStackTrace.cpp
@@ -96,7 +96,7 @@ void PrettyStackTraceSILFunction::printFunctionInfo(llvm::raw_ostream &out) cons
   if (SILPrintOnError)
     func->print(out);
   if (SILPrintModuleOnError)
-    func->getModule().print(out);
+    func->getModule().print(out, func->getModule().getSwiftModule());
 }
 
 void PrettyStackTraceSILNode::print(llvm::raw_ostream &out) const {

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -860,7 +860,7 @@ void PrunedLiveRange<LivenessWithDefs>::computeBoundary(
   // Visit each post-dominating block as the starting point for a
   // backward CFG traversal.
   for (auto *block : postDomBlocks) {
-    blockWorklist.push(block);
+    blockWorklist.pushIfNotVisited(block);
   }
   while (auto *block = blockWorklist.pop()) {
     // Process each block that has not been visited and is not LiveOut.

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -512,11 +512,12 @@ void SILCombiner::processInstruction(SILInstruction *I,
 
 namespace swift::test {
 // Arguments:
-// - instruction: the instruction to be canonicalized
+// - instruction: the instruction to be visited
 // Dumps:
-// - the function after the canonicalization is attempted
-static FunctionTest SILCombineCanonicalizeInstruction(
-    "sil_combine_instruction", [](auto &function, auto &arguments, auto &test) {
+// - the function after the visitation is attempted
+static FunctionTest SILCombineVisitInstruction(
+    "sil_combine_visit_instruction",
+    [](auto &function, auto &arguments, auto &test) {
       SILCombiner combiner(test.getPass(), false, false);
       auto inst = arguments.takeInstruction();
       combiner.Builder.setInsertionPoint(inst);

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -511,6 +511,36 @@ void SILCombiner::processInstruction(SILInstruction *I,
 }
 
 namespace swift::test {
+struct SILCombinerProcessInstruction {
+  void operator()(SILCombiner &combiner, SILInstruction *inst,
+                  SILCombineCanonicalize &canonicalizer, bool &madeChange) {
+    combiner.processInstruction(inst, canonicalizer, madeChange);
+  }
+};
+// Arguments:
+// - instruction: the instruction to be processed
+// - bool: remove cond_fails
+// - bool: enable lifetime canonicalization
+// Dumps:
+// - the function after the processing is attempted
+static FunctionTest SILCombineProcessInstruction(
+    "sil_combine_process_instruction",
+    [](auto &function, auto &arguments, auto &test) {
+      auto inst = arguments.takeInstruction();
+      auto removeCondFails = arguments.takeBool();
+      auto enableCopyPropagation = arguments.takeBool();
+      SILCombiner combiner(test.getPass(), removeCondFails,
+                           enableCopyPropagation);
+      SILCombineCanonicalize canonicalizer(combiner.Worklist,
+                                           *test.getDeadEndBlocks());
+      bool madeChange = false;
+      SILCombinerProcessInstruction()(combiner, inst, canonicalizer,
+                                      madeChange);
+      function.dump();
+    });
+} // end namespace swift::test
+
+namespace swift::test {
 // Arguments:
 // - instruction: the instruction to be visited
 // Dumps:

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -120,6 +120,8 @@ void SILCombiner::addReachableCodeToWorklist(SILBasicBlock *BB) {
 //                               Implementation
 //===----------------------------------------------------------------------===//
 
+namespace swift {
+
 // Define a CanonicalizeInstruction subclass for use in SILCombine.
 class SILCombineCanonicalize final : CanonicalizeInstruction {
   SmallSILInstructionWorklist<256> &Worklist;
@@ -161,6 +163,8 @@ public:
     return changed;
   }
 };
+
+} // end namespace swift
 
 SILCombiner::SILCombiner(SILFunctionTransform *trans,
                          bool removeCondFails, bool enableCopyPropagation) :

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -418,90 +418,96 @@ bool SILCombiner::doOneIteration(SILFunction &F, unsigned Iteration) {
     if (!parentTransform->continueWithNextSubpassRun(I))
       return false;
 
-    // Check to see if we can DCE the instruction.
-    if (isInstructionTriviallyDead(I)) {
-      LLVM_DEBUG(llvm::dbgs() << "SC: DCE: " << *I << '\n');
-      eraseInstFromFunction(*I);
-      ++NumDeadInst;
-      MadeChange = true;
-      continue;
-    }
-#ifndef NDEBUG
-    std::string OrigIStr;
-#endif
-    LLVM_DEBUG(llvm::raw_string_ostream SS(OrigIStr); I->print(SS);
-               OrigIStr = SS.str(););
-    LLVM_DEBUG(llvm::dbgs() << "SC: Visiting: " << OrigIStr << '\n');
-
-    // Canonicalize the instruction.
-    if (scCanonicalize.tryCanonicalize(I)) {
-      MadeChange = true;
-      continue;
-    }
-
-    // If we have reached this point, all attempts to do simple simplifications
-    // have failed. First if we have an owned forwarding value, we try to
-    // sink. Otherwise, we perform the actual SILCombine operation.
-    if (EnableSinkingOwnedForwardingInstToUses) {
-      // If we have an ownership forwarding single value inst that forwards
-      // through its first argument and it is trivially duplicatable, see if it
-      // only has consuming uses. If so, we can duplicate the instruction into
-      // the consuming use blocks and destroy any destroy_value uses of it that
-      // we see. This makes it easier for SILCombine to fold instructions with
-      // owned parameters since chains of these values will be in the same
-      // block.
-      if (auto *svi = dyn_cast<SingleValueInstruction>(I)) {
-        if (auto fwdOp = ForwardingOperation(svi)) {
-          if (fwdOp.getSingleForwardingOperand() &&
-              SILValue(svi)->getOwnershipKind() == OwnershipKind::Owned) {
-            // Try to sink the value. If we sank the value and deleted it,
-            // continue. If we didn't optimize or sank but we are still able to
-            // optimize further, we fall through to SILCombine below.
-            if (trySinkOwnedForwardingInst(svi)) {
-              continue;
-            }
-          }
-        }
-      }
-    }
-
-    // Then begin... SILCombine.
-    Builder.setInsertionPoint(I);
-
-    SILInstruction *currentInst = I;
-    if (SILInstruction *Result = visit(I)) {
-      ++NumCombined;
-      // Should we replace the old instruction with a new one?
-      Worklist.replaceInstructionWithInstruction(I, Result
-#ifndef NDEBUG
-                                                 ,
-                                                 OrigIStr
-#endif
-      );
-      currentInst = Result;
-      MadeChange = true;
-    }
-
-    // Eliminate copies created that this SILCombine iteration may have
-    // introduced during OSSA-RAUW.
-    canonicalizeOSSALifetimes(currentInst->isDeleted() ? nullptr : currentInst);
-
-    // Builder's tracking list has been accumulating instructions created by the
-    // during this SILCombine iteration. To finish this iteration, go through
-    // the tracking list and add its contents to the worklist and then clear
-    // said list in preparation for the next iteration.
-    for (SILInstruction *I : *Builder.getTrackingList()) {
-      if (!I->isDeleted()) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "SC: add " << *I << " from tracking list to worklist\n");
-        Worklist.add(I);
-      }
-    }
-    Builder.getTrackingList()->clear();
+    processInstruction(I, scCanonicalize, MadeChange);
   }
 
   Worklist.resetChecked();
   return MadeChange;
+}
+
+void SILCombiner::processInstruction(SILInstruction *I,
+                                     SILCombineCanonicalize &scCanonicalize,
+                                     bool &MadeChange) {
+  // Check to see if we can DCE the instruction.
+  if (isInstructionTriviallyDead(I)) {
+    LLVM_DEBUG(llvm::dbgs() << "SC: DCE: " << *I << '\n');
+    eraseInstFromFunction(*I);
+    ++NumDeadInst;
+    MadeChange = true;
+    return;
+  }
+#ifndef NDEBUG
+  std::string OrigIStr;
+#endif
+  LLVM_DEBUG(llvm::raw_string_ostream SS(OrigIStr); I->print(SS);
+             OrigIStr = SS.str(););
+  LLVM_DEBUG(llvm::dbgs() << "SC: Visiting: " << OrigIStr << '\n');
+
+  // Canonicalize the instruction.
+  if (scCanonicalize.tryCanonicalize(I)) {
+    MadeChange = true;
+    return;
+  }
+
+  // If we have reached this point, all attempts to do simple simplifications
+  // have failed. First if we have an owned forwarding value, we try to
+  // sink. Otherwise, we perform the actual SILCombine operation.
+  if (EnableSinkingOwnedForwardingInstToUses) {
+    // If we have an ownership forwarding single value inst that forwards
+    // through its first argument and it is trivially duplicatable, see if it
+    // only has consuming uses. If so, we can duplicate the instruction into
+    // the consuming use blocks and destroy any destroy_value uses of it that
+    // we see. This makes it easier for SILCombine to fold instructions with
+    // owned parameters since chains of these values will be in the same
+    // block.
+    if (auto *svi = dyn_cast<SingleValueInstruction>(I)) {
+      if (auto fwdOp = ForwardingOperation(svi)) {
+        if (fwdOp.getSingleForwardingOperand() &&
+            SILValue(svi)->getOwnershipKind() == OwnershipKind::Owned) {
+          // Try to sink the value. If we sank the value and deleted it,
+          // return. If we didn't optimize or sank but we are still able to
+          // optimize further, we fall through to SILCombine below.
+          if (trySinkOwnedForwardingInst(svi)) {
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  // Then begin... SILCombine.
+  Builder.setInsertionPoint(I);
+
+  SILInstruction *currentInst = I;
+  if (SILInstruction *Result = visit(I)) {
+    ++NumCombined;
+    // Should we replace the old instruction with a new one?
+    Worklist.replaceInstructionWithInstruction(I, Result
+#ifndef NDEBUG
+                                               ,
+                                               OrigIStr
+#endif
+    );
+    currentInst = Result;
+    MadeChange = true;
+  }
+
+  // Eliminate copies created that this SILCombine iteration may have
+  // introduced during OSSA-RAUW.
+  canonicalizeOSSALifetimes(currentInst->isDeleted() ? nullptr : currentInst);
+
+  // Builder's tracking list has been accumulating instructions created by the
+  // during this SILCombine iteration. To finish this iteration, go through
+  // the tracking list and add its contents to the worklist and then clear
+  // said list in preparation for the next iteration.
+  for (SILInstruction *I : *Builder.getTrackingList()) {
+    if (!I->isDeleted()) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "SC: add " << *I << " from tracking list to worklist\n");
+      Worklist.add(I);
+    }
+  }
+  Builder.getTrackingList()->clear();
 }
 
 namespace swift::test {

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -47,6 +47,10 @@
 namespace swift {
 
 class AliasAnalysis;
+class SILCombineCanonicalize;
+namespace test {
+struct SILCombinerProcessInstruction;
+}
 
 /// This is a class which maintains the state of the combiner and simplifies
 /// many operations such as removing/adding instructions and syncing them with
@@ -420,6 +424,8 @@ private:
   void processInstruction(SILInstruction *instruction,
                           SILCombineCanonicalize &scCanonicalize,
                           bool &MadeChange);
+  friend test::SILCombinerProcessInstruction;
+
   /// Add reachable code to the worklist. Meant to be used when starting to
   /// process a new function.
   void addReachableCodeToWorklist(SILBasicBlock *BB);

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -417,6 +417,9 @@ private:
   /// Perform one SILCombine iteration.
   bool doOneIteration(SILFunction &F, unsigned Iteration);
 
+  void processInstruction(SILInstruction *instruction,
+                          SILCombineCanonicalize &scCanonicalize,
+                          bool &MadeChange);
   /// Add reachable code to the worklist. Meant to be used when starting to
   /// process a new function.
   void addReachableCodeToWorklist(SILBasicBlock *BB);

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -857,3 +857,30 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on consume_copy_before_use_in_dead_end
+// CHECK-LABEL: sil [ossa] @consume_copy_before_use_in_dead_end : {{.*}} {
+// CHECK-NOT:     destroy_value [dead_end]
+// CHECK-LABEL: } // end sil function 'consume_copy_before_use_in_dead_end'
+// CHECK-LABEL: end running test {{.*}} on consume_copy_before_use_in_dead_end
+sil [ossa] @consume_copy_before_use_in_dead_end : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  cond_br undef, exit, die
+
+exit:
+  destroy_value %c
+  %retval = tuple ()
+  return %retval
+
+die:
+  %move = move_value [lexical] %c
+  %copy = copy_value %move
+  specify_test "canonicalize_ossa_lifetime true false true %move"
+  apply undef(%move) : $@convention(thin) (@owned C) -> ()
+  %addr = alloc_stack $C
+  %token = store_borrow %copy to %addr
+  apply undef() : $@convention(thin) () -> ()
+  %reload = load_borrow %token
+  apply undef(%reload) : $@convention(thin) (@guaranteed C) -> ()
+  unreachable
+}

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -162,9 +162,9 @@ exit(%phi : @owned $C, %typhi : $S):
 sil @empty : $@convention(thin) () -> () {
 [global: ]
 bb0:
-  %0 = tuple ()                                   
-  return %0 : $()                                 
-} 
+  %0 = tuple ()
+  return %0 : $()
+}
 
 // Even though the apply of %empty is not a deinit barrier, verify that the
 // destroy is not hoisted, because MoS is move-only.
@@ -568,16 +568,16 @@ entry(%c1 : @owned $C):
 // CHECK:       bb0([[C1:%[^,]+]] : @owned $C):
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
-// CHECK:         cond_br undef, [[LEFT]], [[RIGHT]]                         
-// CHECK:       [[LEFT]]:                                              
+// CHECK:         cond_br undef, [[LEFT]], [[RIGHT]]
+// CHECK:       [[LEFT]]:
 // CHECK:         [[M:%[^,]+]] = move_value [[C1]]
 // CHECK:         apply [[TAKE_C]]([[M]])
-// CHECK:         br [[EXIT]]                                          
-// CHECK:       [[RIGHT]]:                                              
+// CHECK:         br [[EXIT]]
+// CHECK:       [[RIGHT]]:
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
-// CHECK:         br [[EXIT]]                                          
-// CHECK:       [[EXIT]]:                                              
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
 // CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
@@ -858,6 +858,7 @@ exit:
   return %retval : $()
 }
 
+
 // CHECK-LABEL: begin running test {{.*}} on consume_copy_before_use_in_dead_end
 // CHECK-LABEL: sil [ossa] @consume_copy_before_use_in_dead_end : {{.*}} {
 // CHECK-NOT:     destroy_value [dead_end]
@@ -868,19 +869,19 @@ entry(%c : @owned $C):
   cond_br undef, exit, die
 
 exit:
-  destroy_value %c
+  destroy_value %c : $C
   %retval = tuple ()
-  return %retval
+  return %retval : $()
 
 die:
-  %move = move_value [lexical] %c
-  %copy = copy_value %move
+  %move = move_value [lexical] %c : $C
+  %copy = copy_value %move : $C
   specify_test "canonicalize_ossa_lifetime true false true %move"
   apply undef(%move) : $@convention(thin) (@owned C) -> ()
   %addr = alloc_stack $C
-  %token = store_borrow %copy to %addr
+  %token = store_borrow %copy to %addr : $*C
   apply undef() : $@convention(thin) () -> ()
-  %reload = load_borrow %token
+  %reload = load_borrow %token : $*C
   apply undef(%reload) : $@convention(thin) (@guaranteed C) -> ()
   unreachable
 }

--- a/test/SILOptimizer/sil_combine_apply_unit.sil
+++ b/test/SILOptimizer/sil_combine_apply_unit.sil
@@ -40,7 +40,7 @@ entry(%input : $*Input):
   %nunca = alloc_stack $Nunca
   %callee = function_ref @rdar127452206_callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
   %convert = convert_function %callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output> to $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output> // user: %216
-  specify_test "sil_combine_instruction @instruction[4]"
+  specify_test "sil_combine_visit_instruction @instruction[4]"
   apply [nothrow] %convert(%output, %nunca, %input) : $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
   dealloc_stack %nunca : $*Nunca
   dealloc_stack %output : $*Output
@@ -62,7 +62,7 @@ entry(%c : @owned $C):
   %borrowMaybeC = function_ref @borrowMaybeC : $@convention(thin) (@guaranteed Optional<C>) -> ()
   %borrowC = convert_function %borrowMaybeC : $@convention(thin) (@guaranteed Optional<C>) -> () to $@convention(thin) (@guaranteed C) -> ()
   %void = apply %borrowC(%c) : $@convention(thin) (@guaranteed C) -> ()
-  specify_test "sil_combine_instruction %void"
+  specify_test "sil_combine_visit_instruction %void"
   destroy_value %c : $C
   %retval = tuple ()
   return %retval : $()
@@ -89,7 +89,7 @@ entry(%c : @owned $C, %c2 : @owned $C):
   %borrowMaybeC2 = function_ref @borrowMaybeC2 : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> ()
   %borrowC2 = convert_function %borrowMaybeC2 : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> () to $@convention(thin) (@guaranteed C, @guaranteed C) -> ()
   %void = apply %borrowC2(%c, %c2) : $@convention(thin) (@guaranteed C, @guaranteed C) -> ()
-  specify_test "sil_combine_instruction %void"
+  specify_test "sil_combine_visit_instruction %void"
   destroy_value %c : $C
   destroy_value %c2 : $C
   %retval = tuple ()
@@ -116,7 +116,7 @@ sil [ossa] @convert_function__to_optional__owned_as_guaranteed__3 : $@convention
 entry(%c : @owned $C):
   %borrowMaybeC = function_ref @borrowMaybeCThrowing : $@convention(thin) (@guaranteed Optional<C>) -> (@error Error)
   %borrowC = convert_function %borrowMaybeC : $@convention(thin) (@guaranteed Optional<C>) -> (@error Error) to $@convention(thin) (@guaranteed C) -> (@error Error)
-  specify_test "sil_combine_instruction @instruction"
+  specify_test "sil_combine_visit_instruction @instruction"
   try_apply %borrowC(%c) : $@convention(thin) (@guaranteed C) -> (@error Error),
     normal success,
     error failure
@@ -160,7 +160,7 @@ sil [ossa] @convert_function__to_optional__owned_as_guaranteed__4 : $@convention
 entry(%c : @owned $C, %c2 : @owned $C):
   %borrowMaybeC2 = function_ref @borrowMaybeC2Throwing : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> (@error Error)
   %borrowC2 = convert_function %borrowMaybeC2 : $@convention(thin) (@guaranteed Optional<C>, @guaranteed Optional<C>) -> (@error Error) to $@convention(thin) (@guaranteed C, @guaranteed C) -> (@error Error)
-  specify_test "sil_combine_instruction @instruction"
+  specify_test "sil_combine_visit_instruction @instruction"
   try_apply %borrowC2(%c, %c2) : $@convention(thin) (@guaranteed C, @guaranteed C) -> (@error Error),
     normal success,
     error failure


### PR DESCRIPTION
**Explanation**: Fix a use-after-free on dead-end paths.

To ensure that it doesn't illegally hoist the destroys of any values across deinit barriers, `CopyPropagation`'s `OSSACanonicalizeOwned` utility must add to liveness instructions at the end of a value's lifetime on every path.  Concretely, the final destroys of a value are added to liveness.  Until values have complete lifetimes throughout the OSSA pipeline, however, a value need not have a final destroy on a dead-end path.  The utility must still add _something_ to liveness to avoid "hoisting" a destroy from "the end of the dead-end path" to somewhere above it.  To find the appropriate instructions to add to liveness, the utility relies on `OSSACompleteLifetime` to visit the availability boundary of the value; that boundary describes where the value's lifetime ends on dead-end paths (not always simply just before `unreachable` instructions, say).  `OSSACompleteLifetime` depends on an instance of liveness for its work, and `OSSACanonicalizeOwned` provides it with a perturbed version of its own.

`OSSACanonicalizeOwned` operates on a "copy-extended value".  `OSSACompleteLifetime` operates on a standard OSSA value.  The liveness produced by `OSSACanonicalizeOwned` reflects that copy-extended-ness: it may contain consuming uses in the middle (corresponding to a consume of a copy of the base value in the middle).  `OSSACompleteLifetime` relies on _its_ liveness being that for a standard OSSA value: it may not have consuming uses in the middle (that would correspond to a use-after-free).  So there is a mismatch in the characteristics of the liveness produced by the former and used by the latter.

Fix this by perturbing even more the copy of liveness passed from `OSSACanonicalizeOwned` to `OSSACompleteLifetime`: demote consuming uses in the middle to non-consuming uses.

**Scope**: Affects optimized code.
**Issue**: rdar://142846936
**Original PR**: https://github.com/swiftlang/swift/pull/78624
**Risk**: Low.
**Testing**: Added tests.
**Reviewer**: Andrew Trick ( @atrick )