### PR TITLE
[cxx-interop] Support borrowing from self in SwiftifyImport

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8796,7 +8796,8 @@ public:
 
   void printLifetimeboundReturn(int idx, bool borrow) {
     printSeparator();
-    out << ".lifetimeDependence(dependsOn: " << (idx + 1);
+    out << ".lifetimeDependence(dependsOn: ";
+    printParamOrReturn(idx);
     out << ", pointer: .return, type: ";
     out << (borrow ? ".borrow" : ".copy");
     out << ")";
@@ -8825,7 +8826,9 @@ private:
   }
 
   void printParamOrReturn(ssize_t pointerIndex) {
-    if (pointerIndex == -1)
+    if (pointerIndex == -2)
+      out << ".self";
+    else if (pointerIndex == -1)
       out << ".return";
     else
       out << ".param(" << pointerIndex + 1 << ")";
@@ -8866,15 +8869,21 @@ void ClangImporter::Implementation::importSpanAttributes(FuncDecl *MappedDecl) {
                              ->getDesugaredType()
                              ->getString()));
     }
+    bool lifetimeDependenceOn = MappedDecl->getASTContext().LangOpts.hasFeature(
+        Feature::LifetimeDependence);
+    if (SwiftDeclConverter::getImplicitObjectParamAnnotation<
+            clang::LifetimeBoundAttr>(ClangDecl) &&
+        lifetimeDependenceOn && returnIsSpan) {
+      printer.printLifetimeboundReturn(-2, true);
+      attachMacro = true;
+    }
     for (auto [index, param] : llvm::enumerate(ClangDecl->parameters())) {
       auto paramTy = param->getType();
       const auto *decl = paramTy->getAsTagDecl();
       auto swiftParam = MappedDecl->getParameters()->get(index);
       bool isSpan =
           decl && decl->isInStdNamespace() && decl->getName() == "span";
-      if (param->hasAttr<clang::LifetimeBoundAttr>() &&
-          MappedDecl->getASTContext().LangOpts.hasFeature(
-              Feature::LifetimeDependence) &&
+      if (param->hasAttr<clang::LifetimeBoundAttr>() && lifetimeDependenceOn &&
           (isSpan || returnIsSpan)) {
         printer.printLifetimeboundReturn(
             index, !isSpan && swiftParam->getInterfaceType()->isEscapable());

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -1,6 +1,7 @@
 public enum _SwiftifyExpr {
     case param(_ index: Int)
     case `return`
+    case `self`
 }
 
 public enum _DependenceType {
@@ -41,7 +42,7 @@ public enum _SwiftifyInfo {
     case nonescaping(pointer: _SwiftifyExpr)
     /// Can express lifetime dependencies between inputs and outputs of a function.
     /// 'dependsOn' is the input on which the output 'pointer' depends.
-    case lifetimeDependence(dependsOn: Int, pointer: _SwiftifyExpr, type: _DependenceType)
+    case lifetimeDependence(dependsOn: _SwiftifyExpr, pointer: _SwiftifyExpr, type: _DependenceType)
 }
 
 /// Generates a safe wrapper for function with Unsafe[Mutable][Raw]Pointer[?] or std::span arguments.

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -54,6 +54,12 @@ inline SpanOfInt initSpan(int arr[], size_t size) {
   return SpanOfInt(arr, size);
 }
 
+struct DependsOnSelf {
+  std::vector<int> v;
+  __attribute__((swift_name("get()")))
+  ConstSpanOfInt get() [[clang::lifetimebound]] { return ConstSpanOfInt(v.data(), v.size()); }
+};
+
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }
 
 inline void funcWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -14,6 +14,11 @@ import StdSpan
 #endif
 import CxxStdlib
 
+// CHECK:     struct DependsOnSelf {
+// CHECK:       @lifetime(borrow self)
+// CHECK-NEXT:  @_alwaysEmitIntoClient public mutating func get() -> Span<CInt>
+// CHECK-NEXT:  mutating func get() -> ConstSpanOfInt
+
 // CHECK:      func funcWithSafeWrapper(_ s: ConstSpanOfInt)
 // CHECK-NEXT: func funcWithSafeWrapper2(_ s: borrowing ConstSpanOfInt) -> ConstSpanOfInt
 // CHECK-NEXT: func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> ConstSpanOfInt

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -13,20 +13,25 @@ import StdSpan
 
 public struct VecOfInt {}
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
 func myFunc(_ span: SpanOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
 func myFunc2(_ vec: borrowing VecOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .copy), .lifetimeDependence(dependsOn: 2, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
 func myFunc3(_ span1: SpanOfInt, _ span2: SpanOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: 1, pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: 2, pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
 func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
+}
+
+struct X {
+  @_SwiftifyImport(.lifetimeDependence(dependsOn: .self, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+  func myFunc5() -> SpanOfInt {}
 }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(span)
@@ -47,4 +52,9 @@ func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, span)
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
 // CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span)))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self)
+// CHECK-NEXT: func myFunc5() -> Span<CInt> {
+// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc5())
 // CHECK-NEXT: }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -802,6 +802,7 @@ Added: _$ss7RawSpanVN
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC
+Added: _$ss13_SwiftifyExprO4selfyA2BmFWC
 Added: _$ss13_SwiftifyExprOMa
 Added: _$ss13_SwiftifyExprOMn
 Added: _$ss13_SwiftifyExprON
@@ -809,7 +810,7 @@ Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
-Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABSi_s01_A4ExprOs01_D4TypeOtcABmFWC
+Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABs01_A4ExprO_AEs01_D4TypeOtcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -803,6 +803,7 @@ Added: _$ss7RawSpanVN
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC
+Added: _$ss13_SwiftifyExprO4selfyA2BmFWC
 Added: _$ss13_SwiftifyExprOMa
 Added: _$ss13_SwiftifyExprOMn
 Added: _$ss13_SwiftifyExprON
@@ -810,7 +811,7 @@ Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC
-Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABSi_s01_A4ExprOs01_D4TypeOtcABmFWC
+Added: _$ss13_SwiftifyInfoO18lifetimeDependenceyABs01_A4ExprO_AEs01_D4TypeOtcABmFWC
 Added: _$ss13_SwiftifyInfoOMa
 Added: _$ss13_SwiftifyInfoOMn
 Added: _$ss13_SwiftifyInfoON


### PR DESCRIPTION
Support adding safe wrappers for APIs returning std::span depending on the this object. This also fixes an issue for APIs with 0 parameters.

rdar://139074571
