### PR TITLE
TypeCheckType: Rework IUO diagnostics using behavior limitation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6145,14 +6145,12 @@ ERROR(closure_unlabeled_parameter_following_variadic_parameter,none,
 ERROR(parameter_vararg_default,none,
       "variadic parameter cannot have a default value", ())
 
-WARNING(implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional,none,
-        "using '!' is not allowed here; treating this as '?' instead", ())
-
-WARNING(implicitly_unwrapped_optional_deprecated_in_this_position,Deprecation,
-        "using '!' here is deprecated and will be removed in a future release", ())
-
-ERROR(implicitly_unwrapped_optional_in_illegal_position,none,
-        "using '!' is not allowed here; perhaps '?' was intended?", ())
+ERROR(iuo_invalid_here, none,
+      "using '!' is not allowed here", ())
+ERROR(iuo_deprecated_here,Deprecation,
+      "using '!' here is deprecated", ())
+NOTE(iuo_use_optional_instead,none,
+     "use '?' instead", ())
 
 // Ownership
 ERROR(invalid_ownership_type,none,

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -179,43 +179,6 @@ class rdar37241550 {
   }
 }
 
-class B {}
-class D : B {
-  var i: Int!
-}
-
-func coerceToIUO(d: D?) -> B {
-  return d as B! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func forcedDowncastToOptional(b: B?) -> D? {
-  return b as! D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func forcedDowncastToObject(b: B?) -> D {
-  return b as! D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func forcedDowncastToObjectIUOMember(b: B?) -> Int {
-  return (b as! D!).i // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func forcedUnwrapViaForcedCast(b: B?) -> B {
-  return b as! B! // expected-warning {{forced cast from 'B?' to 'B' only unwraps optionals; did you mean to use '!'?}}
-  // expected-warning@-1 {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func conditionalDowncastToOptional(b: B?) -> D? {
-  return b as? D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-}
-
-func conditionalDowncastToObject(b: B?) -> D {
-  return b as? D! // expected-error {{value of optional type 'D?' must be unwrapped to a value of type 'D'}}
-  // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-  // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-  // expected-warning@-3 {{using '!' here is deprecated and will be removed in a future release}}
-}
-
 // https://github.com/apple/swift/issues/49536
 // Ensure that we select the overload that does *not* involve forcing an IUO.
 do {

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -swift-version 4 -verify-additional-prefix swift4-
 
 // These are all legal uses of '!'.
 struct Fine {
@@ -42,8 +43,14 @@ func functionSigil(
 
 // Not okay because '!' is not at the top level of the type.
 func functionSigilArray(
-  _: [Int!] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
-) -> [Int!] { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
+  _: [Int!]
+  // expected-swift4-warning@-1:10 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:10 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:10 {{use '?' instead}}{{10-11=?}}
+) -> [Int!] {
+  // expected-swift4-warning@-1:10 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:10 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:10 {{use '?' instead}}{{10-11=?}}
   return [1]
 }
 
@@ -60,9 +67,18 @@ func genericFunctionSigil<T>(
   return iuo
 }
 
+// FIXME: Duplicate diagnostics in -swift-version 4
 func genericFunctionSigilArray<T>(
-  iuo: [T!] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
-) -> [T!] { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
+  iuo: [T!]
+  // expected-swift4-warning@-1:10 2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:10 {{'!' is not allowed here}}{{none}}
+  // expected-swift4-note@-3:10 2 {{use '?' instead}}{{10-11=?}}
+  // expected-swift5-note@-4:10 {{use '?' instead}}{{10-11=?}}
+) -> [T!] {
+  // expected-swift4-warning@-1:8 2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:8 {{'!' is not allowed here}}{{none}}
+  // expected-swift4-note@-3:8 2 {{use '?' instead}}{{8-9=?}}
+  // expected-swift5-note@-4:8 {{use '?' instead}}{{8-9=?}}
   return iuo
 }
 
@@ -75,13 +91,25 @@ struct S : P {
   typealias T = ImplicitlyUnwrappedOptional<Int> // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{17-44=Optional}}
   typealias U = Optional<ImplicitlyUnwrappedOptional<Int>> // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{26-53=Optional}}
 
-  typealias V = Int!  // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
-  typealias W = Int!? // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
+  typealias V = Int!
+  // expected-swift4-warning@-1:20 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:20 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:20 {{use '?' instead}}{{20-21=?}}
+  typealias W = Int!?
+  // expected-swift4-warning@-1:20 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:20 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:20 {{use '?' instead}}{{20-21=?}}
 
   var x: V
   var y: W
-  var fn1: (Int!) -> Int // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{16-17=?}}
-  var fn2: (Int) -> Int! // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
+  var fn1: (Int!) -> Int
+  // expected-swift4-warning@-1:16 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:16 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:16 {{use '?' instead}}{{16-17=?}}
+  var fn2: (Int) -> Int!
+  // expected-swift4-warning@-1:24 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:24 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:24 {{use '?' instead}}{{24-25=?}}
 
   subscript (
     index: ImplicitlyUnwrappedOptional<Int> // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{12-39=Optional}}
@@ -107,42 +135,131 @@ func testClosure() -> Int {
   }(1)!
 }
 
-_ = Array<Int!>() // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{14-15=?}}
-let _: Array<Int!> = [1] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{17-18=?}}
-_ = [Int!]() // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{9-10=?}}
-let _: [Int!] = [1] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{12-13=?}}
-_ = Optional<Int!>(nil) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{17-18=?}}
-let _: Optional<Int!> = nil // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{20-21=?}}
-_ = Int!?(0) // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-let _: Int!? = 0 // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{11-12=?}}
+_ = Array<Int!>()
+// expected-swift4-warning@-1:14 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:14 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:14 {{use '?' instead}}{{14-15=?}}
+let _: Array<Int!> = [1]
+// expected-swift4-warning@-1:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:17 {{use '?' instead}}{{17-18=?}}
+_ = [Int!]()
+// expected-swift4-warning@-1:9 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:9 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:9 {{use '?' instead}}{{9-10=?}}
+// <rdar://problem/21684837> typeexpr not being formed for postfix !
+let _ = [Int!](repeating: nil, count: 2)
+// expected-swift4-warning@-1:13 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:13 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:13 {{use '?' instead}}{{13-14=?}}
+let _: [Int!] = [1]
+// expected-swift4-warning@-1:12 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:12 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:12 {{use '?' instead}}{{12-13=?}}
+
+// FIXME: Duplicate diagnostics in -swift-version 4
+_ = Optional<Int!>(nil)
+// expected-swift4-warning@-1:17 2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{'!' is not allowed here}}{{none}}
+// expected-swift4-note@-3:17 2 {{use '?' instead}}{{17-18=?}}
+// expected-swift5-note@-4:17 {{use '?' instead}}{{17-18=?}}
+let _: Optional<Int!> = nil
+// expected-swift4-warning@-1:20 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:20 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:20 {{use '?' instead}}{{20-21=?}}
+
+// FIXME: Duplicate diagnostics in -swift-version 4
+_ = Int!?(0)
+// expected-swift4-warning@-1:8 2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:8 {{'!' is not allowed here}}{{none}}
+// expected-swift4-note@-3:8 2 {{use '?' instead}}{{8-9=?}}
+// expected-swift5-note@-4:8 {{use '?' instead}}{{8-9=?}}
+let _: Int!? = 0
+// expected-swift4-warning@-1:11 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:11 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:11 {{use '?' instead}}{{11-12=?}}
 _ = (
-  Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{6-7=?}}
-  Float!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-  String! // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{9-10=?}}
+  Int!,
+  // expected-swift4-warning@-1:6 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:6 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:6 {{use '?' instead}}{{6-7=?}}
+  Float!,
+  // expected-swift4-warning@-1:8 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:8 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:8 {{use '?' instead}}{{8-9=?}}
+  String!
+  // expected-swift4-warning@-1:9 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:9 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:9 {{use '?' instead}}{{9-10=?}}
 )(1, 2.0, "3")
 let _: (
-  Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{6-7=?}}
-  Float!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-  String! // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{9-10=?}}
+  Int!,
+  // expected-swift4-warning@-1:6 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:6 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:6 {{use '?' instead}}{{6-7=?}}
+  Float!,
+  // expected-swift4-warning@-1:8 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:8 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:8 {{use '?' instead}}{{8-9=?}}
+  String!
+  // expected-swift4-warning@-1:9 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-2:9 {{'!' is not allowed here}}{{none}}
+  // expected-note@-3:9 {{use '?' instead}}{{9-10=?}}
 ) = (1, 2.0, "3")
 
 struct Generic<T, U, C> {
   init(_ t: T, _ u: U, _ c: C) {}
 }
-_ = Generic<Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{16-17=?}}
-            Float!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{18-19=?}}
-            String!>(1, 2.0, "3") // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{19-20=?}}
-let _: Generic<Int!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{19-20=?}}
-               Float!, // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{21-22=?}}
-               String!> = Generic(1, 2.0, "3") // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{22-23=?}}
+_ = Generic<Int!,
+// expected-swift4-warning@-1:16 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:16 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:16 {{use '?' instead}}{{16-17=?}}
+            Float!,
+// expected-swift4-warning@-1:18 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:18 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:18 {{use '?' instead}}{{18-19=?}}
+            String!>(1, 2.0, "3")
+// expected-swift4-warning@-1:19 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:19 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:19 {{use '?' instead}}{{19-20=?}}
+let _: Generic<Int!,
+// expected-swift4-warning@-1:19 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:19 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:19 {{use '?' instead}}{{19-20=?}}
+               Float!,
+// expected-swift4-warning@-1:21 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:21 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:21 {{use '?' instead}}{{21-22=?}}
+               String!> = Generic(1, 2.0, "3")
+// expected-swift4-warning@-1:22 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:22 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:22 {{use '?' instead}}{{22-23=?}}
 
