### PR TITLE
[cxx-interop] Make borrowing specifiers more precise

### DIFF
--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -111,9 +111,9 @@ CaptureView getCaptureView(const Owner& owner [[clang::lifetimebound]]) {
 // CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow 0, borrow 1) @owned View
 // CHECK: sil [clang Owner.handOutView] {{.*}} : $@convention(cxx_method) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned View
 // CHECK: sil [clang Owner.handOutView2] {{.*}} : $@convention(cxx_method) (View, @in_guaranteed Owner) -> @lifetime(borrow 1) @owned View
-// CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (@guaranteed View, @guaranteed View) -> @lifetime(copy 0, copy 1) @owned View
+// CHECK: sil [clang getViewFromEither] {{.*}} : $@convention(c) (View, View) -> @lifetime(copy 0, copy 1) @owned View
 // CHECK: sil [clang View.init] {{.*}} : $@convention(c) () -> @lifetime(immortal) @out View
-// CHECK: sil [clang OtherView.init] {{.*}} : $@convention(c) (@guaranteed View) -> @lifetime(copy 0) @out OtherView
+// CHECK: sil [clang OtherView.init] {{.*}} : $@convention(c) (View) -> @lifetime(copy 0) @out OtherView
 // CHECK: sil [clang returnsImmortal] {{.*}} : $@convention(c) () -> @lifetime(immortal) @owned View
 // CHECK: sil [clang copyView] {{.*}} : $@convention(c) (View, @lifetime(copy 0) @inout View) -> ()
 // CHECK: sil [clang getCaptureView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned CaptureView

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -62,6 +62,13 @@ struct DependsOnSelf {
 
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }
 
+struct CaptureByReference {
+    void set(const std::vector<int>& x [[clang::lifetime_capture_by(this)]]) { 
+        this->x = ConstSpanOfInt(x.data(), x.size());
+    };
+    ConstSpanOfInt x;
+};
+
 inline void funcWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}
 
 inline ConstSpanOfInt funcWithSafeWrapper2(ConstSpanOfInt s

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -19,8 +19,9 @@ import CxxStdlib
 // CHECK-NEXT:  @_alwaysEmitIntoClient public mutating func get() -> Span<CInt>
 // CHECK-NEXT:  mutating func get() -> ConstSpanOfInt
 
+// CHECK:      mutating func set(_ x: borrowing std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>)
 // CHECK:      func funcWithSafeWrapper(_ s: ConstSpanOfInt)
-// CHECK-NEXT: func funcWithSafeWrapper2(_ s: borrowing ConstSpanOfInt) -> ConstSpanOfInt
+// CHECK-NEXT: func funcWithSafeWrapper2(_ s: ConstSpanOfInt) -> ConstSpanOfInt
 // CHECK-NEXT: func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> ConstSpanOfInt
 // CHECK:      struct X {
 // CHECK-NEXT:   init()
@@ -29,6 +30,6 @@ import CxxStdlib
 // CHECK-NEXT: }
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT: @lifetime(s)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: borrowing Span<CInt>) -> Span<CInt>
+// CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>


### PR DESCRIPTION
We do not need to borrow from view objects passed by value but we need to borrow from owners taken by const reference regardless of whether it was annotated using lifetimebound or lifetime_capture_by.
