### PR TITLE
[embedded] Support withoutActuallyEscaping in Embedded Swift

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -272,9 +272,17 @@ public func swift_dynamicCastClass(object: UnsafeMutableRawPointer, targetMetada
 public func swift_dynamicCastClassUnconditional(object: UnsafeMutableRawPointer, targetMetadata: UnsafeRawPointer,
     file: UnsafePointer<CChar>, line: CUnsignedInt, column: CUnsignedInt) -> UnsafeMutableRawPointer {
   guard let result = swift_dynamicCastClass(object: object, targetMetadata: targetMetadata) else {
-    Builtin.int_trap()
+    fatalError("failed cast")
   }
   return result
+}
+
+@_cdecl("swift_isEscapingClosureAtFileLocation")
+public func swift_isEscapingClosureAtFileLocation(object: Builtin.RawPointer, filename: UnsafePointer<CChar>, filenameLength: Int32, line: Int32, column: Int32, verificationType: CUnsignedInt) -> Bool {
+  guard swift_isUniquelyReferenced_native(object: object) else {
+    fatalError("non-escaping closure escaped")
+  }
+  return false
 }
 
 @_cdecl("swift_isUniquelyReferenced_native")

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -279,6 +279,9 @@ public func swift_dynamicCastClassUnconditional(object: UnsafeMutableRawPointer,
 
 @_cdecl("swift_isEscapingClosureAtFileLocation")
 public func swift_isEscapingClosureAtFileLocation(object: Builtin.RawPointer, filename: UnsafePointer<CChar>, filenameLength: Int32, line: Int32, column: Int32, verificationType: CUnsignedInt) -> Bool {
+  let objectBits = UInt(Builtin.ptrtoint_Word(object))
+  if objectBits == 0 { return false }
+
   guard swift_isUniquelyReferenced_native(object: object) else {
     fatalError("non-escaping closure escaped")
   }

--- a/test/embedded/without-actually-escaping.swift
+++ b/test/embedded/without-actually-escaping.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -x c -c %S/Inputs/unbuffered-putchar.c -o %t/unbuffered-putchar.o
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+var sink: ()->() = {}
+
+func dontEscape(f: () -> ()) {
+  withoutActuallyEscaping(f) {
+    $0()
+  }
+}
+
+func dontEscape2(f: () -> ()) {
+  withoutActuallyEscaping(f) {
+    sink = $0
+    sink()
+    sink = {}
+  }
+}
+
+func letEscape(f: () -> ()) {
+  withoutActuallyEscaping(f) {
+    sink = $0
+    sink()
+  }
+}
+
+dontEscape(f: { print("A") })
+dontEscape2(f: { print("B") })
+letEscape(f: { print("C") })
+
+// CHECK: A
+// CHECK: B
+// CHECK: C
+// CHECK: non-escaping closure escaped

--- a/test/embedded/without-actually-escaping.swift
+++ b/test/embedded/without-actually-escaping.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: swift_feature_Embedded
 
 var sink: ()->() = {}


### PR DESCRIPTION
We were missing `swift_isEscapingClosureAtFileLocation` in the Embedded Swift runtime.

rdar://143070738
