### PR TITLE
[Diagnostics] Fix generic arguments mismatch diagnostic related to le…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1044,7 +1044,8 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       break;
     }
 
-    case ConstraintLocator::Member: {
+    case ConstraintLocator::Member:
+    case ConstraintLocator::UnresolvedMember: {
       auto *memberLoc = getConstraintLocator(anchor, path);
       auto selectedOverload = getOverloadChoiceIfAvailable(memberLoc);
       if (!selectedOverload)

--- a/test/Concurrency/sendable_to_any_for_generic_arguments.swift
+++ b/test/Concurrency/sendable_to_any_for_generic_arguments.swift
@@ -175,3 +175,17 @@ func test_subscript_computed_property_and_mutating_access(u: User) {
 
   u.dict.testMutating() // Ok
 }
+
+extension Dictionary where Key == String, Value == Any {
+  init(age: Int) { // expected-note {{'init(age:)' declared here}}
+    self.init()
+  }
+}
+
+extension User {
+  convenience init(age: Int) {
+    self.init()
+    self.dict = .init(age: age)
+    // expected-error@-1 {{referencing initializer 'init(age:)' on '[String : any Sendable].Type' requires the types 'any Sendable' and 'Any' be equivalent}}
+  }
+}


### PR DESCRIPTION
…ading-dot syntax

`GenericArgumentsMismatchFailure` missed a case where location of the failure points to a member spelled with leading-dot syntax.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
