### PR TITLE
Runtimes: extract platform and arch from the driver

### DIFF
--- a/Runtimes/Core/cmake/modules/PlatformInfo.cmake
+++ b/Runtimes/Core/cmake/modules/PlatformInfo.cmake
@@ -4,17 +4,35 @@ if(NOT SwiftCore_SIZEOF_POINTER)
   mark_as_advanced(SwiftCore_SIZEOF_POINTER)
 endif()
 
+# TODO: This logic should migrate to CMake once CMake supports installing swiftmodules
+set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+if(CMAKE_Swift_COMPILER_TARGET)
+  list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+endif()
+execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+message(CONFIGURE_LOG "Swift target info: ${module_triple_command}\n"
+"${target_info_json}")
+
 if(NOT SwiftCore_MODULE_TRIPLE)
-  # TODO: This logic should migrate to CMake once CMake supports installing swiftmodules
-  set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
-  if(CMAKE_Swift_COMPILER_TARGET)
-    list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
-  endif()
-  execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
-  message(CONFIGURE_LOG "Swift target info: ${module_triple_command}\n"
-  "${target_info_json}")
   string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
-  set(SwiftCore_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
-  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+  set(SwiftCore_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{doc,module,interface} files")
   mark_as_advanced(SwiftCore_MODULE_TRIPLE)
+
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()
+
+if(NOT SwiftCore_PLATFORM_SUBDIR)
+  string(JSON platform GET "${target_info_json}" "target" "platform")
+  set(SwiftCore_PLATFORM_SUBDIR "${platform}" CACHE STRING "Platform name used for installed swift{doc,module,interface} files")
+  mark_as_advanced(SwiftCore_PLATFORM_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift platform: ${platform}")
+endif()
+
+if(NOT SwiftCore_ARCH_SUBDIR)
+  string(JSON platform GET "${target_info_json}" "target" "arch")
+  set(SwiftCore_PLATFORM_SUBDIR "${platform}" CACHE STRING "Architecture name used for installed swift{doc,module,interface} files")
+  mark_as_advanced(SwiftCore_PLATFORM_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift platform: ${platform}")
 endif()

--- a/Runtimes/Core/cmake/modules/PlatformInfo.cmake
+++ b/Runtimes/Core/cmake/modules/PlatformInfo.cmake
@@ -30,9 +30,9 @@ if(NOT SwiftCore_PLATFORM_SUBDIR)
 endif()
 
 if(NOT SwiftCore_ARCH_SUBDIR)
-  string(JSON platform GET "${target_info_json}" "target" "arch")
-  set(SwiftCore_PLATFORM_SUBDIR "${platform}" CACHE STRING "Architecture name used for installed swift{doc,module,interface} files")
-  mark_as_advanced(SwiftCore_PLATFORM_SUBDIR)
+  string(JSON arch GET "${target_info_json}" "target" "arch")
+  set(SwiftCore_ARCH_SUBDIR "${arch}" CACHE STRING "Architecture used for setting the architecture subdirectory")
+  mark_as_advanced(SwiftCore_ARCH_SUBDIR)
 
-  message(CONFIGURE_LOG "Swift platform: ${platform}")
+  message(CONFIGURE_LOG "Swift Arch: ${arch}")
 endif()


### PR DESCRIPTION
With swiftlang/swift#78717 we now can extract the platform and architecture subdirectories required for deploying the files. Restructure the code when adding this functionality to invoke the command once and then extract the various fields that we need.