### PR TITLE
[AVR] Fix IRGen function emission to respect LLVM DataLayout program address space.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6358,7 +6358,7 @@ Signature irgen::emitCastOfFunctionPointer(IRGenFunction &IGF,
                             : IGF.IGM.getSignature(fnType);
 
   // Emit the cast.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.FunctionPtrTy);
 
   // Return the information.
   return sig;
@@ -6531,7 +6531,7 @@ FunctionPointer FunctionPointer::forExplosionValue(IRGenFunction &IGF,
                                                    llvm::Value *fnPtr,
                                                    CanSILFunctionType fnType) {
   // Bitcast out of an opaque pointer type.
-  assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
+  assert(fnPtr->getType() == IGF.IGM.Int8ProgramSpacePtrTy);
   auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
   auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
 
@@ -6550,7 +6550,7 @@ FunctionPointer::getExplosionValue(IRGenFunction &IGF,
   }
 
   // Bitcast to an opaque pointer type.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8ProgramSpacePtrTy);
 
   return fnPtr;
 }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6417,7 +6417,7 @@ Signature irgen::emitCastOfFunctionPointer(IRGenFunction &IGF,
                             : IGF.IGM.getSignature(fnType);
 
   // Emit the cast.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.FunctionPtrTy);
 
   // Return the information.
   return sig;
@@ -6616,7 +6616,7 @@ FunctionPointer FunctionPointer::forExplosionValue(IRGenFunction &IGF,
                                                    llvm::Value *fnPtr,
                                                    CanSILFunctionType fnType) {
   // Bitcast out of an opaque pointer type.
-  assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
+  assert(fnPtr->getType() == IGF.IGM.Int8ProgramSpacePtrTy);
   auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
   auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
 
@@ -6635,7 +6635,7 @@ FunctionPointer::getExplosionValue(IRGenFunction &IGF,
   }
 
   // Bitcast to an opaque pointer type.
-  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8PtrTy);
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8ProgramSpacePtrTy);
 
   return fnPtr;
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2517,7 +2517,8 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM, LinkInfo &linkInfo,
   }
 
   llvm::Function *fn =
-    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(), name);
+    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(),
+     /*addrspace*/IGM.DataLayout.getProgramAddressSpace(), name);
   fn->setCallingConv(signature.getCallingConv());
 
   if (insertBefore) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2524,7 +2524,8 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM, LinkInfo &linkInfo,
   }
 
   llvm::Function *fn =