-func vararg(_ first: Int, more: Int!...) { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{36-37=?}}
+extension Optional {
+  typealias Wrapped = Wrapped
+}
+let _: Int!.Wrapped
+// expected-swift4-warning@-1:11 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:11 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:11 {{use '?' instead}}{{11-12=?}}
+let _: (Int!).Wrapped
+// expected-swift4-warning@-1:12 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:12 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:12 {{use '?' instead}}{{12-13=?}}
+
+func vararg(_ first: Int, more: Int!...) {
+// expected-swift4-warning@-1:36 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:36 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:36 {{use '?' instead}}{{36-37=?}}
 }
 
 func varargIdentifier(_ first: Int, more: ImplicitlyUnwrappedOptional<Int>...) { // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{43-70=Optional}}
 }
 
-func iuoInTuple() -> (Int!) { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{26-27=?}}
+func iuoInTuple() -> (Int!) {
+// expected-swift4-warning@-1:26 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:26 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:26 {{use '?' instead}}{{26-27=?}}
   return 1
 }
 
@@ -150,7 +267,10 @@ func iuoInTupleIdentifier() -> (ImplicitlyUnwrappedOptional<Int>) { // expected-
   return 1
 }
 
-func iuoInTuple2() -> (Float, Int!) { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{34-35=?}}
+func iuoInTuple2() -> (Float, Int!) {
+// expected-swift4-warning@-1:34 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:34 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:34 {{use '?' instead}}{{34-35=?}}
   return (1.0, 1)
 }
 
