### PR TITLE
[Backtracing] Don't include things inside a namespace.

### DIFF
--- a/stdlib/public/Backtracing/modules/FixedLayout.h
+++ b/stdlib/public/Backtracing/modules/FixedLayout.h
@@ -18,13 +18,13 @@
 #ifndef SWIFT_BACKTRACING_FIXED_LAYOUT_H
 #define SWIFT_BACKTRACING_FIXED_LAYOUT_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 namespace swift {
 namespace runtime {
 namespace backtrace {
 #endif
-
-#include <stdint.h>
 
 struct x86_64_gprs {
   uint64_t _r[16];


### PR DESCRIPTION
We shouldn't be including `<stdint.h>` inside the namespace.
