### PR TITLE
[embedded] Don't emit extensions to API descriptor under Embedded Swift, avoid compiler crash

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -741,6 +741,9 @@ public:
     if (canSkipNominal(nominal))
       return;
 
+    if (ED->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+      return;
+
     if (auto CD = dyn_cast_or_null<ClassDecl>(ED->getImplementedObjCDecl())) {
       // @_objcImplementation extensions generate the class metadata symbols.
       (void)addClassMetadata(CD);

--- a/test/embedded/api-descriptor-crash.swift
+++ b/test/embedded/api-descriptor-crash.swift
@@ -15,7 +15,7 @@ extension MyStruct: Equatable {
 // CHECK:      "target"
 // CHECK-NEXT: "globals": [
 // CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_main",
+// CHECK-NEXT:     "name": "{{(_main)|(main)}}",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "",
 // CHECK-NEXT:     "linkage": "exported"

--- a/test/embedded/api-descriptor-crash.swift
+++ b/test/embedded/api-descriptor-crash.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -emit-api-descriptor-path %t.json
+// RUN: %validate-json %t.json | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+public struct MyStruct {
+}
+
+extension MyStruct: Equatable {
+   public static func == (lhs: Self, rhs: Self) -> Bool { return false }
+}
+
+// CHECK:      "target"
+// CHECK-NEXT: "globals": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_main",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "interfaces": [],
+// CHECK-NEXT: "categories": [],
+// CHECK-NEXT: "version": "1.0"


### PR DESCRIPTION
The attached test case shows a crash of the compiler when using `-emit-api-descriptor` / `-emit-api-descriptor-path` under Embedded Swift. Fix is to avoid adding protocol witness tables or protocol conformance descriptors into the symbol list when compiling under Embedded Swift.
