### PR TITLE
Require explicit statement of all `Copyable`/`Escapable` requirements for conditional `Copyable`/`Escapable` conformances.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2094,7 +2094,12 @@ public:
 
   /// Does this extension add conformance to an invertible protocol for the
   /// extended type?
-  bool isAddingConformanceToInvertible() const;
+  ///
+  /// Returns \c nullopt if the extension does not add conformance to any
+  /// invertible protocol. Returns one of the invertible protocols being
+  /// conformed to otherwise.
+  std::optional<InvertibleProtocolKind>
+  isAddingConformanceToInvertible() const;
 
   /// If this extension represents an imported Objective-C category, returns the
   /// category's name. Otherwise returns the empty identifier.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7850,6 +7850,16 @@ ERROR(extension_conforms_to_invertible_and_others, none,
 ERROR(invertible_conformance_other_source_file,none,
       "conformance to '%0' must occur in the same source file as %kind1",
       (StringRef, const ValueDecl *))
+ERROR(inverse_conditional_must_be_fully_explicit,none,
+        "conditional conformance to %0 must explicitly "
+        "state whether %1 is required to conform to %2 or not",
+        (const ProtocolDecl *, Type, const ProtocolDecl *))
+NOTE(make_inverse_conditional_non_requirement_explicit,none,
+     "specify that the conformance does not require %0 to conform to %1",
+     (Type, const ProtocolDecl *))
+NOTE(make_inverse_conditional_requirement_explicit,none,
+     "specify that the conformance requires %0 to conform to %1",
+     (Type, const ProtocolDecl *))
 
 // -- older ones below --
 ERROR(noncopyable_parameter_requires_ownership, none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2118,7 +2118,8 @@ class InferredGenericSignatureRequest :
                                                     WhereClauseOwner,
                                                     SmallVector<Requirement, 2>,
                                                     SmallVector<TypeBase *, 2>,
-                                                    SourceLoc, bool, bool),
+                                                    SourceLoc, ExtensionDecl *,
+                                                    bool),
                          RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2134,7 +2135,8 @@ private:
            WhereClauseOwner whereClause,
            SmallVector<Requirement, 2> addedRequirements,
            SmallVector<TypeBase *, 2> inferenceSources,
-           SourceLoc loc, bool isExtension, bool allowInverses) const;
+           SourceLoc loc, ExtensionDecl *forExtension,
+           bool allowInverses) const;
 
 public:
   /// Inferred generic signature requests don't have source-location info.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -206,7 +206,7 @@ SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
                                          WhereClauseOwner,
                                          SmallVector<Requirement, 2>,
                                          SmallVector<TypeBase *, 2>,
-                                         SourceLoc, bool, bool),
+                                         SourceLoc, ExtensionDecl *, bool),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DistributedModuleIsAvailableRequest,
               bool(const ValueDecl *), Cached, NoLocationInfo)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -995,6 +995,7 @@ public:
     SwapSelfAndDependentMemberType = 8,
     PrintInherited = 16,
     PrintInverseRequirements = 32,
+    PrintExplicitInvertibleRequirements = 64,
   };
 
   /// The default generic signature flags for printing requirements.
