### PR TITLE
🌸[6.1] Correct newline emission in generated headers

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -488,7 +488,6 @@ public:
         (inserted || !it->second.second))
       ClangValueTypePrinter::forwardDeclType(os, CD, printer);
     it->second = {EmissionState::Defined, true};
-    os << '\n';
     printer.print(CD);
     return true;
   }
@@ -507,7 +506,6 @@ public:
           forwardDeclareType(TD);
         });
 
-    os << '\n';
     printer.print(FD);
     return true;
   }
@@ -550,7 +548,6 @@ public:
       return false;
 
     seenTypes[PD] = { EmissionState::Defined, true };
-    os << '\n';
     printer.print(PD);
     return true;
   }
@@ -576,7 +573,6 @@ public:
     if (!forwardDeclareMemberTypes(ED->getAllMembers(), ED))
       return false;
 
-    os << '\n';
     printer.print(ED);
     return true;
   }
@@ -840,6 +836,7 @@ public:
     while (!declsToWrite.empty()) {
       const Decl *D = declsToWrite.back();
       bool success = true;
+      auto posBefore = os.tell();
 
       if (auto ED = dyn_cast<EnumDecl>(D)) {
         success = writeEnum(ED);
@@ -870,7 +867,10 @@ public:
 
       if (success) {
         assert(declsToWrite.back() == D);
-        os << "\n";
+        // If we actually wrote something to the file, add a newline after it.
+        // (As opposed to, for instance, an extension we decided to skip.)
+        if (posBefore != os.tell())
+          os << "\n";
         declsToWrite.pop_back();
       }
     }

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -589,7 +589,7 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
                  clangHeaderSearchInfo, exposedModuleHeaderNames);
   });
   writePostImportPrologue(os, *M);
