### PR TITLE
use correct path for libclang* libraries

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -50,6 +50,23 @@ toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
       .str();
 }
 
+StringRef getOSLibName(llvm::Triple Triple) {
+  if (Triple.isOSDarwin())
+    return "darwin";
+  switch (Triple.getOS()) {
+  case llvm::Triple::FreeBSD:
+    return "freebsd";
+  case llvm::Triple::NetBSD:
+    return "netbsd";
+  case llvm::Triple::Solaris:
+    return "sunos";
+  case llvm::Triple::AIX:
+    return "aix";
+  default:
+    return Triple.getOSName();
+  }
+}
+
 ToolChain::InvocationInfo
 toolchains::GenericUnix::constructInvocation(const InterpretJobAction &job,
                                              const JobContext &context) const {
@@ -366,7 +383,7 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");
 
-    llvm::sys::path::append(LibProfile, getTriple().getOSName(),
+    llvm::sys::path::append(LibProfile, getOSLibName(getTriple()),
                             Twine("libclang_rt.profile-") +
                                 getTriple().getArchName() + ".a");
     Arguments.push_back(context.Args.MakeArgString(LibProfile));


### PR DESCRIPTION
Currently resolution to the path containing libclang*.a libraries is incorrect for some platforms. The directory containing the libraries can not determined just by `getOSName()` but instead is platform specific, see llvm: [clang/lib/Driver/ToolChain.cpp#L686](https://github.com/swiftlang/llvm-project/blob/985636ed916ef54e2df74f9d72fc20656b11c094/clang/lib/Driver/ToolChain.cpp#L686).

Copying the `getOSLibName` over from `llvm` and use it instead. This fixes some SIL tests on `x86_64-unknown-freebsd`