### PR TITLE
[cxx-interop] Fix crash when operator doesn't name parameter in header

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -13,6 +13,7 @@
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Builtins.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
@@ -2214,7 +2215,11 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
   newParams.push_back(lhsParam);
 
   for (auto param : *paramList) {
-    newParams.push_back(param);
+    auto clonedParam = ParamDecl::clone(ctx, param);
+    if (clonedParam->getParameterName().empty()) {
+      clonedParam->setName(ctx.getIdentifier("other"));
+    }
+    newParams.push_back(clonedParam);
   }
 
   auto oldArgNames = operatorMethod->getName().getArgumentNames();

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -561,4 +561,10 @@ public:
   }
 };
 
+struct ClassWithOperatorEqualsParamUnnamed {
+  bool operator==(const ClassWithOperatorEqualsParamUnnamed &) const {
+    return false;
+  }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -39,3 +39,13 @@ int& ReadWriteIntArray::operator[](int x) {
 int NonTrivialIntArrayByVal::operator[](int x) {
   return values[x];
 }
+
+bool ClassWithOperatorEqualsParamUnnamed::operator==(
+    const ClassWithOperatorEqualsParamUnnamed &other) const {
+  return false;
+}
+
+bool ClassWithOperatorEqualsParamUnnamed::operator!=(
+    const ClassWithOperatorEqualsParamUnnamed &) const {
+  return true;
+}

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -44,4 +44,9 @@ private:
   int values[5] = { 1, 2, 3, 4, 5 };
 };
 
+struct ClassWithOperatorEqualsParamUnnamed {
+  bool operator==(const ClassWithOperatorEqualsParamUnnamed &) const;
+  bool operator!=(const ClassWithOperatorEqualsParamUnnamed &) const;
+};
+
 #endif

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -87,6 +87,13 @@ inline LoadableBoolWrapper operator||(LoadableBoolWrapper lhs, LoadableBoolWrapp
   return LoadableBoolWrapper{.value = lhs.value || rhs.value};
 }
 
+struct ClassWithOperatorEqualsParamUnnamed {};
+
+inline bool operator==(const ClassWithOperatorEqualsParamUnnamed &,
+                       const ClassWithOperatorEqualsParamUnnamed &) {
+  return false;
+}
+
 // Make sure that we don't crash on templated operators
 template<typename T> struct S {};
 template<typename T> S<T> operator+(S<T> lhs, S<T> rhs);

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
@@ -3,3 +3,13 @@
 LoadableIntWrapper operator+(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return LoadableIntWrapper{.value = lhs.value + rhs.value};
 }
+
+bool operator==(const ClassWithOperatorEqualsParamUnnamed &lhs,
+                const ClassWithOperatorEqualsParamUnnamed &rhs) {
+  return false;
+}
+
+bool operator!=(const ClassWithOperatorEqualsParamUnnamed &,
+                const ClassWithOperatorEqualsParamUnnamed &) {
+  return true;
+}

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
@@ -7,4 +7,12 @@ struct LoadableIntWrapper {
 
 LoadableIntWrapper operator+(LoadableIntWrapper lhs, LoadableIntWrapper rhs);
 
+struct ClassWithOperatorEqualsParamUnnamed {};
+
+bool operator==(const ClassWithOperatorEqualsParamUnnamed &,
+                const ClassWithOperatorEqualsParamUnnamed &);
+
+bool operator!=(const ClassWithOperatorEqualsParamUnnamed &,
+                const ClassWithOperatorEqualsParamUnnamed &);
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -464,4 +464,10 @@ OperatorsTestSuite.test("HasStaticOperatorCallWithConstOperator.call") {
   expectEqual(8, res2)
 }
 
+OperatorsTestSuite.test("UnnamedParameterInOperator.equal") {
+  let lhs = ClassWithOperatorEqualsParamUnnamed()
+  let rhs = ClassWithOperatorEqualsParamUnnamed()
+  expectFalse(lhs == rhs)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -72,4 +72,11 @@ OperatorsTestSuite.test("NonTrivialIntArrayByVal.subscript (out-of-line)") {
   expectEqual(42, result5)
 }
 
+OperatorsTestSuite.test("UnnamedParameterInOperator.equal") {
+  let lhs = ClassWithOperatorEqualsParamUnnamed()
+  let rhs = ClassWithOperatorEqualsParamUnnamed()
+  expectFalse(lhs == rhs)
+  expectTrue(lhs != rhs)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -187,4 +187,10 @@ OperatorsTestSuite.test("pipe pipe (||)") {
   expectEqual(true, result.value)
 }
 
+OperatorsTestSuite.test("UnnamedParameterInOperator.equal") {
+  let lhs = ClassWithOperatorEqualsParamUnnamed()
+  let rhs = ClassWithOperatorEqualsParamUnnamed()
+  expectFalse(lhs == rhs)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -20,4 +20,11 @@ OperatorsTestSuite.test("plus") {
   expectEqual(65, result.value)
 }
 
+OperatorsTestSuite.test("UnnamedParameterInOperator.equal") {
+  let lhs = ClassWithOperatorEqualsParamUnnamed()
+  let rhs = ClassWithOperatorEqualsParamUnnamed()
+  expectFalse(lhs == rhs)
+  expectTrue(lhs != rhs)
+}
+
 runAllTests()


### PR DESCRIPTION
rdar://140994231
