### PR TITLE
Add static .nanoseconds(_: Double) to Duration

### DIFF
--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -163,7 +163,7 @@ extension Duration {
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 
-  /// Construct a `Duration` given a number of seconds milliseconds as a 
+  /// Construct a `Duration` given a number of milliseconds as a 
   /// `Double` by converting the value into the closest attosecond scale value.
   ///
   ///       let d: Duration = .milliseconds(88.3)
@@ -192,7 +192,7 @@ extension Duration {
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 
-  /// Construct a `Duration` given a number of seconds microseconds as a 
+  /// Construct a `Duration` given a number of microseconds as a
   /// `Double` by converting the value into the closest attosecond scale value.
   ///
   ///       let d: Duration = .microseconds(382.9)
@@ -219,6 +219,18 @@ extension Duration {
     let lowScaled = low.multipliedFullWidth(by: 1_000_000_000)
     let highScaled = high * 1_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
+  }
+  
+  /// Construct a `Duration` given a number of nanoseconds as a `Double`
+  /// by converting the value into the closest attosecond scale value.
+  ///
+  ///       let d: Duration = .nanoseconds(1929)
+  ///
+  /// - Returns: A `Duration` representing the given number of nanoseconds.
+  @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
+  public static func nanoseconds(_ nanoseconds: Double) -> Duration {
+    Duration(nanoseconds, scale: 1_000_000_000)
   }
 }
 

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -46,6 +46,7 @@ public struct Duration: Sendable {
     self._high = _high
   }
 
+  @_alwaysEmitIntoClient
   internal init(_attoseconds: _Int128) {
     self.init(_high: _attoseconds.high, low: _attoseconds.low)
   }
@@ -119,7 +120,7 @@ extension Duration {
   
   /// Construct a `Duration` given a duration and scale, taking care so that
   /// exact integer durations are preserved exactly.
-  @usableFromInline
+  @_alwaysEmitIntoClient
   internal init(_ duration: Double, scale: UInt64) {
     // Split the duration into integral and fractional parts, as we need to
     // handle them slightly differently to ensure that integer values are

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -119,6 +119,7 @@ extension Duration {
   
   /// Construct a `Duration` given a duration and scale, taking care so that
   /// exact integer durations are preserved exactly.
+  @usableFromInline
   internal init(_ duration: Double, scale: UInt64) {
     // Split the duration into integral and fractional parts, as we need to
     // handle them slightly differently to ensure that integer values are
@@ -163,7 +164,7 @@ extension Duration {
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 
-  /// Construct a `Duration` given a number of milliseconds as a 
+  /// Construct a `Duration` given a number of milliseconds as a
   /// `Double` by converting the value into the closest attosecond scale value.
   ///
   ///       let d: Duration = .milliseconds(88.3)

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -53,6 +53,15 @@ if #available(SwiftStdlib 5.7, *) {
     }
   }
   
+  suite.test("nanoseconds from Double") {
+    for _ in 0 ..< 100 {
+      let integerValue = Double(Int64.random(in: 0 ... 0x7fff_ffff_ffff_fc00))
+      let (sec, attosec) = Duration.nanoseconds(integerValue).components
+      expectEqual(sec, Int64(integerValue) / 1_000_000_000)
+      expectEqual(attosec, Int64(integerValue) % 1_000_000_000 * 1_000_000_000)
+    }
+  }
+  
   suite.test("seconds from Int64") {
     let one = Duration.seconds(1 as Int64)
     expectEqual(one._high, 0)


### PR DESCRIPTION
SE-0329 defines the following static factory methods:

```
public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration
public static func seconds(_ seconds: Double) -> Duration
public static func milliseconds<T: BinaryInteger>(_ milliseconds: T) -> Duration
public static func milliseconds(_ milliseconds: Double) -> Duration
public static func microseconds<T: BinaryInteger>(_ microseconds: T) -> Duration
public static func microseconds(_ microseconds: Double) -> Duration
public static func nanoseconds<T: BinaryInteger>(_ value: T) -> Duration
```

For no good reason, the obvious additional method:
```
public static func nanoseconds(_ nanoseconds: Double) -> Duration
```
was omitted. After talking this through with the LSG, we have decided that this is simply a bug, and we will add this method without formal evolution review.