### PR TITLE
Work around Foundation NS_TYPED_ENUM bug

### DIFF
--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -20,6 +20,7 @@
 
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILNode.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -80,6 +81,18 @@ public:
     : Node(node), Action(action) {}
 
   virtual void print(llvm::raw_ostream &OS) const override;
+};
+
+/// Observe that we are processing a reference to a SIL decl.
+class PrettyStackTraceSILDeclRef : public llvm::PrettyStackTraceEntry {
+  SILDeclRef declRef;
+  StringRef action;
+
+public:
+  PrettyStackTraceSILDeclRef(const char *action, SILDeclRef declRef)
+      : declRef(declRef), action(action) {}
+
+  virtual void print(llvm::raw_ostream &os) const override;
 };
 
 } // end namespace swift

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4870,6 +4870,7 @@ namespace {
       printCommon(#Name, label);                           \
                                                            \
       printFieldQuoted(T->getDecl()->printRef(), "decl");  \
+      printFlag(T->getDecl()->hasClangNode(), "foreign");  \
                                                            \
       if (T->getParent())                                  \
         printRec(T->getParent(), "parent");                \
@@ -4877,11 +4878,26 @@ namespace {
       printFoot();                                         \
     }
 
-    VISIT_NOMINAL_TYPE(EnumType, enum_type)
-    VISIT_NOMINAL_TYPE(StructType, struct_type)
-    VISIT_NOMINAL_TYPE(ClassType, class_type)
+#define VISIT_BINDABLE_NOMINAL_TYPE(TypeClass, Name)       \
+    VISIT_NOMINAL_TYPE(TypeClass, Name)                    \
+    void visitBoundGeneric##TypeClass(                     \
+        BoundGeneric##TypeClass *T, StringRef label) {     \
+      printCommon("bound_generic_" #Name, label);          \
+      printFieldQuoted(T->getDecl()->printRef(), "decl");  \
+      printFlag(T->getDecl()->hasClangNode(), "foreign");  \
+      if (T->getParent())                                  \
+        printRec(T->getParent(), "parent");                \
+      for (auto arg : T->getGenericArgs())                 \
+        printRec(arg);                                     \
+      printFoot();                                         \
+    }
+
+    VISIT_BINDABLE_NOMINAL_TYPE(EnumType, enum_type)
+    VISIT_BINDABLE_NOMINAL_TYPE(StructType, struct_type)
+    VISIT_BINDABLE_NOMINAL_TYPE(ClassType, class_type)
     VISIT_NOMINAL_TYPE(ProtocolType, protocol_type)
 
+#undef VISIT_BINDABLE_NOMINAL_TYPE
 #undef VISIT_NOMINAL_TYPE
 
     void visitBuiltinTupleType(BuiltinTupleType *T, StringRef label) {
@@ -4916,6 +4932,7 @@ namespace {
     void visitModuleType(ModuleType *T, StringRef label) {
       printCommon("module_type", label);
       printDeclNameField(T->getModule(), "module");
+      printFlag(T->getModule()->isNonSwiftModule(), "foreign");
       printFoot();
     }
 
@@ -5033,7 +5050,7 @@ namespace {
     void printAnyFunctionParamsRec(ArrayRef<AnyFunctionType::Param> params,
                                    StringRef label) {
       printRecArbitrary([&](StringRef label) {
-        printCommon("function_params", label);
+        printHead("function_params", FieldLabelColor, label);
 
         printField(params.size(), "num_params");
         for (const auto &param : params) {
@@ -5241,37 +5258,6 @@ namespace {
       printFieldQuoted(T->getDecl()->printRef(), "decl");
       if (T->getParent())
         printRec(T->getParent(), "parent");
-      printFoot();
-    }
-
-    void visitBoundGenericClassType(BoundGenericClassType *T, StringRef label) {
-      printCommon("bound_generic_class_type", label);
-      printFieldQuoted(T->getDecl()->printRef(), "decl");
-      if (T->getParent())
-        printRec(T->getParent(), "parent");
-      for (auto arg : T->getGenericArgs())
-        printRec(arg);
-      printFoot();
-    }
-
-    void visitBoundGenericStructType(BoundGenericStructType *T,
-                                     StringRef label) {
-      printCommon("bound_generic_struct_type", label);
-      printFieldQuoted(T->getDecl()->printRef(), "decl");
-      if (T->getParent())
-        printRec(T->getParent(), "parent");
-      for (auto arg : T->getGenericArgs())
-        printRec(arg);
-      printFoot();
-    }
-
-    void visitBoundGenericEnumType(BoundGenericEnumType *T, StringRef label) {
-      printCommon("bound_generic_enum_type", label);
-      printFieldQuoted(T->getDecl()->printRef(), "decl");
-      if (T->getParent())
-        printRec(T->getParent(), "parent");
-      for (auto arg : T->getGenericArgs())
-        printRec(arg);
       printFoot();
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6335,6 +6335,19 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
       synthesizedProtocols.push_back(kind);
       return true;
     }
+    // HACK: This method may be called before all extensions have been bound.
+    // This is a problem for newtypes in Foundation, which is what provides the
+    // `String: _ObjectiveCBridgeable` conformance; it can cause us to create
+    // `String`-backed newtypes which aren't bridgeable, causing typecheck
+    // failures and crashes down the line (rdar://142693093). Hardcode knowledge
+    // that this conformance will exist.
+    // FIXME: Defer adding conformances to newtypes instead of this. (#78731)
+    if (structDecl->getModuleContext()->isFoundationModule()
+          && kind == KnownProtocolKind::ObjectiveCBridgeable
+          && computedNominal == ctx.getStringDecl()) {
+      synthesizedProtocols.push_back(kind);
+      return true;
+    }
 
     return false;
   };

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/Config.h"
@@ -1473,6 +1474,8 @@ static bool doesClangExpansionMatchSchema(IRGenModule &IGM,
 /// Expand the result and parameter types to the appropriate LLVM IR
 /// types for C, C++ and Objective-C signatures.
 void SignatureExpansion::expandExternalSignatureTypes() {
+  PrettyStackTraceType entry(IGM.Context, "using clang to expand signature for",
+                             FnType);
   assert(FnType->getLanguage() == SILFunctionLanguage::C);
 
   auto SILResultTy = [&]() {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -34,6 +34,7 @@
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Subsystems.h"
@@ -3515,6 +3516,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   assert(forDefinition || !isDynamicallyReplaceableImplementation);
   assert(!forDefinition || !shouldCallPreviousImplementation);
 
+  PrettyStackTraceSILFunction entry("lowering address of", f);
   LinkEntity entity =
       LinkEntity::forSILFunction(f, shouldCallPreviousImplementation);
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -33,6 +33,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILModule.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
@@ -779,6 +780,8 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
                                   llvm::Value *selfValue,
                                   CalleeInfo &&info) {
   SILDeclRef method = methodInfo.getMethod();
+  PrettyStackTraceSILDeclRef entry("lowering reference to ObjC method", method);
+
   // Note that isolated deallocator is never called directly, only from regular
   // deallocator
   assert((method.kind == SILDeclRef::Kind::Initializer

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3117,6 +3117,8 @@ static bool mayDirectlyCallAsync(SILFunction *fn) {
 
 void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   auto fn = i->getInitiallyReferencedFunction();
+  PrettyStackTraceSILFunction entry("lowering reference to", fn);
+
   auto fnType = fn->getLoweredFunctionType();
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
@@ -8098,6 +8100,8 @@ void IRGenSILFunction::visitWitnessMethodInst(swift::WitnessMethodInst *i) {
   CanType baseTy = i->getLookupType();
   ProtocolConformanceRef conformance = i->getConformance();
   SILDeclRef member = i->getMember();
+  PrettyStackTraceSILDeclRef entry("lowering use of witness method", member);
+
   auto fnType = IGM.getSILTypes().getConstantFunctionType(
       IGM.getMaximalTypeExpansionContext(), member);
 
@@ -8282,6 +8286,7 @@ void IRGenSILFunction::visitSuperMethodInst(swift::SuperMethodInst *i) {
   llvm::Value *baseValue = base.claimNext();
 
   auto method = i->getMember().getOverriddenVTableEntry();
+  PrettyStackTraceSILDeclRef entry("lowering super call to", method);
   auto methodType = i->getType().castTo<SILFunctionType>();
 
   auto *classDecl = cast<ClassDecl>(method.getDecl()->getDeclContext());
@@ -8378,6 +8383,8 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
   llvm::Value *baseValue = base.claimNext();
 
   SILDeclRef method = i->getMember().getOverriddenVTableEntry();
+  PrettyStackTraceSILDeclRef entry("lowering class method call to", method);
+
   auto methodType = i->getType().castTo<SILFunctionType>();
 
   auto *classDecl = cast<ClassDecl>(method.getDecl()->getDeclContext());

--- a/lib/SIL/Utils/PrettyStackTrace.cpp
+++ b/lib/SIL/Utils/PrettyStackTrace.cpp
@@ -104,3 +104,9 @@ void PrettyStackTraceSILNode::print(llvm::raw_ostream &out) const {
   if (Node)
     out << *Node;
 }
+
+void PrettyStackTraceSILDeclRef::print(llvm::raw_ostream &out) const {
+  out << "While " << action << " SIL decl '";
+  declRef.print(out);
+  out << "'\n";
+}

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -18,7 +18,7 @@ func acceptHashable<T: Hashable>(_: T) {}
 func acceptComparable<T: Comparable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
-func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
+func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
   acceptEquatable(x)
   acceptHashable(x)
   acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
@@ -28,6 +28,8 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
   _ = x != y
   _ = x.hashValue
   _ = x as NSString
+
+  _ = z as NSString
 }
 
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -4,6 +4,11 @@
 
 public let NSUTF8StringEncoding: UInt = 8
 
+// This extension will cause ClangImporter/newtype_conformance.swift to fail
+// unless rdar://142693093 is fixed. To reproduce, it's important that this
+// extension come *before* the _ObjectiveCBridgeable extension for String.
+extension NSFileAttributeKey { }
+
 extension AnyHashable : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSObject {
     return NSObject()

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -867,6 +867,8 @@ extern void CGColorRelease(CGColorRef color) __attribute__((availability(macosx,
 
 typedef NSString *_Nonnull NSNotificationName
     __attribute((swift_newtype(struct)));
+typedef NSString *_Nonnull NSFileAttributeKey
+    __attribute((swift_newtype(struct)));
 
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 extern NSString * const NSConnectionReplyMode;


### PR DESCRIPTION
Consider code like:

```swift
// Foo.h
typealias NSString * FooKey NS_EXTENSIBLE_TYPED_ENUM;

// Foo.swift
extension FooKey { … }
```

When Swift binds the extension to `FooKey`, that forces ClangImporter to import `FooKey`. ClangImporter’s newtype logic, among other things, checks whether the underlying type (`Swift.String` here) is Objective-C bridgeable and, if so, makes `FooKey` bridgeable too.

But what happens if this code is actually *in* Foundation, which is where the `extension String: _ObjectiveCBridgeable` lives? Well, if the compiler has already bound that extension, it works fine…but if it hasn’t, `FooKey` ends up unbridgeable, which can cause both type checking failures and IRGen crashes when code tries to use its bridging capabilities. And these symptoms are sensitive to precise details of the order Swift happens to bind extensions in, so e.g. adding empty files to the project can make the bug appear or disappear. Spooky.

Add a narrow hack to ClangImporter (only active when we are compiling Foundation) to *assume* that `String` is bridgeable even if the extension declaring this hasn’t been bound yet.

This PR also incorporates minor improvements to type dumping that I added while debugging this issue.

Fixes rdar://142693093.
