### PR TITLE
AST: Model Embedded Swift availability with a domain

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -151,7 +151,7 @@ protected:
       Value : 32
     );
 
-    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 4+1+1+1+1,
+    SWIFT_INLINE_BITFIELD(AvailableAttr, DeclAttribute, 4+1+1+1,
       /// An `AvailableAttr::Kind` value.
       Kind : 4,
 
@@ -160,10 +160,7 @@ protected:
       HasRenamedDecl : 1,
 
       /// Whether this attribute was spelled `@_spi_available`.
-      IsSPI : 1,
-
-      /// Whether this attribute was spelled `@_unavailableInEmbedded`.
-      IsForEmbedded : 1
+      IsSPI : 1
     );
 
     SWIFT_INLINE_BITFIELD(ClangImporterSynthesizedTypeAttr, DeclAttribute, 1,
@@ -741,7 +738,7 @@ public:
                 const llvm::VersionTuple &Deprecated,
                 SourceRange DeprecatedRange,
                 const llvm::VersionTuple &Obsoleted, SourceRange ObsoletedRange,
-                bool Implicit, bool IsSPI, bool IsForEmbedded = false);
+                bool Implicit, bool IsSPI);
 
   /// The optional message.
   const StringRef Message;
@@ -788,9 +785,6 @@ public:
 
   /// Whether this attribute was spelled `@_spi_available`.
   bool isSPI() const { return Bits.AvailableAttr.IsSPI; }
-
-  /// Whether this attribute was spelled `@_unavailableInEmbedded`.
-  bool isForEmbedded() const { return Bits.AvailableAttr.IsForEmbedded; }
 
   /// Returns the `AvailabilityDomain` associated with the attribute, or
   /// `std::nullopt` if it has either not yet been resolved or could not be
@@ -3277,8 +3271,8 @@ public:
     return getDomain().isPackageDescription() && isVersionSpecific();
   }
 
-  /// Whether this attribute was spelled `@_unavailableInEmbedded`.
-  bool isEmbeddedSpecific() const { return attr->isForEmbedded(); }
+  /// Whether this attribute an attribute that is specific to Embedded Swift.
+  bool isEmbeddedSpecific() const { return getDomain().isEmbedded(); }
 
   /// Returns the active version from the AST context corresponding to
   /// the available kind. For example, this will return the effective language

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -41,6 +41,9 @@ public:
     /// Represents PackageDescription availability.
     PackageDescription,
 
+    /// Represents Embedded Swift availability.
+    Embedded,
+
     /// Represents availability for a specific operating system platform.
     Platform,
   };
@@ -132,6 +135,10 @@ public:
     return AvailabilityDomain(Kind::PackageDescription);
   }
 
+  static AvailabilityDomain forEmbedded() {
+    return AvailabilityDomain(Kind::Embedded);
+  }
+
   Kind getKind() const {
     if (auto inlineDomain = getInlineDomain())
       return inlineDomain->getKind();
@@ -148,6 +155,8 @@ public:
   bool isPackageDescription() const {
     return getKind() == Kind::PackageDescription;
   }
+
+  bool isEmbedded() const { return getKind() == Kind::Embedded; }
 
   /// Returns the platform kind for this domain if applicable.
   PlatformKind getPlatformKind() const {
@@ -184,6 +193,7 @@ public:
     case Kind::Universal:
     case Kind::SwiftLanguage:
     case Kind::PackageDescription:
+    case Kind::Embedded:
       // These availability domains are singletons.
       return false;
     case Kind::Platform:

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -21,6 +21,7 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   case Kind::Universal:
   case Kind::SwiftLanguage:
   case Kind::PackageDescription:
+  case Kind::Embedded:
     return true;
   case Kind::Platform:
     return isPlatformActive(getPlatformKind(), ctx.LangOpts);
@@ -35,6 +36,8 @@ llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
     return "Swift";
   case Kind::PackageDescription:
     return "PackageDescription";
+  case Kind::Embedded:
+    return "Embedded Swift";
   case Kind::Platform:
     return swift::prettyPlatformString(getPlatformKind());
   }
@@ -48,6 +51,8 @@ llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
     return "swift";
   case Kind::PackageDescription:
     return "_PackageDescription";
+  case Kind::Embedded:
+    return "Embedded";
   case Kind::Platform:
     return swift::platformString(getPlatformKind());
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4392,12 +4392,11 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
     if (Context.LangOpts.hasFeature(Feature::Embedded)) {
       StringRef Message = "unavailable in embedded Swift", Renamed;
       auto attr = new (Context) AvailableAttr(
-          AtLoc, SourceRange(AtLoc, attrLoc),
-          AvailabilityDomain::forUniversal(), AvailableAttr::Kind::Unavailable,
-          Message, Renamed, llvm::VersionTuple(), SourceRange(),
+          AtLoc, SourceRange(AtLoc, attrLoc), AvailabilityDomain::forEmbedded(),
+          AvailableAttr::Kind::Unavailable, Message, Renamed,
           llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
-          SourceRange(),
-          /*Implicit=*/false, /*IsSPI=*/false, /*IsForEmbedded=*/true);
+          SourceRange(), llvm::VersionTuple(), SourceRange(),
+          /*Implicit=*/false, /*IsSPI=*/false);
       Attributes.add(attr);
     }
     return makeParserSuccess();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3028,6 +3028,7 @@ public:
   bool shouldHideDomainNameInUnversionedDiagnostics() const {
     switch (getDomain().getKind()) {
     case AvailabilityDomain::Kind::Universal:
+    case AvailabilityDomain::Kind::Embedded:
       return true;
     case AvailabilityDomain::Kind::Platform:
       return false;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5636,6 +5636,8 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
     domain = isPackageDescriptionVersionSpecific
                  ? AvailabilityDomain::forPackageDescription()
                  : AvailabilityDomain::forSwiftLanguage();
+  } else if (isForEmbedded) {
+    domain = AvailabilityDomain::forEmbedded();
   } else {
     domain = AvailabilityDomain::forUniversal();
   }
@@ -5643,7 +5645,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   auto attr = new (ctx)
       AvailableAttr(SourceLoc(), SourceRange(), domain, kind, message, rename,
                     Introduced, SourceRange(), Deprecated, SourceRange(),
-                    Obsoleted, SourceRange(), isImplicit, isSPI, isForEmbedded);
+                    Obsoleted, SourceRange(), isImplicit, isSPI);
   return attr;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3074,7 +3074,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isNoAsync(),
           domain->isPackageDescription(),
           theAttr->isSPI(),
-          theAttr->isForEmbedded(),
+          domain->isEmbedded(),
           LIST_VER_TUPLE_PIECES(Introduced),
           LIST_VER_TUPLE_PIECES(Deprecated),
           LIST_VER_TUPLE_PIECES(Obsoleted),


### PR DESCRIPTION
Remove the bit on `AvailableAttr` that previously modeled this.

Resolves rdar://138802876.
