### PR TITLE
Package CMO: downgrade error to warning when checking for deserialization errors.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4735,7 +4735,7 @@ NOTE(ambiguous_because_of_trailing_closure,none,
      (bool, const ValueDecl *))
 
 // In-package resilience bypassing
-ERROR(cannot_bypass_resilience_due_to_missing_member,none,
+WARNING(cannot_bypass_resilience_due_to_missing_member,none,
       "cannot bypass resilience due to member deserialization failure while attempting to access %select{member %0|missing member}1 of %2 in module %3 from module %4",
       (Identifier, bool, Identifier, Identifier, Identifier))
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4752,6 +4752,7 @@ bool ValueDecl::bypassResilienceInPackage(ModuleDecl *accessingModule) const {
         if (auto IDC = dyn_cast<IterableDeclContext>(this)) {
           // Recursively check if members and their members have failing
           // deserialization, and emit a diagnostic.
+          // FIXME: It throws a warning for now; need to upgrade to an error.
           IDC->checkDeserializeMemberErrorInPackage(accessingModule);
         }
       }

--- a/test/SILOptimizer/package-cmo-disallow-bypass-resilience-on-deserialization-fail.swift
+++ b/test/SILOptimizer/package-cmo-disallow-bypass-resilience-on-deserialization-fail.swift
@@ -22,14 +22,14 @@
 
 /// Build a swift module that depends on the above Core swift module without `INCLUDE_FOO`;
 /// it should fail and diagnose that there was a deserialization failure.
-// RUN: not %target-build-swift-dylib(%t/artifacts/SwiftBuilds/%target-library-name(MyUIA)) %t/src/UIA.swift \
+// RUN: %target-build-swift-dylib(%t/artifacts/SwiftBuilds/%target-library-name(MyUIA)) %t/src/UIA.swift \
 // RUN: -module-name MyUIA -emit-module -package-name pkg \
 // RUN: -enable-library-evolution -O -wmo \
 // RUN: -I %t/artifacts/SwiftBuilds -L %t/artifacts/SwiftBuilds \
 // RUN: -I %t/artifacts/ObjcBuilds -L %t/artifacts/ObjcBuilds \
 // RUN: -lMyCore -lObjCAPI -Rmodule-loading \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK
-// CHECK-DAG: error: cannot bypass resilience due to member deserialization failure while attempting to access missing member of 'PkgStructA' in module 'MyCore' from module 'MyCore'
+// CHECK-DAG: warning: cannot bypass resilience due to member deserialization failure while attempting to access missing member of 'PkgStructA' in module 'MyCore' from module 'MyCore'
 
 /// Build a swift module that depends on Core without `INCLUDE_FOO` but
 /// opt out of deserialization checks; it builds even though deserialization failed.


### PR DESCRIPTION
Binary module built with Package CMO can be loaded for package-external client modules which do not have direct access to decls that are serialized_for_package. Downgrade build-time error to warning when a deserialization error is found for a decl that should be allowed to access by package-external clients resiliently.

rdar://143800032