### PR TITLE
[windows] Enable tests for LLDB in Swift CI

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,
+set TestArg=-Test lld,lldb,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/76894 prepared the toolchain build to run tests for LLDB in Swift CI. Here we just turn it on. In case we clog Swift PR testing, we can easily revert this one without loosing all the infrastructure.