### PR TITLE
DeinitDevirtualizer: bail out for C++ move-only types

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -20,6 +20,9 @@ public class Decl: CustomStringConvertible, Hashable {
 
   public var description: String { String(taking: bridged.getDebugDescription()) }
 
+  // True if this declaration is imported from C/C++/ObjC.
+  public var hasClangNode: Bool { bridged.hasClangNode() }
+
   public static func ==(lhs: Decl, rhs: Decl) -> Bool { lhs === rhs }
 
   public func hash(into hasher: inout Hasher) {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -39,6 +39,12 @@ private func devirtualize(destroy: some DevirtualizableDestroy, _ context: some 
     return true
   }
 
+  // We cannot de-virtualize C++ destructor calls of C++ move-only types because we cannot get
+  // its destructor (`nominal.valueTypeDestructor` is nil).
+  if nominal.hasClangNode {
+    return false
+  }
+
   if nominal.valueTypeDestructor != nil && !destroy.shouldDropDeinit {
     guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
       return false

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -333,6 +333,7 @@ struct BridgedDeclObj {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef Type_getName() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef Value_getUserFacingName() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSourceLoc Value_getNameLoc() const;
+  BRIDGED_INLINE bool hasClangNode() const;
   BRIDGED_INLINE bool Value_isObjC() const;
   BRIDGED_INLINE bool GenericType_isGenericAtAnyLevel() const;
   BRIDGED_INLINE bool NominalType_isGlobalActor() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -158,6 +158,10 @@ BridgedSourceLoc BridgedDeclObj::Value_getNameLoc() const {
   return BridgedSourceLoc(getAs<swift::ValueDecl>()->getNameLoc().getOpaquePointerValue());
 }
 
+bool BridgedDeclObj::hasClangNode() const {
+  return unbridged()->hasClangNode();
+}
+
 bool BridgedDeclObj::Value_isObjC() const {
   return getAs<swift::ValueDecl>()->isObjC();
 }

--- a/test/SILOptimizer/Inputs/CXXTypesWithUserProvidedDestructor.h
+++ b/test/SILOptimizer/Inputs/CXXTypesWithUserProvidedDestructor.h
@@ -19,4 +19,15 @@ struct HasMemberWithUserProvidedDestructor {
   ~HasMemberWithUserProvidedDestructor() {}
 };
 
+void foo();
+
+struct NonCopyable {
+  NonCopyable(int x) : x(x) {}
+  NonCopyable(const NonCopyable &) = delete;
+  NonCopyable(NonCopyable &&other) : x(other.x) { other.x = -123; }
+  ~NonCopyable() { foo(); }
+
+  int x;
+};
+
 #endif // TEST_SIL_OPTIMIZER_CXX_WITH_CUSTOM_DESTRUCTOR_H

--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types %s -deinit-devirtualizer -module-name=test | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types %s -deinit-devirtualizer -module-name=test -enable-experimental-cxx-interop -I %S/Inputs | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 
@@ -7,6 +7,7 @@ sil_stage canonical
 import Builtin
 import Swift
 import SwiftShims
+import CXXTypesWithUserProvidedDestructor
 
 @inline(never) func log(_ s: StaticString)
 
@@ -281,6 +282,16 @@ bb0(%0 : $*T):
   destroy_addr %0 : $*T
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nodevirt_of_cxx_type :
+// CHECK:         destroy_addr %0
+// CHECK:       } // end sil function 'nodevirt_of_cxx_type'
+sil [ossa] @nodevirt_of_cxx_type : $@convention(thin) (@in NonCopyable) -> () {
+bb0(%0 : $*NonCopyable):
+  destroy_addr %0
+  %5 = tuple ()
+  return %5
 }
 
 // CHECK-LABEL: sil @test_non_ossa :


### PR DESCRIPTION
We cannot de-virtualize C++ destructor calls of C++ move-only types because we cannot get its destructor in SIL.
Fixes a miscompile.

This is part of rdar://140229560