### PR TITLE
[WIP] Allow users to write "implicitly nested" types at the top level.

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1160,6 +1160,12 @@ BridgedExtensionDecl BridgedExtensionDecl_createParsed(
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
+SWIFT_NAME(
+    "BridgedExtensionDecl.createImplicit(_:declContext:extendedType:)")
+BridgedExtensionDecl BridgedExtensionDecl_createImplicit(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedTypeRepr opaqueExtendedType);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedOperatorFixity {
   BridgedOperatorFixityInfix,
   BridgedOperatorFixityPrefix,

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -541,6 +541,19 @@ BridgedExtensionDecl BridgedExtensionDecl_createParsed(
   return decl;
 }
 
+BridgedExtensionDecl BridgedExtensionDecl_createImplicit(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedTypeRepr extendedType) {
+  ASTContext &context = cContext.unbridged();
+
+  auto *decl = ExtensionDecl::create(
+      context, /*extensionKeywordLoc*/ SourceLoc(), extendedType.unbridged(),
+      /*inherited*/ {}, cDeclContext.unbridged(),
+      /*genericWhereClause*/ nullptr);
+  decl->setImplicit(true);
+  return decl;
+}
+
 BridgedMacroExpansionDecl BridgedMacroExpansionDecl_createParsed(
     BridgedDeclContext cDeclContext, BridgedSourceLoc cPoundLoc,
     BridgedDeclNameRef cMacroNameRef, BridgedDeclNameLoc cMacroNameLoc,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9117,13 +9117,20 @@ Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
 ///   decl-enum-body:
 ///      decl*
 /// \endverbatim
-ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
+ParserResult<Decl> Parser::parseDeclEnum(ParseDeclOptions Flags,
                                              DeclAttributes &Attributes) {
   SourceLoc EnumLoc = consumeToken(tok::kw_enum);
 
   Identifier EnumName;
   SourceLoc EnumNameLoc;
   ParserStatus Status;
+
+  ParserResult<ExtensionDecl> ImplicitExtensionResult = maybeParseImplicitNominalTypeExtension();
+  if (ImplicitExtensionResult.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  ExtensionDecl *ImplicitExtension = ImplicitExtensionResult.getPtrOrNull();
+  ContextChange MaybeExtensionCC(*this, ImplicitExtension ? ImplicitExtension : CurDeclContext);
 
   Status |= parseIdentifierDeclName(
       *this, EnumName, EnumNameLoc, "enum", [&](const Token &next) {
@@ -9181,7 +9188,9 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
 
   ED->setBraces({LBLoc, RBLoc});
 
-  return DCC.fixupParserResult(Status, ED);
+  return maybeFinalizeImplicitNominalTypeExtension(ImplicitExtension, ED, [&](Decl *D){
+    return makeParserResult(Status, D);
+  });
 }
 
 /// Parse a 'case' of an enum.
@@ -9376,13 +9385,20 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
 ///   decl-struct-body:
 ///      decl*
 /// \endverbatim
-ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
-                                                 DeclAttributes &Attributes) {
+ParserResult<Decl> Parser::parseDeclStruct(ParseDeclOptions Flags,
+                                           DeclAttributes &Attributes) {
   SourceLoc StructLoc = consumeToken(tok::kw_struct);
   
   Identifier StructName;
   SourceLoc StructNameLoc;
   ParserStatus Status;
+
+  ParserResult<ExtensionDecl> ImplicitExtensionResult = maybeParseImplicitNominalTypeExtension();
+  if (ImplicitExtensionResult.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  ExtensionDecl *ImplicitExtension = ImplicitExtensionResult.getPtrOrNull();
+  ContextChange MaybeExtensionCC(*this, ImplicitExtension ? ImplicitExtension : CurDeclContext);
 
   Status |= parseIdentifierDeclName(
       *this, StructName, StructNameLoc, "struct", [&](const Token &next) {
@@ -9445,7 +9461,9 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
 
   SD->setBraces({LBLoc, RBLoc});
 
-  return DCC.fixupParserResult(Status, SD);
+  return maybeFinalizeImplicitNominalTypeExtension(ImplicitExtension, SD, [&](Decl *D){
+    return makeParserResult(Status, D);
+  });
 }
 
 /// Parse a 'class' declaration, doing no token skipping on error.
@@ -9457,7 +9475,7 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
 ///   decl-class-body:
 ///      decl*
 /// \endverbatim
-ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
+ParserResult<Decl> Parser::parseDeclClass(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes) {
   bool isExplicitActorDecl = Tok.isContextualKeyword("actor");
 
@@ -9472,6 +9490,13 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   Identifier ClassName;
   SourceLoc ClassNameLoc;
   ParserStatus Status;
+
+  ParserResult<ExtensionDecl> ImplicitExtensionResult = maybeParseImplicitNominalTypeExtension();
+  if (ImplicitExtensionResult.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  ExtensionDecl *ImplicitExtension = ImplicitExtensionResult.getPtrOrNull();
+  ContextChange MaybeExtensionCC(*this, ImplicitExtension ? ImplicitExtension : CurDeclContext);
 
   Status |= parseIdentifierDeclName(
       *this, ClassName, ClassNameLoc, isExplicitActorDecl ? "actor" : "class",
@@ -9561,7 +9586,9 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
 
   CD->setBraces({LBLoc, RBLoc});
 
-  return DCC.fixupParserResult(Status, CD);
+  return maybeFinalizeImplicitNominalTypeExtension(ImplicitExtension, CD, [&](Decl *D){
+    return makeParserResult(Status, D);
+  });
 }
 
 ParserStatus Parser::parsePrimaryAssociatedTypes(
@@ -9626,13 +9653,20 @@ ParserStatus Parser::parsePrimaryAssociatedTypeList(
 ///      decl-var-simple
 ///      decl-typealias
 /// \endverbatim
-ParserResult<ProtocolDecl> Parser::
+ParserResult<Decl> Parser::
 parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   SourceLoc ProtocolLoc = consumeToken(tok::kw_protocol);
   
   SourceLoc NameLoc;
   Identifier ProtocolName;
   ParserStatus Status;
+
+  ParserResult<ExtensionDecl> ImplicitExtensionResult = maybeParseImplicitNominalTypeExtension();
+  if (ImplicitExtensionResult.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  ExtensionDecl *ImplicitExtension = ImplicitExtensionResult.getPtrOrNull();
+  ContextChange MaybeExtensionCC(*this, ImplicitExtension ? ImplicitExtension : CurDeclContext);
 
   Status |= parseIdentifierDeclName(
       *this, ProtocolName, NameLoc, "protocol",
@@ -9698,7 +9732,43 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     Proto->setBraces({LBraceLoc, RBraceLoc});
   }
   
-  return DCC.fixupParserResult(Status, Proto);
+  return maybeFinalizeImplicitNominalTypeExtension(ImplicitExtension, Proto, [&](Decl *D){
+    return makeParserResult(Status, D);
+  });
+}
+
+/// Attempt to parse a type preceding another dot and an identifier, used to
+/// implicitly synthesize a nesting extension when declaring a nominal type.
+/// Returns the synthesized extension if successful, or a null result if there
+/// was no such type.
+ParserResult<ExtensionDecl> Parser::maybeParseImplicitNominalTypeExtension() {
+  {
+    BacktrackingScope backtrack(*this);
+    if (!(canParseType(ParseTypeReason::NominalTypeDeclExtendedName) && Tok.isAny(tok::period_prefix, tok::period)))
+      return nullptr;
+  }
+
+  auto ExtendedType = parseType(diag::expected_type, ParseTypeReason::NominalTypeDeclExtendedName);
+  if (ExtendedType.hasCodeCompletion())
+    return makeParserCodeCompletionStatus();
+
+  // Consume the period just before the decl's name.
+  consumeToken();
+
+  auto *ED = ExtensionDecl::create(Context, /*extensionKeywordLoc*/ SourceLoc(), ExtendedType.get(), /*inherited*/ {}, CurDeclContext, /*genericWhereClause*/ nullptr);
+  ED->setImplicit(true);
+  return makeParserResult(ParserStatus(), ED);
+}
+
+ParserResult<Decl> Parser::maybeFinalizeImplicitNominalTypeExtension(ExtensionDecl *EDOrNull, Decl *D, std::function<ParserResult<Decl>(Decl *)> Callback) {
+  if (EDOrNull) {
+    Context.evaluator.cacheOutput(
+        ParseMembersRequest{EDOrNull},
+        FingerprintAndMembers{
+            std::nullopt, Context.AllocateCopy(llvm::ArrayRef({D}))});
+    return Callback(EDOrNull);
+  }
+  return Callback(D);
 }
 
 /// Parse a 'subscript' declaration.

--- a/test/decl/nested/implicit_toplevel_nesting.swift
+++ b/test/decl/nested/implicit_toplevel_nesting.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -dump-ast | %FileCheck %s
+
+struct Outer {}
+
+actor Outer.InnerActor {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (actor_decl {{.*}} "InnerActor" interface type="Outer.InnerActor.Type"
+
+class Outer.InnerClass {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (class_decl {{.*}} "InnerClass" interface type="Outer.InnerClass.Type"
+
+enum Outer.InnerEnum {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (enum_decl {{.*}} "InnerEnum" interface type="Outer.InnerEnum.Type"
+
+protocol Outer.InnerProtocol {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (protocol_decl {{.*}} "InnerProtocol" interface type="Outer.InnerProtocol.Type"
+
+struct Outer.InnerStruct {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (struct_decl {{.*}} "InnerStruct" interface type="Outer.InnerStruct.Type"
+
+struct Outer.Middle {}
+// CHECK:      (extension_decl implicit "Outer"
+// CHECK-NEXT:   (struct_decl {{.*}} "Middle" interface type="Outer.Middle.Type"
+
+struct Outer.Middle.Deepest {}
+// CHECK:      (extension_decl implicit "Outer.Middle"
+// CHECK-NEXT:   (struct_decl {{.*}} "Deepest" interface type="Outer.Middle.Deepest.Type"
+
+struct [Int].Nested {}
+// CHECK:      (extension_decl implicit "[Int]"
+// CHECK-NEXT:   (struct_decl {{.*}} "Nested" interface type="Array<Element>.Nested.Type"
+
+struct [Int].SubSequence.Nested {}
+// CHECK:      (extension_decl implicit "Array<Int>.SubSequence"
+// CHECK-NEXT:   (struct_decl {{.*}} "Nested" interface type="ArraySlice<Element>.Nested.Type"


### PR DESCRIPTION
[WIP] Allow users to write "implicitly nested" types at the top level, like

```swift
struct Outer.Inner {}
```

which would be equivalent to

```swift
extension Outer {
  struct Inner {}
}
```
