### PR TITLE
[SymbolGraphGen] synthesize child symbols for type aliases of private decls

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -37,19 +37,21 @@ using namespace swift;
 using namespace symbolgraphgen;
 
 Symbol::Symbol(SymbolGraph *Graph, const ExtensionDecl *ED,
-               const NominalTypeDecl *SynthesizedBaseTypeDecl, Type BaseType)
+               const ValueDecl *SynthesizedBaseTypeDecl, Type BaseType)
     : Symbol::Symbol(Graph, nullptr, ED, SynthesizedBaseTypeDecl, BaseType) {}
 
 Symbol::Symbol(SymbolGraph *Graph, const ValueDecl *VD,
-               const NominalTypeDecl *SynthesizedBaseTypeDecl, Type BaseType)
+               const ValueDecl *SynthesizedBaseTypeDecl, Type BaseType)
     : Symbol::Symbol(Graph, VD, nullptr, SynthesizedBaseTypeDecl, BaseType) {}
 
 Symbol::Symbol(SymbolGraph *Graph, const ValueDecl *VD, const ExtensionDecl *ED,
-               const NominalTypeDecl *SynthesizedBaseTypeDecl, Type BaseType)
+               const ValueDecl *SynthesizedBaseTypeDecl, Type BaseType)
     : Graph(Graph), D(VD), BaseType(BaseType),
       SynthesizedBaseTypeDecl(SynthesizedBaseTypeDecl) {
-  if (!BaseType && SynthesizedBaseTypeDecl)
-    BaseType = SynthesizedBaseTypeDecl->getDeclaredInterfaceType();
+  if (!BaseType && SynthesizedBaseTypeDecl) {
+    if (const auto *NTD = dyn_cast<NominalTypeDecl>(SynthesizedBaseTypeDecl))
+      BaseType = NTD->getDeclaredInterfaceType();
+  }
   if (D == nullptr) {
     D = ED;
   }

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -35,10 +35,10 @@ class Symbol {
   /// Either a ValueDecl* or ExtensionDecl*.
   const Decl *D;
   Type BaseType;
-  const NominalTypeDecl *SynthesizedBaseTypeDecl;
+  const ValueDecl *SynthesizedBaseTypeDecl;
 
   Symbol(SymbolGraph *Graph, const ValueDecl *VD, const ExtensionDecl *ED,
-         const NominalTypeDecl *SynthesizedBaseTypeDecl,
+         const ValueDecl *SynthesizedBaseTypeDecl,
          Type BaseTypeForSubstitution = Type());
 
   swift::DeclName getName(const Decl *D) const;
@@ -87,11 +87,11 @@ class Symbol {
 
 public:
   Symbol(SymbolGraph *Graph, const ExtensionDecl *ED,
-         const NominalTypeDecl *SynthesizedBaseTypeDecl,
+         const ValueDecl *SynthesizedBaseTypeDecl,
          Type BaseTypeForSubstitution = Type());
 
   Symbol(SymbolGraph *Graph, const ValueDecl *VD,
-         const NominalTypeDecl *SynthesizedBaseTypeDecl,
+         const ValueDecl *SynthesizedBaseTypeDecl,
          Type BaseTypeForSubstitution = Type());
 
   void serialize(llvm::json::OStream &OS) const;
@@ -108,7 +108,7 @@ public:
     return BaseType;
   }
 
-  const NominalTypeDecl *getSynthesizedBaseTypeDecl() const {
+  const ValueDecl *getSynthesizedBaseTypeDecl() const {
     return SynthesizedBaseTypeDecl;
   }
 
@@ -175,19 +175,19 @@ using SymbolGraph = swift::symbolgraphgen::SymbolGraph;
 
 template <> struct DenseMapInfo<Symbol> {
   static inline Symbol getEmptyKey() {
-    return Symbol {
-      DenseMapInfo<SymbolGraph *>::getEmptyKey(),
-      DenseMapInfo<const swift::ValueDecl *>::getEmptyKey(),
-      DenseMapInfo<const swift::NominalTypeDecl *>::getTombstoneKey(),
-      DenseMapInfo<swift::Type>::getEmptyKey(),
+    return Symbol{
+        DenseMapInfo<SymbolGraph *>::getEmptyKey(),
+        DenseMapInfo<const swift::ValueDecl *>::getEmptyKey(),
+        DenseMapInfo<const swift::ValueDecl *>::getTombstoneKey(),
+        DenseMapInfo<swift::Type>::getEmptyKey(),
     };
   }
   static inline Symbol getTombstoneKey() {
-    return Symbol {
-      DenseMapInfo<SymbolGraph *>::getTombstoneKey(),
-      DenseMapInfo<const swift::ValueDecl *>::getTombstoneKey(),
-      DenseMapInfo<const swift::NominalTypeDecl *>::getTombstoneKey(),
-      DenseMapInfo<swift::Type>::getTombstoneKey(),
+    return Symbol{
+        DenseMapInfo<SymbolGraph *>::getTombstoneKey(),
+        DenseMapInfo<const swift::ValueDecl *>::getTombstoneKey(),
+        DenseMapInfo<const swift::ValueDecl *>::getTombstoneKey(),
+        DenseMapInfo<swift::Type>::getTombstoneKey(),
     };
   }
   static unsigned getHashValue(const Symbol S) {
@@ -195,7 +195,8 @@ template <> struct DenseMapInfo<Symbol> {
     H ^= DenseMapInfo<SymbolGraph *>::getHashValue(S.getGraph());
     H ^=
         DenseMapInfo<const swift::Decl *>::getHashValue(S.getLocalSymbolDecl());
-    H ^= DenseMapInfo<const swift::NominalTypeDecl *>::getHashValue(S.getSynthesizedBaseTypeDecl());
+    H ^= DenseMapInfo<const swift::ValueDecl *>::getHashValue(
+        S.getSynthesizedBaseTypeDecl());
     H ^= DenseMapInfo<swift::Type>::getHashValue(S.getBaseType());
     return H;
   }

--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -220,10 +220,12 @@ struct SymbolGraph {
   /// implicitly internal/private, such as underscore prefixes,
   /// and checking every named parent context as well.
   ///
-  /// \param IgnoreContext If `true`, don't consider
-  /// the context of the declaration to determine whether it is implicitly private.
-  bool isImplicitlyPrivate(const Decl *D,
-                           bool IgnoreContext = false) const;
+  /// \param IgnoreContext A function ref that receives the parent decl
+  /// and returns whether or not the context should be ignored when determining
+  /// privacy.
+  bool isImplicitlyPrivate(
+      const Decl *D,
+      llvm::function_ref<bool(const Decl *)> IgnoreContext = nullptr) const;
 
   /// Returns `true` if the declaration has an availability attribute
   /// that marks it as unconditionally unavailable on all platforms (i.e., where
@@ -232,7 +234,11 @@ struct SymbolGraph {
 
   /// Returns `true` if the declaration should be included as a node
   /// in the graph.
-  bool canIncludeDeclAsNode(const Decl *D) const;
+  ///
+  /// If `PublicAncestorDecl` is set and is an ancestor of `D`, that declaration
+  /// is considered to be public, regardless of its surrounding context.
+  bool canIncludeDeclAsNode(const Decl *D,
+                            const Decl *PublicAncestorDecl = nullptr) const;
 
   /// Returns `true` if the declaration is a requirement of a protocol
   /// or is a default implementation of a protocol

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -59,6 +59,16 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   /// A map of modules whose types were extended by the main module of interest `M`.
   llvm::StringMap<SymbolGraph *> ExtendedModuleGraphs;
 
+  /// A temporary pointer to a base decl when crawling symbols to synthesize.
+  const ValueDecl *BaseDecl;
+
+  /// A temporary pointer to the top-level decl being crawled when synthesizing
+  /// child symbols.
+  const Decl *SynthesizedChildrenBaseDecl;
+
+  /// Maps any internal symbol with a public type alias of that symbol.
+  llvm::DenseMap<const ValueDecl *, const ValueDecl *> PublicPrivateTypeAliases;
+
   // MARK: - Initialization
 
   SymbolGraphASTWalker(
@@ -102,6 +112,10 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   virtual bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
     
   // MARK: - Utilities
+
+  /// Walk the given decl and add its children as synthesized children of the
+  /// given base decl.
+  bool synthesizeChildSymbols(Decl *D, const ValueDecl *BaseDecl);
 
   /// Returns whether the given declaration was itself imported via an `@_exported import`
   /// statement, or if it is an extension or child symbol of something else that was.

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -60,11 +60,11 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   llvm::StringMap<SymbolGraph *> ExtendedModuleGraphs;
 
   /// A temporary pointer to a base decl when crawling symbols to synthesize.
-  const ValueDecl *BaseDecl;
+  const ValueDecl *BaseDecl = nullptr;
 
   /// A temporary pointer to the top-level decl being crawled when synthesizing
   /// child symbols.
-  const Decl *SynthesizedChildrenBaseDecl;
+  const Decl *SynthesizedChildrenBaseDecl = nullptr;
 
   /// Maps any internal symbol with a public type alias of that symbol.
   llvm::DenseMap<const ValueDecl *, const ValueDecl *> PublicPrivateTypeAliases;

--- a/test/SymbolGraph/ClangImporter/TypedefStructUnderscore.swift
+++ b/test/SymbolGraph/ClangImporter/TypedefStructUnderscore.swift
@@ -1,0 +1,27 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/TypedefStructUnderscore)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-symbolgraph-extract -module-name TypedefStructUnderscore -I %t/TypedefStructUnderscore -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/TypedefStructUnderscore.symbols.json
+
+// _MyStruct.myField, synthesized on MyStruct
+// CHECK-DAG: "precise": "c:@S@_MyStruct@FI@myField::SYNTHESIZED::c:TypedefStructUnderscore.h@T@MyStruct"
+
+// MyStruct.myField is a member of MyStruct
+// CHECK-DAG: "kind": "memberOf",{{[[:space:]]*}}"source": "c:@S@_MyStruct@FI@myField::SYNTHESIZED::c:TypedefStructUnderscore.h@T@MyStruct",{{[[:space:]]*}}"target": "c:TypedefStructUnderscore.h@T@MyStruct"
+
+// MyStruct automatically conforms to Sendable
+// CHECK-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "c:TypedefStructUnderscore.h@T@MyStruct",{{[[:space:]]*}}"target": "s:s8SendableP"
+
+//--- TypedefStructUnderscore/module.modulemap
+module TypedefStructUnderscore {
+  header "TypedefStructUnderscore.h"
+}
+
+//--- TypedefStructUnderscore/TypedefStructUnderscore.h
+typedef struct _MyStruct {
+    int myField;
+} MyStruct;

--- a/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name HiddenTypeAlias -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name HiddenTypeAlias -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/HiddenTypeAlias.symbols.json
+
+// Ensure that public type aliases of effectively-private symbols inherit the child symbols of the
+// inner type.
+
+// CHECK-NOT: "OuterType._InnerType"
+// CHECK-DAG: "title": "OuterType"
+
+// CHECK-DAG: "precise": "s:15HiddenTypeAlias06_InnerB0V8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a"
+
+// CHECK-DAG: "kind": "memberOf",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias06_InnerB0V8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias05OuterB0a"
+
+public struct _InnerType {
+    public func someFunc() {}
+}
+
+public typealias OuterType = _InnerType

--- a/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
@@ -2,12 +2,13 @@
 // RUN: %target-build-swift %s -module-name HiddenTypeAlias -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name HiddenTypeAlias -I %t -pretty-print -output-dir %t -v
 // RUN: %FileCheck %s --input-file %t/HiddenTypeAlias.symbols.json
+// RUN: %FileCheck %s --input-file %t/HiddenTypeAlias.symbols.json --check-prefix INNER
 
 // Ensure that public type aliases of effectively-private symbols inherit the child symbols of the
 // inner type.
 
 // _InnerType's type name should only appear in quotes like this once, in the declaration for OuterType
-// CHECK-COUNT-1: "_InnerType"
+// INNER-COUNT-1: "_InnerType"
 
 // _InnerType.someFunc() as synthesized on OuterType
 // CHECK-DAG: "precise": "s:15HiddenTypeAlias06_InnerB0C8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a"

--- a/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/HiddenTypeAlias.swift
@@ -1,19 +1,39 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name HiddenTypeAlias -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name HiddenTypeAlias -I %t -pretty-print -output-dir %t
+// RUN: %target-swift-symbolgraph-extract -module-name HiddenTypeAlias -I %t -pretty-print -output-dir %t -v
 // RUN: %FileCheck %s --input-file %t/HiddenTypeAlias.symbols.json
 
 // Ensure that public type aliases of effectively-private symbols inherit the child symbols of the
 // inner type.
 
-// CHECK-NOT: "OuterType._InnerType"
-// CHECK-DAG: "title": "OuterType"
+// _InnerType's type name should only appear in quotes like this once, in the declaration for OuterType
+// CHECK-COUNT-1: "_InnerType"
 
-// CHECK-DAG: "precise": "s:15HiddenTypeAlias06_InnerB0V8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a"
+// _InnerType.someFunc() as synthesized on OuterType
+// CHECK-DAG: "precise": "s:15HiddenTypeAlias06_InnerB0C8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a"
 
-// CHECK-DAG: "kind": "memberOf",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias06_InnerB0V8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias05OuterB0a"
+// someFunc is a member of OuterType
+// CHECK-DAG: "kind": "memberOf",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias06_InnerB0C8someFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias05OuterB0a"
 
-public struct _InnerType {
+// OuterType conforms to SomeProtocol
+// CHECK-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias12SomeProtocolP"
+
+// OuterType "inherits from" BaseType
+// CHECK-DAG: "kind": "inheritsFrom",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias04BaseB0C"
+
+// bonusFunc as a synthesized member of OuterType
+// CHECK-DAG: "precise": "s:15HiddenTypeAlias12SomeProtocolPAAE9bonusFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a",
+// CHECK-DAG: "kind": "memberOf",{{[[:space:]]*}}"source": "s:15HiddenTypeAlias12SomeProtocolPAAE9bonusFuncyyF::SYNTHESIZED::s:15HiddenTypeAlias05OuterB0a",{{[[:space:]]*}}"target": "s:15HiddenTypeAlias05OuterB0a",
+
+public protocol SomeProtocol {}
+
+extension SomeProtocol {
+    public func bonusFunc() {}
+}
+
+public class BaseType {}
+
+public class _InnerType: BaseType, SomeProtocol {
     public func someFunc() {}
 }
 


### PR DESCRIPTION
Resolves rdar://141460819

Consider the following C code:

```c
typedef struct {
  int myField;
} MyStruct;

typedef struct OtherStruct {
  int myField;
} OtherStruct;
```

When this C code is processed in ClangImporter, it initially sees four top-level Clang decls: two typedefs and their respective underlying struct decls, one anonymous and one named. [In `canSkipOverTypedef`, it then folds the underlying type into the typedef decl](https://github.com/swiftlang/swift/blob/6c4d5de6312f934cc0ddbff91e5507b53d979356/lib/ClangImporter/ImportDecl.cpp#L8263-L8269), creating two final Swift top-level decls.

However, when processing this code:

```c
typedef struct _MyStruct {
  int myField;
} MyStruct;
```

...this folding process fails, instead creating Swift decls for both the typedef and its underlying type.

When these decls are then rendered in SymbolGraphGen, the underlying struct decl is then hidden, due to its underscored name, leaving the converted type alias pointing to nowhere.

This PR adds behavior in SymbolGraphGen to effectively fold these decls together: When a type alias (including a converted Clang typedef) is encountered whose underlying type is (1) from the same module and (2) hidden by the current settings, it will crawl the underlying type and create synthesized symbols to clone its children as children of the type alias.