### PR TITLE
AST: Track an unavailable domain instead of platform in AvailabilityContext

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_AST_AVAILABILITY_CONTEXT_H
 #define SWIFT_AST_AVAILABILITY_CONTEXT_H
 
+#include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/Debug.h"
@@ -51,7 +52,7 @@ private:
   /// parameters.
   static AvailabilityContext
   get(const AvailabilityRange &platformAvailability,
-      std::optional<PlatformKind> unavailablePlatform, bool deprecated,
+      std::optional<AvailabilityDomain> unavailableDomain, bool deprecated,
       ASTContext &ctx);
 
 public:
@@ -73,21 +74,15 @@ public:
   /// availability context, starting at its introduction version.
   AvailabilityRange getPlatformRange() const;
 
-  /// When the context is unavailable on the current platform this returns the
-  /// broadest `PlatformKind` for which the context is unavailable. Otherwise,
-  /// returns `nullopt`.
-  std::optional<PlatformKind> getUnavailablePlatformKind() const;
+  /// Returns the broadest AvailabilityDomain that is unavailable in this
+  /// context.
+  std::optional<AvailabilityDomain> getUnavailableDomain() const;
 
   /// Returns true if this context is unavailable.
-  bool isUnavailable() const {
-    return getUnavailablePlatformKind().has_value();
-  }
+  bool isUnavailable() const { return getUnavailableDomain().has_value(); }
 
   /// Returns true if this context is deprecated on the current platform.
   bool isDeprecated() const;
-
-  /// Returns true if this context is `@_unavailableInEmbedded`.
-  bool isUnavailableInEmbedded() const;
 
   /// Constrain with another `AvailabilityContext`.
   void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerUnion.h"
 
@@ -205,6 +206,10 @@ public:
     case Kind::Platform:
       return getPlatformKind() < other.getPlatformKind();
     }
+  }
+
+  void Profile(llvm::FoldingSetNodeID &ID) const {
+    ID.AddPointer(getOpaqueValue());
   }
 };
 

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -177,6 +177,11 @@ public:
   /// Returns the string to use when printing an `@available` attribute.
   llvm::StringRef getNameForAttributePrinting() const;
 
+  /// Returns true if availability in `other` is a subset of availability in
+  /// this domain. The set of all availability domains form a lattice where the
+  /// universal domain (`*`) is the bottom element.
+  bool contains(const AvailabilityDomain &other) const;
+
   bool operator==(const AvailabilityDomain &other) const {
     return storage.getOpaqueValue() == other.storage.getOpaqueValue();
   }
@@ -185,6 +190,7 @@ public:
     return !(*this == other);
   }
 
