### PR TITLE
utils: remove duplication from a bad merge

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1938,12 +1938,6 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         (Get-Variable "${Platform}$($Arch.ShortName)" -ValueOnly).SDKInstallRoot
       }
 
-      $SDKRoot = if ($Platform -eq "Windows") {
-        ""
-      } else {
-        (Get-Variable "${Platform}$($Arch.ShortName)" -ValueOnly).SDKInstallRoot
-      }
-
       Build-CMakeProject `
         -Src $SourceCache\swift-corelibs-foundation `
         -Bin $FoundationBinaryCache `


### PR DESCRIPTION
We were computing the SDKROOT multiply with the same logic twice which is unneeded. Clean this up to compute it once.