@@ -158,7 +278,10 @@ func iuoInTuple2Identifier() -> (Float, ImplicitlyUnwrappedOptional<Int>) { // e
   return (1.0, 1)
 }
 
-func takesFunc(_ fn: (Int!) -> Int) -> Int { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{26-27=?}}
+func takesFunc(_ fn: (Int!) -> Int) -> Int {
+// expected-swift4-warning@-1:26 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:26 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:26 {{use '?' instead}}{{26-27=?}}
   return fn(0)
 }
 
@@ -166,7 +289,10 @@ func takesFuncIdentifier(_ fn: (ImplicitlyUnwrappedOptional<Int>) -> Int) -> Int
   return fn(0)
 }
 
-func takesFunc2(_ fn: (Int) -> Int!) -> Int { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{35-36=?}}
+func takesFunc2(_ fn: (Int) -> Int!) -> Int {
+// expected-swift4-warning@-1:35 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:35 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:35 {{use '?' instead}}{{35-36=?}}
   return fn(0)!
 }
 
@@ -174,7 +300,10 @@ func takesFunc2Identifier(_ fn: (Int) -> ImplicitlyUnwrappedOptional<Int>) -> In
   return fn(0)!
 }
 
-func returnsFunc() -> (Int!) -> Int { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{27-28=?}}
+func returnsFunc() -> (Int!) -> Int {
+// expected-swift4-warning@-1:27 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:27 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:27 {{use '?' instead}}{{27-28=?}}
   return { $0! }
 }
 
@@ -182,7 +311,10 @@ func returnsFuncIdentifier() -> (ImplicitlyUnwrappedOptional<Int>) -> Int { // e
   return { $0! }
 }
 
-func returnsFunc2() -> (Int) -> Int! { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{36-37=?}}
+func returnsFunc2() -> (Int) -> Int! {
+// expected-swift4-warning@-1:36 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:36 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:36 {{use '?' instead}}{{36-37=?}}
   return { $0 }
 }
 
