### PR TITLE
AST: Fix weak linking for potentially unavailable accessors in extensions

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -766,10 +766,12 @@ Decl::getAvailableAttrForPlatformIntroduction() const {
   // itself. This check relies on the fact that we cannot have nested
   // extensions.
 
-  DeclContext *DC = getDeclContext();
-  if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
-    if (auto attr = getDeclAvailableAttrForPlatformIntroduction(ED))
-      return attr;
+  if (auto parent =
+          AvailabilityInference::parentDeclForInferredAvailability(this)) {
+    if (auto *ED = dyn_cast<ExtensionDecl>(parent)) {
+      if (auto attr = getDeclAvailableAttrForPlatformIntroduction(ED))
+        return attr;
+    }
   }
 
   return std::nullopt;

--- a/test/IRGen/Inputs/weak_import_availability_helper.swift
+++ b/test/IRGen/Inputs/weak_import_availability_helper.swift
@@ -5,6 +5,11 @@ public func conditionallyAvailableFunction() {}
 public func unavailableFunction() {}
 
 @available(macOS 50, *)
+public func conditionallyAvailableOpaqueReturnFunction() -> some AlwaysAvailableProtocol {
+  return AlwaysAvailableStruct()
+}
+
+@available(macOS 50, *)
 public var conditionallyAvailableGlobal: Int {
   get {return 0}
   set {}
@@ -33,6 +38,53 @@ public struct UnavailableStruct {
 public protocol AlwaysAvailableProtocol {}
 
 public struct AlwaysAvailableStruct {}
+
+@available(macOS 50, *)
+extension AlwaysAvailableStruct {
+  public func methodInConditionallyAvailableExtension() {}
+
+  public func opaqueReturnMethodInConditionallyAvailableExtension() -> some AlwaysAvailableProtocol {
+    return AlwaysAvailableStruct()
+  }
+
+  public var varInConditionallyAvailableExtension: Int {
+    get {return 0}
+    set {}
+  }
+}
+
+extension AlwaysAvailableStruct {
+  @available(macOS 50, *)
+  public func conditionallyAvailableMethodInExtension() {}
+
+  @available(macOS 50, *)
+  public func conditionallyAvailableOpaqueReturnMethodInExtension() -> some AlwaysAvailableProtocol {
+    return AlwaysAvailableStruct()
+  }
+
+  @available(macOS 50, *)
+  public var conditionallyAvailableVarInExtension: Int {
+    get {return 0}
+    set {}
+  }
+}
+
+@available(macOS 10.9, *)
+extension AlwaysAvailableStruct {
+  @available(macOS 50, *)
+  public func conditionallyAvailableMethodInExplicitlyAvailableExtension() {}
+
+  @available(macOS 50, *)
+  public func conditionallyAvailableOpaqueReturnMethodInExplicitlyAvailableExtension() -> some AlwaysAvailableProtocol {
+    return AlwaysAvailableStruct()
+  }
+
+  @available(macOS 50, *)
+  public var conditionallyAvailableVarInExplicitlyAvailablextension: Int {
+    get {return 0}
+    set {}
+  }
+}
 
 @available(macOS 50, *)
 extension AlwaysAvailableStruct : AlwaysAvailableProtocol {}

--- a/test/IRGen/Inputs/weak_import_native_helper.swift
+++ b/test/IRGen/Inputs/weak_import_native_helper.swift
@@ -33,6 +33,17 @@ public struct S {
   }
 }
 
+extension S {
+  @_weakLinked
+  public func extensionFn() {}
+
+  @_weakLinked
+  public var extensionProp: Int {
+    get { return 1 }
+    set {}
+  }
+}
+
 public enum E {
   case strong
 

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -12,15 +12,48 @@
 
 import weak_import_availability_helper
 
+// AlwaysAvailableEnum.conditionallyAvailableCase enum case
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper19AlwaysAvailableEnumO013conditionallyF4CaseyA2CmFWC" = extern_weak constant
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper19AlwaysAvailableEnumO013conditionallyF4CaseyA2CmFWC" = external constant
+
+
+// Protocol witness table for AlwaysAvailableStruct: AlwaysAvailableProtocol
+// FIXME: We reference the witness table directly -- that's a bug since the
+// module is resilient. Should reference the conformance descriptor instead.
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA0eF8ProtocolAAWP" = extern_weak global ptr
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA0eF8ProtocolAAWP" = external global ptr
+
+
+// Protocol witness table for AlwaysAvailableStruct: UnavailableProtocol
+// CHECK-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA19UnavailableProtocolAAWP" = extern_weak global ptr
+
+
+// Opaque type descriptor for conditionallyAvailableOpaqueReturnFunction()
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper42conditionallyAvailableOpaqueReturnFunctionQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper42conditionallyAvailableOpaqueReturnFunctionQryFQOMQ" = external global %swift.type_descriptor
+
+
+// Opaque type descriptor for AlwaysAvailableStruct.opaqueReturnMethodInConditionallyAvailableExtension()
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV033opaqueReturnMethodInConditionallyF9ExtensionQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV033opaqueReturnMethodInConditionallyF9ExtensionQryFQOMQ" = external global %swift.type_descriptor
+
+
+// Opaque type descriptor for AlwaysAvailableStruct.conditionallyAvailableOpaqueReturnMethodInExtension()
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF29OpaqueReturnMethodInExtensionQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF29OpaqueReturnMethodInExtensionQryFQOMQ" = external global %swift.type_descriptor
+
+
+// Opaque type descriptor for AlwaysAvailableStruct.conditionallyAvailableOpaqueReturnMethodInExplicitlyAvailableExtension()
+// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf30OpaqueReturnMethodInExplicitlyF9ExtensionQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf30OpaqueReturnMethodInExplicitlyF9ExtensionQryFQOMQ" = external global %swift.type_descriptor
+
+
 public func useConditionallyAvailableCase(e: AlwaysAvailableEnum) {
   switch e {
     case .alwaysAvailableCase: break
     case .conditionallyAvailableCase: break
   }
 }
-
-// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper19AlwaysAvailableEnumO013conditionallyF4CaseyA2CmFWC" = extern_weak constant i32
-// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper19AlwaysAvailableEnumO013conditionallyF4CaseyA2CmFWC" = external constant i32
 
 func useConformance<T : AlwaysAvailableProtocol>(_: T.Type) {}
 
@@ -29,12 +62,6 @@ public func useConditionallyAvailableConformance() {
   useConformance(AlwaysAvailableStruct.self)
 }
 
-// FIXME: We reference the witness table directly -- that's a bug since the module is resilient. Should reference the
-// conformance descriptor instead.
-
-// CHECK-OLD-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA0eF8ProtocolAAWP" = extern_weak global ptr
-// CHECK-NEW-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA0eF8ProtocolAAWP" = external global ptr
-
 @available(macOS, unavailable)
 func useUnavailableConformance<T : UnavailableProtocol>(_: T.Type) {}
 
@@ -42,8 +69,6 @@ func useUnavailableConformance<T : UnavailableProtocol>(_: T.Type) {}
 public func useUnavailableConformance() {
   useUnavailableConformance(AlwaysAvailableStruct.self)
 }
-
-// CHECK-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA19UnavailableProtocolAAWP" = extern_weak global ptr, align 8
 
 @available(macOS 50, *)
 public func callConditionallyAvailableFunction() {
@@ -59,6 +84,14 @@ public func callUnavailableFunction() {
 }
 
 // CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper19unavailableFunctionyyF"()
+
+@available(macOS 50, *)
+public func callConditionallyAvailableOpaqueReturnFunction() {
+  blackHole(conditionallyAvailableOpaqueReturnFunction())
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper42conditionallyAvailableOpaqueReturnFunctionQryF"
+// CHECK-NEW-LABEL: declare swiftcc void @"$s31weak_import_availability_helper42conditionallyAvailableOpaqueReturnFunctionQryF"
 
 @available(macOS 50, *)
 public func useConditionallyAvailableGlobal() {
@@ -112,6 +145,99 @@ public func useConditionallyAvailableMethod(s: ConditionallyAvailableStruct) {
 
 // CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias swiftself)
 // CHECK-NEW-LABEL: declare swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias swiftself)
+
+@available(macOS 50, *)
+public func useMethodInConditionallyAvailableExtension(s: AlwaysAvailableStruct) {
+  s.methodInConditionallyAvailableExtension()
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV021methodInConditionallyF9ExtensionyyF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV021methodInConditionallyF9ExtensionyyF"
+
+@available(macOS 50, *)
+public func useOpaqueReturnMethodInConditionallyAvailableExtension(s: AlwaysAvailableStruct) {
+  blackHole(s.opaqueReturnMethodInConditionallyAvailableExtension())
+}
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV033opaqueReturnMethodInConditionallyF9ExtensionQryF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV033opaqueReturnMethodInConditionallyF9ExtensionQryF"
+
+@available(macOS 50, *)
+public func useVarInConditionallyAvailableExtension(s: inout AlwaysAvailableStruct) {
+  _ = s.varInConditionallyAvailableExtension
+  s.varInConditionallyAvailableExtension = 0
+  s.varInConditionallyAvailableExtension += 0
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivg"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivs"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivM"
+
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivg"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivs"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV018varInConditionallyF9ExtensionSivM"
+
+@available(macOS 50, *)
+public func useConditionallyAvailableMethodInExtension(s: AlwaysAvailableStruct) {
+  s.conditionallyAvailableMethodInExtension()
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF17MethodInExtensionyyF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF17MethodInExtensionyyF"
+
+@available(macOS 50, *)
+public func useConditionallyAvailableOpaqueReturnMethodInExtension(s: AlwaysAvailableStruct) {
+  blackHole(s.conditionallyAvailableOpaqueReturnMethodInExtension())
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF29OpaqueReturnMethodInExtensionQryF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF29OpaqueReturnMethodInExtensionQryF"
+
+@available(macOS 50, *)
+public func useConditionallyAvailableVarInExtension(s: inout AlwaysAvailableStruct) {
+  _ = s.conditionallyAvailableVarInExtension
+  s.conditionallyAvailableVarInExtension = 0
+  s.conditionallyAvailableVarInExtension += 0
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivg"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivs"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivM"
+
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivg"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivs"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF14VarInExtensionSivM"
+
+@available(macOS 50, *)
+public func useConditionallyAvailableMethodInExplicitlyAvailableExtension(s: AlwaysAvailableStruct) {
+  s.conditionallyAvailableMethodInExplicitlyAvailableExtension()
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf18MethodInExplicitlyF9ExtensionyyF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf18MethodInExplicitlyF9ExtensionyyF"
+
+@available(macOS 50, *)
+public func useConditionallyAvailableOpaqueReturnMethodInExplicitlyAvailableExtension(s: AlwaysAvailableStruct) {
+  blackHole(s.conditionallyAvailableOpaqueReturnMethodInExplicitlyAvailableExtension())
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf30OpaqueReturnMethodInExplicitlyF9ExtensionQryF"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyf30OpaqueReturnMethodInExplicitlyF9ExtensionQryF"
+
+
+@available(macOS 50, *)
+public func useConditionallyAvailableVarInExplicitlyAvailableExtension(s: inout AlwaysAvailableStruct) {
+  _ = s.conditionallyAvailableVarInExplicitlyAvailablextension
+  s.conditionallyAvailableVarInExplicitlyAvailablextension = 0
+  s.conditionallyAvailableVarInExplicitlyAvailablextension += 0
+}
+
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivg"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivs"
+// CHECK-OLD-LABEL: declare extern_weak swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivM"
+
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivg"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivs"
+// CHECK-NEW-LABEL: declare swiftcc {{.+}} @"$s31weak_import_availability_helper21AlwaysAvailableStructV013conditionallyF32VarInExplicitlyAvailablextensionSivM"
 
 @available(macOS, unavailable)
 public func useUnavailableStruct() {

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -58,6 +58,16 @@ func testStruct() {
   s[0] = z
   s[0] += 1
 
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1SV11extensionFnyyF"
+  s.extensionFn()
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1SV13extensionPropSivg"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1SV13extensionPropSivs"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1SV13extensionPropSivM"
+  let yy = s.extensionProp
+  s.extensionProp = yy
+  s.extensionProp += 1
+
   // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper5WeakSV0A6MemberyyF"
   let w = WeakS()
   w.weakMember()


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/78454 queries for the platform availability of decl were consolidated into
`Decl::getAvailableAttrForPlatformIntroduction()`. In addition to checking the attributes directly attached to the decl, this method also checks whether the decl is a member directly contained inside of an extension and checks for attributes attached to the extension as well. Previously, this logic was only used for availability checking diagnostics, where special casing extension members was a requirement. As a result of the consolidation, though, the logic is now also shared by the query that determines whether to weakly link symbols associated with a decl. That determination already had its own way of handling members of extensions but it seemed like consolidating the logic would still be a net improvement that would reduce overall complexity.

Unfortunately, the existing approach to getting the availability of the enclosing extension had a subtle bug for both `AccessorDecl` and `OpaqueTypeDecl`. If an `AvailableAttr` was not directly attached to the immediate decl, then `Decl::getAvailableAttrForPlatformIntroduction()` would check if the enclosing decl context was an extension and look at its attributes as well. For `AccessorDecl` and `OpaqueTypeDecl`, checking the enclosing decl context would accidentally skip over the `VarDecl` and `AbstractFunctionDecl` that are formally the parents of those decls for the purposes of attribute inheritance. As a result, the availability of the enclosing property or function could be ignored if the enclosing extension had explicit availability attributes.

The fix is to use `AvailabilityInference::parentDeclForInferredAvailability()` instead of `getDeclContext()` when looking for the immediately enclosing extension.

Resolves rdar://143139472.
