### PR TITLE
[Cmake] add SwiftifyImport.swift to source list

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -223,6 +223,7 @@ add_library(swiftCore
   Int128.swift
   Mirror.swift
   PlaygroundDisplay.swift
+  SwiftifyImport.swift
   CommandLine.swift
   SliceBuffer.swift
   StaticBigInt.swift


### PR DESCRIPTION
Missed a source file in the new Runtimes cmake from
https://github.com/swiftlang/swift/pull/78210
