### PR TITLE
build: silence C4067 on Windows (NFCI)

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -325,9 +325,15 @@ macro(swift_common_cxx_warnings)
   # dynamic libraries with this flag.
   check_cxx_compiler_flag("-fapplication-extension" CXX_SUPPORTS_FAPPLICATION_EXTENSION)
 
-  # Disable C4068: unknown pragma. This means that MSVC doesn't report hundreds of warnings across
-  # the repository for IDE features such as #pragma mark "Title".
+  # Disable C4067: expected tokens following preprocessor directive - expected a
+  # newline.
+  #
+  # Disable C4068: unknown pragma.
+  #
+  # This means that MSVC doesn't report hundreds of warnings across the
+  # repository for IDE features such as #pragma mark "Title".
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4067>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4068>)
 
     check_cxx_compiler_flag("/permissive-" CXX_SUPPORTS_PERMISSIVE_FLAG)


### PR DESCRIPTION
This silences a warning that the MSVC compiler emits about unknown pragmas. This helps clear up the build a small amount so real issues do not get hidden.