### PR TITLE
[cxx-interop] Workaround compiler error when importing AppKit/UIKit with C++ interop

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2205,7 +2205,10 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   // interop enabled by the Swift CI because it uses an old host SDK.
   // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
   // of a CF_OPTIONS bug (rdar://142762174).
-  if (moduleName == "Darwin" || moduleName == "CoreGraphics") {
+  // FIXME: Hack for AppKit.swiftmodule / UIKit.swiftmodule, which cannot be
+  // rebuilt because of an NS_OPTIONS bug (rdar://143033209)
+  if (moduleName == "Darwin" || moduleName == "CoreGraphics"
+      || moduleName == "AppKit" || moduleName == "UIKit") {
     subInvocation.getLangOptions().EnableCXXInterop = false;
     subInvocation.getLangOptions().cxxInteropCompatVersion = {};
     BuildArgs.erase(llvm::remove_if(BuildArgs,

--- a/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
+++ b/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+#if canImport(AppKit)
+import AppKit
+
+var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
+
+#elseif canImport(UIKit)
+import UIKit
+
+var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
+
+#endif


### PR DESCRIPTION
The AppKit/UIKit overlay refers to symbols declared via NS_OPTIONS macro, which is causing issues in C++ language mode due to the macro definition being different. This teaches the module interface loader to drop the C++ interop flag when rebuilding the AppKit and UIKit overlay from its interface.

This is the same fix as #78636, but for different modules.

rdar://143033209