### PR TITLE
Sema: Replace UnavailabilityDiagnosticInfo with AvailabilityConstraint

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_AVAILABILITY_CONSTRAINT_H
 #define SWIFT_AST_AVAILABILITY_CONSTRAINT_H
 
+#include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/LLVM.h"
@@ -87,6 +88,9 @@ public:
   SemanticAvailableAttr getAttr() const {
     return static_cast<SemanticAvailableAttr>(attrAndKind.getPointer());
   }
+
+  /// Returns the domain that the constraint applies to.
+  AvailabilityDomain getDomain() const { return getAttr().getDomain(); }
 
   /// Returns the platform that this constraint applies to, or
   /// `PlatformKind::none` if it is not platform specific.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2222,7 +2222,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     return true;
   }
 
-  // FIXME: Possibly should extend to more availability checking.
+  // FIXME: [availability] Possibly should extend to more availability checking.
   auto unavailabilityStatusAndAttr =
       checkOverrideUnavailability(override, base);
   auto unavailableAttr = unavailabilityStatusAndAttr.second;


### PR DESCRIPTION
`AvailabilityConstraint` models a superset of `UnavailabilityDiagnosticInfo` and will become the currency type for unsatisfied availability everywhere.

NFC.