### PR TITLE
Fixit for operator parameter types in protocol extensions

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3772,10 +3772,22 @@ public:
       if (FD->isOperator() && !isMemberOperator(FD, nullptr)) {
         auto selfNominal = FD->getDeclContext()->getSelfNominalTypeDecl();
         auto isProtocol = isa_and_nonnull<ProtocolDecl>(selfNominal);
+        auto isExtension = isa_and_nonnull<ExtensionDecl>(FD->getDeclContext()->getAsDecl());
         // We did not find 'Self'. Complain.
-        FD->diagnose(diag::operator_in_unrelated_type,
-                     FD->getDeclContext()->getDeclaredInterfaceType(),
-                     isProtocol, FD);
+        auto diagnostic = FD->diagnose(diag::operator_in_unrelated_type,
+                                       FD->getDeclContext()->getDeclaredInterfaceType(),
+                                       isProtocol, FD);
+        
+        // If we are in a protocol extension and 'isMemberOperator' fails, see if we can suggest a fix-it where we change the type of a single parameter from the protocol itself into 'Self'
+        if (isProtocol && isExtension) {
+          for (auto param : *FD->getParameters()) {
+            auto paramType = param->getInterfaceType()->getMetatypeInstanceType();
+            if (paramType->getAnyNominal() == selfNominal) {
+              diagnostic.fixItReplace(param->getTypeSourceRangeForDiagnostics(), "Self");
+              break;
+            }
+          }
+        }
       }
     }
 

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -297,13 +297,13 @@ struct Unrelated { }
 
 struct S2 {
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
-  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}} {{none}}
 
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> S2 { }
-  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}} {{none}}
 
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> S2.Type { }
-  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}} {{none}}
 
   // Okay: refers to S2
   static func %%%(lhs: S2, rhs: Unrelated) -> Unrelated { }
@@ -318,13 +318,13 @@ struct S2 {
 
 extension S2 {
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
-  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}} {{none}}
 
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> S2 { }
-  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}} {{none}}
 
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> S2.Type { }
-  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}} {{none}}
 
   // Okay: refers to S2
   static func %%%%(lhs: S2, rhs: Unrelated) -> Unrelated { }
@@ -339,13 +339,13 @@ extension S2 {
 
 protocol P2 {
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated
-  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> Self
-  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   static func %%%(lhs: Unrelated, rhs: Unrelated) -> Self.Type
-  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   // Okay: refers to Self
   static func %%%(lhs: Self, rhs: Unrelated) -> Unrelated
@@ -360,13 +360,13 @@ protocol P2 {
 
 extension P2 {
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
-  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Self { }
-  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Self.Type { }
-  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}} {{none}}
 
   // Okay: refers to Self
   static func %%%%(lhs: Self, rhs: Unrelated) -> Unrelated { }
@@ -382,13 +382,24 @@ extension P2 {
 protocol P3 {
   // Not allowed: there's no way to infer 'Self' from this interface type
   static func %%%(lhs: P3, rhs: Unrelated) -> Unrelated
-  // expected-error@-1 {{member operator '%%%' of protocol 'P3' must have at least one argument of type 'Self'}}
+  // expected-error@-1 {{member operator '%%%' of protocol 'P3' must have at least one argument of type 'Self'}} {{none}}
 }
 
 extension P3 {
   // Not allowed: there's no way to infer 'Self' from this interface type
   static func %%%%(lhs: P3, rhs: Unrelated) -> Unrelated { }
-  // expected-error@-1 {{member operator '%%%%' of protocol 'P3' must have at least one argument of type 'Self'}}
+  // expected-error@-1 {{member operator '%%%%' of protocol 'P3' must have at least one argument of type 'Self'}} {{25-27=Self}}
+  static func %%%%(lhs: P3, rhs: P3) -> Unrelated { }
+  // expected-error@-1 {{member operator '%%%%' of protocol 'P3' must have at least one argument of type 'Self'}} {{25-27=Self}}
+  static func %%%%(lhs: Unrelated, rhs: P3) -> Unrelated { }
+  // expected-error@-1 {{member operator '%%%%' of protocol 'P3' must have at least one argument of type 'Self'}} {{41-43=Self}}
+}
+
+protocol P4 { }
+extension P4 {
+  // Not allowed: there's no way to infer 'Self' from this interface type
+  static func %%%%<T: P4>(lhs: T, rhs: Unrelated) -> Unrelated { }
+  // expected-error@-1 {{member operator '%%%%' of protocol 'P4' must have at least one argument of type 'Self'}} {{none}}
 }
 
 // rdar://problem/27940842 - recovery with a non-static '=='.


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
## Context
With https://github.com/swiftlang/swift/pull/73204, operators in protocol extensions can no longer get around the requirement to have at least one argument of type `Self` by having an argument with the protocol itself as its type. Examples of this are given in https://github.com/swiftlang/swift/issues/78733. 

## Change
For the cases that has now been made illegal, this PR introduces a fixit which finds the first argument that has the protocol as its type, and substitutes that with `Self`. This would allow any existing declarations of these new illegal operators to be used as they were intended by the programmer.

### Unhandled cases
This fixit is currently a little too eager, for example it suggests replacing `any P5<Unrelated>`  with `Self` in the following example test case:
```swift
protocol P5<A> {
  associatedtype A
}
extension P5 {
  static func %%%%(lhs: Unrelated, rhs: any P5<Unrelated>) -> Unrelated { }
  // expected-error@-1 {{member operator '%%%%' of protocol 'P5' must have at least one argument of type 'Self'}} {{none}}
  static func %%%%(lhs: Unrelated, rhs: any P5<A>) -> Unrelated { }
  // expected-error@-1 {{member operator '%%%%' of protocol 'P5' must have at least one argument of type 'Self'}} {{41-50=Self}}
}
```
It could also make sense to exclude infix operators that return `Self` when both parameters has the protocol as its type. As then, there would be semantic differences depending on which parameter is changed to `Self`.


## Remarks and assumptions
This PR makes the overall assumption that the behaviour reported in https://github.com/swiftlang/swift/issues/78733 is intended.

This is my first (non gardening) PR on this project, so please let me know if there is a smarter way to implement this. I would also appreciate pointers on how to handle the extra cases mentioned above.
