### PR TITLE
Sema: Fix crash in type resolution when tuple type contains type variables

### DIFF
--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -267,28 +267,24 @@ checkRequirementsImpl(ArrayRef<Requirement> requirements,
   while (!worklist.empty()) {
     auto req = worklist.pop_back_val();
 
-  // Check preconditions.
-#ifndef NDEBUG
-  {
+    // Check preconditions.
     auto firstType = req.getFirstType();
-    assert((allowTypeParameters || !firstType->hasTypeParameter())
+    ASSERT((allowTypeParameters || !firstType->hasTypeParameter())
            && "must take a contextual type. if you really are ok with an "
             "indefinite answer (and usually YOU ARE NOT), then consider whether "
             "you really, definitely are ok with an indefinite answer, and "
             "use `checkRequirementsWithoutContext` instead");
-    assert(!firstType->hasTypeVariable());
+    ASSERT(!firstType->hasTypeVariable());
 
     if (req.getKind() != RequirementKind::Layout) {
       auto secondType = req.getSecondType();
-      assert((allowTypeParameters || !secondType->hasTypeParameter())
+      ASSERT((allowTypeParameters || !secondType->hasTypeParameter())
              && "must take a contextual type. if you really are ok with an "
               "indefinite answer (and usually YOU ARE NOT), then consider whether "
               "you really, definitely are ok with an indefinite answer, and "
               "use `checkRequirementsWithoutContext` instead");
-      assert(!secondType->hasTypeVariable());
+      ASSERT(!secondType->hasTypeVariable());
     }
-  }
-#endif
 
     switch (req.checkRequirement(worklist, /*allowMissing=*/true)) {
     case CheckRequirementResult::Success:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5676,6 +5676,7 @@ NeverNullType TypeResolver::resolveTupleType(TupleTypeRepr *repr,
         inStage(TypeResolutionStage::Interface) &&
         !moveOnlyElementIndex.has_value() &&
         !ty->hasUnboundGenericType() &&
+        !ty->hasTypeVariable() &&
         !isa<TupleTypeRepr>(tyR)) {
       auto contextTy = GenericEnvironment::mapTypeIntoContext(
           resolution.getGenericSignature().getGenericEnvironment(), ty);

--- a/test/Constraints/issue-77315.swift
+++ b/test/Constraints/issue-77315.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo<T>(_: () -> (Optional<T>, Int)) -> T { fatalError() }
+
+let x: Int = foo { () -> (Optional, Int) in fatalError() }


### PR DESCRIPTION
This can happen when we're generating constraints and resolving the type annotations written in a closure expression. Just skip the non-copyable check in this case since there's not enough information to make a decision.

Fixes rdar://problem/143031466. 
Fixes https://github.com/swiftlang/swift/issues/77315.