### PR TITLE
Sema: Always allow method overrides to be as available as the context

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1575,6 +1575,12 @@ TypeChecker::availabilityAtLocation(SourceLoc loc, const DeclContext *DC,
   return availability;
 }
 
+AvailabilityContext
+TypeChecker::availabilityForDeclSignature(const Decl *decl) {
+  return TypeChecker::availabilityAtLocation(decl->getLoc(),
+                                             decl->getInnermostDeclContext());
+}
+
 AvailabilityRange TypeChecker::overApproximateAvailabilityAtLocation(
     SourceLoc loc, const DeclContext *DC,
     const AvailabilityScope **MostRefined) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1817,10 +1817,10 @@ static bool isAvailabilitySafeForOverride(ValueDecl *override,
 
   // Allow overrides that are not as available as the base decl as long as the
   // override is as available as its context.
-  auto overrideTypeAvailability = AvailabilityInference::availableRange(
+  auto availabilityContext = TypeChecker::availabilityForDeclSignature(
       override->getDeclContext()->getSelfNominalTypeDecl());
 
-  return overrideTypeAvailability.isContainedIn(overrideInfo);
+  return availabilityContext.getPlatformRange().isContainedIn(overrideInfo);
 }
 
 /// Returns true if a diagnostic about an accessor being less available

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1011,6 +1011,9 @@ AvailabilityContext
 availabilityAtLocation(SourceLoc loc, const DeclContext *DC,
                        const AvailabilityScope **MostRefined = nullptr);
 
+/// Returns the availability context of the signature of the given declaration.
+AvailabilityContext availabilityForDeclSignature(const Decl *decl);
+
 /// Returns an over-approximation of the range of operating system versions
 /// that could the passed-in location could be executing upon for
 /// the target platform. If MostRefined != nullptr, set to the most-refined

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -238,7 +238,7 @@ protocol BaseProto {
 
   var property: A { get set } // expected-note {{overridden declaration is here}}
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   var newProperty: A { get set } // expected-note {{overridden declaration is here}}
 
   func method() // expected-note {{overridden declaration is here}}
@@ -247,24 +247,24 @@ protocol BaseProto {
 protocol RefinesBaseProto_AsAvailableOverrides: BaseProto {
   var property: A { get set }
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   var newProperty: A { get set }
 
   func method()
 }
 
 protocol RefinesBaseProto_LessAvailableOverrides: BaseProto {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   var property: A { get set } // expected-error {{overriding 'property' must be as available as declaration it overrides}}
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   var newProperty: A { get set } // expected-error {{overriding 'newProperty' must be as available as declaration it overrides}}
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func method()  // expected-error {{overriding 'method' must be as available as declaration it overrides}}
 }
 
-@available(OSX 10.52, *)
+@available(OSX 52, *)
 protocol RefinesBaseProto_LessAvailable: BaseProto {
   var property: A { get set }
   var newProperty: A { get set }
@@ -889,6 +889,57 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
     @available(OSX, introduced: 51)
     get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
+  }
+}
+
+extension ClassAvailableOn10_9 {
+  class NestedSubWithLimitedMemberAvailability: SuperWithAlwaysAvailableMembers {
+    @available(OSX, introduced: 10.9)
+    override func shouldAlwaysBeAvailableMethod() {}
+
+    @available(OSX, introduced: 10.9)
+    override var shouldAlwaysBeAvailableProperty: Int {
+      get { return 10 }
+      set(newVal) {}
+    }
+
+    override var setterShouldAlwaysBeAvailableProperty: Int {
+      get { return 9 }
+      @available(OSX, introduced: 10.9)
+      set(newVal) {}
+    }
+
+    override var getterShouldAlwaysBeAvailableProperty: Int {
+      @available(OSX, introduced: 10.9)
+      get { return 9 }
+      set(newVal) {}
+    }
+  }
+}
+
+@available(OSX, introduced: 51)
+extension ClassAvailableOn51 {
+  class NestedSubWithLimitedMemberAvailability: SuperWithAlwaysAvailableMembers {
+    @available(OSX, introduced: 51)
+    override func shouldAlwaysBeAvailableMethod() {}
+
+    @available(OSX, introduced: 51)
+    override var shouldAlwaysBeAvailableProperty: Int {
+      get { return 10 }
+      set(newVal) {}
+    }
+
+    override var setterShouldAlwaysBeAvailableProperty: Int {
+      get { return 9 }
+      @available(OSX, introduced: 51)
+      set(newVal) {}
+    }
+
+    override var getterShouldAlwaysBeAvailableProperty: Int {
+      @available(OSX, introduced: 51)
+      get { return 9 }
+      set(newVal) {}
+    }
   }
 }
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1690,3 +1690,170 @@ public enum UnavailableEnumWithClasses {
   public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {}
   public class InheritsUnavailable: UnavailableClass {}
 }
+
+// MARK: - Overrides
+
+public class Base {
+  @available(macOS 10.9, *)
+  public func beforeInliningTargetMethod() {} // expected-note 3 {{overridden declaration is here}}
+
+  @available(macOS 10.10, *)
+  public func atInliningTargetMethod() {}// expected-note 3 {{overridden declaration is here}}
+
+  @available(macOS 10.14.5, *)
+  public func betweenTargetsMethod() {}// expected-note 3 {{overridden declaration is here}}
+
+  @available(macOS 10.15, *)
+  public func atDeploymentTargetMethod() {}// expected-note 2 {{overridden declaration is here}}
+
+  @available(macOS 11, *)
+  public func afterDeploymentTargetMethod() {}// expected-note {{overridden declaration is here}}
+}
+
+public class DerivedNoAvailable: Base {
+  public override func beforeInliningTargetMethod() {}
+  public override func atInliningTargetMethod() {}
+  public override func betweenTargetsMethod() {}
+  public override func atDeploymentTargetMethod() {}
+  public override func afterDeploymentTargetMethod() {}
+}
+
+@available(macOS 10.9, *)
+public class DerivedBeforeInliningTarget: Base {
+  @available(macOS 10.9, *)
+  public override func beforeInliningTargetMethod() {}
+  @available(macOS 10.9, *)
+  public override func atInliningTargetMethod() {}
+  @available(macOS 10.9, *)
+  public override func betweenTargetsMethod() {}
+  @available(macOS 10.9, *)
+  public override func atDeploymentTargetMethod() {}
+  @available(macOS 10.9, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+@available(macOS 10.10, *)
+public class DerivedAtInliningTarget: Base {
+  @available(macOS 10.10, *)
+  public override func beforeInliningTargetMethod() {}
+  @available(macOS 10.10, *)
+  public override func atInliningTargetMethod() {}
+  @available(macOS 10.10, *)
+  public override func betweenTargetsMethod() {}
+  @available(macOS 10.10, *)
+  public override func atDeploymentTargetMethod() {}
+  @available(macOS 10.10, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+@available(macOS 10.14.5, *)
+public class DerivedBetweenTargets: Base {
+  @available(macOS 10.14.5, *)
+  public override func beforeInliningTargetMethod() {}
+  @available(macOS 10.14.5, *)
+  public override func atInliningTargetMethod() {}
+  @available(macOS 10.14.5, *)
+  public override func betweenTargetsMethod() {}
+  @available(macOS 10.14.5, *)
+  public override func atDeploymentTargetMethod() {}
+  @available(macOS 10.14.5, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+@available(macOS 10.15, *)
+public class DerivedAtDeploymentTarget: Base {
+  @available(macOS 10.15, *)
+  public override func beforeInliningTargetMethod() {}
+  @available(macOS 10.15, *)
+  public override func atInliningTargetMethod() {}
+  @available(macOS 10.15, *)
+  public override func betweenTargetsMethod() {}
+  @available(macOS 10.15, *)
+  public override func atDeploymentTargetMethod() {}
+  @available(macOS 10.15, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+@available(macOS 11, *)
+public class DerivedAfterDeploymentTarget: Base {
+  @available(macOS 11, *)
+  public override func beforeInliningTargetMethod() {}
+  @available(macOS 11, *)
+  public override func atInliningTargetMethod() {}
+  @available(macOS 11, *)
+  public override func betweenTargetsMethod() {}
+  @available(macOS 11, *)
+  public override func atDeploymentTargetMethod() {}
+  @available(macOS 11, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+public class DerivedAtDeploymentTargetOverrides: Base {
+  @available(macOS 10.15, *)
+  public override func beforeInliningTargetMethod() {} // expected-error {{overriding 'beforeInliningTargetMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 10.15, *)
+  public override func atInliningTargetMethod() {} // expected-error {{overriding 'atInliningTargetMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 10.15, *)
+  public override func betweenTargetsMethod() {} // expected-error {{overriding 'betweenTargetsMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 10.15, *)
+  public override func atDeploymentTargetMethod() {}
+
+  @available(macOS 10.15, *)
+  public override func afterDeploymentTargetMethod() {}
+}
+
+public class DerivedFutureOverrides: Base {
+  @available(macOS 12, *)
+  public override func beforeInliningTargetMethod() {} // expected-error {{overriding 'beforeInliningTargetMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 12, *)
+  public override func atInliningTargetMethod() {} // expected-error {{overriding 'atInliningTargetMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 12, *)
+  public override func betweenTargetsMethod() {} // expected-error {{overriding 'betweenTargetsMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 12, *)
+  public override func atDeploymentTargetMethod() {} // expected-error {{overriding 'atDeploymentTargetMethod' must be as available as declaration it overrides}}
+
+  @available(macOS 12, *)
+  public override func afterDeploymentTargetMethod() {} // expected-error {{overriding 'afterDeploymentTargetMethod' must be as available as declaration it overrides}}
+}
+
+extension AtDeploymentTarget {
+  public class DerivedAtDeploymentTargetOverrides: Base {
+    @available(macOS 10.15, *)
+    public override func beforeInliningTargetMethod() {}
+
+    @available(macOS 10.15, *)
+    public override func atInliningTargetMethod() {}
+
+    @available(macOS 10.15, *)
+    public override func betweenTargetsMethod() {}
+
+    @available(macOS 10.15, *)
+    public override func atDeploymentTargetMethod() {}
+
+    @available(macOS 10.15, *)
+    public override func afterDeploymentTargetMethod() {}
+  }
+
+  public class DerivedAfterDeploymentTargetOverrides: Base {
+    @available(macOS 11, *)
+    public override func beforeInliningTargetMethod() {} // expected-error {{overriding 'beforeInliningTargetMethod' must be as available as declaration it overrides}}
+
+    @available(macOS 11, *)
+    public override func atInliningTargetMethod() {} // expected-error {{overriding 'atInliningTargetMethod' must be as available as declaration it overrides}}
+
+    @available(macOS 11, *)
+    public override func betweenTargetsMethod() {} // expected-error {{overriding 'betweenTargetsMethod' must be as available as declaration it overrides}}
+
+    @available(macOS 11, *)
+    public override func atDeploymentTargetMethod() {} // expected-error {{overriding 'atDeploymentTargetMethod' must be as available as declaration it overrides}}
+
+    @available(macOS 11, *)
+    public override func afterDeploymentTargetMethod() {}
+  }
+}


### PR DESCRIPTION
When a method override is as available as the class it's a member of, then it can't be any more available. It doesn't make sense to diagnose such a method as less available than the method it overrides. This regressed recently for methods belonging to classes that are nested inside extensions. The availability of the derived class may be defined by its context, but the compiler was only checking the availability attributes directly on the class.

Resolves rdar://143600638.