### PR TITLE
[6.1][TypeChecker] Downgrade `noasync` availability to warnings on `@preco…

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4128,6 +4128,8 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl,
                                    D, attr->Message);
     diag.warnUntilSwiftVersion(6);
+    diag.limitBehaviorWithPreconcurrency(DiagnosticBehavior::Warning,
+                                         D->preconcurrency());
 
     if (!attr->Rename.empty()) {
       fixItAvailableAttrRename(diag, R, D, attr, call);

--- a/test/Concurrency/unavailable_from_async_swift6.swift
+++ b/test/Concurrency/unavailable_from_async_swift6.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+struct API {
+  @available(*, noasync, message: "use complete() instead")
+  func wait() {}
+
+  @preconcurrency
+  @available(*, noasync, message: "use complete() instead")
+  func waitUntilComplete() {}
+
+  func complete() async {}
+}
+
+func test(v: API) async {
+  v.wait() // expected-error {{instance method 'wait' is unavailable from asynchronous contexts; use complete() instead}}
+  v.waitUntilComplete() // expected-warning {{instance method 'waitUntilComplete' is unavailable from asynchronous contexts; use complete() instead}}
+}


### PR DESCRIPTION
…ncurrency` declarations

Cherry-pick of https://github.com/swiftlang/swift/pull/78721

---

- Explanation:

  This change helps to stage in new `async` overloads in Swift 6 language mode if `@preconcurrency` declaration is not available from async contexts.

- Main Branch PR: https://github.com/swiftlang/swift/pull/78721

- Risk: Very Low (allows some code that previously was rejected by the compiler to type-check successfully).

- Reviewed By: @tshortli @hborla 

- Testing: Added new tests to the Sema test suite.

(cherry picked from commit 00fe5632d7458698c7841c84a45f62e2664d7783)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
