### PR TITLE
Make Optional<T>.TangentVector methods inlineable

### DIFF
--- a/stdlib/public/Differentiation/OptionalDifferentiation.swift
+++ b/stdlib/public/Differentiation/OptionalDifferentiation.swift
@@ -19,14 +19,17 @@ extension Optional: Differentiable where Wrapped: Differentiable {
 
     public var value: Wrapped.TangentVector?
 
+    @inlinable
     public init(_ value: Wrapped.TangentVector?) {
       self.value = value
     }
 
+    @inlinable
     public static var zero: Self {
       return Self(.zero)
     }
 
+    @inlinable
     public static func + (lhs: Self, rhs: Self) -> Self {
       switch (lhs.value, rhs.value) {
       case (nil, nil): return Self(nil)
@@ -36,6 +39,7 @@ extension Optional: Differentiable where Wrapped: Differentiable {
       }
     }
 
+    @inlinable
     public static func - (lhs: Self, rhs: Self) -> Self {
       switch (lhs.value, rhs.value) {
       case (nil, nil): return Self(nil)
@@ -45,6 +49,7 @@ extension Optional: Differentiable where Wrapped: Differentiable {
       }
     }
 
+    @inlinable
     public mutating func move(by offset: TangentVector) {
       if let value = offset.value {
         self.value?.move(by: value)
@@ -52,6 +57,7 @@ extension Optional: Differentiable where Wrapped: Differentiable {
     }
   }
 
+  @inlinable
   public mutating func move(by offset: TangentVector) {
     if let value = offset.value {
       self?.move(by: value)


### PR DESCRIPTION
This enables lots of possible optimizations when optionals are used in autodiff code.

As there is no stable ABI for `Differentiable`, there is no ABI break.