### PR TITLE
utils: disable C compiler for ASN1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2325,7 +2325,7 @@ function Build-ASN1($Arch) {
     -Src $SourceCache\swift-asn1 `
     -Bin (Get-HostProjectBinaryCache ASN1) `
     -Arch $Arch `
-    -UseBuiltCompilers C,Swift `
+    -UseBuiltCompilers Swift `
     -SwiftSDK (Get-HostSwiftSDK) `
     -BuildTargets default `
     -Defines @{


### PR DESCRIPTION
The ASN1 project does not have C code so passing the C compiler causes some warnings.