### PR TITLE
Two workarounds for autodiff specific optimizations with OSSA

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -503,6 +503,12 @@ private func handleApplies(for rootClosure: SingleValueInstruction, callSiteMap:
       continue
     }
 
+    // Workaround for a problem with OSSA: https://github.com/swiftlang/swift/issues/78847
+    // TODO: remove this if-statement once the underlying problem is fixed.
+    if callee.hasOwnership {
+      continue
+    }
+
     if callee.isDefinedExternally {
       continue
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -1020,6 +1020,11 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
   // %vjp' = convert_function %vjp
   // %y = differentiable_function(%orig', %jvp', %vjp')
   if (auto *DFI = dyn_cast<DifferentiableFunctionInst>(cfi->getOperand())) {
+    // Workaround for a problem with OSSA: https://github.com/swiftlang/swift/issues/78848
+    // TODO: remove this if-statement once the underlying problem is fixed.
+    if (cfi->getFunction()->hasOwnership())
+      return nullptr;
+
     auto createConvertFunctionOfComponent =
       [&](NormalDifferentiableFunctionTypeComponent extractee) {
         if (!DFI->hasExtractee(extractee))


### PR DESCRIPTION
* AutodiffClosureSpecialization
* SILCombine of `differential_function`

Disable these optimizations for OSSA until the underlying problems are fixed.
https://github.com/swiftlang/swift/issues/78847
https://github.com/swiftlang/swift/issues/78848

Part of rdar://140229560