### PR TITLE
[windows][toolchain] Build CMake from source (wip)

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -63,7 +63,7 @@
         },
         "cmake": {
             "remote": { "id": "KitWare/CMake" },
-            "platforms": [ "Linux" ]
+            "platforms": [ "Linux", "Windows" ]
         },
         "swift-cmark-gfm": {
              "remote": { "id": "swiftlang/swift-cmark" } },


### PR DESCRIPTION
The CMake that ships with MSVC used to be fine for building the Windows toolchain. This might change in the future. Maybe we need a newer version or we get new requirements. The latter had originally motivated this patch: use a cross-compiled ctest binary as a test driver in on-device tests with the Android emulator. For now, the benefits were not compelling and we decided to use a custom script. However, we may want to use this in the future, so let's keep it around as a draft for a while.