### PR TITLE
[Tests] Enable C++ interop for Runtime in the overlay verification test.

### DIFF
--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -794,6 +794,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   }
 
   Invocation.getLangOptions().EnableCXXInterop = options.EnableCxxInterop;
+  Invocation.computeCXXStdlibOptions();
 
   Invocation.getLangOptions().UnavailableDeclOptimizationMode =
       options.UnavailableDeclOptimization;

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -38,11 +38,13 @@ for module_file in os.listdir(sdk_overlay_dir):
     # TODO: fix the DifferentiationUnittest module.
     if module_name == "DifferentiationUnittest":
         continue
-    # Backtracing needs its own additional modules in the module path
+    # Runtime needs its own additional modules in the module path, and
+    # also needs C++ interop enabled
     if module_name == "Runtime":
         extra_args = ["-I", os.path.join(source_dir, "stdlib",
                                          "public", "RuntimeModule", "modules"),
-                      "-I", os.path.join(source_dir, "include")]
+                      "-I", os.path.join(source_dir, "include"),
+                      "--enable-experimental-cxx-interop"]
     # _Concurrency needs its own additional modules in the module path
     if module_name == "_Concurrency":
         extra_args = ["-I", os.path.join(source_dir, "stdlib",


### PR DESCRIPTION
The Runtime module requires C++ interop enabled, because that's the only way to robustly fix things so that it is able to declare various types and constants without clashing with system headers.

rdar://143050566
