### PR TITLE
[Debug Info] Remove the mostly unused FragmentStorageType from DebugTypeInfo 

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -26,12 +26,11 @@
 using namespace swift;
 using namespace irgen;
 
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *FragmentStorageTy,
-                             Alignment Align, bool HasDefaultAlignment,
-                             bool IsMetadata, bool IsFixedBuffer,
+DebugTypeInfo::DebugTypeInfo(swift::Type Ty, Alignment Align,
+                             bool HasDefaultAlignment, bool IsMetadata,
+                             bool IsFixedBuffer,
                              std::optional<uint32_t> NumExtraInhabitants)
-    : Type(Ty.getPointer()), FragmentStorageType(FragmentStorageTy),
-      NumExtraInhabitants(NumExtraInhabitants),
+    : Type(Ty.getPointer()), NumExtraInhabitants(NumExtraInhabitants),
       Align(Align), DefaultAlignment(HasDefaultAlignment),
       IsMetadataType(IsMetadata), IsFixedBuffer(IsFixedBuffer) {
   assert(Align.getValue() != 0);
@@ -49,15 +48,14 @@ static bool hasDefaultAlignment(swift::Type Ty) {
 
 DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &TI,
                                              IRGenModule &IGM) {
-  llvm::Type *StorageType = TI.getStorageType();
   std::optional<uint32_t> NumExtraInhabitants;
   if (TI.isFixedSize()) {
     const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&TI);
     NumExtraInhabitants = FixTy.getFixedExtraInhabitantCount(IGM);
   }
   assert(TI.getStorageType() && "StorageType is a nullptr");
-  return DebugTypeInfo(Ty.getPointer(), StorageType,
-                       TI.getBestKnownAlignment(), ::hasDefaultAlignment(Ty),
+  return DebugTypeInfo(Ty.getPointer(), TI.getBestKnownAlignment(),
+                       ::hasDefaultAlignment(Ty),
                        /* IsMetadataType = */ false,
                        /* IsFixedBuffer = */ false, NumExtraInhabitants);
 }
@@ -81,25 +79,21 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
   return getFromTypeInfo(Type, Info, IGM);
 }
 
-DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
-                                               llvm::Type *StorageTy, Size size,
+DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty, Size size,
                                                Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align,
+  DebugTypeInfo DbgTy(Ty.getPointer(), align,
                       /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ false);
-  assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
   return DbgTy;
 }
 
-DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty,
-                                             llvm::Type *StorageTy, Size size,
+DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty, Size size,
                                              Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align,
+  DebugTypeInfo DbgTy(Ty.getPointer(), align,
                       /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ true);
-  assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
   return DbgTy;
@@ -111,7 +105,6 @@ DebugTypeInfo DebugTypeInfo::getForwardDecl(swift::Type Ty) {
 }
 
 DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
-                                       llvm::Type *FragmentStorageType,
                                        IRGenModule &IGM) {
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
@@ -124,16 +117,14 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
   }
   auto &TI = IGM.getTypeInfoForUnlowered(Type);
   DebugTypeInfo DbgTy = getFromTypeInfo(Type, TI, IGM);
-  assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of global variable cannot be an archetype");
   return DbgTy;
 }
 
-DebugTypeInfo
-DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
-                                    llvm::Type *FragmentStorageType,
-                                    Size SizeInBytes, Alignment Align) {
+DebugTypeInfo DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
+                                                  Size SizeInBytes,
+                                                  Alignment Align) {
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
   auto LowTy = GV->getLoweredType().getASTType();
@@ -143,23 +134,18 @@ DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }
-  DebugTypeInfo DbgTy(Type, FragmentStorageType,
-                      Align, ::hasDefaultAlignment(Type),
+  DebugTypeInfo DbgTy(Type, Align, ::hasDefaultAlignment(Type),
                       /* IsMetadataType = */ false, /* IsFixedBuffer = */ true);
-  assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of global variable cannot be an archetype");
   return DbgTy;
 }
 
-DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
-                                          llvm::Type *FragmentStorageType,
-                                          Size SizeInBytes, Alignment align) {
-  DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(),
-                      FragmentStorageType, align,
+DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass, Size SizeInBytes,
+                                          Alignment align) {
+  DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(), align,
                       /* HasDefaultAlignment = */ true,
                       /* IsMetadataType = */ false);
-  assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of objc class cannot be an archetype");
   return DbgTy;
