### PR TITLE
[build.ps1] remove Android API level from Dispatch.swiftmodule names

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -486,7 +486,7 @@ function Get-BuildProjectCMakeModules([BuildComponent]$Project) {
 }
 
 function Get-TargetInfo($Arch) {
-  # Cache the result of "swift -print-target-info" as $Arch.TargetInfo
+  # Cache the result of "swift -print-target-info" as $Arch.Cache.TargetInfo
   $cacheKey = "TargetInfo"
   if (-not $Arch.Cache.ContainsKey($cacheKey)) {
     $swiftExe = Join-Path -Path (Get-PinnedToolchainTool) -ChildPath "swift.exe"

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -229,6 +229,7 @@ $ArchX64 = @{
   XCTestInstallRoot = "$BinaryCache\x64\Windows.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\x64\Windows.platform\Developer\Library\Testing-development";
   ToolchainInstallRoot = "$BinaryCache\x64\toolchains\$ProductVersion+Asserts";
+  Cache = @{};
 }
 
 $ArchX86 = @{
@@ -244,6 +245,7 @@ $ArchX86 = @{
   SDKInstallRoot = "$BinaryCache\x86\Windows.platform\Developer\SDKs\Windows.sdk";
   XCTestInstallRoot = "$BinaryCache\x86\Windows.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\x86\Windows.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $ArchARM64 = @{
@@ -260,6 +262,7 @@ $ArchARM64 = @{
   XCTestInstallRoot = "$BinaryCache\arm64\Windows.platform\Developer\Library\XCTest-development";
   ToolchainInstallRoot = "$BinaryCache\arm64\toolchains\$ProductVersion+Asserts";
   SwiftTestingInstallRoot = "$BinaryCache\arm64\Windows.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $AndroidARM64 = @{
@@ -275,6 +278,7 @@ $AndroidARM64 = @{
   SDKInstallRoot = "$BinaryCache\arm64\Android.platform\Developer\SDKs\Android.sdk";
   XCTestInstallRoot = "$BinaryCache\arm64\Android.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\arm64\Android.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $AndroidARMv7 = @{
@@ -290,6 +294,7 @@ $AndroidARMv7 = @{
   SDKInstallRoot = "$BinaryCache\armv7\Android.platform\Developer\SDKs\Android.sdk";
   XCTestInstallRoot = "$BinaryCache\armv7\Android.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\armv7\Android.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $AndroidX86 = @{
@@ -305,6 +310,7 @@ $AndroidX86 = @{
   SDKInstallRoot = "$BinaryCache\x86\Android.platform\Developer\SDKs\Android.sdk";
   XCTestInstallRoot = "$BinaryCache\x86\Android.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\x86\Android.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $AndroidX64 = @{
@@ -320,6 +326,7 @@ $AndroidX64 = @{
   SDKInstallRoot = "$BinaryCache\x64\Android.platform\Developer\SDKs\Android.sdk";
   XCTestInstallRoot = "$BinaryCache\x64\Android.platform\Developer\Library\XCTest-development";
   SwiftTestingInstallRoot = "$BinaryCache\x64\Android.platform\Developer\Library\Testing-development";
+  Cache = @{};
 }
 
 $HostArch = switch ($HostArchName) {
@@ -479,14 +486,14 @@ function Get-BuildProjectCMakeModules([BuildComponent]$Project) {
 }
 
 function Get-TargetInfo($Arch) {
-  # Cache the result of "swift -print-target-info" as $Arch.targetInfo
-  $key = "targetInfo"
-  if (-not $Arch.ContainsKey($key)) {
+  # Cache the result of "swift -print-target-info" as $Arch.TargetInfo
+  $cacheKey = "TargetInfo"
+  if (-not $Arch.Cache.ContainsKey($cacheKey)) {
     $swiftExe = Join-Path -Path (Get-PinnedToolchainTool) -ChildPath "swift.exe"
     $targetInfoJson = & $swiftExe -target $Arch.LLVMTarget -print-target-info
-    $Arch[$key] = $targetInfoJson | ConvertFrom-Json
+    $Arch.Cache[$cacheKey] = $targetInfoJson | ConvertFrom-Json
   }
-  return $Arch[$key]
+  return $Arch.Cache[$cacheKey]
 }
 
 function Get-ModuleTriple($Arch) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -498,7 +498,7 @@ function Get-TargetInfo($Arch) {
     $CMarkDir = Join-Path -Path (Get-CMarkBinaryCache $BuildArch) -ChildPath "src"
     $SwiftExe = Join-Path -Path $ToolchainBinDir -ChildPath "swift.exe"
     Isolate-EnvVars {
-      $env:Path = "$ToolchainBinDir;$CMarkDir;${env:Path}"
+      $env:Path = "$ToolchainBinDir;$CMarkDir;$(Get-PinnedToolchainRuntime);${env:Path}"
       $TargetInfoJson = & $SwiftExe -target $Arch.LLVMTarget -print-target-info
       if ($LastExitCode -ne 0) {
         throw "Unable to print target info for $($Arch.LLVMTarget) $TargetInfoJson"


### PR DESCRIPTION
## Purpose
When determining output paths for Android binaries in the SDK, ensure that the Android API level integer is not included in paths. E.g. use the versionless "module triple" `aarch64-unknown-linux-android` instead of `aarch64-unknown-linux-android28`.

## Overview
* Add a new `Get-TargetInfo $Arch` method that returns the result of `swift.exe -target $Arch.LLVMTarget -print-target-info` as parsed JSON object using the newly built toolchain
  * Cache the result in the `$Arch` hashtable to avoid making multiple calls
* Add a new `Get-ModuleTriple $Arch` method that calls `Get-TargetInfo $Arch` and returns the resulting `.target.moduleTriple` string
* Use `Get-ModuleTriple` to calculate the target path in `Install-Platform` when copying `.swiftmodule`, `.swiftdoc`, and `.swiftinterface` files (this case includes `Dispatch.swiftmodule`).
* Replace existing calls to `$Arch.LLVMTarget.Replace("$AndroidAPILevel","")` with a `Get-ModuleTriple $Arch`

## Validation
Local toolchain build with `-AndroidSDKs aarch64,x86_64` and verified the expected directory structure of the Dispatch module in the Android SDK:
```
S:\Program Files>dir /s /b "S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule"
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftdoc
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftmodule
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftdoc
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftmodule
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftdoc
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftmodule
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftdoc
S:\Program Files\Swift\Platforms\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftmodule
```

Successfully built [this simple Swift program](https://github.com/andrurogerz/swift-hello) for Android using the locally built SDK.