### PR TITLE
Sema: Loosen the decl more available than enclosing diagnostic

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2470,6 +2470,12 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
           // not diagnosed previously, so only emit a warning in that case.
           if (isa<ExtensionDecl>(DC->getTopmostDeclarationDeclContext()))
             limit = DiagnosticBehavior::Warning;
+        } else if (enclosingAttr.getPlatform() != attr->getPlatform()) {
+          // Downgrade to a warning when the limiting attribute is for a more
+          // specific platform.
+          if (inheritsAvailabilityFromPlatform(enclosingAttr.getPlatform(),
+                                               attr->getPlatform()))
+            limit = DiagnosticBehavior::Warning;
         }
         diagnose(D->isImplicit() ? enclosingDecl->getLoc()
                                  : parsedAttr->getLocation(),

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -164,3 +164,17 @@ public extension UnavailableOniOS { // ok
 public struct AvailableOnMacCatalyst { }
 
 public extension AvailableOnMacCatalyst { } // ok
+
+@available(iOS, introduced: 14.0)
+@available(macCatalyst, introduced: 14.5)
+public struct AvailableLaterOnMacCatalyst { // expected-note {{enclosing scope requires availability of Mac Catalyst 14.5 or newer}}
+  @available(iOS, introduced: 14.0) // expected-warning {{instance method cannot be more available than enclosing scope}}
+  func iOSOnly() { }
+
+  @available(macCatalyst, introduced: 14.5)
+  func macCatalystOnly() { }
+
+  @available(iOS, introduced: 14.0)
+  @available(macCatalyst, introduced: 14.5)
+  func iOSAndMacCatalyst() { }
+}


### PR DESCRIPTION
Downgrade the `cannot be more available than enclosing scope` error to a warning when the attribute making the decl too available is specified for a less specific platform.

Resolves rdar://143423070.
