### PR TITLE
[embedded] Mark test/embedded/ptrauth-none-macho.swift as REQUIRES: embedded_stdlib_cross_compiling

### DIFF
--- a/test/embedded/ptrauth-none-macho.swift
+++ b/test/embedded/ptrauth-none-macho.swift
@@ -3,6 +3,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded
 
 var callback: (()->())? = nil


### PR DESCRIPTION
rdar://143218047