### PR TITLE
[cxx-interop] Support transforming lifetimebound spans

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -7,7 +7,7 @@ import SwiftSyntaxMacros
 // avoids depending on SwiftifyImport.swift
 // all instances are reparsed and reinstantiated by the macro anyways,
 // so linking is irrelevant
-enum SwiftifyExpr {
+enum SwiftifyExpr: Hashable {
   case param(_ index: Int)
   case `return`
 }
@@ -21,11 +21,21 @@ extension SwiftifyExpr: CustomStringConvertible {
   }
 }
 
+enum DependenceType {
+  case borrow, copy
+}
+
+struct LifetimeDependence {
+  let dependsOn: Int
+  let type: DependenceType
+}
+
 protocol ParamInfo: CustomStringConvertible {
   var description: String { get }
   var original: SyntaxProtocol { get }
   var pointerIndex: SwiftifyExpr { get }
   var nonescaping: Bool { get set }
+  var dependencies: [LifetimeDependence] { get set }
 
   func getBoundsCheckedThunkBuilder(
     _ base: BoundsCheckedThunkBuilder, _ funcDecl: FunctionDeclSyntax,
@@ -55,8 +65,9 @@ func getSwiftifyExprType(_ funcDecl: FunctionDeclSyntax, _ expr: SwiftifyExpr) -
 struct CxxSpan: ParamInfo {
   var pointerIndex: SwiftifyExpr
   var nonescaping: Bool
-  var original: SyntaxProtocol
+  var dependencies: [LifetimeDependence]
   var typeMappings: [String: String]
+  var original: SyntaxProtocol
 
   var description: String {
     return "std::span(pointer: \(pointerIndex), nonescaping: \(nonescaping))"
@@ -71,9 +82,8 @@ struct CxxSpan: ParamInfo {
       return CxxSpanThunkBuilder(base: base, index: i - 1, signature: funcDecl.signature,
         typeMappings: typeMappings, node: original, nonescaping: nonescaping)
     case .return:
-      // TODO: actually implement std::span in return position
-      return CxxSpanThunkBuilder(base: base, index: -1, signature: funcDecl.signature,
-        typeMappings: typeMappings, node: original, nonescaping: nonescaping)
+      return CxxSpanReturnThunkBuilder(base: base, signature: funcDecl.signature,
+        typeMappings: typeMappings, node: original)
     }
   }
 }
@@ -83,6 +93,7 @@ struct CountedBy: ParamInfo {
   var count: ExprSyntax
   var sizedBy: Bool
   var nonescaping: Bool
+  var dependencies: [LifetimeDependence]
   var original: SyntaxProtocol
 
   var description: String {
@@ -156,6 +167,8 @@ func getTypeName(_ type: TypeSyntax) throws -> TokenSyntax {
     return memberType.name
   case .identifierType:
     return type.as(IdentifierTypeSyntax.self)!.name
+  case .attributedType:
+    return try getTypeName(type.as(AttributedTypeSyntax.self)!.baseType)
   default:
     throw DiagnosticError("expected pointer type, got \(type) with kind \(type.kind)", node: type)
   }
@@ -167,6 +180,13 @@ func replaceTypeName(_ type: TypeSyntax, _ name: TokenSyntax) -> TypeSyntax {
   }
   let idType = type.as(IdentifierTypeSyntax.self)!
   return TypeSyntax(idType.with(\.name, name))
+}
+
+func replaceBaseType(_ type: TypeSyntax, _ base: TypeSyntax) -> TypeSyntax {
+  if let attributedType = type.as(AttributedTypeSyntax.self) {
+    return TypeSyntax(attributedType.with(\.baseType, base))
+  }
+  return base
 }
 
 func getPointerMutability(text: String) -> Mutability? {
@@ -352,7 +372,7 @@ struct CxxSpanThunkBuilder: ParamPointerBoundsThunkBuilder {
     let parsedDesugaredType = TypeSyntax("\(raw: getUnqualifiedStdName(desugaredType)!)")
     let genericArg = TypeSyntax(parsedDesugaredType.as(IdentifierTypeSyntax.self)!
       .genericArgumentClause!.arguments.first!.argument)!
-    types[index] = TypeSyntax("Span<\(raw: try getTypeName(genericArg).text)>")
+    types[index] = replaceBaseType(param.type, TypeSyntax("Span<\(raw: try getTypeName(genericArg).text)>"))
     return try base.buildFunctionSignature(types, returnType)
   }
 
@@ -362,6 +382,38 @@ struct CxxSpanThunkBuilder: ParamPointerBoundsThunkBuilder {
     assert(args[index] == nil)
     args[index] = ExprSyntax("\(raw: typeName)(\(raw: name))")
     return try base.buildFunctionCall(args)
+  }
+}
+
+struct CxxSpanReturnThunkBuilder: BoundsCheckedThunkBuilder {
+  public let base: BoundsCheckedThunkBuilder
+  public let signature: FunctionSignatureSyntax
+  public let typeMappings: [String: String]
+  public let node: SyntaxProtocol
+
+  func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
+    return []
+  }
+
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
+    -> FunctionSignatureSyntax {
+    assert(returnType == nil)
+    let typeName = try getTypeName(signature.returnClause!.type).text
+    guard let desugaredType = typeMappings[typeName] else {
+      throw DiagnosticError(
+        "unable to desugar type with name '\(typeName)'", node: node)
+    }
+    let parsedDesugaredType = TypeSyntax("\(raw: getUnqualifiedStdName(desugaredType)!)")
+    let genericArg = TypeSyntax(parsedDesugaredType.as(IdentifierTypeSyntax.self)!
+      .genericArgumentClause!.arguments.first!.argument)!
+    let newType = replaceBaseType(signature.returnClause!.type,
+      TypeSyntax("Span<\(raw: try getTypeName(genericArg).text)>"))
+    return try base.buildFunctionSignature(argTypes, newType)
+  }
+
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
+    let call = try base.buildFunctionCall(pointerArgs)
+    return "Span(_unsafeCxxSpan: \(call))"
   }
 }
 
@@ -723,7 +775,7 @@ public struct SwiftifyImportMacro: PeerMacro {
     }
     return CountedBy(
       pointerIndex: pointerExpr, count: unwrappedCountExpr, sizedBy: false,
-      nonescaping: false, original: ExprSyntax(enumConstructorExpr))
+      nonescaping: false, dependencies: [], original: ExprSyntax(enumConstructorExpr))
   }
 
   static func parseSizedByEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> ParamInfo {
@@ -738,7 +790,7 @@ public struct SwiftifyImportMacro: PeerMacro {
     let unwrappedCountExpr = ExprSyntax(stringLiteral: sizeExprStringLit.representedLiteralValue!)
     return CountedBy(
       pointerIndex: pointerExpr, count: unwrappedCountExpr, sizedBy: true, nonescaping: false,
-      original: ExprSyntax(enumConstructorExpr))
+      dependencies: [], original: ExprSyntax(enumConstructorExpr))
   }
 
   static func parseEndedByEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> ParamInfo {
@@ -756,6 +808,24 @@ public struct SwiftifyImportMacro: PeerMacro {
     let pointerExpr: SwiftifyExpr = try parseSwiftifyExpr(pointerExprArg)
     let pointerParamIndex: Int = paramOrReturnIndex(pointerExpr)
     return pointerParamIndex
+  }
+
+  static func parseLifetimeDependence(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> (SwiftifyExpr, LifetimeDependence) {
+    let argumentList = enumConstructorExpr.arguments
+    let pointer: SwiftifyExpr = try parseSwiftifyExpr(try getArgumentByName(argumentList, "pointer"))
+    let dependsOn: Int = try getIntLiteralValue(try getArgumentByName(argumentList, "dependsOn"))
+    let type = try getArgumentByName(argumentList, "type") 
+    let depType: DependenceType
+    switch try parseEnumName(type) {
+      case "borrow":
+        depType = DependenceType.borrow
+      case "copy":
+        depType = DependenceType.copy
+      default:
+        throw DiagnosticError("expected '.copy' or '.borrow', got '\(type)'", node: type)
+    }
+    let dependence = LifetimeDependence(dependsOn: dependsOn, type: depType)
+    return (pointer, dependence)
   }
 
   static func parseTypeMappingParam(_ paramAST: LabeledExprSyntax?) throws -> [String: String]? {
@@ -786,7 +856,7 @@ public struct SwiftifyImportMacro: PeerMacro {
     return dict
   }
 
-  static func parseCxxSpanParams(
+  static func parseCxxSpansInSignature(
     _ signature: FunctionSignatureSyntax,
     _ typeMappings: [String: String]?
   ) throws -> [ParamInfo] {
@@ -794,23 +864,30 @@ public struct SwiftifyImportMacro: PeerMacro {
       return []
     }
     var result : [ParamInfo] = []
-    for (idx, param) in signature.parameterClause.parameters.enumerated() {
-      let typeName = try getTypeName(param.type).text;
+    let process = { type, expr, orig in
+      let typeName = try getTypeName(type).text;
       if let desugaredType = typeMappings[typeName] {
         if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
           if unqualifiedDesugaredType.starts(with: "span<") {
-            result.append(CxxSpan(pointerIndex: .param(idx + 1), nonescaping: false,
-              original: param, typeMappings: typeMappings))
+            result.append(CxxSpan(pointerIndex: expr, nonescaping: false,
+              dependencies: [], typeMappings: typeMappings, original: orig))
           }
         }
       }
+    }
+    for (idx, param) in signature.parameterClause.parameters.enumerated() {
+      try process(param.type, .param(idx + 1), param)
+    }
+    if let retClause = signature.returnClause {
+      try process(retClause.type, .`return`, retClause)
     }
     return result
   }
 
   static func parseMacroParam(
     _ paramAST: LabeledExprSyntax, _ signature: FunctionSignatureSyntax,
-    nonescapingPointers: inout Set<Int>
+    nonescapingPointers: inout Set<Int>,
+    lifetimeDependencies: inout [SwiftifyExpr: [LifetimeDependence]]
   ) throws -> ParamInfo? {
     let paramExpr = paramAST.expression
     guard let enumConstructorExpr = paramExpr.as(FunctionCallExprSyntax.self) else {
@@ -826,9 +903,23 @@ public struct SwiftifyImportMacro: PeerMacro {
       let index = try parseNonEscaping(enumConstructorExpr)
       nonescapingPointers.insert(index)
       return nil
+    case "lifetimeDependence":
+      let (expr, dependence) = try parseLifetimeDependence(enumConstructorExpr)
+      lifetimeDependencies[expr, default: []].append(dependence)
+      // We assume pointers annotated with lifetimebound do not escape.
+      if dependence.type == DependenceType.copy {
+        nonescapingPointers.insert(dependence.dependsOn)
+      }
+      // The escaping is controlled when a parameter is the target of a lifetimebound.
+      // So we want to do the transformation to Swift's Span.
+      let idx = paramOrReturnIndex(expr)
+      if idx != -1 {
+        nonescapingPointers.insert(idx)
+      }
+      return nil
     default:
       throw DiagnosticError(
-        "expected 'countedBy', 'sizedBy', 'endedBy' or 'nonescaping', got '\(enumName)'",
+        "expected 'countedBy', 'sizedBy', 'endedBy', 'nonescaping' or 'lifetimeDependence', got '\(enumName)'",
         node: enumConstructorExpr)
     }
   }
@@ -898,9 +989,46 @@ public struct SwiftifyImportMacro: PeerMacro {
   }
 
   static func setNonescapingPointers(_ args: inout [ParamInfo], _ nonescapingPointers: Set<Int>) {
+    if args.isEmpty {
+      return
+    }
     for i in 0...args.count - 1 where nonescapingPointers.contains(paramOrReturnIndex(args[i].pointerIndex)) {
       args[i].nonescaping = true
     }
+  }
+
+  static func setLifetimeDependencies(_ args: inout [ParamInfo], _ lifetimeDependencies: [SwiftifyExpr: [LifetimeDependence]]) {
+    if args.isEmpty {
+      return
+    }
+    for i in 0...args.count - 1 where lifetimeDependencies.keys.contains(args[i].pointerIndex) {
+      args[i].dependencies = lifetimeDependencies[args[i].pointerIndex]!
+    }
+  }
+
+  static func lifetimeAttributes(_ funcDecl: FunctionDeclSyntax,
+    _ dependencies: [SwiftifyExpr: [LifetimeDependence]]) -> [AttributeListSyntax.Element] {
+    let returnDependencies = dependencies[.`return`, default: []]
+    if returnDependencies.isEmpty {
+      return []
+    }
+    var args : [LabeledExprSyntax] = []
+    for dependence in returnDependencies {
+      if (dependence.type == .borrow) {
+        args.append(LabeledExprSyntax(expression: 
+          DeclReferenceExprSyntax(baseName: TokenSyntax("borrow"))))
+      }
+      args.append(LabeledExprSyntax(expression: 
+        DeclReferenceExprSyntax(baseName: TokenSyntax(tryGetParamName(funcDecl, .param(dependence.dependsOn)))!),
+        trailingComma: .commaToken()))
+    }
+    args[args.count - 1] = args[args.count - 1].with(\.trailingComma, nil)
+    return [.attribute(AttributeSyntax(
+              atSign: .atSignToken(),
+              attributeName: IdentifierTypeSyntax(name: "lifetime"),
+              leftParen: .leftParenToken(),
+              arguments: .argumentList(LabeledExprListSyntax(args)),
+              rightParen: .rightParenToken()))]
   }
 
   public static func expansion(
@@ -920,13 +1048,21 @@ public struct SwiftifyImportMacro: PeerMacro {
         arguments = arguments.dropLast()
       }
       var nonescapingPointers = Set<Int>()
+      var lifetimeDependencies : [SwiftifyExpr: [LifetimeDependence]] = [:]
       var parsedArgs = try arguments.compactMap {
-        try parseMacroParam($0, funcDecl.signature, nonescapingPointers: &nonescapingPointers)
+        try parseMacroParam($0, funcDecl.signature, nonescapingPointers: &nonescapingPointers,
+          lifetimeDependencies: &lifetimeDependencies)
       }
-      parsedArgs.append(contentsOf: try parseCxxSpanParams(funcDecl.signature, typeMappings))
+      parsedArgs.append(contentsOf: try parseCxxSpansInSignature(funcDecl.signature, typeMappings))
       setNonescapingPointers(&parsedArgs, nonescapingPointers)
+      setLifetimeDependencies(&parsedArgs, lifetimeDependencies)
+      // We only transform non-escaping spans.
       parsedArgs = parsedArgs.filter {
-        !($0 is CxxSpan) || ($0 as! CxxSpan).nonescaping
+        if let cxxSpanArg = $0 as? CxxSpan {
+          return cxxSpanArg.nonescaping || cxxSpanArg.pointerIndex == .return
+        } else {
+          return true
+        }
       }
       try checkArgs(parsedArgs, funcDecl)
       let baseBuilder = FunctionCallBuilder(funcDecl)
@@ -951,6 +1087,7 @@ public struct SwiftifyImportMacro: PeerMacro {
             returnKeyword: .keyword(.return, trailingTrivia: " "),
             expression: try builder.buildFunctionCall([:]))))
       let body = CodeBlockSyntax(statements: CodeBlockItemListSyntax(checks + [call]))
+      let lifetimeAttrs = lifetimeAttributes(funcDecl, lifetimeDependencies)
       let newFunc =
         funcDecl
         .with(\.signature, newSignature)
@@ -970,7 +1107,8 @@ public struct SwiftifyImportMacro: PeerMacro {
               AttributeSyntax(
                 atSign: .atSignToken(),
                 attributeName: IdentifierTypeSyntax(name: "_alwaysEmitIntoClient")))
-          ])
+          ]
+          + lifetimeAttrs)
       return [DeclSyntax(newFunc)]
     } catch let error as DiagnosticError {
       context.diagnose(

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -2,6 +2,11 @@ public enum _SwiftifyExpr {
     case param(_ index: Int)
     case `return`
 }
+
+public enum _DependenceType {
+    case borrow
+    case copy
+}
 /// Different ways to annotate pointer parameters using the `@_SwiftifyImport` macro.
 /// All indices into parameter lists start at 1. Indices __must__ be integer literals, and strings
 /// __must__ be string literals, because their contents are parsed by the `@_SwiftifyImport` macro.
@@ -34,6 +39,9 @@ public enum _SwiftifyInfo {
     /// object past the lifetime of the function.
     /// Parameter pointer: index of pointer in function parameter list.
     case nonescaping(pointer: _SwiftifyExpr)
+    /// Can express lifetime dependencies between inputs and outputs of a function.
+    /// 'dependsOn' is the input on which the output 'pointer' depends.
+    case lifetimeDependence(dependsOn: Int, pointer: _SwiftifyExpr, type: _DependenceType)
 }
 
 /// Generates a safe wrapper for function with Unsafe[Mutable][Raw]Pointer[?] or std::span arguments.

--- a/test/Macros/SwiftifyImport/CxxSpan/Inputs/module.modulemap
+++ b/test/Macros/SwiftifyImport/CxxSpan/Inputs/module.modulemap
@@ -1,0 +1,5 @@
+module StdSpan {
+  header "std-span.h"
+  requires cplusplus
+  export *
+}

--- a/test/Macros/SwiftifyImport/CxxSpan/Inputs/std-span.h
+++ b/test/Macros/SwiftifyImport/CxxSpan/Inputs/std-span.h
@@ -1,0 +1,5 @@
+#pragma  once
+
+#include <span>
+
+using SpanOfInt = std::span<const int>;

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -1,0 +1,50 @@
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_Span
+// REQUIRES: swift_feature_LifetimeDependence
+
+// RUN: %target-swift-frontend %s -enable-experimental-cxx-interop -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature Span -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+
+// FIXME swift-ci linux tests do not support std::span
+// UNSUPPORTED: OS=linux-gnu
+
+import CxxStdlib
+import StdSpan
+
+public struct VecOfInt {}
+
+@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+func myFunc(_ span: SpanOfInt) -> SpanOfInt {
+}
+
+@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+func myFunc2(_ vec: borrowing VecOfInt) -> SpanOfInt {
+}
+
+@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .copy), .lifetimeDependence(dependsOn: 2, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+func myFunc3(_ span1: SpanOfInt, _ span2: SpanOfInt) -> SpanOfInt {
+}
+
+@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: 2, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
+}
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(span)
+// CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
+// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc(SpanOfInt(span)))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec)
+// CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
+// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc2(vec))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(span1, span2)
+// CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
+// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2)))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, span)
+// CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
+// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span)))
+// CHECK-NEXT: }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -809,9 +809,24 @@ Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
+Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABSi_s01_A4ExprOs01_D4TypeOtcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON
+// _DependenceType for _SwiftifyImports macro
+Added: _$ss15_DependenceTypeO2eeoiySbAB_ABtFZ
+Added: _$ss15_DependenceTypeO4copyyA2BmFWC
+Added: _$ss15_DependenceTypeO4hash4intoys6HasherVz_tF
+Added: _$ss15_DependenceTypeO6borrowyA2BmFWC
+Added: _$ss15_DependenceTypeO9hashValueSivg
+Added: _$ss15_DependenceTypeO9hashValueSivpMV
+Added: _$ss15_DependenceTypeOMa
+Added: _$ss15_DependenceTypeOMn
+Added: _$ss15_DependenceTypeON
+Added: _$ss15_DependenceTypeOSHsMc
+Added: _$ss15_DependenceTypeOSHsWP
+Added: _$ss15_DependenceTypeOSQsMc
+Added: _$ss15_DependenceTypeOSQsWP
 
 // Eager-lazy Array bridging
 Added: _$ss12_ArrayBufferV14associationKeySVvpZMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -810,9 +810,24 @@ Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
+Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABSi_s01_A4ExprOs01_D4TypeOtcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON
+// _DependenceType for _SwiftifyImports macro
+Added: _$ss15_DependenceTypeO2eeoiySbAB_ABtFZ
+Added: _$ss15_DependenceTypeO4copyyA2BmFWC
+Added: _$ss15_DependenceTypeO4hash4intoys6HasherVz_tF
+Added: _$ss15_DependenceTypeO6borrowyA2BmFWC
+Added: _$ss15_DependenceTypeO9hashValueSivg
+Added: _$ss15_DependenceTypeO9hashValueSivpMV
+Added: _$ss15_DependenceTypeOMa
+Added: _$ss15_DependenceTypeOMn
+Added: _$ss15_DependenceTypeON
+Added: _$ss15_DependenceTypeOSHsMc
+Added: _$ss15_DependenceTypeOSHsWP
+Added: _$ss15_DependenceTypeOSQsMc
+Added: _$ss15_DependenceTypeOSQsWP
 
 // Eager-lazy Array bridging
 Added: _$ss12_ArrayBufferV14associationKeySVvpZMV

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -824,4 +824,5 @@ Struct String.Index has added a conformance to an existing protocol CustomDebugS
 
 Enum _SwiftifyInfo is a new API without @available attribute
 Enum _SwiftifyExpr is a new API without @available attribute
+Enum _DependenceType is a new API without @available attribute
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
This PR adds basic support for storing lifetime dependence information, transform Span return types, and generate lifetime annotations.

rdar://139074571
