### PR TITLE
runtime: sprinkle some linker pragmas to autolink

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -19,6 +19,8 @@
 #define NOMINMAX
 #include <windows.h>
 
+#pragma comment(lib, "User32.Lib")
+
 #include <mutex>
 #endif
 

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -21,6 +21,8 @@
 #define NOMINMAX
 #include <Windows.h>
 #include <DbgHelp.h>
+
+#pragma comment(lib, "DbgHelp.Lib")
 #endif
 
 #include "swift/Runtime/Win32.h"

--- a/stdlib/public/runtime/SymbolInfo.cpp
+++ b/stdlib/public/runtime/SymbolInfo.cpp
@@ -18,6 +18,9 @@
 #include <Windows.h>
 #include <DbgHelp.h>
 #include <psapi.h>
+
+#pragma comment(lib, "DbgHelp.Lib")
+
 #elif SWIFT_STDLIB_HAS_DLADDR
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
This prepares the runtime to be closed with its dependencies when performing static linking. The pragma ensures that the linker will automatically pick up the dependent libraries avoiding the need to explicitly add the dependencies.