### PR TITLE
[cxx-interop] Diagnose resilience for C++ types declared within namespaces correctly

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -231,7 +231,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
                                               const ExportContext &where) {
   assert(where.mustOnlyReferenceExportedDecls());
 
-  auto definingModule = D->getModuleContext();
+  auto definingModule = D->getModuleContextForNameLookup();
   auto downgradeToWarning = DowngradeToWarning::No;
 
   auto reason = where.getExportabilityReason();

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1939,7 +1939,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
                                const ExportContext &where,
                                DowngradeToWarning &downgradeToWarning) {
   downgradeToWarning = DowngradeToWarning::No;
-  ModuleDecl *M = decl->getModuleContext();
+  ModuleDecl *M = decl->getModuleContextForNameLookup();
   auto *SF = where.getDeclContext()->getParentSourceFile();
 
   RestrictedImportKind howImported = SF->getRestrictedImportKind(M);
@@ -2040,7 +2040,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
       where.getDeclContext()->getAsDecl()->getModuleContext()->isResilient() &&
       !where.getDeclContext()
            ->getAsDecl()
-           ->getModuleContext()
+           ->getModuleContextForNameLookup()
            ->getUnderlyingModuleIfOverlay() &&
       decl->hasClangNode() && !decl->getModuleContext()->isSwiftShimsModule() &&
       isFragileClangNode(decl->getClangNode()) &&

--- a/test/Interop/Cxx/library-evolution/allow-cxx-api-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/allow-cxx-api-in-evolving-libraries.swift
@@ -49,6 +49,10 @@ void freeCxxFunction();
 
 using BuiltinIntTypealis = int;
 
+namespace NS {
+class CxxClassInNamespace {};
+}
+
 //--- test.swift
 
 import CxxModule
@@ -62,6 +66,9 @@ public func usesCxxSingletonReference() -> SingletonReference {
 }
 
 public func usesCxxStruct(_ x: CxxStruct) {
+}
+
+public func usesCxxClassInNamespace(_ x: NS.CxxClassInNamespace) {
 }
 
 public typealias EnumT = CxxEnum

--- a/test/Interop/Cxx/library-evolution/prohibit-cxx-api-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/prohibit-cxx-api-in-evolving-libraries.swift
@@ -47,6 +47,10 @@ void freeCxxFunction();
 
 using BuiltinIntTypealis = int;
 
+namespace NS {
+class CxxClassInNamespace {};
+}
+
 //--- test.swift
 
 import CxxModule
@@ -63,6 +67,10 @@ public func usesCxxSingletonReference() -> SingletonReference {
 
 // expected-error@+1 {{cannot use struct 'CxxStruct' here; C++ types from imported module 'CxxModule' do not support library evolution}}
 public func usesCxxStruct(_ x: CxxStruct) {
+}
+
+// expected-error@+1 {{cannot use struct 'CxxClassInNamespace' here; C++ types from imported module 'CxxModule' do not support library evolution}}
+public func usesCxxClassInNamespace(_ x: NS.CxxClassInNamespace) {
 }
 
 // expected-error@+1 {{cannot use enum 'CxxEnum' here; C++ types from imported module 'CxxModule' do not support library evolution}}


### PR DESCRIPTION
C++ types that are declared within namespaces are imported into a fake __ObjC module in Swift. This is meant to be a workaround for namespaces spanning across multiple Clang modules, which Swift decls normally cannot do.

This change fixes two issues:
1. If a C++ type is declared within a namespace, the type isn't compatible with resilience, and it is used in a public resilient Swift interface, the compiler would emit an incorrect warning that mentioned the fake __ObjC module instead of the actual Clang module.
2. If the declaration is in an overlay for another module, the compiler would emit an error, while we actually consider this kind of usage to be safe.

rdar://143631944

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
