### PR TITLE
[Sema] Rework slab literal handing to a conversion instead

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -295,6 +295,8 @@ enum class ConversionRestrictionKind {
   ///    - Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int>
   ///    - Unsafe[Mutable]Pointer<Int{8, 16, ...}> <-> Unsafe[Mutable]Pointer<UInt{8, 16, ...}>
   PointerToCPointer,
+  /// Conversion from an array literal to an InlineArray
+  ArrayLiteralToInlineArray,
 };
 
 /// Specifies whether a given conversion requires the creation of a temporary

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7334,6 +7334,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       finishApply(implicitInit, toType, callLocator, callLocator);
       return implicitInit;
     }
+
+    case ConversionRestrictionKind::ArrayLiteralToInlineArray: {
+      cs.setType(expr, toType);
+      if (!finishArrayExpr(cast<ArrayExpr>(expr))) return nullptr;
+
+      return expr;
+    }
     }
   }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7337,7 +7337,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     case ConversionRestrictionKind::ArrayLiteralToInlineArray: {
       cs.setType(expr, toType);
-      if (!finishArrayExpr(cast<ArrayExpr>(expr))) return nullptr;
+
+      if (!finishArrayExpr(cast<ArrayExpr>(expr))) {
+        return nullptr;
+      }
 
       return expr;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7986,6 +7986,7 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::ArrayLiteralToInlineArray:
     llvm_unreachable("Expected an ephemeral conversion!");
   }
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1349,7 +1349,7 @@ namespace {
       };
 
       // If a contextual type exists for this expression, apply it directly.
-      if (contextualType && contextualType->isArrayType()) {
+      if (contextualType && contextualType->isArray()) {
         // Now that we know we're actually going to use the type, get the
         // version for use in a constraint.
         contextualType = CS.getContextualType(expr, /*forConstraint=*/true);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1349,7 +1349,9 @@ namespace {
       };
 
       // If a contextual type exists for this expression, apply it directly.
-      if (contextualType && contextualType->isArray()) {
+      if (contextualType &&
+          contextualType->isArray() &&
+          contextualType->isArrayType()) {
         // Now that we know we're actually going to use the type, get the
         // version for use in a constraint.
         contextualType = CS.getContextualType(expr, /*forConstraint=*/true);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8103,7 +8103,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   if (type1->isArray() && type2->isSlab()) {
     // If the locator is pointing directly at an array literal, allow the
     // conversion.
-    if (isExpr<ArrayExpr>(locator.getAnchor())) {
+    if (locator.directlyAt<ArrayExpr>() ||
+        isExpr<ArrayExpr>(locator.getAnchor())) {
       conversionsOrFixes.push_back(
         ConversionRestrictionKind::ArrayLiteralToInlineArray);
     }
@@ -14877,6 +14878,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     auto slabEltTy = slabTy->getGenericArgs()[1];
 
     addConstraint(ConstraintKind::Bind, arrayEltTy, slabEltTy, locator);
+    increaseScore(SK_ImplicitValueConversion, locator);
 
     // <let count: Int, Element>
     // Attempt to bind the number of elements in the literal with the

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -620,6 +620,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[CGFloat-to-Double]";
   case ConversionRestrictionKind::DoubleToCGFloat:
     return "[Double-to-CGFloat]";
+  case ConversionRestrictionKind::ArrayLiteralToInlineArray:
+    return "[Array-Literal-to-Inline-Array]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1666,20 +1666,6 @@ struct TypeSimplifier {
         auto *proto = assocType->getProtocol();
         auto conformance = CS.lookupConformance(lookupBaseType, proto);
         if (!conformance) {
-          // Special case: When building slab literals, we go through the same
-          // array literal machinery, so there will be a conversion constraint
-          // for the element to ExpressibleByArrayLiteral.ArrayLiteralType.
-          if (lookupBaseType->isSlab()) {
-            auto &ctx = CS.getASTContext();
-            auto arrayProto =
-                ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-            auto elementAssocTy = arrayProto->getAssociatedTypeMembers()[0];
-
-            if (proto == arrayProto && assocType == elementAssocTy) {
-              return lookupBaseType->isArrayType();
-            }
-          }
-
           // If the base type doesn't conform to the associatedtype's protocol,
           // there will be a missing conformance fix applied in diagnostic mode,
           // so the concrete dependent member type is considered a "hole" in
@@ -4466,6 +4452,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::ArrayLiteralToInlineArray:
     // @_nonEphemeral has no effect on these conversions, so treat them as all
     // being non-ephemeral in order to allow their passing to an @_nonEphemeral
     // parameter.

--- a/test/Sema/slab.swift
+++ b/test/Sema/slab.swift
@@ -32,12 +32,15 @@ takeVectorOf2Int([1]) // expected-error {{expected '2' elements in slab literal,
 
 takeVectorOf2Int([1, 2, 3]) // expected-error {{expected '2' elements in slab literal, but got '3'}}
 
-takeVectorOf2Int(["hello"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'Slab<2, Int>'}}
+takeVectorOf2Int(["hello"]) // expected-error {{expected '2' elements in slab literal, but got '1'}}
+                            // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
 
 takeVectorOf2Int(["hello", "world"]) // expected-error {{cannot convert value of type 'String' to expected element type 'Int'}}
                                      // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
 
-takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'Slab<2, Int>'}}
+takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type 'String' to expected element type 'Int'}}
+                                          // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
+                                          // expected-error@-2 {{cannot convert value of type 'String' to expected element type 'Int'}}
 
 struct X {
   var sprites: Slab<2, Int>

--- a/test/Sema/slab.swift
+++ b/test/Sema/slab.swift
@@ -83,3 +83,23 @@ extension Slab where Element: ~Copyable {
     }
   }
 }
+
+func test(_: [Int]) -> Int {
+  123
+}
+
+func test(_: Slab<2, Int>) -> String {
+  "123"
+}
+
+func takeInt(_: Int) {}
+func takeString(_: String) {}
+
+let g = test([1, 2])
+takeInt(g) // OK
+takeString(g) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+
+let h: String = test([1, 2])
+takeInt(h) // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+takeString(h) // OK
+


### PR DESCRIPTION
Instead of trying to special case this in the literal simplification, allow a conversion to occur in matchTypes if the locator is at an array expression and we want to go from Array -> Slab.