### PR TITLE
Mark Differentiation related FloatingPoint methods with @inlinable 

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -42,6 +42,7 @@ extension ${Self}: Differentiable {
   public typealias TangentVector = ${Self}
 
   ${Availability(bits)}
+  @inlinable
   public mutating func move(by offset: TangentVector) {
     self += offset
   }
@@ -95,7 +96,7 @@ extension ${Self} {
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
 extension ${Self} {
-  @usableFromInline
+  @inlinable
   @_transparent
   @derivative(of: -)
   static func _vjpNegate(x: ${Self})
@@ -103,7 +104,7 @@ extension ${Self} {
     return (-x, { v in -v })
   }
 
-  @usableFromInline
+  @inlinable
   @_transparent
   @derivative(of: -)
   static func _jvpNegate(x: ${Self})


### PR DESCRIPTION
Mark Differentiation related FloatingPoint methods with @inlinable for more optimization opportunities
Inspired by earlier performance improvements in #75778 and #78796 

As there is no stable ABI for `Differentiable`, there is no ABI break.