### PR TITLE
[caches] Use `arm64-apple-darwin` triple

### DIFF
--- a/cmake/caches/Darwin-arm64.cmake
+++ b/cmake/caches/Darwin-arm64.cmake
@@ -29,7 +29,7 @@ set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
 
 # NOTE(compnerd) we can hardcode the default target triple since the cache files
 # are target dependent.
-set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-apple-darwin CACHE STRING "")
+set(LLVM_DEFAULT_TARGET_TRIPLE arm64-apple-darwin CACHE STRING "")
 
 set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")


### PR DESCRIPTION
`LLVM_DEFAULT_TARGET_TRIPLE` was previously set to `aarch64-apple-darwin` for Darwin Arm64 platforms. The correct value should be `arm64-apple-darwin`.