### PR TITLE
[6.1] [NFC] Switch from backticks to quotes in several diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5575,7 +5575,7 @@ ERROR(concurrent_access_of_inout_param,none,
       "concurrently-executing code",
       (DeclName))
 ERROR(non_sendable_capture,none,
-      "capture of %1 with non-sendable type %0 in a `@Sendable` "
+      "capture of %1 with non-sendable type %0 in a '@Sendable' "
       "%select{local function|closure}2",
       (Type, DeclName, bool))
 ERROR(non_sendable_isolated_capture,none,
@@ -5586,7 +5586,7 @@ ERROR(self_capture_deinit_task,none,
       "capture of 'self' in a closure that outlives deinit",
       ())
 ERROR(implicit_non_sendable_capture,none,
-      "implicit capture of %1 requires that %0 conforms to `Sendable`",
+      "implicit capture of %1 requires that %0 conforms to 'Sendable'",
       (Type, DeclName))
 
 NOTE(actor_isolated_sync_func,none,

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -137,22 +137,22 @@ func testSendableAttrs(
 
   doSomethingConcurrently {
     print(sendableClass)               // no-error
-    print(nonSendableClass)            // expected-warning{{capture of 'nonSendableClass' with non-sendable type 'NonSendableClass' in a `@Sendable` closure}}
+    print(nonSendableClass)            // expected-warning{{capture of 'nonSendableClass' with non-sendable type 'NonSendableClass' in a '@Sendable' closure}}
 
     print(sendableEnum)                // no-error
-    print(nonSendableEnum)             // expected-warning{{capture of 'nonSendableEnum' with non-sendable type 'NonSendableEnum' in a `@Sendable` closure}}
+    print(nonSendableEnum)             // expected-warning{{capture of 'nonSendableEnum' with non-sendable type 'NonSendableEnum' in a '@Sendable' closure}}
 
     print(sendableOptions)             // no-error
-    print(nonSendableOptions)          // expected-warning{{capture of 'nonSendableOptions' with non-sendable type 'NonSendableOptions' in a `@Sendable` closure}}
+    print(nonSendableOptions)          // expected-warning{{capture of 'nonSendableOptions' with non-sendable type 'NonSendableOptions' in a '@Sendable' closure}}
 
     print(sendableError)               // no-error
     print(nonSendableError)            // no-error--we don't respect `@_nonSendable` on `ns_error_domain` types because all errors are Sendable
 
     print(sendableStringEnum)          // no-error
-    print(nonSendableStringEnum)       // expected-warning{{capture of 'nonSendableStringEnum' with non-sendable type 'NonSendableStringEnum' in a `@Sendable` closure}}
+    print(nonSendableStringEnum)       // expected-warning{{capture of 'nonSendableStringEnum' with non-sendable type 'NonSendableStringEnum' in a '@Sendable' closure}}
 
     print(sendableStringStruct)        // no-error
-    print(nonSendableStringStruct)     // expected-warning{{capture of 'nonSendableStringStruct' with non-sendable type 'NonSendableStringStruct' in a `@Sendable` closure}}
+    print(nonSendableStringStruct)     // expected-warning{{capture of 'nonSendableStringStruct' with non-sendable type 'NonSendableStringStruct' in a '@Sendable' closure}}
   }
 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -742,7 +742,7 @@ func checkLocalFunctions() async {
 
   // Escaping closures can make the local function execute concurrently.
   acceptConcurrentClosure {
-    local2() // expected-warning{{capture of 'local2()' with non-sendable type '() -> ()' in a `@Sendable` closure}}
+    local2() // expected-warning{{capture of 'local2()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
     // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 
@@ -752,7 +752,7 @@ func checkLocalFunctions() async {
   var k = 17
   func local4() {
     acceptConcurrentClosure {
-      local3() // expected-warning{{capture of 'local3()' with non-sendable type '() -> ()' in a `@Sendable` closure}}
+      local3() // expected-warning{{capture of 'local3()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
       // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
   }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -210,8 +210,8 @@ func testConcurrency() {
     print(y) // okay
   }
   acceptConcurrent {
-    print(x) // expected-warning{{capture of 'x' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
-    print(y) // expected-warning{{capture of 'y' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    print(x) // expected-warning{{capture of 'x' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
+    print(y) // expected-warning{{capture of 'y' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
     // expected-warning@-1{{reference to captured var 'y' in concurrently-executing code}}
   }
 }
@@ -308,7 +308,7 @@ func acceptConcurrentUnary<T>(_: @Sendable (T) -> T) { }
 func concurrentClosures<T>(_: T) { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{26-26=: Sendable}}
   acceptConcurrentUnary { (x: T) in
     _ = x // ok
-    acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a `@Sendable` closure}}
+    acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a '@Sendable' closure}}
     let y: T? = nil
     return y!
   }
@@ -475,7 +475,7 @@ enum E12<T>: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecate
 func testSendableOptionalInference(nc: NotConcurrent) {
   var fn: (@Sendable () -> Void)? = nil
   fn = {
-    print(nc) // expected-warning{{capture of 'nc' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    print(nc) // expected-warning{{capture of 'nc' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
   }
   _ = fn
 }

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -60,7 +60,7 @@ func testAsync() async {
 class C { // expected-complete-tns-note {{class 'C' does not conform to the 'Sendable' protocol}}
   func test() {
     f(arg: 5, withFn: { [weak self] () -> OtherHandler? in
-        _ = self // expected-complete-tns-warning {{capture of 'self' with non-sendable type 'C?' in a `@Sendable` closure}}
+        _ = self // expected-complete-tns-warning {{capture of 'self' with non-sendable type 'C?' in a '@Sendable' closure}}
         return nil
       })
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -201,9 +201,9 @@ class C { // expected-complete-tns-note {{'C' does not conform to the 'Sendable'
     func doNext() { // expected-complete-tns-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
       doPreconcurrency {
         self.ev?.scheduleTask(deadline: i, doNext)
-        // expected-complete-tns-warning @-1 {{capture of 'self' with non-sendable type 'C' in a `@Sendable` closure}}
+        // expected-complete-tns-warning @-1 {{capture of 'self' with non-sendable type 'C' in a '@Sendable' closure}}
         // expected-complete-tns-warning @-2 {{converting non-sendable function value to '@Sendable () throws -> ()' may introduce data races}}
-        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-sendable type '() -> ()' in a `@Sendable` closure}}
+        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
         // expected-complete-tns-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         return
       }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -352,7 +352,7 @@ func testLocalCaptures() {
   @Sendable
   func a2() -> NonSendable {
     return ns
-    // expected-complete-and-tns-warning @-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+    // expected-complete-and-tns-warning @-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 }
 
@@ -434,7 +434,7 @@ struct DowngradeForPreconcurrency {
     preconcurrencyContext {
       Task {
         completion()
-        // expected-warning@-1 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in a `@Sendable` closure}}
+        // expected-warning@-1 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in a '@Sendable' closure}}
         // expected-warning@-2 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in an isolated closure}}
         // expected-note@-3 2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         // expected-warning@-4 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/sendable_checking_captures_swift5.swift
+++ b/test/Concurrency/sendable_checking_captures_swift5.swift
@@ -9,10 +9,10 @@ var testLocalCaptures: Int {
   let ns = NonSendable()
 
   @Sendable func localFunc() -> NonSendable {
-    return ns // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+    return ns // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 
-  callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` closure}}
+  callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
 
   return 3
 }
@@ -20,7 +20,7 @@ var testLocalCaptures: Int {
 struct Bad {
   var c: Int = {
     let ns = NonSendable()
-    callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` closure}}
+    callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
     return 3
   }()
 }
@@ -40,13 +40,13 @@ do {
   withMutable { test in
     sendable {
       test.update()
-      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
+      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
       // expected-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
 
     sendable_preconcurrency {
       test.update()
-      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
+      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
       // expected-complete-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
   }
@@ -63,7 +63,7 @@ func testPreconcurrencyDowngrade(ns: NotSendable) {
   var x = 0
   withSendableClosure {
     _ = ns
-    // expected-complete-warning@-1 {{capture of 'ns' with non-sendable type 'NotSendable' in a `@Sendable` closure}}
+    // expected-complete-warning@-1 {{capture of 'ns' with non-sendable type 'NotSendable' in a '@Sendable' closure}}
 
     x += 1
     // expected-complete-warning@-1 {{mutation of captured var 'x' in concurrently-executing code}}

--- a/test/Concurrency/sendable_checking_captures_swift6.swift
+++ b/test/Concurrency/sendable_checking_captures_swift6.swift
@@ -8,10 +8,10 @@ var testLocalCaptures: Int {
   let ns = NonSendable()
 
   @Sendable func localFunc() -> NonSendable {
-    return ns // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+    return ns // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 
-  callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` closure}}
+  callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
 
   return 3
 }
@@ -19,7 +19,7 @@ var testLocalCaptures: Int {
 struct Bad {
   var c: Int = {
     let ns = NonSendable()
-    callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` closure}}
+    callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
     return 3
   }()
 }
@@ -39,13 +39,13 @@ do {
   withMutable { test in
     sendable {
       test.update()
-      // expected-error@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
+      // expected-error@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
       // expected-error@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
 
     sendable_preconcurrency {
       test.update()
-      // expected-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a `@Sendable` closure}}
+      // expected-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
       // expected-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
   }

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -42,22 +42,22 @@ func passSendable(
 ) async {
   // Don't warn about implicitly non-Sendable types when minimal is
   // enabled... but do when we are doing targeted
-  takeSendable { print(c1) } // expected-targeted-warning {{capture of 'c1' with non-sendable type 'C1' in a `@Sendable` closure}}
-  takeSendable { print(fn) } // expected-targeted-warning {{capture of 'fn' with non-sendable type '() -> Void' in a `@Sendable` closure}}
+  takeSendable { print(c1) } // expected-targeted-warning {{capture of 'c1' with non-sendable type 'C1' in a '@Sendable' closure}}
+  takeSendable { print(fn) } // expected-targeted-warning {{capture of 'fn' with non-sendable type '() -> Void' in a '@Sendable' closure}}
   // expected-targeted-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   // Warn about explicitly non-Sendable types
-  takeSendable { print(c2) } // expected-warning {{capture of 'c2' with non-sendable type 'C2' in a `@Sendable` closure}}
-  takeSendable { print(c3) } // expected-warning {{capture of 'c3' with non-sendable type 'C3' in a `@Sendable` closure}}
+  takeSendable { print(c2) } // expected-warning {{capture of 'c2' with non-sendable type 'C2' in a '@Sendable' closure}}
+  takeSendable { print(c3) } // expected-warning {{capture of 'c3' with non-sendable type 'C3' in a '@Sendable' closure}}
 
   // Don't warn about explicitly Sendable type, even when it's wrong.
   takeSendable { print(s1) }
 
   // Don't warn when we wrapped an implicitly non-Sendable type in a struct unless we are >= targeted
-  takeSendable { print(s2) } // expected-targeted-warning {{capture of 's2' with non-sendable type 'S2' in a `@Sendable` closure}}
+  takeSendable { print(s2) } // expected-targeted-warning {{capture of 's2' with non-sendable type 'S2' in a '@Sendable' closure}}
 
   // FIXME: Ideally, we would warn about cases where a type in this module is
   // inferred to be non-Sendable based on something explicitly non-Sendable,
   // like in the case below. We do warn about it with >= targeted.
-  takeSendable { print(s3) } // expected-targeted-warning {{capture of 's3' with non-sendable type 'S3' in a `@Sendable` closure}}
+  takeSendable { print(s3) } // expected-targeted-warning {{capture of 's3' with non-sendable type 'S3' in a '@Sendable' closure}}
 }

--- a/test/Concurrency/taskgroup_cancelAll_from_child.swift
+++ b/test/Concurrency/taskgroup_cancelAll_from_child.swift
@@ -17,14 +17,14 @@ func test_taskGroup_cancelAll() async {
        }
 
        group.spawn { // expected-error {{escaping closure captures 'inout' parameter 'group'}}
-         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a `@Sendable` closure}}
+         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
          //expected-warning@-1{{mutable capture of 'inout' parameter 'group' is not allowed in concurrently-executing code; this is an error in the Swift 6 language mode}}
          // expected-note@-2 {{captured here}}
 
          return 0
        }
        group.spawn { [group] in
-         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a `@Sendable` closure}}
+         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
          return 0
        }
        _ = await group.next()

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -593,14 +593,14 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
 func testSendableClosureCapturesNonSendable(a: MyActor) {
   let klass = NonSendableKlass()
   let _ = { @Sendable in
-    _ = klass // expected-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+    _ = klass // expected-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 }
 
 func testSendableClosureCapturesNonSendable2(a: FinalMainActorIsolatedKlass) {
   let klass = NonSendableKlass()
   let _ = { @Sendable @MainActor in
-    a.klass = klass // expected-complete-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+    a.klass = klass // expected-complete-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 }
 
@@ -1548,7 +1548,7 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
     let _ = x // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '() -> ()' in a `@Sendable` closure}}
+    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '() -> ()' in a '@Sendable' closure}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 }
@@ -1736,7 +1736,7 @@ func sendableGlobalActorIsolated() {
   let _ = { @Sendable @MainActor in
     print(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
   print(x) // expected-tns-note {{access can happen concurrently}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -209,7 +209,7 @@ struct Clock {
     // nonisolated instead of custom actor isolated.
     print(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 
   useValue(ns)

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -229,7 +229,7 @@ func withVouchers(call: @Sendable @escaping (voucher_t?, voucher_t?, voucher_t?)
 
       // Clear any voucher that the call adopted.
       adopt(voucher: nil)
-      group.leave() // expected-complete-tns-warning {{capture of 'group' with non-sendable type 'DispatchGroup' in a `@Sendable` closure}}
+      group.leave() // expected-complete-tns-warning {{capture of 'group' with non-sendable type 'DispatchGroup' in a '@Sendable' closure}}
     }
     group.wait()
 
@@ -418,7 +418,7 @@ if #available(SwiftStdlib 5.1, *) {
            _ = await (g, add)
 
            if await n.get() >= limit {
-             group.leave() // expected-warning 2{{capture of 'group' with non-sendable type 'DispatchGroup' in a `@Sendable` closure}}
+             group.leave() // expected-warning 2{{capture of 'group' with non-sendable type 'DispatchGroup' in a '@Sendable' closure}}
            } else {
              await n.increment()
              await detachedTask()


### PR DESCRIPTION
  - **Explanation**: The convention for Swift diagnostics is to delimit code with single quotes.
  - **Scope**: Concurrency diagnostic messages.
  - **Issues**: —
  - **Original PRs**: #79002.
  - **Risk**: None.
  - **Testing**: No additional testing warranted.
  - **Reviewers**: @xedin
