### PR TITLE
[Serialization] Ensure we run `InheritedTypeRequest` before serializing inherited type

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4080,7 +4080,16 @@ public:
   /// \returns the number of entries added.
   size_t addInherited(InheritedTypes inheritedEntries,
                       SmallVectorImpl<uint64_t> &result) {
-    for (const auto &inherited : inheritedEntries.getEntries()) {
+    for (size_t i : inheritedEntries.getIndices()) {
+      // Ensure that we run the `InheritedTypeRequest` before getting the
+      // inherited type. We serialize the inherited type from `getEntry` rather
+      // than `getResolvedType` since the former represents a suppressed
+      // conformance as a separate bit distinct from the type, which is how we
+      // want to serialize it. We thus need to get the type to serialize using a
+      // subsequent call to `getEntry(i).getType()` (see
+      // `InheritedTypeRequest::cacheResult`).
+      (void)inheritedEntries.getResolvedType(i);
+      const InheritedEntry &inherited = inheritedEntries.getEntry(i);
       assert(!inherited.getType() || !inherited.getType()->hasArchetype());
       uint64_t typeRef = S.addTypeRef(inherited.getType());
       uint64_t originalTypeRef = typeRef;

--- a/test/IDE/rdar141440011.swift
+++ b/test/IDE/rdar141440011.swift
@@ -1,0 +1,8 @@
+public protocol MyProto {}
+public struct MyStruct: MyProto {}
+
+// RUN: %empty-directory(%t)
+// RUN: %swift -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck -target %target-triple
+// RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - -target %target-triple | %FileCheck %s
+
+// CHECK: public struct MyStruct : swift_mod.MyProto

--- a/test/Serialization/AllowErrors/invalid-inheritance.swift
+++ b/test/Serialization/AllowErrors/invalid-inheritance.swift
@@ -27,13 +27,13 @@ extension SomeStruct: undefined {} // expected-error {{cannot find type 'undefin
 extension SomeEnum: undefined {} // expected-error {{cannot find type 'undefined'}}
 
 extension undefined {} // expected-error {{cannot find type 'undefined'}}
-extension undefined: undefined {} // expected-error {{cannot find type 'undefined'}}
+extension undefined: undefined {} // expected-error 2 {{cannot find type 'undefined'}}
 extension undefined: SomeProto {} // expected-error {{cannot find type 'undefined'}}
 
 public extension undefined { // expected-error {{cannot find type 'undefined' in scope}}
   protocol SomeProtoInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
-  class SomeClassInner: undefined {}
-  struct SomeStructInner: undefined {}
+  class SomeClassInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
+  struct SomeStructInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
   enum SomeEnumInner: undefined { // expected-error {{cannot find type 'undefined' in scope}}
     case a
   }


### PR DESCRIPTION
When using `-experimental-skip-all-function-bodies` we don’t run the `TypeCheckSourceFileRequest` and thus don’t go through the decl checker, which calls `InheritedTypeRequest` on all inheritance clauses. This means that the inherited entries are not populated by the time we serialize the module. Trigger the computation of inherited entries by calling `InheritedTypeRequest` during serialization.

Unfortunately, we can’t use the type returned by `getResolvedType` for the serialization because `getResolvedType` returns an inverted protocol type for suppressed conformances but during serialization, we want to serialize the suppressed type with a `isSuppressedBit`. We thus need to call `getEntry(i).getType()` again to get the type to serialize.

rdar://141440011

---

Thanks @hamishknight for the pointer what might be causing this issue.