### PR TITLE
Basic: fix a small corner case for ODR violations

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -34,10 +34,10 @@
 
 // Don't pre-declare certain LLVM types in the runtime, which must
 // not put things in namespace llvm for ODR reasons.
-#if !defined(swiftCore_EXPORTS)
-#define SWIFT_LLVM_ODR_SAFE 1
-#else
+#if defined(SWIFT_RUNTIME)
 #define SWIFT_LLVM_ODR_SAFE 0
+#else
+#define SWIFT_LLVM_ODR_SAFE 1
 #endif
 
 // Forward declarations.

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1983,7 +1983,7 @@ private:
     std::set<std::pair<const TypeRef *, const MetadataSource *>> Done;
     GenericArgumentMap Subs;
 
-    ArrayRef<const TypeRef *> CaptureTypes = Info.CaptureTypes;
+    llvm::ArrayRef<const TypeRef *> CaptureTypes = Info.CaptureTypes;
 
     // Closure context element layout depends on the layout of the
     // captured types, but captured types might depend on element


### PR DESCRIPTION
When building the runtime we define `SWIFT_RUNTIME`. `swiftCore_EXPORTS` is only defined when building swiftCore as a shared library. This would thus allow the ODR violations to appear in a static library form of the standard library. This was uncovered with the new runtime build system.