### PR TITLE
[embedded] Fix lit site config for embedded QEMU tests to generate lit.swift-features.cfg

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -581,6 +581,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
 
   set(VARIANT_SUFFIX "-embedded-avr")
   set(VARIANT_TRIPLE "avr-none-none-elf")
@@ -591,6 +592,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
 
   set(VARIANT_SUFFIX "-embedded-riscv32")
   set(VARIANT_TRIPLE "riscv32-none-none-eabi")
@@ -601,6 +603,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
 endif()
 
 # Add shortcuts for the default variant.


### PR DESCRIPTION
`lit.swift-features.cfg` is nowadays required and we're missing it in the Embedded Swift QEMU test setup.