### PR TITLE
[Observation] Disable caching of KeyPaths

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -101,10 +101,6 @@ public struct ObservableMacro {
       """
   }
 
-  static func canCacheKeyPaths(_ lexicalContext: [Syntax]) -> Bool {
-    lexicalContext.allSatisfy { $0.isNonGeneric }
-  }
-
   static var ignoredAttribute: AttributeSyntax {
     AttributeSyntax(
       leadingTrivia: .space,
@@ -357,88 +353,45 @@ public struct ObservationTrackedMacro: AccessorMacro {
         _\(identifier) = initialValue
       }
       """
-    if ObservableMacro.canCacheKeyPaths(context.lexicalContext) {
-      let getAccessor: AccessorDeclSyntax =
-        """
-        get {
-          access(keyPath: \(container.trimmed.name)._cachedKeypath_\(identifier))
-          return _\(identifier)
-        }
-        """
+    let getAccessor: AccessorDeclSyntax =
+      """
+      get {
+        access(keyPath: \\.\(identifier))
+        return _\(identifier)
+      }
+      """
 
-      let setAccessor: AccessorDeclSyntax =
-        """
-        set {
-          guard shouldNotifyObservers(_\(identifier), newValue) else {
-            return
-          }
-          withMutation(keyPath: \(container.trimmed.name)._cachedKeypath_\(identifier)) {
-            _\(identifier) = newValue
-          }
+    let setAccessor: AccessorDeclSyntax =
+      """
+      set {
+        guard shouldNotifyObservers(_\(identifier), newValue) else {
+          return
         }
-        """
-        
-      // Note: this accessor cannot test the equality since it would incur
-      // additional CoW's on structural types. Most mutations in-place do
-      // not leave the value equal so this is "fine"-ish.
-      // Warning to future maintence: adding equality checks here can make
-      // container mutation O(N) instead of O(1).
-      // e.g. observable.array.append(element) should just emit a change
-      // to the new array, and NOT cause a copy of each element of the
-      // array to an entirely new array.
-      let modifyAccessor: AccessorDeclSyntax =
-        """
-        _modify {
-          let keyPath = \(container.trimmed.name)._cachedKeypath_\(identifier)
-          access(keyPath: keyPath)
-          \(raw: ObservableMacro.registrarVariableName).willSet(self, keyPath: keyPath)
-          defer { \(raw: ObservableMacro.registrarVariableName).didSet(self, keyPath: keyPath) }
-          yield &_\(identifier)
+        withMutation(keyPath: \\.\(identifier)) {
+          _\(identifier) = newValue
         }
-        """
+      }
+      """
+      
+    // Note: this accessor cannot test the equality since it would incur
+    // additional CoW's on structural types. Most mutations in-place do
+    // not leave the value equal so this is "fine"-ish.
+    // Warning to future maintence: adding equality checks here can make
+    // container mutation O(N) instead of O(1).
+    // e.g. observable.array.append(element) should just emit a change
+    // to the new array, and NOT cause a copy of each element of the
+    // array to an entirely new array.
+    let modifyAccessor: AccessorDeclSyntax =
+      """
+      _modify {
+        access(keyPath: \\.\(identifier))
+        \(raw: ObservableMacro.registrarVariableName).willSet(self, keyPath: \\.\(identifier))
+        defer { \(raw: ObservableMacro.registrarVariableName).didSet(self, keyPath: \\.\(identifier)) }
+        yield &_\(identifier)
+      }
+      """
 
-      return [initAccessor, getAccessor, setAccessor, modifyAccessor]
-    } else {
-      let getAccessor: AccessorDeclSyntax =
-        """
-        get {
-          access(keyPath: \\.\(identifier))
-          return _\(identifier)
-        }
-        """
-
-      let setAccessor: AccessorDeclSyntax =
-        """
-        set {
-          guard shouldNotifyObservers(_\(identifier), newValue) else {
-            return
-          }
-          withMutation(keyPath: \\.\(identifier)) {
-            _\(identifier) = newValue
-          }
-        }
-        """
-        
-      // Note: this accessor cannot test the equality since it would incur
-      // additional CoW's on structural types. Most mutations in-place do
-      // not leave the value equal so this is "fine"-ish.
-      // Warning to future maintence: adding equality checks here can make
-      // container mutation O(N) instead of O(1).
-      // e.g. observable.array.append(element) should just emit a change
-      // to the new array, and NOT cause a copy of each element of the
-      // array to an entirely new array.
-      let modifyAccessor: AccessorDeclSyntax =
-        """
-        _modify {
-          access(keyPath: \\.\(identifier))
-          \(raw: ObservableMacro.registrarVariableName).willSet(self, keyPath: \\.\(identifier))
-          defer { \(raw: ObservableMacro.registrarVariableName).didSet(self, keyPath: \\.\(identifier)) }
-          yield &_\(identifier)
-        }
-        """
-
-      return [initAccessor, getAccessor, setAccessor, modifyAccessor]
-    }
+    return [initAccessor, getAccessor, setAccessor, modifyAccessor]
   }
 }
 
@@ -467,15 +420,7 @@ extension ObservationTrackedMacro: PeerMacro {
     }
     
     let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-    if ObservableMacro.canCacheKeyPaths(context.lexicalContext) {
-      let cachedKeypath: DeclSyntax =
-        """
-        private static let _cachedKeypath_\(identifier) = \\\(container.name).\(identifier)
-        """
-      return [storage, cachedKeypath]
-    } else {
-      return [storage]
-    }
+    return [storage]
   }
 }
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -51,7 +51,7 @@ public macro Observable() =
 /// framework isn't necessary.
 @available(SwiftStdlib 5.9, *)
 @attached(accessor, names: named(init), named(get), named(set), named(_modify))
-@attached(peer, names: prefixed(_), prefixed(_cachedKeypath_))
+@attached(peer, names: prefixed(_))
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 


### PR DESCRIPTION
Caching KeyPaths have a number of sharp edges; firstly some KeyPaths may be invalid for caching - such as KeyPaths that ought to in all rights be Sendable... but sadly by the nature of them cannot be since it is a generic specific condition (not a type level or macro exposed condition). This includes cases where the value of the generic of the KeyPath is `any X` or `some X`. Furthermore we cannot cache the KeyPaths as a static member of a generic type.