### PR TITLE
🌸 [6.1] Work around Foundation NS_TYPED_ENUM bug

### DIFF
--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -20,6 +20,7 @@
 
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILNode.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -80,6 +81,18 @@ public:
     : Node(node), Action(action) {}
 
   virtual void print(llvm::raw_ostream &OS) const override;
+};
+
+/// Observe that we are processing a reference to a SIL decl.
+class PrettyStackTraceSILDeclRef : public llvm::PrettyStackTraceEntry {
+  SILDeclRef declRef;
+  StringRef action;
+
+public:
+  PrettyStackTraceSILDeclRef(const char *action, SILDeclRef declRef)
+      : declRef(declRef), action(action) {}
+
+  virtual void print(llvm::raw_ostream &os) const override;
 };
 
 } // end namespace swift

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5777,6 +5777,7 @@ namespace {
       printCommon(#Name, label);                           \
                                                            \
       printFieldQuoted(T->getDecl()->printRef(), Label::always("decl"));  \
+      printFlag(T->getDecl()->hasClangNode(), "foreign");  \
                                                            \
       if (T->getParent())                                  \
         printRec(T->getParent(), Label::always("parent")); \
@@ -5790,6 +5791,7 @@ namespace {
         BoundGeneric##TypeClass *T, Label label) {         \
       printCommon("bound_generic_" #Name, label);          \
       printFieldQuoted(T->getDecl()->printRef(), Label::always("decl"));  \
+      printFlag(T->getDecl()->hasClangNode(), "foreign");  \
       if (T->getParent())                                  \
         printRec(T->getParent(), Label::always("parent")); \
       printList(T->getGenericArgs(), [&](auto arg, Label label) {  \
@@ -5838,6 +5840,7 @@ namespace {
     void visitModuleType(ModuleType *T, Label label) {
       printCommon("module_type", label);
       printDeclName(T->getModule(), Label::always("module"));
+      printFlag(T->getModule()->isNonSwiftModule(), "foreign");
       printFoot();
     }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/Config.h"
@@ -1473,6 +1474,8 @@ static bool doesClangExpansionMatchSchema(IRGenModule &IGM,
 /// Expand the result and parameter types to the appropriate LLVM IR
 /// types for C, C++ and Objective-C signatures.
 void SignatureExpansion::expandExternalSignatureTypes() {
+  PrettyStackTraceType entry(IGM.Context, "using clang to expand signature for",
+                             FnType);
   assert(FnType->getLanguage() == SILFunctionLanguage::C);
 
   auto SILResultTy = [&]() {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -34,6 +34,7 @@
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Subsystems.h"
@@ -3512,6 +3513,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   assert(forDefinition || !isDynamicallyReplaceableImplementation);
   assert(!forDefinition || !shouldCallPreviousImplementation);
 
+  PrettyStackTraceSILFunction entry("lowering address of", f);
   LinkEntity entity =
       LinkEntity::forSILFunction(f, shouldCallPreviousImplementation);
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -33,6 +33,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILModule.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
@@ -779,6 +780,8 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
                                   llvm::Value *selfValue,
                                   CalleeInfo &&info) {
   SILDeclRef method = methodInfo.getMethod();
+  PrettyStackTraceSILDeclRef entry("lowering reference to ObjC method", method);
+
   // Note that isolated deallocator is never called directly, only from regular
   // deallocator
   assert((method.kind == SILDeclRef::Kind::Initializer

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3118,6 +3118,8 @@ static bool mayDirectlyCallAsync(SILFunction *fn) {
 
 void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   auto fn = i->getInitiallyReferencedFunction();
+  PrettyStackTraceSILFunction entry("lowering reference to", fn);
+
   auto fnType = fn->getLoweredFunctionType();
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
@@ -8101,6 +8103,8 @@ void IRGenSILFunction::visitWitnessMethodInst(swift::WitnessMethodInst *i) {
   CanType baseTy = i->getLookupType();
   ProtocolConformanceRef conformance = i->getConformance();
   SILDeclRef member = i->getMember();
+  PrettyStackTraceSILDeclRef entry("lowering use of witness method", member);
+
   auto fnType = IGM.getSILTypes().getConstantFunctionType(
       IGM.getMaximalTypeExpansionContext(), member);
 
@@ -8285,6 +8289,7 @@ void IRGenSILFunction::visitSuperMethodInst(swift::SuperMethodInst *i) {
   llvm::Value *baseValue = base.claimNext();
 
   auto method = i->getMember().getOverriddenVTableEntry();
+  PrettyStackTraceSILDeclRef entry("lowering super call to", method);
   auto methodType = i->getType().castTo<SILFunctionType>();
 
   auto *classDecl = cast<ClassDecl>(method.getDecl()->getDeclContext());
@@ -8381,6 +8386,8 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
   llvm::Value *baseValue = base.claimNext();
 
   SILDeclRef method = i->getMember().getOverriddenVTableEntry();
+  PrettyStackTraceSILDeclRef entry("lowering class method call to", method);
+
   auto methodType = i->getType().castTo<SILFunctionType>();
 
   auto *classDecl = cast<ClassDecl>(method.getDecl()->getDeclContext());

--- a/lib/SIL/Utils/PrettyStackTrace.cpp
+++ b/lib/SIL/Utils/PrettyStackTrace.cpp
@@ -104,3 +104,9 @@ void PrettyStackTraceSILNode::print(llvm::raw_ostream &out) const {
   if (Node)
     out << *Node;
 }
+
+void PrettyStackTraceSILDeclRef::print(llvm::raw_ostream &out) const {
+  out << "While " << action << " SIL decl '";
+  declRef.print(out);
+  out << "'\n";
+}

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -18,7 +18,7 @@ func acceptHashable<T: Hashable>(_: T) {}
 func acceptComparable<T: Comparable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
-func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
+func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name, z: NSFileAttributeKey) {
   acceptEquatable(x)
   acceptHashable(x)
   acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
@@ -28,6 +28,8 @@ func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
   _ = x != y
   _ = x.hashValue
   _ = x as NSString
+
+  _ = z as NSString
 }
 
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -4,6 +4,11 @@
 
 public let NSUTF8StringEncoding: UInt = 8
 
+// This extension will cause ClangImporter/newtype_conformance.swift to fail
+// unless rdar://142693093 is fixed. To reproduce, it's important that this
+// extension come *before* the _ObjectiveCBridgeable extension for String.
+extension NSFileAttributeKey { }
+
 extension AnyHashable : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSObject {
     return NSObject()

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -867,6 +867,8 @@ extern void CGColorRelease(CGColorRef color) __attribute__((availability(macosx,
 
 typedef NSString *_Nonnull NSNotificationName
     __attribute((swift_newtype(struct)));
+typedef NSString *_Nonnull NSFileAttributeKey
+    __attribute((swift_newtype(struct)));
 
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 extern NSString * const NSConnectionReplyMode;


### PR DESCRIPTION
- Explanation: Works around a bug that affects `NS_TYPED_ENUM`s extended in Foundation by assuming the existence of a conformance the compiler may not have discovered yet. Without this fix, the compiler may import `NS_TYPED_ENUM`s without the correct bridging conformances, causing typechecking failures or compiler crashes. This change also includes compiler debugging improvements, including new PrettyStackTraces around the crash site.
- Scope: Active only when importing `NS_TYPED_ENUM` types from the Foundation module.
- Issues: rdar://142693093
- Original PRs: #78697
- Risk: Low. Effects limited to Foundation.
- Testing: Lit tests included.
- Reviewers: @Xazax-hun 