### PR TITLE
[6.1 cp] [embedded] Add a test for arm64e ptrauth using -none-macho triple

### DIFF
--- a/test/embedded/ptrauth-none-macho.swift
+++ b/test/embedded/ptrauth-none-macho.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -target arm64e-apple-none-macho -enable-experimental-feature Embedded -emit-ir %s -o - -Xcc -D__APPLE__ -Xcc -D__MACH__ | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64e-apple-macos14 -enable-experimental-feature Embedded -emit-ir %s -o - -Xcc -D__APPLE__ -Xcc -D__MACH__ | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+var callback: (()->())? = nil
+var callback2: ((Bool)->())? = nil
+var callback3: ((Bool, Bool)->())? = nil
+
+public func foo() {
+  callback?()
+  callback2?(true)
+  callback3?(true, true)
+}
+
+// CHECK-LABEL: define swiftcc void @"$e4main3fooyyF"()
+
+// CHECK:       [[P1:%.*]] = load ptr, ptr @"$e4main8callbackyycSgvp"
+// CHECK:       call swiftcc void [[P1:%.*]](ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 3848) ]
+
+// CHECK:       [[P2:%.*]] = load ptr, ptr @"$e4main9callback2ySbcSgvp"
+// CHECK:       call swiftcc void [[P2:%.*]](i1 true, ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 25457) ]
+
+// CHECK:       [[P3:%.*]] = load ptr, ptr @"$e4main9callback3ySb_SbtcSgvp"
+// CHECK:       call swiftcc void [[P3:%.*]](i1 true, i1 true, ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 25424) ]

--- a/test/embedded/ptrauth-none-macho.swift
+++ b/test/embedded/ptrauth-none-macho.swift
@@ -15,13 +15,13 @@ public func foo() {
   callback3?(true, true)
 }
 
-// CHECK-LABEL: define swiftcc void @"$e4main3fooyyF"()
+// CHECK-LABEL: define swiftcc void @"$s4main3fooyyF"()
 
-// CHECK:       [[P1:%.*]] = load ptr, ptr @"$e4main8callbackyycSgvp"
+// CHECK:       [[P1:%.*]] = load ptr, ptr @"$s4main8callbackyycSgvp"
 // CHECK:       call swiftcc void [[P1:%.*]](ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 3848) ]
 
-// CHECK:       [[P2:%.*]] = load ptr, ptr @"$e4main9callback2ySbcSgvp"
+// CHECK:       [[P2:%.*]] = load ptr, ptr @"$s4main9callback2ySbcSgvp"
 // CHECK:       call swiftcc void [[P2:%.*]](i1 true, ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 25457) ]
 
-// CHECK:       [[P3:%.*]] = load ptr, ptr @"$e4main9callback3ySb_SbtcSgvp"
+// CHECK:       [[P3:%.*]] = load ptr, ptr @"$s4main9callback3ySb_SbtcSgvp"
 // CHECK:       call swiftcc void [[P3:%.*]](i1 true, i1 true, ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 25424) ]


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/78613

Scope: Embedded Swift only, arm64e users only.
Risk: Low, this is only a new test.

rdar://141676141