+  /// A total, stable ordering on domains.
   bool operator<(const AvailabilityDomain &other) const {
     if (getKind() != other.getKind())
       return getKind() < other.getKind();

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2017,7 +2017,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
       // Decls with @_spi_available aren't hidden entirely from public interfaces,
       // thus public interfaces may still refer them. Be forgiving here so public
       // interfaces can compile.
-      if (where.getUnavailablePlatformKind().has_value())
+      if (where.getAvailability().isUnavailable())
         return DisallowedOriginKind::None;
       // We should only diagnose SPI_AVAILABLE usage when the library level is API.
       // Using SPI_AVAILABLE symbols in private frameworks or executable targets

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5050,13 +5050,13 @@ void AttributeChecker::checkBackDeployedAttrs(
     if (Ctx.LangOpts.DisableAvailabilityChecking)
       continue;
 
-    auto availability =
-        TypeChecker::availabilityAtLocation(D->getLoc(), D->getDeclContext());
+    auto availability = TypeChecker::availabilityAtLocation(
+        D->getLoc(), D->getInnermostDeclContext());
 
     // Unavailable decls cannot be back deployed.
-    if (auto unavailablePlatform = availability.getUnavailablePlatformKind()) {
-      if (!inheritsAvailabilityFromPlatform(*unavailablePlatform,
-                                            Attr->Platform)) {
+    if (auto unavailableDomain = availability.getUnavailableDomain()) {
+      auto backDeployedDomain = AvailabilityDomain::forPlatform(Attr->Platform);
+      if (unavailableDomain->contains(backDeployedDomain)) {
         auto platformString = prettyPlatformString(Attr->Platform);
         llvm::VersionTuple ignoredVersion;
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -193,10 +193,6 @@ public:
   /// reference other deprecated declarations without warning.
   bool isDeprecated() const { return Availability.isDeprecated(); }
 
-  std::optional<PlatformKind> getUnavailablePlatformKind() const {
-    return Availability.getUnavailablePlatformKind();
-  }
-
   /// If true, the context can only reference exported declarations, either
   /// because it is the signature context of an exported declaration, or
   /// because it is the function body context of an inlinable function.

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -13,7 +13,7 @@ public struct UniverallyUnavailable {}
 
 @_unavailableInEmbedded
 public func unavailable_in_embedded() { }
-// expected-note@-1 2 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public func universally_unavailable() { }
@@ -22,8 +22,8 @@ public func universally_unavailable() { }
 @_unavailableInEmbedded
 public func unused() { } // no error
 
-public struct S1 {} // expected-note {{found this candidate}}
-public struct S2 {} // expected-note {{found this candidate}}
+public struct S1 {} // expected-note 2 {{found this candidate}}
+public struct S2 {} // expected-note 2 {{found this candidate}}
 
 @_unavailableInEmbedded
 public func has_unavailable_in_embedded_overload(_ s1: S1) { }
@@ -61,8 +61,8 @@ public func also_universally_unavailable(
   _ uie: UnavailableInEmbedded, // OK
   _ uu: UniverallyUnavailable // OK
 ) {
-  unavailable_in_embedded() // expected-error {{'unavailable_in_embedded()' is unavailable: unavailable in embedded Swift}}
+  unavailable_in_embedded()
   universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
-  has_unavailable_in_embedded_overload(.init()) // not ambiguous, selects available overload
+  has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -1,0 +1,77 @@
+#include "swift/AST/AvailabilityDomain.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+class AvailabilityDomainLattice : public ::testing::Test {
+public:
+  AvailabilityDomain domainForPlatform(PlatformKind kind) {
+    return AvailabilityDomain::forPlatform(kind);
+  }
+  AvailabilityDomain Universal = AvailabilityDomain::forUniversal();
+  AvailabilityDomain Swift = AvailabilityDomain::forSwiftLanguage();
+  AvailabilityDomain Package = AvailabilityDomain::forPackageDescription();
+  AvailabilityDomain Embedded = AvailabilityDomain::forEmbedded();
+  AvailabilityDomain macOS = domainForPlatform(PlatformKind::macOS);
+  AvailabilityDomain macOSAppExt =
+      domainForPlatform(PlatformKind::macOSApplicationExtension);
+  AvailabilityDomain iOS = domainForPlatform(PlatformKind::iOS);
+  AvailabilityDomain iOSAppExt =
+      domainForPlatform(PlatformKind::iOSApplicationExtension);
+  AvailabilityDomain macCatalyst = domainForPlatform(PlatformKind::macCatalyst);
+  AvailabilityDomain macCatalystAppExt =
+      domainForPlatform(PlatformKind::macCatalystApplicationExtension);
+  AvailabilityDomain visionOS = domainForPlatform(PlatformKind::visionOS);
+  AvailabilityDomain visionOSAppExt =
+      domainForPlatform(PlatformKind::visionOSApplicationExtension);
+
+  std::vector<AvailabilityDomain> all() const {
+    return {
+        Universal,   Swift,         Package,   Embedded,    macOS,
+        macOSAppExt, iOS,           iOSAppExt, macCatalyst, macCatalystAppExt,
+        visionOS,    visionOSAppExt};
+  }
+};
+
+TEST_F(AvailabilityDomainLattice, Contains) {
+  for (auto const &domain : all()) {
+    // The universal domain is the bottom domain and contains all others.
+    EXPECT_TRUE(Universal.contains(domain));
+
+    // FIXME: [availability] The following assertions should change when
+    // AvailabilityContext can support multiple simultaneous unavailable
+    // domains.
+
+    // The Swift domain is second from the bottom.
+    EXPECT_EQ(Swift.contains(domain), !domain.isUniversal());
+
+    // Package and Embedded are both third from the bottom.
+    EXPECT_EQ(Package.contains(domain), !domain.isUniversal() && !domain.isSwiftLanguage());
+    EXPECT_EQ(Embedded.contains(domain), !domain.isUniversal() && !domain.isSwiftLanguage());
+  }
+
+  // Platform kind domains form their own lattice in which app extension domains
+  // are contained within the domain of the same platform.
+  EXPECT_TRUE(macOS.contains(macOS));
+  EXPECT_FALSE(macOS.contains(iOS));
+  EXPECT_TRUE(macOS.contains(macOSAppExt));
+  EXPECT_FALSE(macOSAppExt.contains(macOS));
+  EXPECT_FALSE(macOS.contains(macCatalyst));
+  EXPECT_FALSE(macCatalyst.contains(macOS));
+
+  // Additionally, iOS is the ABI platform for both macCatalyst and visionOS and
+  // thus the iOS domain contains those domains.
+  EXPECT_TRUE(iOS.contains(iOS));
+  EXPECT_TRUE(iOS.contains(iOSAppExt));
+  EXPECT_FALSE(iOSAppExt.contains(iOS));
+  EXPECT_TRUE(iOS.contains(macCatalyst));
+  EXPECT_FALSE(macCatalyst.contains(iOS));
+  EXPECT_TRUE(iOS.contains(macCatalystAppExt));
+  EXPECT_FALSE(macCatalystAppExt.contains(iOS));
+  EXPECT_TRUE(iOS.contains(visionOS));
+  EXPECT_FALSE(visionOS.contains(iOS));
+  EXPECT_TRUE(iOS.contains(visionOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.contains(iOS));
+  EXPECT_FALSE(iOS.contains(macOS));
+  EXPECT_FALSE(iOS.contains(macOSAppExt));
+}

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
   ASTDumperTests.cpp
   ASTWalkerTests.cpp
+  AvailabilityDomainTests.cpp
   IndexSubsetTests.cpp
   DiagnosticBehaviorTests.cpp
   DiagnosticConsumerTests.cpp


### PR DESCRIPTION
Now that most of the compiler tracks availability in terms of `AvailabilityDomain`, it's time to do so in `AvailabilityContext` as well. This will ensure that the compiler accurately suppresses diagnostics about a decl being unavailable in an arbitrary domain when the context of the use is already unavailable in that domain.

With this change, most of the special-casing for the Embedded Swift availability domain has been removed from the compiler, outside of parsing and interface printing.
