### PR TITLE
[ScanDependency] Fix a corner case for swift overlay module discovery

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -962,7 +962,7 @@ ModuleDependenciesCache::getClangDependencies(const ModuleDependencyID &moduleID
   auto clangImportedDepsRef = moduleInfo.getImportedClangDependencies();
   result.insert(clangImportedDepsRef.begin(),
                 clangImportedDepsRef.end());
-  if (moduleInfo.isSwiftSourceModule()) {
+  if (moduleInfo.isSwiftSourceModule() || moduleInfo.isSwiftBinaryModule()) {
     auto headerClangDepsRef = moduleInfo.getHeaderClangDependencies();
     result.insert(headerClangDepsRef.begin(),
                   headerClangDepsRef.end());

--- a/test/ScanDependencies/recursive-resolve.swift
+++ b/test/ScanDependencies/recursive-resolve.swift
@@ -1,0 +1,74 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/B.framework/Modules/B.swiftmodule/%target-swiftmodule-name -module-name B \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -I %t -F %t -import-objc-header %t/Bridging.h \
+// RUN:   %t/B.swift
+
+// RUN: %target-swift-frontend -emit-module -o %t/A.framework/Modules/A.swiftmodule/%target-swiftmodule-name -module-name A \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -I %t -F %t -import-objc-header %t/Bridging2.h \
+// RUN:   %t/A.swift
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps.json -import-objc-header %t/Bridging3.h \
+// RUN:   -I %t -F %t
+
+// RUN: %FileCheck %s --input-file=%t/deps.json
+// CHECK-DAG: "swiftPrebuiltExternal": "A"
+// CHECK-DAG: "swiftPrebuiltExternal": "B"
+
+//--- A.swift
+@_exported import A
+public func testA() {}
+
+//--- B.swift
+@_exported import B
+import C
+public func testB() {}
+
+//--- user.swift
+public func skip() {}
+
+//--- Bridging.h
+void nothing(void);
+
+//--- Bridging2.h
+#include "B/B.h"
+
+//--- Bridging3.h
+#include "A/A.h"
+
+//--- A.framework/Headers/A.h
+struct A {
+  int a;
+};
+
+//--- B.framework/Headers/B.h
+void b(void);
+@interface B
+@end
+
+//--- C.h
+void c(void);
+
+//--- A.framework/Modules/module.modulemap
+framework module A {
+  umbrella header "A.h"
+  export *
+}
+
+//--- B.framework/Modules/module.modulemap
+framework module B {
+  umbrella header "B.h"
+  export *
+}
+
+//--- module.modulemap
+module C {
+  header "C.h"
+  export *
+}


### PR DESCRIPTION
Make sure the clang headers imported from bridging headers can bring in the swift overlay as well.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
