### PR TITLE
mark move @inlinable to better signal intent

### DIFF
--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -40,6 +40,7 @@ public protocol Differentiable {
 
 public extension Differentiable where TangentVector == Self {
   @_alwaysEmitIntoClient
+  @inlinable
   mutating func move(by offset: TangentVector) {
     self += offset
   }


### PR DESCRIPTION
Mark default implementation of `move(by:)` with `@inlinable` to mark intent that it should be inlined. It was already marked with `@_alwaysEmitIntoClient` so this change probably won't provide more inlining opportunities. 

As there is no stable ABI for Differentiable, there is no ABI break.