### PR TITLE
[ASTPrinter] Print SPI by default

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -194,7 +194,7 @@ struct PrintOptions {
     Package // prints package, SPI, and public/inlinable decls
   };
 
-  InterfaceMode InterfaceContentKind;
+  InterfaceMode InterfaceContentKind = InterfaceMode::Private;
 
   bool printPublicInterface() const {
     return InterfaceContentKind == InterfaceMode::Public;

--- a/test/SourceKit/CursorInfo/cursor_spi.swift
+++ b/test/SourceKit/CursorInfo/cursor_spi.swift
@@ -1,0 +1,7 @@
+@_spi(Hello)
+public struct World {}
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:15 %s -- %s | %FileCheck -check-prefix=CHECK %s
+// CHECK: source.lang.swift.decl.struct (2:15-2:20)
+// CHECK: <Declaration>@_spi(Hello) public struct World</Declaration>
+// CHECK: <decl.struct><syntaxtype.attribute.name>@_spi</syntaxtype.attribute.name>(Hello) <syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>World</decl.name></decl.struct>


### PR DESCRIPTION
`PrintOptions.InterfaceContentKind` was not initialized. Set it to `InteraceMode::Private` by default, so SPI declarations and their `@_spi` attribues are printed. This basically restores the behavior before
https://github.com/swiftlang/swift/commit/aba3b6c24eca4f68c62f5af5fe551f6245d62601 , and is align with `AccessFilter` being `AccessLevel::Private` by default.

rdar://131726756