@@ -194,7 +180,7 @@ TypeDecl *DebugTypeInfo::getDecl() const {
 }
 
 bool DebugTypeInfo::isForwardDecl() const {
-  return isNull() || (!FragmentStorageType && !isa<TypeAliasType>(getType()));
+  return isNull() || (!isa<TypeAliasType>(getType()));
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -204,17 +190,14 @@ LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   if (auto *Type = getType())
     Type->dump(llvm::errs());
 
-  if (FragmentStorageType) {
-    llvm::errs() << "FragmentStorageType=";
-    FragmentStorageType->dump();
-  }
   if (isForwardDecl())
     llvm::errs() << "forward-declared\n";
 }
 #endif
 
 std::optional<CompletedDebugTypeInfo>
-CompletedDebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &Info, IRGenModule &IGM) {
+CompletedDebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &Info,
+                                        IRGenModule &IGM) {
   auto *StorageType = IGM.getStorageTypeForUnlowered(Ty);
   std::optional<uint64_t> SizeInBits;
   if (StorageType->isSized())

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -193,6 +193,10 @@ TypeDecl *DebugTypeInfo::getDecl() const {
   return nullptr;
 }
 
+bool DebugTypeInfo::isForwardDecl() const {
+  return isNull() || (!FragmentStorageType && !isa<TypeAliasType>(getType()));
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   llvm::errs() << "[";
@@ -203,7 +207,8 @@ LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   if (FragmentStorageType) {
     llvm::errs() << "FragmentStorageType=";
     FragmentStorageType->dump();
-  } else
+  }
+  if (isForwardDecl())
     llvm::errs() << "forward-declared\n";
 }
 #endif

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -43,7 +43,6 @@ protected:
   TypeBase *Type = nullptr;
   /// Needed to determine the size of basic types and to determine
   /// the storage type for undefined variables.
-  llvm::Type *FragmentStorageType = nullptr;
   std::optional<uint32_t> NumExtraInhabitants;
   Alignment Align;
   bool DefaultAlignment = true;
@@ -52,8 +51,7 @@ protected:
 
 public:
   DebugTypeInfo() = default;
-  DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy = nullptr,
-                Alignment AlignInBytes = Alignment(1),
+  DebugTypeInfo(swift::Type Ty, Alignment AlignInBytes = Alignment(1),
                 bool HasDefaultAlignment = true, bool IsMetadataType = false,
                 bool IsFixedBuffer = false,
                 std::optional<uint32_t> NumExtraInhabitants = {});
@@ -62,11 +60,11 @@ public:
   static DebugTypeInfo getLocalVariable(VarDecl *Decl, swift::Type Ty,
                                         const TypeInfo &Info, IRGenModule &IGM);
   /// Create type for global type metadata.
-  static DebugTypeInfo getGlobalMetadata(swift::Type Ty, llvm::Type *StorageTy,
-                                         Size size, Alignment align);
+  static DebugTypeInfo getGlobalMetadata(swift::Type Ty, Size size,
+                                         Alignment align);
   /// Create type for an artificial metadata variable.
-  static DebugTypeInfo getTypeMetadata(swift::Type Ty, llvm::Type *StorageTy,
-                                       Size size, Alignment align);
+  static DebugTypeInfo getTypeMetadata(swift::Type Ty, Size size,
+                                       Alignment align);
 
   /// Create a forward declaration for a type whose size is unknown.
   static DebugTypeInfo getForwardDecl(swift::Type Ty);
@@ -75,14 +73,11 @@ public:
   static DebugTypeInfo getFromTypeInfo(swift::Type Ty, const TypeInfo &Info,
                                        IRGenModule &IGM);
   /// Global variables.
-  static DebugTypeInfo getGlobal(SILGlobalVariable *GV,
-                                 llvm::Type *StorageType, IRGenModule &IGM);
+  static DebugTypeInfo getGlobal(SILGlobalVariable *GV, IRGenModule &IGM);
   static DebugTypeInfo getGlobalFixedBuffer(SILGlobalVariable *GV,
-                                            llvm::Type *StorageType,
                                             Size SizeInBytes, Alignment align);
   /// ObjC classes.
-  static DebugTypeInfo getObjCClass(ClassDecl *theClass,
-                                    llvm::Type *StorageType, Size size,
+  static DebugTypeInfo getObjCClass(ClassDecl *theClass, Size size,
                                     Alignment align);
   /// Error type.
   static DebugTypeInfo getErrorResult(swift::Type Ty, IRGenModule &IGM);
@@ -100,7 +95,6 @@ public:
     return false;
   }
 
