### PR TITLE
swift-demangle: don't require the $-prefix for embedded symbols

### DIFF
--- a/test/Demangle/demangle-embedded.swift
+++ b/test/Demangle/demangle-embedded.swift
@@ -1,4 +1,7 @@
 ; This is not really a Swift source file: -*- Text -*-
 
 ; RUN: echo '$e4main8MyStructV3fooyyFAA1XV_Tg5' | swift-demangle | %FileCheck %s
+; RUN: swift-demangle '$e4main8MyStructV3fooyyFAA1XV_Tg5' | %FileCheck %s
+; RUN: swift-demangle e4main8MyStructV3fooyyFAA1XV_Tg5 | %FileCheck %s
+
 ; CHECK: generic specialization <main.X> of main.MyStruct.foo() -> ()

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -441,7 +441,7 @@ int main(int argc, char **argv) {
                         "is quoted or escaped.\n";
         continue;
       }
-      if (!DemangleType && (name.starts_with("S") || name.starts_with("s"))) {
+      if (!DemangleType && (name.starts_with("S") || name.starts_with("s") || name.starts_with("e"))) {
         std::string correctedName = std::string("$") + name.str();
         demangle(llvm::outs(), correctedName, DCtx, options);
       } else {


### PR DESCRIPTION
Support `swift-demangle e4main8MyStructV3fooyyFAA1XV_Tg5` (note the missing $-prefix)
