### PR TITLE
🍒[cxx-interop] Workaround compiler error when importing AppKit/UIKit with C++ interop

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2195,7 +2195,10 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   // interop enabled by the Swift CI because it uses an old host SDK.
   // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
   // of a CF_OPTIONS bug (rdar://142762174).
-  if (moduleName == "Darwin" || moduleName == "CoreGraphics") {
+  // FIXME: Hack for AppKit.swiftmodule / UIKit.swiftmodule, which cannot be
+  // rebuilt because of an NS_OPTIONS bug (rdar://143033209)
+  if (moduleName == "Darwin" || moduleName == "CoreGraphics"
+      || moduleName == "AppKit" || moduleName == "UIKit") {
     subInvocation.getLangOptions().EnableCXXInterop = false;
     subInvocation.getLangOptions().cxxInteropCompatVersion = {};
     BuildArgs.erase(llvm::remove_if(BuildArgs,

--- a/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
+++ b/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+#if canImport(AppKit)
+import AppKit
+
+var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
+
+#elseif canImport(UIKit)
+import UIKit
+
+var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
+
+#endif

--- a/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
+++ b/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx || OS=ios
 
 #if canImport(AppKit)
 import AppKit
@@ -11,6 +12,6 @@ var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
 #elseif canImport(UIKit)
 import UIKit
 
-var _: AttributeScopes.AppKitAttributes.UnderlineStyleAttribute! = nil
+var _: AttributeScopes.UIKitAttributes.UnderlineStyleAttribute! = nil
 
 #endif


### PR DESCRIPTION
  - **Explanation**: The AppKit/UIKit overlay refers to symbols declared via NS_OPTIONS macro, which is causing issues in the C++ language mode due to the macro definition being different. This teaches the module interface loader to drop the C++ interop flag when rebuilding the AppKit/UIKit overlays from their interface.
  - **Scope**: This changes the compiler flags used to rebuild AppKit/UIKit when C++ interop is enabled.
  - **Issues**: rdar://143033209
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78694
  - **Risk**: Low, this only affects rebuilding of a single SDK module from its interface when C++ interop is enabled.
  - **Testing**: Unit testing, manual testing against code where this was discovered.
  - **Reviewers**: @Xazax-hun 
  
  This is the same as #78657 but with different modules.