### PR TITLE
Update Swift NIO checkout to 2.78.0

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -161,7 +161,7 @@
                 "swift-docc-render-artifact": "main",
                 "swift-docc-symbolkit": "main",
                 "swift-markdown": "main",
-                "swift-nio": "2.65.0",
+                "swift-nio": "2.78.0",
                 "swift-experimental-string-processing": "swift/main",
                 "swift-sdk-generator": "main",
                 "wasi-libc": "wasi-sdk-24",


### PR DESCRIPTION
This updates the Swift NIO version in `utils/update_checkout/update-checkout-config.json` for the main branch  to [2.78.0](https://github.com/apple/swift-nio/releases/tag/2.78.0)—which is the first release which contains https://github.com/apple/swift-nio/pull/2969.

This enables projects like Swift-DocC to avoid warning about capturing non-sendable types when working with NIO types like `EventLoopPromise`.