@@ -1763,7 +1764,18 @@ void PrintAST::printGenericSignature(
   SmallVector<Requirement, 2> requirements;
   SmallVector<InverseRequirement, 2> inverses;
 
-  if (flags & PrintInverseRequirements) {
+  if (flags & PrintExplicitInvertibleRequirements) {
+    // Collect the inverted requirements…
+    SmallVector<Requirement, 2> filteredRequirements;
+    genericSig->getRequirementsWithInverses(filteredRequirements, inverses);
+    llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
+      return !inverseFilter(inverse);
+    });
+    // …and also all of the unfiltered requirements, including the ones for
+    // invertible protocols.
+    requirements.append(genericSig.getRequirements().begin(),
+                        genericSig.getRequirements().end());
+  } else if (flags & PrintInverseRequirements) {
     genericSig->getRequirementsWithInverses(requirements, inverses);
     llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
       return !inverseFilter(inverse);
@@ -3115,7 +3127,7 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
       // in such an extension. We need to print the whole signature:
       //     extension S: Copyable where T: Copyable
       if (decl->isAddingConformanceToInvertible())
-        genSigFlags &= ~PrintInverseRequirements;
+        genSigFlags |= PrintExplicitInvertibleRequirements;
 
       printGenericSignature(genericSig,
                             genSigFlags,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1992,7 +1992,8 @@ Type ExtensionDecl::getExtendedType() const {
   return ErrorType::get(ctx);
 }
 
-bool ExtensionDecl::isAddingConformanceToInvertible() const {
+std::optional<InvertibleProtocolKind>
+ExtensionDecl::isAddingConformanceToInvertible() const {
   const unsigned numEntries = getInherited().size();
   for (unsigned i = 0; i < numEntries; ++i) {
     InheritedTypeRequest request{this, i, TypeResolutionStage::Structural};
@@ -2010,10 +2011,10 @@ bool ExtensionDecl::isAddingConformanceToInvertible() const {
 
     if (inheritedTy)
       if (auto kp = inheritedTy->getKnownProtocol())
-        if (getInvertibleProtocolKind(*kp))
-          return true;
+        if (auto kind = getInvertibleProtocolKind(*kp))
+          return kind;
   }
-  return false;
+  return std::nullopt;
 }
 
 bool Decl::isObjCImplementation() const {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3492,7 +3492,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
       /*addedRequirements=*/{},
       /*inferenceSources=*/{},
       attr->getLocation(),
-      /*isExtension=*/false,
+      /*forExtension=*/nullptr,
       /*allowInverses=*/true};
 
   auto specializedSig = evaluateOrDefault(Ctx.evaluator, request,
@@ -6078,7 +6078,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
         /*addedRequirements=*/{},
         /*inferenceSources=*/{},
         attr->getLocation(),
-        /*isExtension=*/false,
+        /*forExtension=*/nullptr,
         /*allowInverses=*/true};
 
     // Compute generic signature for derivative functions.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -516,7 +516,7 @@ swift::handleSILGenericParams(GenericParamList *genericParams,
       /*parentSig=*/nullptr,
       nestedList.back(), WhereClauseOwner(),
       {}, {}, genericParams->getLAngleLoc(),
-      /*isExtension=*/false,
+      /*forExtension=*/nullptr,
       allowInverses};
   return evaluateOrDefault(DC->getASTContext().evaluator, request,
                            GenericSignatureWithError()).getPointer();

--- a/test/Generics/inverse_conditional_conformance_copyable_and_escapable.swift
+++ b/test/Generics/inverse_conditional_conformance_copyable_and_escapable.swift
@@ -1,0 +1,88 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct C_C1<T: ~Copyable>: ~Copyable {}
+extension C_C1: Copyable where T: Copyable {}
+
+struct C_C2<T: ~Copyable>: ~Copyable {}
+// expected-error @+2 {{conditional conformance to 'Copyable' must explicitly state whether 'T' is required to conform to 'Copyable'}}
+// expected-error @+1 {{marked with '~Copyable'}}
+extension C_C2: Copyable {}
+
+struct C_CE1<T: ~Copyable & ~Escapable>: ~Copyable {}
+extension C_CE1: Copyable where T: Copyable, T: ~Escapable {}
+
+struct C_CE2<T: ~Copyable & ~Escapable>: ~Copyable {}
+// expected-error @+1 {{conditional conformance to 'Copyable' must explicitly state whether 'T' is required to conform to 'Escapable'}}
+extension C_CE2: Copyable where T: Copyable {}
+
+struct C_CE3<T: ~Copyable & ~Escapable>: ~Copyable {}
+// expected-error @+2 {{conditional conformance to 'Copyable' must explicitly state whether 'T' is required to conform to 'Copyable'}}
+// expected-error @+1 {{marked with '~Copyable'}}
+extension C_CE3: Copyable where T: ~Escapable {}
+
+struct CE_C<T: ~Copyable>: ~Copyable, ~Escapable {}
+extension CE_C: Copyable where T: Copyable {}
+
+struct CE_E<T: ~Escapable>: ~Copyable, ~Escapable {}
+extension CE_E: Escapable where T: Escapable {}
+
+struct CE_CE1<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+extension CE_CE1: Copyable where T: Copyable, T: ~Escapable {}
+extension CE_CE1: Escapable where T: ~Copyable, T: Escapable {}
+
+struct CE_CE2<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+// expected-error @+1 {{conditional conformance to 'Copyable' must explicitly state whether 'T' is required to conform to 'Escapable'}}
+extension CE_CE2: Copyable where T: Copyable {}
+// expected-error @+1 {{conditional conformance to 'Escapable' must explicitly state whether 'T' is required to conform to 'Copyable'}}
+extension CE_CE2: Escapable where T: Escapable {}
+
+struct CE_CE3<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+// expected-error @+2 {{conditional conformance to 'Copyable' must explicitly state whether 'T' is required to conform to 'Copyable'}}
+// expected-error @+1 {{marked with '~Copyable'}}
+extension CE_CE3: Copyable where T: ~Escapable {}
+// expected-error @+2 {{conditional conformance to 'Escapable' must explicitly state whether 'T' is required to conform to 'Escapable'}}
+// expected-error @+1 {{marked with '~Escapable'}}
+extension CE_CE3: Escapable where T: ~Copyable {}
+
+struct C_C_X<T: ~Copyable, U>: ~Copyable {}
+extension C_C_X: Copyable where T: Copyable {}
+
+protocol Floppyable {} // implied Copyable requirement
+
+struct C_C_P<T: ~Copyable, U: Floppyable>: ~Copyable {}
+extension C_C_P: Copyable where T: Copyable {}
+
+class Sloppyable {} // implied Copyable requirement since it's a class
+
+struct C_C_K<T: ~Copyable, U: Sloppyable>: ~Copyable {}
+extension C_C_K: Copyable where T: Copyable {}
+
+protocol Ploppyable: ~Copyable {}
+
+struct C_C_PC1<T: ~Copyable, U: Ploppyable & ~Copyable>: ~Copyable {}
+// expected-error @+1 {{conditional conformance to 'Copyable' must explicitly state whether 'U' is required to conform to 'Copyable'}}
+extension C_C_PC1: Copyable where T: Copyable {}
+
+struct C_C_PC2<T: ~Copyable, U: Ploppyable & ~Copyable>: ~Copyable {}
+extension C_C_PC2: Copyable where T: Copyable, U: Copyable {}
+
+struct C_C_X2<T: ~Copyable, U: Ploppyable /*& Copyable*/>: ~Copyable {}
+extension C_C_X2: Copyable where T: Copyable {}
+
+struct C_C_L<T: ~Copyable, U: AnyObject>: ~Copyable {}
+extension C_C_L: Copyable where T: Copyable {}
+
+struct C_C_C<T: ~Copyable, U: ~Copyable> {}
+extension C_C_C where T: ~Copyable, U == Int {
+    struct SubInt: ~Copyable {}
+}
+
+extension C_C_C.SubInt: Copyable where T: Copyable {}
+
+struct NC: ~Copyable {}
+
+extension C_C_C where T: ~Copyable, U: ~Copyable, U == NC {
+    struct SubNC: ~Copyable {}
+}
+
+extension C_C_C.SubNC: Copyable where T: Copyable {}

--- a/test/Generics/inverse_conditional_conformance_restriction.swift
+++ b/test/Generics/inverse_conditional_conformance_restriction.swift
@@ -15,8 +15,8 @@ extension Blah: Escapable where T: Copyable, T: Escapable {}
 // expected-error@-1 {{conditional conformance to suppressible protocol 'Escapable' cannot depend on 'T: Copyable'}}
 
 struct Fixed<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
-extension Fixed: Copyable where T: Copyable {}
-extension Fixed: Escapable where T: Escapable {}
+extension Fixed: Copyable where T: Copyable, T: ~Escapable {}
+extension Fixed: Escapable where T: Escapable, T: ~Copyable {}
 
 struct TryConformance<Whatever: ~Copyable>: ~Copyable {}
 extension TryConformance: Copyable

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -11,16 +11,20 @@ struct AttemptImplicitConditionalConformance<T: ~Copyable>: ~Copyable {
 }
 extension AttemptImplicitConditionalConformance: Copyable {}
 // expected-error@-1 {{generic struct 'AttemptImplicitConditionalConformance' required to be 'Copyable' but is marked with '~Copyable'}}
+// expected-error@-2 {{must explicitly state whether 'T' is required to conform to 'Copyable'}}
 
 enum Hello<T: ~Escapable & ~Copyable>: ~Escapable & ~Copyable {}
 extension Hello: Escapable {} // expected-error {{generic enum 'Hello' required to be 'Escapable' but is marked with '~Escapable'}}
+// expected-error@-1 {{must explicitly state whether 'T' is required to conform to 'Copyable'}}
+// expected-error@-2 {{must explicitly state whether 'T' is required to conform to 'Escapable'}}
 extension Hello: Copyable {} // expected-error {{generic enum 'Hello' required to be 'Copyable' but is marked with '~Copyable'}}
+// expected-error@-1 {{must explicitly state whether 'T' is required to conform to 'Copyable'}}
+// expected-error@-2 {{must explicitly state whether 'T' is required to conform to 'Escapable'}}
 
 enum HelloExplicitlyFixed<T: ~Escapable & ~Copyable>: Escapable, Copyable {}
 
 struct NoInverseBecauseNoDefault<T: ~Copyable & ~Escapable>: ~Copyable {}
 extension NoInverseBecauseNoDefault: Copyable where T: Copyable, T: ~Escapable {}
-// expected-error@-1 {{cannot suppress '~Escapable' on generic parameter 'T' defined in outer scope}}
 
 // Check support for explicit conditional conformance
 public struct ExplicitCond<T: ~Copyable>: ~Copyable {}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -59,8 +59,8 @@ extension ExplicitHello: Copyable where T: Copyable {}
 
 public struct Hello<T: ~Copyable>: ~Copyable, ~Escapable where T: ~Escapable {}
 
-extension Hello: Escapable where T: Escapable {}
-extension Hello: Copyable where T: Copyable {}
+extension Hello: Escapable where T: Escapable, T: ~Copyable {}
+extension Hello: Copyable where T: Copyable, T: ~Escapable {}
 
 public protocol TestAssocTypes {
   associatedtype A: ~Copyable, _NoCopyP = Int
@@ -98,7 +98,7 @@ extension Outer: Copyable where A: Copyable {}
 extension Outer.InnerStruct: Copyable where C: Copyable, A: Copyable {}
 
 extension Outer.InnerVariation1: Copyable where A: Copyable, D: Copyable & Escapable {}
-extension Outer.InnerVariation2: Escapable where A: Escapable, D: Escapable {}
+extension Outer.InnerVariation2: Escapable where A: ~Copyable, A: Escapable, D: Escapable {}
 
 extension Outer.InnerStruct {
     public func hello<T: ~Escapable>(_ t: T) {}
@@ -149,5 +149,5 @@ public enum Moptional<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
   case none
   case some(Wrapped)
 }
-extension Moptional: Copyable where Wrapped: Copyable {}
-extension Moptional: Escapable where Wrapped: Escapable {}
+extension Moptional: Copyable where Wrapped: Copyable, Wrapped: ~Escapable {}
+extension Moptional: Escapable where Wrapped: Escapable, Wrapped: ~Copyable {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -82,10 +82,10 @@ import NoncopyableGenerics_Misc
 
 // CHECK-MISC: public struct Hello<T> : ~Swift.Copyable, ~Swift.Escapable where T : ~Copyable, T : ~Escapable {
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : Swift.Escapable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : Swift.Escapable, T : ~Copyable {
 // CHECK-MISC-NEXT: }
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : Swift.Copyable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : Swift.Copyable, T : ~Escapable {
 // CHECK-MISC-NEXT: }
 
 // CHECK-MISC: public protocol TestAssocTypes {
@@ -118,7 +118,7 @@ import NoncopyableGenerics_Misc
 
 // CHECK-MISC: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable where A : Swift.Copyable, D : Swift.Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where D : Swift.Escapable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where D : Swift.Escapable, A : ~Copyable {
 
 // CHECK-MISC: extension {{.*}}.Outer.InnerStruct {
 // CHECK-MISC-NEXT: #if compiler(>=5.3) && $NonescapableTypes
@@ -164,8 +164,8 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: public struct Continuation<T, E> where E : Swift.Error, T : ~Copyable {
 
 // CHECK-MISC: @frozen public enum Moptional<Wrapped> : ~Swift.Copyable, ~Swift.Escapable where Wrapped : ~Copyable, Wrapped : ~Escapable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Copyable where Wrapped : Swift.Copyable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Escapable where Wrapped : Swift.Escapable {
+// CHECK-MISC: extension {{.*}}.Moptional : Swift.Copyable where Wrapped : Swift.Copyable, Wrapped : ~Escapable {
+// CHECK-MISC: extension {{.*}}.Moptional : Swift.Escapable where Wrapped : Swift.Escapable, Wrapped : ~Copyable {
 
 // CHECK-MISC-NOT:  ~
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -145,7 +145,7 @@ extension Burrito: Alias {} // expected-error {{conformance to 'Copyable' must b
 extension Burrito: Copyable & Edible & P {} // expected-warning {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
 
 struct Blah<T: ~Copyable>: ~Copyable {}
-extension Blah: P, Q, Copyable, R {} // expected-error {{generic struct 'Blah' required to be 'Copyable' but is marked with '~Copyable'}}
+extension Blah: P, Q, Copyable, R {} // expected-error{{must explicitly state whether 'T' is required to conform to 'Copyable' or not}} expected-error {{generic struct 'Blah' required to be 'Copyable' but is marked with '~Copyable'}}
 // expected-error@-1 {{conformance to 'Copyable' must be declared in a separate extension}}
 
 enum Hello<Gesture: ~Copyable>: ~Copyable {}

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -144,18 +144,18 @@ struct MyStruct<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
     var x: T
 }
 
-extension MyStruct: Copyable where T: Copyable {}
+extension MyStruct: Copyable where T: Copyable, T: ~Escapable {}
 
-extension MyStruct: Escapable where T: Escapable {}
+extension MyStruct: Escapable where T: Escapable, T: ~Copyable {}
 
 enum MyEnum<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
     case x(T)
     case knoll
 }
 
-extension MyEnum: Copyable where T: Copyable {}
+extension MyEnum: Copyable where T: Copyable, T: ~Escapable {}
 
-extension MyEnum: Escapable where T: Escapable {}
+extension MyEnum: Escapable where T: Escapable, T: ~Copyable {}
 
 enum Trivial {
     case a, b, c

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -20,9 +20,9 @@ public enum Nillable<Wrapped: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
   case some(Wrapped)
 }
 
-extension Nillable: Copyable where Wrapped: Copyable {}
+extension Nillable: Copyable where Wrapped: Copyable, Wrapped: ~Escapable {}
 
-extension Nillable: Escapable where Wrapped: Escapable {}
+extension Nillable: Escapable where Wrapped: Escapable, Wrapped: ~Copyable {}
 
 extension Nillable: Sendable where Wrapped: ~Copyable & ~Escapable & Sendable { }
 


### PR DESCRIPTION
As specified by the SE-0446 acceptance, extensions that declare a type's conditional `Copyable` or `Escapable` ability must reiterate explicitly all of the `Copyable` and/or `Escapable` requirements, whether required or not required (by e.g. `~Copyable`) that were suppressed in the original type declaration.