### PR TITLE
lib: simplify some pragma usage

### DIFF
--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -199,15 +199,10 @@ CatchNode ASTScope::lookupCatchNode(ModuleDecl *module, SourceLoc loc) {
 }
 
 #if SWIFT_COMPILER_IS_MSVC
-#pragma warning(push)
-#pragma warning(disable : 4996)
+#pragma warning(supress: 4996)
 #endif
 
 void ASTScope::dump() const { impl->dump(); }
-
-#if SWIFT_COMPILER_IS_MSVC
-#pragma warning(pop)
-#endif
 
 void ASTScope::print(llvm::raw_ostream &out) const { impl->print(out); }
 void ASTScope::dumpOneScopeMapLocation(std::pair<unsigned, unsigned> lineCol) {

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -562,13 +562,9 @@ void Constraint::dump(SourceManager *sm) const {
 void Constraint::dump(ConstraintSystem *CS) const {
   // Disable MSVC warning: only for use within the debugger.
 #if SWIFT_COMPILER_IS_MSVC
-#pragma warning(push)
-#pragma warning(disable: 4996)
+#pragma warning(suppress: 4996)
 #endif
   dump(&CS->getASTContext().SourceMgr);
-#if SWIFT_COMPILER_IS_MSVC
-#pragma warning(pop)
-#endif
 }
 
 


### PR DESCRIPTION
When suppressing a warning for a single line, prefer to use `suppress` to avoid the push/pop dance.