### PR TITLE
Disable the new stdlib build

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -669,7 +669,8 @@ skip-test-sourcekit-lsp
 skip-test-swiftpm
 skip-test-llbuild
 
-swift-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
+# TODO: Look into why this causes the new test suite to fail to find the concurrency modules
+# swift-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx


### PR DESCRIPTION
Somehow the new build system is affecting the old build system in such a way that it's not producing the Swift Concurrency runtime for smoke testing, resulting in test failures due to the missing library.

```
/Users/ec2-user/jenkins/workspace/swift-PR-macos-smoke-test/branch-main/build/buildbot_incremental/llvm-macosx-x86_64/bin/llvm-nm: error: /Users/ec2-user/jenkins/workspace/swift-PR-macos-smoke-test/branch-main/build/buildbot_incremental/swift-macosx-x86_64/lib/swift/macosx/x86_64/libswift_Concurrency.dylib: No such file or directory
```

This isn't even a directory that is affected by the new build, but disabling to try to bring things back up.