### PR TITLE
[Build System: update-checkout] avoid multiprocessing when n is 1

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -122,6 +122,9 @@ def setup_mock_remote(base_dir, base_config):
                      cwd=local_repo_path)
         call_quietly(['git', 'config', 'user.email', 'no-reply@swift.org'],
                      cwd=local_repo_path)
+        # any installed user certificate won't match the email address
+        call_quietly(['git', 'config', 'commit.gpgsign', 'false'],
+                     cwd=local_repo_path)
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=local_repo_path)
         for (i, (filename, contents)) in enumerate(v):

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -30,6 +30,17 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
             repo_path = os.path.join(self.source_root, repo)
             self.assertTrue(os.path.isdir(repo_path))
 
+    def test_single_threaded_clone(self):
+        self.call([self.update_checkout_path,
+                   '--config', self.config_path,
+                   '--source-root', self.source_root,
+                   '--clone',
+                   '-j', '1'])
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            self.assertTrue(os.path.isdir(repo_path))
+
 
 class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
     def __init__(self, *args, **kwargs):

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -55,6 +55,13 @@ class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
                    '--source-root', self.worktree_path,
                    '--scheme', 'main'])
 
+    def test_worktree_single_threaded(self):
+        self.call([self.update_checkout_path,
+                   '--config', self.config_path,
+                   '--source-root', self.worktree_path,
+                   '--scheme', 'main',
+                   '-j', '1'])
+
     def setUp(self):
         super(WorktreeTestCase, self).setUp()
         self.worktree_path = os.path.join(self.workspace, WORKTREE_NAME)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -41,6 +41,9 @@ def run_parallel(fn, pool_args, n_processes=0):
 
     if n_processes == 0:
         n_processes = cpu_count() * 2
+    if n_processes == 1:
+        print("Running ``%s`` with a single process." % fn.__name__)
+        return [fn(args) for args in pool_args]
 
     lk = Lock()
     print("Running ``%s`` with up to %d processes." %


### PR DESCRIPTION
There's no need to fiddle with locks etc. when there's no actual parallelism going on.
