### PR TITLE
[Observation] Add type annotation on cached keypaths

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -468,10 +468,18 @@ extension ObservationTrackedMacro: PeerMacro {
     
     let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
     if ObservableMacro.canCacheKeyPaths(context.lexicalContext) {
-      let cachedKeypath: DeclSyntax =
-        """
-        private static let _cachedKeypath_\(identifier) = \\\(container.name).\(identifier)
-        """
+      let cachedKeypath: DeclSyntax
+      if let type = property.type {
+        cachedKeypath =
+          """
+          private static let _cachedKeypath_\(identifier): ReferenceWritableKeyPath<\(container.name), \(type)> = \\\(container.name).\(identifier)
+          """
+      } else {
+        cachedKeypath =
+          """
+          private static let _cachedKeypath_\(identifier) = \\\(container.name).\(identifier)
+          """
+      }
       return [storage, cachedKeypath]
     } else {
       return [storage]

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -218,6 +218,40 @@ class GenericClassParent<T> {
   }
 }
 
+protocol MemberProtocol {}
+struct MemberType: MemberProtocol {}
+
+@Observable
+class HasUniversalMember {
+  var member: any MemberProtocol = MemberType()
+}
+
+@Observable
+class HasExistentialMember {
+  var member: some MemberProtocol = MemberType()
+}
+
+protocol HasAssociatedType {
+  associatedtype Associated
+  static var associatedMember: Associated { get }
+}
+
+@Observable
+class HasHiddenExistential: HasAssociatedType {
+  var member: Associated = HasHiddenExistential.associatedMember
+  static var associatedMember: some MemberProtocol { MemberType() }
+}
+
+/*
+// FIXME: This case is not handled yet. Properties that have no type annotation
+// that are inferred as containing a `some` type fail to compile.
+@Observable
+class HasMoreHiddenExistential: HasAssociatedType {
+  var member = HasMoreHiddenExistential.associatedMember
+  static var associatedMember: some MemberProtocol { MemberType() }
+}
+*/
+
 @Observable
 class RecursiveOuter {
   var inner = RecursiveInner()


### PR DESCRIPTION
Having a KeyPath with an inferred type that contains a "some" type gives an error, like:

```
error: property definition has inferred type '...', involving the 'some' return type of another declaration
```

This is not diagnosed if there is an explicit type, so add an explicit type for the cached keypath when the property has an annotated type. This doesn't resolve cases where there is no type annotation on a property and the inferred type contains a `some` type, but this can always be resolved by adding an explicit type.

rdar://143466616