### PR TITLE
[stdlib] Add Comparable conformance to WordPair

### DIFF
--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -185,8 +185,6 @@ extension WordPair: Hashable {
 
 @available(SwiftStdlib 6.2, *)
 extension WordPair: Comparable {
-  // Note: This function can have a lower availability than the conformance
-  // itself because it's always emit into client.
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @_transparent

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -190,7 +190,7 @@ extension WordPair: Comparable {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func <(lhs: WordPair, rhs: WordPair) -> Bool {
+  public static func <(lhs: WordPair, rhs: WordPair) -> Bool {
     if lhs.first != rhs.first {
       return lhs.first < rhs.first
     } else {

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -183,6 +183,18 @@ extension WordPair: Hashable {
   }
 }
 
+@available(SwiftStdlib 6.2, *)
+extension WordPair: Comparable {
+  // Note: This function can have a lower availability than the conformance
+  // itself because it's always emit into client.
+  @available(SwiftStdlib 6.0, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func <(lhs: WordPair, rhs: WordPair) -> Bool {
+    lhs.first < rhs.first || lhs.second < rhs.second
+  }
+}
+
 @available(SwiftStdlib 6.0, *)
 @_unavailableInEmbedded
 extension WordPair: CustomStringConvertible {

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -191,7 +191,11 @@ extension WordPair: Comparable {
   @_alwaysEmitIntoClient
   @_transparent
   public func <(lhs: WordPair, rhs: WordPair) -> Bool {
-    lhs.first < rhs.first || lhs.second < rhs.second
+    if lhs.first != rhs.first {
+      return lhs.first < rhs.first
+    } else {
+      return lhs.second < rhs.second
+    }
   }
 }
 

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -187,15 +187,11 @@ extension WordPair: Hashable {
 extension WordPair: Comparable {
   // Note: This function can have a lower availability than the conformance
   // itself because it's always emit into client.
-  @available(SwiftStdlib 6.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @_transparent
   public static func <(lhs: WordPair, rhs: WordPair) -> Bool {
-    if lhs.first != rhs.first {
-      return lhs.first < rhs.first
-    } else {
-      return lhs.second < rhs.second
-    }
+    (lhs.first, lhs.second) < (rhs.first, rhs.second)
   }
 }
 

--- a/test/abi/macOS/arm64/synchronization.swift
+++ b/test/abi/macOS/arm64/synchronization.swift
@@ -698,3 +698,6 @@ Added: _$s15Synchronization20AtomicUpdateOrderingV22sequentiallyConsistentACvpZM
 Added: _$s15Synchronization20AtomicUpdateOrderingV7relaxedACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9acquiringACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9releasingACvpZMV
+
+// WordPair to Comparable conformance
+Added: _$s15Synchronization8WordPairVSLAAMc

--- a/test/abi/macOS/x86_64/synchronization.swift
+++ b/test/abi/macOS/x86_64/synchronization.swift
@@ -692,3 +692,6 @@ Added: _$s15Synchronization20AtomicUpdateOrderingV22sequentiallyConsistentACvpZM
 Added: _$s15Synchronization20AtomicUpdateOrderingV7relaxedACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9acquiringACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9releasingACvpZMV
+
+// WordPair to Comparable conformance
+Added: _$s15Synchronization8WordPairVSLAAMc

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -50,11 +50,15 @@ suite.test("basics") {
   let c1 = WordPair(first: 1, second: 0)
   let c2 = WordPair(first: 2, second: 0)
   let c3 = WordPair(first: 0, second: 1)
+  let c4 = WordPair(first: 1, second: 2)
+  let c5 = WordPair(first: 2, second: 1)
   expectFalse(c0 < c0)
   expectTrue(c0 < c1)
   expectTrue(c0 < c2)
   expectTrue(c0 < c3)
   expectFalse(c1 < c0)
+  expectTrue(c4 < c5)
+  expectFalse(c5 < c4)
 }
 
 } // if #available(SwiftStdlib 6.0, *)

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -45,7 +45,12 @@ suite.test("basics") {
   let value1 = WordPair(first: .max, second: 0)
   expectEqual(value1.first, .max)
   expectEqual(value1.second, 0)
+}
 
+} // if #available(SwiftStdlib 6.0, *)
+
+if #available(SwiftStdlib 6.2, *) {
+suite.test("comparable") {
   let c0 = WordPair(first: 0, second: 0)
   let c1 = WordPair(first: 1, second: 0)
   let c2 = WordPair(first: 2, second: 0)
@@ -60,7 +65,6 @@ suite.test("basics") {
   expectTrue(c4 < c5)
   expectFalse(c5 < c4)
 }
-
-} // if #available(SwiftStdlib 6.0, *)
+} // if #available(SwiftStdlib 6.2, *)
 
 runAllTests()

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -45,6 +45,16 @@ suite.test("basics") {
   let value1 = WordPair(first: .max, second: 0)
   expectEqual(value1.first, .max)
   expectEqual(value1.second, 0)
+
+  let c0 = WordPair(first: 0, second: 0)
+  let c1 = WordPair(first: 1, second: 0)
+  let c2 = WordPair(first: 2, second: 0)
+  let c3 = WordPair(first: 0, second: 1)
+  expectFalse(c0 < c0)
+  expectTrue(c0 < c1)
+  expectTrue(c0 < c2)
+  expectTrue(c0 < c3)
+  expectFalse(c1 < c0)
 }
 
 } // if #available(SwiftStdlib 6.0, *)


### PR DESCRIPTION
The initial PR to add `WordPair` to the stdlib forgot to include the proposed `Comparable` conformance. Let's add it. Unfortunately the conformance itself will have a higher availability than the type itself, but the function alone can share the availability of the type at least.