### PR TITLE
Change enum to enum class in DeclNameLoc

### DIFF
--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -44,11 +44,11 @@ class DeclNameLoc {
   /// The number of argument labels stored in the name.
   unsigned NumArgumentLabels;
 
-  enum {
-    BaseNameIndex = 0,
-    LParenIndex = 1,
-    RParenIndex = 2,
-    FirstArgumentLabelIndex = 3,
+  enum Index : uint8_t {
+    BaseName = 0,
+    LParen = 1,
+    RParen = 2,
+    FirstArgumentLabel = 3,
   };
 
   /// Retrieve a pointer to either the only source location that was
@@ -89,26 +89,26 @@ public:
 
   /// Retrieve the location of the base name.
   SourceLoc getBaseNameLoc() const {
-    return getSourceLocs()[BaseNameIndex];
+    return getSourceLocs()[Index::BaseName];
   }
 
   /// Retrieve the location of the left parentheses.
   SourceLoc getLParenLoc() const {
     if (NumArgumentLabels == 0) return SourceLoc();
-    return getSourceLocs()[LParenIndex];
+    return getSourceLocs()[Index::LParen];
   }
 
   /// Retrieve the location of the right parentheses.
   SourceLoc getRParenLoc() const {
     if (NumArgumentLabels == 0) return SourceLoc();
-    return getSourceLocs()[RParenIndex];
+    return getSourceLocs()[Index::RParen];
   }
 
   /// Retrieve the location of an argument label.
   SourceLoc getArgumentLabelLoc(unsigned index) const {
     if (index >= NumArgumentLabels)
       return SourceLoc();
-    return getSourceLocs()[FirstArgumentLabelIndex + index];
+    return getSourceLocs()[Index::FirstArgumentLabel + index];
   }
 
   SourceLoc getStartLoc() const {

--- a/lib/AST/DeclNameLoc.cpp
+++ b/lib/AST/DeclNameLoc.cpp
@@ -29,10 +29,10 @@ DeclNameLoc::DeclNameLoc(ASTContext &ctx, SourceLoc baseNameLoc,
 
   // Copy the location information into permanent storage.
   auto storedLocs = ctx.Allocate<SourceLoc>(NumArgumentLabels + 3);
-  storedLocs[BaseNameIndex] = baseNameLoc;
-  storedLocs[LParenIndex] = lParenLoc;
-  storedLocs[RParenIndex] = rParenLoc;
-  std::memcpy(storedLocs.data() + FirstArgumentLabelIndex,
+  storedLocs[Index::BaseName] = baseNameLoc;
+  storedLocs[Index::LParen] = lParenLoc;
+  storedLocs[Index::RParen] = rParenLoc;
+  std::memcpy(storedLocs.data() + Index::FirstArgumentLabel,
               argumentLabelLocs.data(),
               argumentLabelLocs.size() * sizeof(SourceLoc));
 


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Change a enum to enum class to improve type safety and avoid potential naming conflicts.
