### PR TITLE
[cxx-interop] Assume that plain-C enums are resilient

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1906,6 +1906,8 @@ bool isFragileClangDecl(const clang::Decl *decl) {
     return isFragileClangType(pd->getType());
   if (auto *typedefDecl = dyn_cast<clang::TypedefNameDecl>(decl))
     return isFragileClangType(typedefDecl->getUnderlyingType());
+  if (auto *enumDecl = dyn_cast<clang::EnumDecl>(decl))
+    return enumDecl->isScoped();
   if (auto *rd = dyn_cast<clang::RecordDecl>(decl)) {
     auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(rd);
     if (!cxxRecordDecl)

--- a/test/Interop/Cxx/library-evolution/Inputs/my_c_header.h
+++ b/test/Interop/Cxx/library-evolution/Inputs/my_c_header.h
@@ -1,3 +1,11 @@
 struct MyCStruct {
   int x;
 };
+
+enum MyCEnum {
+  MCE_One, MCE_Two
+};
+
+enum MyCFixedEnum : unsigned {
+  MCFE_One, MCFE_Two
+};

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-evolving-libraries.swift
@@ -17,6 +17,14 @@ public:
     void method() const;
 };
 
+enum CEnum {
+    a, b
+};
+
+enum class CxxEnum {
+    aa, bb
+};
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -34,6 +42,12 @@ struct CStruct {
 import CxxModule
 
 public func useCStruct(_ x: CStruct) {
+}
+
+public func useCEnum(_ x: CEnum) {
+}
+
+public func useCxxEnum(_ x: CxxEnum) { // expected-error {{cannot use enum 'CxxEnum' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 }
 
 // expected-error@+1 {{cannot use struct 'CxxStruct' here; C++ types from imported module 'CxxModule' do not support library evolution}}

--- a/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
+++ b/test/Interop/Cxx/library-evolution/allow-c-in-cxx-mode-in-interfaces.swift
@@ -32,6 +32,14 @@ extension MyCStruct {
   }
 }
 
+public func getMyCEnum() -> MyCEnum {
+  return MCE_One
+}
+
+public func getMyCFixedEnum() -> MyCFixedEnum {
+  return MCFE_One
+}
+
 //--- main.swift
 
 import UsesCLibrary
@@ -39,3 +47,5 @@ import UsesCLibrary
 let _ = getMyCStruct()
 let _ = getMyCStruct().y
 let _ = getMyCStruct().anotherInstanceOfSelf
+let _ = getMyCEnum()
+let _ = getMyCFixedEnum()


### PR DESCRIPTION
This fixes sudden compiler errors that are emitted when trying to use CoreText.framework with C++ interop enabled.

When Swift is trying to rebuild a dependency module from its textual interface, it should not complain on usages of C enums in public Swift APIs.

This still leaves the resilience safety guardrail enabled for C++ scoped enums.

rdar://143215914

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
