### PR TITLE
[windows][toolchain] Build sanitizers and builtins standalone for all SDKs

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -26,22 +26,6 @@ set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-unknown-windows-msvc CACHE STRING "")
 set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
-set(LLVM_RUNTIME_TARGETS
-      aarch64-unknown-windows-msvc
-    CACHE STRING "")
-foreach(target ${LLVM_RUNTIME_TARGETS})
-  set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
-        compiler-rt
-      CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
-endforeach()
 
 set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
 
@@ -167,7 +151,6 @@ set(LLVM_DISTRIBUTION_COMPONENTS
       libclang
       libclang-headers
       LTO
-      runtimes
       ${LLVM_TOOLCHAIN_TOOLS}
       ${CLANG_TOOLS}
       ${LLD_TOOLS}

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -27,62 +27,6 @@ set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
 
-set(DEFAULT_BUILTIN_TARGETS
-      x86_64-unknown-windows-msvc
-      aarch64-unknown-windows-msvc)
-# Build the android builtins if NDK path is provided.
-if(NOT "$ENV{NDKPATH}" STREQUAL "")
-  list(APPEND DEFAULT_BUILTIN_TARGETS
-       aarch64-unknown-linux-android
-       x86_64-unknown-linux-android)
-endif()
-
-# The builtin targets are used to build the compiler-rt builtins.
-set(LLVM_BUILTIN_TARGETS ${DEFAULT_BUILTIN_TARGETS} CACHE STRING "")
-
-# The runtime targets are used to build the compiler-rt profile library.
-set(LLVM_RUNTIME_TARGETS
-      x86_64-unknown-windows-msvc
-      aarch64-unknown-windows-msvc
-    CACHE STRING "")
-
-foreach(target ${LLVM_RUNTIME_TARGETS})
-  set(RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES
-        compiler-rt
-      CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_MT mt CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
-  set(RUNTIMES_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_BUILTINS NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_ORC NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
-  set(RUNTIMES_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
-endforeach()
-
-foreach(target ${LLVM_BUILTIN_TARGETS})
-  set(BUILTINS_${target}_CMAKE_MT mt CACHE STRING "")
-  if(${target} MATCHES windows-msvc)
-    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Windows CACHE STRING "")
-  elseif(${target} MATCHES linux-android)
-    # Use a single 'linux' directory and arch-based lib names on Android.
-    set(BUILTINS_${target}_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR NO CACHE BOOL "")
-    set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Android CACHE STRING "")
-    if(${target} MATCHES aarch64)
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "")
-    else()
-      set(BUILTINS_${target}_CMAKE_ANDROID_ARCH_ABI x86_64 CACHE STRING "")
-    endif()
-    set(BUILTINS_${target}_CMAKE_ANDROID_NDK $ENV{NDKPATH} CACHE PATH "")
-    set(BUILTINS_${target}_CMAKE_ANDROID_API 21 CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_C_COMPILER_TARGET "${target}21" CACHE STRING "")
-    set(BUILTINS_${target}_CMAKE_CXX_COMPILER_TARGET "${target}21" CACHE STRING "")
-  endif()
-  set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
-endforeach()
-
 set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
 
 # Disable certain targets to reduce the configure time or to avoid configuration
@@ -207,8 +151,6 @@ set(LLVM_DISTRIBUTION_COMPONENTS
       libclang
       libclang-headers
       LTO
-      builtins
-      runtimes
       ${LLVM_TOOLCHAIN_TOOLS}
       ${CLANG_TOOLS}
       ${LLD_TOOLS}

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=windows-msvc
+
 // Different sanitizer coverage types
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=func -sanitize=address %s | %FileCheck -check-prefix=SANCOV_FUNC %s
 // RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=bb -sanitize=address %s | %FileCheck -check-prefix=SANCOV_BB %s

--- a/test/IRGen/address_sanitizer_use_odr_indicator.swift
+++ b/test/IRGen/address_sanitizer_use_odr_indicator.swift
@@ -1,3 +1,4 @@
+// XFAIL: OS=windows-msvc
 // REQUIRES: asan_runtime
 
 // Default instrumentation that does not use ODR indicators

--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=windows-msvc
+
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env ASAN_OPTIONS=detect_leaks=0 %target-run %t_asan-binary

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,4 +1,5 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// XFAIL: OS=windows-msvc
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=windows-msvc
+
 // RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run %t_asan-binary 2>&1 | %FileCheck %s

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -9,6 +9,7 @@
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
 // UNSUPPORTED: remote_run
+// XFAIL: OS=windows-msvc
 
 func sayHello() {
   print("Hello")

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -77,8 +77,6 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
   %TestArg% ^
-  -AndroidSDKs x86_64 ^
-  -WindowsSDKs X64 ^
   -Stage %PackageRoot% ^
   -Summary || (exit /b 1)
 

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -77,6 +77,8 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
   %TestArg% ^
+  -AndroidSDKs x86_64 ^
+  -WindowsSDKs X64 ^
   -Stage %PackageRoot% ^
   -Summary || (exit /b 1)
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1609,7 +1609,6 @@ function Build-LLVM([Platform]$Platform, $Arch) {
 }
 
 function Build-Sanitizers([Platform]$Platform, $Arch) {
-  $BareTarget = $Arch.LLVMTarget.Replace("$AndroidAPILevel", "")
   $LLVMTargetCache = $(Get-TargetProjectBinaryCache $Arch LLVM)
   $LITVersionStr = $(Invoke-Program $(Get-PythonExecutable) "$LLVMTargetCache\bin\llvm-lit.py" --version)
   if (-not ($LITVersionStr -match "lit (\d+)\.\d+\.\d+.*")) {
@@ -1648,7 +1647,6 @@ function Build-Sanitizers([Platform]$Platform, $Arch) {
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LLVM_DIR = "$LLVMTargetCache\lib\cmake\llvm";
       LLVM_ENABLE_PER_TARGET_RUNTIME_DIR = "YES";
-      LLVM_RUNTIMES_TARGET = $BareTarget;
       COMPILER_RT_DEFAULT_TARGET_ONLY = "YES";
       COMPILER_RT_BUILD_BUILTINS = "NO";
       COMPILER_RT_BUILD_CRT = "NO";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1627,7 +1627,6 @@ function Build-Sanitizers([Platform]$Platform, $Arch) {
     -UseBuiltCompilers C,CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines (@{
-      CMAKE_MT = "mt";
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LLVM_DIR = "$LLVMTargetCache\lib\cmake\llvm";
       LLVM_ENABLE_PER_TARGET_RUNTIME_DIR = "YES";
@@ -1643,7 +1642,6 @@ function Build-Sanitizers([Platform]$Platform, $Arch) {
     -UseBuiltCompilers C,CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines (@{
-      CMAKE_MT = "mt";
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LLVM_DIR = "$LLVMTargetCache\lib\cmake\llvm";
       LLVM_ENABLE_PER_TARGET_RUNTIME_DIR = "YES";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1624,7 +1624,7 @@ function Build-Sanitizers([Platform]$Platform, $Arch) {
     -InstallTo $InstallTo `
     -Arch $Arch `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX `
+    -UseBuiltCompilers ASM,C,CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines (@{
       CMAKE_SYSTEM_NAME = $Platform.ToString();
@@ -1639,7 +1639,7 @@ function Build-Sanitizers([Platform]$Platform, $Arch) {
     -InstallTo $InstallTo `
     -Arch $Arch `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX `
+    -UseBuiltCompilers ASM,C,CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines (@{
       CMAKE_SYSTEM_NAME = $Platform.ToString();

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1601,7 +1601,7 @@ function Build-LLVM([Platform]$Platform, $Arch) {
     -Bin (Get-TargetProjectBinaryCache $Arch LLVM) `
     -Arch $Arch `
     -Platform $Platform `
-    -UseMSVCCompilers C,CXX `
+    -UseBuiltCompilers C,CXX `
     -Defines @{
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       LLVM_HOST_TRIPLE = $Arch.LLVMTarget;


### PR DESCRIPTION
Unified build of compiler-rt together with LLVM failed for the Android SDKs. It got too complicated to redirect the way LLVM would configure the nested build-trees. Standalone builds slightly increase build time, but they turned out much simpler and we end up with less duplication of definitions.