### PR TITLE
[embedded] Start building embedded stdlib for arm64-apple-ios + arm64e-apple-ios

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -179,6 +179,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
       "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
       "arm64e   arm64e-apple-none-macho   arm64e-apple-none-macho"
+      "arm64    arm64-apple-ios           arm64-apple-ios18"
+      "arm64e   arm64e-apple-ios          arm64e-apple-ios18"
     )
   endif()
 


### PR DESCRIPTION
6.1 cherry-pick of https://github.com/swiftlang/swift/pull/77941

- **Explanation:** We are building Embedded Swift stdlib for macOS (Darwin), but it's also useful to build one for iOS (Darwin). Let's do that.
- **Scope:** Embedded Swift users.
- **Issue/Radar:** rdar://142897117
- **Original PR:** https://github.com/swiftlang/swift/pull/77941
- **Risk:** Low. Adds a new configuration that is currently unused.
- **Testing:** N/A, this just adds a new stdlib configuration
- **Reviewer:** @rauhul 
