### PR TITLE
[6.1 🍒][Dependency Scanning] Synchronize on updating Swift dependency lookup results in-parallel

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -928,16 +928,19 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
   for (const auto &dependsOn : moduleDependencyInfo.getModuleImports())
     moduleLookupResult.insert(
         std::make_pair(dependsOn.importIdentifier, std::nullopt));
+  std::mutex lookupResultLock;
 
   // A scanning task to query a module by-name. If the module already exists
   // in the cache, do nothing and return.
   auto scanForSwiftModuleDependency =
-      [this, &cache, &moduleLookupResult](Identifier moduleIdentifier,
-                                          bool isTestable) {
+      [this, &cache, &lookupResultLock, &moduleLookupResult](Identifier moduleIdentifier,
+                                                             bool isTestable) {
         auto moduleName = moduleIdentifier.str().str();
-        // If this is already in the cache, no work to do here
-        if (cache.hasSwiftDependency(moduleName))
-          return;
+        {
+          std::lock_guard<std::mutex> guard(lookupResultLock);
+          if (cache.hasSwiftDependency(moduleName))
+            return;
+        }
 
         auto moduleDependencies = withDependencyScanningWorker(
             [&cache, moduleIdentifier,
@@ -946,7 +949,11 @@ void ModuleDependencyScanner::resolveSwiftImportsForModule(
                   moduleIdentifier, cache.getModuleOutputPath(),
                   cache.getScanService().getPrefixMapper(), isTestable);
             });
-        moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
+
+        {
+          std::lock_guard<std::mutex> guard(lookupResultLock);
+          moduleLookupResult.insert_or_assign(moduleName, moduleDependencies);
+        }
       };
 
   // Enque asynchronous lookup tasks


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/78856
----------------------------------
• **Description**: When querying multiple Swift module dependencies in-parallel, multiple queries may be updating the hash map data structure where query results are recorded. This is not thread-safe and may cause a re-hashing of the hash map while other threads are accessing it. This change establishes the update of this hash map to be done in a critical section guarded by a lock.

• **Risk**: Low, this change adds a synchronization mechanism to establish a critical section in the parallel section of the scan, without otherwise changing functionality.
• **Reviewed by**: @cachemeifyoucan 
• Original PR: https://github.com/swiftlang/swift/pull/78856
• Radar: rdar://142978967
