### PR TITLE
[CSOptimizer] MemberImportVisibility: Don't consider overloads that c…

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -175,6 +175,18 @@ void forEachDisjunctionChoice(
     if (!decl)
       continue;
 
+    // Ignore declarations that come from implicitly imported modules
+    // when `MemberImportVisibility` feature is enabled otherwise
+    // we might end up favoring an overload that would be diagnosed
+    // as unavailable later.
+    if (cs.getASTContext().LangOpts.hasFeature(
+            Feature::MemberImportVisibility)) {
+      if (auto *useDC = constraint->getOverloadUseDC()) {
+        if (!useDC->isDeclImported(decl))
+          continue;
+      }
+    }
+
     // If disjunction choice is unavailable or disfavored we cannot
     // do anything with it.
     if (decl->getAttrs().hasAttribute<DisfavoredOverloadAttr>() ||

--- a/test/Constraints/member_import_visibility.swift
+++ b/test/Constraints/member_import_visibility.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A \
+// RUN:   -emit-module-path %t/A.swiftmodule
+
+/// Build the library B
+// RUN: %target-swift-frontend -I %t -emit-module %t/src/B.swift \
+// RUN:   -module-name B \
+// RUN:   -emit-module-path %t/B.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -I %t %t/src/Main.swift %t/src/Other.swift -enable-upcoming-feature MemberImportVisibility
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- A.swift
+public struct Test {
+  public init(a: Double) { }
+}
+
+//--- B.swift
+import A
+
+extension Test {
+  public init(a: Int) { fatalError() }
+}
+
+//--- Main.swift
+import A
+
+func test() {
+  _ = Test(a: 0) // Ok, selects the overload that takes Double.
+}
+
+//--- Other.swift
+import B


### PR DESCRIPTION
…ome from implicit imports

Ignore declarations that come from implicitly imported modules when `MemberImportVisibility` 
feature is enabled otherwise we might end up favoring an overload that would be diagnosed as unavailable later.

Resolves: rdar://143582881

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
