### PR TITLE
SourceKit: correct the macro definitions to avoid warnings on Windows

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CodeCompletionSwiftInterop.h
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CodeCompletionSwiftInterop.h
@@ -43,12 +43,15 @@
 #define SWIFTIDE_END_DECLS
 #endif
 
-#ifndef SWIFTIDE_PUBLIC
-#if defined(_MSC_VER)
-#define SWIFTIDE_PUBLIC __declspec(dllimport)
+#if defined(_WIN32)
+// NOTE: static builds are currently unsupported.
+# if defined(sourcekitd_EXPORTS)
+#   define SWIFTIDE_PUBLIC __declspec(dllexport)
+# else
+#   define SWIFTIDE_PUBLIC __declspec(dllimport)
+# endif
 #else
-#define SWIFTIDE_PUBLIC
-#endif
+# define SWIFTIDE_PUBLIC /**/
 #endif
 
 #ifndef __has_feature


### PR DESCRIPTION
This silences a large number of warnings due to
`-Winconsistent-dllimport`. While it is possible to support the library to be built statically, that is not currently supported by the build system, so simply leave that unsupported for decoration.

An option here for ELF targets would be to use
`__attribute__((__visibility__("default")))` and enable hidden visibility by default enabling a small bit of optimization.