### PR TITLE
[XcodeGen] 'Byte' comparison and pattern matching

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CommandParser.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Command/CommandParser.swift
@@ -130,7 +130,7 @@ fileprivate extension ByteScanner {
     // Consume the element, stopping at the first space.
     return try consume(using: { consumer in
       switch consumer.peek {
-      case let c where c.isSpaceOrTab:
+      case \.isSpaceOrTab:
         return false
       case "\"":
         try consumer.consumeStringLiteral()

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/NinjaBuildFile.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/NinjaBuildFile.swift
@@ -154,7 +154,7 @@ extension NinjaBuildFile {
 
 extension Byte {
   fileprivate var isNinjaVarName: Bool {
-    switch self.scalar {
+    switch self {
     case "0"..."9", "a"..."z", "A"..."Z", "_", "-":
       return true
     default:

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/NinjaParser.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Ninja/NinjaParser.swift
@@ -46,13 +46,11 @@ fileprivate extension ByteScanner {
       // Ninja uses '$' as the escape character.
       if c == "$" {
         switch consumer.peek(ahead: 1) {
-        case let c? where c.isSpaceOrTab:
-          fallthrough
-        case "$", ":":
+        case "$", ":", \.isSpaceOrTab:
           // Skip the '$' and take the unescaped character.
           consumer.skip()
           return consumer.eat()
-        case let c? where c.isNewline:
+        case \.isNewline:
           // This is a line continuation, skip the newline, and strip any
           // following space.
           consumer.skip(untilAfter: \.isNewline)
@@ -160,7 +158,7 @@ extension NinjaParser.Lexer {
   private mutating func consumeElement() -> String? {
     input.consumeUnescaped(while: { char in
       switch char {
-      case let c where c.isNinjaOperator || c.isSpaceTabOrNewline:
+      case \.isNinjaOperator, \.isSpaceTabOrNewline:
         false
       default:
         true

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/Byte.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/Byte.swift
@@ -29,18 +29,6 @@ extension Byte: Comparable {
   }
 }
 
-extension Byte? {
-  var isSpaceOrTab: Bool {
-    self?.isSpaceOrTab == true
-  }
-  var isNewline: Bool {
-    self?.isNewline == true
-  }
-  var isSpaceTabOrNewline: Bool {
-    self?.isSpaceTabOrNewline == true
-  }
-}
-
 extension Byte {
   var isSpaceOrTab: Bool {
     self == " " || self == "\t"

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/Byte.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/Byte.swift
@@ -17,26 +17,16 @@ struct Byte: Hashable {
   }
 }
 
-// Please forgive me...
-func == (lhs: UnicodeScalar, rhs: Byte?) -> Bool {
-  guard let rhs else { return false }
-  return lhs.value == rhs.rawValue
-}
-func == (lhs: Byte?, rhs: UnicodeScalar) -> Bool {
-  rhs == lhs
-}
-func != (lhs: UnicodeScalar, rhs: Byte?) -> Bool {
-  !(lhs == rhs)
-}
-func != (lhs: Byte?, rhs: UnicodeScalar) -> Bool {
-  rhs != lhs
+extension Byte: ExpressibleByUnicodeScalarLiteral {
+  init(unicodeScalarLiteral value: UnicodeScalar) {
+    self.init(UInt8(ascii: value))
+  }
 }
 
-func ~= (pattern: UnicodeScalar, match: Byte) -> Bool {
-  pattern == match
-}
-func ~= (pattern: UnicodeScalar, match: Byte?) -> Bool {
-  pattern == match
+extension Byte: Comparable {
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
 }
 
 extension Byte? {
@@ -60,15 +50,5 @@ extension Byte {
   }
   var isSpaceTabOrNewline: Bool {
     isSpaceOrTab || isNewline
-  }
-  init(ascii scalar: UnicodeScalar) {
-    assert(scalar.isASCII)
-    self.rawValue = UInt8(scalar.value)
-  }
-  var scalar: UnicodeScalar {
-    UnicodeScalar(UInt32(rawValue))!
-  }
-  var char: Character {
-    .init(scalar)
   }
 }

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/ByteScanner.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Scanner/ByteScanner.swift
@@ -77,10 +77,6 @@ struct ByteScanner {
     tryEat(where: { $0 == byte })
   }
 
-  mutating func tryEat(_ c: UnicodeScalar) -> Bool {
-    tryEat(where: { $0 == c })
-  }
-
   mutating func tryEat<S: Sequence>(_ seq: S) -> Bool where S.Element == UInt8 {
     let start = cursor
     for byte in seq {

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Utils.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Utils.swift
@@ -132,3 +132,12 @@ extension String {
     }
   }
 }
+
+/// Pattern match by `is` property. E.g. `case \.isNewline: ...`
+func ~= <T>(keyPath: KeyPath<T, Bool>, subject: T) -> Bool {
+  return subject[keyPath: keyPath]
+}
+
+func ~= <T>(keyPath: KeyPath<T, Bool>, subject: T?) -> Bool {
+  return subject?[keyPath: keyPath] == true
+}

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Utils.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Utils.swift
@@ -78,7 +78,7 @@ extension String {
       let result = scanner.consumeWhole { consumer in
         switch consumer.peek {
         case "\\", "\"":
-          consumer.append(Byte(ascii: "\\"))
+          consumer.append("\\")
         case " ", "$": // $ is potentially a variable reference
           needsQuotes = true
         default:


### PR DESCRIPTION
### 👼 Less evil 
Instead of comparing with `UnicodeScalar`, construct `Byte` from literals and compare two `Byte` values.

### 👿 More evil  
Pattern match by `KeyPath<T, Bool>`. Rewrite patterns like `case let c where c.isNewline:` to `case \.isNewline`