### PR TITLE
Revert "AST: Print opaque result types correctly in swiftinterfaces."

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -367,10 +367,6 @@ struct PrintOptions {
   OpaqueReturnTypePrintingMode OpaqueReturnTypePrinting =
       OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
 
-  /// If non-null, opaque types that have this naming decl should be printed as
-  /// `some P1` instead of as a stable reference.
-  const ValueDecl *OpaqueReturnTypeNamingDecl = nullptr;
-
   /// Whether to print decl attributes that are only used internally,
   /// such as _silgen_name, transparent, etc.
   bool PrintUserInaccessibleAttrs = true;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -194,6 +194,24 @@ bool PrintOptions::excludeAttr(const DeclAttribute *DA) const {
   return false;
 }
 
+/// Forces printing types with the `some` keyword, instead of the full stable
+/// reference.
+struct PrintWithOpaqueResultTypeKeywordRAII {
+  PrintWithOpaqueResultTypeKeywordRAII(PrintOptions &Options)
+      : Options(Options) {
+    SavedMode = Options.OpaqueReturnTypePrinting;
+    Options.OpaqueReturnTypePrinting =
+        PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
+  }
+  ~PrintWithOpaqueResultTypeKeywordRAII() {
+    Options.OpaqueReturnTypePrinting = SavedMode;
+  }
+
+private:
+  PrintOptions &Options;
+  PrintOptions::OpaqueReturnTypePrintingMode SavedMode;
+};
+
 PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
                                                    bool preferTypeRepr,
                                                    bool printFullConvention,
@@ -941,19 +959,10 @@ class PrintAST : public ASTVisitor<PrintAST> {
     printTypeLocWithOptions(TL, Options, printBeforeType);
   }
 
-  void printTypeLocForImplicitlyUnwrappedOptional(
-      TypeLoc TL, bool IUO, const ValueDecl *opaqueTypeNamingDecl) {
-    auto savedIOU = Options.PrintOptionalAsImplicitlyUnwrapped;
-    Options.PrintOptionalAsImplicitlyUnwrapped = IUO;
-
-    auto savedOpaqueTypeNamingDecl = Options.OpaqueReturnTypeNamingDecl;
-    if (opaqueTypeNamingDecl)
-      Options.OpaqueReturnTypeNamingDecl = opaqueTypeNamingDecl;
-
-    printTypeLocWithOptions(TL, Options);
-
-    Options.PrintOptionalAsImplicitlyUnwrapped = savedIOU;
-    Options.OpaqueReturnTypeNamingDecl = savedOpaqueTypeNamingDecl;
+  void printTypeLocForImplicitlyUnwrappedOptional(TypeLoc TL, bool IUO) {
+    PrintOptions options = Options;
+    options.PrintOptionalAsImplicitlyUnwrapped = IUO;
+    printTypeLocWithOptions(TL, options);
   }
 
   void printContextIfNeeded(const Decl *decl) {
@@ -1390,17 +1399,18 @@ void PrintAST::printTypedPattern(const TypedPattern *TP) {
   printPattern(TP->getSubPattern());
   Printer << ": ";
 
-  VarDecl *varDecl = nullptr;
+  PrintWithOpaqueResultTypeKeywordRAII x(Options);
+
+  // Make sure to check if the underlying var decl is an implicitly unwrapped
+  // optional.
+  bool isIUO = false;
   if (auto *named = dyn_cast<NamedPattern>(TP->getSubPattern()))
     if (auto decl = named->getDecl())
-      varDecl = decl;
+      isIUO = decl->isImplicitlyUnwrappedOptional();
 
   const auto TyLoc = TypeLoc(TP->getTypeRepr(),
                              TP->hasType() ? TP->getType() : Type());
-
-  printTypeLocForImplicitlyUnwrappedOptional(
-      TyLoc, varDecl ? varDecl->isImplicitlyUnwrappedOptional() : false,
-      varDecl);
+  printTypeLocForImplicitlyUnwrappedOptional(TyLoc, isIUO);
 }
 
 /// Determines if we are required to print the name of a property declaration,
@@ -3854,8 +3864,9 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
     }
     Printer.printDeclResultTypePre(decl, tyLoc);
 
+    PrintWithOpaqueResultTypeKeywordRAII x(Options);
     printTypeLocForImplicitlyUnwrappedOptional(
-        tyLoc, decl->isImplicitlyUnwrappedOptional(), decl);
+      tyLoc, decl->isImplicitlyUnwrappedOptional());
   }
 
   printAccessors(decl);