-  llvm::Type *getFragmentStorageType() const { return FragmentStorageType; }
   Alignment getAlignment() const { return Align; }
   bool isNull() const { return !Type; }
   bool isForwardDecl() const;
@@ -151,7 +145,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   }
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
-        llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
+        llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(),
         swift::irgen::Alignment(), /* HasDefaultAlignment = */ false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -102,8 +102,8 @@ public:
 
   llvm::Type *getFragmentStorageType() const { return FragmentStorageType; }
   Alignment getAlignment() const { return Align; }
-  bool isNull() const { return Type == nullptr; }
-  bool isForwardDecl() const { return FragmentStorageType == nullptr; }
+  bool isNull() const { return !Type; }
+  bool isForwardDecl() const;
   bool isMetadataType() const { return IsMetadataType; }
   bool hasDefaultAlignment() const { return DefaultAlignment; }
   bool isFixedBuffer() const { return IsFixedBuffer; }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2741,10 +2741,9 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
       }
 
       DebugTypeInfo DbgTy =
-          inFixedBuffer
-              ? DebugTypeInfo::getGlobalFixedBuffer(
-                    var, globalTy, fixedSize, fixedAlignment)
-              : DebugTypeInfo::getGlobal(var, globalTy, *this);
+          inFixedBuffer ? DebugTypeInfo::getGlobalFixedBuffer(var, fixedSize,
+                                                              fixedAlignment)
+                        : DebugTypeInfo::getGlobal(var, *this);
 
       gvar = createVariable(*this, link, globalTy, fixedAlignment, DbgTy, loc, name);
     }
