### PR TITLE
[6.1] Build swift-testing as part of the compat-suite toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2944,6 +2944,8 @@ build-ninja
 llbuild
 swiftpm
 swift-driver
+swift-testing
+swift-testing-macros
 install-llbuild
 install-llvm
 install-static-linux-config
@@ -2951,6 +2953,8 @@ install-swift
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 reconfigure
 verbose-build
 skip-build-benchmarks


### PR DESCRIPTION
  - **Explanation**: Various projects (vapor in particular) now depend on swift-testing. The current Xcode installation doesn't contain it and we're not building it, so they're failing. Update the base compat suite preset to also build swift-testing (and its macros).
  - **Scope**: Compatibility suite builds
  - **Original PRs**: https://github.com/swiftlang/swift/pull/78575
  - **Risk**: Extremely low, just building swift-testing in the compat suite preset (which we're already doing elsewhere)
  - **Testing**: Main compat suite now passing with this change
  - **Reviewers**: @etcwilde