### PR TITLE
[Dependency Scanning] Add functionality to validate contents of a loaded scanner cache state for incremental scans

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -212,17 +212,28 @@ ERROR(scanner_arguments_invalid, none,
 ERROR(error_scanner_extra, none,
       "failed inside dependency scanner: '%0'", (StringRef))
 
-WARNING(warn_scanner_deserialize_failed, none,
-        "Failed to load module scanning dependency cache from: '%0', re-building scanner cache from scratch.", (StringRef))
+REMARK(warn_scanner_deserialize_failed, none,
+       "Incremental module scan: Failed to load module scanning dependency cache from: '%0', re-building scanner cache from scratch.", (StringRef))
 
 REMARK(remark_reuse_cache, none,
-       "Re-using serialized module scanning dependency cache from: '%0'.", (StringRef))
+       "Incremental module scan: Re-using serialized module scanning dependency cache from: '%0'.", (StringRef))
 
 REMARK(remark_scanner_uncached_lookups, none,
        "Module Dependency Scanner queries executed: '%0'.", (unsigned))
 
 REMARK(remark_save_cache, none,
-       "Serializing module scanning dependency cache to: '%0'.", (StringRef))
+       "Incremental module scan: Serializing module scanning dependency cache to: '%0'.", (StringRef))
+
+REMARK(remark_scanner_stale_result_invalidate, none,
+       "Incremental module scan: Dependency info for module '%0' invalidated due to a modified input"
+       " since last scan: '%1'.", (StringRef, StringRef))
+
+REMARK(remark_scanner_invalidate_upstream, none,
+       "Incremental module scan: Dependency info for module '%0' invalidated due to an out-of-date"
+       " dependency.", (StringRef))
+
+REMARK(remark_cache_reuse_disabled_with_cas, none,
+       "Incremental module scan: Re-using serialized module scanning dependency cache disabled in Caching build", ())
 
 //------------------------------------------------------------------------------
 // MARK: custom attribute diagnostics

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1129,6 +1129,9 @@ private:
   std::string scannerContextHash;
   /// The location of where the built modules will be output to
   std::string moduleOutputPath;
+  /// The timestamp of the beginning of the scanning query action
+  /// using this cache
+  const llvm::sys::TimePoint<> scanInitializationTime;
 
   /// Retrieve the dependencies map that corresponds to the given dependency
   /// kind.
@@ -1235,6 +1238,9 @@ public:
   /// Update stored dependencies for the given module.
   void updateDependency(ModuleDependencyID moduleID,
                         ModuleDependencyInfo dependencyInfo);
+  
+  /// Remove a given dependency info from the cache.
+  void removeDependency(ModuleDependencyID moduleID);
 
   /// Resolve this module's set of directly-imported Swift module
   /// dependencies

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -165,6 +165,9 @@ FRONTEND_STATISTIC(AST, ModuleVisibilityCacheMiss)
 FRONTEND_STATISTIC(AST, ModuleShadowCacheHit)
 FRONTEND_STATISTIC(AST, ModuleShadowCacheMiss)
 
