### PR TITLE
runtime: restore some typechecking for keypath functions

### DIFF
--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -172,3 +172,24 @@ swift::swift_modifyAtReferenceWritableKeyPath(YieldOnceBuffer *buffer,
              &_release_owner_continuation, buffer),
            addrAndOwner.Addr };
 }
+
+namespace {
+template <typename>
+struct YieldOnceCoroutine;
+
+/// A template which generates the type of the ramp function of a yield-once
+/// coroutine.
+template <typename ResultType, typename... ArgumentTypes>
+struct YieldOnceCoroutine<ResultType(ArgumentTypes...)> {
+  using type =
+      SWIFT_CC(swift) YieldOnceResult<ResultType>(YieldOnceBuffer *,
+                                                  ArgumentTypes...);
+};
+
+static_assert(std::is_same_v<decltype(swift_readAtKeyPath),
+                             YieldOnceCoroutine<const OpaqueValue * (const OpaqueValue *, void *)>::type>);
+static_assert(std::is_same_v<decltype(swift_modifyAtWritableKeyPath),
+                             YieldOnceCoroutine<OpaqueValue * (OpaqueValue *, void *)>::type>);
+static_assert(std::is_same_v<decltype(swift_modifyAtReferenceWritableKeyPath),
+                             YieldOnceCoroutine<OpaqueValue * (const OpaqueValue *, void *)>::type>);
+}


### PR DESCRIPTION
This addresses some feedback on #78141 as per @rjmccall. Ensure that the runtime functions match the expected signature.