### PR TITLE
utils: remove Yams from the checkout set

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -150,7 +150,6 @@
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "v1.11.1",
-                "yams": "5.1.3",
                 "cmake": "v3.30.2",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",


### PR DESCRIPTION
The Yams dependency has been removed, remove it from the checkout set. This should have a minimal speed up on the checkout stage in CI.