+/// Number of types deserialized.
+FRONTEND_STATISTIC(AST, NumDepScanFilesystemLookups)
+
 /// Number of full function bodies parsed.
 FRONTEND_STATISTIC(Parse, NumFunctionsParsed)
 

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -95,6 +95,7 @@ namespace graph_block {
 enum {
   METADATA = 1,
   MODULE_NODE,
+  TIME_NODE,
   LINK_LIBRARY_NODE,
   LINK_LIBRARY_ARRAY_NODE,
   MACRO_DEPENDENCY_NODE,
@@ -113,13 +114,19 @@ enum {
 
 // Always the first record in the file.
 using MetadataLayout = BCRecordLayout<
-    METADATA,    // ID
-    BCFixed<16>, // Inter-Module Dependency graph format major version
-    BCFixed<16>, // Inter-Module Dependency graph format minor version
-    BCBlob       // Scanner Invocation Context Hash
+    METADATA,       // ID
+    BCFixed<16>,    // Inter-Module Dependency graph format major version
+    BCFixed<16>,    // Inter-Module Dependency graph format minor version
+    BCBlob          // Scanner Invocation Context Hash
     >;
 
-// After the metadata record, we have zero or more identifier records,
+// After the metadata record, emit serialization time-stamp.
+using TimeLayout = BCRecordLayout<
+    TIME_NODE,       // ID
+    BCBlob           // Nanoseconds since epoch as a string
+    >;
+
+// After the time stamp record, we have zero or more identifier records,
 // for each unique string that is referenced in the graph.
 //
 // Identifiers are referenced by their sequence number, starting from 1.
@@ -138,29 +145,31 @@ using IdentifierNodeLayout = BCRecordLayout<IDENTIFIER_NODE, BCBlob>;
 using IdentifierArrayLayout =
     BCRecordLayout<IDENTIFIER_ARRAY_NODE, IdentifierIDArryField>;
 
-// ACTODO: Comment
+// A record for a given link library node containing information
+// required for the build system client to capture a requirement
+// to link a given dependency library.
 using LinkLibraryLayout =
     BCRecordLayout<LINK_LIBRARY_NODE,            // ID
                    IdentifierIDField,            // libraryName
                    IsFrameworkField,             // isFramework
                    IsForceLoadField              // forceLoad
                    >;
-// ACTODO: Comment
 using LinkLibraryArrayLayout =
     BCRecordLayout<LINK_LIBRARY_ARRAY_NODE, IdentifierIDArryField>;
 
-// ACTODO: Comment
+// A record for a Macro module dependency of a given dependency
+// node.
 using MacroDependencyLayout =
     BCRecordLayout<MACRO_DEPENDENCY_NODE,        // ID
                    IdentifierIDField,            // macroModuleName
                    IdentifierIDField,            // libraryPath
                    IdentifierIDField             // executablePath
                    >;
-// ACTODO: Comment
 using MacroDependencyArrayLayout =
     BCRecordLayout<MACRO_DEPENDENCY_ARRAY_NODE, IdentifierIDArryField>;
 
-// ACTODO: Comment
+// A record capturing information about a given 'import' statement
+// captured in a dependency node, including its source location.
 using ImportStatementLayout =
     BCRecordLayout<IMPORT_STATEMENT_NODE,        // ID
                    IdentifierIDField,            // importIdentifier
@@ -169,7 +178,6 @@ using ImportStatementLayout =
                    ColumnNumberField,            // columnNumber
                    IsOptionalImport              // isOptional
                    >;
-// ACTODO: Comment
 using ImportStatementArrayLayout =
     BCRecordLayout<IMPORT_STATEMENT_ARRAY_NODE, IdentifierIDArryField>;
 using OptionalImportStatementArrayLayout =
@@ -268,12 +276,14 @@ using ClangModuleDetailsLayout =
 /// Tries to read the dependency graph from the given buffer.
 /// Returns \c true if there was an error.
 bool readInterModuleDependenciesCache(llvm::MemoryBuffer &buffer,
-                                      ModuleDependenciesCache &cache);
+                                      ModuleDependenciesCache &cache,
+                                      llvm::sys::TimePoint<> &serializedCacheTimeStamp);
 
 /// Tries to read the dependency graph from the given path name.
 /// Returns true if there was an error.
 bool readInterModuleDependenciesCache(llvm::StringRef path,
-                                      ModuleDependenciesCache &cache);
+                                      ModuleDependenciesCache &cache,
+                                      llvm::sys::TimePoint<> &serializedCacheTimeStamp);
 
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -363,6 +363,11 @@ public:
   /// Load and re-use a prior serialized dependency scanner cache.
   bool ReuseDependencyScannerCache = false;
 
+  /// Upon loading a prior serialized dependency scanner cache, filter out
+  /// dependency module information which is no longer up-to-date with respect
+  /// to input files of every given module.
+  bool ValidatePriorDependencyScannerCache = false;
+
   /// The path at which to either serialize or deserialize the dependency scanner cache.
   std::string SerializedDependencyScannerCachePath;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -266,7 +266,10 @@ def serialize_dependency_scan_cache : Flag<["-"], "serialize-dependency-scan-cac
    HelpText<"After performing a dependency scan, serialize the scanner's internal state.">;
 
 def reuse_dependency_scan_cache : Flag<["-"], "load-dependency-scan-cache">,
-   HelpText<"After performing a dependency scan, serialize the scanner's internal state.">;
+   HelpText<"For performing a dependency scan, deserialize the scanner's internal state from a prior scan.">;
+   
+def validate_prior_dependency_scan_cache : Flag<["-"], "validate-prior-dependency-scan-cache">,
+   HelpText<"For performing a dependency scan with a prior scanner state, validate module dependencies.">;
 
 def dependency_scan_cache_path : Separate<["-"], "dependency-scan-cache-path">,
   HelpText<"The path to output the dependency scanner's internal state.">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1979,6 +1979,11 @@ def driver_explicit_module_build:
   Flags<[HelpHidden, NewDriverOnlyOption]>,
   HelpText<"Prebuild module dependencies to make them explicit">;
 
+def incremental_dependency_scan:
+  Flag<["-"], "incremental-dependency-scan">,
+  Flags<[HelpHidden, NewDriverOnlyOption]>,
+  HelpText<"Re-use/validate prior build dependency scan artifacts">;
+
 def driver_experimental_explicit_module_build:
   Flag<["-"], "experimental-explicit-module-build">,
   Flags<[HelpHidden, NewDriverOnlyOption]>,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -728,7 +728,8 @@ ModuleDependenciesCache::ModuleDependenciesCache(
     : globalScanningService(globalScanningService),
       mainScanModuleName(mainScanModuleName),
       scannerContextHash(scannerContextHash),
-      moduleOutputPath(moduleOutputPath) {
+      moduleOutputPath(moduleOutputPath),
+      scanInitializationTime(std::chrono::system_clock::now()) {
   for (auto kind = ModuleDependencyKind::FirstKind;
        kind != ModuleDependencyKind::LastKind; ++kind)
     ModuleDependenciesMap.insert({kind, ModuleNameToDependencyMap()});
@@ -807,6 +808,7 @@ ModuleDependenciesCache::findSwiftDependency(StringRef moduleName) const {
 
 const ModuleDependencyInfo &ModuleDependenciesCache::findKnownDependency(
     const ModuleDependencyID &moduleID) const {
+  
   auto dep = findDependency(moduleID);
   assert(dep && "dependency unknown");
   return **dep;
@@ -858,6 +860,11 @@ void ModuleDependenciesCache::updateDependency(
   auto &map = getDependenciesMap(moduleID.Kind);
   assert(map.find(moduleID.ModuleName) != map.end() && "Not yet added to map");
   map.insert_or_assign(moduleID.ModuleName, std::move(dependencyInfo));
+}
+
+void ModuleDependenciesCache::removeDependency(ModuleDependencyID moduleID) {
+  auto &map = getDependenciesMap(moduleID.Kind);
+  map.erase(moduleID.ModuleName);
 }
 
 void

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -58,6 +58,7 @@ class ModuleDependenciesCacheDeserializer {
   bool readSignature();
   bool enterGraphBlock();
   bool readMetadata(StringRef scannerContextHash);
+  bool readSerializationTime(llvm::sys::TimePoint<> &SerializationTimeStamp);
   bool readGraph(ModuleDependenciesCache &cache);
 
   std::optional<std::string> getIdentifier(unsigned n);
@@ -76,7 +77,8 @@ class ModuleDependenciesCacheDeserializer {
 public:
   ModuleDependenciesCacheDeserializer(llvm::MemoryBufferRef Data)
       : Cursor(Data) {}
-  bool readInterModuleDependenciesCache(ModuleDependenciesCache &cache);
+  bool readInterModuleDependenciesCache(ModuleDependenciesCache &cache,
+                                        llvm::sys::TimePoint<> &serializedCacheTimeStamp);
 };
 
 } // namespace swift
@@ -175,6 +177,35 @@ bool ModuleDependenciesCacheDeserializer::readMetadata(StringRef scannerContextH
     return true;
 
   return false;
+}
+
+bool ModuleDependenciesCacheDeserializer::readSerializationTime(llvm::sys::TimePoint<> &SerializationTimeStamp) {
+  using namespace graph_block;
+
+  auto entry = Cursor.advance();
+  if (!entry) {
+    consumeError(entry.takeError());
+    return true;
+  }
+
+  if (entry->Kind != llvm::BitstreamEntry::Record)
+    return true;
+
+  auto recordID = Cursor.readRecord(entry->ID, Scratch, &BlobData);
+  if (!recordID) {
+    consumeError(recordID.takeError());
+    return true;
+  }
+
+  if (*recordID != TIME_NODE)
+    return true;
+  
+  TimeLayout::readRecord(Scratch);
+  std::string serializedTimeStamp = BlobData.str();
+  
+  SerializationTimeStamp =
+    llvm::sys::TimePoint<>(llvm::sys::TimePoint<>::duration(std::stoll(serializedTimeStamp)));
+  return SerializationTimeStamp == llvm::sys::TimePoint<>();
 }
 
 /// Read in the top-level block's graph structure by first reading in
@@ -791,7 +822,8 @@ bool ModuleDependenciesCacheDeserializer::readGraph(
 }
 
 bool ModuleDependenciesCacheDeserializer::readInterModuleDependenciesCache(
-    ModuleDependenciesCache &cache) {
+    ModuleDependenciesCache &cache,
+    llvm::sys::TimePoint<> &serializedCacheTimeStamp) {
   using namespace graph_block;
 
   if (readSignature())
@@ -801,6 +833,9 @@ bool ModuleDependenciesCacheDeserializer::readInterModuleDependenciesCache(
     return true;
 
   if (readMetadata(cache.scannerContextHash))
+    return true;
+  
+  if (readSerializationTime(serializedCacheTimeStamp))
     return true;
 
   if (readGraph(cache))
@@ -975,21 +1010,23 @@ ModuleDependenciesCacheDeserializer::getModuleDependencyIDArray(unsigned n) {
 
 bool swift::dependencies::module_dependency_cache_serialization::
     readInterModuleDependenciesCache(llvm::MemoryBuffer &buffer,
-                                     ModuleDependenciesCache &cache) {
+                                     ModuleDependenciesCache &cache,
+                                     llvm::sys::TimePoint<> &serializedCacheTimeStamp) {
   ModuleDependenciesCacheDeserializer deserializer(buffer.getMemBufferRef());
-  return deserializer.readInterModuleDependenciesCache(cache);
+  return deserializer.readInterModuleDependenciesCache(cache, serializedCacheTimeStamp);
 }
 
 bool swift::dependencies::module_dependency_cache_serialization::
     readInterModuleDependenciesCache(StringRef path,
-                                     ModuleDependenciesCache &cache) {
+                                     ModuleDependenciesCache &cache,
+                                     llvm::sys::TimePoint<> &serializedCacheTimeStamp) {
   PrettyStackTraceStringAction stackTrace(
       "loading inter-module dependency graph", path);
   auto buffer = llvm::MemoryBuffer::getFile(path);
   if (!buffer)
     return true;
 
-  return readInterModuleDependenciesCache(*buffer.get(), cache);
+  return readInterModuleDependenciesCache(*buffer.get(), cache, serializedCacheTimeStamp);
 }
 
 // MARK: Serialization
@@ -1107,6 +1144,7 @@ class ModuleDependenciesCacheSerializer {
   void writeBlockInfoBlock();
 
   void writeMetadata(StringRef scanningContextHash);
+  void writeSerializationTime(const llvm::sys::TimePoint<> &scanInitializationTime);
   void writeIdentifiers();
   void writeArraysOfIdentifiers();
 
@@ -1170,6 +1208,7 @@ void ModuleDependenciesCacheSerializer::writeBlockInfoBlock() {
 
   BLOCK(GRAPH_BLOCK);
   BLOCK_RECORD(graph_block, METADATA);
+  BLOCK_RECORD(graph_block, TIME_NODE);
   BLOCK_RECORD(graph_block, IDENTIFIER_NODE);
   BLOCK_RECORD(graph_block, IDENTIFIER_ARRAY_NODE);
 
@@ -1200,6 +1239,15 @@ void ModuleDependenciesCacheSerializer::writeMetadata(StringRef scanningContextH
                              MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR,
                              MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR,
                              scanningContextHash);
+}
+
+void ModuleDependenciesCacheSerializer::writeSerializationTime(const llvm::sys::TimePoint<> &scanInitializationTime) {
+  using namespace graph_block;
+  auto timeSinceEpoch = scanInitializationTime.time_since_epoch().count();
+  std::string serializationData = std::to_string(timeSinceEpoch);
+  TimeLayout::emitRecord(Out, ScratchRecord,
+                         AbbrCodes[TimeLayout::Code],
+                         serializationData);
 }
 
 void ModuleDependenciesCacheSerializer::writeIdentifiers() {
@@ -1770,6 +1818,7 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
         addIdentifier(swiftBinDeps->sourceInfoPath);
         addIdentifier(swiftBinDeps->moduleCacheKey);
         addIdentifier(swiftBinDeps->headerImport);
+        addIdentifier(swiftBinDeps->definingModuleInterfacePath);
         addIdentifier(swiftBinDeps->userModuleVersion);
         addStringArray(moduleID,
                        ModuleIdentifierArrayKind::HeaderInputModuleDependencies,
@@ -1848,6 +1897,7 @@ void ModuleDependenciesCacheSerializer::writeInterModuleDependenciesCache(
   using namespace graph_block;
 
   registerRecordAbbr<MetadataLayout>();
+  registerRecordAbbr<TimeLayout>();
   registerRecordAbbr<IdentifierNodeLayout>();
   registerRecordAbbr<IdentifierArrayLayout>();
   registerRecordAbbr<LinkLibraryLayout>();
@@ -1869,6 +1919,9 @@ void ModuleDependenciesCacheSerializer::writeInterModuleDependenciesCache(
 
   // Write the version information
   writeMetadata(cache.scannerContextHash);
+
+  // The current time-stamp
+  writeSerializationTime(cache.scanInitializationTime);
 
   // Write the strings
   writeIdentifiers();

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -204,6 +204,8 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
       args.getLastArg(options::OPT_reuse_dependency_scan_cache);
   const Arg *CacheSerializationPath =
       args.getLastArg(options::OPT_dependency_scan_cache_path);
+  const Arg *ValidatePriorCache =
+      args.getLastArg(options::OPT_validate_prior_dependency_scan_cache);
 
   if (ExternalDependencyMap && !ScanDependencies) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
@@ -235,6 +237,11 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
                    "-serialize-dependency-scan-cache",
                    "-dependency-scan-cache-path");
+  }
+  if (ValidatePriorCache && !ReuseCache) {
+    diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
+                   "-validate-prior-dependency-scan-cache",
+                   "-load-dependency-scan-cache");
   }
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -153,6 +153,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.SerializeDependencyScannerCache |= Args.hasArg(OPT_serialize_dependency_scan_cache);
   Opts.ReuseDependencyScannerCache |= Args.hasArg(OPT_reuse_dependency_scan_cache);
+  Opts.ValidatePriorDependencyScannerCache |= Args.hasArg(OPT_validate_prior_dependency_scan_cache);
   Opts.EmitDependencyScannerCacheRemarks |= Args.hasArg(OPT_dependency_scan_cache_remarks);
   Opts.ParallelDependencyScan = Args.hasFlag(OPT_parallel_scan,
                                              OPT_no_parallel_scan,

--- a/test/CAS/no_incremental_scan_for_you.swift
+++ b/test/CAS/no_incremental_scan_for_you.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/Swift -cache-compile-job -cas-path %t/cas -no-clang-include-tree -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/clean_scan_output.txt
+// RUN: cat %t/clean_scan_output.txt | %FileCheck %s
+
+// CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache disabled in Caching build
+import E

--- a/test/ScanDependencies/Incremental/module_deps_invalidate.swift
+++ b/test/ScanDependencies/Incremental/module_deps_invalidate.swift
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Modules)
+
+// RUN: split-file %s %t
+
+// Build Module D
+// RUN: %target-swift-frontend -emit-module %t/D.swift -emit-module-path %t/Modules/D.swiftmodule/%target-swiftmodule-name -module-name D -enable-library-evolution -emit-module-interface-path %t/Modules/D.swiftmodule/%target-swiftinterface-name
+
+// Build Module C
+// RUN: %target-swift-frontend -emit-module %t/C.swift -emit-module-path %t/Modules/C.swiftmodule/%target-swiftmodule-name -module-name C -enable-library-evolution -emit-module-interface-path %t/Modules/C.swiftmodule/%target-swiftinterface-name -I %t/Modules/
+
+// Build Module B
+// RUN: %target-swift-frontend -emit-module %t/B.swift -emit-module-path %t/Modules/B.swiftmodule/%target-swiftmodule-name -module-name B -enable-library-evolution -emit-module-interface-path %t/Modules/B.swiftmodule/%target-swiftinterface-name -I %t/Modules/
+
+// Build Module A
+// RUN: %target-swift-frontend -emit-module %t/A.swift -emit-module-path %t/Modules/A.swiftmodule/%target-swiftmodule-name -module-name A -enable-library-evolution -emit-module-interface-path %t/Modules/A.swiftmodule/%target-swiftinterface-name -I %t/Modules/
+
+// Initial Scan Client module
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_initial.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client
+
+// Clean re-scan
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_clean_rescan.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/clean_incremental_scan_output.txt
+// RUN: cat %t/clean_incremental_scan_output.txt | %FileCheck %s -check-prefix=CLEAN-INCREMENTAL-SCAN-CHECK
+
+// Touch C and re-scan
+// RUN: touch %t/Modules/C.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_stale_C_rescan.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/stale_C_incremental_scan_output.txt
+// RUN: cat %t/stale_C_incremental_scan_output.txt | %FileCheck %s -check-prefix=STALE-C-INCREMENTAL-SCAN-CHECK
+
+// Clean re-scan
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_clean_rescan_2.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/clean_incremental_scan_output_2.txt
+// RUN: cat %t/clean_incremental_scan_output_2.txt | %FileCheck %s -check-prefix=CLEAN-INCREMENTAL-SCAN-CHECK
+
+// Replace a module dependency in A, ensure re-scan detects it
+// RUN: echo "import X" > %t/A.swift
+// RUN: %target-swift-frontend -emit-module %t/A.swift -emit-module-path %t/Modules/A.swiftmodule/%target-swiftmodule-name -module-name A -enable-library-evolution -emit-module-interface-path %t/Modules/A.swiftmodule/%target-swiftinterface-name -I %t/Modules/ -I %S/../Inputs/CHeaders
+
+// Re-scan to ensure A gets scanned again and the new dependency is picked up.
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_new_A_rescan.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/new_A_incremental_scan_output.txt
+// RUN: cat %t/new_A_incremental_scan_output.txt | %FileCheck %s -check-prefix=NEW-A-INCREMENTAL-SCAN-CHECK
+// RUN: %validate-json %t/deps_new_A_rescan.json | %FileCheck %s --check-prefix=NEW-A-DEPS-CHECK
+
+// Touch a header in Clang module X and re-scan
+// RUN: touch %S/../Inputs/CHeaders/X.h
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %t/Client.swift -o %t/deps_stale_X_rescan.json -I %t/Modules -I %S/../Inputs/CHeaders -module-name Client -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/stale_X_incremental_scan_output.txt
+// RUN: cat %t/stale_X_incremental_scan_output.txt | %FileCheck %s -check-prefix=STALE-X-INCREMENTAL-SCAN-CHECK
+
+// CLEAN-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// CLEAN-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Serializing module scanning dependency cache to: {{.*}}cache.moddepcache
+// CLEAN-INCREMENTAL-SCAN-CHECK-NOT: remark: Incremental module scan: Dependency info for module '{{.*}}' invalidated due to
+
+// STALE-C-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// STALE-C-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'C' invalidated due to a modified input since last scan: {{.*}}C.swiftmodule{{.*}}swiftinterface
+// STALE-C-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'B' invalidated due to an out-of-date dependency.
+// STALE-C-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'A' invalidated due to an out-of-date dependency.
+// STALE-C-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Serializing module scanning dependency cache to: {{.*}}cache.moddepcache
+// STALE-C-INCREMENTAL-SCAN-CHECK-NOT: remark: Incremental module scan: Dependency info for module 'D' invalidated
+
+// NEW-A-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// NEW-A-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'A' invalidated due to a modified input since last scan: {{.*}}A.swiftmodule{{.*}}swiftinterface
+// NEW-A-DEPS-CHECK: "clang": "X"
+
+// STALE-X-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// STALE-X-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'X' invalidated due to a modified input since last scan: {{.*}}X.h
+// STALE-X-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Dependency info for module 'A' invalidated due to an out-of-date dependency.
+// STALE-X-INCREMENTAL-SCAN-CHECK: remark: Incremental module scan: Serializing module scanning dependency cache to: {{.*}}cache.moddepcache
+
+//--- A.swift
+import B
+
+//--- B.swift
+import C
+
+//--- C.swift
+import D
+
+//--- D.swift
+public func foo() {}
+
+//--- Client.swift
+import A

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -19,8 +19,8 @@ import E
 import G
 import SubE
 
-// CHECK-REMARK-SAVE: remark: Serializing module scanning dependency cache to:
-// CHECK-REMARK-LOAD: remark: Re-using serialized module scanning dependency cache from:
+// CHECK-REMARK-SAVE: remark: Incremental module scan: Serializing module scanning dependency cache to:
+// CHECK-REMARK-LOAD: remark: Incremental module scan: Re-using serialized module scanning dependency cache from:
 
 // CHECK: "mainModuleName": "deps"
 


### PR DESCRIPTION
Checking each module dependency info if it is up-to-date with respect to when the cache contents were serialized in a prior scan.
