### PR TITLE
[SIMD] Add missing broadcasting functions for concrete Builtin functions on SIMD

### DIFF
--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -260,67 +260,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
       Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
     ))
   }
-
-  @_alwaysEmitIntoClient
-  public static func .==(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .== b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .!=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .!= b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .< b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .<= b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .> b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .>= b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .==(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .== Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .!=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .!= Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .< Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .<= Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .> Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .>= Self(repeating: b)
-  }
-
+    
   /// The wrapping sum of two vectors.
   @_alwaysEmitIntoClient
   public static func &+(a: Self, b: Self) -> Self {
@@ -338,37 +278,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
   public static func &*(a: Self, b: Self) -> Self {
     Self(Builtin.mul_${Builtin}(a._storage._value, b._storage._value))
   }
-
-  @_alwaysEmitIntoClient
-  public static func &+(a: Scalar, b: Self) -> Self {
-    Self(repeating: a) &+ b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func &-(a: Scalar, b: Self) -> Self {
-    Self(repeating: a) &- b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func &*(a: Scalar, b: Self) -> Self {
-    Self(repeating: a) &* b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func &+(a: Self, b: Scalar) -> Self {
-    a &+ Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func &-(a: Self, b: Scalar) -> Self {
-    a &- Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func &*(a: Self, b: Scalar) -> Self {
-    a &* Self(repeating: b)
-  }
-
+        
   /// Updates the left hand side with the wrapping sum of the two
   /// vectors.
   @_alwaysEmitIntoClient
@@ -384,20 +294,36 @@ extension SIMD${n} where Scalar == ${Scalar} {
   @_alwaysEmitIntoClient
   public static func &*=(a: inout Self, b: Self) { a = a &* b }
 
+%   for operator in ['.==', '.!=', '.<', '.<=', '.>', '.>=']:
   @_alwaysEmitIntoClient
-  public static func &+=(a: inout Self, b: Scalar) {
-    a = a &+ Self(repeating: b)
+  public static func ${operator}(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) ${operator} b
   }
 
   @_alwaysEmitIntoClient
-  public static func &-=(a: inout Self, b: Scalar) {
-    a = a &- Self(repeating: b)
+  public static func ${operator}(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a ${operator} Self(repeating: b)
+  }
+%   end
+
+%   for operator in ['&+', '&-', '&*']:
+  @_alwaysEmitIntoClient
+  public static func ${operator}(a: Scalar, b: Self) -> Self {
+    Self(repeating: a) ${operator} b
   }
 
   @_alwaysEmitIntoClient
-  public static func &*=(a: inout Self, b: Scalar) {
-    a = a &* Self(repeating: b)
+  public static func ${operator}(a: Self, b: Scalar) -> Self {
+    a ${operator} Self(repeating: b)
   }
+%   end
+
+%   for operator in ['&+=', '&-=', '&*=']:
+  @_alwaysEmitIntoClient
+  public static func ${operator}(a: inout Self, b: Scalar) {
+    a ${operator} Self(repeating: b)
+  }
+%   end
 }
 
 % end
@@ -468,65 +394,17 @@ extension SIMD${n} where Scalar == ${Scalar} {
     ))
   }
 
+%   for operator in ['.==', '.!=', '.<', '.<=', '.>', '.>=']:
   @_alwaysEmitIntoClient
-  public static func .==(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .== b
+  public static func ${operator}(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) ${operator} b
   }
 
   @_alwaysEmitIntoClient
-  public static func .!=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .!= b
+  public static func ${operator}(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a ${operator} Self(repeating: b)
   }
-
-  @_alwaysEmitIntoClient
-  public static func .<(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .< b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .<= b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .> b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
-    Self(repeating: a) .>= b
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .==(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .== Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .!=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .!= Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .< Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .<=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .<= Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .> Self(repeating: b)
-  }
-
-  @_alwaysEmitIntoClient
-  public static func .>=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
-    a .>= Self(repeating: b)
-  }
+%   end
 }
 %  if bits == 16:
 #endif

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -260,7 +260,67 @@ extension SIMD${n} where Scalar == ${Scalar} {
       Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
     ))
   }
-    
+
+  @_alwaysEmitIntoClient
+  public static func .==(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .== b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .!= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .< b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .<= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .> b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .>= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .==(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .== Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .!= Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .< Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .<= Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .> Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .>= Self(repeating: b)
+  }
+
   /// The wrapping sum of two vectors.
   @_alwaysEmitIntoClient
   public static func &+(a: Self, b: Self) -> Self {
@@ -278,7 +338,37 @@ extension SIMD${n} where Scalar == ${Scalar} {
   public static func &*(a: Self, b: Self) -> Self {
     Self(Builtin.mul_${Builtin}(a._storage._value, b._storage._value))
   }
-        
+
+  @_alwaysEmitIntoClient
+  public static func &+(a: Scalar, b: Self) -> Self {
+    Self(repeating: a) &+ b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &-(a: Scalar, b: Self) -> Self {
+    Self(repeating: a) &- b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &*(a: Scalar, b: Self) -> Self {
+    Self(repeating: a) &* b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &+(a: Self, b: Scalar) -> Self {
+    a &+ Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &-(a: Self, b: Scalar) -> Self {
+    a &- Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &*(a: Self, b: Scalar) -> Self {
+    a &* Self(repeating: b)
+  }
+
   /// Updates the left hand side with the wrapping sum of the two
   /// vectors.
   @_alwaysEmitIntoClient
@@ -293,6 +383,21 @@ extension SIMD${n} where Scalar == ${Scalar} {
   /// vectors.
   @_alwaysEmitIntoClient
   public static func &*=(a: inout Self, b: Self) { a = a &* b }
+
+  @_alwaysEmitIntoClient
+  public static func &+=(a: inout Self, b: Scalar) {
+    a = a &+ Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &-=(a: inout Self, b: Scalar) {
+    a = a &- Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func &*=(a: inout Self, b: Scalar) {
+    a = a &* Self(repeating: b)
+  }
 }
 
 % end
@@ -361,6 +466,66 @@ extension SIMD${n} where Scalar == ${Scalar} {
     SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_oge_${Builtin}(a._storage._value, b._storage._value)
     ))
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .==(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .== b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .!= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .< b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .<= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .> b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    Self(repeating: a) .>= b
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .==(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .== Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .!= Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .< Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .<= Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .> Self(repeating: b)
+  }
+
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    a .>= Self(repeating: b)
   }
 }
 %  if bits == 16:

--- a/test/SILGen/simd_builtin_fp_operations.swift.gyb
+++ b/test/SILGen/simd_builtin_fp_operations.swift.gyb
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %gyb -D CMAKE_SIZEOF_VOID_P=$((%target-ptrsize/8)) %s -o %t/simd_builtin_fp_operations.swift
+// RUN: %gyb %s -o %t/simd_builtin_fp_operations.swift
 // RUN: %target-swift-emit-sil -Xllvm -sil-print-types %t/simd_builtin_fp_operations.swift | %FileCheck %t/simd_builtin_fp_operations.swift
 
 %{

--- a/test/SILGen/simd_builtin_fp_operations.swift.gyb
+++ b/test/SILGen/simd_builtin_fp_operations.swift.gyb
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb -D CMAKE_SIZEOF_VOID_P=$((%target-ptrsize/8)) %s -o %t/simd_builtin_fp_operations.swift
+// RUN: %target-swift-emit-sil -Xllvm -sil-print-types %t/simd_builtin_fp_operations.swift | %FileCheck %t/simd_builtin_fp_operations.swift
+
+%{
+storagescalarCounts = [2,4,8,16,32,64]
+vectorscalarCounts = storagescalarCounts + [3]
+}%
+
+%for (Scalar, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  Builtin = "Vec" + str(storageN) + "xFPIEEE" + str(bits)
+
+%  SIMDMask = "SIMDMask<SIMD" + str(n) + "<Int" + str(bits) + ">>"
+%  for (opSymbol, opName) in [(".==", "oeq"), (".!=", "une"), (".<", "olt"), (".<=", "ole"), (".>", "ogt"), (".>=", "oge")]:
+%   for (LType, RType) in [(Vector, Vector), (Scalar, Vector), (Vector, Scalar)]:
+%    labelSuffix = opName + (Builtin if LType == Vector else Scalar) + (Builtin if RType == Vector else Scalar)
+%    if bits == 16:
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+@available(SwiftStdlib 5.3, *)
+// CHECK: sil hidden [available 11.0] @[[FUNC_${labelSuffix}:\$.*]] : $@convention(thin) (${LType}, ${RType}) -> ${SIMDMask} {
+%    else:
+// CHECK: sil hidden @[[FUNC_${labelSuffix}:\$.*]] : $@convention(thin) (${LType}, ${RType}) -> ${SIMDMask} {
+%    end
+func f_${Builtin}_${opName}(a: ${LType}, b: ${RType}) -> ${SIMDMask} {
+  // CHECK: bb0([[LHS:%.*]] : $$${LType}, [[RHS:%.*]] : $$${RType}):
+  // CHECK: [[META:%.*]] = metatype $@thin ${Vector}.Type
+  // CHECK: [[FUNC:%.*]] = function_ref @[[FUNC_OPERATOR_${labelSuffix}:\$.*]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask}
+  // CHECK: [[RET:%.*]] = apply [[FUNC]]([[LHS]], [[RHS]], [[META]]) : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask}
+  // CHECK: return [[RET]]
+  // CHECK: } // end sil function '[[FUNC_${labelSuffix}]]'
+  a ${opSymbol} b
+}
+
+%    if bits == 16:
+// CHECK: sil shared [available 11.0] @[[FUNC_OPERATOR_${labelSuffix}]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask} {
+%    else:
+// CHECK: sil shared @[[FUNC_OPERATOR_${labelSuffix}]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask} {
+%    end
+// CHECK: builtin "fcmp_${opName}_${Builtin}"
+// CHECK: } // end sil function '[[FUNC_OPERATOR_${labelSuffix}]]'
+%    if bits == 16:
+#endif
+%    end
+%   end
+%  end
+% end
+%end

--- a/test/SILGen/simd_builtin_integer_operations.swift.gyb
+++ b/test/SILGen/simd_builtin_integer_operations.swift.gyb
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb -D CMAKE_SIZEOF_VOID_P=$((%target-ptrsize/8)) %s -o %t/simd_builtin_integer_operations.swift
+// RUN: %target-swift-emit-sil -Xllvm -sil-print-types %t/simd_builtin_integer_operations.swift | %FileCheck %t/simd_builtin_integer_operations.swift
+
+%{
+from SwiftIntTypes import all_integer_types
+word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+storagescalarCounts = [2,4,8,16,32,64]
+vectorscalarCounts = storagescalarCounts + [3]
+}%
+
+%for int in all_integer_types(word_bits):
+% Scalar = int.stdlib_name
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  s = "s" if int.is_signed else "u"
+%  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
+
+%  SignedScalar = "Int" if int.is_word else ("Int" + str(int.bits))
+%  SIMDMask = "SIMDMask<SIMD" + str(n) + "<" + SignedScalar + ">>"
+%  for (opSymbol, opName) in [(".==", "eq"), (".!=", "ne"), (".<", s + "lt"), (".<=", s + "le"), (".>", s + "gt"), (".>=", s + "ge")]:
+%   for (LType, RType) in [(Vector, Vector), (Scalar, Vector), (Vector, Scalar)]:
+%    labelSuffix = opName + (Builtin if LType == Vector else Scalar) + (Builtin if RType == Vector else Scalar)
+// CHECK: sil hidden @[[FUNC_${labelSuffix}:\$.*]] : $@convention(thin) (${LType}, ${RType}) -> ${SIMDMask} {
+func f_${Builtin}_${opName}(a: ${LType}, b: ${RType}) -> ${SIMDMask} {
+  // CHECK: bb0([[LHS:%.*]] : $$${LType}, [[RHS:%.*]] : $$${RType}):
+  // CHECK: [[META:%.*]] = metatype $@thin ${Vector}.Type
+  // CHECK: [[FUNC:%.*]] = function_ref @[[FUNC_OPERATOR_${labelSuffix}:\$.*]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask}
+  // CHECK: [[RET:%.*]] = apply [[FUNC]]([[LHS]], [[RHS]], [[META]]) : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask}
+  // CHECK: return [[RET]]
+  // CHECK: } // end sil function '[[FUNC_${labelSuffix}]]'
+  a ${opSymbol} b
+}
+
+// CHECK: sil shared @[[FUNC_OPERATOR_${labelSuffix}]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${SIMDMask} {
+// CHECK: builtin "cmp_${opName}_${Builtin}"
+// CHECK: } // end sil function '[[FUNC_OPERATOR_${labelSuffix}]]'
+%   end
+%  end
+
+%  for (opSymbol, opName) in [("&+", "add"), ("&-", "sub"), ("&*", "mul")]:
+%   for (LType, RType) in [(Vector, Vector), (Scalar, Vector), (Vector, Scalar)]:
+%    labelSuffix = opName + (Builtin if LType == Vector else Scalar) + (Builtin if RType == Vector else Scalar)
+// CHECK: sil hidden @[[FUNC_${labelSuffix}:\$.*]] : $@convention(thin) (${LType}, ${RType}) -> ${Vector} {
+func f_${Builtin}_${opName}(a: ${LType}, b: ${RType}) -> ${Vector} {
+  // CHECK: bb0([[LHS:%.*]] : $$${LType}, [[RHS:%.*]] : $$${RType}):
+  // CHECK: [[META:%.*]] = metatype $@thin ${Vector}.Type
+  // CHECK: [[FUNC:%.*]] = function_ref @[[FUNC_OPERATOR_${labelSuffix}:\$.*]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${Vector}
+  // CHECK: [[RET:%.*]] = apply [[FUNC]]([[LHS]], [[RHS]], [[META]]) : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${Vector}
+  // CHECK: return [[RET]]
+  // CHECK: } // end sil function '[[FUNC_${labelSuffix}]]'
+  a ${opSymbol} b
+}
+
+// CHECK: sil shared @[[FUNC_OPERATOR_${labelSuffix}]] : $@convention(method) (${LType}, ${RType}, @thin ${Vector}.Type) -> ${Vector} {
+// CHECK: builtin "${opName}_${Builtin}"
+// CHECK: } // end sil function '[[FUNC_OPERATOR_${labelSuffix}]]'
+
+%    if LType == Vector:
+// CHECK: sil hidden @[[FUNC_MUTATING_${labelSuffix}:\$.*]] : $@convention(thin) (@inout ${LType}, ${RType}) -> () {
+func f_${Builtin}_${opName}_mutating(a: inout ${LType}, b: ${RType}) {
+  // CHECK: bb0([[LHS:%.*]] : $$*${LType}, [[RHS:%.*]] : $$${RType}):
+  // CHECK: [[META:%.*]] = metatype $@thin ${Vector}.Type
+  // CHECK: [[MLHS:%.*]] = begin_access [modify] [static] [[LHS]]
+  // CHECK: [[FUNC:%.*]] = function_ref @[[FUNC_MUTATING_OPERATOR_${labelSuffix}:\$.*]] : $@convention(method) (@inout ${LType}, ${RType}, @thin ${Vector}.Type) -> ()
+  // CHECK: [[RET:%.*]] = apply [[FUNC]]([[MLHS]], [[RHS]], [[META]]) : $@convention(method) (@inout ${LType}, ${RType}, @thin ${Vector}.Type) -> ()
+  // CHECK: end_access [[MLHS]]
+  // CHECK: } // end sil function '[[FUNC_MUTATING_${labelSuffix}]]'
+  a ${opSymbol}= b
+}
+
+// CHECK: sil shared @[[FUNC_MUTATING_OPERATOR_${labelSuffix}]] : $@convention(method) (@inout ${LType}, ${RType}, @thin ${Vector}.Type) -> () {
+// CHECK: builtin "${opName}_${Builtin}"
+// CHECK: } // end sil function '[[FUNC_MUTATING_OPERATOR_${labelSuffix}]]'
+%    end
+%   end
+%  end
+
+% end
+%end

--- a/test/SILGen/simd_builtin_integer_operations.swift.gyb
+++ b/test/SILGen/simd_builtin_integer_operations.swift.gyb
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %gyb -D CMAKE_SIZEOF_VOID_P=$((%target-ptrsize/8)) %s -o %t/simd_builtin_integer_operations.swift
+// RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/simd_builtin_integer_operations.swift
 // RUN: %target-swift-emit-sil -Xllvm -sil-print-types %t/simd_builtin_integer_operations.swift | %FileCheck %t/simd_builtin_integer_operations.swift
 
 %{
 from SwiftIntTypes import all_integer_types
-word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+word_bits = int(WORD_BITS)
 storagescalarCounts = [2,4,8,16,32,64]
 vectorscalarCounts = storagescalarCounts + [3]
 }%

--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -78,6 +78,48 @@ ${Scalar}x${n}_TestSuite.test("comparisons") {
   }
 %  end
 }
+
+${Scalar}x${n}_TestSuite.test("comparisons with scalar") {
+%  if bits == 16:
+  if #available(SwiftStdlib 5.3, *) {
+%  end
+  let s = ${Scalar}.random(in: -1 ..< 1)
+  let sVector = ${Vector}(repeating: s)
+
+  expectTrue(all(s .== sVector))
+  expectFalse(any(s .!= sVector))
+  expectFalse(any(s .< sVector))
+  expectTrue(all(s .<= sVector))
+  expectFalse(any(s .> sVector))
+  expectTrue(all(s .>= sVector))
+
+  expectTrue(all(sVector .== s))
+  expectFalse(any(sVector .!= s))
+  expectFalse(any(sVector .< s))
+  expectTrue(all(sVector .<= s))
+  expectFalse(any(sVector .> s))
+  expectTrue(all(sVector .>= s))
+
+  let aVector = ${Vector}.random(in: -1 ..< 1)
+  let leftScalar = genericComparisons(sVector, aVector)
+  expectEqual(leftScalar.eq, s .== aVector)
+  expectEqual(leftScalar.ne, s .!= aVector)
+  expectEqual(leftScalar.lt, s .<  aVector)
+  expectEqual(leftScalar.le, s .<= aVector)
+  expectEqual(leftScalar.gt, s .>  aVector)
+  expectEqual(leftScalar.ge, s .>= aVector)
+
+  let rightScalar = genericComparisons(aVector, sVector)
+  expectEqual(rightScalar.eq, aVector .== s)
+  expectEqual(rightScalar.ne, aVector .!= s)
+  expectEqual(rightScalar.lt, aVector .<  s)
+  expectEqual(rightScalar.le, aVector .<= s)
+  expectEqual(rightScalar.gt, aVector .>  s)
+  expectEqual(rightScalar.ge, aVector .>= s)
+%  if bits == 16:
+  }
+%  end
+}
 %  if bits == 16:
   #endif
 %  end

--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -15,7 +15,6 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: rdar76545659
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/SIMDConcreteIntegers.swift.gyb
+++ b/test/stdlib/SIMDConcreteIntegers.swift.gyb
@@ -83,6 +83,42 @@ ${Scalar}x${n}_TestSuite.test("comparisons") {
   expectEqual(ge, a .>= b)
 }
 
+${Scalar}x${n}_TestSuite.test("comparisons with scalar") {
+  let s = ${Scalar}.random(in: ${Scalar}.min ... .max)
+  let sVector = ${Vector}(repeating: s)
+
+  expectTrue(all(s .== sVector))
+  expectFalse(any(s .!= sVector))
+  expectFalse(any(s .< sVector))
+  expectTrue(all(s .<= sVector))
+  expectFalse(any(s .> sVector))
+  expectTrue(all(s .>= sVector))
+
+  expectTrue(all(sVector .== s))
+  expectFalse(any(sVector .!= s))
+  expectFalse(any(sVector .< s))
+  expectTrue(all(sVector .<= s))
+  expectFalse(any(sVector .> s))
+  expectTrue(all(sVector .>= s))
+
+  let aVector = ${Vector}.random(in: ${Scalar}.min ... .max)
+  let leftScalar = genericComparisons(sVector, aVector)
+  expectEqual(leftScalar.eq, s .== aVector)
+  expectEqual(leftScalar.ne, s .!= aVector)
+  expectEqual(leftScalar.lt, s .<  aVector)
+  expectEqual(leftScalar.le, s .<= aVector)
+  expectEqual(leftScalar.gt, s .>  aVector)
+  expectEqual(leftScalar.ge, s .>= aVector)
+
+  let rightScalar = genericComparisons(aVector, sVector)
+  expectEqual(rightScalar.eq, aVector .== s)
+  expectEqual(rightScalar.ne, aVector .!= s)
+  expectEqual(rightScalar.lt, aVector .<  s)
+  expectEqual(rightScalar.le, aVector .<= s)
+  expectEqual(rightScalar.gt, aVector .>  s)
+  expectEqual(rightScalar.ge, aVector .>= s)
+}
+
 ${Scalar}x${n}_TestSuite.test("arithmetic") {
   let a = ${Vector}.random(in: ${Scalar}.min ... .max)
   let b = ${Vector}.random(in: ${Scalar}.min ... .max)
@@ -90,6 +126,46 @@ ${Scalar}x${n}_TestSuite.test("arithmetic") {
   expectEqual(add, a &+ b)
   expectEqual(sub, a &- b)
   expectEqual(mul, a &* b)
+
+  var addA = a
+  addA &+= b
+  expectEqual(add, addA)
+
+  var subA = a
+  subA &-= b
+  expectEqual(sub, subA)
+
+  var mulA = a
+  mulA &*= b
+  expectEqual(mul, mulA)
+}
+
+${Scalar}x${n}_TestSuite.test("arithmetic with scalar") {
+  let s = ${Scalar}.random(in: ${Scalar}.min ... .max)
+  let sVector = ${Vector}(repeating: s)
+  let aVector = ${Vector}.random(in: ${Scalar}.min ... .max)
+
+  let leftScalar = genericArithmetic(sVector, aVector)
+  expectEqual(leftScalar.add, s &+ aVector)
+  expectEqual(leftScalar.sub, s &- aVector)
+  expectEqual(leftScalar.mul, s &* aVector)
+
+  let rightScalar = genericArithmetic(aVector, sVector)
+  expectEqual(rightScalar.add, aVector &+ s)
+  expectEqual(rightScalar.sub, aVector &- s)
+  expectEqual(rightScalar.mul, aVector &* s)
+
+  var addA = aVector
+  addA &+= s
+  expectEqual(rightScalar.add, addA)
+
+  var subA = aVector
+  subA &-= s
+  expectEqual(rightScalar.sub, subA)
+
+  var mulA = aVector
+  mulA &*= s
+  expectEqual(rightScalar.mul, mulA)
 }
 
 % end


### PR DESCRIPTION
# Motivation

Although SIMD has operator functions that broadcast scalar into vector like [`func &+(a: Scalar, b: Self)`](https://github.com/swiftlang/swift/blob/5770d59e4d95083c61144b49694ad64fb7a460d3/stdlib/public/core/SIMDVector.swift#L1035-L1038), these functions won't dispatch [builtin vector implementations](https://github.com/swiftlang/swift/blob/5770d59e4d95083c61144b49694ad64fb7a460d3/stdlib/public/core/SIMDConcreteOperations.swift.gyb#L266-L268) since broadcast function are defined only in protocol extension of the `SIMD` and builtin vector implementations are located under each concrete types. 
(as you know, since operators are not part of requirements of the `SIMD` protocol, these protocol extension won't dispatch functions defined in each concrete types.)

```swift
let a: SIMD4<Int> = [1, 2, 3, 4]
let b: SIMD4<Int> = [5, 6, 7, 8]

// builtin vector implementations are dispatched
a &+ b
a .== b

// builtin vector implementations are NOT dispatched
a &+ 1
a .== 0
```

# Solution

Add implementation on each concrete types.