### PR TITLE
[Backtracing] Add JSON backtrace output

### DIFF
--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -381,7 +381,7 @@ backtracer settings:
 +-------------------+--------------------------------------------------------+
 | Field             | Value                                                  |
 +===================+========================================================+
-| threads           | An array of thread record, one for each thread (if the |
+| threads           | An array of thread records, one for each thread (if the |
 |                   | backtracer is set to give backtraces for all threads). |
 +-------------------+--------------------------------------------------------+
 | crashedThread     | A single thread record for the crashing thread (if the |

--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -92,9 +92,17 @@ follows:
 |                 |         | only has effect on platforms that have a symbol  |
 |                 |         | cache that can be controlled by the runtime.     |
 +-----------------+---------+--------------------------------------------------+
+| format          | text    | Set to ``json`` to output JSON crash logs rather |
+|                 |         | than plain text.                                 |
++-----------------+---------+--------------------------------------------------+
 | output-to       | stdout  | Set to ``stderr`` to send the backtrace to the   |
 |                 |         | standard error instead of standard output.  This |
 |                 |         | may be useful in some CI systems.                |
+|                 |         |                                                  |
+|                 |         | You may also specify a path; if this points at a |
+|                 |         | directory, the backtracer will generate unique   |
+|                 |         | filenames within that directory.  Otherwise it   |
+|                 |         | is assumed to be a filename.                     |
 +-----------------+---------+--------------------------------------------------+
 | symbolicate     | full    | Options are ``full``, ``fast``, or ``off``.      |
 |                 |         | Full means to look up source locations and       |
@@ -334,3 +342,184 @@ large number of frames in a much smaller space than would otherwise be possible.
 Similarly, where we need to store address to image mappings, we
 use :download:`Compact ImageMap Format <CompactImageMapFormat.md>` to minimise
 storage requirements.
+
+JSON Crash Logs
+---------------
+
+JSON crash logs are a structured crash log format that the backtracer is able
+to output.  Note that addresses are represented in this format as hexadecimal
+strings, rather than as numbers, in order to avoid representational issues.
+Additionally, boolean fields that are ``false``, as well as fields whose
+values are unknown or empty, will normally be completely omitted to save space.
+
+JSON crash logs will always contain the following top level fields:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| timestamp         | An ISO-8601 formatted timestamp, as a string.          |
++-------------------+--------------------------------------------------------+
+| kind              | The string ``crashReport``.                            |
++-------------------+--------------------------------------------------------+
+| description       | A textual description of the crash or runtime failure. |
++-------------------+--------------------------------------------------------+
+| faultAddress      | The fault address associated with the crash.           |
++-------------------+--------------------------------------------------------+
+| platform          | A string describing the platform; the first token      |
+|                   | identifies the platform itself and is followed by      |
+|                   | platform specific version information.                 |
+|                   |                                                        |
+|                   | e.g. "macOS 13.0 (22A380)",                            |
+|                   |      "linux (Ubuntu 22.04.5 LTS)"                      |
++-------------------+--------------------------------------------------------+
+| architecture      | The name of the processor architecture for this crash. |
++-------------------+--------------------------------------------------------+
+
+These will be followed by some or all of the following, according to the
+backtracer settings:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| threads           | An array of thread record, one for each thread (if the |
+|                   | backtracer is set to give backtraces for all threads). |
++-------------------+--------------------------------------------------------+
+| crashedThread     | A single thread record for the crashing thread (if the |
+|                   | backtracer is set to give a backtrace only for the     |
+|                   | crashed thread).                                       |
++-------------------+--------------------------------------------------------+
+| registers         | A dictionary containing the register contents on the   |
+|                   | crashed thread (if set to give registers for only the  |
+|                   | crashed thread).                                       |
+|                   |                                                        |
+|                   | The dictionary is keyed by architecture specific       |
+|                   | register name; values are given as hexadecimal         |
+|                   | strings.                                               |
++-------------------+--------------------------------------------------------+
+| capturedMemory    | A dictionary containing captured memory contents, if   |
+|                   | any.  This will not be present if the ``sanitize``     |
+|                   | setting is enabled, or if no data was captured.        |
+|                   |                                                        |
+|                   | The dictionary is keyed by hexadecimal addresses, as   |
+|                   | strings; values are also hexadecimal strings.          |
++-------------------+--------------------------------------------------------+
+| omittedImages     | If ``images`` is set to ``mentioned``, this is an      |
+|                   | integer giving the number of images whose details were |
+|                   | omitted from the crash log.                            |
++-------------------+--------------------------------------------------------+
+| images            | Unless ``images`` is ``none``, an array of records     |
+|                   | describing the loaded images in the crashed process.   |
++-------------------+--------------------------------------------------------+
+| backtraceTime     | The time taken to generate the crash report, in        |
+|                   | seconds.                                               |
++-------------------+--------------------------------------------------------+
+
+Thread Records
+^^^^^^^^^^^^^^
+
+A thread record is a dictionary with the following fields:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| name              | The name of the thread.  Omitted if no name.           |
++-------------------+--------------------------------------------------------+
+| crashed           | ``true`` if the thread is the one that crashed,        |
+|                   | omitted otherwise.                                     |
++-------------------+--------------------------------------------------------+
+| registers         | If ``registers`` is set to ``all``, the registers for  |
+|                   | the thread (see above for the format).                 |
++-------------------+--------------------------------------------------------+
+| frames            | An array of frames forming the backtrace for the       |
+|                   | thread.                                                |
++-------------------+--------------------------------------------------------+
+
+Each frame in the backtrace is described by a dictionary containing the
+following fields:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| kind              | ``programCounter`` if the frame address is a directly  |
+|                   | captured program counter/instruction pointer.          |
+|                   |                                                        |
+|                   | ``returnAddress`` if the frame address is a return     |
+|                   | address.                                               |
+|                   |                                                        |
+|                   | ``asyncResumePoint`` if the frame address is a         |
+|                   | resumption point in an ``async`` function.             |
+|                   |                                                        |
+|                   | ``omittedFrames`` if this is a frame omission record.  |
+|                   |                                                        |
+|                   | ``truncated`` to indicate that the backtrace is        |
+|                   | truncated at this point and that more frames were      |
+|                   | available but not captured.                            |
++-------------------+--------------------------------------------------------+
+| address           | The frame address as a string (for records containing  |
+|                   | an address).                                           |
++-------------------+--------------------------------------------------------+
+| count             | The number of frames omitted at this point in the      |
+|                   | backtrace (``omittedFrames`` only).                    |
++-------------------+--------------------------------------------------------+
+
+If the backtrace is symbolicated, the frame record may also contain the
+following additional information:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| inlined           | ``true`` if this frame is inlined, omitted otherwise.  |
++-------------------+--------------------------------------------------------+
+| runtimeFailure    | ``true`` if this frame represents a Swift runtime      |
+|                   | failure, omitted otherwise.                            |
++-------------------+--------------------------------------------------------+
+| thunk             | ``true`` if this frame is a compiler-generated thunk   |
+|                   | function, omitted otherwise.                           |
++-------------------+--------------------------------------------------------+
+| system            | ``true`` if this frame is a system frame, omitted      |
+|                   | otherwise.                                             |
++-------------------+--------------------------------------------------------+
+
+If symbol lookup succeeded for the frame address, the following additional
+fields will be present:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| symbol            | The mangled name of the symbol corresponding to the    |
+|                   | frame address.                                         |
++-------------------+--------------------------------------------------------+
+| offset            | The offset from the symbol to the frame address.       |
++-------------------+--------------------------------------------------------+
+| description       | If demangling is enabled, a human readable description |
+|                   | of the frame address, otherwise omitted.               |
++-------------------+--------------------------------------------------------+
+| image             | The name of the image in which the symbol was found;   |
+|                   | omitted if no corresponding image exists.              |
++-------------------+--------------------------------------------------------+
+| sourceLocation    | If the source location of the symbol is known, a       |
+|                   | dictionary containing ``file``, ``line`` and           |
+|                   | ``column`` keys that identify the location of the      |
+|                   | symbol in the source files.                            |
++-------------------+--------------------------------------------------------+
+
+Image Records
+^^^^^^^^^^^^^
+
+An image record is a dictionary with the following fields:
+
++-------------------+--------------------------------------------------------+
+| Field             | Value                                                  |
++===================+========================================================+
+| name              | The name of the image (omitted if not known).          |
++-------------------+--------------------------------------------------------+
+| buildId           | The build ID (aka unique ID) of the image (omitted if  |
+|                   | not known).                                            |
++-------------------+--------------------------------------------------------+
+| path              | The path to the image (omitted if not known).          |
++-------------------+--------------------------------------------------------+
+| baseAddress       | The base address of the image text, as a hexadecimal   |
+|                   | string.                                                |
++-------------------+--------------------------------------------------------+
+| endOfText         | The end of the image text, as a hexadecimal string.    |
++-------------------+--------------------------------------------------------+

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -194,6 +194,30 @@ public struct Backtrace: CustomStringConvertible, Sendable {
           return "..."
       }
     }
+
+    /// A JSON description of this frame, less the surrounding braces.
+    /// This is useful if you want to add extra information.
+    @_spi(Internal)
+    public var jsonBody: String {
+      switch self {
+        case let .programCounter(addr):
+          return "\"kind\": \"programCounter\", \"address\": \"\(addr)\""
+        case let .returnAddress(addr):
+          return "\"kind\": \"returnAddress\", \"address\": \"\(addr)\""
+        case let .asyncResumePoint(addr):
+          return "\"kind\": \"asyncResumePoint\", \"address\": \"\(addr)\""
+        case let .omittedFrames(count):
+          return "\"kind\": \"omittedFrames\", \"count\": \(count)"
+        case .truncated:
+          return "\"kind\": \"truncated\""
+      }
+    }
+
+    /// A JSON description of this frame.
+    @_spi(Internal)
+    public var jsonDescription: String {
+      return "{ \(jsonBody) }"
+    }
   }
 
   /// Represents an image loaded in the process's address space

