### PR TITLE
SIL: when updating borrowed-from instructions, remove the old enclosing values first

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
@@ -96,6 +96,11 @@ private extension Phi {
 
 extension BorrowedFromInst : VerifiableInstruction {
   func verify(_ context: FunctionPassContext) {
+
+    for ev in enclosingValues {
+      require(ev.isValidEnclosingValueInBorrowedFrom, "invalid enclosing value in borrowed-from: \(ev)")
+    }
+
     var computedEVs = Stack<Value>(context)
     defer { computedEVs.deinitialize() }
 
@@ -110,6 +115,21 @@ extension BorrowedFromInst : VerifiableInstruction {
     for computedEV in computedEVs {
       require(existingEVs.contains(computedEV),
                    "\(computedEV)\n  missing in enclosing values of \(self)")
+    }
+  }
+}
+
+private extension Value {
+  var isValidEnclosingValueInBorrowedFrom: Bool {
+    switch ownership {
+    case .owned:
+      return true
+    case .guaranteed:
+      return BeginBorrowValue(self) != nil ||
+             self is BorrowedFromInst ||
+             forwardingInstruction != nil
+    case .none, .unowned:
+      return false
     }
   }
 }

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -1209,7 +1209,7 @@ bb0(%0 : @guaranteed $C):
 }
 
 // CHECK-LABEL: sil [ossa] @test_updating_borrowed_from :
-// CHECK:         borrowed {{.*}} from {{.*}} %0 : $HasObject
+// CHECK:         borrowed {{.*}} from (%0 : $HasObject)
 // CHECK-LABEL: } // end sil function 'test_updating_borrowed_from'
 sil [ossa] @test_updating_borrowed_from : $@convention(thin) (@guaranteed HasObject) -> () {
 bb0(%0 : @guaranteed $HasObject):

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -37,8 +37,8 @@ exit:
 
 // CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_endborrow : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[UNRELATED:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
-// CHECK:         destroy_value [[VALUE]]
 // CHECK:         [[BF:%.*]] = borrowed [[UNRELATED]] : $X from (%0 : $X)
+// CHECK:         destroy_value [[VALUE]]
 // CHECK:         end_borrow [[BF]]
 // CHECK-LABEL: } // end sil function 'hoist_destroy_over_unrelated_endborrow'
 sil [ossa] @hoist_destroy_over_unrelated_endborrow : $@convention(thin) (@guaranteed X) -> () {
@@ -90,8 +90,8 @@ exit:
 // CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_reborrow_reborrow_endborrow : {{.*}} {
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @reborrow $X, {{%[^,]+}} : @owned $X):
 // CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @reborrow $X, [[VALUE:%[^,]+]] : @owned $X):
-// CHECK:         destroy_value [[VALUE]]
 // CHECK:         [[BF:%.*]] = borrowed [[REBORROW]] : $X from (%0 : $X)
+// CHECK:         destroy_value [[VALUE]]
 // CHECK:         end_borrow [[BF]]
 // CHECK-LABEL: } // end sil function 'hoist_destroy_over_unrelated_reborrow_reborrow_endborrow'
 sil [ossa] @hoist_destroy_over_unrelated_reborrow_reborrow_endborrow : $@convention(thin) (@guaranteed X) -> () {

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1612,3 +1612,32 @@ bb4(%4 : @owned $Klass):
   return %t : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_borrowed_from_updating : 
+// CHECK:       bb3({{.*}}):
+// CHECK-NEXT:    borrowed {{.*}} from (%0 : $FakeOptional<Klass>)
+// CHECK-NEXT:    borrowed {{.*}} from (%0 : $FakeOptional<Klass>)
+// CHECK-LABEL: } // end sil function 'test_borrowed_from_updating'
+sil [ossa] @test_borrowed_from_updating : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Klass>):
+  %1 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  %2 = begin_borrow %1
+  %3 = copy_value %0
+  switch_enum %3, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%5 : @owned $Klass):
+  end_borrow %2
+  %7 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %5
+  %8 = begin_borrow %7
+  br bb3(%8, %7)
+
+bb2:
+  br bb3(%2, %1)
+
+bb3(%11 : @reborrow $FakeOptional<Klass>, %12 : @owned $FakeOptional<Klass>):
+  %13 = borrowed %11 from (%12)
+  end_borrow %13
+  destroy_value %12
+  %16 = tuple ()
+  return %16
+}
+

--- a/test/SILOptimizer/sil_combine_misc_opts.sil
+++ b/test/SILOptimizer/sil_combine_misc_opts.sil
@@ -102,7 +102,7 @@ bb0(%0 : $*Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @test_updating_borrowed_from :
-// CHECK:         borrowed {{.*}} from {{.*}} %0 : $S
+// CHECK:         borrowed {{.*}} from (%0 : $S)
 // CHECK-LABEL: } // end sil function 'test_updating_borrowed_from'
 sil [ossa] @test_updating_borrowed_from : $@convention(thin) (@guaranteed S) -> () {
 bb0(%0 : @guaranteed $S):


### PR DESCRIPTION
When an optimization updates borrowed-from instruction it might be necessary to remove the old enclosing values from the borrowed-from instructions.
An optimization might transform the SIL in a way that an existing enclosing value is not valid anymore.

Also, check that the enclosing values of a borrowed-from instructions are valid in the SIL verifier

Fixes a compiler crash:
rdar://142991910