### PR TITLE
[6.1] Sema: Partially revert #77236

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2926,7 +2926,7 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
 
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
-static bool diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
+bool swift::diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
                                            const ExportContext &Where,
                                            const Expr *call,
                                            DeclAvailabilityFlags Flags) {
@@ -4165,6 +4165,8 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
                                      const Expr *call,
                                      const ExportContext &Where,
                                      DeclAvailabilityFlags Flags) {
+  assert(!Where.isImplicit());
+
   // Generic parameters are always available.
   if (isa<GenericTypeParamDecl>(D))
     return false;

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -241,6 +241,13 @@ void diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
                                        const ValueDecl *base,
                                        const AvailableAttr *attr);
 
+/// Emit a diagnostic for references to declarations that have been
+/// marked as unavailable, either through "unavailable" or "obsoleted:".
+bool diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
+                                    const ExportContext &Where,
+                                    const Expr *call,
+                                    DeclAvailabilityFlags Flags = std::nullopt);
+
 /// Checks whether a declaration should be considered unavailable when referred
 /// to in the given declaration context and availability context and, if so,
 /// returns a result that describes the unsatisfied constraint.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1223,10 +1223,13 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
         // Check for availability of wrappedValue.
         if (accessor->getAccessorKind() == AccessorKind::Get ||
             isYieldingImmutableAccessor(accessor->getAccessorKind())) {
-          diagnoseDeclAvailability(
-              wrappedValue,
-              var->getAttachedPropertyWrappers()[i]->getRangeWithAt(), nullptr,
-              ExportContext::forDeclSignature(accessor));
+          if (wrappedValue->getAttrs().getUnavailable(ctx)) {
+            ExportContext where = ExportContext::forDeclSignature(var);
+            diagnoseExplicitUnavailability(
+                wrappedValue,
+                var->getAttachedPropertyWrappers()[i]->getRangeWithAt(),
+                where, nullptr);
+          }
         }
 
         underlyingVars.push_back({ wrappedValue, isWrapperRefLValue });