@@ -3937,7 +3948,7 @@ void PrintAST::printOneParameter(const ParamDecl *param,
     }
 
     printTypeLocForImplicitlyUnwrappedOptional(
-        TheTypeLoc, param->isImplicitlyUnwrappedOptional(), nullptr);
+      TheTypeLoc, param->isImplicitlyUnwrappedOptional());
   }
 
   if (param->isDefaultArgument() && Options.PrintDefaultArgumentValue) {
@@ -4229,6 +4240,8 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         }
       }
 
+      PrintWithOpaqueResultTypeKeywordRAII x(Options);
+
       // Check if we would go down the type repr path... in such a case, see if
       // we can find a type repr and if that type has a sending type repr. In
       // such a case, look through the sending type repr since we handle it here
@@ -4255,7 +4268,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
       // If we printed using type repr printing, do not print again.
       if (!usedTypeReprPrinting) {
         printTypeLocForImplicitlyUnwrappedOptional(
-            ResultTyLoc, decl->isImplicitlyUnwrappedOptional(), decl);
+            ResultTyLoc, decl->isImplicitlyUnwrappedOptional());
       }
       Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
     }
@@ -4404,8 +4417,9 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
     Printer.printDeclResultTypePre(decl, elementTy);
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
 
+    PrintWithOpaqueResultTypeKeywordRAII x(Options);
     printTypeLocForImplicitlyUnwrappedOptional(
-        elementTy, decl->isImplicitlyUnwrappedOptional(), decl);
+      elementTy, decl->isImplicitlyUnwrappedOptional());
     Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
   }
 
@@ -7223,11 +7237,7 @@ public:
     auto genericSig = namingDecl->getInnermostDeclContext()
           ->getGenericSignatureOfContext();
 
-    auto mode = Options.OpaqueReturnTypePrinting;
-    if (Options.OpaqueReturnTypeNamingDecl == T->getDecl()->getNamingDecl())
-      mode = PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
-
-    switch (mode) {
+    switch (Options.OpaqueReturnTypePrinting) {
     case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
       if (printNamedOpaque())
         return;

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -50,7 +50,6 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
-// CHECK-LABEL: public struct Bar<T> : OpaqueResultTypes.AssocTypeInference
 @available(SwiftStdlib 5.1, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
@@ -258,30 +257,5 @@ public struct Zim: AssocTypeInference {
   @available(SwiftStdlib 5.1, *)
   public subscript() -> some Foo {
     return 123
-  }
-}
-
-public protocol PrimaryAssociatedTypeInference<Assoc> {
-  associatedtype Assoc
-
-  func foo(_: Int) -> Assoc
-}
-
-// CHECK-LABEL: public struct Baz : OpaqueResultTypes.PrimaryAssociatedTypeInference
-
-public struct Baz: PrimaryAssociatedTypeInference {
-  // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-  public func foo(_: Int) -> some Foo {
-    return 123
-  }
-
-  // CHECK-LABEL: public func callsFoo() -> @_opaqueReturnTypeOf("$s17OpaqueResultTypes3BazV3fooyQrSiF", 0) __
-  public func callsFoo() -> Assoc {
-    return foo(123)
-  }
-
-  // CHECK-LABEL: public func identity() -> some OpaqueResultTypes.PrimaryAssociatedTypeInference<@_opaqueReturnTypeOf("$s17OpaqueResultTypes3BazV3fooyQrSiF", 0) __>
-  public func identity() -> some PrimaryAssociatedTypeInference<Assoc> {
-    return self
   }
 }


### PR DESCRIPTION
This reverts https://github.com/swiftlang/swift/pull/77550 because that fix exposed a different existing bug in opaque type result printing where generic archetypes are not consistently resugared on stable addresses, yielding unparsable swiftinterfaces. Reverting this fix returns interface printing to the status quo in which the interfaces are parseable but incorrect (with `some P` printed where `@_opaqueReturnTypeOf()` is actually necessary).