-    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(), name);
+    llvm::Function::Create(signature.getType(), linkInfo.getLinkage(),
+     /*addrspace*/IGM.DataLayout.getProgramAddressSpace(), name);
   fn->setCallingConv(signature.getCallingConv());
 
   if (insertBefore) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -534,7 +534,7 @@ emitGlobalList(IRGenModule &IGM, ArrayRef<llvm::WeakTrackingVH> handles,
       llvm::Constant *elt = cast<llvm::Constant>(&*handle);
       std::string eltName = name.str() + "_" + elt->getName().str();
       if (elt->getType() != eltTy)
-        elt = llvm::ConstantExpr::getBitCast(elt, eltTy);
+        elt = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(elt, eltTy);
       auto var = new llvm::GlobalVariable(IGM.Module, eltTy, isConstant,
                                           linkage, elt, eltName);
       var->setSection(section);
@@ -562,7 +562,7 @@ emitGlobalList(IRGenModule &IGM, ArrayRef<llvm::WeakTrackingVH> handles,
   for (auto &handle : handles) {
     auto elt = cast<llvm::Constant>(&*handle);
     if (elt->getType() != eltTy)
-      elt = llvm::ConstantExpr::getBitCast(elt, eltTy);
+      elt = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(elt, eltTy);
     elts.push_back(elt);
   }
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2066,7 +2066,7 @@ namespace {
           uint64_t word = offset / ptrBytes; // pointer-aligned, fills one word
           for (; nextWord < word; ++nextWord)
             types.push_back(IGM.SizeTy);
-          types.push_back(IGM.PtrTy);
+          types.push_back(ty);
           ++nextWord;
           hasPointer = true;
         }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -261,6 +261,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   
   VoidTy = llvm::Type::getVoidTy(getLLVMContext());
   PtrTy = llvm::PointerType::getUnqual(getLLVMContext());
+  // respect program address space in llvm data layout
+  // for function pointers
+  FunctionPtrTy = llvm::PointerType::get(getLLVMContext(),
+    DataLayout.getProgramAddressSpace());
   Int1Ty = llvm::Type::getInt1Ty(getLLVMContext());
   Int8Ty = llvm::Type::getInt8Ty(getLLVMContext());
   Int16Ty = llvm::Type::getInt16Ty(getLLVMContext());

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -235,6 +235,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   
   VoidTy = llvm::Type::getVoidTy(getLLVMContext());
   PtrTy = llvm::PointerType::getUnqual(getLLVMContext());
+  // respect program address space in llvm data layout
+  // for function pointers
+  FunctionPtrTy = llvm::PointerType::get(getLLVMContext(),
+    DataLayout.getProgramAddressSpace());
   Int1Ty = llvm::Type::getInt1Ty(getLLVMContext());
   Int8Ty = llvm::Type::getInt8Ty(getLLVMContext());
   Int16Ty = llvm::Type::getInt16Ty(getLLVMContext());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -768,7 +768,6 @@ public:
     llvm::PointerType *FullBoxMetadataPtrTy;  /// %swift.full_boxmetadata*
     llvm::PointerType *FullHeapMetadataPtrTy; /// %swift.full_heapmetadata*
     llvm::PointerType *FullTypeMetadataPtrTy; /// %swift.full_type*
-    llvm::PointerType *FunctionPtrTy;
     llvm::PointerType *Int8PtrTy;      /// i8*
     llvm::PointerType *Int8PtrPtrTy;   /// i8**
     llvm::PointerType *Int32PtrTy;     /// i32 *
@@ -806,6 +805,10 @@ public:
     llvm::PointerType *WitnessTablePtrTy;
     llvm::PointerType *WitnessTablePtrPtrTy; /// i8***
     llvm::PointerType *WitnessTableTy;
+  };
+  union {
+    llvm::PointerType *FunctionPtrTy;
+    llvm::PointerType *Int8ProgramSpacePtrTy; /// i8* in same address space as programs
   };
 
   llvm::StructType *RefCountedStructTy;/// %swift.refcounted = type { ... }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -782,7 +782,6 @@ public:
     llvm::PointerType *FullBoxMetadataPtrTy;  /// %swift.full_boxmetadata*
     llvm::PointerType *FullHeapMetadataPtrTy; /// %swift.full_heapmetadata*
     llvm::PointerType *FullTypeMetadataPtrTy; /// %swift.full_type*
-    llvm::PointerType *FunctionPtrTy;
     llvm::PointerType *Int8PtrTy;      /// i8*
     llvm::PointerType *Int8PtrPtrTy;   /// i8**
     llvm::PointerType *Int32PtrTy;     /// i32 *
@@ -820,6 +819,10 @@ public:
     llvm::PointerType *WitnessTablePtrTy;
     llvm::PointerType *WitnessTablePtrPtrTy; /// i8***
     llvm::PointerType *WitnessTableTy;
+  };
+  union {
+    llvm::PointerType *FunctionPtrTy;
+    llvm::PointerType *Int8ProgramSpacePtrTy; /// i8* in same address space as programs
   };
 
   llvm::StructType *RefCountedStructTy;/// %swift.refcounted = type { ... }

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -359,7 +359,11 @@ _swift_embedded_error_box_destroy(SWIFT_CONTEXT void * _Nonnull object) {
 
 // Returns the address of the calling convention bridge for metadata storage init.
 static inline void * _Nonnull _swift_embedded_error_destroy_ptr(void) {
+#if defined(__AVR__)
+  return (void *)(__UINTPTR_TYPE__)_swift_embedded_error_box_destroy;
+#else
   return (void *)_swift_embedded_error_box_destroy;
+#endif
 }
 
 #ifdef __cplusplus

--- a/test/embedded/avr/avrCallbackEmission.swift
+++ b/test/embedded/avr/avrCallbackEmission.swift
@@ -1,0 +1,59 @@
+// RUN: %swift-frontend -S -O %s -target avr-none-none-elf \
+// RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
+// REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: CODEGENERATOR=AVR
+// REQUIRES: swift_feature_Embedded
+
+// IRGen needs various patches to work with program address space 1 on AVR.
+// Even the most basic stub program will fail to lower to IR without them.
+
+import Swift
+
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
+let i: Int = 1
+
+var firstCallback: ((Int) -> Void)?
+
+var secondCallback: (@convention(c) (UInt8) -> UInt8)?
+
+#endif
+
+var j = i
+
+firstCallback = {
+	j += $0
+}
+
+secondCallback = {
+	return $0 * 2 - UInt8(j)
+}
+
+// CHECK-LABEL: main:
+// CHECK: ldi	r16, 0
+// CHECK: ldi	r17, 0
+// CHECK: ldi	r24, 1
+// CHECK: ldi	r25, 0
+// CHECK: sts	$e19avrCallbackEmission1iSivp+1, r25
+// CHECK: sts	$e19avrCallbackEmission1iSivp, r24
+// CHECK: sts	$e19avrCallbackEmission1jSivp+1, r25
+// CHECK: sts	$e19avrCallbackEmission1jSivp, r24
+// CHECK: sts	$e19avrCallbackEmission05firstB0ySicSgvp+3, r17
+// CHECK: sts	$e19avrCallbackEmission05firstB0ySicSgvp+2, r16
+// CHECK: ldi	r24, pm_lo8($e19avrCallbackEmissionySicfU_)
+// CHECK: ldi	r25, pm_hi8($e19avrCallbackEmissionySicfU_)
+// CHECK: sts	$e19avrCallbackEmission05firstB0ySicSgvp+1, r25
+// CHECK: sts	$e19avrCallbackEmission05firstB0ySicSgvp, r24
+// CHECK: ldi	r24, pm_lo8($e19avrCallbackEmissions5UInt8VACcfU0_To)
+// CHECK: ldi	r25, pm_hi8($e19avrCallbackEmissions5UInt8VACcfU0_To)
+// CHECK: sts	$e19avrCallbackEmission06secondB0s5UInt8VADXCSgvp+1, r25
+// CHECK: sts	$e19avrCallbackEmission06secondB0s5UInt8VADXCSgvp, r24
+
+// CHECK-LABEL: .protected	$e19avrCallbackEmissions5UInt8VACcfU0_To
+// CHECK: .globl	$e19avrCallbackEmissions5UInt8VACcfU0_To
+// CHECK: .p2align	1
+// CHECK: .type	$e19avrCallbackEmissions5UInt8VACcfU0_To,@function
+// CHECK-LABEL: $e19avrCallbackEmissions5UInt8VACcfU0_To:
+// CHECK: lds	r20, $e19avrCallbackEmission1jSivp
+// CHECK: lds	r21, $e19avrCallbackEmission1jSivp+1
+// CHECK: ret
+

--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -1,0 +1,42 @@
+// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+// RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
+// REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: CODEGENERATOR=AVR
+// REQUIRES: swift_feature_Embedded
+
+// IRGen needs various patches to work with program address space 1 on AVR.
+// Even the most basic stub program will fail to lower to IR without them.
+// We test IR rather than object code for now, to avoid any issues with an
+// out of date LLVM AVR back end throwing off the tests.
+// We are focusing on getting the front end functioning.
+
+import Swift
+
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
+let i: Int = 1
+
+var firstCallback: ((Int) -> Void)?
+
+var secondCallback: (@convention(c) (UInt8) -> UInt8)?
+
+#endif
+
+var j = i
+
+firstCallback = {
+	j += $0
+}
+
+secondCallback = {
+	return $0 * 2 - UInt8(j)
+}
+
+
+// CHECK: target triple = "avr-none-none-elf"
+// CHECK-DAG: 20testIRGenFunctioning1iSivp
+// CHECK-DAG: @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
+// CHECK-DAG: @"$e20testIRGenFunctioning14secondCallbacks5UInt8VADXCSgvp"
+// CHECK-DAG: 20testIRGenFunctioning1jSivp
+// CHECK: define protected i32 @main(i32 %0, ptr %1) addrspace(1)
+// CHECK: store i16 ptrtoint (ptr addrspace(1) @"$e20testIRGenFunctioningySicfU_" to i16), ptr @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
+// CHECK: define protected void @"$e20testIRGenFunctioningySicfU_"(i16 %0) addrspace(1)

--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -38,5 +38,5 @@ secondCallback = {
 // CHECK-DAG: @"$e20testIRGenFunctioning14secondCallbacks5UInt8VADXCSgvp"
 // CHECK-DAG: 20testIRGenFunctioning1jSivp
 // CHECK: define protected i32 @main(i32 %0, ptr %1) addrspace(1)
-// CHECK: store i16 ptrtoint (ptr addrspace(1) @"$e20testIRGenFunctioningySicfU_" to i16), ptr @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
+// CHECK: store ptr addrspace(1) {{.*}}@"$e20testIRGenFunctioningySicfU_"{{.*}}, ptr @"$e20testIRGenFunctioning13firstCallbackySicSgvp"
 // CHECK: define protected void @"$e20testIRGenFunctioningySicfU_"(i16 %0) addrspace(1)


### PR DESCRIPTION
[AVR] Fix IRGen function emission to respect LLVM DataLayout program address space.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

[IRGen/LLVM] Fix broken IRGen emission not respecting LLVM Datalayout



IRGen crashes when attempting to lower even the most basic Swift programs on AVR. I have encountered many problems similar to this over the years and it's always to do with program address space. (See forum discussion: https://forums.swift.org/t/avr-irgen-traps-on-lowering-invalid-cast-assertion-thrown-by-llvm/76883).

This seems to work for at least basic IRGen functionality on AVR. We may need more PRs in future for AVR but this is a start at least.

This is the approach I took on my fork, changing the structure of IRGenModule a bit to separate out `FunctionPtrTy`, if this is too intrusive for other platforms, I'm happy to use another approach, whatever seems sensible. I'm not attached to any one approach.

---

Note: AVR uses pointers with a different address space for program (flash) memory on the microcontrollers to distinguish RAM from Flash memory. Because AVR uses 16-bit pointers, there are not enough addresses to keep the two types of memory separate otherwise. This is well established in LLVM now (it has been in mainstream LLVM for years now) and all other AVR front ends (Rust, C, TinyGo) depend on it.

Resolves https://github.com/swiftlang/swift/issues/78380

@kubamracek @rauhul @phausler 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
