### PR TITLE
[NFC] Include `<cstdlib>` and `<cstdint>` where necessary.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -27,6 +27,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <string>

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -22,6 +22,7 @@
 #include "swift/SwiftRemoteMirror/MemoryReaderInterface.h"
 #include <optional>
 
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <memory>

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_CONCURRENCY_DEBUG_H
 #define SWIFT_CONCURRENCY_DEBUG_H
 
+#include <cstdint>
+
 #include "swift/Runtime/Config.h"
 
 namespace swift {


### PR DESCRIPTION
Our Bazel builds have become more strict about libc++ dependencies recently, so these are required to pick up declarations of `malloc` and `uint32_t`, respectively.
