### PR TITLE
Fix AddressOwnership for unidentified access

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1049,7 +1049,9 @@ struct AddressOwnership {
 
   AddressOwnership(AccessBase base) : base(base) {}
 
-  operator bool() const { return bool(base); }
+  operator bool() const {
+    return bool(base) && base.getKind() != AccessRepresentation::Unidentified;
+  }
 
   bool operator==(const AddressOwnership &other) const {
     return base.hasIdenticalAccessInfo(other.base);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -164,6 +164,9 @@ GuaranteedOwnershipExtension::Status
 GuaranteedOwnershipExtension::checkAddressOwnership(SILValue parentAddress,
                                                     SILValue childAddress) {
   AddressOwnership addressOwnership(parentAddress);
+  if (!addressOwnership) {
+    return Invalid;
+  }
   if (!addressOwnership.hasLocalOwnershipLifetime()) {
     // Indirect Arg, Stack, Global, Unidentified, Yield
     // (these have no reference lifetime to extend).
@@ -1409,6 +1412,12 @@ OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
   // NOTE: We also need to handle this here since a pointer_to_address is not a
   // valid base value for an access path since it doesn't refer to any storage.
   AddressOwnership addressOwnership(newValue);
+
+  if (!addressOwnership) {
+    invalidate();
+    return;
+  }
+
   if (!addressOwnership.hasLocalOwnershipLifetime())
     return;
 

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -565,13 +565,8 @@ sil [ossa] @sil_string_different_encodings : $@convention(thin) () -> Builtin.Wo
 }
 
 // CHECK-LABEL: sil [ossa] @raw_idx_cse :
-// CHECK: integer_literal
-// CHECK-NEXT: index_raw_pointer
-// CHECK-NEXT: pointer_to_address
-// CHECK-NEXT: load
-// CHECK-NEXT: load
-// CHECK-NEXT: apply
-// CHECK-NEXT: tuple
+// CHECK: pointer_to_address
+// CHECK: pointer_to_address
 // CHECK-LABEL: } // end sil function 'raw_idx_cse'
 sil [ossa] @raw_idx_cse: $@convention(thin) (Builtin.RawPointer) -> () {
 bb0(%0 : $Builtin.RawPointer):
@@ -1091,10 +1086,8 @@ bb0(%0 : @guaranteed $Proto & Ping):
 sil [ossa] [global_init] @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
 
 // CHECK-LABEL: sil [ossa] @cse_global_init :
-// CHECK:   [[P:%[0-9]+]] = apply
-// CHECK:   [[A:%[0-9]+]] = pointer_to_address [[P]]
-// CHECK:   begin_access [modify] [dynamic] [no_nested_conflict] [[A]]
-// CHECK:   begin_access [read] [dynamic] [no_nested_conflict] [[A]]
+// CHECK:   pointer_to_address
+// CHECK:   pointer_to_address
 // CHECK: // end sil function 'cse_global_init'
 sil [ossa] @cse_global_init : $@convention(thin) () -> Int64 {
 bb0:

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -1033,3 +1033,44 @@ bb0(%0 : @owned $_NativeDictionary<Int, Klass>):
   destroy_value %49
   unreachable
 }
+
+struct Pointer<Element> {
+  @_hasStorage let pointer: UnsafePointer<Klass> { get }
+}
+
+struct Wrapper {
+  let k: Klass
+  var ptr: Pointer<Klass> 
+}
+
+sil @use_wrapper : $@convention(thin) (@in_guaranteed Wrapper) -> ()
+
+// CHECK-LABEL: sil [ossa] @testMarkDepNonEscAddressValue : $@convention(thin) (@in Wrapper) -> () {
+// CHECK: mark_dependence
+// CHECK: mark_dependence
+// CHECK-LABEL: } // end sil function 'testMarkDepNonEscAddressValue'
+sil [ossa] @testMarkDepNonEscAddressValue : $@convention(thin) (@in Wrapper) -> () {
+bb0(%0 : $*Wrapper):
+  %f = function_ref @use_wrapper : $@convention(thin) (@in_guaranteed Wrapper) -> ()
+  %1 = load [copy] %0
+  %2 = begin_borrow %1
+  %3 = struct_extract %2, #Wrapper.ptr
+  %4 = struct_extract %3, #Pointer.pointer
+  %5 = struct_extract %4, #UnsafePointer._rawValue
+  %6 = pointer_to_address %5 to [strict] $*Wrapper
+  %7 = mark_dependence [nonescaping] %6 on %2
+  apply %f(%7) : $@convention(thin) (@in_guaranteed Wrapper) -> ()
+  end_borrow %2
+  %9 = begin_borrow %1
+  %10 = struct_extract %9, #Wrapper.ptr
+  %11 = struct_extract %10, #Pointer.pointer
+  %12 = struct_extract %11, #UnsafePointer._rawValue
+  %13 = pointer_to_address %12 to [strict] $*Wrapper
+  %14 = mark_dependence [nonescaping] %13 on %9
+  apply %f(%14) : $@convention(thin) (@in_guaranteed Wrapper) -> ()
+  end_borrow %9
+  destroy_value %1
+  destroy_addr %0
+  %18 = tuple ()
+  return %18
+}


### PR DESCRIPTION
AccessBase can have Unindentified kind where the base value maybe invalid.

Bailout early for such accesses in ownership rauw.

