### PR TITLE
[embedded] Centralize the OS/target requirements on (most) Embedded Swift tests

### DIFF
--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 import Builtin

--- a/test/embedded/array-zero-size-struct.swift
+++ b/test/embedded/array-zero-size-struct.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct MyStruct {

--- a/test/embedded/arrays-enums.swift
+++ b/test/embedded/arrays-enums.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 enum Node {

--- a/test/embedded/class-func.swift
+++ b/test/embedded/class-func.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @main

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class MyClass {

--- a/test/embedded/classes-indirect-return.swift
+++ b/test/embedded/classes-indirect-return.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // CHECK: sil @$e4main1XC3fooxyFSi_Tg5 : $@convention(method) (@guaranteed X<Int>) -> Int {

--- a/test/embedded/classes-optional.swift
+++ b/test/embedded/classes-optional.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class Foo {

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -7,7 +7,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public class MyClass {

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class MyClass {

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public class MyClass {

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 

--- a/test/embedded/cxx-no-metadata.swift
+++ b/test/embedded/cxx-no-metadata.swift
@@ -4,7 +4,6 @@
 // RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN header.h

--- a/test/embedded/cxxshim.swift
+++ b/test/embedded/cxxshim.swift
@@ -4,7 +4,6 @@
 // RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN header.h

--- a/test/embedded/debuginfo-dwarf-types.swift
+++ b/test/embedded/debuginfo-dwarf-types.swift
@@ -10,7 +10,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct MyType {

--- a/test/embedded/debuginfo.swift
+++ b/test/embedded/debuginfo.swift
@@ -7,7 +7,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func foo<T>(_ array: inout [T]) {

--- a/test/embedded/deinit-release.swift
+++ b/test/embedded/deinit-release.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class C {}

--- a/test/embedded/deinit-release2.swift
+++ b/test/embedded/deinit-release2.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public var global_c: C? = nil

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -28,7 +28,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 // REQUIRES: rdar121923818

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 

--- a/test/embedded/duration.swift
+++ b/test/embedded/duration.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-emit-ir -Osize %s -enable-experimental-feature Embedded -wmo
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @available(SwiftStdlib 5.7, *)

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -parse-as-library -module-name main | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class MyClass {

--- a/test/embedded/existential-class-bound1.swift
+++ b/test/embedded/existential-class-bound1.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/existential-class-bound2.swift
+++ b/test/embedded/existential-class-bound2.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/existential-class-bound3.swift
+++ b/test/embedded/existential-class-bound3.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/existential-class-bound5.swift
+++ b/test/embedded/existential-class-bound5.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/existential-class-bound6.swift
+++ b/test/embedded/existential-class-bound6.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public var global: AnyObject? = nil

--- a/test/embedded/existential-class-bound7.swift
+++ b/test/embedded/existential-class-bound7.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public protocol P: AnyObject {

--- a/test/embedded/existential-class-bound8.swift
+++ b/test/embedded/existential-class-bound8.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN MyModule.swift

--- a/test/embedded/existential-class-bound9.swift
+++ b/test/embedded/existential-class-bound9.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/existential-composition.swift
+++ b/test/embedded/existential-composition.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo
 
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol ClassBound: AnyObject {

--- a/test/embedded/failable-crash.swift
+++ b/test/embedded/failable-crash.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func test() {

--- a/test/embedded/float-abi-hard.swift
+++ b/test/embedded/float-abi-hard.swift
@@ -6,7 +6,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -3,7 +3,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func foo() -> [Int] {

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/generic-class-multi-module.swift
+++ b/test/embedded/generic-class-multi-module.swift
@@ -4,7 +4,6 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 protocol Fooable {

--- a/test/embedded/generic-classes2.swift
+++ b/test/embedded/generic-classes2.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 class B<T> {

--- a/test/embedded/generic-modules.swift
+++ b/test/embedded/generic-modules.swift
@@ -6,7 +6,6 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -o %t/Main.o -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library
 
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN MyModule.swift

--- a/test/embedded/init-failable-generic.swift
+++ b/test/embedded/init-failable-generic.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct FooError: Error {}

--- a/test/embedded/init-failable.swift
+++ b/test/embedded/init-failable.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct FooError: Error {}

--- a/test/embedded/init-throwing.swift
+++ b/test/embedded/init-throwing.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct FooError: Error {}

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @propertyWrapper

--- a/test/embedded/keypaths.swift
+++ b/test/embedded/keypaths.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 struct MyStruct {

--- a/test/embedded/keypaths2.swift
+++ b/test/embedded/keypaths2.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @dynamicMemberLookup

--- a/test/embedded/keypaths3.swift
+++ b/test/embedded/keypaths3.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @dynamicMemberLookup

--- a/test/embedded/keypaths4.swift
+++ b/test/embedded/keypaths4.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func foo() {

--- a/test/embedded/lazy-collections.swift
+++ b/test/embedded/lazy-collections.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @main

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -1,6 +1,9 @@
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 
+# A handful of test setup tweaks that we want for *all* Embedded Swift tests (i.e. all tests in this directory):
+
+# (1) When targeting macOS, raise the deployment target to macOS 14.0 (from the default 13.0)
 if config.target_sdk_name == 'macosx':
   def do_fixup(key, value):
     if isinstance(value, str):
@@ -11,9 +14,17 @@ if config.target_sdk_name == 'macosx':
 
   config.substitutions = [do_fixup(a, b) for (a, b) in config.substitutions]
 
+# (2) If building embedded stdlib is off (SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB in CMake), make all tests unsupported
 if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
+# (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf"]
+if config.available_features.intersection(set(supported_test_os_list)) == set():
+  config.unsupported = True
+
+# (4) Use the new Swift driver (swift-driver), instead of the legacy C++ Swift driver (which is unfortunately what
+# standard Swift lit tests still use by default).
 config.environment = dict(config.environment)
 if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
 if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']

--- a/test/embedded/managed-buffer.swift
+++ b/test/embedded/managed-buffer.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // CHECK: @"$e4main8MyBufferCN" = {{.*global.*}} <{ ptr @"$es13ManagedBufferCySis5UInt8VGN", ptr @"$e4main8MyBufferCfD{{[^"]*}}", ptr null, ptr @"$e4main8MyBufferC12_doNotCallMeACyt_tcfC{{[^"]*}}" }>

--- a/test/embedded/metatype-type-hint.swift
+++ b/test/embedded/metatype-type-hint.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct AsyncStream2<Element> {

--- a/test/embedded/metatype-type-hint2.swift
+++ b/test/embedded/metatype-type-hint2.swift
@@ -7,7 +7,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN MyModule.swift

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func sink<T>(t: T) {}

--- a/test/embedded/mirror.swift
+++ b/test/embedded/mirror.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct MyStruct {

--- a/test/embedded/modules-empty-object.swift
+++ b/test/embedded/modules-empty-object.swift
@@ -10,7 +10,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 //--- MyModuleA.swift

--- a/test/embedded/modules-extern.swift
+++ b/test/embedded/modules-extern.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -7,7 +7,6 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // Dependencies look like this:

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN MyModule.swift

--- a/test/embedded/no-allocations-print.swift
+++ b/test/embedded/no-allocations-print.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/no-autolink.swift
+++ b/test/embedded/no-autolink.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func staticstring() -> StaticString {

--- a/test/embedded/non-copyable-deinit.swift
+++ b/test/embedded/non-copyable-deinit.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -O -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 var deinitCalled = false

--- a/test/embedded/noncopyable-captures.swift
+++ b/test/embedded/noncopyable-captures.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -DIGNORE_FAILS -enable-experimental-feature Embedded -wmo -o /dev/null
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -verify
 
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 struct MyStruct<Item> : ~Copyable {

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct MyStructA {

--- a/test/embedded/optionset.swift
+++ b/test/embedded/optionset.swift
@@ -4,7 +4,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 struct ShippingOptions: OptionSet {

--- a/test/embedded/osize-genericspecializer.swift
+++ b/test/embedded/osize-genericspecializer.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir -Osize %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func foo<T>(n: T) {

--- a/test/embedded/osize-releasedevirt.swift
+++ b/test/embedded/osize-releasedevirt.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func foo() {

--- a/test/embedded/ptrauth-fieldptr1.swift
+++ b/test/embedded/ptrauth-fieldptr1.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-ir %t/Main.swift -enable-experimental-feature Embedded -import-objc-header %t/header.h | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CPU=arm64e
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/ptrauth-fieldptr2.swift
+++ b/test/embedded/ptrauth-fieldptr2.swift
@@ -6,7 +6,6 @@
 // RUN: %target-swift-frontend -O -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded -import-objc-header %t/header.h
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CPU=arm64e
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/runtime-release.swift
+++ b/test/embedded/runtime-release.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 @main

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 

--- a/test/embedded/shared-linkage.swift
+++ b/test/embedded/shared-linkage.swift
@@ -11,7 +11,6 @@
 // RUN: %target-swift-frontend -Osize -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN Module.swift

--- a/test/embedded/static-object-non-darwin.swift
+++ b/test/embedded/static-object-non-darwin.swift
@@ -3,7 +3,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -6,7 +6,6 @@
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 // Check if the optimizer is able to convert array literals to constant statically initialized arrays.
 

--- a/test/embedded/static-string-interpolation.swift
+++ b/test/embedded/static-string-interpolation.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public struct MyInterpolation : StringInterpolationProtocol {

--- a/test/embedded/stdlib-strings-interpolation3.swift
+++ b/test/embedded/stdlib-strings-interpolation3.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded -Osize
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -6,7 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: synchronization
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/throw-trap-stdlib.swift
+++ b/test/embedded/throw-trap-stdlib.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func test() {

--- a/test/embedded/throw-trap.swift
+++ b/test/embedded/throw-trap.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-IR
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 enum MyError : Error {

--- a/test/embedded/throw-typed.swift
+++ b/test/embedded/throw-typed.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public enum MyError : Error, Equatable {

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -6,7 +6,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func test() {

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 public func unsafeWriteArray<T, R>(_ elementType: R.Type, array: inout T, index n: Int, value: R) {

--- a/test/embedded/value-type-deinits.swift
+++ b/test/embedded/value-type-deinits.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -emit-sil -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_feature_Embedded
 
 // BEGIN MyModule.swift

--- a/test/embedded/volatile-exec.swift
+++ b/test/embedded/volatile-exec.swift
@@ -3,7 +3,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: volatile
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern


### PR DESCRIPTION
Let's remove the `// REQUIRES: OS=macosx || OS=linux-gnu` line that we have duplicated across most of our Embedded Swift tests in `test/embedded/`. Instead, put the OS filtering logic into `lit.local.cfg`. This enables a lot of tests to start working in the RISC-V and ARM baremetal QEMU harness (not yet present in CI).