### PR TITLE
Fix LifetimeDependenceDiagnostics for @out dependencies

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -197,7 +197,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
   }
 
   var description: String {
-    return "full-assign: \(_isFullyAssigned == nil ? "unknown" : String(describing: _isFullyAssigned!)) "
+    return "full-assign: \(_isFullyAssigned == nil ? "unknown" : String(describing: _isFullyAssigned!)), "
       + "\(access)"
   }
 
@@ -205,12 +205,10 @@ class LocalVariableAccessInfo: CustomStringConvertible {
   // assignment. This should match any instructions that the LocalVariableAccessMap initializer below recognizes as an
   // allocation.
   static private func isBase(address: Value) -> Bool {
-    switch address {
-    case is AllocBoxInst, is AllocStackInst, is BeginAccessInst:
-      return true
-    default:
-      return false
-    }
+    // TODO: create an API alternative to 'accessPath' that bails out on the first path component and succeeds on the
+    // first begin_access.
+    let path = address.accessPath
+    return path.base.isLocal && path.projectionPath.isEmpty
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -43,6 +43,7 @@ struct LocalVariableAccess: CustomStringConvertible {
     case inoutYield       // indirect yield from this accessor
     case beginAccess // Reading or reassigning a 'var'
     case load        // Reading a 'let'. Returning 'var' from an initializer.
+    case dependence  // A mark_dependence after an apply with an indirect result. No effect.
     case store       // 'var' initialization and destruction
     case apply       // indirect arguments
     case escape      // alloc_box captures
@@ -76,7 +77,7 @@ struct LocalVariableAccess: CustomStringConvertible {
       case .`init`, .modify:
         return true
       }
-    case .load:
+    case .load, .dependence:
       return false
     case .incomingArgument, .outgoingArgument, .store, .inoutYield:
       return true
@@ -115,6 +116,8 @@ struct LocalVariableAccess: CustomStringConvertible {
       str += "beginAccess"
     case .load:
       str += "load"
+    case .dependence:
+      str += "dependence"
     case .store:
       str += "store"
     case .apply:
@@ -149,7 +152,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
       case .`init`, .modify:
         break // lazily compute full assignment
       }
-    case .load:
+    case .load, .dependence:
       self._isFullyAssigned = false
     case .store:
       if let store = localAccess.instruction as? StoringInstruction {
@@ -375,6 +378,10 @@ extension LocalVariableAccessWalker : ForwardingDefUseWalker {
 extension LocalVariableAccessWalker: AddressUseVisitor {
   private mutating func walkDownAddressUses(address: Value) -> WalkResult {
     for operand in address.uses.ignoreTypeDependence {
+      if let md = operand.instruction as? MarkDependenceInst, operand == md.valueOperand {
+        // Record the forwarding mark_dependence as a fake access before continuing to walk down.
+        visit(LocalVariableAccess(.dependence, operand))
+      }
       if classifyAddress(operand: operand) == .abortWalk {
         return .abortWalk
       }

--- a/test/ModuleInterface/Inputs/lifetime_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_dependence.swift
@@ -1,3 +1,21 @@
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(borrow source)
+internal func _overrideLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  _ dependent: consuming T, borrowing source: borrowing U) -> T {
+  dependent
+}
+
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(source)
+internal func _overrideLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  _ dependent: consuming T, copying source: borrowing U) -> T {
+  dependent
+}
+
 public struct AnotherView : ~Escapable {
   @usableFromInline let _ptr: UnsafeRawBufferPointer
   @usableFromInline let _count: Int
@@ -21,19 +39,23 @@ public struct BufferView : ~Escapable {
   @inlinable
   @lifetime(borrow a)
   internal init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
-    self.init(ptr, a.count)
+    let bv = BufferView(ptr, a.count)
+    self = _overrideLifetime(bv, borrowing: a)
   }
   @inlinable
   @lifetime(a)
   internal init(_ ptr: UnsafeRawBufferPointer, _ a: consuming AnotherView) {
-    self.init(ptr, a._count)
+    let bv = BufferView(ptr, a._count)
+    self = _overrideLifetime(bv, copying: a)
   }
 }
 
 @inlinable
 @lifetime(x)
 public func derive(_ x: consuming BufferView) -> BufferView {
-  return BufferView(x._ptr, x._count)
+  let pointer = x._ptr
+  let bv = BufferView(pointer, x._count)
+  return _overrideLifetime(bv, copying: x)
 }
 
 @inlinable
@@ -42,7 +64,9 @@ public func use(_ x: consuming BufferView) {}
 @inlinable
 @lifetime(view)
 public func consumeAndCreate(_ view: consuming BufferView) -> BufferView {
-  return BufferView(view._ptr, view._count)
+  let pointer = view._ptr
+  let bv = BufferView(pointer, view._count)
+  return _overrideLifetime(bv, copying: view)
 }
 
 @inlinable
@@ -52,14 +76,6 @@ public func deriveThisOrThat(_ this: consuming BufferView, _ that: consuming Buf
     return BufferView(this._ptr, this._count)
   }
   return BufferView(that._ptr, that._count)
-}
-
-@_unsafeNonescapableResult
-@_transparent
-@lifetime(borrow source)
-internal func _overrideLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
-  _ dependent: consuming T, borrowing source: borrowing U) -> T {
-  dependent
 }
 
 public struct Container {

--- a/test/SILOptimizer/lifetime_dependence/scopefixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scopefixup.sil
@@ -85,7 +85,7 @@ bb2:
 sil @pointeeAddressor : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
 
 // Test dependence on a loaded trivial value. The dependence scope should not be on the access scope, which is narrower
-// than the scoped of the loaded value.
+// than the scope of the loaded value.
 //
 // CHECK-LABEL: sil hidden [ossa] @testTrivialAccess : $@convention(thin) (UnsafePointer<Int64>) -> () {
 // CHECK: bb0(%0 : $UnsafePointer<Int64>):


### PR DESCRIPTION
Record a forwarding mark_dependence as a local access. This is necessary because
we now emit a mark_dependence for @out arguments, which will be the starting
point for diagnostics:

    %out = alloc_stack
    apply %f(%owned, %out) : $(Owner) -> @Lifetime(borrow 0) @out View
    %unused = mark_dependence [unresolved] %out on %owner
    %dependentValue = load %out

This mark_dependence has no uses. Instead, it simply records the dependency of
the in-memory value on the owner. Consequently, simply walking the uses of
LifetimeDependence.dependentValue does fails to diagnose any escapes. Instead,
if the dependentValue is an address-type mark_dependence, treat it as a local
access to the address that it forwards. Then we find any reachable uses of that
local variable as a potential escape.

Fixes rdar://143040479 (Borrow diagnostics not triggered for @out return values)