### PR TITLE
Parse/Sema: Resolve availability domains in SemanticAvailableAttrRequest

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -737,8 +737,17 @@ public:
     NoAsync,
   };
 
-  AvailableAttr(SourceLoc AtLoc, SourceRange Range,
-                const AvailabilityDomain &Domain, Kind Kind, StringRef Message,
+  AvailableAttr(SourceLoc AtLoc, SourceRange Range, AvailabilityDomain Domain,
+                SourceLoc DomainLoc, Kind Kind, StringRef Message,
+                StringRef Rename, const llvm::VersionTuple &Introduced,
+                SourceRange IntroducedRange,
+                const llvm::VersionTuple &Deprecated,
+                SourceRange DeprecatedRange,
+                const llvm::VersionTuple &Obsoleted, SourceRange ObsoletedRange,
+                bool Implicit, bool IsSPI);
+
+  AvailableAttr(SourceLoc AtLoc, SourceRange Range, StringRef DomainString,
+                SourceLoc DomainLoc, Kind Kind, StringRef Message,
                 StringRef Rename, const llvm::VersionTuple &Introduced,
                 SourceRange IntroducedRange,
                 const llvm::VersionTuple &Deprecated,
@@ -749,7 +758,11 @@ public:
 private:
   friend class SemanticAvailableAttr;
 
-  AvailabilityDomain Domain;
+  union {
+    AvailabilityDomain Domain;
+    StringRef DomainString;
+  };
+  const SourceLoc DomainLoc;
 
   const StringRef Message;
   const StringRef Rename;
@@ -762,6 +775,30 @@ private:
   const SourceRange ObsoletedRange;
 
 public:
+  /// Returns true if the `AvailabilityDomain` associated with the attribute
+  /// has been resolved successfully.
+  bool hasCachedDomain() const { return Bits.AvailableAttr.HasDomain; }
+
+  /// Returns the `AvailabilityDomain` associated with the attribute, or
+  /// `std::nullopt` if it has either not yet been resolved or could not be
+  /// resolved successfully.
+  std::optional<AvailabilityDomain> getCachedDomain() const {
+    if (hasCachedDomain())
+      return Domain;
+    return std::nullopt;
+  }
+
+  /// If the attribute does not already have a cached `AvailabilityDomain`, this
+  /// returns the domain string that was written in source, from which an
+  /// `AvailabilityDomain` can be resolved.
+  std::optional<StringRef> getDomainString() const {
+    if (hasCachedDomain())
+      return std::nullopt;
+    return DomainString;
+  }
+
+  SourceLoc getDomainLoc() const { return DomainLoc; }
+
   /// Returns the parsed version for `introduced:`.
   std::optional<llvm::VersionTuple> getRawIntroduced() const {
     if (Introduced.empty())
@@ -812,19 +849,6 @@ public:
 
   /// Whether this attribute was spelled `@_spi_available`.
   bool isSPI() const { return Bits.AvailableAttr.IsSPI; }
-
-  /// Returns the `AvailabilityDomain` associated with the attribute, or
-  /// `std::nullopt` if it has either not yet been resolved or could not be
-  /// resolved successfully.
-  std::optional<AvailabilityDomain> getCachedDomain() const {
-    if (hasCachedDomain())
-      return Domain;
-    return std::nullopt;
-  }
-
-  /// Returns true if the `AvailabilityDomain` associated with the attribute
-  /// has been resolved successfully.
-  bool hasCachedDomain() const { return Bits.AvailableAttr.HasDomain; }
 
   /// Returns the kind of availability the attribute specifies.
   Kind getKind() const { return static_cast<Kind>(Bits.AvailableAttr.Kind); }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -767,11 +767,11 @@ private:
   const StringRef Message;
   const StringRef Rename;
 
-  const llvm::VersionTuple Introduced;
+  llvm::VersionTuple Introduced;
   const SourceRange IntroducedRange;
-  const llvm::VersionTuple Deprecated;
+  llvm::VersionTuple Deprecated;
   const SourceRange DeprecatedRange;
-  const llvm::VersionTuple Obsoleted;
+  llvm::VersionTuple Obsoleted;
   const SourceRange ObsoletedRange;
 
 public:
@@ -911,6 +911,12 @@ private:
 
 private:
   friend class SemanticAvailableAttrRequest;
+
+  void setRawIntroduced(llvm::VersionTuple version) { Introduced = version; }
+
+  void setRawDeprecated(llvm::VersionTuple version) { Deprecated = version; }
+
+  void setRawObsoleted(llvm::VersionTuple version) { Obsoleted = version; }
 
   void setCachedDomain(AvailabilityDomain domain) {
     assert(!Bits.AvailableAttr.HasDomain);

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -912,6 +912,12 @@ private:
 private:
   friend class SemanticAvailableAttrRequest;
 
+  void setCachedDomain(AvailabilityDomain domain) {
+    assert(!Bits.AvailableAttr.HasDomain);
+    Domain = domain;
+    Bits.AvailableAttr.HasDomain = true;
+  }
+
   bool hasComputedSemanticAttr() const {
     return Bits.AvailableAttr.HasComputedSemanticAttr;
   }

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -140,6 +140,10 @@ public:
     return AvailabilityDomain(Kind::Embedded);
   }
 
+  /// Returns the built-in availability domain identified by the given string.
+  static std::optional<AvailabilityDomain>
+  builtinDomainForString(StringRef string);
+
   Kind getKind() const {
     if (auto inlineDomain = getInlineDomain())
       return inlineDomain->getKind();

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1579,16 +1579,6 @@ ERROR(attr_availability_expected_equal,none,
 ERROR(attr_availability_expected_version,none,
       "expected version number in '%0' attribute", (StringRef))
 
-WARNING(attr_availability_platform_agnostic_expected_option,none,
-      "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
-      "for platform '%1'", (StringRef, StringRef))
-WARNING(attr_availability_platform_agnostic_expected_deprecated_version,none,
-      "expected version number with 'deprecated' in '%0' attribute for "
-      "platform '%1'", (StringRef, StringRef))
-WARNING(attr_availability_platform_agnostic_infeasible_option,none,
-      "'%0' cannot be used in '%1' attribute for platform '%2'",
-      (StringRef, StringRef, StringRef))
-
 WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
       "'*'", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6715,6 +6715,16 @@ NOTE(type_eraser_init_spi,none,
 // MARK: @available
 //------------------------------------------------------------------------------
 
+WARNING(attr_availability_expected_deprecated_version, none,
+       "expected version number with 'deprecated' in '%0' attribute for "
+       "platform '%1'", (StringRef, StringRef))
+WARNING(attr_availability_cannot_be_used_for_domain, none,
+       "'%0' cannot be used in '%1' attribute for platform '%2'",
+       (StringRef, StringRef, StringRef))
+WARNING(attr_availability_expected_version_spec, none,
+       "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
+       "for platform '%1'", (StringRef, StringRef))
+
 ERROR(availability_decl_unavailable, none,
       "%0 is unavailable%select{ in %2|}1%select{|: %3}3",
       (const ValueDecl *, bool, StringRef, StringRef))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -191,9 +191,10 @@ static AvailableAttr *createAvailableAttr(AvailabilityDomain Domain,
       Inferred.Obsoleted.value_or(llvm::VersionTuple());
 
   return new (Context) AvailableAttr(
-      SourceLoc(), SourceRange(), Domain, Inferred.Kind, Inferred.Message,
-      Inferred.Rename, Introduced, SourceRange(), Deprecated, SourceRange(),
-      Obsoleted, SourceRange(), /*Implicit=*/true, Inferred.IsSPI);
+      SourceLoc(), SourceRange(), Domain, SourceLoc(), Inferred.Kind,
+      Inferred.Message, Inferred.Rename, Introduced, SourceRange(), Deprecated,
+      SourceRange(), Obsoleted, SourceRange(), /*Implicit=*/true,
+      Inferred.IsSPI);
 }
 
 void AvailabilityInference::applyInferredAvailableAttrs(

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2735,4 +2735,6 @@ void SemanticAvailableAttrRequest::cacheResult(
     std::optional<SemanticAvailableAttr> value) const {
   AvailableAttr *attr = const_cast<AvailableAttr *>(std::get<0>(getStorage()));
   attr->setComputedSemanticAttr();
+  if (!value)
+    attr->setInvalid();
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8078,7 +8078,7 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
     llvm::VersionTuple NoVersion;
     auto *attr = new (SwiftContext) AvailableAttr(
         SourceLoc(), SourceRange(), AvailabilityDomain::forUniversal(),
-        AvailableAttr::Kind::Default,
+        SourceLoc(), AvailableAttr::Kind::Default,
         /*Message=*/"", /*Rename=*/"", /*Introduced=*/NoVersion, SourceRange(),
         /*Deprecated=*/NoVersion, SourceRange(),
         /*Obsoleted=*/NoVersion, SourceRange(),
@@ -9107,12 +9107,12 @@ void ClangImporter::Implementation::importAttributes(
       if (!replacement.empty())
         swiftReplacement = getSwiftNameFromClangName(replacement);
 
-      auto AvAttr = new (C)
-          AvailableAttr(SourceLoc(), SourceRange(),
-                        AvailabilityDomain::forPlatform(*platformK), AttrKind,
-                        message, swiftReplacement, introduced, SourceRange(),
-                        deprecated, SourceRange(), obsoleted, SourceRange(),
-                        /*Implicit=*/false, EnableClangSPI && IsSPI);
+      auto AvAttr = new (C) AvailableAttr(
+          SourceLoc(), SourceRange(),
+          AvailabilityDomain::forPlatform(*platformK), SourceLoc(), AttrKind,
+          message, swiftReplacement, introduced, SourceRange(), deprecated,
+          SourceRange(), obsoleted, SourceRange(),
+          /*Implicit=*/false, EnableClangSPI && IsSPI);
 
       MappedDecl->getAttrs().add(AvAttr);
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -628,8 +628,8 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   }
 
   auto Attr = new (Context) AvailableAttr(
-      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Domain, PlatformLoc, AttrKind,
-      Message, Renamed, Introduced.Version, Introduced.Range,
+      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Platform, PlatformLoc,
+      AttrKind, Message, Renamed, Introduced.Version, Introduced.Range,
       Deprecated.Version, Deprecated.Range, Obsoleted.Version, Obsoleted.Range,
       /*Implicit=*/false, AttrName == SPI_AVAILABLE_ATTRNAME);
   return makeParserResult(Attr);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -542,62 +542,14 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
              /*isDeclModifier*/ false);
   }
 
-  auto PlatformKind = platformFromString(Platform);
-  auto Domain = (PlatformKind && *PlatformKind != PlatformKind::none)
-                    ? AvailabilityDomain::forPlatform(*PlatformKind)
-                    : AvailabilityDomain::forUniversal();
+  if (AnyArgumentInvalid)
+    return nullptr;
 
-  // Treat 'swift' as a valid version-qualifying token, when
-  // at least some versions were mentioned and no other
-  // platform-agnostic availability spec has been provided.
+  // Warn if any version is specified with the universal domain ('*').
   bool SomeVersion = (!Introduced.empty() ||
                       !Deprecated.empty() ||
                       !Obsoleted.empty());
-  if (!PlatformKind.has_value() &&
-      (Platform == "swift" || Platform == "_PackageDescription")) {
-
-    if (AttrKind == AvailableAttr::Kind::Deprecated) {
-      diagnose(AttrLoc,
-               diag::attr_availability_platform_agnostic_expected_deprecated_version,
-               AttrName, Platform);
-      return nullptr;
-    }
-    if (AttrKind == AvailableAttr::Kind::Unavailable) {
-      diagnose(AttrLoc, diag::attr_availability_platform_agnostic_infeasible_option,
-               "unavailable", AttrName, Platform);
-      return nullptr;
-    }
-    assert(AttrKind == AvailableAttr::Kind::Default);
-
-    if (!SomeVersion) {
-      diagnose(AttrLoc, diag::attr_availability_platform_agnostic_expected_option,
-               AttrName, Platform);
-      return nullptr;
-    }
-
-    PlatformKind = PlatformKind::none;
-    Domain = (Platform == "swift")
-                 ? AvailabilityDomain::forSwiftLanguage()
-                 : AvailabilityDomain::forPackageDescription();
-  }
-
-
-  if (AnyArgumentInvalid)
-    return nullptr;
-  if (!PlatformKind.has_value()) {
-    if (auto CorrectedPlatform = closestCorrectedPlatformString(Platform)) {
-      diagnose(PlatformLoc, diag::attr_availability_suggest_platform, Platform,
-               AttrName, *CorrectedPlatform)
-          .fixItReplace(SourceRange(PlatformLoc), *CorrectedPlatform);
-    } else {
-      diagnose(AttrLoc, diag::attr_availability_unknown_platform, Platform,
-               AttrName);
-    }
-    return nullptr;
-  }
-
-  // Warn if any version is specified for non-specific platform '*'.
-  if (Domain.isUniversal() && SomeVersion) {
+  if (Platform == "*" && SomeVersion) {
     auto diag = diagnose(AttrLoc,
         diag::attr_availability_nonspecific_platform_unexpected_version,
         AttrName);
@@ -613,7 +565,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     return nullptr;
   }
 
-  if (PlatformKind) {
+  if (auto PlatformKind = platformFromString(Platform)) {
       if (!Introduced.empty())
         Introduced.Version =
             canonicalizePlatformVersion(*PlatformKind, Introduced.Version);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -628,9 +628,9 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   }
 
   auto Attr = new (Context) AvailableAttr(
-      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Domain, AttrKind, Message,
-      Renamed, Introduced.Version, Introduced.Range, Deprecated.Version,
-      Deprecated.Range, Obsoleted.Version, Obsoleted.Range,
+      AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Domain, PlatformLoc, AttrKind,
+      Message, Renamed, Introduced.Version, Introduced.Range,
+      Deprecated.Version, Deprecated.Range, Obsoleted.Version, Obsoleted.Range,
       /*Implicit=*/false, AttrName == SPI_AVAILABLE_ATTRNAME);
   return makeParserResult(Attr);
 
@@ -899,7 +899,8 @@ bool Parser::parseAvailability(
             canonicalizePlatformVersion(Domain.getPlatformKind(), Version);
 
       addAttribute(new (Context) AvailableAttr(
-          AtLoc, attrRange, Domain, AvailableAttr::Kind::Default,
+          AtLoc, attrRange, Domain, Spec->getSourceRange().Start,
+          AvailableAttr::Kind::Default,
           /*Message=*/StringRef(),
           /*Rename=*/StringRef(),
           /*Introduced=*/Version,
@@ -4410,7 +4411,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
       StringRef Message = "unavailable in embedded Swift", Renamed;
       auto attr = new (Context) AvailableAttr(
           AtLoc, SourceRange(AtLoc, attrLoc), AvailabilityDomain::forEmbedded(),
-          AvailableAttr::Kind::Unavailable, Message, Renamed,
+          SourceLoc(), AvailableAttr::Kind::Unavailable, Message, Renamed,
           llvm::VersionTuple(), SourceRange(), llvm::VersionTuple(),
           SourceRange(), llvm::VersionTuple(), SourceRange(),
           /*Implicit=*/false, /*IsSPI=*/false);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -565,20 +565,6 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     return nullptr;
   }
 
-  if (auto PlatformKind = platformFromString(Platform)) {
-      if (!Introduced.empty())
-        Introduced.Version =
-            canonicalizePlatformVersion(*PlatformKind, Introduced.Version);
-
-      if (!Deprecated.empty())
-        Deprecated.Version =
-            canonicalizePlatformVersion(*PlatformKind, Deprecated.Version);
-
-      if (!Obsoleted.empty())
-        Obsoleted.Version =
-            canonicalizePlatformVersion(*PlatformKind, Obsoleted.Version);
-  }
-
   auto Attr = new (Context) AvailableAttr(
       AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Platform, PlatformLoc,
       AttrKind, Message, Renamed, Introduced.Version, Introduced.Range,
@@ -845,10 +831,6 @@ bool Parser::parseAvailability(
       } else {
         continue;
       }
-
-      if (Domain.isPlatform())
-        Version =
-            canonicalizePlatformVersion(Domain.getPlatformKind(), Version);
 
       addAttribute(new (Context) AvailableAttr(
           AtLoc, attrRange, Domain, Spec->getSourceRange().Start,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8298,18 +8298,25 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   }
 
   if (domain->isSwiftLanguage() || domain->isPackageDescription()) {
-    if (attrKind == AvailableAttr::Kind::Deprecated) {
+    switch (attrKind) {
+    case AvailableAttr::Kind::Deprecated:
       diags.diagnose(attrLoc,
                      diag::attr_availability_expected_deprecated_version,
                      attrName, *string);
       return std::nullopt;
-    }
-    if (attrKind == AvailableAttr::Kind::Unavailable) {
+
+    case AvailableAttr::Kind::Unavailable:
       diags.diagnose(attrLoc, diag::attr_availability_cannot_be_used_for_domain,
                      "unavailable", attrName, *string);
       return std::nullopt;
+
+    case AvailableAttr::Kind::NoAsync:
+      diags.diagnose(attrLoc, diag::attr_availability_cannot_be_used_for_domain,
+                     "noasync", attrName, *string);
+      break;
+    case AvailableAttr::Kind::Default:
+      break;
     }
-    assert(attrKind == AvailableAttr::Kind::Default);
 
     bool hasVersionSpec = (attr->getRawIntroduced() ||
                            attr->getRawDeprecated() || attr->getRawObsoleted());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8270,6 +8270,17 @@ std::optional<SemanticAvailableAttr>
 SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
                                        const AvailableAttr *attr,
                                        const Decl *decl) const {
+  if (attr->hasCachedDomain())
+    return SemanticAvailableAttr(attr);
+
+  auto string = attr->getDomainString();
+  ASSERT(string);
+
+  auto domain = AvailabilityDomain::builtinDomainForString(*string);
+  if (!domain)
+    return std::nullopt;
+
+  const_cast<AvailableAttr *>(attr)->setCachedDomain(*domain);
   return SemanticAvailableAttr(attr);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6664,7 +6664,7 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
 
       auto attr = new (ctx) AvailableAttr(
           SourceLoc(), SourceRange(),
-          AvailabilityDomain::forPlatform(available.getPlatform()),
+          AvailabilityDomain::forPlatform(available.getPlatform()), SourceLoc(),
           AvailableAttr::Kind::Unavailable, available.getMessage(),
           /*Rename=*/"", available.getIntroduced().value_or(noVersion),
           SourceRange(), available.getDeprecated().value_or(noVersion),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5643,7 +5643,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   }
 
   auto attr = new (ctx)
-      AvailableAttr(SourceLoc(), SourceRange(), domain, kind, message, rename,
+      AvailableAttr(SourceLoc(), SourceRange(), domain, SourceLoc(), kind, message, rename,
                     Introduced, SourceRange(), Deprecated, SourceRange(),
                     Obsoleted, SourceRange(), isImplicit, isSPI);
   return attr;

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -18,6 +18,16 @@ func asyncReplacement() async -> Int { }
 @available(*, noasync, renamed: "IOActor.readString()")
 func readStringFromIO() -> String {}
 
+// expected-warning@+2 {{'noasync' cannot be used in 'available' attribute for platform 'swift'}}
+// expected-warning@+1 {{expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'swift'}}
+@available(swift, noasync)
+func swiftNoAsync() { }
+
+// expected-warning@+2 {{'noasync' cannot be used in 'available' attribute for platform '_PackageDescription'}}
+// expected-warning@+1 {{expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform '_PackageDescription'}}
+@available(_PackageDescription, noasync)
+func packageDescriptionNoAsync() { }
+
 @available(SwiftStdlib 5.5, *)
 actor IOActor {
     func readString() -> String {


### PR DESCRIPTION
Make `SemanticAvailableAttrRequest` responsible for looking up the `AvailabilityDomain` for an `@available` attribute. Move domain-specific diagnostics out of parsing and into `SemanticAvailableAttrRequest`.

Progress towards rdar://138441297.