### PR TITLE
AST: Only apply MemberImportVisibility to lookups from the main module

### DIFF
--- a/validation-test/ClangImporter/cfobject-conformances.swift
+++ b/validation-test/ClangImporter/cfobject-conformances.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil %s -enable-upcoming-feature MemberImportVisibility -verify
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: swift_feature_MemberImportVisibility
+
+import CoreFoundation
+
+public func takesHashable<T: Hashable>(_ t: T) {}
+
+public func takesCFObjects(
+  _ string: CFString,
+  _ number: CFNumber,
+  _ date: CFDate,
+  _ data: CFData,
+  _ set: CFSet,
+) {
+  takesHashable(string)
+  takesHashable(number)
+  takesHashable(date)
+  takesHashable(data)
+  takesHashable(set)
+}


### PR DESCRIPTION
`MemberImportVisibility` rules should only apply to source code in the main module. The rules were being applied when resolving witnesses for synthesized `Hashable` conformances on CF types imported by ClangImporter, which caused the lookups to fail and bad conformances to be generated.

Resolves https://github.com/swiftlang/swift/issues/78870 and rdar://142433039.
