### PR TITLE
SIL: look through `end_init_let_ref` instructions when checking for `isLexical`

### DIFF
--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -153,6 +153,13 @@ bool ValueBase::isLexical() const {
     return bbi->isLexical();
   if (auto *mvi = dyn_cast<MoveValueInst>(this))
     return mvi->isLexical();
+
+  // TODO: This is only a workaround. Optimizations should look through such instructions to
+  // get the isLexical state, instead of doing it here.
+  // rdar://143577158
+  if (auto *eilr = dyn_cast<EndInitLetRefInst>(this))
+    return eilr->getOperand()->isLexical();
+
   return false;
 }
 

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -1071,3 +1071,24 @@ sil [ossa] @dontShortenDeadMoveOnlyLifetime : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil [ossa] @look_through_end_init_let_ref :
+// CHECK:         [[E:%.*]] = end_init_let_ref
+// CHECK:         [[D:%.*]] = function_ref @dummy
+// CHECK:         apply [[D]]
+// CHECK:         destroy_value [[E]]
+// CHECK-LABEL: } // end sil function 'look_through_end_init_let_ref'
+sil [ossa] @look_through_end_init_let_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C
+  %1 = move_value [lexical] %0
+  %2 = end_init_let_ref %1
+  %4 = function_ref @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+  apply %4(%2) : $@convention(thin) (@guaranteed C) -> ()
+  %6 = function_ref @dummy : $@convention(thin) () -> ()
+  apply %6() : $@convention(thin) () -> ()
+  destroy_value %2
+  %3 = tuple ()
+  return %3
+}
+


### PR DESCRIPTION
`end_init_let_ref` instructions are inserted in class initializers after all fields are initialized. It's important to look through such instructions when checking the `isLexical` property of a value.

Fixes a mis-compile due to shrinking a lexical liverange of a class.
Part of rdar://140229560
