### PR TITLE
Implement experimental`@execution(concurrent | caller)` attribute

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -601,6 +601,16 @@ BridgedABIAttr BridgedABIAttr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc atLoc,
     BridgedSourceRange range, BridgedNullableDecl abiDecl);
 
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedExecutionKind {
+  BridgedExecutionKindConcurrent,
+  BridgedExecutionKindCaller,
+};
+
+SWIFT_NAME("BridgedExecutionAttr.createParsed(_:atLoc:range:behavior:)")
+BridgedExecutionAttr BridgedExecutionAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc atLoc,
+    BridgedSourceRange range, BridgedExecutionKind behavior);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedAccessLevel {
   BridgedAccessLevelPrivate,
   BridgedAccessLevelFilePrivate,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -220,6 +220,10 @@ protected:
 
       NumFeatures : 31
     );
+
+    SWIFT_INLINE_BITFIELD(ExecutionAttr, DeclAttribute, NumExecutionKindBits,
+      Behavior : NumExecutionKindBits
+    );
   } Bits;
   // clang-format on
 
@@ -2920,6 +2924,30 @@ public:
   }
 
   UNIMPLEMENTED_CLONE(ABIAttr)
+};
+
+class ExecutionAttr : public DeclAttribute {
+public:
+  ExecutionAttr(SourceLoc AtLoc, SourceRange Range,
+                ExecutionKind behavior,
+                bool Implicit)
+      : DeclAttribute(DeclAttrKind::Execution, AtLoc, Range, Implicit) {
+    Bits.ExecutionAttr.Behavior = static_cast<uint8_t>(behavior);
+  }
+
+  ExecutionAttr(ExecutionKind behavior, bool Implicit)
+      : ExecutionAttr(/*AtLoc=*/SourceLoc(), /*Range=*/SourceRange(), behavior,
+                      Implicit) {}
+
+  ExecutionKind getBehavior() const {
+    return static_cast<ExecutionKind>(Bits.ExecutionAttr.Behavior);
+  }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::Execution;
+  }
+
+  UNIMPLEMENTED_CLONE(ExecutionAttr)
 };
 
 /// Attributes that may be applied to declarations.

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -130,6 +130,15 @@ enum class ExternKind: uint8_t {
 enum : unsigned { NumExternKindBits =
   countBitsUsed(static_cast<unsigned>(ExternKind::Last_ExternKind)) };
 
+enum class ExecutionKind : uint8_t {
+  Concurrent = 0,
+  Caller,
+  Last_ExecutionKind = Caller
+};
+
+enum : unsigned { NumExecutionKindBits =
+  countBitsUsed(static_cast<unsigned>(ExecutionKind::Last_ExecutionKind)) };
+
 enum class DeclAttrKind : unsigned {
 #define DECL_ATTR(_, CLASS, ...) CLASS,
 #define LAST_DECL_ATTR(CLASS) Last_DeclAttr = CLASS,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -538,7 +538,12 @@ DECL_ATTR(abi, ABI,
   165)
 DECL_ATTR_FEATURE_REQUIREMENT(ABI, ABIAttribute)
 
-LAST_DECL_ATTR(ABI)
+DECL_ATTR(execution, Execution,
+  OnFunc | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  166)
+DECL_ATTR_FEATURE_REQUIREMENT(Execution, NonIsolatedAsyncInheritsIsolationFromContext)
+
+LAST_DECL_ATTR(Execution)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8220,7 +8220,7 @@ ERROR(attr_execution_concurrent_only_on_async,none,
 
 ERROR(attr_execution_concurrent_incompatible_with_global_actor,none,
       "cannot use '@execution(concurrent)' on %kind0 isolated to global actor %1",
-      (ValueDecl *, ValueDecl *))
+      (ValueDecl *, Type))
 
 ERROR(attr_execution_concurrent_incompatible_isolated_parameter,none,
       "cannot use '@execution(concurrent)' on %kind0 because it has "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8211,5 +8211,32 @@ ERROR(attr_abi_incompatible_with_silgen_name,none,
       "the same purpose",
       (DescriptiveDeclKind))
 
+//===----------------------------------------------------------------------===//
+// MARK: @execution Attribute
+//===----------------------------------------------------------------------===//
+ERROR(attr_execution_concurrent_only_on_async,none,
+      "cannot use '@execution(concurrent)' on non-async %kind0",
+      (ValueDecl *))
+
+ERROR(attr_execution_concurrent_incompatible_with_global_actor,none,
+      "cannot use '@execution(concurrent)' on %kind0 isolated to global actor %1",
+      (ValueDecl *, ValueDecl *))
+
+ERROR(attr_execution_concurrent_incompatible_isolated_parameter,none,
+      "cannot use '@execution(concurrent)' on %kind0 because it has "
+      "an isolated parameter: %1",
+      (ValueDecl *, ValueDecl *))
+
+ERROR(attr_execution_concurrent_incompatible_dynamically_isolated_parameter,none,
+      "cannot use '@execution(concurrent)' on %kind0 because it has "
+      "a dynamically isolated parameter: %1",
+      (ValueDecl *, ValueDecl *))
+
+ERROR(attr_execution_concurrent_incompatible_with_nonisolated,none,
+      "cannot use '@execution(concurrent)' and 'nonisolated' on the same %0 "
+      "because they serve the same purpose",
+      (ValueDecl *))
+
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -332,6 +332,8 @@ IDENTIFIER(size)
 IDENTIFIER(speed)
 IDENTIFIER(unchecked)
 IDENTIFIER(unsafe)
+IDENTIFIER(concurrent)
+IDENTIFIER(caller)
 
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -526,6 +526,14 @@ static StringRef getDumpString(NonSendableKind kind) {
     return "Specific";
   }
 }
+static StringRef getDumpString(ExecutionKind kind) {
+  switch (kind) {
+  case ExecutionKind::Concurrent:
+    return "concurrent";
+  case ExecutionKind::Caller:
+    return "caller";
+  }
+}
 static StringRef getDumpString(StringRef s) {
   return s;
 }
@@ -3871,6 +3879,11 @@ public:
 
 #undef TRIVIAL_ATTR_PRINTER
 
+  void visitExecutionAttr(ExecutionAttr *Attr, StringRef label) {
+    printCommon(Attr, "execution_attr", label);
+    printField(Attr->getBehavior(), "behavior");
+    printFoot();
+  }
   void visitABIAttr(ABIAttr *Attr, StringRef label) {
     printCommon(Attr, "abi_attr", label);
     printRec(Attr->abiDecl, "decl");

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1650,6 +1650,19 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::Execution: {
+    auto *attr = cast<ExecutionAttr>(this);
+    switch (attr->getBehavior()) {
+    case ExecutionKind::Concurrent:
+      Printer << "@execution(concurrent)";
+      break;
+    case ExecutionKind::Caller:
+      Printer << "@execution(caller)";
+      break;
+    }
+    break;
+  }
+
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
 #include "swift/AST/DeclAttr.def"
     llvm_unreachable("handled above");
@@ -1861,6 +1874,15 @@ StringRef DeclAttribute::getAttrName() const {
     }
   case DeclAttrKind::Lifetime:
     return "lifetime";
+  case DeclAttrKind::Execution: {
+    switch (cast<ExecutionAttr>(this)->getBehavior()) {
+    case ExecutionKind::Concurrent:
+      return "execution(concurrent)";
+    case ExecutionKind::Caller:
+      return "execution(caller)";
+    }
+    llvm_unreachable("Invalid execution kind");
+  }
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -585,3 +585,21 @@ BridgedUnavailableFromAsyncAttr BridgedUnavailableFromAsyncAttr_createParsed(
       UnavailableFromAsyncAttr(cMessage.unbridged(), cAtLoc.unbridged(),
                                cRange.unbridged(), /*implicit=*/false);
 }
+
+static ExecutionKind unbridged(BridgedExecutionKind kind) {
+  switch (kind) {
+  case BridgedExecutionKindConcurrent:
+    return ExecutionKind::Concurrent;
+  case BridgedExecutionKindCaller:
+    return ExecutionKind::Caller;
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+BridgedExecutionAttr BridgedExecutionAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc atLoc,
+    BridgedSourceRange range, BridgedExecutionKind behavior) {
+  return new (cContext.unbridged())
+      ExecutionAttr(atLoc.unbridged(), range.unbridged(),
+                    unbridged(behavior), /*implicit=*/false);
+}

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -111,6 +111,8 @@ extension ASTGenVisitor {
       let attrName = identTy.name.rawText
       let attrKind = BridgedDeclAttrKind(from: attrName.bridged)
       switch attrKind {
+      case .execution:
+        return handle(self.generateExecutionAttr(attribute: node)?.asDeclAttribute)
       case .ABI:
         return handle(self.generateABIAttr(attribute: node)?.asDeclAttribute)
       case .alignment:
@@ -327,6 +329,33 @@ extension ASTGenVisitor {
     }
 
     return handle(self.generateCustomAttr(attribute: node)?.asDeclAttribute)
+  }
+
+  /// E.g.:
+  ///   ```
+  ///   @execution(concurrent)
+  ///   @execution(caller)
+  ///   ```
+  func generateExecutionAttr(attribute node: AttributeSyntax) -> BridgedExecutionAttr? {
+    let behavior: BridgedExecutionKind? = self.generateSingleAttrOption(
+      attribute: node,
+      {
+        switch $0.rawText {
+        case "concurrent": return .concurrent
+        case "caller": return .caller
+        default: return nil
+        }
+      }
+    )
+    guard let behavior else {
+      return nil
+    }
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      behavior: behavior
+    )
   }
 
   /// E.g.:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2706,6 +2706,8 @@ ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
       /* implicit */ false, lifetimeEntry.get()));
 }
 