-  emitObjCConditional(os, [&] { os << objcModuleContents.str(); });
+  emitObjCConditional(os, [&] { os << "\n" << objcModuleContents.str(); });
   writeObjCEpilogue(os);
   emitCxxConditional(os, [&] {
     // FIXME: Expose Swift with @expose by default.

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -269,7 +269,6 @@ public struct Strct {
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
 // CHECK-NEXT: namespace UseCxxTy SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("UseCxxTy") {
-// CHECK-EMPTY:
 // CHECK-NEXT: SWIFT_INLINE_THUNK ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -98,11 +98,9 @@ public final class ExposedClass {
 // CHECK-NEXT:   _impl::$s6Expose8exposed1yyF();
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-EMPTY:
 // CHECK-NEXT: SWIFT_INLINE_THUNK void exposed3() noexcept SWIFT_SYMBOL("{{.*}}") {
 // CHECK-NEXT:   _impl::$s6Expose8exposed3yyF();
 // CHECK-NEXT: }
-// CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: SWIFT_INLINE_THUNK void exposed4() noexcept SWIFT_SYMBOL("{{.*}}") {
 // CHECK-NEXT:   _impl::$s6Expose15exposed4RenamedyyF();

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -94,6 +94,7 @@
 // CHECK-NEXT:  #if __has_feature(objc_modules)
 
 // CHECK-LABEL: #if defined(__OBJC__)
+// CHECK-EMPTY:
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #if __has_attribute(external_source_symbol)
 // CHECK-NEXT:  # pragma clang attribute pop

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -2,7 +2,6 @@ SWIFT_CLASS("_TtC8comments4A000")
 @interface A000
 @end
 
-
 /// Aaa.  A010.  Bbb.
 SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
 @interface A010_AttachToEntities
@@ -17,12 +16,10 @@ SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger v2;)
 + (NSInteger)v2 SWIFT_WARN_UNUSED_RESULT;
 @end
 
-
 /// Aaa.  A013.
 SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
 @protocol A013_AttachToEntities
 @end
-
 
 SWIFT_CLASS("_TtC8comments10ATXHeaders")
 @interface ATXHeaders
@@ -31,7 +28,6 @@ SWIFT_CLASS("_TtC8comments10ATXHeaders")
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments10Attributes")
 @interface Attributes
 /// Here is an attribute:
@@ -39,14 +35,12 @@ SWIFT_CLASS("_TtC8comments10Attributes")
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments13AutomaticLink")
 @interface AutomaticLink
 /// And now for a URL.
 /// <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments10BlockQuote")
 @interface BlockQuote
@@ -61,7 +55,6 @@ SWIFT_CLASS("_TtC8comments10BlockQuote")
 /// </blockquote>
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments5Brief")
 @interface Brief
@@ -81,13 +74,11 @@ SWIFT_CLASS("_TtC8comments5Brief")
 - (void)f3;
 @end
 
-
 SWIFT_CLASS("_TtC8comments15ClosingComments")
 @interface ClosingComments
 /// Some comment. */
 - (void)closingComment;
 @end
-
 
 SWIFT_CLASS("_TtC8comments16ClosureContainer")
 @interface ClosureContainer
@@ -156,7 +147,6 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
 - (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
 @end
 
-
 SWIFT_CLASS("_TtC8comments9CodeBlock")
 @interface CodeBlock
 /// This is how you use this code.
@@ -169,14 +159,12 @@ SWIFT_CLASS("_TtC8comments9CodeBlock")
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments8Emphasis")
 @interface Emphasis
 /// Aaa <em>bbb</em> ccc.
 /// Aaa <em>bbb</em> ccc.
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments13EmptyComments")
 @interface EmptyComments
@@ -192,7 +180,6 @@ SWIFT_CLASS("_TtC8comments13EmptyComments")
 - (void)f4;
 @end
 
-
 SWIFT_CLASS("_TtC8comments9Footnotes")
 @interface Footnotes
 /// Has some footnotes.
@@ -201,7 +188,6 @@ SWIFT_CLASS("_TtC8comments9Footnotes")
 /// enable the feature.
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 @interface HasThrowingFunction
@@ -214,7 +200,6 @@ SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 - (void)f1:(NSInteger)x;
 @end
 
-
 SWIFT_CLASS("_TtC8comments15HorizontalRules")
 @interface HorizontalRules
 /// Briefly.
@@ -223,13 +208,11 @@ SWIFT_CLASS("_TtC8comments15HorizontalRules")
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 @interface ImplicitNameLink
 /// <a href="https://www.apple.com/">Apple</a>
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 @interface IndentedBlockComment
@@ -257,20 +240,17 @@ SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 - (void)f2;
 @end
 
-
 SWIFT_CLASS("_TtC8comments10InlineCode")
 @interface InlineCode
 /// Aaa <code>bbb</code> ccc.
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments10InlineLink")
 @interface InlineLink
 /// Aaa <a href="/path/to/something">bbb</a> ccc.
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 @interface MultiLineBrief
@@ -279,7 +259,6 @@ SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 /// Some paragraph text.
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments11OrderedList")
 @interface OrderedList
@@ -294,7 +273,6 @@ SWIFT_CLASS("_TtC8comments11OrderedList")
 /// </ol>
 - (void)f0;
 @end
-
 
 /// \param x A number
 ///
@@ -340,7 +318,6 @@ SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 - (void)f4;
 @end
 
-
 SWIFT_CLASS("_TtC8comments16ParameterOutline")
 @interface ParameterOutline
 /// \param x A number
@@ -351,7 +328,6 @@ SWIFT_CLASS("_TtC8comments16ParameterOutline")
 ///
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 @end
-
 
 SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
 @interface ParameterOutlineMiddle
@@ -372,11 +348,9 @@ SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 @end
 
-
 SWIFT_CLASS("_TtC8comments13ReferenceLink")
 @interface ReferenceLink
 @end
-
 
 SWIFT_CLASS("_TtC8comments7Returns")
 @interface Returns
@@ -386,14 +360,12 @@ SWIFT_CLASS("_TtC8comments7Returns")
 - (NSInteger)f0 SWIFT_WARN_UNUSED_RESULT;
 @end
 
-
 SWIFT_CLASS("_TtC8comments18SeparateParameters")
 @interface SeparateParameters
 /// \param x A number
 ///
 - (void)f0:(NSInteger)x y:(NSInteger)y;
 @end
-
 
 SWIFT_CLASS("_TtC8comments13SetextHeaders")
 @interface SetextHeaders
@@ -406,14 +378,12 @@ SWIFT_CLASS("_TtC8comments13SetextHeaders")
 - (void)f0;
 @end
 
-
 SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 @interface StrongEmphasis
 /// Aaa <em>bbb</em> ccc.
 /// Aaa <em>bbb</em> ccc.
 - (void)f0;
 @end
-
 
 SWIFT_CLASS("_TtC8comments13UnorderedList")
 @interface UnorderedList

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -19,32 +19,38 @@ import objc_generics
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc @objcMembers class A1 {}
-
+// CHECK-EMPTY:
 // NEGATIVE-NOT: @interface A1 (SWIFT_EXTENSION(extensions))
 extension A1 {}
 
 // CHECK-LABEL: @interface A2{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
-// CHECK-LABEL: @interface A2 (SWIFT_EXTENSION(extensions))
+// CHECK-EMPTY:
+// CHECK-NEXT: @interface A2 (SWIFT_EXTENSION(extensions))
 // CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension A2 {
   @objc var some: Int { return 1 }
 }
 @objc @objcMembers class A2 {}
 
-// CHECK-LABEL: @interface A3{{$}}
+// CHECK-NEXT: SWIFT_CLASS
+// CHECK-NEXT: @interface A3{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 @objc @objcMembers class A3 {}
 
-// CHECK-LABEL: @interface A3 (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @interface A3 (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger more;
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
-// CHECK-DAG: @end
-// CHECK: @end
+// CHECK-NEXT: @interface A3 (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger some;
+// CHECK-NEXT: @end
+// CHECK-EMPTY:
+// CHECK-NEXT: @interface A3 (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger more;
+// CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension A3 {
   @objc var some: Int { return 1 }
 }
@@ -52,23 +58,30 @@ extension A3 {
   @objc var more: Int { return 10 }
 }
 
-// CHECK-LABEL: @interface A4{{$}}
+// CHECK-NEXT: SWIFT_CLASS
+// CHECK-NEXT: @interface A4{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 @objc @objcMembers class A4 {}
 
-// CHECK-LABEL: @interface A4 (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @interface A4 (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension A4 {
-  // CHECK-LABEL: @interface Inner
+  // CHECK-NEXT: SWIFT_CLASS
+  // CHECK-NEXT: @interface Inner
   // CHECK-NEXT: init
   // CHECK-NEXT: @end
+  // CHECK-EMPTY:
   @objc @objcMembers class Inner {}
 }
 
