### PR TITLE
Fix the JSON AST dump macro test to use its own macro instead of relying on `DebugDescription`.

### DIFF
--- a/test/Frontend/Inputs/json_ast_macro_definitions.swift
+++ b/test/Frontend/Inputs/json_ast_macro_definitions.swift
@@ -1,0 +1,19 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+struct MemberInjectingMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let member: DeclSyntax =
+      """
+      private var _macroInjectedMember: String = ""
+      """
+
+    return [member]
+  }
+}

--- a/test/Frontend/Inputs/json_ast_macro_library.swift
+++ b/test/Frontend/Inputs/json_ast_macro_library.swift
@@ -1,0 +1,2 @@
+@attached(member, names: named(_macroInjectedMember))
+public macro InjectMember() = #externalMacro(module: "MacroDefinition", type: "MemberInjectingMacro")

--- a/test/Frontend/ast-dump-json-macros.swift
+++ b/test/Frontend/ast-dump-json-macros.swift
@@ -3,15 +3,18 @@
 
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend -target %target-swift-5.9-abi-triple -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -dump-ast -dump-ast-format json %s -module-name main -o - | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/json_ast_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/json_ast_macro_library.swiftmodule %S/Inputs/json_ast_macro_library.swift -module-name json_ast_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -target %target-swift-5.9-abi-triple -I %t -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -dump-ast -dump-ast-format json %s -module-name main -o - | %FileCheck %s
 
-@DebugDescription
+import json_ast_macro_library
+
+@InjectMember
 struct X {
     var y: Int
-
-    var debugDescription: String {
-        "y is \(y)"
-    }
 }
 
-// CHECK: "buffer_id":"@__swiftmacro_
+// CHECK:      "_kind":"pattern_binding_decl"
+// CHECK-SAME: "buffer_id":"@__swiftmacro_4main1X12InjectMemberfMm_.swift"
+// CHECK-SAME: "name":"_macroInjectedMember"


### PR DESCRIPTION
The original test that leaned on `DebugDescription` passed on `main` but failed on Windows in the 6.1 branch. I've already merged this into `release/6.1` [here](https://github.com/swiftlang/swift/pull/78955/commits/5b53cd85858e1783bcb65fc5bf4455476331205b), so this PR just brings the fixed test back over to `main` for the future. (It's better to keep it insulated from any changes to `DebugDescription`, anyway.)