### PR TITLE
🍒[cxx-interop] Do not import `std::__compressed_pair`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2764,6 +2764,7 @@ namespace {
           decl->getDeclContext()->getParent()->isStdNamespace() &&
           decl->getIdentifier() &&
           (decl->getName() == "tzdb" || decl->getName() == "time_zone_link" ||
+           decl->getName() == "__compressed_pair" ||
            decl->getName() == "time_zone"))
         return nullptr;
 


### PR DESCRIPTION
**Explanation**: This type is triggering modularization issues in libc++:
```
error: definition of '__builtin_new_deleter' must be imported from module 'std_private_memory_builtin_new_allocator' before it is required
```
This is a workaround to keep things building.

**Risk**: Low, this only affects import of one specific C++ type.
**Issue**: rdar://142576799
**Reviewer**: @Xazax-hun 

Original PR: https://github.com/swiftlang/swift/pull/78696