### PR TITLE
[6.1] AST: Fix missing source loc in actor isolation diagnostics

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2515,14 +2515,14 @@ KeyPathExpr::Component KeyPathExpr::Component::forSubscript(
     ASTContext &ctx, ConcreteDeclRef subscript, ArgumentList *argList,
     Type elementType, ArrayRef<ProtocolConformanceRef> indexHashables) {
   return Component(subscript, argList, indexHashables, Kind::Subscript,
-                   elementType, argList->getLParenLoc());
+                   elementType, argList->getStartLoc());
 }
 
 KeyPathExpr::Component
 KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
                                                ArgumentList *argList) {
   return Component({}, argList, {}, Kind::UnresolvedSubscript, Type(),
-                   argList->getLParenLoc());
+                   argList->getStartLoc());
 }
 
 KeyPathExpr::Component::Component(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4200,6 +4200,15 @@ namespace {
                 isolation, decl)
               .warnUntilSwiftVersionIf(downgrade, 6);
 
+            // If the culprit is a synthesized reference to a
+            // `@dynamicMemberLookup` subscript, point to it for clarify.
+            if (keyPath->isImplicit()) {
+              auto *subscript = dyn_cast<SubscriptDecl>(decl);
+              if (subscript && isValidKeyPathDynamicMemberLookup(subscript)) {
+                decl->diagnose(diag::decl_declared_here, decl);
+              }
+            }
+
             diagnosed = !downgrade;
             break;
           }

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -115,6 +115,7 @@ do {
   @dynamicMemberLookup struct S2 {
     @MainActor
     subscript(dynamicMember keyPath: KeyPath<S1, Int>) -> Int { get {} }
+    // expected-note@-1 {{'subscript(dynamicMember:)' declared here}}
   }
   @dynamicMemberLookup struct S3 {
     subscript(dynamicMember keyPath: KeyPath<S2, Int>) -> Int { get {} }


### PR DESCRIPTION
- **Explanation**: Form key path subscript components using the first valid location in the argument list instead of the '(' location, which is invalid in implicit argument lists containing explicit arguments. Such arguments lists are synthesized for the `@dynamicMemberLookup` feature. 

  Also add a note to diagnostic about isolated key path components when the component is an implicit ref to `@dynamicMemberLookup` subscript for clarify. This is the exact circumstance under which the issue manifested.

- **Scope**: Diagnostics for implicit key path expressions.
- **Issues**: rdar://129310334.
- **Original PRs**: #78871.
- **Risk**: Low.
- **Testing**:  Added regression tests.
- **Reviewers**: @xedin
