### PR TITLE
Runtimes: fix the install location for `-static`

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -325,9 +325,12 @@ elseif(NOT APPLE AND NOT LINUX AND NOT ANDROID AND UNIX)
   target_link_libraries(swiftCore PRIVATE "${EXECINFO_LIBRARY}")
 endif()
 
-install(TARGETS swiftCore)
+install(TARGETS swiftCore
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}/$<$<NOT:$<PLATFORM_ID:Darwin>>:swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}>"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/$<$<NOT:$<PLATFORM_ID:Darwin>>:swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}>"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Swift.swiftmodule"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/Swift.swiftmodule"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftCore_PLATFORM_SUBDIR}/Swift.swiftmodule"
   RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule")
 emit_swift_interface(swiftCore)
 install_swift_interface(swiftCore)


### PR DESCRIPTION
When building the static SDK, we need to adjust the install locations so that the driver search will find the proper swiftmodule and library. The changes here adjust the install to use `swift_static` when building statically.