### PR TITLE
Introduce the @safe attribute as described in the opt-in safety checking proposal

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -516,7 +516,7 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
 SIMPLE_DECL_ATTR(unsafe, Unsafe,
   OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
   OnExtension | OnTypeAlias | OnEnumElement | UserInaccessible |
-  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   160)
 
 DECL_ATTR(lifetime, Lifetime,
@@ -531,7 +531,11 @@ SIMPLE_DECL_ATTR(_addressableForDependencies, AddressableForDependencies,
   OnNominalType | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UserInaccessible,
   163)
 
-// 164 was the never-shipped @safe attribute and can be reused
+SIMPLE_DECL_ATTR(safe, Safe,
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
+  OnExtension | OnEnumElement | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  164)
 
 DECL_ATTR(abi, ABI,
   OnAbstractFunction | OnVar /* will eventually add types */ | LongAttribute | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8126,9 +8126,13 @@ NOTE(note_use_of_unsafe_conformance_is_unsafe,none,
      (Type, const ValueDecl *))
 
 GROUPED_WARNING(decl_signature_involves_unsafe,Unsafe,none,
-      "%kindbase0 has an interface that is not memory-safe; "
-      "use '@unsafe' to indicate that its use is unsafe",
+      "%kindbase0 has an interface that involves unsafe types",
       (const Decl *))
+NOTE(decl_signature_mark_unsafe,none,
+      "add '@unsafe' to indicate that this declaration is unsafe to use",
+      ())
+NOTE(decl_signature_mark_safe,none,
+      "add '@safe' to indicate that this declaration is memory-safe to use", ())
 
 GROUPED_WARNING(conformance_involves_unsafe,Unsafe,none,
      "conformance of %0 to %kind1 involves unsafe code; use '@unsafe' to "

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -654,9 +654,14 @@ public:
   /// known.
   SourceLoc getPreconcurrencyLoc() const { return PreconcurrencyLoc; }
 
-  /// Whether this is an "unsafe" conformance.
-  bool isUnsafe() const {
-    return getOptions().contains(ProtocolConformanceFlags::Unsafe);
+  /// Query whether this conformance was explicitly declared to be safe or
+  /// unsafe.
+  ExplicitSafety getExplicitSafety() const {
+    if (getOptions().contains(ProtocolConformanceFlags::Unsafe))
+      return ExplicitSafety::Unsafe;
+    if (getOptions().contains(ProtocolConformanceFlags::Safe))
+      return ExplicitSafety::Safe;
+    return ExplicitSafety::Unspecified;
   }
 
   /// Determine whether we've lazily computed the associated conformance array

--- a/include/swift/AST/ProtocolConformanceOptions.h
+++ b/include/swift/AST/ProtocolConformanceOptions.h
@@ -34,6 +34,9 @@ enum class ProtocolConformanceFlags {
   /// @retroactive conformance
   Retroactive = 0x08,
 
+  /// @safe conformance
+  Safe = 0x10,
+
   // Note: whenever you add a bit here, update
   // NumProtocolConformanceOptions below.
 };
@@ -49,7 +52,7 @@ inline ProtocolConformanceOptions operator|(
 }
 
 enum : unsigned {
-  NumProtocolConformanceOptions = 4
+  NumProtocolConformanceOptions = 5
 };
 
 } // end namespace swift

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5175,24 +5175,6 @@ void simple_display(llvm::raw_ostream &out,
                     RegexLiteralPatternFeatureKind kind);
 SourceLoc extractNearestSourceLoc(RegexLiteralPatternFeatureKind kind);
 
-class IsUnsafeRequest
-    : public SimpleRequest<IsUnsafeRequest,
-                           bool(Decl *decl),
-                           RequestFlags::SeparatelyCached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  bool evaluate(Evaluator &evaluator, Decl *decl) const;
-
-public:
-  bool isCached() const { return true; }
-  std::optional<bool> getCachedResult() const;
-  void cacheResult(bool value) const;
-};
-
 class GenericTypeParamDeclGetValueTypeRequest
     : public SimpleRequest<GenericTypeParamDeclGetValueTypeRequest,
                            Type(GenericTypeParamDecl *decl),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -605,9 +605,6 @@ SWIFT_REQUEST(TypeChecker, CaptureInfoRequest,
 SWIFT_REQUEST(TypeChecker, ParamCaptureInfoRequest,
               CaptureInfo(ParamDecl *),
               SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsUnsafeRequest,
-              bool(Decl *),
-              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CustomDerivativesRequest,
               CustomDerivativesResult(SourceFile *),
               Cached, NoLocationInfo)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -23,7 +23,6 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AnyFunctionRef.h"
-#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/Types.h"

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4076,7 +4076,8 @@ get(GenericTypeDecl *TheDecl, Type Parent, const ASTContext &C) {
   UnboundGenericType::Profile(ID, TheDecl, Parent);
   void *InsertPos = nullptr;
   RecursiveTypeProperties properties;
-  if (TheDecl->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (TheDecl->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
 
   auto arena = getArena(properties);
@@ -4129,7 +4130,8 @@ BoundGenericType *BoundGenericType::get(NominalTypeDecl *TheDecl,
   llvm::FoldingSetNodeID ID;
   BoundGenericType::Profile(ID, TheDecl, Parent, GenericArgs);
   RecursiveTypeProperties properties;
-  if (TheDecl->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (TheDecl->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
   for (Type Arg : GenericArgs) {
     properties |= Arg->getRecursiveProperties();
@@ -4211,7 +4213,8 @@ EnumType::EnumType(EnumDecl *TheDecl, Type Parent, const ASTContext &C,
 
 EnumType *EnumType::get(EnumDecl *D, Type Parent, const ASTContext &C) {
   RecursiveTypeProperties properties;
-  if (D->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (D->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
   auto arena = getArena(properties);
 
@@ -4228,7 +4231,8 @@ StructType::StructType(StructDecl *TheDecl, Type Parent, const ASTContext &C,
 
 StructType *StructType::get(StructDecl *D, Type Parent, const ASTContext &C) {
   RecursiveTypeProperties properties;
-  if (D->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (D->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
   auto arena = getArena(properties);
 
@@ -4245,7 +4249,8 @@ ClassType::ClassType(ClassDecl *TheDecl, Type Parent, const ASTContext &C,
 
 ClassType *ClassType::get(ClassDecl *D, Type Parent, const ASTContext &C) {
   RecursiveTypeProperties properties;
-  if (D->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (D->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
   auto arena = getArena(properties);
 
@@ -5396,7 +5401,8 @@ OptionalType *OptionalType::get(Type base) {
 ProtocolType *ProtocolType::get(ProtocolDecl *D, Type Parent,
                                 const ASTContext &C) {
   RecursiveTypeProperties properties;
-  if (D->isUnsafe()) properties |= RecursiveTypeProperties::IsUnsafe;
+  if (D->getExplicitSafety() == ExplicitSafety::Unsafe)
+    properties |= RecursiveTypeProperties::IsUnsafe;
   if (Parent) properties |= Parent->getRecursiveProperties();
   auto arena = getArena(properties);
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3857,6 +3857,7 @@ public:
                        requires_stored_property_inits)
   TRIVIAL_ATTR_PRINTER(ResultBuilder, result_builder)
   TRIVIAL_ATTR_PRINTER(Rethrows, rethrows)
+  TRIVIAL_ATTR_PRINTER(Safe, safe)
   TRIVIAL_ATTR_PRINTER(SPIOnly, spi_only)
   TRIVIAL_ATTR_PRINTER(Sendable, sendable)
   TRIVIAL_ATTR_PRINTER(Sensitive, sensitive)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2895,8 +2895,18 @@ void PrintAST::printInherited(const Decl *decl) {
         Printer << "@retroactive ";
       if (inherited.isPreconcurrency())
         Printer << "@preconcurrency ";
-      if (inherited.isUnsafe())
+      switch (inherited.getExplicitSafety()) {
+      case ExplicitSafety::Unspecified:
+        break;
+
+      case ExplicitSafety::Safe:
+        Printer << "@safe ";
+        break;
+
+      case ExplicitSafety::Unsafe:
         Printer << "@unsafe ";
+        break;
+      }
       if (inherited.isSuppressed())
         Printer << "~";
     });

--- a/lib/AST/Effects.cpp
+++ b/lib/AST/Effects.cpp
@@ -86,7 +86,7 @@ bool AbstractFunctionDecl::hasEffect(EffectKind kind) const {
   case EffectKind::Async:
     return hasAsync();
   case EffectKind::Unsafe:
-    return isUnsafe();
+    return getExplicitSafety() == ExplicitSafety::Unsafe;
   }
   llvm_unreachable("Bad effect kind");
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3566,7 +3566,7 @@ RecursiveTypeProperties ArchetypeType::archetypeProperties(
   properties |= subs.getRecursiveProperties();
 
   for (auto proto : conformsTo) {
-    if (proto->isUnsafe()) {
+    if (proto->getExplicitSafety() == ExplicitSafety::Unsafe) {
       properties |= RecursiveTypeProperties::IsUnsafe;
       break;
     }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2715,23 +2715,6 @@ void ParamCaptureInfoRequest::cacheResult(CaptureInfo info) const {
 }
 
 //----------------------------------------------------------------------------//
-// IsUnsafeRequest computation.
-//----------------------------------------------------------------------------//
-
-std::optional<bool> IsUnsafeRequest::getCachedResult() const {
-  auto *decl = std::get<0>(getStorage());
-  if (!decl->isUnsafeComputed())
-    return std::nullopt;
-
-  return decl->isUnsafeRaw();
-}
-
-void IsUnsafeRequest::cacheResult(bool value) const {
-  auto *decl = std::get<0>(getStorage());
-  decl->setUnsafe(value);
-}
-
-//----------------------------------------------------------------------------//
 // SemanticAvailableAttrRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -252,6 +252,7 @@ extension ASTGenVisitor {
         .propertyWrapper,
         .requiresStoredPropertyInits,
         .resultBuilder,
+        .safe,
         .sendable,
         .sensitive,
         .spiOnly,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2696,9 +2696,16 @@ void swift::checkAccessControl(Decl *D) {
 
   // If there were any unsafe uses, this declaration needs "@unsafe".
   if (!unsafeUsesVec.empty()) {
-    D->diagnose(diag::decl_signature_involves_unsafe, D)
-      .fixItInsert(D->getAttributeInsertionLoc(/*forModifier=*/false),
-                   "@unsafe ");
+    D->diagnose(diag::decl_signature_involves_unsafe, D);
+
+    ASTContext &ctx = D->getASTContext();
+    auto insertLoc = D->getAttributeInsertionLoc(/*forModifier=*/false);
+
+    ctx.Diags.diagnose(insertLoc, diag::decl_signature_mark_unsafe)
+      .fixItInsert(insertLoc, "@unsafe ");
+    ctx.Diags.diagnose(insertLoc, diag::decl_signature_mark_safe)
+      .fixItInsert(insertLoc, "@safe ");
+
     std::for_each(unsafeUsesVec.begin(), unsafeUsesVec.end(),
                   diagnoseUnsafeUse);
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2683,7 +2683,8 @@ void swift::checkAccessControl(Decl *D) {
   llvm::SmallVector<UnsafeUse, 2> unsafeUsesVec;
   llvm::SmallVectorImpl<UnsafeUse> *unsafeUses = nullptr;
   if (D->getASTContext().LangOpts.hasFeature(Feature::WarnUnsafe) &&
-      !D->isImplicit() && !D->isUnsafe()) {
+      !D->isImplicit() &&
+      D->getExplicitSafety() == ExplicitSafety::Unspecified) {
     unsafeUses = &unsafeUsesVec;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -602,6 +602,7 @@ public:
   void visitWeakLinkedAttr(WeakLinkedAttr *attr);
   void visitSILGenNameAttr(SILGenNameAttr *attr);
   void visitUnsafeAttr(UnsafeAttr *attr);
+  void visitSafeAttr(SafeAttr *attr);
   void visitLifetimeAttr(LifetimeAttr *attr);
   void visitAddressableSelfAttr(AddressableSelfAttr *attr);
   void visitAddressableForDependenciesAttr(AddressableForDependenciesAttr *attr);
@@ -7997,6 +7998,13 @@ void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {
 }
 
 void AttributeChecker::visitUnsafeAttr(UnsafeAttr *attr) {
+  if (Ctx.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
+    return;
+
+  diagnoseAndRemoveAttr(attr, diag::unsafe_attr_disabled);
+}
+
+void AttributeChecker::visitSafeAttr(SafeAttr *attr) {
   if (Ctx.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
     return;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4651,7 +4651,7 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
   if (auto unsafeUses = where.getUnsafeUses()) {
     if (auto normalConf = dyn_cast<NormalProtocolConformance>(rootConf)) {
       // @unsafe conformances are considered... unsafe.
-      if (normalConf->isUnsafe()) {
+      if (normalConf->getExplicitSafety() == ExplicitSafety::Unsafe) {
         unsafeUses->push_back(
             UnsafeUse::forConformance(
               concreteConf->getType(), conformance, loc));

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3201,45 +3201,6 @@ SourceFile::getIfConfigClausesWithin(SourceRange outer) const {
 }
 
 //----------------------------------------------------------------------------//
-// IsUnsafeRequest
-//----------------------------------------------------------------------------//
-
-bool IsUnsafeRequest::evaluate(Evaluator &evaluator, Decl *decl) const {
-  // If it's marked @unsafe, it's unsafe.
-  if (decl->getAttrs().hasAttribute<UnsafeAttr>())
-    return true;
-
-  // Inference: A member of an @unsafe type is also unsafe.
-  if (auto enclosingDC = decl->getDeclContext()) {
-    if (auto enclosingNominal = enclosingDC->getSelfNominalTypeDecl())
-      if (enclosingNominal->isUnsafe())
-        return true;
-
-    if (auto ext = dyn_cast<ExtensionDecl>(enclosingDC)) {
-      if (ext->isUnsafe())
-        return true;
-    }
-  }
-
-  // If an extension extends and unsafe nominal type, it's unsafe.
-  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (auto nominal = ext->getExtendedNominal())
-      if (nominal->isUnsafe())
-        return true;
-  }
-
-  // If this is a pattern binding declaration, check whether the first
-  // variable is @unsafe.
-  if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
-    if (auto var = patternBinding->getSingleVar())
-      if (var->isUnsafe())
-        return true;
-  }
-
-  return false;
-}
-
-//----------------------------------------------------------------------------//
 // PrettyPrintDeclRequest
 //----------------------------------------------------------------------------//
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1741,6 +1741,7 @@ namespace  {
     UNINTERESTING_ATTR(Lifetime)
     UNINTERESTING_ATTR(AddressableSelf)
     UNINTERESTING_ATTR(Unsafe)
+    UNINTERESTING_ATTR(Safe)
     UNINTERESTING_ATTR(AddressableForDependencies)
 #undef UNINTERESTING_ATTR
 
@@ -2261,7 +2262,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     if (isUnsafe(overrideRef) && !isUnsafe(baseRef)) {
       // Don't diagnose @unsafe overrides if the subclass is @unsafe.
       auto overridingClass = override->getDeclContext()->getSelfClassDecl();
-      bool shouldDiagnose = !overridingClass || !overridingClass->isUnsafe();
+      bool shouldDiagnose = !overridingClass || !isUnsafe(overridingClass);
 
       if (shouldDiagnose) {
         diagnoseUnsafeUse(UnsafeUse::forOverride(override, base));

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -274,7 +274,7 @@ bool ConformanceHasEffectRequest::evaluate(
     if (kind == EffectKind::Unsafe) {
       auto rootConf = current->getRootConformance();
       if (auto normalConf = dyn_cast<NormalProtocolConformance>(rootConf)) {
-        if (normalConf->isUnsafe())
+        if (normalConf->getExplicitSafety() == ExplicitSafety::Unsafe)
           return true;
       }
     }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3168,11 +3168,15 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
   /// Find the top location where we should put the await
   static Expr *walkToAnchor(Expr *e, llvm::DenseMap<Expr *, Expr *> &parentMap,
                             bool isInterpolatedString) {
+    llvm::SmallPtrSet<Expr *, 4> visited;
     Expr *parent = e;
     Expr *lastParent = e;
     while (parent && !isEffectAnchor(parent)) {
       lastParent = parent;
       parent = parentMap[parent];
+
+      if (!visited.insert(parent).second)
+        break;
     }
 
     if (parent && !isAnchorTooEarly(parent)) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2547,7 +2547,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
   // If we're enforcing strict memory safety and this conformance hasn't
   // opted out, look for safe/unsafe witness mismatches.
-  if (!conformance->isUnsafe() &&
+  if (conformance->getExplicitSafety() == ExplicitSafety::Unspecified &&
       Context.LangOpts.hasFeature(Feature::WarnUnsafe)) {
     // Collect all of the unsafe uses for this conformance.
     SmallVector<UnsafeUse, 2> unsafeUses;
@@ -2559,7 +2559,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
           TypeWitnessAndDecl typeWitnessAndDecl =
             conformance->getTypeWitnessAndDecl(assocType);
           Type typeWitness = typeWitnessAndDecl.getWitnessType();
-          if (!assocType->isUnsafe() && typeWitness && typeWitness->isUnsafe()) {
+          if (!isUnsafe(assocType) && typeWitness && typeWitness->isUnsafe()) {
             SourceLoc loc;
             if (auto typeDecl = typeWitnessAndDecl.getWitnessDecl()) {
               loc = typeDecl->getLoc();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3302,8 +3302,8 @@ class DeclDeserializer {
 
       // The next bits are the protocol conformance options.
       // Update the mask below whenever this changes.
-      static_assert(NumProtocolConformanceOptions == 4);
-      ProtocolConformanceOptions options(rawID & 0x0F);
+      static_assert(NumProtocolConformanceOptions == 5);
+      ProtocolConformanceOptions options(rawID & 0x1F);
       rawID = rawID >> NumProtocolConformanceOptions;
 
       TypeID typeID = rawID;

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -71,16 +71,22 @@ import Test
 import CoreFoundation
 import CxxStdlib
 
-// expected-warning@+1{{global function 'useUnsafeParam' has an interface that is not memory-safe}}{{1-1=@unsafe }}
+// expected-warning@+3{{global function 'useUnsafeParam' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{{1-1=@safe }}
 func useUnsafeParam(x: Unannotated) { // expected-note{{reference to unsafe struct 'Unannotated'}}
 }
 
-// expected-warning@+2{{global function 'useUnsafeParam2' has an interface that is not memory-safe}}{{11:1-1=@unsafe }}
+// expected-warning@+4{{global function 'useUnsafeParam2' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{{1-1=@safe }}
 @available(SwiftStdlib 5.8, *)
 func useUnsafeParam2(x: UnsafeReference) { // expected-note{{reference to unsafe class 'UnsafeReference'}}
 }
 
-// expected-warning@+1{{global function 'useUnsafeParam3' has an interface that is not memory-safe}}{{1-1=@unsafe }}
+// expected-warning@+3{{global function 'useUnsafeParam3' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{{1-1=@safe }}
 func useUnsafeParam3(x: UnknownEscapabilityAggregate) { // expected-note{{reference to unsafe struct 'UnknownEscapabilityAggregate'}}
 }
 
@@ -95,7 +101,9 @@ func useCfType(x: CFArray) {
 func useString(x: std.string) {
 }
 
-// expected-warning@+1{{global function 'useVecOfPtr' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{global function 'useVecOfPtr' has an interface}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func useVecOfPtr(x: VecOfPtr) { // expected-note{{reference to unsafe type alias 'VecOfPtr'}}
 }
 
@@ -105,15 +113,21 @@ func useVecOfInt(x: VecOfInt) {
 func useSafeTuple(x: SafeTuple) {
 }
 
-// expected-warning@+1{{global function 'useUnsafeTuple' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{global function 'useUnsafeTuple' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func useUnsafeTuple(x: UnsafeTuple) { // expected-note{{reference to unsafe type alias 'UnsafeTuple'}}
 }
 
-// expected-warning@+1{{global function 'useCppSpan' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{global function 'useCppSpan' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func useCppSpan(x: SpanOfInt) { // expected-note{{reference to unsafe type alias 'SpanOfInt'}}
 }
 
-// expected-warning@+1{{global function 'useCppSpan2' has an interface that is not memory-safe}}
+// expected-warning@+3{{global function 'useCppSpan2' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func useCppSpan2(x: SpanOfIntAlias) { // expected-note{{reference to unsafe type alias 'SpanOfIntAlias'}}
 }
 

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -17,7 +17,9 @@ func g() {
   unsafe unsafeFunction()
 }
 
-// expected-warning@+1{{global function 'h' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{global function 'h' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{{1-1=@safe }}
 func h(_: UnsafeType) { // expected-note{{reference to unsafe struct 'UnsafeType'}}
 // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
   unsafeFunction() // expected-note{{reference to unsafe global function 'unsafeFunction()'}}
@@ -29,11 +31,15 @@ func h(_: UnsafeType) { // expected-note{{reference to unsafe struct 'UnsafeType
   unsafe g()
 }
 
-// expected-warning@+1 {{global function 'rethrowing' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}{{1-1=@unsafe }}
+// expected-warning@+3 {{global function 'rethrowing' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func rethrowing(body: (UnsafeType) throws -> Void) rethrows { } // expected-note{{reference to unsafe struct 'UnsafeType'}}
 
 class HasStatics {
-  // expected-warning@+1{{static method 'f' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe }}{{3-3=@unsafe }}
+  // expected-warning@+3{{static method 'f' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{3-3=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{3-3=@safe }}
   static internal func f(_: UnsafeType) { } // expected-note{{reference to unsafe struct 'UnsafeType'}}
 
   

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -168,6 +168,9 @@ extension UnsafeBufferPointer {
 
 func testMyArray(ints: MyArray<Int>) {
   ints.withUnsafeBufferPointer { buffer in
+    let bufferCopy = unsafe buffer
+    _ = unsafe bufferCopy
+
     // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
     print(buffer.safeCount) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
     unsafe print(buffer.baseAddress!)

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -9,9 +9,11 @@ func iAmUnsafe() { }
 @unsafe
 struct UnsafeType { }
 
-// expected-note@+1{{reference to unsafe struct 'UnsafeType'}}
+// expected-note@+3{{reference to unsafe struct 'UnsafeType'}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func iAmImpliedUnsafe() -> UnsafeType? { nil }
-// expected-warning@-1{{global function 'iAmImpliedUnsafe' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}{{1-1=@unsafe }}
+// expected-warning@-1{{global function 'iAmImpliedUnsafe' has an interface that involves unsafe types}}
 
 @unsafe
 func labeledUnsafe(_: UnsafeType) {

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -130,7 +130,9 @@ class UnsafeSub: UnsafeSuper { }
 @unsafe var unsafeVar: Int = 0
 
 
-// expected-warning@+1{{global function 'testMe' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}{{1-1=@unsafe }}
+// expected-warning@+3{{global function 'testMe' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func testMe(
   _ pointer: PointerType, // expected-note{{reference to unsafe struct 'PointerType'}}
   _ unsafeSuper: UnsafeSuper // expected-note{{reference to unsafe class 'UnsafeSuper'}}
@@ -151,14 +153,18 @@ func testMe(
 // Various declaration kinds
 // -----------------------------------------------------------------------
 
-// expected-warning@+1{{type alias 'SuperUnsafe' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{type alias 'SuperUnsafe' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 typealias SuperUnsafe = UnsafeSuper // expected-note{{reference to unsafe class 'UnsafeSuper'}}
 
 @unsafe typealias SuperUnsafe2 = UnsafeSuper
 
 enum HasUnsafeThings {
 
-// expected-warning@+1{{enum case 'one' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe }}{{1-1=@unsafe }}
+// expected-warning@+3{{enum case 'one' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 case one(UnsafeSuper)  // expected-note{{reference to unsafe class 'UnsafeSuper'}}
 
 @unsafe case two(UnsafeSuper)

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -9,7 +9,9 @@
 import unsafe_decls
 import unsafe_swift_decls
 
-// expected-warning@+1{{global function 'testUnsafe' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}{{1-1=@unsafe }}
+// expected-warning@+3{{global function 'testUnsafe' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func testUnsafe(_ ut: UnsafeType) { // expected-note{{reference to unsafe struct 'UnsafeType'}}
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
   unsafe_c_function() // expected-note{{reference to unsafe global function 'unsafe_c_function()'}}
@@ -23,7 +25,9 @@ func testUnsafe(_ ut: UnsafeType) { // expected-note{{reference to unsafe struct
 // Reference a typealias that isn't itself @unsafe, but refers to an unsafe
 // type.
 
-// expected-warning@+1{{global function 'testUnsafeThroughAlias' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}
+// expected-warning@+3{{global function 'testUnsafeThroughAlias' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func testUnsafeThroughAlias(_ ut: UnsafeTypeAlias) { // expected-note{{reference to type alias 'UnsafeTypeAlias' involves unsafe type 'UnsafeTypeAlias' (aka 'PointerType')}}
   // TODO: Diagnostic above could be better
 }

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -6,7 +6,9 @@
 // REQUIRES: swift_feature_AllowUnsafeAttribute
 // REQUIRES: swift_feature_WarnUnsafe
 
-// expected-warning@+1{{global function 'test' has an interface that is not memory-safe; use '@unsafe' to indicate that its use is unsafe}}{{1-1=@unsafe }}
+// expected-warning@+3{{global function 'test' has an interface that involves unsafe types}}
+// expected-note@+2{{add '@unsafe' to indicate that this declaration is unsafe to use}}{{1-1=@unsafe }}
+// expected-note@+1{{add '@safe' to indicate that this declaration is memory-safe to use}}{1-1=@safe }}
 func test(
   x: OpaquePointer, // expected-note{{reference to unsafe struct 'OpaquePointer'}}
   other: UnsafeMutablePointer<Int> // expected-note{{reference to unsafe generic struct 'UnsafeMutablePointer'}}

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -213,7 +213,6 @@ Accessor UnsafePointer.hashValue.Get() has generic signature change from <Pointe
 Accessor UnsafePointer.pointee.Get() has been removed
 Accessor UnsafePointer.subscript(_:).Get() has been removed
 Class ManagedBuffer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
-Constructor ClosedRange.init(uncheckedBounds:) is now with @unsafe
 Constructor ExpressibleByNilLiteral.init(nilLiteral:) has generic signature change from <Self where Self : Swift.ExpressibleByNilLiteral> to <Self where Self : Swift.ExpressibleByNilLiteral, Self : ~Copyable>
 Constructor ManagedBufferPointer.init(bufferClass:minimumCapacity:makingHeaderWith:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Constructor ManagedBufferPointer.init(unsafeBufferObject:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
@@ -221,7 +220,6 @@ Constructor OpaquePointer.init(_:) has generic signature change from <T> to <T w
 Constructor Optional.init(_:) has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable>
 Constructor Optional.init(_:) has parameter 0 changing from Default to Owned
 Constructor Optional.init(nilLiteral:) has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable>
-Constructor Range.init(uncheckedBounds:) is now with @unsafe
 Constructor Result.init(catching:) has generic signature change from <Success, Failure where Failure == any Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable>
 Constructor UnsafeBufferPointer.init(_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Constructor UnsafeBufferPointer.init(start:count:) has generic signature change from <Element> to <Element where Element : ~Copyable>
@@ -362,19 +360,3 @@ Func ContiguousArray.withUnsafeBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
-
-// Adoption of @unsafe
-Func unsafeBitCast(_:to:) is now with @unsafe
-Func unsafeDowncast(_:to:) is now with @unsafe
-Struct CVaListPointer is now with @unsafe
-Struct OpaquePointer is now with @unsafe
-Struct Unmanaged is now with @unsafe
-Struct UnsafeBufferPointer is now with @unsafe
-Struct UnsafeMutableBufferPointer is now with @unsafe
-Struct UnsafeMutablePointer is now with @unsafe
-Struct UnsafeMutableRawBufferPointer is now with @unsafe
-Struct UnsafeMutableRawPointer is now with @unsafe
-Struct UnsafePointer is now with @unsafe
-Struct UnsafeRawBufferPointer is now with @unsafe
-Struct UnsafeRawPointer is now with @unsafe
-Var Optional.unsafelyUnwrapped is now with @unsafe


### PR DESCRIPTION
Add `@safe`, which can be applied to a declaration that has unsafe types in its signature. This change makes it such that references to such a declaration will be considered safe even if its signature involves unsafe types.