### PR TITLE
Change dictionary literal duplicate entries from warning to error

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -27,6 +27,7 @@
 #include "swift/Basic/Version.h"
 #include "swift/Basic/WarningAsErrorRule.h"
 #include "swift/Localization/LocalizationFormat.h"
+#include "swift/AST/DiagnosticsCommon.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -1784,6 +1785,11 @@ namespace swift {
   }
 
   void printClangDeclName(const clang::NamedDecl *ND, llvm::raw_ostream &os);
+
+  void DiagnosticEngine::diagnoseDuplicateDictionaryKey(SourceLoc loc, StringRef type, StringRef key) {
+    diagnose(loc, diag::duplicate_entry_in_dict_literal)
+        << type << key;
+  }
 
   /// Temporary on-stack storage and unescaping for encoded diagnostic
   /// messages.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -26,6 +26,12 @@
 DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
+#define DIAG_DEF(kind, id, text) kind##_##id,
+
+DIAG(diag::duplicate_entry_in_dict_literal, Error,
+     "Dictionary literal of type '%0' has duplicate entries for key '%1'")
+
+
 NOTE(decl_declared_here,none,
      "%0 declared here", (const ValueDecl *))
 NOTE(decl_declared_here_base,none,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -571,6 +571,19 @@ void TypeChecker::checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name) {
   }
 }
 
+void TypeChecker::checkDictionaryLiteral(DictionaryExpr *dictExpr) {
+  llvm::DenseSet<KeyType> seenKeys;
+
+  for (auto entry : dictExpr->getElements()) {
+    auto key = entry->getKey();
+    if (seenKeys.count(key)) {
+      diagnose(entry->getKey()->getLoc(),diag::duplicate_entry_in_dict_literal, dictExpr->getType(), key->getValue());
+    } else {
+        seenKeys.insert(key);
+    }
+  }
+}
+
 DeclTypeCheckingSemantics
 TypeChecker::getDeclTypeCheckingSemantics(ValueDecl *decl) {
   // Check for a @_semantics attribute.

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -198,3 +198,14 @@ f59215(["", "", "", ""]) //expected-error{{dictionary of type '[String : String]
 // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}} {{19-20=:}}
 f59215(["", "", "", ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
 // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}} {{19-20=:}}
+
+let validMap = [1: "one", 2: "two"]
+
+let invalidMap = [1: "one", 1: "also one"]
+
+let invalidStringMap = ["key": "value", "key": "another value"]
+
+#define DUPLICATE_KEY 1
+let macroKey = [DUPLICATE_KEY: "macro", DUPLICATE_KEY: "duplicate"]
+
+let nestedMap = ["outer": [1: "one", 1: "duplicate"]]


### PR DESCRIPTION
This change resolves issue #78595 by updating the compiler to treat duplicate entries in dictionary literals as errors instead of warnings. It ensures more reliable error handling, preventing runtime crashes and making the code safer, especially in CI pipelines that may ignore warnings.