-// CHECK-LABEL: @interface A5{{$}}
+// CHECK-NEXT: SWIFT_CLASS
+// CHECK-NEXT: @interface A5{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 @objc @objcMembers class A5 {}
 
 // NEGATIVE-NOT: @interface A5 (SWIFT_EXTENSION(extensions))
@@ -79,7 +92,8 @@ extension A5 {
 // Check that two otherwise tied extensions will print in alphabetical
 // order by first member with a differing Swift name.
 
-// CHECK-LABEL: @interface A6
+// CHECK-NEXT: SWIFT_CLASS
+// CHECK-NEXT: @interface A6
 @objc class A6 {}
 
 extension A6 {
@@ -91,23 +105,30 @@ extension A6 {
   @objc func abc() {}
 }
 // CHECK: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK: - (void)skippedInt:
-// CHECK: - (void)abc
-// CHECK: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK: - (void)skippedBool:
-// CHECK: - (void)def
+// CHECK-NEXT: - (void)skippedInt:
+// CHECK-NEXT: - (void)abc
+// CHECK-NEXT: @end
+// CHECK-EMPTY:
+// CHECK-NEXT: @interface A6 (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: - (void)skippedBool:
+// CHECK-NEXT: - (void)def
+// CHECK-NEXT: @end
+// CHECK-EMPTY:
 
-// CHECK-LABEL: @interface CustomName{{$}}
+// CHECK-NEXT: SWIFT_CLASS
+// CHECK-NEXT: @interface CustomName{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 @objc(CustomName)
 @objcMembers
 class ClassWithCustomName {
 }
 
-// CHECK-LABEL: @interface CustomName (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @interface CustomName (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (void)foo;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension ClassWithCustomName {
   @objc func foo() {}
 }
@@ -117,9 +138,10 @@ extension CGColor {
   func anyOldMethod() {}
 }
 
-// CHECK-LABEL: @interface GenericClass<T> (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @interface GenericClass<T> (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (void)bar;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension GenericClass {
   @objc func bar() {}
 }
@@ -131,19 +153,21 @@ extension NotObjC {}
 // NEGATIVE-NOT: @interface NSObject{{$}}
 // NEGATIVE-NOT: @class NSObject
 // CHECK-LABEL: @interface NSObject (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger some;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension NSObject {
   @objc var some: Int { return 1 }
 }
 
 // NEGATIVE-NOT: @class NSString;
 // CHECK: @class NSColor;
-// CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @interface NSString (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (void)test;
 // CHECK-NEXT: + (void)test2;
 // CHECK-NEXT: + (NSString * _Nullable)fromColor:(NSColor * _Nonnull)color SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension NSString {
   @objc func test() {}
   @objc class func test2() {}
@@ -151,13 +175,15 @@ extension NSString {
   @objc class func fromColor(_ color: NSColor) -> NSString? { return nil; }
 }
 
-// CHECK-LABEL: @interface PettableContainer<T> (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: @protocol Pettable;
+// CHECK-NEXT: @interface PettableContainer<T> (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate2 SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (PettableContainer<PettableOverextendedMetaphor *> * _Nonnull)duplicate3 SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (T _Nonnull)extract SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (T _Nullable)extract2 SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @end
+// CHECK-EMPTY:
 extension PettableContainer {
   @objc func duplicate() -> PettableContainer { fatalError() }
   @objc func duplicate2() -> PettableContainer<T> { fatalError() }


### PR DESCRIPTION
- Explanation: PrintAsClang was printing excessive blank lines between declarations, including blank lines that might shift around depending on when empty extensions were visited during printing. This could cause different compilation runs to emit headers that had the same declarations in the same order, but were not byte-for-byte identical, raising false alarms in build system consistency checks. This PR prints a blank line after visiting a top-level decl only when content was actually added to header, and removes excessive blank lines more generally.
- Scope: Generated headers for Objective-C and C++
- Issues: rdar://143533893
- Original PRs: https://github.com/swiftlang/swift/pull/78898
- Risk: Low. This changes only the printing of newlines, and constructs that are terminated by a newline (e.g. `#if`) are always printed with at least one newline attached.
- Testing: Unit tests included.
- Reviewers: @tshortli and @nkcsgexi 
