### PR TITLE
[Distributed] ban typed throws in distributed funcs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5656,6 +5656,9 @@ ERROR(distributed_actor_func_unsupported_specifier, none,
 ERROR(distributed_actor_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))
+ERROR(distributed_actor_func_typed_throws, none,
+      "cannot declare distributed function function with typed throws",
+      ())
 NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",
      (DescriptiveDeclKind))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5657,7 +5657,7 @@ ERROR(distributed_actor_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))
 ERROR(distributed_actor_func_typed_throws, none,
-      "cannot declare distributed function function with typed throws",
+      "cannot declare distributed function with typed throws",
       ())
 NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -618,6 +618,19 @@ bool CheckDistributedFunctionRequest::evaluate(
     return true;
   }
 
+  // TODO: rdar://136467591 Currently typed throws were not implemented for distributed methods
+  if (func->hasThrows()) {
+    if (auto thrownError = func->getEffectiveThrownErrorType()) {
+      // Basically we only support throwing `any Error` out of a distributed
+      // function because then the effective error thrown by thunk calls naturally
+      // is correct and the same `any Error`
+      if (thrownError.has_value() &&
+          !(*thrownError)->isEqual(C.getErrorExistentialType())) {
+        func->diagnose(diag::distributed_actor_func_typed_throws);
+      }
+    }
+  }
+
   return false;
 }
 

--- a/test/Distributed/distributed_actor_unsupported_typed_throws.swift
+++ b/test/Distributed/distributed_actor_unsupported_typed_throws.swift
@@ -9,7 +9,7 @@ import Distributed
 typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
 
 distributed actor Foo {
-  distributed func alwaysThrows() throws(FooError) { // expected-error{{cannot declare distributed function function with typed throws}}
+  distributed func alwaysThrows() throws(FooError) { // expected-error{{cannot declare distributed function with typed throws}}
     throw FooError()
   }
 }

--- a/test/Distributed/distributed_actor_unsupported_typed_throws.swift
+++ b/test/Distributed/distributed_actor_unsupported_typed_throws.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+distributed actor Foo {
+  distributed func alwaysThrows() throws(FooError) { // expected-error{{cannot declare distributed function function with typed throws}}
+    throw FooError()
+  }
+}
+
+struct FooError: Codable, Error { }
+struct RemoteInvocationError: Codable, Error { }
+
+func test(foo: Foo) async throws {
+  do {
+    try await foo.alwaysThrows() // actually, this is throws(Error) because network errors etc
+    fatalError("Should not reach here")
+    // FIXME: the following warning is showing why we had to ban typed throws;
+    //        the error type must instead be (FooError | Error (from the distributed thunk))
+    //        rdar://136467591
+  } catch let error as RemoteInvocationError { // expected-warning{{cast from 'FooError' to unrelated type 'RemoteInvocationError' always fails}}
+    print("error = \(error)")
+  }
+}


### PR DESCRIPTION
They don't yield a correct error type as we didn't implement it, so rather allow it and risk crashes, ban it until we get the time to implement it.

The real solution is to adjust typed throws error inference to do an union of the thrown error of the func and the type thrown by the distributed actor system remote call -- which today always would be (E | Error) -> Error...

We could add a new associated type to DAS and then we could make it more proper...

resolves rdar://136467528

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
