### PR TITLE
AST/Sema: Parse custom availability domains

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -26,6 +26,7 @@
 
 namespace swift {
 class ASTContext;
+class DeclContext;
 
 /// Represents a dimension of availability (e.g. macOS platform or Swift
 /// language mode).
@@ -142,7 +143,7 @@ public:
 
   /// Returns the built-in availability domain identified by the given string.
   static std::optional<AvailabilityDomain>
-  builtinDomainForString(StringRef string);
+  builtinDomainForString(StringRef string, const DeclContext *declContext);
 
   Kind getKind() const {
     if (auto inlineDomain = getInlineDomain())

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -447,6 +447,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)
 /// calling context.
 EXPERIMENTAL_FEATURE(NonIsolatedAsyncInheritsIsolationFromContext, false)
 
+/// Allow custom availability domains to be defined and referenced.
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -573,6 +573,18 @@ public:
   /// All block list configuration files to be honored in this compilation.
   std::vector<std::string> BlocklistConfigFilePaths;
 
+  struct CustomAvailabilityDomains {
+    /// Domains defined with `-define-enabled-availability-domain=`.
+    llvm::SmallVector<std::string> EnabledDomains;
+    /// Domains defined with `-define-disabled-availability-domain=`.
+    llvm::SmallVector<std::string> DisabledDomains;
+    /// Domains defined with `-define-dynamic-availability-domain=`.
+    llvm::SmallVector<std::string> DynamicDomains;
+  };
+
+  /// The collection of AvailabilityDomain definitions specified as arguments.
+  CustomAvailabilityDomains AvailabilityDomains;
+
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -561,6 +561,21 @@ def unavailable_decl_optimization_EQ : Joined<["-"], "unavailable-decl-optimizat
            "value may be 'none' (no optimization) or 'complete' (code is not "
            "generated at all unavailable declarations)">;
 
+def define_enabled_availability_domain : Separate<["-"], "define-enabled-availability-domain">,
+    Flags<[HelpHidden, FrontendOption, NoInteractiveOption, ModuleInterfaceOptionIgnorable]>,
+    HelpText<"Defines a custom availability domain that is available at compile time">,
+    MetaVarName<"<domain>">;
+
+def define_disabled_availability_domain : Separate<["-"], "define-disabled-availability-domain">,
+    Flags<[HelpHidden, FrontendOption, NoInteractiveOption, ModuleInterfaceOptionIgnorable]>,
+    HelpText<"Defines a custom availability domain that is unavailable at compile time">,
+    MetaVarName<"<domain>">;
+
+def define_dynamic_availability_domain : Separate<["-"], "define-dynamic-availability-domain">,
+    Flags<[HelpHidden, FrontendOption, NoInteractiveOption, ModuleInterfaceOptionIgnorable]>,
+    HelpText<"Defines a custom availability domain that can be enabled or disabled at runtime">,
+    MetaVarName<"<domain>">;
+
 def experimental_package_bypass_resilience : Flag<["-"], "experimental-package-bypass-resilience">,
   Flags<[FrontendOption]>,
   HelpText<"Deprecated; has no effect">;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3239,6 +3239,14 @@ suppressingFeatureAddressableTypes(PrintOptions &options,
   action();
 }
 
+static void
+suppressingFeatureCustomAvailability(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
+  // FIXME: [availability] Save and restore a bit controlling whether
+  // @available attributes for custom domains are printed.
+  action();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -18,7 +18,11 @@
 using namespace swift;
 
 std::optional<AvailabilityDomain>
-AvailabilityDomain::builtinDomainForString(StringRef string) {
+AvailabilityDomain::builtinDomainForString(StringRef string,
+                                           const DeclContext *declContext) {
+  // This parameter is used in downstream forks, do not remove.
+  (void)declContext;
+
   auto domain = llvm::StringSwitch<std::optional<AvailabilityDomain>>(string)
                     .Case("*", AvailabilityDomain::forUniversal())
                     .Case("swift", AvailabilityDomain::forSwiftLanguage())

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -407,6 +407,12 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
   }
 }
 
+static bool usesFeatureCustomAvailability(Decl *decl) {
+  // FIXME: [availability] Check whether @available attributes for custom
+  // domains are attached to the decl.
+  return false;
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -48,6 +48,7 @@ private:
   void computePlaygroundOptions();
   void computePrintStatsOptions();
   void computeTBDOptions();
+  bool computeAvailabilityDomains();
 
   bool setUpImmediateArgs();
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -537,7 +537,8 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     }
   }
 
-  if (!AnyAnnotations) {
+  if (!AnyAnnotations &&
+      !Context.LangOpts.hasFeature(Feature::CustomAvailability)) {
     diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
              /*isDeclModifier*/ false);
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8284,7 +8284,8 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
 
     // Attempt to resolve the domain specified for the attribute and diagnose
     // if no domain is found.
-    domain = AvailabilityDomain::builtinDomainForString(*string);
+    auto declContext = decl->getInnermostDeclContext();
+    domain = AvailabilityDomain::builtinDomainForString(*string, declContext);
     if (!domain) {
       if (auto suggestion = closestCorrectedPlatformString(*string)) {
         diags

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8271,7 +8271,6 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   auto &diags = decl->getASTContext().Diags;
   auto attrLoc = attr->getLocation();
   auto attrName = attr->getAttrName();
-  auto attrKind = attr->getKind();
   auto domainLoc = attr->getDomainLoc();
   auto introducedVersion = attr->getRawIntroduced();
   auto deprecatedVersion = attr->getRawDeprecated();
@@ -8305,7 +8304,7 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   auto domainName = domain->getNameForAttributePrinting();
 
   if (domain->isSwiftLanguage() || domain->isPackageDescription()) {
-    switch (attrKind) {
+    switch (attr->getKind()) {
     case AvailableAttr::Kind::Deprecated:
       diags.diagnose(attrLoc,
                      diag::attr_availability_expected_deprecated_version,
@@ -8320,7 +8319,8 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
     case AvailableAttr::Kind::NoAsync:
       diags.diagnose(attrLoc, diag::attr_availability_cannot_be_used_for_domain,
                      "noasync", attrName, domainName);
-      break;
+      return std::nullopt;
+
     case AvailableAttr::Kind::Default:
       break;
     }

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:  -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-enabled-availability-domain RedefinedDomain \
+// RUN:  -define-disabled-availability-domain DisabledDomain \
+// RUN:  -define-dynamic-availability-domain DynamicDomain \
+// RUN:  -define-disabled-availability-domain RedefinedDomain
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// expected-error@+1 {{expected ',' in 'available' attribute}}
+@available(EnabledDomain) // expected-warning {{unknown platform 'EnabledDomain' for attribute 'available'}}
+func availableInEnabledDomain() { }
+
+@available(DisabledDomain, unavailable) // expected-warning {{unknown platform 'DisabledDomain' for attribute 'available'}}
+func availableInDisabledDomain() { }
+
+@available(RedefinedDomain, deprecated, message: "Use something else") // expected-warning {{unknown platform 'RedefinedDomain' for attribute 'available'}}
+func availableInRedefinedDomain() { }
+
+// expected-error@+1 {{expected ',' in 'available' attribute}}
+@available(DynamicDomain) // expected-warning {{unknown platform 'DynamicDomain' for attribute 'available'}}
+func availableInDynamicDomain() { }
+
+// expected-error@+1 {{expected ',' in 'available' attribute}}
+@available(UnknownDomain) // expected-warning {{unknown platform 'UnknownDomain' for attribute 'available'}}
+func availableInUnknownDomain() { }
+
+func test() {
+  availableInEnabledDomain()
+  availableInDisabledDomain()
+  availableInRedefinedDomain()
+  availableInDynamicDomain()
+  availableInUnknownDomain()
+}

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -8,7 +8,6 @@
 
 // REQUIRES: swift_feature_CustomAvailability
 
-// expected-error@+1 {{expected ',' in 'available' attribute}}
 @available(EnabledDomain) // expected-warning {{unknown platform 'EnabledDomain' for attribute 'available'}}
 func availableInEnabledDomain() { }
 
@@ -18,11 +17,9 @@ func availableInDisabledDomain() { }
 @available(RedefinedDomain, deprecated, message: "Use something else") // expected-warning {{unknown platform 'RedefinedDomain' for attribute 'available'}}
 func availableInRedefinedDomain() { }
 
-// expected-error@+1 {{expected ',' in 'available' attribute}}
 @available(DynamicDomain) // expected-warning {{unknown platform 'DynamicDomain' for attribute 'available'}}
 func availableInDynamicDomain() { }
 
-// expected-error@+1 {{expected ',' in 'available' attribute}}
 @available(UnknownDomain) // expected-warning {{unknown platform 'UnknownDomain' for attribute 'available'}}
 func availableInUnknownDomain() { }
 

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -18,13 +18,11 @@ func asyncReplacement() async -> Int { }
 @available(*, noasync, renamed: "IOActor.readString()")
 func readStringFromIO() -> String {}
 
-// expected-warning@+2 {{'noasync' cannot be used in 'available' attribute for platform 'swift'}}
-// expected-warning@+1 {{expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'swift'}}
+// expected-warning@+1 {{'noasync' cannot be used in 'available' attribute for platform 'swift'}}
 @available(swift, noasync)
 func swiftNoAsync() { }
 
-// expected-warning@+2 {{'noasync' cannot be used in 'available' attribute for platform '_PackageDescription'}}
-// expected-warning@+1 {{expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform '_PackageDescription'}}
+// expected-warning@+1 {{'noasync' cannot be used in 'available' attribute for platform '_PackageDescription'}}
 @available(_PackageDescription, noasync)
 func packageDescriptionNoAsync() { }
 


### PR DESCRIPTION
Introduce the `CustomAvailability` experimental feature and some frontend options that can be used to define custom availability domains. Also, tweak the parser to allow attributes like `@available(SomeDomain)`. A future PR will wire up the custom availability domain definitions so that availability checking can use them.

Resolves rdar://138441297.