### PR TITLE
Threading: add a linker directive for Windows autolinking

### DIFF
--- a/lib/Threading/Win32.cpp
+++ b/lib/Threading/Win32.cpp
@@ -20,6 +20,8 @@
 #define NOMINMAX
 #include <windows.h>
 
+#pragma comment(lib, "synchronization.lib")
+
 #include "swift/Threading/Errors.h"
 #include "swift/Threading/Impl.h"
 


### PR DESCRIPTION
This library is pulled into the standard library. Add autolinking directives to enable the use of the library with static linking without specifying the system dependencies. This is required to enable the user to use `-static-stdlib` without having to specify all dependencies.