### PR TITLE
AST: Eliminate remaining direct access to AvailableAttr's fields

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1361,11 +1361,10 @@ static bool isABIPlaceholderRecursive(Decl *D) {
 StringRef SDKContext::getPlatformIntroVersion(Decl *D, PlatformKind Kind) {
   if (!D)
     return StringRef();
-  for (auto semanticAttr : D->getSemanticAvailableAttrs()) {
-    auto attr = semanticAttr.getParsedAttr();
-    auto domain = semanticAttr.getDomain();
-    if (domain.getPlatformKind() == Kind && attr->Introduced) {
-      return buffer(attr->Introduced->getAsString());
+  for (auto attr : D->getSemanticAvailableAttrs()) {
+    auto domain = attr.getDomain();
+    if (domain.getPlatformKind() == Kind && attr.getIntroduced()) {
+      return buffer(attr.getIntroduced()->getAsString());
     }
   }
   return StringRef();
@@ -1374,12 +1373,11 @@ StringRef SDKContext::getPlatformIntroVersion(Decl *D, PlatformKind Kind) {
 StringRef SDKContext::getLanguageIntroVersion(Decl *D) {
   if (!D)
     return StringRef();
-  for (auto semanticAttr : D->getSemanticAvailableAttrs()) {
-    auto attr = semanticAttr.getParsedAttr();
-    auto domain = semanticAttr.getDomain();
+  for (auto attr : D->getSemanticAvailableAttrs()) {
+    auto domain = attr.getDomain();
 
-    if (domain.isSwiftLanguage() && attr->Introduced) {
-      return buffer(attr->Introduced->getAsString());
+    if (domain.isSwiftLanguage() && attr.getIntroduced()) {
+      return buffer(attr.getIntroduced()->getAsString());
     }
   }
   return getLanguageIntroVersion(D->getDeclContext()->getAsDecl());

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3928,22 +3928,19 @@ public:
       printFlag("noasync");
       break;
     }
-    if (Attr->Introduced.has_value())
-      printFieldRaw(
-          [&](auto &out) { out << Attr->Introduced.value().getAsString(); },
-          "introduced");
-    if (Attr->Deprecated.has_value())
-      printFieldRaw(
-          [&](auto &out) { out << Attr->Deprecated.value().getAsString(); },
-          "deprecated");
-    if (Attr->Obsoleted.has_value())
-      printFieldRaw(
-          [&](auto &out) { out << Attr->Obsoleted.value().getAsString(); },
-          "obsoleted");
-    if (!Attr->Message.empty())
-      printFieldQuoted(Attr->Message, "message");
-    if (!Attr->Rename.empty())
-      printFieldQuoted(Attr->Rename, "rename");
+    if (auto introduced = Attr->getRawIntroduced())
+      printFieldRaw([&](auto &out) { out << introduced.value().getAsString(); },
+                    "introduced");
+    if (auto deprecated = Attr->getRawDeprecated())
+      printFieldRaw([&](auto &out) { out << deprecated.value().getAsString(); },
+                    "deprecated");
+    if (auto obsoleted = Attr->getRawObsoleted())
+      printFieldRaw([&](auto &out) { out << obsoleted.value().getAsString(); },
+                    "obsoleted");
+    if (!Attr->getMessage().empty())
+      printFieldQuoted(Attr->getMessage(), "message");
+    if (!Attr->getRename().empty())
+      printFieldQuoted(Attr->getRename(), "rename");
     printFoot();
   }
   void visitBackDeployedAttr(BackDeployedAttr *Attr, StringRef label) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -471,7 +471,7 @@ isShortFormAvailabilityImpliedByOther(SemanticAvailableAttr Attr,
     if (!inheritsAvailabilityFromPlatform(platform, otherPlatform))
       continue;
 
-    if (Attr.getParsedAttr()->Introduced == other.getParsedAttr()->Introduced)
+    if (Attr.getIntroduced() == other.getIntroduced())
       return true;
   }
   return false;
@@ -495,14 +495,14 @@ static void printShortFormAvailable(const Decl *D,
 
   bool isFirst = true;
   bool isPlatformAvailability = false;
-  for (auto semanticAttr : Attrs) {
-    auto *availAttr = semanticAttr.getParsedAttr();
-    auto domain = semanticAttr.getDomain();
-    assert(availAttr->Introduced.has_value());
+  for (auto attr : Attrs) {
+    auto domain = attr.getDomain();
+    auto introduced = attr.getIntroduced();
+    assert(introduced);
 
     // Avoid omitting available attribute when we are printing module interface.
     if (!Options.IsForSwiftInterface &&
-        isShortFormAvailabilityImpliedByOther(semanticAttr, Attrs))
+        isShortFormAvailabilityImpliedByOther(attr, Attrs))
       continue;
 
     Printer << (isFirst ? "" : ", ");
@@ -512,7 +512,7 @@ static void printShortFormAvailable(const Decl *D,
       isPlatformAvailability = true;
 
     Printer << domain.getNameForAttributePrinting() << " "
-            << availAttr->Introduced.value().getAsString();
+            << introduced.value().getAsString();
   }
 
   if (isPlatformAvailability)

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -557,13 +557,14 @@ std::optional<SemanticAvailableAttr> Decl::getNoAsyncAttr() const {
 
 bool Decl::isUnavailableInCurrentSwiftVersion() const {
   llvm::VersionTuple vers = getASTContext().LangOpts.EffectiveLanguageVersion;
-  for (auto semanticAttr :
-       getSemanticAvailableAttrs(/*includingInactive=*/false)) {
-    if (semanticAttr.isSwiftLanguageModeSpecific()) {
-      auto attr = semanticAttr.getParsedAttr();
-      if (attr->Introduced.has_value() && attr->Introduced.value() > vers)
+  for (auto attr : getSemanticAvailableAttrs(/*includingInactive=*/false)) {
+    if (attr.isSwiftLanguageModeSpecific()) {
+      auto introduced = attr.getIntroduced();
+      if (introduced && *introduced > vers)
         return true;
-      if (attr->Obsoleted.has_value() && attr->Obsoleted.value() <= vers)
+
+      auto obsoleted = attr.getObsoleted();
+      if (obsoleted && *obsoleted <= vers)
         return true;
     }
   }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -307,7 +307,7 @@ getAvailabilityConditionVersionSourceRange(const Decl *D, PlatformKind Platform,
       if (Range.isValid())
         return SourceRange();
       else
-        Range = Attr.getParsedAttr()->IntroducedRange;
+        Range = Attr.getIntroducedSourceRange();
     }
   }
   return Range;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -963,11 +963,11 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
         public:
           static AvailabilityRange from(const ValueDecl *VD) {
             AvailabilityRange result;
-            for (auto semanticAttr : VD->getSemanticAvailableAttrs()) {
-              if (semanticAttr.isSwiftLanguageModeSpecific()) {
-                if (auto introduced = semanticAttr.getParsedAttr()->Introduced)
+            for (auto attr : VD->getSemanticAvailableAttrs()) {
+              if (attr.isSwiftLanguageModeSpecific()) {
+                if (auto introduced = attr.getIntroduced())
                   result.introduced = introduced;
-                if (auto obsoleted = semanticAttr.getParsedAttr()->Obsoleted)
+                if (auto obsoleted = attr.getObsoleted())
                   result.obsoleted = obsoleted;
               }
             }


### PR DESCRIPTION
Most of the compiler should use SemanticAvailableAttr instead. In contexts like ASTDumper where a semantic attribute is unavailable use accessors on AvailableAttr.

NFC.
