### PR TITLE
Add support to llvm and cmark to cross-compile using an external sysroot

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1117,7 +1117,7 @@ function false_true() {
 CROSS_COMPILE_HOSTS=($CROSS_COMPILE_HOSTS)
 for t in "${CROSS_COMPILE_HOSTS[@]}"; do
     case ${t} in
-        macosx* | iphone* | appletv* | watch* | linux-armv5 | linux-armv6 | linux-armv7 | android-* | openbsd-* | linux-static-* )
+        macosx* | iphone* | appletv* | watch* | android-* | openbsd-* | linux-* | linux-static-* )
             ;;
         *)
             echo "Unknown host to cross-compile for: ${t}"

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -484,6 +484,10 @@ class Product(object):
         if self.is_release():
             cross_flags.append('-fno-stack-protector')
 
+        # Use lld when cross-compiling to a Linux arch
+        if self.is_cross_compile_target("{}-{}".format(platform, arch)) and platform == 'linux':
+            cross_flags.append('-w -fuse-ld=lld')
+
         return self.common_c_flags + cross_flags
 
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -485,7 +485,8 @@ class Product(object):
             cross_flags.append('-fno-stack-protector')
 
         # Use lld when cross-compiling to a Linux arch
-        if self.is_cross_compile_target("{}-{}".format(platform, arch)) and platform == 'linux':
+        if (self.is_cross_compile_target("{}-{}".format(platform, arch))
+                and platform == 'linux'):
             cross_flags.append('-w -fuse-ld=lld')
 
         return self.common_c_flags + cross_flags

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -379,6 +379,11 @@ class Product(object):
     def get_linux_sysroot(self, platform, arch):
         if not self.is_cross_compile_target('{}-{}'.format(platform, arch)):
             return None
+
+        # If the deps path was passed, use it instead
+        if self.args.cross_compile_deps_path:
+            return self.args.cross_compile_deps_path
+
         sysroot_arch, _, abi = self.get_linux_target_components(arch)
         # $ARCH-$PLATFORM-$ABI
         # E.x.: aarch64-linux-gnu

--- a/utils/swift_build_support/tests/products/test_llvm_linux_cross_compile.py
+++ b/utils/swift_build_support/tests/products/test_llvm_linux_cross_compile.py
@@ -40,7 +40,8 @@ class LLVMLinuxCrossCompileTestCase(unittest.TestCase):
             clang_compiler_version=None,
             clang_user_visible_version=None,
             cross_compile_hosts='linux-aarch64',
-            cross_compile_deps_path='sysroot'
+            cross_compile_deps_path=None,
+            build_variant='Release'
         )
 
         # Setup shell
@@ -59,7 +60,7 @@ class LLVMLinuxCrossCompileTestCase(unittest.TestCase):
         self.toolchain = None
         self.args = None
 
-    def test_llvm_get_linux_sysroot(self):
+    def test_llvm_get_linux_sysroot_default(self):
         llvm = LLVM(
             args=self.args,
             toolchain=self.toolchain,
@@ -67,3 +68,30 @@ class LLVMLinuxCrossCompileTestCase(unittest.TestCase):
             build_dir='/path/to/build')
         expected_arg = '/usr/aarch64-linux-gnu'
         self.assertIn(expected_arg, llvm.get_linux_sysroot("linux", "aarch64"))
+
+    def test_llvm_get_linux_sysroot_external(self):
+        self.args = argparse.Namespace(
+            llvm_targets_to_build='X86;ARM;AArch64',
+            llvm_assertions='true',
+            compiler_vendor='none',
+            clang_compiler_version=None,
+            clang_user_visible_version=None,
+            cross_compile_hosts='linux-armv7',
+            cross_compile_deps_path='sysroot'
+        )
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        expected_arg = 'sysroot'
+        self.assertIn(expected_arg, llvm.get_linux_sysroot("linux", "armv7"))
+
+    def test_llvm_c_flags_includes_lld(self):
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        expected_flag = '-w -fuse-ld=lld'
+        self.assertIn(expected_flag, llvm.llvm_c_flags("linux", "aarch64"))


### PR DESCRIPTION
This goes towards #78960...

When cross-compiling, we typically do not want to build all of LLVM so we just add `--build-llvm=0` to the build script parameters. However, the cmake configuration stage for llvm still needs to be able to verify that it "can" cross-compile to the target arch, so that is what this PR does. This also applies to cmark if it is enabled.

**Changes**

 - Return `cross_compile_deps_path` from `get_linux_sysroot` if it is set to allow using an external sysroot.
 - Use `lld` when cross compiling to a Linux architecture, since `lld` is better at finding cross-libraries in a variety of sysroots.
 - Enable cross-compiling to any `linux-<arch>` in the build scripts, including `linux-x86_64` or `linux-aarch64`, which could be a useful tool when running on the opposite platform.
 - Add tests for all functionality added.

**Testing Locally**

To test this, I created a swift:jammy docker container like this:

 - `docker run -it --name swift-armv7-builder -v $(pwd):/src swift:jammy /bin/bash`

Then, I installed the needed/missing packages:

 - `apt update && apt install cmake ninja-build libsqlite3-dev ncurses-dev git python3 libstdc++-11-dev-armhf-cross`

Then, to just test that llvm and cmark configure correctly without building anything else, I ran the following command from the workspace inside the container:

 - `./swift/utils/build-script --cross-compile-hosts=linux-armv7 --cross-compile-deps-path=/ --build-llvm=0 --skip-local-build --skip-build-swift`

This finds dependencies for armhf in the root "/", which were installed with the **libstdc++-11-dev-armhf-cross** package. However, an external sysroot can also be supplied:

 - `./swift/utils/build-script --cross-compile-hosts=linux-armv7 --cross-compile-deps-path=/path/to/arch-sysroot--build-llvm=0 --skip-local-build --skip-build-swift`

**macOS Compatibility**

This also can be run on macOS as long as `lld` is installed (`brew install lld`) and you have an external sysroot. Using a sysroot from https://github.com/xtremekforever/swift-armv7/releases/tag/6.0.3, I was able to run the following command:

 - `./swift/utils/build-script --cross-compile-hosts=linux-armv7 --cross-compile-deps-path=sysroot-debian-bookworm --build-llvm=0 --skip-local-build --skip-build-swift`

**Conclusions**

This is only step 1 of adding support to the Swift build scripts for cross-compiling to Linux architectures. Next will be the Swift stdlib along with libdispatch, which is required for Swift Concurrency.

@MaxDesiatov @finagolfin 