### PR TITLE
utils: re-enable testing for libdispatch in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1852,7 +1852,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
     $Targets = @("default", "ExperimentalTest")
     $InstallPath = ""
   } else {
-    $Targets = @("default")
+    $Targets = @("install")
     $InstallPath = "$($Arch.SDKInstallRoot)\usr"
   }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1862,6 +1862,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
     -InstallTo $InstallPath `
     -Arch $Arch `
     -Platform $Platform `
+    -BuildTargets $Targets `
     -UseBuiltCompilers C,CXX,Swift `
     -Defines @{
       ENABLE_SWIFT = "YES";


### PR DESCRIPTION
We lost libdispatch testing (by accident I guess) in 9819577c9693c4e537fa258d4192e99a05baba62