### PR TITLE
[CSOptimizer] Don't consider CGFloat widening when explicit initializ…

### DIFF
--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -366,3 +366,18 @@ func test_cgfloat_operator_is_attempted_with_literal_arguments(v: CGFloat?) {
   let ratio = v ?? (2.0 / 16.0)
   let _: CGFloat = ratio // Ok
 }
+
+// Make sure that optimizer doesn't favor CGFloat -> Double conversion
+// in presence of CGFloat initializer, otherwise it could lead to ambiguities.
+func test_explicit_cgfloat_use_avoids_ambiguity(v: Int) {
+  func test(_: CGFloat) -> CGFloat { 0 }
+  func test(_: Double) -> Double { 0 }
+
+  func hasCGFloatElement<C: Collection>(_: C) where C.Element == CGFloat {}
+
+  let arr = [test(CGFloat(v))]
+  hasCGFloatElement(arr) // Ok
+
+  var total = 0.0 // This is Double by default
+  total += test(CGFloat(v)) + CGFloat(v) // Ok
+}


### PR DESCRIPTION
…er is used

Disable implicit `CGFloat` -> `Double` widening conversion if argument is an explicit call to `CGFloat` initializer.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
