### PR TITLE
Driver: extend `-print-target-info` with additional components

### DIFF
--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -129,6 +129,9 @@ void targetinfo::printTripleInfo(
   writeEscaped(getTargetSpecificModuleTriple(triple).getTriple(), out);
   out << "\",\n";
 
+  out << "    \"platform\": \"" << getPlatformNameForTriple(triple) << "\",\n";
+  out << "    \"arch\": \"" << swift::getMajorArchitectureName(triple) << "\",\n";
+
   if (runtimeVersion) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";
     writeEscaped(runtimeVersion->getAsString(), out);

--- a/test/Driver/print-target-info-extended.swift
+++ b/test/Driver/print-target-info-extended.swift
@@ -1,0 +1,15 @@
+// RUN: %swift_driver_plain -target aarch64-unknown-windows-msvc -print-target-info | %FileCheck -check-prefix CHECK-windows -check-prefix CHECK-aarch64 %s
+// RUN: %target-swift-frontend -print-target-info | %FileCheck -check-prefix CHECK-%target-sdk-name -check-prefix CHECK-%target-arch %s
+
+// CHECK-android: "platform": "android",
+// CHECK-cygwin: "platform": "cgywin",
+// CHECK-embedded: "platform": "embedded",
+// CHECK-freebsd: "platform": "freebsd",
+// CHECK-linux: "platform": "linux",
+// CHECK-mingw: "platform": "mingw",
+// CHECK-openbsd: "platform": "openbsd",
+// CHECK-wasi: "platform": "wasi",
+// CHECK-windows: "platform": "windows",
+
+// CHECK-aarch64: "arch": "aarch64"
+// CHECK-x86_64: "arch": "x86_64"


### PR DESCRIPTION
Render the platform and architecture directories that the target uses to allow computation of paths for installation.