### PR TITLE
utils: include Fetch-Dependencies step in build.ps1 time tracking

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -716,6 +716,11 @@ function Fetch-Dependencies {
 
   if ($SkipBuild -and $SkipPackaging) { return }
 
+  $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+  if ($ToBatch) {
+    Write-Host -ForegroundColor Cyan "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Fetch-Dependencies..."
+  }
+
   $WiXURL = "https://www.nuget.org/api/v2/package/wix/$WiXVersion"
   $WiXHash = "DF9BDB347183716F82EFE2CECB8C54BB3554AA907A69F47A41741D6FA4D0A754"
   DownloadAndVerify $WixURL "$BinaryCache\WiX-$WiXVersion.zip" $WiXHash
@@ -826,6 +831,11 @@ function Fetch-Dependencies {
         Copy-Directory "$NugetRoot\$Package.$($Arch.ShortName).$WinSDKVersion\c\*" "$CustomWinSDKRoot\lib\$WinSDKVersionRevisionZero"
       }
     }
+  }
+
+  if (-not $ToBatch) {
+    Write-Host -ForegroundColor Cyan "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Fetch-Dependencies took $($Stopwatch.Elapsed)"
+    Write-Host ""
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -837,6 +837,14 @@ function Fetch-Dependencies {
     Write-Host -ForegroundColor Cyan "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Fetch-Dependencies took $($Stopwatch.Elapsed)"
     Write-Host ""
   }
+  if ($Summary) {
+    $TimingData.Add([PSCustomObject]@{
+      Arch = $BuildArch.LLVMName
+      Platform = 'Windows'
+      Checkout = 'Fetch-Dependencies'
+      "Elapsed Time" = $Stopwatch.Elapsed.ToString()
+    })
+  }
 }
 
 function Get-PinnedToolchainTool() {


### PR DESCRIPTION
Build bot runtimes are very long and not fully transparent right now. In addition to the steps for build and test, we should keep an eye on Fetch-Dependencies.