--- a/test/SPI/spi-only-import-exportability.swift
+++ b/test/SPI/spi-only-import-exportability.swift
@@ -150,7 +150,6 @@ public func implementationDetailsUser() {
 public struct ClientStruct {
 #if !SKIP_ERRORS
   public var a: SPIOnlyStruct // expected-error {{cannot use struct 'SPIOnlyStruct' here; 'SPIOnlyImportedLib' was imported for SPI only}}
-  // expected-error@+1 {{cannot use property 'wrappedValue' here; 'SPIOnlyImportedLib' was imported for SPI only}}
   @SPIOnlyPropertyWrapper(42) public var aWrapped: Any // expected-error {{cannot use generic struct 'SPIOnlyPropertyWrapper' as property wrapper here; 'SPIOnlyImportedLib' was imported for SPI only}}
 #endif
   @PublicPropertyWrapper(SPIOnlyStruct()) public var bWrapped: Any

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -88,7 +88,6 @@ fileprivate import FileprivateLib
 // expected-note@-1 2 {{generic struct 'FileprivateImportWrapper' imported as 'fileprivate' from 'FileprivateLib' here}}
 // expected-note@-2 2 {{initializer 'init(wrappedValue:)' imported as 'fileprivate' from 'FileprivateLib' here}}
 // expected-note@-3 2 {{protocol 'FileprivateImportProto' imported as 'fileprivate' from 'FileprivateLib' here}}
-// expected-note@-4 2 {{property 'wrappedValue' imported as 'fileprivate' from 'FileprivateLib' here}}
 
 private import PrivateLib
 // expected-note@-1 10 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
@@ -129,7 +128,6 @@ public struct GenericType<T, U> {}
 
   @FileprivateImportWrapper // expected-error {{initializer 'init(wrappedValue:)' is fileprivate and cannot be referenced from an '@inlinable' function}}
   // expected-error @-1 {{generic struct 'FileprivateImportWrapper' is fileprivate and cannot be referenced from an '@inlinable' function}}
-  // expected-error @-2 {{property 'wrappedValue' is fileprivate and cannot be referenced from an '@inlinable' function}}
   var wrappedFileprivate: PublicImportType
 
   let _: GenericType<PublicImportType, PublicImportType>
@@ -170,7 +168,6 @@ public struct GenericType<T, U> {}
 
   @FileprivateImportWrapper // expected-error {{initializer 'init(wrappedValue:)' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
   // expected-error @-1 {{generic struct 'FileprivateImportWrapper' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-2 {{property 'wrappedValue' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
   var wrappedFileprivate: PublicImportType
 
   let _: GenericType<PublicImportType, PublicImportType>

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -56,7 +56,6 @@ public struct TestInit {
 
 public struct TestPropertyWrapper {
   @BadWrapper public var BadProperty: Int // expected-error {{cannot use struct 'BadWrapper' as property wrapper here; 'BADLibrary' has been imported as implementation-only}}
-  // expected-error@-1 {{cannot use property 'wrappedValue' here; 'BADLibrary' has been imported as implementation-only}}
 }
 
 public protocol TestInherited: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -81,7 +81,6 @@ public class InheritsFromClazzAlias: ClazzAlias {}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 public struct HasMembers {
-  // expected-warning@+3 {{cannot use property 'wrappedValue' here; 'Original' was not imported by this file}}
   // expected-warning@+2 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
  // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
   @WrapperAlias public var wrapped: Int

--- a/test/Sema/property_wrapper_availability.swift
+++ b/test/Sema/property_wrapper_availability.swift
@@ -27,29 +27,8 @@ struct UnavailableWrapper<T> { // expected-note 8 {{'UnavailableWrapper' has bee
   var wrappedValue: T
 }
 
-@propertyWrapper
-struct WrappedValueUnavailableOnMacOS<T> {
-  init(wrappedValue: T) { fatalError() }
 
-  @available(macOS, unavailable)
-  var wrappedValue: T { // expected-note 6 {{'wrappedValue' has been explicitly marked unavailable here}}
-    get { fatalError() }
-    set { fatalError() }
-  }
-}
-
-@propertyWrapper
-struct WrappedValueAvailable51<T> {
-  init(wrappedValue: T) { fatalError() }
-
-  @available(macOS 51, *)
-  var wrappedValue: T {
-    get { fatalError() }
-    set { fatalError() }
-  }
-}
-
-struct AlwaysAvailableStruct { // expected-note 3 {{add @available attribute to enclosing struct}}
+struct AlwaysAvailableStruct { // expected-note 2 {{add @available attribute to enclosing struct}}
   @AlwaysAvailableWrapper var alwaysAvailableExplicit: S
   @AlwaysAvailableWrapper var alwaysAvailableInferred = S()
 
@@ -61,9 +40,6 @@ struct AlwaysAvailableStruct { // expected-note 3 {{add @available attribute to 
 
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
-
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S // expected-error {{'wrappedValue' is unavailable in macOS}}
-  @WrappedValueAvailable51 var wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
 @available(macOS 51, *)
@@ -79,9 +55,6 @@ struct Available51Struct {
 
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
-
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S // expected-error {{'wrappedValue' is unavailable in macOS}}
-  @WrappedValueAvailable51 var wrappedValueAavailable51: S
 }
 
 @available(*, unavailable)
@@ -97,9 +70,6 @@ struct UnavailableStruct {
 
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
-
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S
-  @WrappedValueAvailable51 var wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
 @available(macOS, unavailable)
@@ -115,25 +85,18 @@ struct UnavailableOnMacOSStruct {
 
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
-
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValue: S
-  @WrappedValueAvailable51 var wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
-func alwaysAvailableFunc( // expected-note 4 {{add @available attribute to enclosing global function}}
+func alwaysAvailableFunc( // expected-note 2 {{add @available attribute to enclosing global function}}
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
   @Available51Wrapper _ available51: S, // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
   @DeprecatedWrapper _ deprecated: S, // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper _ unavailable: S, // expected-error {{'UnavailableWrapper' is unavailable}}
-  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
-  @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 ) {
   @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
   @Available51Wrapper var available51Local = S() // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
   @DeprecatedWrapper var deprecatedLocal = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper var unavailableLocal = S() // expected-error {{'UnavailableWrapper' is unavailable}}
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
-  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
 @available(macOS 51, *)
@@ -142,15 +105,11 @@ func available51Func(
   @Available51Wrapper _ available51: S,
   @DeprecatedWrapper _ deprecated: S, // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper _ unavailable: S, // expected-error {{'UnavailableWrapper' is unavailable}}
-  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S, // expected-error {{'wrappedValue' is unavailable in macOS}}
-  @WrappedValueAvailable51 _ wrappedValueAavailable51: S
 ) {
   @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
   @Available51Wrapper var available51Local = S()
   @DeprecatedWrapper var deprecatedLocal = S() // expected-warning {{'DeprecatedWrapper' is deprecated}}
   @UnavailableWrapper var unavailableLocal = S() // expected-error {{'UnavailableWrapper' is unavailable}}
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S() // expected-error {{'wrappedValue' is unavailable}}
-  @WrappedValueAvailable51 var wrappedValueAavailable51 = S()
 }
 
 @available(*, unavailable)
@@ -159,15 +118,11 @@ func unavailableFunc(
   @Available51Wrapper _ available51: S,
   @DeprecatedWrapper _ deprecated: S,
   @UnavailableWrapper _ unavailable: S,
-  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S,
-  @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 ) {
   @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
   @Available51Wrapper var available51Local = S()
   @DeprecatedWrapper var deprecatedLocal = S()
   @UnavailableWrapper var unavailableLocal = S()
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S()
-  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }
 
 @available(macOS, unavailable)
@@ -176,13 +131,9 @@ func unavailableOnMacOSFunc(
   @Available51Wrapper _ available51: S,
   @DeprecatedWrapper _ deprecated: S,
   @UnavailableWrapper _ unavailable: S,
-  @WrappedValueUnavailableOnMacOS _ unavailableWrappedValue: S,
-  @WrappedValueAvailable51 _ wrappedValueAavailable51: S // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 ) {
   @AlwaysAvailableWrapper var alwaysAvailableLocal = S()
   @Available51Wrapper var available51Local = S()
   @DeprecatedWrapper var deprecatedLocal = S()
   @UnavailableWrapper var unavailableLocal = S()
-  @WrappedValueUnavailableOnMacOS var unavailableWrappedValueLocal = S()
-  @WrappedValueAvailable51 var wrappedValueAavailable51 = S() // expected-error {{'wrappedValue' is only available in macOS 51 or newer}}
 }

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -77,7 +77,6 @@ struct Wrapper<T> { // expected-note 3 {{type declared here}}
     self.wrappedValue = projectedValue.value
   }
 
-  // expected-note@+1 {{property 'wrappedValue' is not '@usableFromInline' or public}}
   var wrappedValue: T
   var projectedValue: Projection<T> { Projection(value: wrappedValue) }
 }
@@ -128,7 +127,6 @@ enum E {
 // expected-error@+1 {{function cannot be declared public because its parameter uses an internal API wrapper type}}
 public func f1(@Wrapper value: Int) {}
 
-// expected-error@+4 {{property 'wrappedValue' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+3 {{generic struct 'Wrapper' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+2 {{the parameter API wrapper of a '@usableFromInline' function must be '@usableFromInline' or public}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is internal and cannot be referenced from an '@inlinable' function}}
@@ -157,7 +155,6 @@ public struct PublicWrapper<T> {
 // expected-note@+2 2 {{generic struct 'PackageWrapper' is not '@usableFromInline' or public}}
 @propertyWrapper
 package struct PackageWrapper<T> { // expected-note 3 {{type declared here}}
-  // expected-note@+1 2 {{property 'wrappedValue' is not '@usableFromInline' or public}}
   package var wrappedValue: T
 
   // expected-note@+1 2 {{initializer 'init(wrappedValue:)' is not '@usableFromInline' or public}}
@@ -167,7 +164,6 @@ package struct PackageWrapper<T> { // expected-note 3 {{type declared here}}
 // expected-note@+2 2 {{generic struct 'InternalWrapper' is not '@usableFromInline' or public}}
 @propertyWrapper
 struct InternalWrapper<T> { // expected-note 3 {{type declared here}}
-  // expected-note@+1 2 {{property 'wrappedValue' is not '@usableFromInline' or public}}
   var wrappedValue: T
 
   // expected-note@+1 2 {{initializer 'init(wrappedValue:)' is not '@usableFromInline' or public}}
@@ -204,24 +200,20 @@ public func testComposition2pkg(@PackageWrapper @PublicWrapper value: Int) {}
 // Okay because `PackageWrapper` is implementation-detail.
 @usableFromInline func testComposition4pkg(@PackageWrapper @PublicWrapper value: Int) {}
 
-// expected-error@+4 {{property 'wrappedValue' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+3 {{generic struct 'InternalWrapper' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+2 {{the parameter API wrapper of a '@usableFromInline' function must be '@usableFromInline' or public}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is internal and cannot be referenced from an '@inlinable' function}}
 @inlinable func testComposition5(@PublicWrapper @InternalWrapper value: Int) {}
 
-// expected-error@+3 {{property 'wrappedValue' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+2 {{generic struct 'InternalWrapper' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is internal and cannot be referenced from an '@inlinable' function}}
 @inlinable func testComposition6(@InternalWrapper @PublicWrapper value: Int) {}
 
-// expected-error@+4 {{property 'wrappedValue' is package and cannot be referenced from an '@inlinable' function}}
 // expected-error@+3 {{generic struct 'PackageWrapper' is package and cannot be referenced from an '@inlinable' function}}
 // expected-error@+2 {{the parameter API wrapper of a '@usableFromInline' function must be '@usableFromInline' or public}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is package and cannot be referenced from an '@inlinable' function}}
 @inlinable func testComposition5pkg(@PublicWrapper @PackageWrapper value: Int) {}
 
-// expected-error@+3 {{property 'wrappedValue' is package and cannot be referenced from an '@inlinable' function}}
 // expected-error@+2 {{generic struct 'PackageWrapper' is package and cannot be referenced from an '@inlinable' function}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is package and cannot be referenced from an '@inlinable' function}}
 @inlinable func testComposition6pkg(@PackageWrapper @PublicWrapper value: Int) {}

--- a/test/Sema/spi-in-decls.swift
+++ b/test/Sema/spi-in-decls.swift
@@ -36,7 +36,7 @@ public struct IntLike: ExpressibleByIntegerLiteral, Equatable { // expected-note
 @_spi(X)
 @propertyWrapper
 public struct BadWrapper { // expected-note {{struct declared here}}
-    public var wrappedValue: Int // expected-note {{property declared here}}
+    public var wrappedValue: Int
     public init(wrappedValue: Int) {
         self.wrappedValue = wrappedValue
     }
@@ -87,7 +87,6 @@ public struct TestInit {
 
 public struct TestPropertyWrapper {
   @BadWrapper public var BadProperty: Int // expected-error {{cannot use struct 'BadWrapper' as property wrapper here; it is SPI}}
-  // expected-error@-1 {{cannot use property 'wrappedValue' here; it is SPI}}
 }
 
 public protocol TestInherited: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; it is SPI}}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -961,7 +961,7 @@ struct Observable<Value> {
   }
 
   @available(*, unavailable, message: "must be in a class")
-  var wrappedValue: Value { // expected-note 2{{'wrappedValue' has been explicitly marked unavailable here}}
+  var wrappedValue: Value { // expected-note{{'wrappedValue' has been explicitly marked unavailable here}}
     get { fatalError("called wrappedValue getter") }
     set { fatalError("called wrappedValue setter") }
   }
@@ -982,13 +982,6 @@ struct Observable<Value> {
 
 struct MyObservedValueType {
   @Observable // expected-error{{'wrappedValue' is unavailable: must be in a class}}
-  var observedProperty = 17
-}
-
-func takesObservable(@Observable _ observable: Int) {} // expected-error{{'wrappedValue' is unavailable: must be in a class}}
-
-class MyObservedClass {
-  @Observable
   var observedProperty = 17
 }
 


### PR DESCRIPTION
- **Explanation:** Partially revert https://github.com/swiftlang/swift/pull/77236 in order to work around some issues related to the way `@_spi` attributes are printed and checked in swiftinterfaces.
- **Scope:** Modules with library evolution enabled and properties that are both annotated with `@_spi` and have attached property wrappers.
- **Issue/Radar:** rdar://143029729
- **Original PR:** N/A (this will be fixed separately on `main`)
- **Risk:** Low, returns behavior to the shipping status quo.
- **Testing:** Existing compiler tests.
- **Reviewer:** @xymus 