### PR TITLE
[embedded] Support Dictionary.init(uniqueKeysWithValues:) in Embedded Swift

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -486,6 +486,12 @@ public struct Dictionary<Key: Hashable, Value> {
     // error instead of calling fatalError() directly because we want the
     // message to include the duplicate key, and the closure only has access to
     // the conflicting values.
+    #if !$Embedded
+    try! native.merge(
+      keysAndValues,
+      isUnique: true,
+      uniquingKeysWith: { _, _ in throw _MergeError.keyCollision })
+    #else
     native.merge(
       keysAndValues,
       isUnique: true,
@@ -493,6 +499,7 @@ public struct Dictionary<Key: Hashable, Value> {
         throw _MergeError.keyCollision
       }
     )
+    #endif
     self.init(_native: native)
   }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -486,10 +486,13 @@ public struct Dictionary<Key: Hashable, Value> {
     // error instead of calling fatalError() directly because we want the
     // message to include the duplicate key, and the closure only has access to
     // the conflicting values.
-    try! native.merge(
+    native.merge(
       keysAndValues,
       isUnique: true,
-      uniquingKeysWith: { _, _ in throw _MergeError.keyCollision })
+      uniquingKeysWith: { _, _ throws(_MergeError) in
+        throw _MergeError.keyCollision
+      }
+    )
     self.init(_native: native)
   }
 

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -792,6 +792,33 @@ extension _NativeDictionary { // High-level operations
   }
 
   @inlinable
+  internal mutating func merge<S: Sequence>(
+    _ keysAndValues: __owned S,
+    isUnique: Bool,
+    uniquingKeysWith combine: (Value, Value) throws(_MergeError) -> Value
+  ) where S.Element == (Key, Value) {
+    var isUnique = isUnique
+    for (key, value) in keysAndValues {
+      let (bucket, found) = mutatingFind(key, isUnique: isUnique)
+      isUnique = true
+      if found {
+        do throws(_MergeError) {
+          let newValue = try combine(uncheckedValue(at: bucket), value)
+          _values[bucket.offset] = newValue
+        } catch {
+          #if !$Embedded
+          fatalError("Duplicate values for key: '\(key)'")
+          #else
+          fatalError("Duplicate values for a key in a Dictionary")
+          #endif
+        }
+      } else {
+        _insert(at: bucket, key: key, value: value)
+      }
+    }
+  }
+
+  @inlinable
   @inline(__always)
   internal init<S: Sequence>(
     grouping values: __owned S,

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -791,6 +791,7 @@ extension _NativeDictionary { // High-level operations
     }
   }
 
+  #if $Embedded
   @inlinable
   internal mutating func merge<S: Sequence>(
     _ keysAndValues: __owned S,
@@ -817,6 +818,7 @@ extension _NativeDictionary { // High-level operations
       }
     }
   }
+  #endif
 
   @inlinable
   @inline(__always)

--- a/test/embedded/dict-init.swift
+++ b/test/embedded/dict-init.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -wmo) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+public func foo() {
+    let d = Dictionary<Int, StaticString>.init(uniqueKeysWithValues: [(10, "hello"), (20, "world")])
+    print(d[10]!)
+    print(d[20]!)
+}
+
+foo()
+
+// CHECK: hello
+// CHECK: world

--- a/test/embedded/dict-init.swift
+++ b/test/embedded/dict-init.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 
 public func foo() {


### PR DESCRIPTION
See attached test case -- currently, attempting to use `Dictionary.init(uniqueKeysWithValues:)` results in:

```
Cannot use a value of protocol type ‘any Error’ in embedded Swift
Cannot do dynamic casting in embedded Swift
```

Both the errors are a result of using untyped throws in the implementation of `Dictionary.init(uniqueKeysWithValues:)`. Let's avoid that by using typed throws instead.

rdar://143089660