### PR TITLE
[Backtracing] Declare a CMake dependency on CxxStdlib overlay

### DIFF
--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -22,6 +22,11 @@ if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
   set(concurrency _Concurrency)
 endif()
 
+set(cxxstdlib_overlay)
+if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
+  set(cxxstdlib_overlay CxxStdlib)
+endif()
+
 set(RUNTIME_SOURCES
   Address.swift
   Backtrace.swift
@@ -90,7 +95,7 @@ set(LLVM_OPTIONAL_SOURCES
 add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ${RUNTIME_SOURCES}
 
-  SWIFT_MODULE_DEPENDS ${concurrency}
+  SWIFT_MODULE_DEPENDS ${concurrency} ${cxxstdlib_overlay}
 
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc


### PR DESCRIPTION
The Swift code in the Backtracing library enables C++ interop and uses C++ libraries that `#include` C++ stdlib headers. This means that Swift will pull in the C++ stdlib module, along with its overlay. The overlay module needs to be already built at that point.

This should fix an occasional compiler error:
```
error: could not find module 'CxxStdlib' for target
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
