### PR TITLE
🍒6.1 [cxx-interop] Workaround name lookup issues with namespace simd

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1155,6 +1155,14 @@ namespace {
           decl->getOwningModule() &&
           decl->getOwningModule()->getTopLevelModuleName() == "os")
         return nullptr;
+      // Workaround for simd module declaring `namespace simd` on Darwin,
+      // causing name lookup issues. That namespace declares C++ overlays of
+      // types that are already refined for Swift, so let's not import the
+      // namespace (rdar://143007477).
+      if (decl->getIdentifier() && decl->getName() == "simd" &&
+          decl->getOwningModule() &&
+          decl->getOwningModule()->getTopLevelModuleName() == "simd")
+        return nullptr;
       // If this is a top-level namespace, don't put it in the module we're
       // importing, put it in the "__ObjC" module that is implicitly imported.
       if (!decl->getParent()->isNamespace())

--- a/test/Interop/Cxx/objc-correctness/simd_quatf.swift
+++ b/test/Interop/Cxx/objc-correctness/simd_quatf.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+import simd
+
+var _: simd.simd_quatf! = nil


### PR DESCRIPTION
- **Explanation**: On Apple platforms, a system module `simd` declares a `namespace simd` under `#if defined(__cplusplus)`. This namespace defines C++ overlays of the simd types, but these types are already refined for Swift separately, so it's not necessary to import this namespace. This is the same issue previously encountered for the `os` module, work around it in the same way.
- **Scope**: Projects with C++ interop enabled that import SDK modules and (transitively) import `simd`.
- **Issues**: rdar://143007477
- **Original PRs**: https://github.com/swiftlang/swift/pull/78676
- **Risk**: Low, this disables importing declarations which we only recently started importing and which never worked properly.
- **Testing**:
- **Reviewers**: @egorzhdan @Xazax-hun 