### PR TITLE
[Distributed] Fix IRGen accessor emitting for distributed properties with protocols

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4567,8 +4567,6 @@ void ASTMangler::appendDistributedThunk(
                                                        false);
   // TODO: add a flag to skip class/struct information from parameter types
 
-  BaseEntitySignature base(thunk);
-
   // Since computed property SILDeclRef's refer to the "originator"
   // of the thunk, we need to mangle distributed thunks of accessors
   // specially.
@@ -4590,6 +4588,8 @@ void ASTMangler::appendDistributedThunk(
     thunk = storage->getDistributedThunk();
     assert(thunk);
   }
+
+  BaseEntitySignature base(thunk);
   assert(isa<AbstractFunctionDecl>(thunk) &&
          "distributed thunk to mangle must be function decl");
   assert(thunk->getContextKind() == DeclContextKind::AbstractFunctionDecl);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -985,6 +985,16 @@ namespace {
 
       {
         auto *requirement = cast<AbstractFunctionDecl>(func.getDecl());
+        // Check if it's a computed property accessor with a distributed thunk
+        if (auto *accessor = dyn_cast<AccessorDecl>(requirement)) {
+          auto *storage = accessor->getStorage();
+          if (auto *distributedThunk = storage->getDistributedThunk()) {
+            // This is an accessor with a distributed thunk, use the
+            // thunk when emitting distributed target accessor
+            requirement = distributedThunk;
+          }
+        }
+
         if (requirement->isDistributedThunk()) {
           // when thunk, because in protocol we want access of for the thunk
           IGM.emitDistributedTargetAccessor(requirement);

--- a/test/Distributed/Runtime/distributed_resolvable_protocol_computed_property.swift
+++ b/test/Distributed/Runtime/distributed_resolvable_protocol_computed_property.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir
+// RUN: %target-build-swift -module-name main  -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import FakeDistributedActorSystems
+import Distributed
+
+@Resolvable
+protocol EchoProtocol: DistributedActor, Codable where ActorSystem == FakeRoundtripActorSystem {
+  distributed func echo(_ val: Int) -> Int
+  distributed var number: Int { get }
+}
+
+distributed actor EchoActor: EchoProtocol {
+  typealias ActorSystem = FakeRoundtripActorSystem
+
+  distributed func echo(_ val: Int) -> Int {
+    print("\(#function): \(val)")
+    return val
+  }
+
+  distributed var number: Int {
+    13
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let system = FakeRoundtripActorSystem()
+
+    let echo = EchoActor(actorSystem: system)
+    let echoStub: any EchoProtocol = try $EchoProtocol.resolve(id: echo.id, using: system)
+
+    let echoed = try await echoStub.echo(2)
+    print("Echoed number = \(echoed)") // CHECK: Echoed number = 2
+
+    // This used to fail because IRGen wrongly would miss to emit an accessor for the distributed property
+    let number = try await echoStub.number
+    print("Number = \(number)") // CHECK: Number = 13
+  }
+}


### PR DESCRIPTION
Previously we'd miss emitting an accessor for it causing failure to lookup accessor for distributed computed properties when used through protocol like this.

resolves rdar://142761605
