### PR TITLE
Revert "[cxx-interop] Workaround name lookup issues with namespace simd"

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1166,14 +1166,6 @@ namespace {
           decl->getOwningModule() &&
           decl->getOwningModule()->getTopLevelModuleName() == "os")
         return nullptr;
-      // Workaround for simd module declaring `namespace simd` on Darwin,
-      // causing name lookup issues. That namespace declares C++ overlays of
-      // types that are already refined for Swift, so let's not import the
-      // namespace (rdar://143007477).
-      if (decl->getIdentifier() && decl->getName() == "simd" &&
-          decl->getOwningModule() &&
-          decl->getOwningModule()->getTopLevelModuleName() == "simd")
-        return nullptr;
       // If this is a top-level namespace, don't put it in the module we're
       // importing, put it in the "__ObjC" module that is implicitly imported.
       if (!decl->getParent()->isNamespace())

--- a/test/Interop/Cxx/objc-correctness/simd_quatf.swift
+++ b/test/Interop/Cxx/objc-correctness/simd_quatf.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
-
-// REQUIRES: objc_interop
-// REQUIRES: VENDOR=apple
-
-import simd
-
-var _: simd.simd_quatf! = nil


### PR DESCRIPTION
This reverts commit c7021ae979d148382a16831ead01479998f42831.

The change triggers a compiler regression for some projects that rely on simd and enable C++ interop.

rdar://143352205

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
