### PR TITLE
Enable new stdlib build in macOS smoke tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -669,8 +669,7 @@ skip-test-sourcekit-lsp
 skip-test-swiftpm
 skip-test-llbuild
 
-# TODO: Look into why this causes the new test suite to fail to find the concurrency modules
-# swift-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
+extra-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx


### PR DESCRIPTION
This patch enables the new runtime build in macOS smoke testing in CI. This is only ensuring that the default configuration builds and does not enable anything fancy at this time.

This was disabled after tests started failing due to a missing `swift_Concurrency` runtime. This happened because I had uses `swift-cmake-options` to enable the new build, which overwrites existing build-script settings, like `enable-experimental-concurrency=1`. I've opted to go with `extra-cmake-options`, which appends options to all of the builds.