--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -416,7 +416,8 @@ private func untabify(_ s: String, tabWidth: Int = 8) -> String {
 /// @param path  The path to sanitize.
 ///
 /// @returns A string containing the sanitized path.
-private func sanitizePath(_ path: String) -> String {
+@_spi(Formatting)
+public func sanitizePath(_ path: String) -> String {
   #if os(macOS)
   return CRCopySanitizedPath(path,
                              kCRSanitizePathGlobAllTypes

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -33,6 +33,7 @@ set(BACKTRACING_COMPILE_FLAGS
 set(BACKTRACING_SOURCES
   main.swift
   AnsiColor.swift
+  JSON.swift
   TargetMacOS.swift
   TargetLinux.swift
   Themes.swift

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -272,6 +272,7 @@ extension SwiftBacktrace {
       }
       write("]")
     } else {
+      write(#", "crashedThread": "#)
       outputJSONThread(ndx: target.crashingThreadNdx,
                        thread: crashingThread)
     }

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -46,12 +46,22 @@ extension SwiftBacktrace {
       description = target.signalDescription
     }
 
+    let architecture: String
+    switch crashingThread.backtrace {
+      case let .raw(backtrace):
+        architecture = backtrace.architecture
+      case let .symbolicated(backtrace):
+        architecture = backtrace.architecture
+    }
+
     write("""
             { \
             "timestamp": "\(formatISO8601(now))", \
             "kind": "crashReport", \
             "description": "\(escapeJSON(description))", \
-            "faultAddress": "\(hex(target.faultAddress))"
+            "faultAddress": "\(hex(target.faultAddress))", \
+            "platform": "\(escapeJSON(target.images.platform))", \
+            "architecture": "\(escapeJSON(architecture))",
             """)
 
     var mentionedImages = Set<Int>()

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -26,8 +26,6 @@ import CRT
 @_spi(Internal) import Runtime
 @_spi(MemoryReaders) import Runtime
 
-// ###TODO: Escape JSON strings
-
 extension SwiftBacktrace {
 
   static func outputJSONCrashLog() {
@@ -277,7 +275,7 @@ extension SwiftBacktrace {
     }
 
     if !capturedBytes.isEmpty && !(args.sanitize ?? false) {
-      write(#"", capturedMemory": {"#)
+      write(#", "capturedMemory": {"#)
       var first = true
       for (address, bytes) in capturedBytes {
         let formattedBytes = bytes
@@ -290,7 +288,7 @@ extension SwiftBacktrace {
         }
         write(" \"\(hex(address))\": \"\(formattedBytes)\"")
       }
-      write(" }, ")
+      write(" }")
     }
 
     func outputJSONImage(_ image: Backtrace.Image, first: Bool) {

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -1,0 +1,362 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(CRT)
+import CRT
+#endif
+
+@_spi(Contexts) import Runtime
+@_spi(Registers) import Runtime
+@_spi(Formatting) import Runtime
+@_spi(Internal) import Runtime
+@_spi(MemoryReaders) import Runtime
+
+// ###TODO: Escape JSON strings
+
+extension SwiftBacktrace {
+
+  static func outputJSONCrashLog() {
+    guard let target = target else {
+      print("swift-backtrace: unable to get target",
+            to: &standardError)
+      return
+    }
+
+    let crashingThread = target.threads[target.crashingThreadNdx]
+
+    let description: String
+
+    if case let .symbolicated(symbolicated) = crashingThread.backtrace,
+       let failure = symbolicated.swiftRuntimeFailure {
+      description = failure
+    } else {
+      description = target.signalDescription
+    }
+
+    write("""
+            { \
+            "timestamp": "\(formatISO8601(now))", \
+            "kind": "crashReport", \
+            "description": "\(escapeJSON(description))", \
+            "faultAddress": "\(hex(target.faultAddress))"
+            """)
+
+    var mentionedImages = Set<Int>()
+    var capturedBytes: [UInt64:Array<UInt8>] = [:]
+
+    func outputJSONRegister<T: FixedWidthInteger>(
+      name: String, value: T, first: Bool = false
+    ) {
+      if !first {
+        write(", ")
+      }
+      write("\"\(name)\": \"\(hex(value))\"")
+
+      if let bytes = try? target.reader.fetch(
+           from: RemoteMemoryReader.Address(value),
+           count: 16,
+           as: UInt8.self) {
+        capturedBytes[UInt64(truncatingIfNeeded: value)] = bytes
+      }
+    }
+
+    func outputJSONRegister<C: Context>(
+      name: String, context: C, register: C.Register, first: Bool = false
+    ) {
+      let value = context.getRegister(register)!
+      outputJSONRegister(name: name, value: value, first: first)
+    }
+
+    func outputJSONGPRs<C: Context, Rs: Sequence>(_ context: C, range: Rs)
+      where Rs.Element == C.Register
+    {
+      var first = true
+      for reg in range {
+        outputJSONRegister(name: "\(reg)", context: context, register: reg,
+                           first: first)
+        if first {
+          first = false
+        }
+      }
+    }
+
+    func outputJSONRegisterDump(_ context: X86_64Context) {
+      outputJSONGPRs(context, range: .rax ... .r15)
+      outputJSONRegister(name: "rip", value: context.programCounter)
+      outputJSONRegister(name: "rflags", context: context, register: .rflags)
+      outputJSONRegister(name: "cs", context: context, register: .cs)
+      outputJSONRegister(name: "fs", context: context, register: .fs)
+      outputJSONRegister(name: "gs", context: context, register: .gs)
+    }
+
+    func outputJSONRegisterDump(_ context: I386Context) {
+      outputJSONGPRs(context, range: .eax ... .edi)
+      outputJSONRegister(name: "eip", value: context.programCounter)
+      outputJSONRegister(name: "eflags", context: context, register: .eflags)
+      outputJSONRegister(name: "es", context: context, register: .es)
+      outputJSONRegister(name: "cs", context: context, register: .cs)
+      outputJSONRegister(name: "ss", context: context, register: .ss)
+      outputJSONRegister(name: "ds", context: context, register: .ds)
+      outputJSONRegister(name: "fs", context: context, register: .fs)
+      outputJSONRegister(name: "gs", context: context, register: .gs)
+    }
+
+    func outputJSONRegisterDump(_ context: ARM64Context) {
+      outputJSONGPRs(context, range: .x0 ..< .x29)
+      outputJSONRegister(name: "fp", context: context, register: .x29)
+      outputJSONRegister(name: "lr", context: context, register: .x30)
+      outputJSONRegister(name: "sp", context: context, register: .sp)
+      outputJSONRegister(name: "pc", context: context, register: .pc)
+    }
+
+    func outputJSONRegisterDump(_ context: ARMContext) {
+      outputJSONGPRs(context, range: .r0 ... .r10)
+      outputJSONRegister(name: "fp", context: context, register: .r11)
+      outputJSONRegister(name: "ip", context: context, register: .r12)
+      outputJSONRegister(name: "sp", context: context, register: .r13)
+      outputJSONRegister(name: "lr", context: context, register: .r14)
+      outputJSONRegister(name: "pc", context: context, register: .r15)
+    }
+
+    func outputJSONThread(ndx: Int, thread: TargetThread) {
+      write("{ ")
+
+      if !thread.name.isEmpty {
+        write("\"name\": \"\(escapeJSON(thread.name))\", ")
+      }
+      if thread.id == target.crashingThread {
+        write(#""crashed": true, "#)
+      }
+      if args.registers! == .all {
+        if let context = thread.context {
+          write(#""registers": {"#)
+          outputJSONRegisterDump(context)
+          write(" }, ")
+        }
+      }
+
+      write(#""frames": ["#)
+      var first = true
+      switch thread.backtrace {
+        case let .raw(backtrace):
+          for frame in backtrace.frames {
+            if first {
+              first = false
+            } else {
+              write(",")
+            }
+
+            write(" { \(frame.jsonBody) }")
+          }
+        case let .symbolicated(backtrace):
+          for frame in backtrace.frames {
+            if first {
+              first = false
+            } else {
+              write(",")
+            }
+
+            write(" { ")
+
+            write(frame.captured.jsonBody)
+
+            if frame.inlined {
+              write(#", "inlined": true"#)
+            }
+            if frame.isSwiftRuntimeFailure {
+              write(#", "runtimeFailure": true"#)
+            }
+            if frame.isSwiftThunk {
+              write(#", "thunk": true"#)
+            }
+            if frame.isSystem {
+              write(#", "system": true"#)
+            }
+
+            if let symbol = frame.symbol {
+              write("""
+                      , "symbol": "\(escapeJSON(symbol.rawName))"\
+                      , "offset": \(symbol.offset)
+                      """)
+
+              if args.demangle {
+                let formattedOffset: String
+                if symbol.offset > 0 {
+                  formattedOffset = " + \(symbol.offset)"
+                } else if symbol.offset < 0 {
+                  formattedOffset = " - \(symbol.offset)"
+                } else {
+                  formattedOffset = ""
+                }
+
+                write("""
+                        , "description": \"\(escapeJSON(symbol.name))\(formattedOffset)\"
+                        """)
+              }
+
+              if symbol.imageIndex >= 0 {
+                write(", \"image\": \"\(symbol.imageName)\"")
+              }
+
+              if var sourceLocation = symbol.sourceLocation {
+                if args.sanitize ?? false {
+                  sourceLocation.path = sanitizePath(sourceLocation.path)
+                }
+                write(#", "sourceLocation": { "#)
+
+                write("""
+                        "file": "\(escapeJSON(sourceLocation.path))", \
+                        "line": \(sourceLocation.line), \
+                        "column": \(sourceLocation.column)
+                        """)
+
+                write(" } ")
+              }
+            }
+            write(" }")
+          }
+      }
+      write(" ] ")
+
+      write("} ")
+
+      if args.showImages! == .mentioned {
+        switch thread.backtrace {
+          case let .raw(backtrace):
+            for frame in backtrace.frames {
+              let address = frame.adjustedProgramCounter
+              if let imageNdx = target.images.firstIndex(
+                   where: { address >= $0.baseAddress
+                              && address < $0.endOfText }
+                 ) {
+                mentionedImages.insert(imageNdx)
+              }
+            }
+          case let .symbolicated(backtrace):
+            for frame in backtrace.frames {
+              if let symbol = frame.symbol, symbol.imageIndex >= 0 {
+                mentionedImages.insert(symbol.imageIndex)
+              }
+            }
+        }
+      }
+    }
+
+    if args.threads! {
+      write(#", "threads": [ "#)
+      for (ndx, thread) in target.threads.enumerated() {
+        outputJSONThread(ndx: ndx, thread: thread)
+      }
+      write("]")
+    } else {
+      outputJSONThread(ndx: target.crashingThreadNdx,
+                       thread: crashingThread)
+    }
+
+    if args.registers! == .crashedOnly {
+      if let context = target.threads[target.crashingThreadNdx].context {
+        write(#", "registers": { "#)
+        outputJSONRegisterDump(context)
+        write(" }")
+      }
+    }
+
+    if !capturedBytes.isEmpty && !(args.sanitize ?? false) {
+      write(#"", capturedMemory": {"#)
+      var first = true
+      for (address, bytes) in capturedBytes {
+        let formattedBytes = bytes
+          .map{ hex($0, withPrefix: false) }
+          .joined(separator: "")
+        if first {
+          first = false
+        } else {
+          write(",")
+        }
+        write(" \"\(hex(address))\": \"\(formattedBytes)\"")
+      }
+      write(" }, ")
+    }
+
+    func outputJSONImage(_ image: Backtrace.Image, first: Bool) {
+      if !first {
+        write(", ")
+      }
+
+      write("{ ")
+
+      if let name = image.name {
+        write("\"name\": \"\(escapeJSON(name))\", ")
+      }
+
+      if let bytes = image.uniqueID {
+        let buildID = hex(bytes)
+        write("\"buildId\": \"\(buildID)\", ")
+      }
+
+      if var path = image.path {
+        if args.sanitize ?? false {
+          path = sanitizePath(path)
+        }
+        write("\"path\": \"\(path)\", ")
+      }
+
+      write("""
+              "baseAddress": "\(image.baseAddress)", \
+              "endOfText": "\(image.endOfText)"
+              """)
+
+      write(" }")
+    }
+
+    switch args.showImages! {
+      case .none:
+        break
+      case .mentioned:
+        let images = mentionedImages.sorted().map{ target.images[$0] }
+        let omitted = target.images.count - images.count
+        write(", \"omittedImages\": \(omitted), \"images\": [ ")
+        var first = true
+        for image in images {
+          outputJSONImage(image, first: first)
+          if first {
+            first = false
+          }
+        }
+        write(" ] ")
+      case .all:
+        write(#", "images": [ "#)
+        var first = true
+        for image in target.images {
+          outputJSONImage(image, first: first)
+          if first {
+            first = false
+          }
+        }
+        write(" ] ")
+    }
+
+    let secs = Double(backtraceDuration.tv_sec)
+      + 1.0e-9 * Double(backtraceDuration.tv_nsec)
+
+    write(", \"backtraceTime\": \(secs) ")
+
+    writeln("}")
+  }
+
+}

--- a/stdlib/public/libexec/swift-backtrace/JSON.swift
+++ b/stdlib/public/libexec/swift-backtrace/JSON.swift
@@ -61,7 +61,7 @@ extension SwiftBacktrace {
             "description": "\(escapeJSON(description))", \
             "faultAddress": "\(hex(target.faultAddress))", \
             "platform": "\(escapeJSON(target.images.platform))", \
-            "architecture": "\(escapeJSON(architecture))",
+            "architecture": "\(escapeJSON(architecture))"
             """)
 
     var mentionedImages = Set<Int>()
@@ -233,7 +233,7 @@ extension SwiftBacktrace {
                         "column": \(sourceLocation.column)
                         """)
 
-                write(" } ")
+                write(" }")
               }
             }
             write(" }")
@@ -267,7 +267,13 @@ extension SwiftBacktrace {
 
     if args.threads! {
       write(#", "threads": [ "#)
+      var first = true
       for (ndx, thread) in target.threads.enumerated() {
+        if first {
+          first = false
+        } else {
+          write(", ")
+        }
         outputJSONThread(ndx: ndx, thread: thread)
       }
       write("]")

--- a/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/libexec/swift-backtrace/Themes.swift
+++ b/stdlib/public/libexec/swift-backtrace/Themes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -264,6 +264,8 @@ func escapeJSON(_ s: String) -> String {
   var pos = chunk
   let end = utf8View.endIndex
 
+  result.reserveCapacity(utf8View.count)
+
   while pos != end {
     let scalar = utf8View[pos]
     switch scalar {

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -34,15 +34,32 @@ typealias CrashInfo = swift.runtime.backtrace.CrashInfo
 typealias thread = swift.runtime.backtrace.thread
 #endif
 
+extension String {
+  init<T: BinaryInteger>(_ value: T,
+                         width: Int,
+                         radix: Int = 10,
+                         uppercase: Bool = false) {
+    let digits = String(value, radix: radix, uppercase: uppercase)
+    if digits.count >= width {
+      self = digits
+      return
+    }
+
+    let padding = String(repeating: "0",
+                         count: width - digits.count)
+    self = padding + digits
+  }
+}
+
 internal func hex<T: FixedWidthInteger>(_ value: T,
                                         withPrefix: Bool = true) -> String {
-  let digits = String(value, radix: 16)
-  let padTo = value.bitWidth / 4
-  let padding = digits.count >= padTo ? "" : String(repeating: "0",
-                                                    count: padTo - digits.count)
-  let prefix = withPrefix ? "0x" : ""
+  let formatted = String(value, width: value.bitWidth / 4, radix: 16)
 
-  return "\(prefix)\(padding)\(digits)"
+  if withPrefix {
+    return "0x" + formatted
+  } else {
+    return formatted
+  }
 }
 
 internal func hex(_ bytes: [UInt8]) -> String {
@@ -104,6 +121,7 @@ internal func recursiveRemoveContents(_ dir: String) throws {
   }
 }
 
+/// Remove a directory and its contents.
 internal func recursiveRemove(_ dir: String) throws {
   try recursiveRemoveContents(dir)
 
@@ -112,8 +130,25 @@ internal func recursiveRemove(_ dir: String) throws {
   }
 }
 
-internal func withTemporaryDirectory(pattern: String, shouldDelete: Bool = true,
-                                     body: (String) throws -> ()) throws {
+/// Run a closure, passing in the name of a temporary directory that will
+/// (optionally) be deleted automatically when the closure returns.
+///
+/// Parameters:
+///
+/// - pattern:       A string with some number of trailing 'X's giving the name
+///                  to use for the directory; the 'X's will be replaced with a
+///                  unique combination of alphanumeric characters.
+/// - shouldDelete:  If `true` (the default), the directory and its contents
+///                  will be removed automatically when the closure returns.
+/// - body:          The closure to execute.
+///
+/// Returns:
+///
+/// This function returns whatever the closure returns.
+internal func withTemporaryDirectory<R>(
+  pattern: String, shouldDelete: Bool = true,
+  body: (String) throws -> R
+) throws -> R {
   var buf = Array<UInt8>(pattern.utf8)
   buf.append(0)
 
@@ -132,9 +167,10 @@ internal func withTemporaryDirectory(pattern: String, shouldDelete: Bool = true,
     }
   }
 
-  try body(dir)
+  return try body(dir)
 }
 
+/// Start a program with the specified arguments
 internal func spawn(_ path: String, args: [String]) throws {
   var cargs = args.map{ strdup($0) }
   cargs.append(nil)
@@ -151,6 +187,7 @@ internal func spawn(_ path: String, args: [String]) throws {
 
 #endif // os(macOS)
 
+/// Test if the specified path is a directory
 internal func isDir(_ path: String) -> Bool {
   var st = stat()
   guard stat(path, &st) == 0 else {
@@ -159,6 +196,7 @@ internal func isDir(_ path: String) -> Bool {
   return (st.st_mode & S_IFMT) == S_IFDIR
 }
 
+/// Test if the specified path exists
 internal func exists(_ path: String) -> Bool {
   var st = stat()
   guard stat(path, &st) == 0 else {
@@ -197,3 +235,52 @@ struct CFileStream: TextOutputStream {
 
 var standardOutput = CFileStream(fp: stdout)
 var standardError = CFileStream(fp: stderr)
+
+/// Format a timespec as an ISO8601 date/time
+func formatISO8601(_ time: timespec) -> String {
+  var exploded = tm()
+  var secs = time.tv_sec
+
+  gmtime_r(&secs, &exploded)
+
+  let isoTime = """
+\(String(exploded.tm_year + 1900, width: 4))-\
+\(String(exploded.tm_mon + 1, width: 2))-\
+\(String(exploded.tm_mday, width: 2))T\
+\(String(exploded.tm_hour, width: 2)):\
+\(String(exploded.tm_min, width: 2)):\
+\(String(exploded.tm_sec, width: 2)).\
+\(String(time.tv_nsec / 1000, width: 6))Z
+"""
+
+  return isoTime
+}
+
+/// Escape a JSON string
+func escapeJSON(_ s: String) -> String {
+  var result = ""
+  let utf8View = s.utf8
+  var chunk = utf8View.startIndex
+  var pos = chunk
+  let end = utf8View.endIndex
+
+  while pos != end {
+    let scalar = utf8View[pos]
+    switch scalar {
+      case 0x22, 0x5c, 0x00...0x1f:
+        result += s[chunk..<pos]
+        result += "\\"
+        result += String(Unicode.Scalar(scalar))
+        pos = utf8View.index(after: pos)
+        chunk = pos
+      default:
+        pos = utf8View.index(after: pos)
+    }
+  }
+
+  if chunk != end {
+    result += s[chunk..<pos]
+  }
+
+  return result
+}

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -606,8 +606,8 @@ Generate a backtrace for the parent process.
           while fd < 0 && (errno == EEXIST || errno == EINTR) {
             if errno != EINTR {
               ndx += 1
+              filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).\(ext)"
             }
-            filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).\(ext)"
             fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
           }
 

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023-25 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-25 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -65,6 +65,11 @@ internal struct SwiftBacktrace {
     case full
   }
 
+  enum OutputFormat {
+    case text
+    case json
+  }
+
   struct Arguments {
     var unwindAlgorithm: UnwindAlgorithm = .precise
     var demangle = false
@@ -82,6 +87,7 @@ internal struct SwiftBacktrace {
     var cache = true
     var outputTo: OutputTo = .stdout
     var symbolicate: Symbolication = .full
+    var format: OutputFormat = .text
     var outputPath: String = "/tmp"
   }
 
@@ -90,6 +96,9 @@ internal struct SwiftBacktrace {
 
   static var target: Target? = nil
   static var currentThread: Int = 0
+
+  static var now = timespec(tv_sec: 0, tv_nsec: 0)
+  static var backtraceDuration = timespec(tv_sec: 0, tv_nsec: 0)
 
   static var theme: any Theme {
     if args.color {
@@ -208,6 +217,9 @@ Generate a backtrace for the parent process.
                         Alternatively, you may specify a file path here.  If
                         the path points to a directory, a unique filename will
                         be generated automatically.
+
+--format <format>       Set the output format.  Options are "text" and "json";
+                        the default is "text".
 
 --crashinfo <addr>
 -a <addr>               Provide a pointer to a platform specific CrashInfo
@@ -447,6 +459,23 @@ Generate a backtrace for the parent process.
         } else {
           args.symbolicate = .full
         }
+      case "--format":
+        if let v = value {
+          switch v.lowercased() {
+            case "text":
+              args.format = .text
+            case "json":
+              args.format = .json
+            default:
+              print("swift-backtrace: unknown output format '\(v)'",
+                    to: &standardError)
+          }
+        } else {
+          print("swift-backtrace: missing format value",
+                to: &standardError)
+          usage()
+          exit(1)
+        }
       default:
         print("swift-backtrace: unknown argument '\(arg)'",
               to: &standardError)
@@ -530,13 +559,20 @@ Generate a backtrace for the parent process.
 
     // Target's initializer fetches and symbolicates backtraces, so
     // we want to time that part here.
-    let duration = measureDuration {
+    backtraceDuration = measureDuration {
       target = Target(crashInfoAddr: crashInfoAddr,
                       limit: args.limit, top: args.top,
                       cache: args.cache,
                       symbolicate: args.symbolicate)
 
       currentThread = target!.crashingThreadNdx
+    }
+
+    // Grab the current wall clock time; if clock_gettime() fails, get a
+    // lower resolution version instead.
+    if clock_gettime(CLOCK_REALTIME, &now) != 0 {
+      now.tv_sec = time(nil)
+      now.tv_nsec = 0
     }
 
     // Set up the output stream
@@ -553,21 +589,25 @@ Generate a backtrace for the parent process.
           let pid = target!.pid
           var now = timespec(tv_sec: 0, tv_nsec: 0)
 
-          if clock_gettime(CLOCK_REALTIME, &now) != 0 {
-            now.tv_sec = time(nil)
-            now.tv_nsec = 0
+          let ext: String
+          switch args.format {
+            case .text:
+              ext = "log"
+            case .json:
+              ext = "json"
           }
 
           var filename =
-            "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec).log"
+            "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec).\(ext)"
 
           var fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
           var ndx = 1
+
           while fd < 0 && (errno == EEXIST || errno == EINTR) {
             if errno != EINTR {
               ndx += 1
             }
-            filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).log"
+            filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).\(ext)"
             fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
           }
 
@@ -604,14 +644,33 @@ Generate a backtrace for the parent process.
       }
     }
 
-    printCrashLog()
+    // Clear (or complete) the message written by the crash handler; this
+    // is always on stdout or stderr, even if you specify a file for output.
+    var handlerOut: CFileStream
+    if args.outputTo == .stdout {
+      handlerOut = standardOutput
+    } else {
+      handlerOut = standardError
+    }
+    if args.color {
+      print("\r\u{1b}[0K", terminator: "", to: &handlerOut)
+    } else {
+      print(" done ***\n\n", terminator: "", to: &handlerOut)
+    }
 
-    writeln("")
+    switch args.format {
+      case .text:
+        printCrashLog()
 
-    let formattedDuration = format(duration: duration)
+        writeln("")
 
-    writeln("Backtrace took \(formattedDuration)s")
-    writeln("")
+        let formattedDuration = format(duration: backtraceDuration)
+
+        writeln("Backtrace took \(formattedDuration)s")
+        writeln("")
+      case .json:
+        outputJSONCrashLog()
+    }
 
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     // On Darwin, if Developer Mode is turned off, or we can't tell if it's
@@ -769,20 +828,6 @@ Generate a backtrace for the parent process.
       description = failure
     } else {
       description = "Program crashed: \(target.signalDescription) at \(hex(target.faultAddress))"
-    }
-
-    // Clear (or complete) the message written by the crash handler; this
-    // is always on stdout or stderr, even if you specify a file for output.
-    var handlerOut: CFileStream
-    if args.outputTo == .stdout {
-      handlerOut = standardOutput
-    } else {
-      handlerOut = standardError
-    }
-    if args.color {
-      print("\r\u{1b}[0K", terminator: "", to: &handlerOut)
-    } else {
-      print(" done ***\n\n", terminator: "", to: &handlerOut)
     }
 
     writeln(theme.crashReason(description))
@@ -1329,11 +1374,15 @@ Generate a backtrace for the parent process.
          from: RemoteMemoryReader.Address(value),
          count: 16,
          as: UInt8.self) {
-      let formattedBytes = theme.data(bytes.map{
-        hex($0, withPrefix: false)
-      }.joined(separator: " "))
-      let printedBytes = printableBytes(from: bytes)
-      writeln("\(reg) \(hexValue)  \(formattedBytes)  \(printedBytes)")
+      if args.sanitize ?? false {
+        writeln("\(reg) \(hexValue)  <memory>")
+      } else {
+        let formattedBytes = theme.data(bytes.map{
+                                          hex($0, withPrefix: false)
+                                        }.joined(separator: " "))
+        let printedBytes = printableBytes(from: bytes)
+        writeln("\(reg) \(hexValue)  \(formattedBytes)  \(printedBytes)")
+      }
     } else {
       let decValue = theme.decimalValue("\(value)")
       writeln("\(reg) \(hexValue)  \(decValue)")

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -104,6 +104,11 @@ enum class Symbolication {
   Full = 2,
 };
 
+enum class OutputFormat {
+  Text = 0,
+  JSON = 1
+};
+
 struct BacktraceSettings {
   UnwindAlgorithm  algorithm;
   OnOffTty         enabled;
@@ -122,6 +127,7 @@ struct BacktraceSettings {
   OutputTo         outputTo;
   Symbolication    symbolicate;
   bool             suppressWarnings;
+  OutputFormat     format;
   const char      *swiftBacktracePath;
   const char      *outputPath;
 };

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/JSON
+// RUN: %target-codesign %t/JSON
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/JSON 2>&1 || true) | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to crash")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct JSON {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK: Thread 0 {{(".*" )?}}crashed:
+
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:42:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:36:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:32:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:28:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:24:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static JSON.main() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:48:5
+// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static JSON.$main() + {{[0-9]+}} in JSON at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in JSON at {{.*}}/JSON.swift
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{([0-9a-f]+|<no build ID>)}}{{ +}}JSON{{ +}}{{.*}}/JSON

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -22,7 +22,6 @@
 // RUN: %validate-json %t/crash7.json
 // RUN: %validate-json %t/crash8.json
 
-
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: asan
@@ -87,6 +86,12 @@ struct Crash {
 // CHECK-NEXT: "threads": [
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "crashed": true,
+// CHECK-NEXT:     "registers": {
+// CHECK-NEXT:       "{{.*}}": "0x{{[0-9a-f]+}}",
+
+// More registers here, but the number is system specific
+
+// CHECK:          },
 // CHECK-NEXT:     "frames": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "programCounter",
@@ -97,7 +102,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 52,
+// CHECK-NEXT:           "line": 51,
 // CHECK-NEXT:           "column": 15
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -110,7 +115,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 46,
+// CHECK-NEXT:           "line": 45,
 // CHECK-NEXT:           "column": 3
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -123,7 +128,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 42,
+// CHECK-NEXT:           "line": 41,
 // CHECK-NEXT:           "column": 3
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -136,7 +141,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 38,
+// CHECK-NEXT:           "line": 37,
 // CHECK-NEXT:           "column": 3
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -149,7 +154,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 34,
+// CHECK-NEXT:           "line": 33,
 // CHECK-NEXT:           "column": 3
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -162,7 +167,7 @@ struct Crash {
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
 // CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
-// CHECK-NEXT:           "line": 58,
+// CHECK-NEXT:           "line": 57,
 // CHECK-NEXT:           "column": 5
 // CHECK-NEXT:         }
 // CHECK-NEXT:       },
@@ -200,12 +205,6 @@ struct Crash {
 // CHECK:          ]
 // CHECK:        }
 // CHECK-NEXT: ],
-// CHECK-NEXT: "registers": {
-// CHECK-NEXT:   "{{.*}}": "0x{{[0-9a-f]+}}",
-
-// More registers here, again, system specific
-
-// CHECK:      },
 // CHECK-NEXT: "capturedMemory": {
 // CHECK-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
 

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -1,7 +1,27 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/JSON
-// RUN: %target-codesign %t/JSON
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/JSON 2>&1 || true) | %FileCheck %s
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Crash
+// RUN: %target-codesign %t/Crash
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash.json %target-run %t/Crash 2>&1 || true
+// RUN: %validate-json %t/crash.json | %FileCheck %s
+
+
+// Also check that we generate valid JSON with various different options set.
+
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash2.json,threads=crashed %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash3.json,registers=all %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash4.json,sanitize=yes %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash5.json,images=none %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash6.json,images=all %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash7.json,symbolicate=off %target-run %t/Crash 2>&1 || true
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,format=json,output-to=%t/crash8.json,demangle=no %target-run %t/Crash 2>&1 || true
+// RUN: %validate-json %t/crash2.json
+// RUN: %validate-json %t/crash3.json
+// RUN: %validate-json %t/crash4.json
+// RUN: %validate-json %t/crash5.json
+// RUN: %validate-json %t/crash6.json
+// RUN: %validate-json %t/crash7.json
+// RUN: %validate-json %t/crash8.json
+
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
@@ -33,27 +53,181 @@ func level5() {
 }
 
 @main
-struct JSON {
+struct Crash {
   static func main() {
     level1()
   }
 }
 
-// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+// CHECK: {
 
-// CHECK: Thread 0 {{(".*" )?}}crashed:
+// JSON logs start with an ISO timestamp
 
-// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:42:15
-// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:36:3
-// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:32:3
-// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:28:3
-// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:24:3
-// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static JSON.main() + {{[0-9]+}} in JSON at {{.*}}/JSON.swift:48:5
-// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static JSON.$main() + {{[0-9]+}} in JSON at {{.*}}/<compiler-generated>
-// CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in JSON at {{.*}}/JSON.swift
+// CHECK-NEXT: "timestamp": "{{[0-9]{4,}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z}}",
 
-// CHECK: Registers:
 
-// CHECK: Images ({{[0-9]+}} omitted):
+// Then a tag identifying this as a crash report
 
-// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{([0-9a-f]+|<no build ID>)}}{{ +}}JSON{{ +}}{{.*}}/JSON
+// CHECK-NEXT: "kind": "crashReport",
+
+
+// This is followed by a description and the fault address
+
+// CHECK-NEXT: "description": "Bad pointer dereference",
+// CHECK-NEXT: "faultAddress": "0x{{0+}}4",
+
+
+// And then by the platform and architecture
+// CHECK-NEXT: "platform": "{{.*}}",
+// CHECK-NEXT: "architecture": "{{.*}}",
+
+
+// And then a list of threads
+
+// CHECK-NEXT: "threads": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "crashed": true,
+// CHECK-NEXT:     "frames": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "programCounter",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level5yyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "level5() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 52,
+// CHECK-NEXT:           "column": 15
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level4yyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "level4() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 46,
+// CHECK-NEXT:           "column": 3
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level3yyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "level3() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 42,
+// CHECK-NEXT:           "column": 3
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level2yyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "level2() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 38,
+// CHECK-NEXT:           "column": 3
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5Crash6level1yyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "level1() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 34,
+// CHECK-NEXT:           "column": 3
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s5CrashAAV4mainyyFZ",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "static Crash.main() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 58,
+// CHECK-NEXT:           "column": 5
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "system": true,
+// CHECK-NEXT:         "symbol": "{{_?}}$s5CrashAAV5$mainyyFZ",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "static Crash.$main() + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "line": 0,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "system": true,
+// CHECK-NEXT:         "symbol": "{{_?main}}",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "description": "main + [[OFFSET]]",
+// CHECK-NEXT:         "image": "Crash",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSON.swift",
+// CHECK-NEXT:           "line": 0,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+
+// More frames here, but they're system specific
+
+// CHECK:          ]
+// CHECK:        }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "registers": {
+// CHECK-NEXT:   "{{.*}}": "0x{{[0-9a-f]+}}",
+
+// More registers here, again, system specific
+
+// CHECK:      },
+// CHECK-NEXT: "capturedMemory": {
+// CHECK-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
+
+// More captures here, but system specific
+
+// CHECK:      },
+// CHECK-NEXT: "omittedImages": {{[0-9]+}},
+// CHECK-NEXT: "images": [
+// CHECK-NEXT:   {
+
+// Maybe multiple images before this one
+
+// CHECK:          "name": "Crash",
+// CHECK-NEXT:     "buildId": "{{([0-9a-f][0-9a-f])+}}",
+// CHECK-NEXT:     "path": "{{.*}}/Crash",
+// CHECK-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
+// CHECK-NEXT:   }
+
+// Maybe multiple images after this one
+
+// CHECK:      ],
+// CHECK-NEXT: "backtraceTime": {{[0-9]+(\.[0-9]+)?}}
+
+// CHECK-NEXT: }

--- a/test/Backtracing/JSON.swift
+++ b/test/Backtracing/JSON.swift
@@ -85,7 +85,10 @@ struct Crash {
 
 // CHECK-NEXT: "threads": [
 // CHECK-NEXT:   {
-// CHECK-NEXT:     "crashed": true,
+
+// On Linux there's a name here
+
+// CHECK:          "crashed": true,
 // CHECK-NEXT:     "registers": {
 // CHECK-NEXT:       "{{.*}}": "0x{{[0-9a-f]+}}",
 
@@ -180,7 +183,7 @@ struct Crash {
 // CHECK-NEXT:         "description": "static Crash.$main() + [[OFFSET]]",
 // CHECK-NEXT:         "image": "Crash",
 // CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "file": "{{/*}}<compiler-generated>",
 // CHECK-NEXT:           "line": 0,
 // CHECK-NEXT:           "column": 0
 // CHECK-NEXT:         }
@@ -218,8 +221,8 @@ struct Crash {
 // Maybe multiple images before this one
 
 // CHECK:          "name": "Crash",
-// CHECK-NEXT:     "buildId": "{{([0-9a-f][0-9a-f])+}}",
-// CHECK-NEXT:     "path": "{{.*}}/Crash",
+//                 "buildId": ... is optional
+// CHECK:          "path": "{{.*}}/Crash",
 // CHECK-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
 // CHECK-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
 // CHECK-NEXT:   }

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -1,0 +1,220 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/JSONAsync
+// RUN: %target-codesign %t/JSONAsync
+
+// RUN: env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync 2>&1 || true
+// RUN: %validate-json %t/crash.json | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@available(SwiftStdlib 5.1, *)
+func crash() {
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@available(SwiftStdlib 5.1, *)
+func level(_ n: Int) async {
+  if n < 5 {
+    await level(n + 1)
+  } else {
+    crash()
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@main
+struct JSONAsync {
+  static func main() async {
+    await level(1)
+  }
+}
+
+// CHECK: {
+
+// JSON logs start with an ISO timestamp
+
+// CHECK-NEXT: "timestamp": "{{[0-9]{4,}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z}}",
+
+
+// Then a tag identifying this as a crash report
+
+// CHECK-NEXT: "kind": "crashReport",
+
+
+// This is followed by a description and the fault address
+
+// CHECK-NEXT: "description": "Bad pointer dereference",
+// CHECK-NEXT: "faultAddress": "0x{{0+}}4",
+
+
+// And then by the platform and architecture
+
+// CHECK-NEXT: "platform": "{{.*}}",
+// CHECK-NEXT: "architecture": "{{.*}}",
+
+
+// And then a list of threads
+
+// CHECK-NEXT: "threads": [
+// CHECK-NEXT:   {
+
+// The crashing thread isn't necessarily the first
+
+// CHECK:          "crashed": true,
+// CHECK-NEXT:     "frames": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "programCounter",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5crashyyF",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 18,
+// CHECK-NEXT:           "column": 15
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "returnAddress",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5levelyySiYaFTY0_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 26,
+// CHECK-NEXT:           "column": 5
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5levelyySiYaFTQ1_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 24,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5levelyySiYaFTQ1_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 24,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5levelyySiYaFTQ1_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 24,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsync5levelyySiYaFTQ1_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 24,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsyncAAV4mainyyYaFZTQ0_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{.*}}/JSONAsync.swift",
+// CHECK-NEXT:           "line": 34,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "system": true,
+// CHECK-NEXT:         "symbol": "{{_?}}$s9JSONAsyncAAV5$mainyyYaFZTQ0_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "line": 0,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "kind": "asyncResumePoint",
+// CHECK-NEXT:         "address": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:         "system": true,
+// CHECK-NEXT:         "symbol": "{{_?}}async_MainTQ0_",
+// CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
+// CHECK-NEXT:         "image": "JSONAsync",
+// CHECK-NEXT:         "sourceLocation": {
+// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "line": 0,
+// CHECK-NEXT:           "column": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+
+// More frames here, but they're system specific
+
+// CHECK:          ]
+// CHECK-NEXT:   }
+
+// Potentially more threads here
+
+// CHECK:      ],
+// CHECK-NEXT: "registers": {
+// CHECK-NEXT:   "{{.*}}": "0x{{[0-9a-f]+}}",
+
+// More registers here, again, system specific
+
+// CHECK:      },
+// CHECK-NEXT: "capturedMemory": {
+// CHECK-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
+
+// More captures here, but system specific
+
+// CHECK:      },
+// CHECK-NEXT: "omittedImages": {{[0-9]+}},
+// CHECK-NEXT: "images": [
+// CHECK-NEXT:   {
+
+// Maybe multiple images before this one
+
+// CHECK:          "name": "JSONAsync",
+// CHECK-NEXT:     "buildId": "{{([0-9a-f][0-9a-f])+}}",
+// CHECK-NEXT:     "path": "{{.*}}/JSONAsync",
+// CHECK-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
+// CHECK-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
+// CHECK-NEXT:   }
+
+// Maybe multiple images after this one
+
+// CHECK:      ],
+// CHECK-NEXT: "backtraceTime": {{[0-9]+(\.[0-9]+)?}}
+
+// CHECK-NEXT: }

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -166,7 +166,7 @@ struct JSONAsync {
 // CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
 // CHECK-NEXT:         "image": "JSONAsync",
 // CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "file": "{{/*}}<compiler-generated>",
 // CHECK-NEXT:           "line": 0,
 // CHECK-NEXT:           "column": 0
 // CHECK-NEXT:         }
@@ -179,7 +179,7 @@ struct JSONAsync {
 // CHECK-NEXT:         "offset": [[OFFSET:[0-9]+]],
 // CHECK-NEXT:         "image": "JSONAsync",
 // CHECK-NEXT:         "sourceLocation": {
-// CHECK-NEXT:           "file": "{{/?}}<compiler-generated>",
+// CHECK-NEXT:           "file": "{{/*}}<compiler-generated>",
 // CHECK-NEXT:           "line": 0,
 // CHECK-NEXT:           "column": 0
 // CHECK-NEXT:         }
@@ -206,8 +206,8 @@ struct JSONAsync {
 // Maybe multiple images before this one
 
 // CHECK:          "name": "JSONAsync",
-// CHECK-NEXT:     "buildId": "{{([0-9a-f][0-9a-f])+}}",
-// CHECK-NEXT:     "path": "{{.*}}/JSONAsync",
+//                 "buildId": ... is optional
+// CHECK:          "path": "{{.*}}/JSONAsync",
 // CHECK-NEXT:     "baseAddress": "0x{{[0-9a-f]+}}",
 // CHECK-NEXT:     "endOfText": "0x{{[0-9a-f]+}}"
 // CHECK-NEXT:   }

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -67,6 +67,12 @@ struct JSONAsync {
 // The crashing thread isn't necessarily the first
 
 // CHECK:          "crashed": true,
+// CHECK-NEXT:     "registers": {
+// CHECK-NEXT:       "{{.*}}": "0x{{[0-9a-f]+}}",
+
+// More registers here, but the number is system specific
+
+// CHECK:          },
 // CHECK-NEXT:     "frames": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "kind": "programCounter",
@@ -187,12 +193,6 @@ struct JSONAsync {
 // Potentially more threads here
 
 // CHECK:      ],
-// CHECK-NEXT: "registers": {
-// CHECK-NEXT:   "{{.*}}": "0x{{[0-9a-f]+}}",
-
-// More registers here, again, system specific
-
-// CHECK:      },
 // CHECK-NEXT: "capturedMemory": {
 // CHECK-NEXT:   "0x{{[[0-9a-f]+}}": "{{([0-9a-f][0-9a-f])+}}",
 


### PR DESCRIPTION
Add an option to use JSON for the crash log output; this makes it easy to ingest crash logs using tools like Splunk or Elastic, which is extremely useful in server environments.

rdar://121430255