### PR TITLE
[ConstraintSystem] Add index value (as an impact of the score kind) to output of debug constraints.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1196,12 +1196,11 @@ struct Score {
     bool hasNonDefault = false;
     for (unsigned int i = 0; i < NumScoreKinds; ++i) {
       if (Data[i] != 0) {
-        out << " [component: ";
-        out << "#";
-        out << std::to_string(NumScoreKinds - i);
-        out << " ";
+        out << " [";
         out << getNameFor(ScoreKind(i));
-        out << "(s), impact: ";
+        out << "(s), weight: ";
+        out << std::to_string(NumScoreKinds - i);
+        out << ", impact: ";
         out << std::to_string(Data[i]);
         out << "]";
         hasNonDefault = true;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1198,10 +1198,10 @@ struct Score {
       if (Data[i] != 0) {
         out << " [component: ";
         out << "#";
-        out << std::to_string(i);
+        out << std::to_string(NumScoreKinds - i);
         out << " ";
         out << getNameFor(ScoreKind(i));
-        out << "(s), value: ";
+        out << "(s), impact: ";
         out << std::to_string(Data[i]);
         out << "]";
         hasNonDefault = true;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1197,6 +1197,9 @@ struct Score {
     for (unsigned int i = 0; i < NumScoreKinds; ++i) {
       if (Data[i] != 0) {
         out << " [component: ";
+        out << "#";
+        out << std::to_string(i);
+        out << " ";
         out << getNameFor(ScoreKind(i));
         out << "(s), value: ";
         out << std::to_string(Data[i]);


### PR DESCRIPTION
# Environment

```
swift-driver version: 1.115 Apple Swift version 6.0 (swiftlang-6.0.0.9.10 clang-1600.0.26.2)
Target: arm64-apple-macosx14.0
```

# Motivation

resolve https://github.com/swiftlang/swift/issues/72842

As I mentioned in https://github.com/swiftlang/swift/issues/72842, 
In current output of debug-constraints, We cannot easily recognize which score is more impactful.

```swift
class Animal {}
class Cat: Animal {}
func f(_ a: [Cat?]) { }
func f(_ a: [Any]) { }

let a: [Cat] = [Cat()]
f(a)
```

```
// swiftc -Xfrontend -debug-constraints Source.swift

---Solver statistics---
--- Solution #0 ---
Fixed score: [component: collection upcast conversion(s), value: 1] [component: value to optional promotion(s), value: 1]
...

--- Solution #1 ---
Fixed score: [component: collection upcast conversion(s), value: 1] [component: empty-existential conversion(s), value: 1]
...

---Solution---
Fixed score: [component: collection upcast conversion(s), value: 1] [component: empty-existential conversion(s), value: 1]
...
```

[Full Output](https://gist.github.com/kntkymt/b0e28932d5a2dad6c1502c3ada7120c5)

We cannot recognize which score is more/less impactful. e.g. between `value to optional promotion` of `Solution#0` and `empty-existential conversion` of `Solution#1`.
(We can guess `empty-existential conversion(s)` is less impactful, since final Solution is Solution#1 but it is ambiguous.)

# Proposed Solution

I added number indicating impact of score to output of debug-constraints.
Currently I used index of `enum ScoreKind`. (i.e. smaller number is more impactful).

```
// swiftc -Xfrontend -debug-constraints Source.swift

---Solver statistics---
--- Solution #0 ---
Fixed score: [component: #14 collection upcast conversion(s), value: 1] [component: #15 value to optional promotion(s), value: 1]
...

--- Solution #1 ---
Fixed score: [component: #14 collection upcast conversion(s), value: 1] [component: #16 empty-existential conversion(s), value: 1]
...

---Solution---
Fixed score: [component: #14 collection upcast conversion(s), value: 1] [component: #16 empty-existential conversion(s), value: 1]
...
```

# Alternative Format

Suggestion for other formats are welcome. 

e. g.

```
// reversed index (i.e. bigger number is more impactful)
[component: #8 collection upcast conversion(s), value: 1]

// added label as well (I'm not sure whether "rank" is correct wording or not tho)
[rank: 14, component: collection upcast conversion(s), value: 1]
```