### PR TITLE
stdlib: fix the problem swept under the rug in 58a97f1603

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -57,30 +57,6 @@
 
 using namespace swift;
 
-// Ensure that Job's layout is compatible with what Dispatch expects.
-// Note: MinimalDispatchObjectHeader just has the fields we care about, it is
-// not complete and should not be used for anything other than these asserts.
-struct MinimalDispatchObjectHeader {
-  const void *VTable;
-  int Opaque0;
-  int Opaque1;
-  void *Linkage;
-};
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu-offsetof-extensions"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-static_assert(
-    offsetof(Job, metadata) == offsetof(MinimalDispatchObjectHeader, VTable),
-    "Job Metadata field must match location of Dispatch VTable field.");
-static_assert(offsetof(Job, SchedulerPrivate[Job::DispatchLinkageIndex]) ==
-                  offsetof(MinimalDispatchObjectHeader, Linkage),
-              "Dispatch Linkage field must match Job "
-              "SchedulerPrivate[DispatchLinkageIndex].");
-#pragma clang diagnostic pop
-#pragma clang diagnostic pop
-
 /// The function passed to dispatch_async_f to execute a job.
 static void __swift_run_job(void *_job) {
   SwiftJob *job = (SwiftJob*) _job;

--- a/stdlib/public/Concurrency/ExecutorChecks.cpp
+++ b/stdlib/public/Concurrency/ExecutorChecks.cpp
@@ -23,9 +23,6 @@
 
 #include "ExecutorImpl.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu-offsetof-extensions"
-
 // JobFlags
 static_assert(sizeof(swift::JobFlags) == sizeof(SwiftJobFlags));
 
@@ -51,21 +48,8 @@ static_assert((SwiftJobPriority)swift::JobPriority::Background
 static_assert((SwiftJobPriority)swift::JobPriority::Unspecified
               == SwiftUnspecifiedJobPriority);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
 // Job (has additional fields not exposed via SwiftJob)
 static_assert(sizeof(swift::Job) >= sizeof(SwiftJob));
-static_assert(offsetof(swift::Job, metadata) == offsetof(SwiftJob, metadata));
-#if !SWIFT_CONCURRENCY_EMBEDDED
-static_assert(offsetof(swift::Job, refCounts) == offsetof(SwiftJob, refCounts));
-#else
-static_assert(offsetof(swift::Job, embeddedRefcount) == offsetof(SwiftJob, refCounts));
-#endif
-static_assert(offsetof(swift::Job, SchedulerPrivate) == offsetof(SwiftJob, schedulerPrivate));
-static_assert(offsetof(swift::Job, SchedulerPrivate[0]) == offsetof(SwiftJob, schedulerPrivate[0]));
-static_assert(offsetof(swift::Job, SchedulerPrivate[1]) == offsetof(SwiftJob, schedulerPrivate[1]));
-static_assert(offsetof(swift::Job, Flags) == offsetof(SwiftJob, flags));
-#pragma clang diagnostic pop
 
 // SerialExecutorRef
 static_assert(sizeof(swift::SerialExecutorRef) == sizeof(SwiftExecutorRef));
@@ -73,7 +57,5 @@ static_assert(sizeof(swift::SerialExecutorRef) == sizeof(SwiftExecutorRef));
 // swift_clock_id
 static_assert((SwiftClockId)swift::swift_clock_id_continuous
               == SwiftContinuousClock);
-static_assert((SwiftClockId)swift::swift_clock_id_suspending
-              == SwiftSuspendingClock);
-
-#pragma clang diagnostic pop
+static_assert((SwiftClockId)swift::swift_clock_id_suspending ==
+              SwiftSuspendingClock);

--- a/stdlib/public/runtime/GenericCacheEntry.h
+++ b/stdlib/public/runtime/GenericCacheEntry.h
@@ -1,0 +1,139 @@
+//===--- GenericCacheEntry.h ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_GENERICCACHEENTRY_H
+#define SWIFT_RUNTIME_GENERICCACHEENTRY_H
+
+#include "MetadataCache.h"
+#include "swift/ABI/Metadata.h"
+#include "swift/ABI/MetadataValues.h"
+#include "swift/Basic/Unreachable.h"
+#include "swift/RemoteInspection/GenericMetadataCacheEntry.h"
+#include "swift/Runtime/LibPrespecialized.h"
+
+namespace swift {
+
+bool areAllTransitiveMetadataComplete_cheap(const Metadata *type);
+PrivateMetadataState inferStateForMetadata(Metadata *metadata);
+MetadataDependency checkTransitiveCompleteness(const Metadata *initialType);
+
+struct GenericCacheEntry final
+    : VariadicMetadataCacheEntryBase<GenericCacheEntry> {
+  static const char *getName() { return "GenericCache"; }
+
+  // The constructor/allocate operations that take a `const Metadata *`
+  // are used for the insertion of canonical specializations.
+  // The metadata is always complete after construction.
+
+  GenericCacheEntry(MetadataCacheKey key, MetadataWaitQueue::Worker &worker,
+                    MetadataRequest request, const Metadata *candidate)
+      : VariadicMetadataCacheEntryBase(key, worker,
+                                       PrivateMetadataState::Complete,
+                                       const_cast<Metadata *>(candidate)) {}
+
+  AllocationResult allocate(const Metadata *candidate) {
+    swift_unreachable("always short-circuited");
+  }
+
+  static bool allowMangledNameVerification(const Metadata *candidate) {
+    // Disallow mangled name verification for specialized candidates
+    // because it will trigger recursive entry into the swift_once
+    // in cacheCanonicalSpecializedMetadata.
+    // TODO: verify mangled names in a second pass in that function.
+    return false;
+  }
+
+  // The constructor/allocate operations that take a descriptor
+  // and arguments are used along the normal allocation path.
+
+  GenericCacheEntry(MetadataCacheKey key, MetadataWaitQueue::Worker &worker,
+                    MetadataRequest request,
+                    const TypeContextDescriptor *description,
+                    const void *const *arguments)
+      : VariadicMetadataCacheEntryBase(key, worker,
+                                       PrivateMetadataState::Allocating,
+                                       /*candidate*/ nullptr) {}
+
+  AllocationResult allocate(const TypeContextDescriptor *description,
+                            const void *const *arguments) {
+    if (auto *prespecialized =
+            getLibPrespecializedMetadata(description, arguments))
+      return {prespecialized, PrivateMetadataState::Complete};
+
+    // Find a pattern.  Currently we always use the default pattern.
+    auto &generics = description->getFullGenericContextHeader();
+    auto pattern = generics.DefaultInstantiationPattern.get();
+
+    // Call the pattern's instantiation function.
+    auto metadata =
+        pattern->InstantiationFunction(description, arguments, pattern);
+
+    // If there's no completion function, do a quick-and-dirty check to
+    // see if all of the type arguments are already complete.  If they
+    // are, we can broadcast completion immediately and potentially avoid
+    // some extra locking.
+    PrivateMetadataState state;
+    if (pattern->CompletionFunction.isNull()) {
+      if (areAllTransitiveMetadataComplete_cheap(metadata)) {
+        state = PrivateMetadataState::Complete;
+      } else {
+        state = PrivateMetadataState::NonTransitiveComplete;
+      }
+    } else {
+      state = inferStateForMetadata(metadata);
+    }
+
+    return {metadata, state};
+  }
+
+  static bool
+  allowMangledNameVerification(const TypeContextDescriptor *description,
+                               const void *const *arguments) {
+    return true;
+  }
+
+  MetadataStateWithDependency
+  tryInitialize(Metadata *metadata, PrivateMetadataState state,
+                PrivateMetadataCompletionContext *context) {
+    assert(state != PrivateMetadataState::Complete);
+
+    // Finish the completion function.
+    if (state < PrivateMetadataState::NonTransitiveComplete) {
+      // Find a pattern.  Currently we always use the default pattern.
+      auto &generics =
+          metadata->getTypeContextDescriptor()->getFullGenericContextHeader();
+      auto pattern = generics.DefaultInstantiationPattern.get();
+
+      // Complete the metadata's instantiation.
+      auto dependency =
+          pattern->CompletionFunction(metadata, &context->Public, pattern);
+
+      // If this failed with a dependency, infer the current metadata state
+      // and return.
+      if (dependency) {
+        return {inferStateForMetadata(metadata), dependency};
+      }
+    }
+
+    // Check for transitive completeness.
+    if (auto dependency = checkTransitiveCompleteness(metadata)) {
+      return {PrivateMetadataState::NonTransitiveComplete, dependency};
+    }
+
+    // We're done.
+    return {PrivateMetadataState::Complete, MetadataDependency()};
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -1611,8 +1611,6 @@ public:
   bool matchesKey(const MetadataCacheKey &key) const {
     return key == getKey();
   }
-
-  friend struct StaticAssertGenericMetadataCacheEntryValueOffset;
 };
 
 template <class EntryType, uint16_t Tag>

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -111,6 +111,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     Refcounting.cpp
     Stdlib.cpp
     StackAllocator.cpp
+    TypeLayoutChecks.cpp
     ${PLATFORM_SOURCES}
 
     # The runtime tests link to internal runtime symbols, which aren't exported

--- a/unittests/runtime/TypeLayoutChecks.cpp
+++ b/unittests/runtime/TypeLayoutChecks.cpp
@@ -1,0 +1,90 @@
+//===--- ConcurrencyLayout.cpp - Concurrency Type Layout Checks -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "Concurrency/ExecutorImpl.h"
+#include "runtime/GenericCacheEntry.h"
+#include "swift/ABI/TargetLayout.h"
+#include "swift/ABI/Task.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+
+namespace {
+// Ensure that Job's layout is compatible with what Dispatch expects.
+// Note: MinimalDispatchObjectHeader just has the fields we care about, it is
+// not complete and should not be used for anything other than these asserts.
+struct MinimalDispatchObjectHeader {
+  const void *VTable;
+  int Opaque0;
+  int Opaque1;
+  void *Linkage;
+};
+} // namespace
+
+namespace swift {
+// NOTE: this is not possible to mark as `constexpr` as `reinterpret_cast` is
+// not permitted in `constexpr` statements. Additionally, even if we were able
+// to get away from the `reinterpret_cast`, we cannot de-reference the `nullptr`
+// in a `constexpr` statement. Finally, because we are checking the offsets of
+// members in non-standard layouts, we must delay this check until runtime as
+// the static computation is not well defined by the language standard.
+template <typename Type, typename PMFType>
+size_t offset_of(PMFType Type::*member) {
+  return reinterpret_cast<uintptr_t>(
+      std::addressof(static_cast<Type *>(nullptr)->*member));
+}
+
+#define offset_of(T, d) swift::offset_of(&T::d)
+} // namespace swift
+
+TEST(ConcurrencyLayout, JobLayout) {
+  ASSERT_EQ(offset_of(swift::Job, metadata), offset_of(SwiftJob, metadata));
+#if !SWIFT_CONCURRENCY_EMBEDDED
+  ASSERT_EQ(offset_of(swift::Job, refCounts), offset_of(SwiftJob, refCounts));
+#else
+  ASSERT_EQ(offset_of(swift::Job, embeddedRefcount),
+            offset_of(SwiftJob, refCounts));
+#endif
+  ASSERT_EQ(offset_of(swift::Job, SchedulerPrivate),
+            offset_of(SwiftJob, schedulerPrivate));
+  ASSERT_EQ(offset_of(swift::Job, SchedulerPrivate) +
+                (sizeof(*swift::Job::SchedulerPrivate) * 0),
+            offset_of(SwiftJob, schedulerPrivate) +
+                (sizeof(*SwiftJob::schedulerPrivate) * 0));
+  ASSERT_EQ(offset_of(swift::Job, SchedulerPrivate) +
+                (sizeof(*swift::Job::SchedulerPrivate) * 1),
+            offset_of(SwiftJob, schedulerPrivate) +
+                (sizeof(*SwiftJob::schedulerPrivate) * 1));
+  ASSERT_EQ(offset_of(swift::Job, Flags), offset_of(SwiftJob, flags));
+
+  // Job Metadata field must match location of Dispatch VTable field.
+  ASSERT_EQ(offset_of(swift::Job, metadata),
+            offset_of(MinimalDispatchObjectHeader, VTable));
+
+  // Dispatch Linkage field must match Job
+  // SchedulerPrivate[DispatchLinkageIndex].
+  ASSERT_EQ(offset_of(swift::Job, SchedulerPrivate) +
+                (sizeof(*swift::Job::SchedulerPrivate) *
+                 swift::Job::DispatchLinkageIndex),
+            offset_of(MinimalDispatchObjectHeader, Linkage));
+}
+
+TEST(MetadataLayout, CacheEntryLayout) {
+// error: 'Value' is a private member of
+// 'swift::VariadicMetadataCacheEntryBase<swift::GenericCacheEntry>'
+#if 0
+  ASSERT_EQ(
+      offset_of(swift::GenericCacheEntry, Value),
+      offset_of(swift::GenericMetadataCacheEntry<swift::InProcess::StoredPointer>,
+                Value));
+#endif
+}


### PR DESCRIPTION
The `-Winvalid-offsetof` warning is valid in this case. `offsetof` is being applied to types with a non-standard layout. The layout of this type is undefined by the specification. There is no guarantee that the type layout is uniform across all ABIs. It is not possible to portably compute the offset statically, especially efficiently.