### PR TITLE
[6.1] [Serialization] Ensure we run `InheritedTypeRequest` before serializing inherited type

### DIFF
--- a/test/IDE/rdar141440011.swift
+++ b/test/IDE/rdar141440011.swift
@@ -1,0 +1,8 @@
+public protocol MyProto {}
+public struct MyStruct: MyProto {}
+
+// RUN: %empty-directory(%t)
+// RUN: %swift -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck -target %target-triple
+// RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - -target %target-triple | %FileCheck %s
+
+// CHECK: public struct MyStruct : swift_mod.MyProto

--- a/test/Serialization/AllowErrors/invalid-inheritance.swift
+++ b/test/Serialization/AllowErrors/invalid-inheritance.swift
@@ -27,13 +27,13 @@ extension SomeStruct: undefined {} // expected-error {{cannot find type 'undefin
 extension SomeEnum: undefined {} // expected-error {{cannot find type 'undefined'}}
 
 extension undefined {} // expected-error {{cannot find type 'undefined'}}
-extension undefined: undefined {} // expected-error {{cannot find type 'undefined'}}
+extension undefined: undefined {} // expected-error 2 {{cannot find type 'undefined'}}
 extension undefined: SomeProto {} // expected-error {{cannot find type 'undefined'}}
 
 public extension undefined { // expected-error {{cannot find type 'undefined' in scope}}
   protocol SomeProtoInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
-  class SomeClassInner: undefined {}
-  struct SomeStructInner: undefined {}
+  class SomeClassInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
+  struct SomeStructInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
   enum SomeEnumInner: undefined { // expected-error {{cannot find type 'undefined' in scope}}
     case a
   }


### PR DESCRIPTION
- **Explanation**: When using `-experimental-skip-all-function-bodies` we don’t run the `TypeCheckSourceFileRequest` and thus don’t go through the decl checker, which calls `InheritedTypeRequest` on all inheritance clauses. This means that the inherited entries are not populated by the time we serialize the module and null types are serialized into a module created with these options, which happens during background preparation from SourceKit-LSP. Trigger the computation of inherited entries by calling `InheritedTypeRequest` during serialization.
- **Scope**: Module serialization
- **Issue**: rdar://141440011
- **Original PR**: https://github.com/swiftlang/swift/pull/78899
- **Risk**: Low, invoking the `InheritedTypeRequest` should have no effect if it already ran and otherwise we were serializing an incorrect null type
- **Testing**: Added regression test
- **Reviewer**: @hamishknight 