### PR TITLE
build: only add compiler flag if it is supported

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -295,7 +295,9 @@ macro(swift_common_cxx_warnings)
 
     if(MSVC)
       check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/we4062>)
+      if(CXX_SUPPORTS_WE4062)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/we4062>)
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
This ensures that we only add the flag if it is supported by the compiler rather than doing it unconditionally.