### PR TITLE
[CSBindings] Allow subtype inference from `Void?` for closure result …

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2584,7 +2584,8 @@ bool TypeVarBindingProducer::computeNext() {
         //
         // Let's not perform $T? -> $T for closure result types to avoid having
         // to re-discover solutions that differ only in location of optional
-        // injection.
+        // injection. `Void` is a special case because in $T_result position
+        // it has special semantics and enables T? -> Void conversions.
         //
         // The pattern with such type variables is:
         //
@@ -2595,7 +2596,7 @@ bool TypeVarBindingProducer::computeNext() {
         // expression is non-optional), if we allow  both the solver would
         // find two solutions that differ only in location of optional
         // injection.
-        if (!TypeVar->getImpl().isClosureResultType()) {
+        if (!TypeVar->getImpl().isClosureResultType() || objTy->isVoid()) {
           // If T is a type variable, only attempt this if both the
           // type variable we are trying bindings for, and the type
           // variable we will attempt to bind, both have the same

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1283,3 +1283,25 @@ do {
     }
   }
 }
+
+// Make sure that closure gets both Void? and Void attempted
+// otherwise it won't be possible to type-check the second closure.
+do {
+  struct Semaphore {
+    func signal() -> Int {}
+  }
+
+  func compute(_ completion: (Semaphore?) -> Void?) {}
+
+  func test() {
+    compute { $0?.signal() }
+    // expected-warning@-1 {{result of call to 'signal()' is unused}}
+
+    true
+      ? compute({ $0?.signal() }) // expected-warning {{result of call to 'signal()' is unused}}
+      : compute({
+           let sem = $0!
+           sem.signal() // expected-warning {{result of call to 'signal()' is unused}}
+        })
+  }
+}


### PR DESCRIPTION
…types

We don't want to do that in general because injection should happen only in one place but Void is special because it allows conversions in that position.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