+
+
 /// Parses a (possibly optional) argument for an attribute containing a single, arbitrary identifier.
 ///
 /// \param P The parser object.
@@ -4020,6 +4022,21 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     Status |= Attr;
     if (Attr.isNonNull())
       Attributes.add(Attr.get());
+    break;
+  }
+
+  case DeclAttrKind::Execution: {
+    auto behavior = parseSingleAttrOption<ExecutionKind>(
+        *this, Loc, AttrRange, AttrName, DK,
+        {{Context.Id_concurrent, ExecutionKind::Concurrent},
+         {Context.Id_caller, ExecutionKind::Caller}});
+    if (!behavior)
+      return makeParserSuccess();
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) ExecutionAttr(AtLoc, AttrRange, *behavior,
+                                                 /*Implicit*/ false));
+
     break;
   }
   }
@@ -9729,7 +9746,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
       }
     }
   }
-  
+
   ParserStatus Status;
   SourceLoc SubscriptLoc = consumeToken(tok::kw_subscript);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -253,6 +253,80 @@ private:
   }
 
 public:
+  void visitExecutionAttr(ExecutionAttr *attr) {
+    auto *F = dyn_cast<FuncDecl>(D);
+    if (!F)
+      return;
+
+    if (!F->hasAsync()) {
+      diagnoseAndRemoveAttr(attr, diag::attr_execution_concurrent_only_on_async,
+                            F);
+      return;
+    }
+
+    // Checks based on explicit attributes, inferred ones would
+    // have to be handled during actor isolation inference.
+
+    switch (attr->getBehavior()) {
+    case ExecutionKind::Concurrent: {
+      // 'concurrent' doesn't work with explicit `nonisolated`
+      if (F->hasExplicitIsolationAttribute()) {
+        if (F->getAttrs().hasAttribute<NonisolatedAttr>()) {
+          diagnoseAndRemoveAttr(
+              attr,
+              diag::attr_execution_concurrent_incompatible_with_nonisolated, F);
+          return;
+        }
+
+        if (auto globalActor = F->getGlobalActorAttr()) {
+          diagnoseAndRemoveAttr(
+              attr,
+              diag::attr_execution_concurrent_incompatible_with_global_actor, F,
+              globalActor->second);
+          return;
+        }
+      }
+
+      auto parameters = F->getParameters();
+      if (!parameters)
+        return;
+
+      for (auto *P : *parameters) {
+        auto *repr = P->getTypeRepr();
+        if (!repr)
+          continue;
+
+        // isolated parameters affect isolation of the function itself
+        if (isa<IsolatedTypeRepr>(repr)) {
+          diagnoseAndRemoveAttr(
+              attr,
+              diag::attr_execution_concurrent_incompatible_isolated_parameter,
+              F, P);
+          return;
+        }
+
+        if (auto *attrType = dyn_cast<AttributedTypeRepr>(repr)) {
+          if (attrType->has(TypeAttrKind::Isolated)) {
+            diagnoseAndRemoveAttr(
+                attr,
+                diag::
+                    attr_execution_concurrent_incompatible_dynamically_isolated_parameter,
+                F, P);
+            return;
+          }
+        }
+      }
+
+      break;
+    }
+
+    case ExecutionKind::Caller: {
+      // no restrictions for now.
+      break;
+    }
+    }
+  }
+
   void visitABIAttr(ABIAttr *attr) {
     Decl *AD = attr->abiDecl;
     if (isa<VarDecl>(D) && isa<PatternBindingDecl>(AD)) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1593,6 +1593,7 @@ namespace  {
     UNINTERESTING_ATTR(DynamicCallable)
     UNINTERESTING_ATTR(DynamicMemberLookup)
     UNINTERESTING_ATTR(SILGenName)
+    UNINTERESTING_ATTR(Execution)
     UNINTERESTING_ATTR(Exported)
     UNINTERESTING_ATTR(ForbidSerializingReference)
     UNINTERESTING_ATTR(GKInspectable)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5734,6 +5734,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
       DeclAttribute *Attr = nullptr;
       bool skipAttr = false;
       switch (recordID) {
+      case decls_block::Execution_DECL_ATTR: {
+        unsigned behavior;
+        serialization::decls_block::ExecutionDeclAttrLayout::readRecord(
+            scratch, behavior);
+        Attr = new (ctx) ExecutionAttr(static_cast<ExecutionKind>(behavior),
+                                       /*Implicit=*/false);
+        break;
+      }
       case decls_block::ABI_DECL_ATTR: {
         bool isImplicit;
         DeclID abiDeclID;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 913; // @safe removal
+const uint16_t SWIFTMODULE_VERSION_MINOR = 914; // @execution attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2353,6 +2353,11 @@ namespace decls_block {
   using ExclusivityDeclAttrLayout = BCRecordLayout<
     Optimize_DECL_ATTR,
     BCFixed<2>  // exclusivity mode
+  >;
+
+  using ExecutionDeclAttrLayout = BCRecordLayout<
+    Execution_DECL_ATTR,
+    BCFixed<1>  // execution behavior kind
   >;
 
   using ABIDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2891,6 +2891,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
   }
 #include "swift/AST/DeclAttr.def"
 
+    case DeclAttrKind::Execution: {
+      auto *theAttr = cast<ExecutionAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[ExecutionDeclAttrLayout::Code];
+      ExecutionDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                          (unsigned)theAttr->getKind());
+      return;
+    }
+
     case DeclAttrKind::ABI: {
       auto *theAttr = cast<ABIAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ABIDeclAttrLayout::Code];

--- a/test/IDE/complete_decl_attribute_feature_requirement.swift
+++ b/test/IDE/complete_decl_attribute_feature_requirement.swift
@@ -6,7 +6,9 @@
 // REQUIRES: asserts
 
 // RUN: %batch-code-completion -filecheck-additional-suffix _DISABLED
-// RUN: %batch-code-completion -filecheck-additional-suffix _ENABLED -enable-experimental-feature ABIAttribute
+// RUN: %batch-code-completion -filecheck-additional-suffix _ENABLED \
+// RUN:        -enable-experimental-feature ABIAttribute \
+// RUN:        -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
 
 // NOTE: Please do not include the ", N items" after "Begin completions". The
 // item count creates needless merge conflicts given that an "End completions"
@@ -16,14 +18,18 @@
 
 // KEYWORD2:              Begin completions
 // KEYWORD2_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
+// KEYWORD2_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // KEYWORD2_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD2_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD2:              End completions
 
 @#^KEYWORD3^# class C {}
 
 // KEYWORD3:              Begin completions
 // KEYWORD3_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD3_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD3_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3:              End completions
 
 @#^KEYWORD3_2?check=KEYWORD3^#IB class C2 {}
@@ -32,46 +38,60 @@
 @#^KEYWORD4^# enum E {}
 // KEYWORD4:              Begin completions
 // KEYWORD4_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD4_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD4_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4:              End completions
 
 @#^KEYWORD5^# struct S{}
 // KEYWORD5:              Begin completions
 // KEYWORD5_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD5_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD5_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5:              End completions
 
 @#^ON_GLOBALVAR^# var globalVar
 // ON_GLOBALVAR:              Begin completions
 // ON_GLOBALVAR_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
+// ON_GLOBALVAR_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR:              End completions
 
 struct _S {
   @#^ON_INIT^# init()
 // ON_INIT:              Begin completions
 // ON_INIT_ENABLED-DAG:  Keyword/None:              abi[#Constructor Attribute#]; name=abi
+// ON_INIT_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_INIT_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT:              End completions
 
   @#^ON_PROPERTY^# var foo
 // ON_PROPERTY:              Begin completions
 // ON_PROPERTY_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
+// ON_PROPERTY_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PROPERTY_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY:              End completions
 
   @#^ON_METHOD^# private
   func foo()
 // ON_METHOD:              Begin completions
 // ON_METHOD_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
+// ON_METHOD_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // ON_METHOD_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_METHOD_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_METHOD:              End completions
 
 
   func bar(@#^ON_PARAM_1?check=ON_PARAM^#)
 // ON_PARAM:              Begin completions
 // ON_PARAM_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PARAM_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PARAM_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM:              End completions
 
   func bar(
@@ -94,7 +114,9 @@ struct _S {
   @#^ON_MEMBER_LAST^#
 // ON_MEMBER_LAST:              Begin completions
 // ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_MEMBER_LAST:              End completions
 }
 
@@ -106,7 +128,9 @@ func takeClosure(_: () -> Void) {
 // IN_CLOSURE:              Begin completions
 // FIXME: Not valid in this position (but CompletionLookup can't tell that)
 // IN_CLOSURE_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// IN_CLOSURE_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // IN_CLOSURE_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// IN_CLOSURE_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // IN_CLOSURE:              End completions
 
 @#^KEYWORD_INDEPENDENT_1?check=KEYWORD_LAST^#
@@ -122,5 +146,7 @@ func dummy2() {}
 
 // KEYWORD_LAST:              Begin completions
 // KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST_DISABLED-NOT: Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// KEYWORD_LAST_DISABLED-NOT: Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST:              End completions

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,8 +1,13 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs -enable-experimental-feature ABIAttribute
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs \
+// RUN:  -enable-experimental-feature ABIAttribute \
+// RUN:  -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
+
 // RUN: %FileCheck %s --input-file %t.swiftinterface
 
 // REQUIRES: swift_feature_ABIAttribute
+// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
 
 // CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }
@@ -49,3 +54,11 @@ public var abiAttrOnVar: Int = 42
 // CHECK: @available(*, unavailable, message: "this compiler cannot match the ABI specified by the @abi attribute")
 // CHECK: public var abiAttrOnVar: Swift.Int
 // CHECK: #endif
+
+@execution(concurrent)
+public func testExecutionConcurrent() async {}
+// CHECK: @execution(concurrent) public func testExecutionConcurrent() async
+
+@execution(caller)
+public func testExecutionCaller() async {}
+// CHECK: @execution(caller) public func testExecutionCaller() async

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+
+@execution(something) func invalidAttr() async {} // expected-error {{unknown option 'something' for attribute 'execution'}}
+
+@execution(concurrent) @execution(caller) func mutipleAttrs() async {}
+// expected-error@-1 {{duplicate attribute}} expected-note@-1 {{attribute already specified here}}
+
+@execution(concurrent) func nonAsync1() {}
+// expected-error@-1 {{cannot use '@execution(concurrent)' on non-async global function 'nonAsync1()'}}
+
+@execution(caller) func nonAsync2() {}
+// expected-error@-1 {{cannot use '@execution(concurrent)' on non-async global function 'nonAsync2()'}}
+
+@execution(concurrent) func testGlobal() async {} // Ok
+
+struct Test {
+  @execution(concurrent) init() {}
+  // expected-error@-1 {{@execution(concurrent) may only be used on 'func' declarations}}
+
+  @execution(concurrent) func member() {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on non-async instance method 'member()'}}
+
+  @execution(concurrent) func member() async {} // Ok
+
+  // expected-error@+1 {{@execution(caller) may only be used on 'func' declarations}}
+  @execution(caller) subscript(a: Int) -> Bool {
+    get { false }
+    @execution(concurrent) set { }
+    // expected-error@-1 {{@execution(concurrent) may only be used on 'func' declarations}}
+  }
+
+  @execution(caller) var x: Int
+  // expected-error@-1 {{@execution(caller) may only be used on 'func' declarations}}
+}
+
+do {
+  @execution(caller) func local() async {} // Ok
+}
+
+struct TestAttributeCollisions {
+  @execution(concurrent) nonisolated func testNonIsolated() async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' and 'nonisolated' on the same 'testNonIsolated()' because they serve the same purpose}}
+
+  @execution(concurrent) func test(arg: isolated MainActor) async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}
+
+  @execution(concurrent) func testIsolationAny(arg: @isolated(any) () -> Void) async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'testIsolationAny(arg:)' because it has a dynamically isolated parameter: 'arg'}}
+
+  @MainActor @execution(concurrent) func testGlobalActor() async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'testGlobalActor()' isolated to global actor 'MainActor'}}
+
+  @execution(concurrent) @Sendable func test(_: @Sendable () -> Void, _: sending Int) async {} // Ok
+}

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -55,3 +55,19 @@ struct TestAttributeCollisions {
 
   @execution(concurrent) @Sendable func test(_: @Sendable () -> Void, _: sending Int) async {} // Ok
 }
