### PR TITLE
Sema: Ignore inactive type variables in addTypeVariableConstraintsToWorkList()

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -300,25 +300,18 @@ public:
   /// to a type variable.
   void introduceToInference(TypeVariableType *typeVar, Type fixedType);
 
-  /// Describes which constraints \c gatherConstraints should gather.
-  enum class GatheringKind {
-    /// Gather constraints associated with all of the variables within the
-    /// same equivalence class as the given type variable, as well as its
-    /// immediate fixed bindings.
-    EquivalenceClass,
-    /// Gather all constraints that mention this type variable or type variables
-    /// that it is a fixed binding of. Unlike EquivalenceClass, this looks
-    /// through transitive fixed bindings. This can be used to find all the
-    /// constraints that may be affected when binding a type variable.
-    AllMentions,
-  };
-
-  /// Gather the set of constraints that involve the given type variable,
-  /// i.e., those constraints that will be affected when the type variable
-  /// gets merged or bound to a fixed type.
+  /// Gather constraints associated with all of the variables within the
+  /// same equivalence class as the given type variable, as well as its
+  /// immediate fixed bindings.
   llvm::TinyPtrVector<Constraint *>
-  gatherConstraints(TypeVariableType *typeVar,
-                    GatheringKind kind,
+  gatherAllConstraints(TypeVariableType *typeVar);
+
+  /// Gather all constraints that mention this type variable or type variables
+  /// that it is a fixed binding of. Unlike EquivalenceClass, this looks
+  /// through transitive fixed bindings. This can be used to find all the
+  /// constraints that may be affected when binding a type variable.
+  llvm::TinyPtrVector<Constraint *>
+  gatherNearbyConstraints(TypeVariableType *typeVar,
                     llvm::function_ref<bool(Constraint *)> acceptConstraint =
                         [](Constraint *constraint) { return true; });
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -143,8 +143,8 @@ NullablePtr<Constraint> getApplicableFnConstraint(ConstraintGraph &CG,
   if (!boundVar)
     return nullptr;
 
-  auto constraints = CG.gatherConstraints(
-      boundVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+  auto constraints = CG.gatherNearbyConstraints(
+      boundVar,
       [](Constraint *constraint) {
         return constraint->getKind() == ConstraintKind::ApplicableFunction;
       });
@@ -1129,8 +1129,8 @@ selectBestBindingDisjunction(ConstraintSystem &cs,
     if (!firstBindDisjunction)
       firstBindDisjunction = disjunction;
 
-    auto constraints = cs.getConstraintGraph().gatherConstraints(
-        typeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+    auto constraints = cs.getConstraintGraph().gatherNearbyConstraints(
+        typeVar,
         [](Constraint *constraint) {
           return constraint->getKind() == ConstraintKind::Conversion;
         });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15843,8 +15843,8 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   if (!typeVar)
     return;
 
-  auto constraints = CG.gatherConstraints(
-      typeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+  auto constraints = CG.gatherNearbyConstraints(
+      typeVar,
       [&keyPathExpr](Constraint *constraint) -> bool {
         if (constraint->getKind() != ConstraintKind::KeyPath)
           return false;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1309,8 +1309,8 @@ ConstraintSystem::findConstraintThroughOptionals(
   while (visitedVars.insert(rep).second) {
     // Look for a disjunction that binds this type variable to an overload set.
     TypeVariableType *optionalObjectTypeVar = nullptr;
-    auto constraints = getConstraintGraph().gatherConstraints(
-        rep, ConstraintGraph::GatheringKind::EquivalenceClass,
+    auto constraints = getConstraintGraph().gatherNearbyConstraints(
+        rep,
         [&](Constraint *match) {
           // If we have an "optional object of" constraint, we may need to
           // look through it to find the constraint we're looking for.
@@ -1918,9 +1918,8 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
     }
   }
 
-  auto constraints = cs.CG.gatherConstraints(
+  auto constraints = cs.CG.gatherNearbyConstraints(
       typeVar,
-      ConstraintGraph::GatheringKind::EquivalenceClass,
       [](Constraint *constraint) -> bool {
         switch (constraint->getKind()) {
         case ConstraintKind::Conversion:

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1946,6 +1946,17 @@ bool ConjunctionElement::attempt(ConstraintSystem &cs) const {
     llvm::SmallPtrSet<TypeVariableType *, 4> referencedVars;
     findReferencedVariables(cs, referencedVars);
 
+    if (cs.isDebugMode()) {
+      auto indent = cs.solverState->getCurrentIndent();
+      auto &log = llvm::errs().indent(indent);
+      log << "(Element type variables in scope: ";
+      interleave(
+        referencedVars,
+        [&](TypeVariableType *typeVar) { log << "$T" << typeVar->getID(); },
+        [&] { log << ", "; });
+      log << ")\n";
+    }
+
     for (auto *typeVar : referencedVars)
       cs.addTypeVariable(typeVar);
   }

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -565,6 +565,11 @@ static void depthFirstSearch(
     llvm::function_ref<void(Constraint *)> visitConstraint,
     llvm::SmallPtrSet<TypeVariableType *, 4> &typeVars,
     llvm::SmallPtrSet<Constraint *, 8> &visitedConstraints) {
+  // If we're not looking at this type variable right now because we're
+  // solving a conjunction element, don't consider its adjacencies.
+  if (!cg.getConstraintSystem().isActiveTypeVariable(typeVar))
+    return;
+
   // Visit this node. If we've already seen it, bail out.
   if (!typeVars.insert(typeVar).second)
     return;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -552,18 +552,11 @@ void ConstraintGraph::retractBindings(TypeVariableType *typeVar,
 
 #pragma mark Algorithms
 
-/// Perform a depth-first search.
-///
-/// \param cg The constraint graph.
-/// \param typeVar The type variable we're searching from.
-/// \param visitConstraint Called before considering a constraint.
-/// \param visitedConstraints Set of already-visited constraints, used
-/// internally to avoid duplicated work.
 static void depthFirstSearch(
     ConstraintGraph &cg,
     TypeVariableType *typeVar,
-    llvm::function_ref<void(Constraint *)> visitConstraint,
     llvm::SmallPtrSet<TypeVariableType *, 4> &typeVars,
+    llvm::TinyPtrVector<Constraint *> &constraints,
     llvm::SmallPtrSet<Constraint *, 8> &visitedConstraints) {
   // If we're not looking at this type variable right now because we're
   // solving a conjunction element, don't consider its adjacencies.
@@ -577,11 +570,8 @@ static void depthFirstSearch(
   // Local function to visit adjacent type variables.
   auto visitAdjacencies = [&](ArrayRef<TypeVariableType *> adjTypeVars) {
     for (auto adj : adjTypeVars) {
-      if (adj == typeVar)
-        continue;
-
-      // Recurse into this node.
-      depthFirstSearch(cg, adj, visitConstraint, typeVars, visitedConstraints);
+      if (adj != typeVar)
+        depthFirstSearch(cg, adj, typeVars, constraints, visitedConstraints);
     }
   };
 
@@ -592,7 +582,7 @@ static void depthFirstSearch(
     if (!visitedConstraints.insert(constraint).second)
       continue;
 
-    visitConstraint(constraint);
+    constraints.push_back(constraint);
   }
 
   // Visit all of the other nodes in the equivalence class.
@@ -611,28 +601,22 @@ static void depthFirstSearch(
   visitAdjacencies(node.getReferencedVars());
 }
 
-llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
-    TypeVariableType *typeVar, GatheringKind kind,
-    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
+llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherAllConstraints(
+    TypeVariableType *typeVar) {
   llvm::TinyPtrVector<Constraint *> constraints;
   llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
   llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
 
-  if (kind == GatheringKind::AllMentions) {
-    // If we've been asked for "all mentions" of a type variable, search for
-    // constraints involving both it and its fixed bindings.
-    depthFirstSearch(
-        *this, typeVar,
-        [&](Constraint *constraint) {
-          if (acceptConstraintFn(constraint))
-            constraints.push_back(constraint);
-        },
-        typeVars, visitedConstraints);
-    return constraints;
-  }
+  depthFirstSearch(*this, typeVar, typeVars, constraints, visitedConstraints);
+  return constraints;
+}
 
-  // Otherwise only search in the type var's equivalence class and immediate
-  // fixed bindings.
+llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherNearbyConstraints(
+    TypeVariableType *typeVar, 
+    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
+  llvm::TinyPtrVector<Constraint *> constraints;
+  llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
+  llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
 
   // Local function to add constraints.
   auto addTypeVarConstraints = [&](TypeVariableType *adjTypeVar) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -267,8 +267,7 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
 void ConstraintSystem::addTypeVariableConstraintsToWorkList(
        TypeVariableType *typeVar) {
   // Activate the constraints affected by a change to this type variable.
-  auto gatheringKind = ConstraintGraph::GatheringKind::AllMentions;
-  for (auto *constraint : CG.gatherConstraints(typeVar, gatheringKind))
+  for (auto *constraint : CG.gatherAllConstraints(typeVar))
     if (!constraint->isActive())
       activateConstraint(constraint);
 }

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2044,8 +2044,8 @@ void ConstraintSystem::bindOverloadType(
       increaseScore(SK_KeyPathSubscript, locator);
 
       auto boundTypeVar = boundType->castTo<TypeVariableType>();
-      auto constraints = getConstraintGraph().gatherConstraints(
-          boundTypeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+      auto constraints = getConstraintGraph().gatherNearbyConstraints(
+          boundTypeVar,
           [](Constraint *constraint) {
             return constraint->getKind() == ConstraintKind::ApplicableFunction;
           });

--- a/test/Constraints/rdar143340082.swift
+++ b/test/Constraints/rdar143340082.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Test {
+    var v: String
+    var i: Int
+}
+
+do {
+    let _ = Array(1 ... 20).map { i in
+        _ = 0
+        return Test(v: "\(i * 1000)", i: 1)
+    }
+}


### PR DESCRIPTION
Fixes a regression from commit https://github.com/swiftlang/swift/commit/0c128e5db78068573bf9ca382ab51c8cad79280a.

The old depthFirstSearch() walked all adjacencies via the constraint graph,
and thus it would visit type variables that are currently inactive because
we're solving a conjunction element.

This was inconsistent with the new union-find which only formed the
connected components from the currently active type variables; adjacencies
involving inactive type variables are no longer considered.

Fix the inconsistency by changing gatherConstraints(), which used from
addTypeVariableConstraintsToWorkList(), to also skip inactive type
variables.

Fixes rdar://problem/143340082.