### PR TITLE
[6.1] Sema: Accessors's SPI are tied to the attributes on the storage

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3154,6 +3154,14 @@ SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
       spiGroups.insert(originalSPIs.begin(), originalSPIs.end());
     }
 
+  // Accessors get the SPI groups from the PBD.
+  if (auto AD = dyn_cast<AccessorDecl>(decl))
+    if (auto VD = dyn_cast<VarDecl>(AD->getStorage()))
+      if (auto *PBD = VD->getParentPatternBinding()) {
+        auto moreGroups = PBD->getSPIGroups();
+        spiGroups.insert(moreGroups.begin(), moreGroups.end());
+      }
+
   // If there is no local SPI information, look at the context.
   if (spiGroups.empty()) {
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1277,8 +1277,17 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
     // VD must be public or open to use an @_spi attribute.
     auto declAccess = VD->getFormalAccess();
     auto DC = VD->getDeclContext()->getAsDecl();
-    if (declAccess < AccessLevel::Public &&
-        !VD->getAttrs().hasAttribute<UsableFromInlineAttr>() &&
+
+    AbstractStorageDecl *storage = nullptr;
+    if (auto *AD = dyn_cast<AccessorDecl>(VD))
+      storage = AD->getStorage();
+
+    auto canUseAttr = [](ValueDecl *VD) {
+      return VD->getFormalAccess() >= AccessLevel::Public ||
+        VD->getAttrs().hasAttribute<UsableFromInlineAttr>();
+    };
+    if (!canUseAttr(VD) &&
+        !(storage && canUseAttr(storage)) &&
         !(DC && DC->isSPI())) {
       diagnoseAndRemoveAttr(attr,
                             diag::spi_attribute_on_non_public,

--- a/test/SPI/spi_internal_accessor.swift
+++ b/test/SPI/spi_internal_accessor.swift
@@ -1,0 +1,91 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s -module-name main \
+// RUN:   -swift-version 6 -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/main.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/main.private.swiftinterface
+
+// RUN: %FileCheck %s -check-prefix CHECK-PUBLIC --input-file %t/main.swiftinterface
+// CHECK-PUBLIC-NOT: @_spi
+
+// RUN: %FileCheck %s -check-prefix CHECK-PRIVATE --input-file %t/main.private.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.swiftinterface) -module-name main
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.private.swiftinterface) -module-name main
+
+public struct S {
+    @usableFromInline @_spi(X)
+    internal var v: Int {
+        get { return 42 }
+    }
+}
+
+extension UnsafeMutablePointer {
+  @_spi(X) @available(swift, obsoleted: 1)
+// CHECK-PRIVATE: @_spi(X) @available(swift, obsoleted: 1)
+  @usableFromInline
+// CHECK-PRIVATE: @usableFromInline
+  internal var pointee: Pointee {
+// CHECK-PRIVATE: internal var pointee: Pointee {
+    @_transparent unsafeAddress {
+// CHECK-PRIVATE:   @_spi(X) @_transparent unsafeAddress {
+      return UnsafePointer(self)
+// CHECK-PRIVATE:     return UnsafePointer(self)
+    }
+// CHECK-PRIVATE:   }
+    @_transparent nonmutating unsafeMutableAddress {
+// CHECK-PRIVATE:   @_transparent nonmutating unsafeMutableAddress {
+      return self
+// CHECK-PRIVATE:     return self
+    }
+// CHECK-PRIVATE:   }
+  }
+// CHECK-PRIVATE: }
+}
+
+extension UnsafeMutablePointer {
+  @_spi(X)
+// CHECK-PRIVATE: @_spi(X)
+  public var pointee2: Pointee {
+// CHECK-PRIVATE: public var pointee2: Pointee {
+    unsafeAddress {
+// CHECK-PRIVATE:   unsafeAddress
+      return UnsafePointer(self)
+    }
+    @_transparent nonmutating unsafeMutableAddress {
+// CHECK-PRIVATE:   @_transparent nonmutating unsafeMutableAddress {
+      return self
+// CHECK-PRIVATE:     return self
+    }
+// CHECK-PRIVATE:   }
+  }
+// CHECK-PRIVATE: }
+}
+
+
+@_spi(Foo) @propertyWrapper public struct SPIWrapper<T> {
+// CHECK-PRIVATE: @_spi(Foo) @propertyWrapper public struct SPIWrapper<T> {
+  public init(wrappedValue: T) {}
+// CHECK-PRIVATE:   @_spi(Foo) public init(wrappedValue: T)
+  public var wrappedValue: T { fatalError() }
+// CHECK-PRIVATE:   @_spi(Foo) public var wrappedValue: T {
+// CHECK-PRIVATE:     @_spi(Foo) get
+// CHECK-PRIVATE:   }
+// CHECK-PRIVATE: }
+}
+
+public struct InternalSet {
+// CHECK-PRIVATE: public struct InternalSet {
+  @_spi(X) public internal(set) var long: Int {
+    get { 0 }
+    set { }
+  }
+// CHECK-PRIVATE:   @_spi(X) public var long: Swift.Int {
+// CHECK-PRIVATE:     @_spi(X) get
+// CHECK-PRIVATE:   }
+
+  @_spi(X) public internal(set) var short: Int
+// CHECK-PRIVATE:   @_spi(X) public var short: Swift.Int {
+// CHECK-PRIVATE:     get
+// CHECK-PRIVATE:   }
+}
+// CHECK-PRIVATE: }

--- a/test/SPI/spi_members.swift
+++ b/test/SPI/spi_members.swift
@@ -8,7 +8,7 @@ public struct Wrapper<T> {
 }
 
 @_spi(Foo)
-public class Bar {
+public class SPIType {
   // expected-note@-1 16{{class declared here}}
 
   public init() {}
@@ -17,97 +17,97 @@ public class Bar {
 public struct ResilientStructSPIMembers {
   public init() {}
 
-  @_spi(Foo) public func method(_: Bar) {}
-  @_spi(Foo) public var computedProperty: Bar { Bar() }
+  @_spi(Foo) public func method(_: SPIType) {}
+  @_spi(Foo) public var computedProperty: SPIType { SPIType() }
 
-  @_spi(Foo) public var storedProperty1: Bar
-  @_spi(Foo) public var storedProperty2 = Bar()
-  @_spi(Foo) public lazy var lazyProperty1 = Bar()
-  @_spi(Foo) public lazy var lazyProperty2: Bar = Bar()
-  @_spi(Foo) @Wrapper public var wrappedProperty1: Bar
-  @_spi(Foo) @Wrapper public var wrappedProperty2 = Bar()
+  @_spi(Foo) public var storedProperty1: SPIType
+  @_spi(Foo) public var storedProperty2 = SPIType()
+  @_spi(Foo) public lazy var lazyProperty1 = SPIType()
+  @_spi(Foo) public lazy var lazyProperty2: SPIType = SPIType()
+  @_spi(Foo) @Wrapper public var wrappedProperty1: SPIType
+  @_spi(Foo) @Wrapper public var wrappedProperty2 = SPIType()
 }
 
 @frozen public struct FrozenStructSPIMembers {
   public init() {}
 
-  @_spi(Foo) public func method(_: Bar) {}
-  @_spi(Foo) public var computedProperty: Bar { Bar() }
+  @_spi(Foo) public func method(_: SPIType) {}
+  @_spi(Foo) public var computedProperty: SPIType { SPIType() }
 
-  @_spi(Foo) public var storedProperty1: Bar
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  @_spi(Foo) public var storedProperty1: SPIType
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
   // expected-error@-2 {{stored property 'storedProperty1' cannot be declared '@_spi' in a '@frozen' struct}}
 
-  @_spi(Foo) public var storedProperty2 = Bar()
+  @_spi(Foo) public var storedProperty2 = SPIType()
   // expected-error@-1 {{stored property 'storedProperty2' cannot be declared '@_spi' in a '@frozen' struct}}
 
-  @_spi(Foo) public lazy var lazyProperty1 = Bar()
+  @_spi(Foo) public lazy var lazyProperty1 = SPIType()
   // expected-error@-1 {{stored property 'lazyProperty1' cannot be declared '@_spi' in a '@frozen' struct}}
 
-  @_spi(Foo) public lazy var lazyProperty2: Bar = Bar()
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  @_spi(Foo) public lazy var lazyProperty2: SPIType = SPIType()
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
   // expected-error@-2 {{stored property 'lazyProperty2' cannot be declared '@_spi' in a '@frozen' struct}}
 
-  @_spi(Foo) @Wrapper public var wrappedProperty1: Bar
+  @_spi(Foo) @Wrapper public var wrappedProperty1: SPIType
   // expected-error@-1 {{stored property 'wrappedProperty1' cannot be declared '@_spi' in a '@frozen' struct}}
 
-  @_spi(Foo) @Wrapper public var wrappedProperty2 = Bar()
+  @_spi(Foo) @Wrapper public var wrappedProperty2 = SPIType()
   // expected-error@-1 {{stored property 'wrappedProperty2' cannot be declared '@_spi' in a '@frozen' struct}}
 }
 
 @frozen public struct FrozenStructPublicMembers {
   public init() {}
 
-  public func method(_: Bar) {} // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  public func method(_: SPIType) {} // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  public var storedProperty1: Bar
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  public var storedProperty1: SPIType
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
 
-  public var storedProperty2 = Bar()
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
-  // expected-error@-2 {{class 'Bar' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
+  public var storedProperty2 = SPIType()
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
+  // expected-error@-2 {{class 'SPIType' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
   // expected-error@-3 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
 
-  public var computedProperty: Bar { Bar() } // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  public var computedProperty: SPIType { SPIType() } // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  public lazy var lazyProperty1 = Bar() // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  public lazy var lazyProperty1 = SPIType() // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  public lazy var lazyProperty2: Bar = Bar() // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  public lazy var lazyProperty2: SPIType = SPIType() // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  @Wrapper public var wrappedProperty1: Bar
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  @Wrapper public var wrappedProperty1: SPIType
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
 
-  @Wrapper public var wrappedProperty2 = Bar()
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
-  // expected-error@-2 {{class 'Bar' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
+  @Wrapper public var wrappedProperty2 = SPIType()
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
+  // expected-error@-2 {{class 'SPIType' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
   // expected-error@-3 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
 }
 
 @frozen public struct FrozenStructPrivateMembers {
   private init() {}
 
-  private func method(_: Bar) {}
+  private func method(_: SPIType) {}
 
-  private var storedProperty1: Bar
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  private var storedProperty1: SPIType
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
 
-  private var storedProperty2 = Bar()
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
-  // expected-error@-2 {{class 'Bar' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
+  private var storedProperty2 = SPIType()
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
+  // expected-error@-2 {{class 'SPIType' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
   // expected-error@-3 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
 
-  private var computedProperty: Bar { Bar() }
+  private var computedProperty: SPIType { SPIType() }
 
-  private lazy var lazyProperty1 = Bar() // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  private lazy var lazyProperty1 = SPIType() // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  private lazy var lazyProperty2: Bar = Bar() // expected-error {{cannot use class 'Bar' here; it is SPI}}
+  private lazy var lazyProperty2: SPIType = SPIType() // expected-error {{cannot use class 'SPIType' here; it is SPI}}
 
-  @Wrapper private var wrappedProperty1: Bar
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
+  @Wrapper private var wrappedProperty1: SPIType
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
 
-  @Wrapper private var wrappedProperty2 = Bar()
-  // expected-error@-1 {{cannot use class 'Bar' here; it is SPI}}
-  // expected-error@-2 {{class 'Bar' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
+  @Wrapper private var wrappedProperty2 = SPIType()
+  // expected-error@-1 {{cannot use class 'SPIType' here; it is SPI}}
+  // expected-error@-2 {{class 'SPIType' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
   // expected-error@-3 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because it is SPI}}
 }
 

--- a/test/SPI/spi_members.swift
+++ b/test/SPI/spi_members.swift
@@ -14,7 +14,6 @@ public struct SPIWrapper<T> {
   public init(wrappedValue: T) {}
 
   public var wrappedValue: T { fatalError() }
-  // expected-note@-1 2 {{property declared here}}
 }
 
 @_spi(Foo)
@@ -46,7 +45,6 @@ public struct ResilientStructSPIMembers {
 
   @SPIWrapper public var wrappedProperty4: PublicType
   // expected-error@-1 {{cannot use generic struct 'SPIWrapper' as property wrapper here; it is SPI}}
-  // expected-error@-2 {{cannot use property 'wrappedValue' here; it is SPI}}
 
   @_spi(Foo) public var inlinableGet: Int {
     @inlinable
@@ -131,7 +129,6 @@ public struct ResilientStructSPIMembers {
 
   @SPIWrapper public var wrappedProperty3: PublicType
   // expected-error@-1 {{cannot use generic struct 'SPIWrapper' as property wrapper here; it is SPI}}
-  // expected-error@-2 {{cannot use property 'wrappedValue' here; it is SPI}}
 }
 
 @frozen public struct FrozenStructPrivateMembers {


### PR DESCRIPTION
Recent changes started using SPIGroupRequest on accessors indirectly, it is called to verify access to the wrappedValue of PropertyWrappers within the direct access logic on variables using the property wrapper. Update SPIGroupRequest to support this request and the type-checking logic to accept the @_spi attribute on internal usable from inline accessors.

We need to keep this mostly for backwards compatibility.

- Risk: Low, this only affects the `@_spi` attribute. More of them are printed and more are accepted in sources. The change was already qualified.
- Scope: SPI attributes on accessors.
- Cherry-pick of #78471
- Resolves rdar://141964200