### PR TITLE
BasicCalleeAnalysis: don't crash if the `bca` argument to `isDeinitBarrier` is null

### DIFF
--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -75,7 +75,7 @@ getMemoryBehavior(FullApplySite as, bool observeRetains) {
 
 bool swift::isDeinitBarrier(SILInstruction *const instruction,
                             BasicCalleeAnalysis *bca) {
-  if (!instructionIsDeinitBarrierFunction) {
+  if (!instructionIsDeinitBarrierFunction || !bca) {
     return mayBeDeinitBarrierNotConsideringSideEffects(instruction);
   }
   BridgedInstruction inst = {


### PR DESCRIPTION
Some clients don't provide a callee analysis to this API. Don't crash in this case.
