### PR TITLE
[cxx-interop] Mark C++ reference parameters @addressable

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3946,6 +3946,9 @@ namespace {
           }
           if (selfIdx) {
             func->setSelfIndex(selfIdx.value());
+            if (Impl.SwiftContext.LangOpts.hasFeature(
+                    Feature::AddressableParameters))
+              func->getImplicitSelfDecl()->setAddressable();
           } else {
             func->setStatic();
             func->setImportAsStaticMember();

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -33,6 +33,9 @@ struct HasMethods {
 
   NonTrivialInWrapper nonConstPassThroughAsWrapper(int a) { return {a}; }
   NonTrivialInWrapper constPassThroughAsWrapper(int a) const { return {a}; }
+
+  void nonTrivialTakesConstRef(const NonTrivialInWrapper& w) const {}
+  void nonTrivialTakesRef(NonTrivialInWrapper& w) const {}
 };
 
 struct ReferenceParams {

--- a/test/Interop/Cxx/class/method/methods-addressable-silgen.swift
+++ b/test/Interop/Cxx/class/method/methods-addressable-silgen.swift
@@ -1,0 +1,23 @@
+
+// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-experimental-feature AddressableParameters -enable-experimental-cxx-interop %s | %FileCheck %s
+
+import Methods
+
+// REQUIRES: swift_feature_AddressableParameters
+
+public func addressableTest(x: borrowing @_addressable NonTrivialInWrapper, y: inout NonTrivialInWrapper) {
+  let m = HasMethods()
+  m.nonTrivialTakesConstRef(x)
+  // No copy from the argument to the apply.
+  // CHECK: addressableTest(x:y:)
+  // CHECK: bb0([[INPUT:%[0-9]+]] : @noImplicitCopy $*NonTrivialInWrapper, [[INPUT2:%[0-9]+]] : $*NonTrivialInWrapper)
+  // CHECK: [[WRAPPER:%[0-9]+]] = copyable_to_moveonlywrapper_addr [[INPUT]]
+  // CHECK: [[MARKED:%[0-9]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[WRAPPER]]
+  // CHECK: [[UNWRAPPED:%[0-9]+]] = moveonlywrapper_to_copyable_addr [[MARKED]]
+  // CHECK: %{{[0-9]+}} = apply %{{[0-9]+}}([[UNWRAPPED]], %{{[0-9]+}}) : $@convention(cxx_method) (@in_guaranteed NonTrivialInWrapper, @in_guaranteed HasMethods) -> ()
+  var m2 = HasMethods()
+  // CHECK: [[ACCESS:%[0-9]+]] = begin_access [modify] [unknown] [[INPUT2]]
+  // CHECK: %{{[0-9]+}} = apply %32([[ACCESS]], %{{[0-9]+}}) : $@convention(cxx_method) (@inout NonTrivialInWrapper, @in_guaranteed HasMethods) -> ()
+  // CHECK-NEXT: end_access [[ACCESS]]
+  m2.nonTrivialTakesRef(&y)
+}

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 // RUN: not %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-NO-LIFETIMES
 
+// REQUIRES: swift_feature_LifetimeDependence
 
 //--- Inputs/module.modulemap
 module Test {


### PR DESCRIPTION
C++ code can return values that depend on the storage that backs the references that were passed in as argument. Thus, swift should not introdue temporary copies of that storage before invoking those functions as they could result in lifetime issues.