### PR TITLE
Fix miscompilations for debugger because of resilience

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -6010,6 +6010,14 @@ bool IRGenModule::hasResilientMetadata(ClassDecl *D,
     return false;
   }
 
+  // Because the debugger can extend non public types outside of their module, 
+  // also check that "D" is *not* resilient  from the module that contains 
+  // "asViewedFromRootClass".
+  if (Context.LangOpts.DebuggerSupport && asViewedFromRootClass &&
+      !D->hasResilientMetadata(asViewedFromRootClass->getModuleContext(),
+                               expansion))
+    return false;
+
   return D->hasResilientMetadata(getSwiftModule(), expansion);
 }
 


### PR DESCRIPTION
This patch fixes two instances of the compiler embedded in LLDB miscompiling code for the debugger's expression evaluation, because of a combination of the debugger's access to private types and resilience, which would cause the generated code to access fields indirectly through resilience functions that were never emitted.

rdar://137876089