### PR TITLE
Concurrency: centralise the definition for `std::bit_cast`

### DIFF
--- a/include/swift/Runtime/STLCompatibility.h
+++ b/include/swift/Runtime/STLCompatibility.h
@@ -1,0 +1,45 @@
+//===---- STLCompatibility.h - Runtime C++ Compatibiltiy Stubs --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_STL_COMPATIBILITY_H
+#define SWIFT_RUNTIME_STL_COMPATIBILITY_H
+
+#if __cplusplus >= 202002l || defined(__cpp_lib_bit_cast)
+#include <bit>
+#else
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+
+namespace std {
+inline namespace __swift {
+template <typename Destination, typename Source>
+std::enable_if_t<sizeof(Destination) == sizeof(Source) &&
+                 std::is_trivially_copyable_v<Source> &&
+                 std::is_trivially_copyable_v<Destination>, Destination>
+bit_cast(const Source &src) noexcept {
+  static_assert(std::is_trivially_constructible_v<Destination>,
+                "The destination type must be trivially constructible");
+  Destination dst;
+  if constexpr (std::is_pointer_v<Source> || std::is_pointer_v<Destination>)
+    std::memcpy(reinterpret_cast<uintptr_t *>(&dst),
+                reinterpret_cast<const uintptr_t *>(&src), sizeof(Destination));
+  else
+    std::memcpy(&dst, &src, sizeof(Destination));
+  return dst;
+}
+}
+}
+#endif
+
+#endif

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -26,6 +26,7 @@
 #include "swift/ABI/TaskOptions.h"
 #include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/STLCompatibility.h"
 #include "swift/Threading/Mutex.h"
 #include "llvm/ADT/PointerIntPair.h"
 
@@ -34,28 +35,6 @@
 #endif
 
 #include <new>
-
-#if __cplusplus < 202002l || !defined(__cpp_lib_bit_cast)
-namespace std {
-template <typename Destination, typename Source>
-std::enable_if_t<sizeof(Destination) == sizeof(Source) &&
-                 std::is_trivially_copyable_v<Source> &&
-                 std::is_trivially_copyable_v<Destination>, Destination>
-bit_cast(const Source &src) noexcept {
-  static_assert(std::is_trivially_constructible_v<Destination>,
-                "The destination type must be trivially constructible");
-  Destination dst;
-  if constexpr (std::is_pointer_v<Source> || std::is_pointer_v<Destination>)
-    std::memcpy(reinterpret_cast<uintptr_t *>(&dst),
-                reinterpret_cast<const uintptr_t *>(&src), sizeof(Destination));
-  else
-    std::memcpy(&dst, &src, sizeof(Destination));
-  return dst;
-}
-}
-#else
-#include <bit>
-#endif
 
 using namespace swift;
 

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -32,6 +32,7 @@
 
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/STLCompatibility.h"
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include "swift/Runtime/HeapObject.h"
@@ -53,28 +54,6 @@
 #include "Error.h"
 #include "ExecutorImpl.h"
 #include "TaskPrivate.h"
-
-#if __cplusplus < 202002l || !defined(__cpp_lib_bit_cast)
-namespace std {
-template <typename Destination, typename Source>
-std::enable_if_t<sizeof(Destination) == sizeof(Source) &&
-                 std::is_trivially_copyable_v<Source> &&
-                 std::is_trivially_copyable_v<Destination>, Destination>
-bit_cast(const Source &src) noexcept {
-  static_assert(std::is_trivially_constructible_v<Destination>,
-                "The destination type must be trivially constructible");
-  Destination dst;
-  if constexpr (std::is_pointer_v<Source> || std::is_pointer_v<Destination>)
-    std::memcpy(reinterpret_cast<uintptr_t *>(&dst),
-                reinterpret_cast<const uintptr_t *>(&src), sizeof(Destination));
-  else
-    std::memcpy(&dst, &src, sizeof(Destination));
-  return dst;
-}
-}
-#else
-#include <bit>
-#endif
 
 using namespace swift;
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -33,6 +33,7 @@
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/STLCompatibility.h"
 #include "swift/Threading/Mutex.h"
 #include <atomic>
 #include <deque>
@@ -59,28 +60,6 @@
 
 #if !defined(_WIN32) && !defined(__wasi__) && __has_include(<dlfcn.h>)
 #include <dlfcn.h>
-#endif
-
-#if __cplusplus < 202002l || !defined(__cpp_lib_bit_cast)
-namespace std {
-template <typename Destination, typename Source>
-std::enable_if_t<sizeof(Destination) == sizeof(Source) &&
-                 std::is_trivially_copyable_v<Source> &&
-                 std::is_trivially_copyable_v<Destination>, Destination>
-bit_cast(const Source &src) noexcept {
-  static_assert(std::is_trivially_constructible_v<Destination>,
-                "The destination type must be trivially constructible");
-  Destination dst;
-  if constexpr (std::is_pointer_v<Source> || std::is_pointer_v<Destination>)
-    std::memcpy(reinterpret_cast<uintptr_t *>(&dst),
-                reinterpret_cast<const uintptr_t *>(&src), sizeof(Destination));
-  else
-    std::memcpy(&dst, &src, sizeof(Destination));
-  return dst;
-}
-}
-#else
-#include <bit>
 #endif
 
 using namespace swift;


### PR DESCRIPTION
Remove the multiple definitions of `std::bit_cast` into a header. While this is still not great, it does reduce the duplication. This also silently works towards reducing a bit of the UB introduced here by adding an inline namespace for `std` which you are not technically allowed to use. However, by doing this, we have a clear migration path away from this once we adopt C++20.