### PR TITLE
AST: Use PointerIntPair in AvailabilityConstraint

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -59,11 +59,10 @@ public:
   };
 
 private:
-  Kind kind;
-  SemanticAvailableAttr attr;
+  llvm::PointerIntPair<SemanticAvailableAttr, 2, Kind> attrAndKind;
 
   AvailabilityConstraint(Kind kind, SemanticAvailableAttr attr)
-      : kind(kind), attr(attr) {};
+      : attrAndKind(attr, kind) {};
 
 public:
   static AvailabilityConstraint
@@ -84,8 +83,10 @@ public:
     return AvailabilityConstraint(Kind::IntroducedInNewerVersion, attr);
   }
 
-  Kind getKind() const { return kind; }
-  SemanticAvailableAttr getAttr() const { return attr; }
+  Kind getKind() const { return attrAndKind.getInt(); }
+  SemanticAvailableAttr getAttr() const {
+    return static_cast<SemanticAvailableAttr>(attrAndKind.getPointer());
+  }
 
   /// Returns the platform that this constraint applies to, or
   /// `PlatformKind::none` if it is not platform specific.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -68,24 +68,24 @@ AvailabilityRange AvailabilityRange::forRuntimeTarget(const ASTContext &Ctx) {
 }
 
 PlatformKind AvailabilityConstraint::getPlatform() const {
-  return attr.getPlatform();
+  return getAttr().getPlatform();
 }
 
 std::optional<AvailabilityRange>
 AvailabilityConstraint::getRequiredNewerAvailabilityRange(
     ASTContext &ctx) const {
-  switch (kind) {
+  switch (getKind()) {
   case Kind::AlwaysUnavailable:
   case Kind::RequiresVersion:
   case Kind::Obsoleted:
     return std::nullopt;
   case Kind::IntroducedInNewerVersion:
-    return attr.getIntroducedRange(ctx);
+    return getAttr().getIntroducedRange(ctx);
   }
 }
 
 bool AvailabilityConstraint::isConditionallySatisfiable() const {
-  switch (kind) {
+  switch (getKind()) {
   case Kind::AlwaysUnavailable:
   case Kind::RequiresVersion:
   case Kind::Obsoleted:
@@ -96,10 +96,10 @@ bool AvailabilityConstraint::isConditionallySatisfiable() const {
 }
 
 bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
-  if (attr.getPlatform() == PlatformKind::none)
+  if (getAttr().getPlatform() == PlatformKind::none)
     return true;
 
-  return swift::isPlatformActive(attr.getPlatform(), ctx.LangOpts,
+  return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
                                  /*forTargetVariant=*/false,
                                  /*forRuntimeQuery=*/true);
 }


### PR DESCRIPTION
Now that SemanticAvailableAttr is pointer-like, AvailabilityConstraint can be pointer sized too.

NFC.
