### PR TITLE
Indexing: add blocklist support for avoiding indexing specific module names

### DIFF
--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -25,5 +25,6 @@ BLOCKLIST_ACTION(DowngradeInterfaceVerificationFailure)
 BLOCKLIST_ACTION(ShouldUseLayoutStringValueWitnesses)
 BLOCKLIST_ACTION(ShouldDisableOwnershipVerification)
 BLOCKLIST_ACTION(SkipEmittingFineModuleTrace)
+BLOCKLIST_ACTION(SkipIndexingModule)
 
 #undef BLOCKLIST_ACTION

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -2155,6 +2155,12 @@ void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
 
 void index::indexModule(ModuleDecl *module, IndexDataConsumer &consumer) {
   assert(module);
+  auto mName = module->getRealName().str().str();
+  if (module->getASTContext().blockListConfig.hasBlockListAction(mName,
+      BlockListKeyKind::ModuleName,
+      BlockListAction::SkipIndexingModule)) {
+    return;
+  }
   IndexSwiftASTWalker walker(consumer, module->getASTContext());
   walker.visitModule(*module);
   consumer.finish();


### PR DESCRIPTION
Indexing while building sometimes triggers module deserialization issues, exemplified by a recent issue of rdar://141357099. This change introduces the blocklist support to avoid indexing specific module names so we could rely on external data source for unblocking builds, instead of modifying the compiler source.

Resolves: rdar://143770366

