### PR TITLE
Fix compiler crashes to print InOutConversionFailure

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3659,7 +3659,9 @@ bool ContextualFailure::isIntegerToStringIndexConversion() const {
 std::optional<Diag<Type, Type>>
 ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
                                     Type contextualType) {
-  auto forProtocol = contextualType->isConstraintType();
+  bool forProtocol = false;
+  if (!contextualType.isNull())
+    forProtocol = contextualType->isConstraintType();
   switch (context) {
   case CTP_Initialization: {
     if (contextualType->isAnyObject())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3659,9 +3659,8 @@ bool ContextualFailure::isIntegerToStringIndexConversion() const {
 std::optional<Diag<Type, Type>>
 ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
                                     Type contextualType) {
-  bool forProtocol = false;
-  if (!contextualType.isNull())
-    forProtocol = contextualType->isConstraintType();
+  assert(!contextualType.isNull() && "contextual type should not be null");
+  auto forProtocol = contextualType->isConstraintType();
   switch (context) {
   case CTP_Initialization: {
     if (contextualType->isAnyObject())
@@ -7294,6 +7293,8 @@ bool InOutConversionFailure::diagnoseAsError() {
       assert(locator->findLast<LocatorPathElt::ContextualType>());
       auto anchor = getAnchor();
       auto contextualType = getContextualType(anchor);
+      if (contextualType.isNull())
+        return false;
       auto purpose = getContextualTypePurpose();
       auto diagnostic = getDiagnosticFor(purpose, contextualType);
 

--- a/test/Constraints/issue-78039.swift
+++ b/test/Constraints/issue-78039.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/78039
+protocol A {
+    associatedtype Node
+}
+
+extension A {
+    func foo(arr: inout Node) { }
+
+    func bar(_ f: (inout Node) -> Void = foo) { }
+    // expected-error@-1 {{default argument value of type '(Self) -> (inout Self.Node) -> ()' cannot be converted to type '(inout Self.Node) -> Void'}}
+    // expected-error@-2 {{generic parameter 'Self' could not be inferred}}
+}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

closes #78039 

This PR resolves #78039 .
[Compiler crashes when type checking an extension function with a default parameter that uses associated types as function parameter · Issue #78039 · swiftlang/swift](https://github.com/swiftlang/swift/issues/78039)

It tries to build Diagnostic for the null pointer, but it causes crashes due to accessing to a null pointer.

This PR adds a null check to `InOutConversionFailure`. In addition, assert nulls in `ContextualFailure::getDiagnosticFor`.

## Input

```swift
protocol A {
    associatedtype Node
}

extension A {
    func foo(arr: inout Node) { }

    func bar(_ f: (inout Node) -> Void = foo) { }
}
```

## Before

Crash https://github.com/swiftlang/swift/issues/78039

## After

Raises errors

```
/Users/giginet/work/Swift/swiftc-playground/78039.swift:8:42: error: default argument value of type '(Self) -> (inout Self.Node) -> ()' cannot be converted to type '(inout Self.Node) -> Void'
 6 |     func foo(arr: inout Node) { }
 7 | 
 8 |     func bar(_ f: (inout Node) -> Void = foo) { }
   |                                          `- error: default argument value of type '(Self) -> (inout Self.Node) -> ()' cannot be converted to type '(inout Self.Node) -> Void'
 9 | }
10 | 

/Users/giginet/work/Swift/swiftc-playground/78039.swift:8:42: error: generic parameter 'Self' could not be inferred
 6 |     func foo(arr: inout Node) { }
 7 | 
 8 |     func bar(_ f: (inout Node) -> Void = foo) { }
   |                                          `- error: generic parameter 'Self' could not be inferred
 9 | }
10 | 
```
