### PR TITLE
Fix field count in emitted reflection data

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -932,16 +932,16 @@ private:
     // Filter to select which fields we'll export FieldDescriptors for.
     auto exportable_field =
       [](Field field) {
-	// Don't export private C++ fields that were imported as private Swift fields.
-	// The type of a private field might not have all the type witness
-	// operations that Swift requires, for instance,
-	// `std::unique_ptr<IncompleteType>` would not have a destructor.
-	if (field.getKind() == Field::Kind::Var &&
-	    field.getVarDecl()->getClangDecl() &&
-	    field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
-	  return false;
-	// All other fields are exportable
-	return true;
+        // Don't export private C++ fields that were imported as private Swift fields.
+        // The type of a private field might not have all the type witness
+        // operations that Swift requires, for instance,
+        // `std::unique_ptr<IncompleteType>` would not have a destructor.
+        if (field.getKind() == Field::Kind::Var &&
+            field.getVarDecl()->getClangDecl() &&
+            field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
+          return false;
+        // All other fields are exportable
+        return true;
       };
 
     // Count exportable fields

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -929,18 +929,35 @@ private:
     B.addInt16(uint16_t(kind));
     B.addInt16(FieldRecordSize);
 
-    B.addInt32(getNumFields(NTD));
-    forEachField(IGM, NTD, [&](Field field) {
-      // Skip private C++ fields that were imported as private Swift fields.
-      // The type of a private field might not have all the type witness
-      // operations that Swift requires, for instance,
-      // `std::unique_ptr<IncompleteType>` would not have a destructor.
-      if (field.getKind() == Field::Kind::Var &&
-          field.getVarDecl()->getClangDecl() &&
-          field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
-        return;
+    // Filter to select which fields we'll export FieldDescriptors for.
+    auto exportable_field =
+      [](Field field) {
+	// Don't export private C++ fields that were imported as private Swift fields.
+	// The type of a private field might not have all the type witness
+	// operations that Swift requires, for instance,
+	// `std::unique_ptr<IncompleteType>` would not have a destructor.
+	if (field.getKind() == Field::Kind::Var &&
+	    field.getVarDecl()->getClangDecl() &&
+	    field.getVarDecl()->getFormalAccess() == AccessLevel::Private)
+	  return false;
+	// All other fields are exportable
+	return true;
+      };
 
-      addField(field);
+    // Count exportable fields
+    int exportableFieldCount = 0;
+    forEachField(IGM, NTD, [&](Field field) {
+      if (exportable_field(field)) {
+        ++exportableFieldCount;
+      }
+    });
+
+    // Emit exportable fields, prefixed with a count
+    B.addInt32(exportableFieldCount);
+    forEachField(IGM, NTD, [&](Field field) {
+      if (exportable_field(field)) {
+        addField(field);
+      }
     });
   }
 


### PR DESCRIPTION
PR #78467 omitted certain fields from the FieldDescriptor list,
but did not update the count of fields that's emitted
just before that list.  That PR was merged to release/6.1 in #78607.

This updates the count so it matches the number of field descriptors
we actually emit.

Reviewed by: @egorzhdan @mikeash 

Impact:  Fixes RemoteMirror field reflection, which is used by tools such as `leaks`, `heap`, and `lldb`.

Risk:  Low, fixes a broken count in metadata emitted for certain imported C++ types.

Original PR: #78961

Resolves rdar://143763116

**EDITED**: #79038 has the test that verifies the correctness of this fix.
