### PR TITLE
[swift-inspect] use CMake FetchContent to fetch ArgumentParser when not provided

### DIFF
--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -22,6 +22,7 @@ FetchContent_Declare(ArgumentParser
   FIND_PACKAGE_ARGS CONFIG)
 
 block(SCOPE_FOR VARIABLES)
+  set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build as a shared library")
   set(BUILD_TESTING OFF CACHE INTERNAL "Skip building ArgumentParser tests")
   set(BUILD_EXAMPLES OFF CACHE INTERNAL "Skip building ArgumentParser examples")
   FetchContent_MakeAvailable(ArgumentParser)

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -20,9 +20,12 @@ FetchContent_Declare(ArgumentParser
   GIT_SHALLOW     TRUE
   EXCLUDE_FROM_ALL
   FIND_PACKAGE_ARGS CONFIG)
-set(BUILD_TESTING OFF CACHE INTERNAL "Skip building ArgumentParser tests")
-set(BUILD_EXAMPLES OFF CACHE INTERNAL "Skip building ArgumentParser examples")
-FetchContent_MakeAvailable(ArgumentParser)
+
+block(SCOPE_FOR VARIABLES)
+  set(BUILD_TESTING OFF CACHE INTERNAL "Skip building ArgumentParser tests")
+  set(BUILD_EXAMPLES OFF CACHE INTERNAL "Skip building ArgumentParser examples")
+  FetchContent_MakeAvailable(ArgumentParser)
+endblock()
 
 add_library(SymbolicationShims INTERFACE)
 target_include_directories(SymbolicationShims INTERFACE

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -20,8 +20,8 @@ FetchContent_Declare(ArgumentParser
   GIT_SHALLOW     TRUE
   EXCLUDE_FROM_ALL
   FIND_PACKAGE_ARGS CONFIG)
-set(BUILD_TESTING OFF CACHE INTERNAL "skip building tests")
-set(BUILD_EXAMPLES OFF CACHE INTERNAL "skip building examples")
+set(BUILD_TESTING OFF CACHE INTERNAL "Skip building ArgumentParser tests")
+set(BUILD_EXAMPLES OFF CACHE INTERNAL "Skip building ArgumentParser examples")
 FetchContent_MakeAvailable(ArgumentParser)
 
 add_library(SymbolicationShims INTERFACE)

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.28)
 project(swift-inspect
   LANGUAGES C CXX Swift)
 
+include(FetchContent)
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -12,7 +14,15 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-find_package(ArgumentParser CONFIG REQUIRED)
+FetchContent_Declare(ArgumentParser
+  GIT_REPOSITORY  https://github.com/apple/swift-argument-parser
+  GIT_TAG         1.5.0
+  GIT_SHALLOW     TRUE
+  EXCLUDE_FROM_ALL
+  FIND_PACKAGE_ARGS CONFIG)
+set(BUILD_TESTING OFF CACHE INTERNAL "skip building tests")
+set(BUILD_EXAMPLES OFF CACHE INTERNAL "skip building examples")
+FetchContent_MakeAvailable(ArgumentParser)
 
 add_library(SymbolicationShims INTERFACE)
 target_include_directories(SymbolicationShims INTERFACE

--- a/tools/swift-inspect/Package.swift
+++ b/tools/swift-inspect/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ]
 } else {
     package.dependencies += [.package(path: "../../../swift-argument-parser")]

--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -50,13 +50,13 @@ swift build --triple %ANDROID_ARCH%-unknown-linux-android%ANDROID_API_LEVEL% ^
 In order to build on Windows with CMake, some additional parameters must be passed to the build tool to locate the necessary Swift modules.
 
 ~~~
-cmake -B out -G Ninja -S . -D ArgumentParser_DIR=... -D CMAKE_Swift_FLAGS="-Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror"
+cmake -B out -G Ninja -S . -D CMAKE_Swift_FLAGS="-Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror"
 ~~~
 
 In order to build on Linux with CMake, some additional parameters must be passed to the build tool to locate the necessary Swift modules.
 
 ~~~
-cmake -B out -G Ninja -S . -D ArgumentParser_DIR=... -D CMAKE_Swift_FLAGS="-Xcc -I$(git rev-parse --show-toplevel)/include/swift/SwiftRemoteMirror"
+cmake -B out -G Ninja -S . -D CMAKE_Swift_FLAGS="-Xcc -I$(git rev-parse --show-toplevel)/include/swift/SwiftRemoteMirror"
 ~~~
 
 In order to build for Android with CMake on Windows, some additiona parameters must be passed to the build tool to locate the necessary Swift modules.
@@ -75,12 +75,14 @@ cmake -B build -S . -G Ninja ^
     -D CMAKE_SYSTEM_VERSION=%ANDROID_API_LEVEL% ^
     -D CMAKE_Swift_COMPILER_TARGET=%ANDROID_ARCH%-unknown-linux-android%ANDROID_API_LEVEL% ^
     -D CMAKE_Swift_FLAGS="-sdk %SDKROOT_ANDROID% -L%ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\lib\clang\%ANDROID_CLANG_VERSION%\lib\linux\%ANDROID_ARCH% -Xclang-linker -resource-dir -Xclang-linker %ANDROID_NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\lib\clang\%ANDROID_CLANG_VERSION% -Xcc -I%SDKROOT_ANDROID%\usr\include -I%SDKROOT_ANDROID%\usr\include\swift\SwiftRemoteMirror" ^
-    -D ArgumentParser_DIR=...
 cmake --build build
 ~~~
 
-Building with CMake requires a local copy of [swift-argument-parser](https://github.com/apple/swift-argument-parser) built with CMake.
-The `ArumentParser_DIR=` definition must refer to the `cmake/modules` sub-directory of the swift-argument-parser build output directory.
+Building with CMake can use a local copy of [swift-argument-parser](https://github.com/apple/swift-argument-parser) built with CMake.
+The `ArgumentParser_DIR=` definition must refer to the `cmake/modules` sub-directory of the swift-argument-parser build output directory.
+~~~cmd
+cmake -b out -G Ninja -S . -D ArgumentParser_DIR=S:\swift-argument-parser\build\cmake\modules
+~~~
 
 ### Using
 


### PR DESCRIPTION
## Purpose
Simplify CMake build of `swift-inspect` by using `FetchContent` to fetch and build `swift-argument-parser` when not provided manually via `ArgumentParser_DIR=...`.

## Overview
* Replace CMake `find_package` with `FetchContent` with `FIND_PACKAGE_ARGS`, which will first try `find_package` as before but will fetch from remote if not provided
* Specify `swift-argument-parser` v1.5.0 since it builds properly for Android
* Update `Packages.swift` to also specify `swift-argument-parser` v1.5.0 for consistency
* Update README to reflect the change

## Validation
* CMake build for Android arm64-v8a on Windows 11 with and without `ArgumentParser_DIR`
* CMake build for Windows x64 on Windows 11 with and without `ArgumentParser_DIR`
* CMake build for Linux x86_64 on Fedora 41 with and without `ArgumentParser_DIR`