### PR TITLE
Linux: don't link libicu in static executables, as it is no longer built separately

### DIFF
--- a/stdlib/public/Resources/linux/static-executable-args.lnk
+++ b/stdlib/public/Resources/linux/static-executable-args.lnk
@@ -9,9 +9,6 @@
 -ldispatch
 -lBlocksRuntime
 -lpthread
--licui18nswift
--licuucswift
--licudataswift
 -ldl
 -lstdc++
 -lm


### PR DESCRIPTION
This was dropped in #40340.

@Azoy or @etcwilde, please review. This appears to be the last invocation of these no longer built libraries in this repo, which I only noticed when looking into #46404 today.