### PR TITLE
[embedded] Support _findStringSwitchCaseWithCache in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -86,7 +86,8 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
   // eagerly linking and specializing _findStringSwitchCaseWithCache whenever findStringSwitchCase is found in the module.
   if context.options.enableEmbeddedSwift {
     if function.hasSemanticsAttribute("findStringSwitchCase"),
-        let f = context.lookupStdlibFunction(name: "_findStringSwitchCaseWithCache") {
+        let f = context.lookupStdlibFunction(name: "_findStringSwitchCaseWithCache"),
+        context.loadFunction(function: f, loadCalleesRecursively: true) {
       worklist.pushIfNotVisited(f)
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -80,6 +80,16 @@ fileprivate struct PathFunctionTuple: Hashable {
 
 private func optimize(function: Function, _ context: FunctionPassContext, _ moduleContext: ModulePassContext, _ worklist: inout FunctionWorklist) {
   var alreadyInlinedFunctions: Set<PathFunctionTuple> = Set()
+
+  // ObjectOutliner replaces calls to findStringSwitchCase with _findStringSwitchCaseWithCache, but this happens as a late SIL optimization,
+  // which is a problem for Embedded Swift, because _findStringSwitchCaseWithCache will then reference non-specialized code. Solve this by
+  // eagerly linking and specializing _findStringSwitchCaseWithCache whenever findStringSwitchCase is found in the module.
+  if context.options.enableEmbeddedSwift {
+    if function.hasSemanticsAttribute("findStringSwitchCase"),
+        let f = context.lookupStdlibFunction(name: "_findStringSwitchCaseWithCache") {
+      worklist.pushIfNotVisited(f)
+    }
+  }
   
   var changed = true
   while changed {

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -124,6 +124,14 @@ class DeadFunctionAndGlobalElimination {
     if (F->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
       return true;
 
+    // To support ObjectOutliner's replacing of calls to findStringSwitchCase
+    // with _findStringSwitchCaseWithCache. In Embedded Swift, we have to load
+    // the body of this function early and specialize it, so that ObjectOutliner
+    // can reference it later. To make this work we have to avoid DFE'ing it.
+    // Linker's dead-stripping will eventually remove this if actually unused.
+    if (F->hasSemanticsAttr("findStringSwitchCaseWithCache"))
+      return true;
+
     return false;
   }
 

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1929,7 +1929,11 @@ OptionalBridgedFunction BridgedPassContext::lookupStdlibFunction(BridgedStringRe
 
   SILDeclRef declRef(decl, SILDeclRef::Kind::Func);
   SILOptFunctionBuilder funcBuilder(*invocation->getTransform());
-  return {funcBuilder.getOrCreateFunction(SILLocation(decl), declRef, NotForDefinition)};
+  SILFunction *function = funcBuilder.getOrCreateFunction(SILLocation(decl), declRef, NotForDefinition);
+  if (mod->getOptions().EmbeddedSwift) {
+    mod->linkFunction(function, SILModule::LinkingMode::LinkAll);
+  }
+  return {function};
 }
 
 OptionalBridgedFunction BridgedPassContext::lookUpNominalDeinitFunction(BridgedDeclObj nominal)  const {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1929,11 +1929,7 @@ OptionalBridgedFunction BridgedPassContext::lookupStdlibFunction(BridgedStringRe
 
   SILDeclRef declRef(decl, SILDeclRef::Kind::Func);
   SILOptFunctionBuilder funcBuilder(*invocation->getTransform());
-  SILFunction *function = funcBuilder.getOrCreateFunction(SILLocation(decl), declRef, NotForDefinition);
-  if (mod->getOptions().EmbeddedSwift) {
-    mod->linkFunction(function, SILModule::LinkingMode::LinkAll);
-  }
-  return {function};
+  return {funcBuilder.getOrCreateFunction(SILLocation(decl), declRef, NotForDefinition)};
 }
 
 OptionalBridgedFunction BridgedPassContext::lookUpNominalDeinitFunction(BridgedDeclObj nominal)  const {

--- a/test/embedded/string-switch2.swift
+++ b/test/embedded/string-switch2.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -wmo -O -Xlinker %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+enum MyEnum: String {
+    case case1
+    case case2
+    case case3
+    case case4
+    case case5
+    case case6
+    case case7
+    case case8
+    case case9
+    case case10
+    case case11
+    case case12
+    case case13
+    case case14
+    case case15
+    case case16
+    case case17
+    case case18
+    case case19
+}
+
+var e = MyEnum.case1
+print(e.rawValue)
+e = MyEnum.case2
+print(e.rawValue)
+// CHECK: case1
+// CHECK: case2


### PR DESCRIPTION
ObjectOutliner has an optimization that replaces calls to findStringSwitchCase with _findStringSwitchCaseWithCache. This currently causes a "missing symbol" linker error in Embedded Swift, because this replacement happens without loading the body of the function from the stdlib. See the attached testcase that shows the problem (only happens under -O).

This PR fixes that with two changes:

(1) Calling lookupStdlibFunction under Embedded Swift now triggers loading the body (deserialization) + its dependencies.
(2) The above alone is not a full fix, because ObjectOutliner is a late SIL optimization, and so deserializing stdlib code causes un-specialized code to get added to the module, causing later problems (we don't expect any unspecialized code to be used in Embedded Swift after MandatoryPerformanceOptimizations are run). To fix that, we eagerly link in _findStringSwitchCaseWithCache whenever findStringSwitchCase is present as part of MandatoryPerformanceOptimizations.

Suggestions for a better approach are welcome :)

rdar://143587257