### PR TITLE
update_checkout: add mimalloc

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -105,7 +105,6 @@ set "args=%args% --skip-repository swift"
 set "args=%args% --skip-repository ninja"
 set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
-set "args=%args% --skip-repository swift-xcode-playground-support"
 
 call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote --github-comment "%ghprbCommentBody%"
 

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -429,7 +429,6 @@
                 "wasi-libc": "wasi-sdk-24",
                 "wasmkit": "0.1.2",
                 "curl": "curl-8_9_1",
-                "icu": "maint/maint-69",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
                 "mimalloc": "v3.0.1"

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -55,7 +55,9 @@
         "swift-integration-tests": {
             "remote": { "id": "swiftlang/swift-integration-tests" } },
         "swift-xcode-playground-support": {
-            "remote": { "id": "apple/swift-xcode-playground-support" } },
+            "remote": { "id": "apple/swift-xcode-playground-support" },
+            "platforms": [ "Darwin" ]
+        },
         "ninja": {
             "remote": { "id": "ninja-build/ninja" } },
         "yams": {
@@ -115,7 +117,8 @@
           "remote": { "id": "madler/zlib" }
         },
         "mimalloc": {
-          "remote": { "id": "microsoft/mimalloc" }
+          "remote": { "id": "microsoft/mimalloc" },
+          "platforms": [ "Windows" ]
         }
     },
     "default-branch-scheme": "main",

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -113,6 +113,9 @@
         },
         "zlib": {
           "remote": { "id": "madler/zlib" }
+        },
+        "mimalloc": {
+          "remote": { "id": "microsoft/mimalloc" }
         }
     },
     "default-branch-scheme": "main",
@@ -167,7 +170,8 @@
                 "wasmkit": "0.1.2",
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
-                "zlib": "v1.3.1"
+                "zlib": "v1.3.1",
+                "mimalloc": "v3.0.1"
             }
         },
         "release/6.1": {
@@ -374,7 +378,8 @@
                 "wasmkit": "0.1.2",
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
-                "zlib": "v1.3.1"
+                "zlib": "v1.3.1",
+                "mimalloc": "v3.0.1"
             }
         },
         "next" : {
@@ -423,7 +428,8 @@
                 "curl": "curl-8_9_1",
                 "icu": "maint/maint-69",
                 "libxml2": "v2.11.5",
-                "zlib": "v1.3.1"
+                "zlib": "v1.3.1",
+                "mimalloc": "v3.0.1"
             }
         }
     }


### PR DESCRIPTION
Add mimalloc to the checkout set. This is to allow us to build the project for the Windows toolchain.