### PR TITLE
[6.1] Sema: Ensure access-level on imports only applies to visible imported decls

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4623,7 +4623,11 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   if (localImportRestriction.has_value()) {
     AccessLevel importAccessLevel =
       localImportRestriction.value().accessLevel;
-    if (access > importAccessLevel) {
+    auto isVisible = access >= AccessLevel::Public ||
+      (access == AccessLevel::Package &&
+       useDC->getParentModule()->inSamePackage(resultDC->getParentModule()));
+
+    if (access > importAccessLevel && isVisible) {
       access = std::min(access, importAccessLevel);
       resultDC = useDC->getParentSourceFile();
     }

--- a/test/Sema/access-level-import-downgrades.swift
+++ b/test/Sema/access-level-import-downgrades.swift
@@ -1,0 +1,156 @@
+/// Ensure we only bump down the access-level of imported decls, not up.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build libraries
+// RUN: %target-swift-frontend -emit-module %t/ImportedPrivate.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -package-name pkg \
+// RUN:   -emit-module-path %t/ImportedPrivate.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/ImportedInternal.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -package-name pkg \
+// RUN:   -emit-module-path %t/ImportedInternal.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %t/ImportedPackage.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -package-name pkg \
+// RUN:   -emit-module-path %t/ImportedPackage.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %t/ImportedPublic.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -package-name pkg \
+// RUN:   -emit-module-path %t/ImportedPublic.swiftmodule -I %t
+
+/// Build clients
+// RUN: %target-swift-frontend -typecheck %t/InPackageClient.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -package-name pkg -verify
+// RUN: %target-swift-frontend -typecheck %t/OutOfPackageClient.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -verify
+
+//--- ImportedPrivate.swift
+
+private func privateFunc() {}
+internal func internalFunc() {}
+package func packageFunc() {}
+public func publicFunc() {}
+
+//--- ImportedInternal.swift
+
+private func privateFunc() {}
+internal func internalFunc() {}
+package func packageFunc() {}
+public func publicFunc() {}
+
+//--- ImportedPackage.swift
+
+private func privateFunc() {}
+internal func internalFunc() {}
+package func packageFunc() {}
+public func publicFunc() {}
+
+//--- ImportedPublic.swift
+
+private func privateFunc() {}
+internal func internalFunc() {}
+package func packageFunc() {}
+public func publicFunc() {}
+
+//--- InPackageClient.swift
+
+private import ImportedPrivate
+internal import ImportedInternal
+private import ImportedPackage
+public import ImportedPublic // expected-warning{{public import of 'ImportedPublic' was not used in public declarations or inlinable code}}
+
+ImportedPrivate.privateFunc() // expected-error {{module 'ImportedPrivate' has no member named 'privateFunc'}}
+ImportedPrivate.internalFunc() // expected-error {{module 'ImportedPrivate' has no member named 'internalFunc'}}
+ImportedPrivate.packageFunc()
+ImportedPrivate.publicFunc()
+
+ImportedInternal.privateFunc() // expected-error {{module 'ImportedInternal' has no member named 'privateFunc'}}
+ImportedInternal.internalFunc() // expected-error {{module 'ImportedInternal' has no member named 'internalFunc'}}
+ImportedInternal.packageFunc()
+ImportedInternal.publicFunc()
+
+ImportedPackage.privateFunc() // expected-error {{module 'ImportedPackage' has no member named 'privateFunc'}}
+ImportedPackage.internalFunc() // expected-error {{module 'ImportedPackage' has no member named 'internalFunc'}}
+ImportedPackage.packageFunc()
+ImportedPackage.publicFunc()
+
+ImportedPublic.privateFunc() // expected-error {{module 'ImportedPublic' has no member named 'privateFunc'}}
+ImportedPublic.internalFunc() // expected-error {{module 'ImportedPublic' has no member named 'internalFunc'}}
+ImportedPublic.packageFunc()
+ImportedPublic.publicFunc()
+
+func funcContext() {
+    ImportedPrivate.privateFunc() // expected-error {{module 'ImportedPrivate' has no member named 'privateFunc'}}
+    ImportedPrivate.internalFunc() // expected-error {{module 'ImportedPrivate' has no member named 'internalFunc'}}
+    ImportedPrivate.packageFunc()
+    ImportedPrivate.publicFunc()
+
+    ImportedInternal.privateFunc() // expected-error {{module 'ImportedInternal' has no member named 'privateFunc'}}
+    ImportedInternal.internalFunc() // expected-error {{module 'ImportedInternal' has no member named 'internalFunc'}}
+    ImportedInternal.packageFunc()
+    ImportedInternal.publicFunc()
+
+    ImportedPackage.privateFunc() // expected-error {{module 'ImportedPackage' has no member named 'privateFunc'}}
+    ImportedPackage.internalFunc() // expected-error {{module 'ImportedPackage' has no member named 'internalFunc'}}
+    ImportedPackage.packageFunc()
+    ImportedPackage.publicFunc()
+
+    ImportedPublic.privateFunc() // expected-error {{module 'ImportedPublic' has no member named 'privateFunc'}}
+    ImportedPublic.internalFunc() // expected-error {{module 'ImportedPublic' has no member named 'internalFunc'}}
+    ImportedPublic.packageFunc()
+    ImportedPublic.publicFunc()
+}
+
+//--- OutOfPackageClient.swift
+
+private import ImportedPrivate
+internal import ImportedInternal
+private import ImportedPackage
+public import ImportedPublic // expected-warning{{public import of 'ImportedPublic' was not used in public declarations or inlinable code}}
+
+ImportedPrivate.privateFunc() // expected-error {{module 'ImportedPrivate' has no member named 'privateFunc'}}
+ImportedPrivate.internalFunc() // expected-error {{module 'ImportedPrivate' has no member named 'internalFunc'}}
+ImportedPrivate.packageFunc() // expected-error {{module 'ImportedPrivate' has no member named 'packageFunc'}}
+ImportedPrivate.publicFunc()
+
+ImportedInternal.privateFunc() // expected-error {{module 'ImportedInternal' has no member named 'privateFunc'}}
+ImportedInternal.internalFunc() // expected-error {{module 'ImportedInternal' has no member named 'internalFunc'}}
+ImportedInternal.packageFunc() // expected-error {{module 'ImportedInternal' has no member named 'packageFunc'}}
+ImportedInternal.publicFunc()
+
+ImportedPackage.privateFunc() // expected-error {{module 'ImportedPackage' has no member named 'privateFunc'}}
+ImportedPackage.internalFunc() // expected-error {{module 'ImportedPackage' has no member named 'internalFunc'}}
+ImportedPackage.packageFunc() // expected-error {{module 'ImportedPackage' has no member named 'packageFunc'}}
+ImportedPackage.publicFunc()
+
+ImportedPublic.privateFunc() // expected-error {{module 'ImportedPublic' has no member named 'privateFunc'}}
+ImportedPublic.internalFunc() // expected-error {{module 'ImportedPublic' has no member named 'internalFunc'}}
+ImportedPublic.packageFunc() // expected-error {{module 'ImportedPublic' has no member named 'packageFunc'}}
+ImportedPublic.publicFunc()
+
+func funcContext() {
+    ImportedPrivate.privateFunc() // expected-error {{module 'ImportedPrivate' has no member named 'privateFunc'}}
+    ImportedPrivate.internalFunc() // expected-error {{module 'ImportedPrivate' has no member named 'internalFunc'}}
+    ImportedPrivate.packageFunc() // expected-error {{module 'ImportedPrivate' has no member named 'packageFunc'}}
+    ImportedPrivate.publicFunc()
+
+    ImportedInternal.privateFunc() // expected-error {{module 'ImportedInternal' has no member named 'privateFunc'}}
+    ImportedInternal.internalFunc() // expected-error {{module 'ImportedInternal' has no member named 'internalFunc'}}
+    ImportedInternal.packageFunc() // expected-error {{module 'ImportedInternal' has no member named 'packageFunc'}}
+    ImportedInternal.publicFunc()
+
+    ImportedPackage.privateFunc() // expected-error {{module 'ImportedPackage' has no member named 'privateFunc'}}
+    ImportedPackage.internalFunc() // expected-error {{module 'ImportedPackage' has no member named 'internalFunc'}}
+    ImportedPackage.packageFunc() // expected-error {{module 'ImportedPackage' has no member named 'packageFunc'}}
+    ImportedPackage.publicFunc()
+
+    ImportedPublic.privateFunc() // expected-error {{module 'ImportedPublic' has no member named 'privateFunc'}}
+    ImportedPublic.internalFunc() // expected-error {{module 'ImportedPublic' has no member named 'internalFunc'}}
+    ImportedPublic.packageFunc() // expected-error {{module 'ImportedPublic' has no member named 'packageFunc'}}
+    ImportedPublic.publicFunc()
+}

--- a/test/Sema/private-import-ambiguities.swift
+++ b/test/Sema/private-import-ambiguities.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build libraries
+// RUN: %target-swift-frontend -emit-module %t/LibShared.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/LibShared.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/LibWithPublicFoo.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/LibWithPublicFoo.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %t/LibWithInternalFoo.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/LibWithInternalFoo.swiftmodule -I %t
+
+/// Build client
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
+
+//--- LibShared.swift
+public struct Struct {
+    public init() {}
+}
+
+//--- LibWithPublicFoo.swift
+import LibShared
+
+extension Struct {
+    public func foo() {}
+}
+
+//--- LibWithInternalFoo.swift
+import LibShared
+
+extension Struct {
+    internal func foo() {}
+}
+
+//--- Client.swift
+import LibShared
+import LibWithPublicFoo
+private import LibWithInternalFoo
+
+var s = Struct()
+s.foo() // This is non-ambiguous


### PR DESCRIPTION
Access-level on imports are designed to downgrade the visibility of imported decls. Add a check to apply this logic only to decls that were originally visible: public and same-package decls. Otherwise a `private import` can allow a partial visibility into an imported internal decl.

- Risk: Low to medium, this is a sanity fix that may report new errors in existing sources, specifically declarations not found. I suspect most of these issues lead to different errors later on so they should be rare in practice.
- Scope: Affects source files using `private` and `internal` imports.
- Reviewed-by @tshortli 
- Cherry-pick of https://github.com/swiftlang/swift/pull/78703
- Resolves rdar://143142861