### PR TITLE
Basic: Turn off solver expression time threshold by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -852,7 +852,7 @@ namespace swift {
 
     /// If non-zero, abort the expression type checker if it takes more
     /// than this many seconds.
-    unsigned ExpressionTimeoutThreshold = 600;
+    unsigned ExpressionTimeoutThreshold = 0;
 
     /// The upper bound, in bytes, of temporary data that can be
     /// allocated by the constraint solver.


### PR DESCRIPTION
The check is expensive, the default of 10 minutes is absurd, and the existing scope/trail/memory limits should now be sufficient.