@@ -4738,8 +4737,8 @@ Address IRGenModule::getAddrOfObjCClassRef(ClassDecl *theClass) {
   assert(ObjCInterop && "getting address of ObjC class ref in no-interop mode");
 
   LinkEntity entity = LinkEntity::forObjCClassRef(theClass);
-  auto DbgTy = DebugTypeInfo::getObjCClass(
-      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(theClass, getPointerSize(),
+                                           getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, ConstantInit(), DbgTy);
 
   // Define it lazily.
@@ -4764,8 +4763,8 @@ llvm::Constant *IRGenModule::getAddrOfObjCClass(ClassDecl *theClass,
   assert(ObjCInterop && "getting address of ObjC class in no-interop mode");
   assert(!theClass->isForeign());
   LinkEntity entity = LinkEntity::forObjCClass(theClass);
-  auto DbgTy = DebugTypeInfo::getObjCClass(
-      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(theClass, getPointerSize(),
+                                           getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, forDefinition, DbgTy);
   return addr;
 }
@@ -4784,8 +4783,8 @@ IRGenModule::getAddrOfMetaclassObject(ClassDecl *decl,
                     ? LinkEntity::forObjCMetaclass(decl)
                     : LinkEntity::forSwiftMetaclassStub(decl);
 
-  auto DbgTy = DebugTypeInfo::getObjCClass(
-      decl, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(decl, getPointerSize(),
+                                           getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, forDefinition, DbgTy);
   return addr;
 }
@@ -4800,8 +4799,8 @@ IRGenModule::getAddrOfCanonicalSpecializedGenericMetaclassObject(
   auto entity =
       LinkEntity::forSpecializedGenericSwiftMetaclassStub(concreteType);
 
-  auto DbgTy = DebugTypeInfo::getObjCClass(
-      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(theClass, getPointerSize(),
+                                           getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, forDefinition, DbgTy);
   return addr;
 }
@@ -5149,10 +5148,8 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(
                                          TypeMetadataAddress::AddressPoint);
   }
 
-  auto DbgTy = DebugTypeInfo::getGlobalMetadata(
-      MetatypeType::get(concreteType),
-      entity.getDefaultDeclarationType(*this)->getPointerTo(), Size(0),
-      Alignment(1));
+  auto DbgTy = DebugTypeInfo::getGlobalMetadata(MetatypeType::get(concreteType),
+                                                Size(0), Alignment(1));
 
   // Define the variable.
   llvm::GlobalVariable *var = cast<llvm::GlobalVariable>(
@@ -5316,7 +5313,6 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
     break;
   }
   DbgTy = DebugTypeInfo::getGlobalMetadata(MetatypeType::get(concreteType),
-                                           defaultVarTy->getPointerTo(),
                                            Size(0), Alignment(1));
 
   ConstantReference addr;

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -44,7 +44,7 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
   // variable directly, don't actually emit it; just return undef.
   if (ti.isKnownEmpty(expansion)) {
     if (DebugInfo && var->getDecl()) {
-      auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, *this);
+      auto DbgTy = DebugTypeInfo::getGlobal(var, *this);
       DebugInfo->emitGlobalVariableDeclaration(nullptr, var->getDecl()->getName().str(),
                                                "", DbgTy,
                                                var->getLinkage() != SILLinkage::Public &&

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1475,24 +1475,14 @@ private:
   }
 
   llvm::DIType *getOrCreateDesugaredType(Type Ty, DebugTypeInfo DbgTy) {
-    DebugTypeInfo BlandDbgTy(Ty, DbgTy.getFragmentStorageType(),
-                             DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
+    DebugTypeInfo BlandDbgTy(Ty, DbgTy.getAlignment(),
+                             DbgTy.hasDefaultAlignment(),
                              DbgTy.isMetadataType(), DbgTy.isFixedBuffer());
     return getOrCreateType(BlandDbgTy);
   }
 
   uint64_t getSizeOfBasicType(CompletedDebugTypeInfo DbgTy) {
     uint64_t BitWidth = DbgTy.getSizeInBits();
-    llvm::Type *StorageType = DbgTy.getFragmentStorageType()
-                                  ? DbgTy.getFragmentStorageType()
-                                  : IGM.DataLayout.getSmallestLegalIntType(
-                                        IGM.getLLVMContext(), BitWidth);
-
-    if (StorageType)
-      return IGM.DataLayout.getTypeSizeInBits(StorageType);
-
-    // This type is too large to fit in a register.
-    assert(BitWidth > IGM.DataLayout.getLargestLegalIntTypeSizeInBits());
     return BitWidth;
   }
 
@@ -1732,8 +1722,7 @@ private:
 
   bool shouldCacheDIType(llvm::DIType *DITy, DebugTypeInfo &DbgTy) {
     // Don't cache a type alias to a forward declaration either.
-    if (DbgTy.isForwardDecl() || DbgTy.isFixedBuffer() ||
-        DITy->isForwardDecl())
+    if (DbgTy.isFixedBuffer() || DITy->isForwardDecl())
       return false;
 
     if (auto Ty = DbgTy.getType())
@@ -1744,6 +1733,14 @@ private:
     return true;
   }
 
+  std::optional<CompletedDebugTypeInfo> completeType(DebugTypeInfo DbgTy) {
+    if (!DbgTy.getType() || DbgTy.getType()->hasTypeParameter() ||
+        isa<IntegerType>(DbgTy.getType()))
+      return {};
+    return CompletedDebugTypeInfo::getFromTypeInfo(
+        DbgTy.getType(), IGM.getTypeInfoForUnlowered(DbgTy.getType()), IGM);
+  }
+
   llvm::DIType *createType(DebugTypeInfo DbgTy, StringRef MangledName,
                            llvm::DIScope *Scope, llvm::DIFile *File) {
     // FIXME: For SizeInBits, clang uses the actual size of the type on
@@ -1752,8 +1749,7 @@ private:
     // emitting the storage size of the struct, but it may be necessary
     // to emit the (target!) size of the underlying basic type.
     uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
-    auto CompletedDbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
-      DbgTy.getType(), IGM.getTypeInfoForUnlowered(DbgTy.getType()), IGM);
+    std::optional<CompletedDebugTypeInfo> CompletedDbgTy = completeType(DbgTy);
     std::optional<uint64_t> SizeInBitsOrNull;
     if (CompletedDbgTy)
       SizeInBitsOrNull = CompletedDbgTy->getSizeInBits();
@@ -1791,8 +1787,9 @@ private:
     case TypeKind::BuiltinFixedArray: {
       // TODO: provide proper array debug info
       unsigned FwdDeclLine = 0;
-      return createOpaqueStruct(Scope, "Builtin.FixedArray", MainFile, FwdDeclLine,
-                                SizeInBits, AlignInBits, Flags, MangledName);
+      return createOpaqueStruct(Scope, "Builtin.FixedArray", MainFile,
+                                FwdDeclLine, SizeInBits, AlignInBits, Flags,
+                                MangledName);
     }
 
     case TypeKind::BuiltinPackIndex:
@@ -1832,7 +1829,6 @@ private:
             llvm::dwarf::DW_LANG_Swift, nullptr, {}, nullptr,
             NumExtraInhabitants);
         return PTy;
-
       }
       llvm::DIDerivedType *PTy = DBuilder.createPointerType(
           nullptr, PtrSize, 0,
@@ -1862,8 +1858,8 @@ private:
       auto *Decl = StructTy->getDecl();
       auto L = getFileAndLocation(Decl);
       // No line numbers are attached to type forward declarations.  This is
-      // intentional: It interferes with the efficacy of incremental builds. We
-      // don't want a whitespace change to an secondary file trigger a
+      // intentional: It interferes with the efficacy of incremental builds.
+      // We don't want a whitespace change to an secondary file trigger a
       // recompilation of the debug info of a primary source file.
       unsigned FwdDeclLine = 0;
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
@@ -1999,14 +1995,11 @@ private:
 
     case TypeKind::Pack:
     case TypeKind::PackElement:
-      llvm_unreachable("Unimplemented!");
-
     case TypeKind::SILPack:
     case TypeKind::PackExpansion:
-      //assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
-      return createPointerSizedStruct(Scope,
-                                      MangledName,
-                                      MainFile, 0, Flags, MangledName);
+      // assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      return createPointerSizedStruct(Scope, MangledName, MainFile, 0, Flags,
+                                      MangledName);
 
     case TypeKind::BuiltinTuple:
       llvm_unreachable("BuiltinTupleType should not show up here");
@@ -2032,8 +2025,8 @@ private:
     case TypeKind::PackArchetype: {
       auto *Archetype = BaseTy->castTo<ArchetypeType>();
       AssociatedTypeDecl *assocType = nullptr;
-      if (auto depMemTy = Archetype->getInterfaceType()
-              ->getAs<DependentMemberType>())
+      if (auto depMemTy =
+              Archetype->getInterfaceType()->getAs<DependentMemberType>())
         assocType = depMemTy->getAssocType();
       auto L = getFileAndLocation(assocType);
       if (!L.File)
@@ -2057,9 +2050,9 @@ private:
 
         auto PTy =
             IGM.getLoweredType(ProtocolDecl->getInterfaceType()).getASTType();
-        auto PDbgTy = DebugTypeInfo::getFromTypeInfo(
-            ProtocolDecl->getInterfaceType(), IGM.getTypeInfoForLowered(PTy),
-            IGM);
+        auto PDbgTy =
+            DebugTypeInfo::getFromTypeInfo(ProtocolDecl->getInterfaceType(),
+                                           IGM.getTypeInfoForLowered(PTy), IGM);
         auto PDITy = getOrCreateType(PDbgTy);
         Protocols.push_back(
             DBuilder.createInheritance(FwdDecl.get(), PDITy, 0, 0, Flags));
@@ -2178,8 +2171,7 @@ private:
       // For TypeAlias types, the DeclContext for the aliased type is
       // in the decl of the alias type.
       DebugTypeInfo AliasedDbgTy(
-          AliasedTy, DbgTy.getFragmentStorageType(),
-          DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
+          AliasedTy, DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
           /* IsMetadataType = */ false, DbgTy.isFixedBuffer(),
           DbgTy.getNumExtraInhabitants());
       return DBuilder.createTypedef(getOrCreateType(AliasedDbgTy), MangledName,
@@ -2277,16 +2269,17 @@ private:
     // so skip the sanity check.
     if (CachedType->isTemporary())
       return true;
-    if (DbgTy.isForwardDecl())
-      return true;
-    auto CompletedDbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
-      DbgTy.getType(), IGM.getTypeInfoForUnlowered(DbgTy.getType()), IGM);
     std::optional<uint64_t> SizeInBits;
+    std::optional<CompletedDebugTypeInfo> CompletedDbgTy = completeType(DbgTy);
     if (CompletedDbgTy)
       SizeInBits = CompletedDbgTy->getSizeInBits();
     unsigned CachedSizeInBits = getSizeInBits(CachedType);
-    if ((SizeInBits && CachedSizeInBits != *SizeInBits) ||
-        (!SizeInBits && CachedSizeInBits)) {
+    if (SizeInBits && CachedSizeInBits != *SizeInBits) {
+      // Note that CachedSizeInBits && !SizeInBits may happen and is benign,
+      // because the cached copy would win. When the sizeless type is generated
+      // it should be emitted as a forward declaration and thus never make it
+      // into the cache.
+
       // In some situation a specialized type is emitted with size 0, even if
       // the real type has a size.
       if (DbgTy.getType()->isSpecialized() && SizeInBits && *SizeInBits > 0 &&
@@ -2511,7 +2504,8 @@ private:
 
     // If this is a forward decl, create one for this mangled name and don't
     // cache it.
-    if (DbgTy.isForwardDecl()) {
+    if (!isa<PrimaryArchetypeType>(DbgTy.getType()) &&
+        (DbgTy.isFixedBuffer() || !completeType(DbgTy))) {
       // In LTO type uniquing is performed based on the UID. Forward
       // declarations may not have a unique ID to avoid a forward declaration
       // winning over a full definition.
@@ -2529,7 +2523,7 @@ private:
 
 
     if (!shouldCacheDIType(DITy, DbgTy))
-        return  DITy;
+      return DITy;
 
     // Incrementally build the DIRefMap.
     if (auto *CTy = dyn_cast<llvm::DICompositeType>(DITy)) {
@@ -3731,7 +3725,7 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
   assert(PtrWidthInBits % 8 == 0);
   auto DbgTy = DebugTypeInfo::getTypeMetadata(
       getMetadataType(Name)->getDeclaredInterfaceType().getPointer(),
-      Metadata->getType(), Size(PtrWidthInBits / 8),
+      Size(PtrWidthInBits / 8),
       Alignment(CI.getTargetInfo().getPointerAlign(clang::LangAS::Default)));
   emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
                           {}, {OS.str().str(), 0, false},

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2511,7 +2511,7 @@ private:
 
     // If this is a forward decl, create one for this mangled name and don't
     // cache it.
-    if (DbgTy.isForwardDecl() && !isa<TypeAliasType>(DbgTy.getType())) {
+    if (DbgTy.isForwardDecl()) {
       // In LTO type uniquing is performed based on the UID. Forward
       // declarations may not have a unique ID to avoid a forward declaration
       // winning over a full definition.

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -10,7 +10,7 @@ public let s = S<Int>(t: 0)
 // CHECK-SAME:             templateParams: ![[PARAMS:[0-9]+]]
 // CHECK: ![[PARAMS]] = !{![[INTPARAM:[0-9]+]]}
 // CHECK: ![[INTPARAM]] = !DITemplateTypeParameter(type: ![[INT:[0-9]+]])
-// CHECK: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sSiD",
+// CHECK: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}identifier: "$sSiD"
 
 
 // DWARF: !DICompositeType(tag: DW_TAG_structure_type,
@@ -56,4 +56,4 @@ public let inner = S2<Double>.Inner(t:4.2)
 
 // DWARF: ![[ELEMENTS1]] = !{![[ELEMENTS2:[0-9]+]]}
 
-// DWARF: ![[ELEMENTS2]] = !DIDerivedType(tag: DW_TAG_member, name: "t", scope: !27, file: !3, baseType: ![[GENERIC_PARAM_TYPE]])
+// DWARF: ![[ELEMENTS2]] = !DIDerivedType(tag: DW_TAG_member, name: "t", {{.*}}, baseType: ![[GENERIC_PARAM_TYPE]])

--- a/test/DebugInfo/PrivateDiscriminator.swift
+++ b/test/DebugInfo/PrivateDiscriminator.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend %S/../Inputs/empty.swift -primary-file %s \
 // RUN:   -emit-ir -g | %FileCheck %s
 // CHECK: !DICompileUnit({{.*}}flags: {{[^,]*}}-private-discriminator [[DISCRIMINATOR:_[A-Z0-9]+]]
-// CHECK: ![[MOD:.*]] = !DIModule(scope: null,
+// CHECK: ![[MOD:.*]] = !DIModule(scope: null, name: "empty"
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "InA",
 // CHECK-SAME:             scope: ![[A:[0-9]+]],
 // CHECK: ![[A]] = !DICompositeType(tag: DW_TAG_structure_type, name: "A",

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -27,7 +27,7 @@ func main() -> Int64 {
     // CHECK-DAG: ![[BAZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}} baseType: ![[BAZT:[0-9]+]]
     // CHECK-DAG: ![[BAZT]] = !DISubroutineType(types: ![[BAZARGS:.*]])
     // CHECK-DAG: ![[BAZARGS]] = !{![[INT:.*]], ![[FLOAT:.*]]}
-    // CHECK-DAG: ![[INT]] = {{.*}}name: "$ss5Int64VD"
+    // CHECK-DAG: ![[INT]] = {{.*}}identifier: "$ss5Int64VD"
     // CHECK-DAG: ![[FLOAT]] = {{.*}}identifier: "$sSfD"
     var baz_fnptr = baz
     baz_fnptr(2.89)

--- a/test/DebugInfo/generic_arg5.swift
+++ b/test/DebugInfo/generic_arg5.swift
@@ -12,17 +12,14 @@ public func foo<Type>(_ values : [S<Type>])
   // CHECK-SAME:       ![[ARG:[0-9]+]],
   // CHECK-SAME:       !DIExpression(DW_OP_deref)
   // CHECK: store ptr %1, ptr %[[ALLOCA]], align
-  // CHECK: ![[TYP:[0-9]+]] = !DICompositeType({{.*}}, name: "$s12generic_arg51SVyxGD"
+  // CHECK-DAG: ![[TYP:[0-9]+]] = !DICompositeType({{.*}}, name: "$s12generic_arg51SVyxGD"
   // The argument is a by-ref struct and thus needs to be dereferenced.
-  // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE+8]],
-  // CHECK-SAME:                        type: ![[LET_TYP:[0-9]+]])
-  // CHECK: ![[LET_TYP]] = !DIDerivedType(tag: DW_TAG_const_type,
-  // CHECK-SAME:                          baseType: ![[TYP_CONTAINER:[0-9]+]])
-  // CHECK: ![[TYP_CONTAINER]] = !DICompositeType({{.*}}elements: ![[TYP_ELTS:[0-9]+]]
-  // CHECK: ![[TYP_ELTS]] = !{![[TYP_MEMBER:[0-9]+]]}
-  // CHECK: ![[TYP_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[TYP_:[0-9]+]]
-  // CHECK: ![[TYP_]] = !DICompositeType({{.*}}, name: "$s12generic_arg51SVyxGD"
+  // CHECK-DAG: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,{{.*}}line: [[@LINE+6]],{{.*}} type: ![[LET_TYP:[0-9]+]])
+  // CHECK-DAG: ![[LET_TYP]] = !DIDerivedType(tag: DW_TAG_const_type,{{.*}} baseType: ![[TYP_CONTAINER:[0-9]+]])
+  // CHECK-DAG: ![[TYP_CONTAINER]] = !DICompositeType({{.*}}elements: ![[TYP_ELTS:[0-9]+]]
+  // CHECK-DAG: ![[TYP_ELTS]] = !{![[TYP_MEMBER:[0-9]+]]}
+  // CHECK-DAG: ![[TYP_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[TYP_:[0-9]+]]
+  // CHECK-DAG: ![[TYP_]] = !DICompositeType({{.*}}, name: "$s12generic_arg51SVyxGD"
   let _ = values.flatMap { arg in
     return .some(arg)
   }

--- a/test/DebugInfo/local_type_originally_defined_in.swift
+++ b/test/DebugInfo/local_type_originally_defined_in.swift
@@ -7,7 +7,7 @@ import local_type_originally_defined_in_other
 
 public func definedInOtherModule() {
   let s = Sheep()
-  // CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "Sheep"{{.*}}identifier: "$s4Barn5SheepCD
+  // CHECK-DAG: DICompositeType(tag: DW_TAG_structure_type, name: "Sheep"{{.*}}identifier: "$s4Barn5SheepCD
 }
 public func localTypeAliasTest(horse: Horse) {
   // The local type mangling for 'A' mentions 'Horse', which must
@@ -18,7 +18,7 @@ public func localTypeAliasTest(horse: Horse) {
 
   let info = UnsafeMutablePointer<A>.allocate(capacity: 1)
   _ = info
-  // CHECK: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest5horsey4Barn5HorseV_tF1AL_aD"
+  // CHECK-DAG: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest5horsey4Barn5HorseV_tF1AL_aD"
 }
 
 
@@ -31,7 +31,7 @@ public func localTypeTest(horse: Horse) {
 
   let info = UnsafeMutablePointer<LocalStruct>.allocate(capacity: 1)
   _ = info
-  // CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "$s32local_type_originally_defined_in0A8TypeTest5horsey4Barn5HorseV_tF11LocalStructL_VD"
+  // CHECK-DAG: DICompositeType(tag: DW_TAG_structure_type, {{.*}}identifier: "$s32local_type_originally_defined_in0A8TypeTest5horsey4Barn5HorseV_tF11LocalStructL_VD"
 }
 
 public func localTypeAliasTest() -> Horse {
@@ -40,7 +40,7 @@ public func localTypeAliasTest() -> Horse {
   let info = UnsafeMutablePointer<B>.allocate(capacity: 1)
   _ = info
   return Horse()
-  // CHECK: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest4Barn5HorseVyF1BL_aD"
+  // CHECK-DAG: DIDerivedType(tag: DW_TAG_typedef, name: "$s32local_type_originally_defined_in0A13TypeAliasTest4Barn5HorseVyF1BL_aD"
 }
 
 public func localTypeAliasTestGeneric<T: Cow>(cow: T) {

--- a/test/DebugInfo/protocol-extension.swift
+++ b/test/DebugInfo/protocol-extension.swift
@@ -15,6 +15,5 @@ public extension P {
   }
 }
 
-// CHECK: ![[SELFMETA]] = !DILocalVariable(name: "$\CF\84_0_0",
-// CHECK-SAME: type: ![[SELFTY:[0-9]+]], flags: DIFlagArtificial)
-// CHECK: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Self"
+// CHECK-DAG: ![[SELFMETA]] = !DILocalVariable(name: "$\CF\84_0_0", {{.*}}type: ![[SELFTY:[0-9]+]], flags: DIFlagArtificial)
+// CHECK-DAG: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Self"

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -18,7 +18,7 @@ class MyObject : NSObject {
   // LOC-CHECK: ret
   @objc var MyArr = NSArray()
   // IMPORT-CHECK: filename: "{{.*}}test-foundation.swift"
-  // IMPORT-CHECK-DAG: [[FOUNDATION:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath: {{.*}}Foundation.framework
+  // IMPORT-CHECK-DAG: [[FOUNDATION:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath: {{.*}}Foundation.framework"
   // IMPORT-CHECK-DAG: [[OVERLAY:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath: {{.*}}Foundation.swiftmodule
   // IMPORT-CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray", scope: ![[NSARRAY:[0-9]+]]
   //  IMPORT-CHECK-DAG: ![[NSARRAY]] = !DIModule(scope: ![[FOUNDATION:[0-9]+]], name: "NSArray"

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -9,12 +9,9 @@ class AClass : AProtocol {
 
 // CHECK: define hidden {{.*}}void @{{.*}}aFunction
 // CHECK:  #dbg_declare(ptr %{{.*}}, ![[TYPEARG:.*]], !DIExpression(),
-// CHECK: ![[TYPEARG]] = !DILocalVariable(name: "$\CF\84_0_0"
-// CHECK-SAME:                            type: ![[SWIFTMETATYPE:[^,)]+]]
-// CHECK-SAME:                            flags: DIFlagArtificial
-// CHECK: ![[SWIFTMETATYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "T",
-// CHECK-SAME:                                baseType: ![[VOIDPTR:[0-9]+]]
-// CHECK: ![[VOIDPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null
+// CHECK-DAG: ![[TYPEARG]] = !DILocalVariable(name: "$\CF\84_0_0"{{.*}}type: ![[SWIFTMETATYPE:[^,)]+]]{{.*}}flags: DIFlagArtificial
+// CHECK-DAG: ![[SWIFTMETATYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "T",{{.*}}baseType: ![[VOIDPTR:[0-9]+]]
+// CHECK-DAG: ![[VOIDPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null
 func aFunction<T : AProtocol>(_ x: T) {
     print("I am in aFunction: \(x.f())")
 }

--- a/test/DebugInfo/value-generics.swift
+++ b/test/DebugInfo/value-generics.swift
@@ -10,7 +10,7 @@ struct Slab<let N: Int, Element: ~Copyable>: ~Copyable {
 
 extension Slab: Copyable where Element: Copyable {}
 
-// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$sxq_BVD"
+// CHECK-DAG: !DICompositeType({{.*}}name: "$sxq_BVD"
 func genericBA<let N: Int, Element>(_: Builtin.FixedArray<N, Element>) {}
 
 // CHECK-DAG: !DICompositeType({{.*}}name: "$s4main4SlabVyxq_GD"
@@ -24,5 +24,5 @@ func concreteBA(_: Builtin.FixedArray<4, Int>) {}
 // CHECK-DAG: ![[COUNT_PARAM]] = !DITemplateTypeParameter(type: ![[COUNT_TYPE:.*]])
 // CHECK-DAG: ![[COUNT_TYPE]] = !DICompositeType({{.*}}name: "$s$1_D"
 // CHECK-DAG: ![[ELEMENT_PARAM]] = !DITemplateTypeParameter(type: ![[ELEMENT_TYPE:.*]])
-// CHECK-DAG: ![[ELEMENT_TYPE]] = !DICompositeType({{.*}}name: "$sSiD"
+// CHECK-DAG: ![[ELEMENT_TYPE]] = !DICompositeType({{.*}}identifier: "$sSiD"
 func concreteV(_: Slab<2, Int>) {}


### PR DESCRIPTION
This cleanup allows for more consistent debug info emission since we depend less
on IRGen magic to emit debug info for types.