### PR TITLE
utils: synchronise `-Test '*'` with build-windows-toolchain.bat

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -211,7 +211,7 @@ if ($AndroidSDKs.Length -gt 0) {
 
 if ($Test -contains "*") {
   # Explicitly don't include llbuild yet since tests are known to fail on Windows
-  $Test = @("swift", "dispatch", "foundation", "xctest")
+  $Test = @("lld", "lldb", "swift", "dispatch", "foundation", "xctest", "swift-format", "sourcekit-lsp")
 }
 
 # Architecture definitions


### PR DESCRIPTION
Extend the default full test set to include the same set that the rest of the testing that is now enabled by default on swift.org CI.