### PR TITLE
[CSOptimizer] Prefer some unsupported/un-scored disjunctions over operators

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -125,6 +125,9 @@ static bool isSupportedDisjunction(Constraint *disjunction) {
   // Non-operator disjunctions are supported only if they don't
   // have any generic choices.
   return llvm::all_of(choices, [&](Constraint *choice) {
+    if (choice->isDisabled())
+      return true;
+
     if (choice->getKind() != ConstraintKind::BindOverload)
       return false;
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -299,7 +299,13 @@ static void determineBestChoicesInContext(
     if (applicableFn.isNull()) {
       auto *locator = disjunction->getLocator();
       if (auto expr = getAsExpr(locator->getAnchor())) {
-        if (auto *parentExpr = cs.getParentExpr(expr)) {
+        auto *parentExpr = cs.getParentExpr(expr);
+        // Look through optional evaluation, so
+        // we can cover expressions like `a?.b + 2`.
+        if (isExpr<OptionalEvaluationExpr>(parentExpr))
+          parentExpr = cs.getParentExpr(parentExpr);
+
+        if (parentExpr) {
           // If this is a chained member reference or a direct operator
           // argument it could be prioritized since it helps to establish
           // context for other calls i.e. `(a.)b + 2` if `a` and/or `b`

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -381,3 +381,10 @@ func test_explicit_cgfloat_use_avoids_ambiguity(v: Int) {
   var total = 0.0 // This is Double by default
   total += test(CGFloat(v)) + CGFloat(v) // Ok
 }
+
+func test_no_ambiguity_when_int_and_double_literals_are_mixed(v: CGFloat) {
+  func round<T: FloatingPoint>(_: T) -> T {}
+  func round(_: Double) -> Double { 0 }
+
+  let _ = round(abs(v - v) * 1) / 1.0 // Ok
+}

--- a/validation-test/Sema/type_checker_perf/fast/array_plus_shuffled.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_plus_shuffled.swift.gyb
@@ -1,0 +1,10 @@
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumConstraintScopes %s
+// REQUIRES: asserts,no_asan
+
+func test(a: [String]) {
+  _ = Array(a.shuffled()[0..<2])
+  %for i in range(0, N):
+    + Array(a.shuffled()[0..<2])
+  %end
+    + Array(a.shuffled()[0..<2])
+}

--- a/validation-test/Sema/type_checker_perf/fast/builder_with_nested_closures.swift
+++ b/validation-test/Sema/type_checker_perf/fast/builder_with_nested_closures.swift
@@ -1,0 +1,71 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=300
+// REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
+
+struct Time {
+  static func +(_: Time, _: Double) -> Time {
+    Time()
+  }
+
+  static func now() -> Time { Time() }
+}
+
+struct Queue {
+  static let current = Queue()
+
+  func after(deadline: Time, execute: () -> Void) {}
+  func after(deadline: Time, execute: (Int) -> Void) {}
+}
+
+func compute(_: () -> Void) {}
+
+protocol P {
+}
+
+@resultBuilder
+struct Builder {
+  static func buildExpression<T: P>(_ v: T) -> T {
+    v
+  }
+
+  static func buildBlock<T: P>(_ v: T) -> T {
+    v
+  }
+
+  static func buildBlokc<T0: P, T1: P>(_ v0: T0, _ v1: T1) -> (T0, T1) {
+    (v0, v1)
+  }
+}
+
+struct MyP: P {
+  func onAction(_: () -> Void) -> some P { self }
+}
+
+class Test {
+  var value = 0.0
+
+  @Builder func test() -> some P {
+    MyP().onAction {
+      Queue.current.after(deadline: .now() + 0.1) {
+        compute {
+          value = 0.3
+          Queue.current.after(deadline: .now() + 0.2) {
+            compute {
+              value = 1.0
+              Queue.current.after(deadline: .now() + 0.2) {
+                compute {
+                  value = 0.3
+                  Queue.current.after(deadline: .now() + 0.2) {
+                    compute {
+                      value = 1.0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/validation-test/Sema/type_checker_perf/fast/complex_swiftui_padding_conditions.swift
+++ b/validation-test/Sema/type_checker_perf/fast/complex_swiftui_padding_conditions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -solver-scope-threshold=1000
 // REQUIRES: OS=macosx
 
 import SwiftUI

--- a/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=10000
+// REQUIRES: tools-release,no_asan
+
+// Selecting operators from the closure before arguments to `zip` makes this "too complex"
+func compute(_ ids: [UInt64]) {
+  let _ = zip(ids[ids.indices.dropLast()], ids[ids.indices.dropFirst()]).map { pair in
+    ((pair.0 % 2 == 0) && (pair.1 % 2 == 1)) ? UInt64(pair.1 - pair.0) : 42
+  }
+}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=500
 // REQUIRES: tools-release,no_asan
 
 public class Cookie {


### PR DESCRIPTION
For example: `a.b() + 1` or a more complex `[a.b()].map { $0 + 1 }`.

If `b` has active generic overloads it would be deemed unsupported
but selecting it before `+` (which has a low score due to a literal use)
is preferable because it would either put additional generic requirements
on the argument of `+` or provide a concrete type that would be used
to further filter operator's overload set.

Selecting operator first in these cases could result in the solver
having to attempt every operator overload for every overload of `b`.

There are also a few minor improvements:

- Look through `OptionalEvaluationExpr`s when dealing with unapplied disjunctions to support `a?.b + 1` situations.
- Don't consider disabled overloads when checking whether disjunction is supported

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
