### PR TITLE
[cxx-interop] Make ClangImporter support lifetimebound annotated spans

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8778,6 +8778,14 @@ public:
     out << ")";
   }
 
+  void printLifetimeboundReturn(int idx, bool borrow) {
+    printSeparator();
+    out << ".lifetimeDependence(dependsOn: " << (idx + 1);
+    out << ", pointer: .return, type: ";
+    out << (borrow ? ".borrow" : ".copy");
+    out << ")";
+  }
+
   void printTypeMapping(const llvm::StringMap<std::string> &mapping) {
     printSeparator();
     out << "typeMappings: [";
@@ -8823,23 +8831,44 @@ void ClangImporter::Implementation::importSpanAttributes(FuncDecl *MappedDecl) {
     llvm::raw_svector_ostream out(MacroString);
     llvm::StringMap<std::string> typeMapping;
 
+    auto registerSwiftifyMacro =
+        [&typeMapping, &attachMacro](ParamDecl *swiftParam,
+                                     const clang::ParmVarDecl *param) {
+          typeMapping.insert(std::make_pair(
+              swiftParam->getInterfaceType()->getString(),
+              swiftParam->getInterfaceType()->getDesugaredType()->getString()));
+          attachMacro = true;
+        };
     SwiftifyInfoPrinter printer(getClangASTContext(), out);
+    auto retDecl = ClangDecl->getReturnType()->getAsTagDecl();
+    bool returnIsSpan =
+        retDecl && retDecl->isInStdNamespace() && retDecl->getName() == "span";
+    if (returnIsSpan) {
+      typeMapping.insert(
+          std::make_pair(MappedDecl->getResultInterfaceType()->getString(),
+                         MappedDecl->getResultInterfaceType()
+                             ->getDesugaredType()
+                             ->getString()));
+    }
     for (auto [index, param] : llvm::enumerate(ClangDecl->parameters())) {
       auto paramTy = param->getType();
       const auto *decl = paramTy->getAsTagDecl();
-      if (!decl || !decl->isInStdNamespace())
-        continue;
-      if (decl->getName() != "span")
+      auto swiftParam = MappedDecl->getParameters()->get(index);
+      bool isSpan =
+          decl && decl->isInStdNamespace() && decl->getName() == "span";
+      if (param->hasAttr<clang::LifetimeBoundAttr>() &&
+          MappedDecl->getASTContext().LangOpts.hasFeature(
+              Feature::LifetimeDependence) &&
+          (isSpan || returnIsSpan)) {
+        printer.printLifetimeboundReturn(
+            index, !isSpan && swiftParam->getInterfaceType()->isEscapable());
+        registerSwiftifyMacro(swiftParam, param);
+      }
+      if (!isSpan)
         continue;
       if (param->hasAttr<clang::NoEscapeAttr>()) {
         printer.printNonEscaping(index);
-        clang::PrintingPolicy policy(param->getASTContext().getLangOpts());
-        policy.SuppressTagKeyword = true;
-        auto param = MappedDecl->getParameters()->get(index);
-        typeMapping.insert(std::make_pair(
-            paramTy.getAsString(policy),
-            param->getInterfaceType()->getDesugaredType()->getString()));
-        attachMacro = true;
+        registerSwiftifyMacro(swiftParam, param);
       }
     }
     printer.printTypeMapping(typeMapping);

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -2,13 +2,15 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H
 
 #include <cstddef>
-#include <string>
 #include <span>
+#include <string>
+#include <vector>
 
 using ConstSpanOfInt = std::span<const int>;
 using SpanOfInt = std::span<int>;
 using ConstSpanOfString = std::span<const std::string>;
 using SpanOfString = std::span<std::string>;
+using VecOfInt = std::vector<int>;
 
 static int iarray[]{1, 2, 3};
 static std::string sarray[]{"", "ab", "abc"};
@@ -54,6 +56,15 @@ inline SpanOfInt initSpan(int arr[], size_t size) {
 
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }
 
-void funcWithSafeWrapper(SpanOfInt s [[clang::noescape]]) {}
+inline void funcWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}
+
+inline ConstSpanOfInt funcWithSafeWrapper2(ConstSpanOfInt s
+                                           [[clang::lifetimebound]]) {
+  return s;
+}
+inline ConstSpanOfInt funcWithSafeWrapper3(const VecOfInt &v
+                                           [[clang::lifetimebound]]) {
+  return ConstSpanOfInt(v.data(), v.size());
+}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Span -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t > %t/interface.swift
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t > %t/interface.swift
 // RUN: %FileCheck %s < %t/interface.swift
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Span
+// REQUIRES: swift_feature_LifetimeDependence
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -13,5 +14,11 @@ import StdSpan
 #endif
 import CxxStdlib
 
-// CHECK: func funcWithSafeWrapper(_ s: SpanOfInt)
+// CHECK:      func funcWithSafeWrapper(_ s: ConstSpanOfInt)
+// CHECK-NEXT: func funcWithSafeWrapper2(_ s: borrowing ConstSpanOfInt) -> ConstSpanOfInt
+// CHECK-NEXT: func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> ConstSpanOfInt
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
+// CHECK-NEXT: @lifetime(s)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: borrowing Span<CInt>) -> Span<CInt>
+// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>


### PR DESCRIPTION
Generate safe Swift Span wrappers using the new SwiftifyImport macro.