+
+@MainActor
+protocol P {
+  func test() async
+}
+
+struct InfersMainActor : P {
+  @execution(concurrent) func test() async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'test()' isolated to global actor 'MainActor'}}
+}
+
+@MainActor
+struct IsolatedType {
+  @execution(concurrent) func test() async {}
+  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'test()' isolated to global actor 'MainActor'}}
+}

--- a/test/attr/feature_requirement.swift
+++ b/test/attr/feature_requirement.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -disable-experimental-parser-round-trip -verify-additional-prefix disabled-
-// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute
+// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
 
 // REQUIRES: asserts
 
@@ -13,4 +13,13 @@ func fn() {}  // expected-disabled-error@-1 {{'abi' attribute is only valid when
   #error("does have @abi")  // expected-enabled-error {{does have @abi}}
 #else
   #error("doesn't have @abi")  // expected-disabled-error {{doesn't have @abi}}
+#endif
+
+@execution(concurrent) func testExecutionAttr() async {}
+// expected-disabled-error@-1 {{'execution(concurrent)' attribute is only valid when experimental feature NonIsolatedAsyncInheritsIsolationFromContext is enabled}}
+
+#if hasAttribute(execution)
+  #error("does have @execution") // expected-enabled-error {{does have @execution}}
+#else
+  #error("doesn't have @execution") // expected-disabled-error {{doesn't have @execution}}
 #endif


### PR DESCRIPTION
Implements experimental `@execution(concurrent | caller)` declaration attribute and it's validation.

This attribute is:
  -  tied to `NonIsolatedAsyncInheritsIsolationFromContext` experimental feature
  - allowed on `async` functional declarations
  - `concurrent` behavior cannot be used with `nonisolated`, global actor, `isolated` and `@isolated(any)` marked functions/parameters. 

Resolves: rdar://142920095

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