@@ -190,19 +322,36 @@ func returnsFunc2Identifier() -> (Int) -> ImplicitlyUnwrappedOptional<Int> { // 
   return { $0 }
 }
 
+func opaqueResult() -> (some Equatable)! { return 1 }
+// expected-swift4-warning@-1:40 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:40 {{'!' is not allowed here}}{{none}}
+// expected-note@-3:40 {{use '?' instead}}{{40-41=?}}
+
 let x0 = 1 as ImplicitlyUnwrappedOptional // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{15-42=Optional}}
 
 let x: Int? = 1
-let y0: Int = x as Int! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{23-24=?}}
-let y1: Int = (x as Int!)! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
-let z0: Int = x as! Int! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
-// expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
-let z1: Int = (x as! Int!)! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
-// expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
-let w0: Int = (x as? Int!)! // expected-warning {{conditional cast from 'Int?' to 'Int?' always succeeds}}
-// expected-error@-1 {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
-let w1: Int = (x as? Int!)!! // expected-warning {{conditional cast from 'Int?' to 'Int?' always succeeds}}
-// expected-error@-1 {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
+let y0: Int = x as Int!
+// expected-swift4-warning@-1:23 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:23 {{'!' is not allowed here}}{{none}}
+let y1: Int = (x as Int!)!
+// expected-swift4-warning@-1:24 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:24 {{'!' is not allowed here}}{{none}}
+let z0: Int = x as! Int!
+// expected-swift4-warning@-1:24 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:24 {{'!' is not allowed here}}{{none}}
+// expected-warning@-3 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
+let z1: Int = (x as! Int!)!
+// expected-swift4-warning@-1:25 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:25 {{'!' is not allowed here}}{{none}}
+// expected-warning@-3 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
+let w0: Int = (x as? Int!)!
+// expected-swift4-warning@-1:25 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:25 {{'!' is not allowed here}}{{none}}
+// expected-warning@-3 {{conditional cast from 'Int?' to 'Int?' always succeeds}}
+let w1: Int = (x as? Int!)!!
+// expected-swift4-warning@-1:25 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:25 {{'!' is not allowed here}}{{none}}
+// expected-warning@-3 {{conditional cast from 'Int?' to 'Int?' always succeeds}}
 
 func overloadedByOptionality(_ a: inout Int!) {}
 // expected-note@-1 {{'overloadedByOptionality' previously declared here}}
@@ -219,4 +368,53 @@ struct T {
 func select(i: Int!, m: Int, t: T) {
   let _ = i ? i : m // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}} {{11-11=(}} {{12-12= != nil)}}
   let _ = t.i ? t.j : t.k // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}} {{11-11=(}} {{14-14= != nil)}}
+}
+
+class B {}
+class D : B {
+  var i: Int!
+}
+
+func coerceToIUO(d: D?) -> B {
+  return d as B!
+// expected-swift4-warning@-1:16 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:16 {{using '!' is not allowed here}}
+}
+
+func forcedDowncastToOptional(b: B?) -> D? {
+  return b as! D!
+// expected-swift4-warning@-1:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{using '!' is not allowed here}}
+}
+
+func forcedDowncastToObject(b: B?) -> D {
+  return b as! D!
+// expected-swift4-warning@-1:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{using '!' is not allowed here}}
+}
+
+func forcedDowncastToObjectIUOMember(b: B?) -> Int {
+  return (b as! D!).i
+// expected-swift4-warning@-1:18 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:18 {{using '!' is not allowed here}}
+}
+
+func forcedUnwrapViaForcedCast(b: B?) -> B {
+  return b as! B! // expected-warning {{forced cast from 'B?' to 'B' only unwraps optionals; did you mean to use '!'?}}
+// expected-swift4-warning@-1:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{using '!' is not allowed here}}
+}
+
+func conditionalDowncastToOptional(b: B?) -> D? {
+  return b as? D!
+// expected-swift4-warning@-1:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+// expected-swift5-error@-2:17 {{using '!' is not allowed here}}
+}
+
+func conditionalDowncastToObject(b: B?) -> D {
+  return b as? D! // expected-error {{value of optional type 'D?' must be unwrapped to a value of type 'D'}}
+  // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  // expected-swift4-warning@-3:17 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
+  // expected-swift5-error@-4:17 {{using '!' is not allowed here}}
 }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -460,8 +460,9 @@ func testAnyFixIt() {
   let _: (~Copyable)?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc!
-  // expected-default-swift-mode-warning@+3 {{using '!' is not allowed here; treating this as '?' instead}}
-  // expected-swift-6-error@+2 {{using '!' is not allowed here; perhaps '?' was intended?}} {{19-20=?}}
+  // expected-note@+4 {{use '?' instead}}{{19-20=?}}
+  // expected-default-swift-mode-warning@+3 {{using '!' here is deprecated}}
+  // expected-swift-6-error@+2 {{using '!' is not allowed here}}
   // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
   let _: ~Copyable!
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}

--- a/test/type/nested_types.swift
+++ b/test/type/nested_types.swift
@@ -67,9 +67,6 @@ do {
 
   // Invalid examples.
 
-  let _: Int!.Wrapped // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}
-  let _: (Int!).Wrapped // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}
-
   let _: Any.Undef // expected-error {{'Undef' is not a member type of type 'Any'}}
   let _: Int.Type.Undef // expected-error {{'Undef' is not a member type of type 'Swift.Int.Type'}}
   let _: P1.Protocol.Undef // expected-error {{'Undef' is not a member type of type '(any test.P1).Type'}}

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -12,7 +12,6 @@ class C {}
 class D: P, Q { func paul() {}; func d() {} }
 
 
-func asUnwrappedOptionalBase() -> (some P)! { return 1 } // expected-warning{{using '!' is not allowed here; treating this as '?' instead}}
 //
 // FIXME: We should be able to support this
 func asHOFRetRet() -> () -> some P { return { 1 } } // expected-error{{cannot convert value of type 'Int' to closure result type 'some P'}}

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -139,7 +139,8 @@ typealias E = protocol<Any> // expected-error {{'protocol<...>' composition synt
 typealias F = protocol<Any, Any> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-33=Any & Any}}
 typealias G = protocol<P1>.Type // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-27=P1}}
 typealias H = protocol<P1>! // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-28=P1!}}
