### PR TITLE
[cxx-interop]: Refactor `CxxDictionary` protocols to use generics instead of `Self`.

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -174,10 +174,10 @@ extension CxxDictionary {
   }
 
   @inlinable
-  public mutating func merge<S: Sequence>(
+  public mutating func merge<S: Sequence, E>(
     _ other: __owned S,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows where S.Element == (Key, Value) {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) where S.Element == (Key, Value) {
     for (key, value) in other {
       var iter = self.__findMutatingUnsafe(key)
       if iter != self.__endMutatingUnsafe() {
@@ -190,10 +190,10 @@ extension CxxDictionary {
   }
 
   @inlinable
-  public mutating func merge(
+  public mutating func merge<E>(
     _ other: __owned Dictionary<Key, Value>,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows where Key: Hashable {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) where Key: Hashable {
     for (key, value) in other {
       var iter = self.__findMutatingUnsafe(key)
       if iter != self.__endMutatingUnsafe() {
@@ -206,10 +206,10 @@ extension CxxDictionary {
   }
 
   @inlinable
-  public mutating func merge(
-    _ other: __owned Self,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows {
+  public mutating func merge<T: CxxDictionary, E>(
+    _ other: __owned T,
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) where T.Key == Key, T.Value == Value {
     var iterator = other.__beginUnsafe()
     while iterator != other.__endUnsafe() {
       var iter = self.__findMutatingUnsafe(iterator.pointee.first)
@@ -224,30 +224,30 @@ extension CxxDictionary {
   }
 
   @inlinable
-  public __consuming func merging<S: Sequence>(
+  public __consuming func merging<S: Sequence, E>(
     _ other: __owned S,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows -> Self where S.Element == (Key, Value) {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) -> Self where S.Element == (Key, Value) {
     var result = self
     try result.merge(other, uniquingKeysWith: combine)
     return result
   }
 
   @inlinable
-  public __consuming func merging(
+  public __consuming func merging<E>(
       _ other: __owned Dictionary<Key, Value>,
-      uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows -> Self where Key: Hashable {
+      uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) -> Self where Key: Hashable {
     var result = self
     try result.merge(other, uniquingKeysWith: combine)
     return result
   }
 
   @inlinable
-  public __consuming func merging(
-    _ other: __owned Self,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows -> Self {
+  public __consuming func merging<T: CxxDictionary, E>(
+    _ other: __owned T,
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) -> Self where T.Key == Key, T.Value == Value {
     var result = self
     try result.merge(other, uniquingKeysWith: combine)
     return result

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -427,6 +427,103 @@ StdMapTestSuite.test("UnorderedMap.merge(map)") {
   expectEqual(m[3], 3)
 }
 
+StdMapTestSuite.test("Map.merge(CxxDictionary)") {
+  // Empty map merging with empty map.
+  var emptyMap = initEmptyMap()
+  emptyMap.merge(initEmptyUnorderedMap()) { v0, _ in v0 }
+  expectTrue(emptyMap.empty())
+
+  emptyMap.merge(initEmptyUnorderedMap()) { _, v1 in v1 }
+  expectTrue(emptyMap.empty())
+
+  // Empty map merging with non-empty map.
+  emptyMap.merge(initUnorderedMap()) { v0, _ in v0 }
+  expectEqual(emptyMap[1], 3)
+  expectEqual(emptyMap[2], 2)
+  expectEqual(emptyMap[3], 3)
+
+  emptyMap = initEmptyMap()
+  emptyMap.merge(initUnorderedMap()) { _, v1 in v1 }
+  expectEqual(emptyMap[1], 3)
+  expectEqual(emptyMap[2], 2)
+  expectEqual(emptyMap[3], 3)
+
+  // Non-empty map merging with empty map.
+  var map = initMap()
+  map.merge(initUnorderedMap()) { v0, _ in v0 }
+  expectEqual(emptyMap[1], 3)
+  expectEqual(emptyMap[2], 2)
+  expectEqual(emptyMap[3], 3)
+
+  map.merge(initEmptyUnorderedMap()) { _, v1 in v1 }
+  expectEqual(map[1], 3)
+  expectEqual(map[2], 2)
+  expectEqual(map[3], 3)
+
+  // Non-empty map merging with non-empty map.
+  let noneEmptydMap = UnorderedMap([1: 4, 2: 5, 3: 6, 4: 7])
+  map.merge(noneEmptydMap) { v0, _ in v0 }
+  expectEqual(map[1], 3)
+  expectEqual(map[2], 2)
+  expectEqual(map[3], 3)
+  expectEqual(map[4], 7)
+
+  map.merge(noneEmptydMap) { _, v1 in v1 }
+  expectEqual(map[1], 4)
+  expectEqual(map[2], 5)
+  expectEqual(map[3], 6)
+  expectEqual(map[4], 7)
+}
+
+StdMapTestSuite.test("UnorderedMap.merge(CxxDictionary)") {
+  // Empty map merging with empty map.
+  var emptyMap = initEmptyUnorderedMap()
+  emptyMap.merge(initEmptyMap()) { v0, _ in v0 }
+  expectTrue(emptyMap.empty())
+
+  emptyMap.merge(initEmptyMap()) { _, v1 in v1 }
+  expectTrue(emptyMap.empty())
+
+  // Empty map merging with non-empty map.
+  emptyMap.merge(initMap()) { v0, _ in v0 }
+  expectEqual(emptyMap[1], 3)
+  expectEqual(emptyMap[2], 2)
+  expectEqual(emptyMap[3], 3)
+
+  emptyMap = initEmptyUnorderedMap()
+  emptyMap.merge(initMap()) { _, v1 in v1 }
+  expectEqual(emptyMap[1], 3)
+  expectEqual(emptyMap[2], 2)
+  expectEqual(emptyMap[3], 3)
+
+  // Non-empty map merging with empty map.
+  var map = initUnorderedMap()
+  map.merge(initEmptyMap()) { _, v1 in v1 }
+  expectEqual(map[1], 3)
+  expectEqual(map[2], 2)
+  expectEqual(map[3], 3)
+
+  map.merge(initEmptyMap()) { v0, _ in v0 }
+  expectEqual(map[1], 3)
+  expectEqual(map[2], 2)
+  expectEqual(map[3], 3)
+
+  // Non-empty map merging with non-empty map.
+  let noneEmptyMap = Map([1: 4, 2: 5, 3: 6, 4: 7])
+
+  map.merge(noneEmptyMap) { v0, _ in v0 }
+  expectEqual(map[1], 3)
+  expectEqual(map[2], 2)
+  expectEqual(map[3], 3)
+  expectEqual(map[4], 7)
+
+  map.merge(noneEmptyMap) { _, v1 in v1 }
+  expectEqual(map[1], 4)
+  expectEqual(map[2], 5)
+  expectEqual(map[3], 6)
+  expectEqual(map[4], 7)
+}
+
 // `merging` is implemented by calling `merge`, so we can skip this test
 
 runAllTests()


### PR DESCRIPTION
Replace self type with generics so that `std::map` and `std::unordered_map` can be merged with each other.