### PR TITLE
[Backtracing] Added BacktraceBuffer.

### DIFF
--- a/stdlib/public/RuntimeModule/BacktraceBuffer.swift
+++ b/stdlib/public/RuntimeModule/BacktraceBuffer.swift
@@ -1,0 +1,225 @@
+//===--- BacktraceBuffer.swift --------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  A ring buffer used for capturing multiple backtraces; the expected use
+//  case for this is in-process profiling, so it is important that all the
+//  memory be allocated up-front as no allocation can take place during
+//  backtrace capture itself.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+/// `BacktraceBuffer` is used to repeatedly capture backtraces; it calls
+/// a user-defined closure whenever it runs out of space in the buffer,
+/// in the expectation that the closure will empty data out of the buffer.
+///
+/// To use this class, you would create a `BacktraceBuffer` in advance,
+/// giving the various capture arguments at that time, then you call
+/// the `capture()` method repeatedly, and finally when you are done,
+/// you call `flush()`; something like this:
+///
+///     let fd = open("/tmp/captured.bin", O_RDWR, 0644)
+///     let buffer = BacktraceBuffer(
+///       capacity: 65536,
+///       algorithm: .auto,
+///       limit: 64,
+///       offset: 0,
+///       top: 16
+///     ) { chunk in
+///       return write(fd, chunk.baseAddress, chunk.count)
+///     }
+///     defer {
+///       buffer.flush()
+///       close(fd)
+///     }
+///
+///     let reader = UnsafeLocalMemoryReader()
+///
+///     for threadContext in capturedThreadContexts {
+///       buffer.capture(from: threadContext, using: reader)
+///     }
+@_spi(BacktraceBuffer)
+public class BacktraceBuffer<C: Context, M: MemoryReader> {
+  public typealias Context = C
+  public typealias MemoryReader = M
+  public typealias Address = Context.Address
+  public typealias UnwindAlgorithm = Backtrace.UnwindAlgorithm
+
+  public private(set) var reader: MemoryReader
+
+  var storage: UnsafeMutableRawBufferPointer
+
+  public private(set) var read, write, count: Int
+
+  public private(set) var algorithm: UnwindAlgorithm
+  public private(set) var limit: Int?
+  public private(set) var offset, top: Int
+  public private(set) var images: ImageMap?
+
+  var topBuffer: UnsafeMutableBufferPointer<RichFrame<Address>>
+
+  public private(set) var processChunk: (UnsafeRawBufferPointer) throws -> Int
+
+  /// Construct a BacktraceBuffer.
+  ///
+  /// This constructor allocates memory that will then be used whenever
+  /// you call `capture()`.
+  ///
+  /// Parameters:
+  ///
+  /// - using:         The memory reader to use.
+  /// - capacity:      The size of the buffer to use, in bytes.
+  /// - algorithm:     The unwind algorithm to use.
+  /// - limit:         The maximum number of frames to capture for each call
+  ///                  of `capture()`.
+  /// - offset:        The number of frames to skip for each call of `capture()`.
+  /// - top:           The minimum number of frames to capture at the top of
+  ///                  the stack.
+  /// - images:        (Optional) A list of captured images.
+  /// - processChunk:  Called whenever the buffer fills up to; should
+  ///                  return the number of bytes from the buffer it has
+  ///                  processed.
+  public init(using reader: MemoryReader,
+              capacity: Int = 65536, algorithm: UnwindAlgorithm = .auto,
+              limit: Int? = 64, offset: Int = 0, top: Int = 16,
+              images: ImageMap? = nil,
+              processChunk: @escaping (UnsafeRawBufferPointer) throws -> Int) {
+    self.reader = reader
+
+    storage = .allocate(byteCount: capacity, alignment: 4)
+    read = 0
+    write = 0
+    count = 0
+
+    self.algorithm = algorithm
+    self.limit = limit
+    self.offset = offset
+    self.top = top
+
+    topBuffer = .allocate(capacity: top)
+
+    self.processChunk = processChunk
+
+    #if os(Linux)
+    // On Linux, we need the captured images to resolve async functions
+    self.images = images ?? ImageMap.capture()
+    #else
+    self.images = images
+    #endif
+  }
+
+  deinit {
+    storage.deallocate()
+    topBuffer.deallocate()
+  }
+
+  /// Capture a backtrace into the buffer.
+  ///
+  /// Parameters:
+  ///
+  /// - from:          The `Context` the backtrace is to start from.
+  public func capture(
+    from context: Context,
+  ) throws {
+    switch algorithm {
+      // All algorithms, for now, use the frame pointer unwinder.  In the
+      // long run, we should be using DWARF EH for .precise.
+      default:
+        let unwinder =
+          FramePointerUnwinder(context: context,
+                               images: images,
+                               memoryReader: reader)
+
+        if let limit {
+          let limited = NonAllocatingLimitSequence(unwinder,
+                                                   limit: limit,
+                                                   offset: offset,
+                                                   top: top,
+                                                   topBuffer: topBuffer)
+
+          let encoder = CompactBacktraceFormat.Encoder(limited)
+
+          try fillBuffer(source: encoder)
+        } else {
+          let encoder = CompactBacktraceFormat.Encoder(unwinder)
+
+          try fillBuffer(source: encoder)
+        }
+    }
+  }
+
+  /// Flush any data left in the buffer.
+  ///
+  /// You should call this when you have finished capturing data.
+  ///
+  /// Parameters:
+  ///
+  /// - processChunk:  Called for each remaining chunk of data in the buffer.
+  ///                  (Generally there will be at most two such chunks.)
+  public func flush() throws {
+    // Empty the buffer completely
+    while count > 0 {
+      let chunkSize = Swift.min(storage.count - read, count)
+      let chunkEnd = read + chunkSize
+      let chunk = UnsafeRawBufferPointer(
+        rebasing: storage[read..<chunkEnd]
+      )
+      let done = try processChunk(chunk)
+
+      assert(done > 0 && done <= chunkSize)
+
+      count -= done
+      read += done
+
+      if read >= storage.count {
+        read -= storage.count
+      }
+    }
+  }
+
+  /// Fill the buffer with data from the specified byte source.
+  ///
+  /// Parameters:
+  ///
+  /// - source: The byte source to use to fill the buffer.
+  func fillBuffer<S: Sequence<UInt8>>(source: S) throws {
+    for byte in source {
+      storage[write] = byte
+      write += 1
+      count += 1
+
+      if write == storage.count {
+        write = 0
+      }
+
+      if count == storage.count {
+        // Try to clear some space in the buffer
+        let chunkSize = Swift.min(storage.count - read, count)
+        let chunkEnd = read + chunkSize
+        let chunk = UnsafeRawBufferPointer(
+          rebasing: storage[read..<chunkEnd]
+        )
+        let done = try processChunk(chunk)
+
+        assert(done > 0 && done <= chunkSize)
+
+        count -= done
+        read += done
+
+        if read >= storage.count {
+          read -= storage.count
+        }
+      }
+    }
+  }
+}

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -26,6 +26,7 @@ set(RUNTIME_SOURCES
   Address.swift
   Backtrace.swift
   Backtrace+Codable.swift
+  BacktraceBuffer.swift
   BacktraceFormatter.swift
   Base64.swift
   ByteSwapping.swift
@@ -49,6 +50,7 @@ set(RUNTIME_SOURCES
   LimitSequence.swift
   MemoryReader.swift
   OSReleaseScanner.swift
+  NonAllocatingLimitSequence.swift
   ProcMapsScanner.swift
   Registers.swift
   Runtime.swift

--- a/stdlib/public/RuntimeModule/CompactBacktrace.swift
+++ b/stdlib/public/RuntimeModule/CompactBacktrace.swift
@@ -16,7 +16,8 @@
 
 import Swift
 
-enum CompactBacktraceFormat {
+@_spi(CompactBacktraceFormat)
+public enum CompactBacktraceFormat {
   /// Tells us what size of machine words were used when generating the
   /// backtrace.
   enum WordSize: UInt8 {
@@ -205,14 +206,14 @@ enum CompactBacktraceFormat {
 
   /// Adapts a Sequence containing Compact Backtrace Format data into a
   /// Sequence of `Backtrace.Frame`s.
-  struct Decoder<S: Sequence<UInt8>>: Sequence {
-    typealias Frame = Backtrace.Frame
+  public struct Decoder<S: Sequence<UInt8>>: Sequence {
+    public typealias Element = Backtrace.Frame
     typealias Address = Backtrace.Address
     typealias Storage = S
 
     private var storage: Storage
 
-    init(_ storage: S) {
+    public init(_ storage: S) {
       self.storage = storage
     }
 
@@ -231,7 +232,7 @@ enum CompactBacktraceFormat {
       return Iterator(iterator, size)
     }
 
-    struct Iterator: IteratorProtocol {
+    public struct Iterator: IteratorProtocol {
       var iterator: Storage.Iterator?
       let wordSize: WordSize
       let wordMask: UInt64
@@ -396,8 +397,10 @@ enum CompactBacktraceFormat {
 
   /// Adapts a Sequence of RichFrames into a sequence containing Compact
   /// Backtrace Format data.
-  struct Encoder<A: FixedWidthInteger, S: Sequence<RichFrame<A>>>: Sequence {
-    typealias Element = UInt8
+  public struct Encoder<
+    A: FixedWidthInteger, S: Sequence<RichFrame<A>>
+  >: Sequence {
+    public typealias Element = UInt8
     typealias Frame = Backtrace.Frame
     typealias SourceFrame = RichFrame<A>
     typealias Address = A
@@ -405,7 +408,7 @@ enum CompactBacktraceFormat {
 
     private var source: Source
 
-    init(_ source: Source) {
+    public init(_ source: S) {
       self.source = source
     }
 
@@ -413,7 +416,7 @@ enum CompactBacktraceFormat {
       return Iterator(source.makeIterator())
     }
 
-    struct Iterator: IteratorProtocol {
+    public struct Iterator: IteratorProtocol {
       var iterator: Source.Iterator
       var lastAddress: Address = 0
 
@@ -577,7 +580,7 @@ enum CompactBacktraceFormat {
             // Grab a rich frame and encode it
             guard let frame = iterator.next() else {
               state = .done
-              return nil
+              return Instruction.end.rawValue
             }
 
             if let lastFrame, lastFrame == frame {

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -59,7 +59,7 @@ typealias arm_gprs = swift.runtime.backtrace.arm_gprs
   associatedtype Register: RawRepresentable where Register.RawValue == Int
 
   /// The architecture tag for this context (e.g. arm64, x86_64)
-  var architecture: String { get }
+  static var architecture: String { get }
 
   /// The program counter; this is likely a return address
   var programCounter: GPRValue { get set }
@@ -210,7 +210,7 @@ extension arm_gprs {
 
   var gprs = x86_64_gprs()
 
-  public var architecture: String { "x86_64" }
+  public static var architecture: String { "x86_64" }
 
   public var programCounter: Address {
     get { return gprs.rip }
@@ -451,7 +451,7 @@ extension arm_gprs {
 
   var gprs = i386_gprs()
 
-  public var architecture: String { "i386" }
+  public static var architecture: String { "i386" }
 
   public var programCounter: GPRValue {
     get { return gprs.eip }
@@ -634,7 +634,7 @@ extension arm_gprs {
 
   var gprs = arm64_gprs()
 
-  public var architecture: String { "arm64" }
+  public static var architecture: String { "arm64" }
 
   public var programCounter: GPRValue {
     get { return gprs.pc }
@@ -852,7 +852,7 @@ extension arm_gprs {
 
   var gprs = arm_gprs()
 
-  public var architecture: String { "arm" }
+  public static var architecture: String { "arm" }
 
   public var programCounter: GPRValue {
     get { return gprs.getR(ARMRegister.r15.rawValue) }

--- a/stdlib/public/RuntimeModule/NonAllocatingLimitSequence.swift
+++ b/stdlib/public/RuntimeModule/NonAllocatingLimitSequence.swift
@@ -1,0 +1,204 @@
+//===--- NonAllocatingLimitSequence.swift ---------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines a sequence adapter that implements the ability to limit the
+//  number of items in its output in various ways.  Unlike `LimitSequence`,
+//  this sequence is non-allocating and therefore requires that the user
+//  provide a buffer for top-of-stack capture.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+/// A `Sequence` that adds the ability to limit the output of another sequence.
+@usableFromInline
+struct NonAllocatingLimitSequence<T: LimitableElement, S: Sequence>
+  : Sequence, IteratorProtocol
+  where S.Element == T
+{
+  /// The element type, which must conform to `LimitableElement`
+  @usableFromInline
+  typealias Element = T
+
+  @usableFromInline
+  typealias Source = S
+
+  /// The source iterator
+  var iterator: Source.Iterator
+
+  /// The maximum number of items that we want in the output of this sequence.
+  /// This includes `.omitted()` and `.truncated` items.
+  var limit: Int
+
+  /// The number of items to drop from the head of the sequence.
+  var offset: Int
+
+  /// The minimum number of items to capture at the tail end of the input
+  /// sequence.  This can be _at most_ `limit - 1`.
+  var top: Int
+
+  /// The buffer to use to deal with top-of-stack capture.
+  var topBuffer: UnsafeMutableBufferPointer<T>
+
+  /// Initialise the `NonAllocatingLimitSequence`
+  ///
+  /// - source: The sequence to draw items from.
+  /// - limit:  The maximum number of items of output we desire.
+  /// - offset: The number of items to drop from the head of the input sequence.
+  /// - top:    The minimum number of items to capture at the tail end of the
+  ///           input sequence.
+  ///
+  /// A `NonAllocatingLimitSequence` will read from `source` and emit at most `limit` items,
+  /// after discarding the first `offset` items from `source`, including a
+  /// minimum of `top` items.
+  ///
+  /// When `NonAllocatingLimitSequence` omits items or truncates the sequence, it will
+  /// insert `.omitted(count)` or `.truncated` items into its output.
+  @usableFromInline
+  init(_ source: Source, limit: Int, offset: Int = 0, top: Int = 0,
+       topBuffer: UnsafeMutableBufferPointer<T>) {
+    self.iterator = source.makeIterator()
+    self.limit = limit
+    self.offset = offset
+    self.top = top
+    self.topBuffer = topBuffer
+    self.readAhead = nil
+    self.state = .normal
+    self.topCount = 0
+    self.topBase = 0
+    self.topNdx = 0
+
+    for _ in 0..<offset {
+      if self.iterator.next() == nil {
+        break
+      }
+    }
+
+    readNext()
+  }
+
+  /// We read one element ahead in the input sequence; that element is
+  /// stored here.
+  var readAhead: Element?
+
+  /// Tracks the number of items emitted before getting to `top`.
+  var count = 0
+
+  /// Points at the first item in `topBuffer`.
+  var topBase: Int
+
+  /// A count of the number of items in `topBuffer`.
+  var topCount: Int
+
+  /// The index in `topBuffer` that we should output from the next
+  /// call to `next()`.
+  var topNdx: Int
+
+  /// Tracks the iterator state.
+  var state: State
+
+  enum State {
+    case normal
+    case outputTop
+    case done
+  }
+
+  /// Fill `readAhead` with the next element from the input sequence.
+  private mutating func readNext() {
+    if let elt = self.iterator.next() {
+      readAhead = elt
+    } else {
+      readAhead = nil
+    }
+  }
+
+  /// Retrieve the next element in the output sequence.
+  public mutating func next() -> Element? {
+    switch state {
+      case .done:
+        return nil
+      case .outputTop:
+        let result = topBuffer[topNdx]
+        topNdx += 1
+        if topNdx == top {
+          topNdx = 0
+        }
+        if topNdx == topBase {
+          state = .done
+        }
+        return result
+      case .normal:
+        break
+    }
+
+    guard let element = readAhead else {
+      state = .done
+      return nil
+    }
+
+    readNext()
+
+    // Capture the easy part
+    if count < limit - top - 1 {
+      count += 1
+      return element
+    }
+
+    if top == 0 && readAhead != nil {
+      state = .done
+      return .truncated
+    }
+
+    let beforeTop = element
+
+    // Fill the top buffer
+    while let elt = readAhead, topCount < top {
+      topBuffer[topCount] = elt
+      topCount += 1
+
+      readNext()
+    }
+
+    if readAhead == nil {
+      // No elements means we just output beforeTop and we're done
+      if topCount == 0 {
+        state = .done
+        return beforeTop
+      }
+
+      // Otherwise, output beforeTop and then the top buffer
+      topNdx = 0
+      if topCount < top {
+        topBase = topCount
+      }
+      state = .outputTop
+      return beforeTop
+    }
+
+    // Use the top buffer as a circular buffer
+    var omitted = 1
+    while let elt = readAhead {
+      topBuffer[topBase] = elt
+      topBase += 1
+      omitted += 1
+      if topBase == top {
+        topBase = 0
+      }
+
+      readNext()
+    }
+
+    topNdx = topBase
+    state = .outputTop
+    return .omitted(omitted)
+  }
+}

--- a/test/Backtracing/BacktraceBuffer.swift
+++ b/test/Backtracing/BacktraceBuffer.swift
@@ -1,0 +1,201 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -cxx-interoperability-mode=default -Onone -o %t/BacktraceBuffer
+// RUN: %target-codesign %t/BacktraceBuffer
+// RUN: %target-run %t/BacktraceBuffer | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+#if os(macOS)
+import Darwin
+#else
+import Glibc
+#endif
+
+@_spi(MemoryReaders)
+@_spi(Contexts)
+@_spi(BacktraceBuffer)
+@_spi(Internal)
+import Runtime
+
+class SimpleFileSequence: Sequence, IteratorProtocol {
+  public typealias Element = UInt8
+
+  var fd: Int32
+  var buffer: UnsafeMutableRawBufferPointer
+  var readNdx, count: Int
+  var _atEnd: Bool?
+
+  init(path: String) {
+    fd = open(path, O_RDONLY)
+    buffer = .allocate(byteCount: 65536, alignment: 4096)
+    readNdx = 0
+    count = 0
+    _atEnd = nil
+  }
+  deinit {
+    buffer.deallocate()
+    close(fd)
+  }
+
+  var atEnd: Bool {
+    if readNdx < count {
+      return false
+    }
+
+    if let _atEnd, _atEnd {
+      return true
+    }
+
+    let done = read(fd, buffer.baseAddress, buffer.count)
+    if done == 0 {
+      _atEnd = true
+    } else {
+      count = done
+      readNdx = 0
+      _atEnd = false
+    }
+
+    return _atEnd!
+  }
+
+  public func next() -> UInt8? {
+    // This has the side-effect of refilling the buffer
+    if atEnd {
+      return nil
+    }
+
+    let byte = buffer[readNdx]
+    readNdx += 1
+
+    return byte
+  }
+}
+
+@main
+struct BacktraceBufferTest {
+  static var buffer: BacktraceBuffer<HostContext, UnsafeLocalMemoryReader>! = nil
+
+  static func doFrames(_ count: Int, originalCount: Int) {
+    if count <= 0 {
+      let before = buffer.count
+      HostContext.withCurrentContext { ctx in
+        try! buffer.capture(from: ctx)
+      }
+      let used = buffer.count - before
+      print("Captured \(originalCount) frames in \(used) bytes")
+    } else {
+      doFrames(count - 1, originalCount: originalCount)
+    }
+  }
+
+  static func doFrames(_ count: Int) {
+    doFrames(count, originalCount: count)
+  }
+
+  static func dumpCaptureFile() {
+    let captured = SimpleFileSequence(path: "captured.bin")
+    var count = 0
+
+    while !captured.atEnd {
+      print("Backtrace \(count):")
+      count += 1
+
+      let backtrace = Backtrace(architecture: HostContext.architecture,
+                                compactBacktraceData: captured,
+                                images: nil)
+
+      print(backtrace)
+
+      print("")
+    }
+  }
+
+  static func main() {
+    let fd = open("captured.bin", O_CREAT|O_TRUNC|O_RDWR, 0o644)
+    defer { close(fd) }
+
+    if fd < 0 {
+      fatalError("Unable to create capture file: \(errno)")
+    }
+
+    buffer = BacktraceBuffer<HostContext, UnsafeLocalMemoryReader>(
+      using: UnsafeLocalMemoryReader()
+    ) { chunk in
+      let done = write(fd, chunk.baseAddress, chunk.count)
+      if done < 0 {
+        print("Error \(errno)")
+      } else {
+        print("Wrote \(done) bytes out of \(chunk.count)")
+      }
+      return done
+    }
+
+    // CHECK: Backtrace 0:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 1000 0x{{[0-9a-f]*}} [ra]
+    doFrames(1000)
+
+    // CHECK: Backtrace 1:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 500 0x{{[0-9a-f]*}} [ra]
+    doFrames(500)
+
+    // CHECK: Backtrace 2:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 250 0x{{[0-9a-f]*}} [ra]
+    doFrames(250)
+
+    // CHECK: Backtrace 3:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 125 0x{{[0-9a-f]*}} [ra]
+    doFrames(125)
+
+    // CHECK: Backtrace 4:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 63 0x{{[0-9a-f]*}} [ra]
+    doFrames(63)
+
+    // CHECK: Backtrace 5:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 32 0x{{[0-9a-f]*}} [ra]
+    doFrames(32)
+
+    // CHECK: Backtrace 6:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 16 0x{{[0-9a-f]*}} [ra]
+    doFrames(16)
+
+    // CHECK: Backtrace 7:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 8 0x{{[0-9a-f]*}} [ra]
+    doFrames(8)
+
+    // CHECK: Backtrace 8:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 4 0x{{[0-9a-f]*}} [ra]
+    doFrames(4)
+
+    // CHECK: Backtrace 9:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 2 0x{{[0-9a-f]*}} [ra]
+    doFrames(2)
+
+    // CHECK: Backtrace 10:
+    // CHECK: 0 0x{{[0-9a-f]*}}
+    // CHECK: 1 0x{{[0-9a-f]*}} [ra]
+    doFrames(1)
+
+    // CHECK-NOT: Backtrace 11:
+
+    try! buffer.flush()
+
+    let size = lseek(fd, 0, SEEK_END)
+    print("Used \(size) bytes")
+
+    dumpCaptureFile()
+  }
+}


### PR DESCRIPTION
`BacktraceBuffer` is SPI to allow a client to repeatedly capture backtraces without allocating memory or locking.  Specifically, the backtraces are captured directly into a ring buffer, in CBF format, and `BacktraceBuffer` will call out to a user-provided closure whenever the buffer is full in order to free up space.

This means the user can organise for backtrace data to be saved or transmitted over the network or some such in large chunks, which is far more efficient than writing individual bytes.

I've also added SPI to `Backtrace` to make it easy to decode the resulting data stream.

rdar://117989155