-// expected-warning@-1 {{using '!' is not allowed here; treating this as '?' instead}}
+// expected-warning@-1 {{using '!' here is deprecated}}
+// expected-note@-2:27 {{use '?' instead}}{{27-28=?}}
 typealias J = protocol<P1, P2>.Protocol // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-31=(P1 & P2)}}
 typealias K = protocol<P1, P2>? // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-32=(P1 & P2)?}}
 typealias L = protocol<(P1), P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-33=(P1) & P2}}
@@ -161,8 +162,10 @@ do {
 typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type '(any P1).Type' cannot be used within a protocol-constrained type}}
 typealias T02 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'any P1.Type' cannot be used within a protocol-constrained type}}
 typealias T03 = P1? & P2 // expected-error {{non-protocol, non-class type '(any P1)?' cannot be used within a protocol-constrained type}}
+// FIXME: '!' diagnostic is superfluous here.
 typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type '(any P2)?' cannot be used within a protocol-constrained type}}
-// expected-warning@-1 {{using '!' is not allowed here; treating this as '?' instead}}
+// expected-warning@-1 {{using '!' here is deprecated}}
+// expected-note@-2:24 {{use '?' instead}}
 typealias T05 = P1 & P2 -> P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{24-24=)}}
 typealias T06 = P1 -> P2 & P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{19-19=)}}
 typealias T07 = P1 & protocol<P2, P3> // expected-error {{protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{22-38=P2 & P3}}

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -152,9 +152,6 @@ y17 = z17
 let tupleTypeWithNames = (age:Int, count:Int)(4, 5)
 let dictWithTuple = [String: (age:Int, count:Int)]()
 
-// <rdar://problem/21684837> typeexpr not being formed for postfix !
-let bb2 = [Int!](repeating: nil, count: 2) // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{15-16=?}}
-
 // <rdar://problem/21560309> inout allowed on function return type
 func r21560309<U>(_ body: (_: inout Int) -> inout U) {}  // expected-error {{'inout' may only be used on parameters}}
 r21560309 { x in x }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83072606.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83072606.swift
@@ -4,7 +4,7 @@ struct A {
   var prop: Bool
 
   func test() {
-    _ = AssertUnwrap(prop) as! Bool! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+    _ = AssertUnwrap(prop) as! Bool! // expected-warning {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}
     // expected-warning@-1 {{forced cast from 'Bool?' to 'Bool' only unwraps optionals; did you mean to use '!'?}}
   }
 


### PR DESCRIPTION
Also stop suggesting a '?' fix-it for casts, where it is not likely to be helpful because the common intention is either to force the optional or declare an IUO.