### PR TITLE
[CSOptimizer] Disjunctions with IUO overload choices are unsupported

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -128,8 +128,14 @@ static bool isSupportedDisjunction(Constraint *disjunction) {
     if (choice->getKind() != ConstraintKind::BindOverload)
       return false;
 
-    if (auto *decl = getOverloadChoiceDecl(choice))
+    if (auto *decl = getOverloadChoiceDecl(choice)) {
+      // Cannot optimize declarations that return IUO because
+      // they form a disjunction over a result type once attempted.
+      if (decl->isImplicitlyUnwrappedOptional())
+        return false;
+
       return decl->getInterfaceType()->is<FunctionType>();
+    }
 
     return false;
   });

--- a/validation-test/Sema/rdar143799118.swift
+++ b/validation-test/Sema/rdar143799118.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
+
+func test1(v: Int!) -> [Any]! { nil }
+// This is important because it defeats old solver hack that
+// checked the number of matching overloads purely based on
+// how many parameters there are.
+func test1(v: Int!) async throws -> [Int]! { nil }
+func test1(v: Int!, other: String = "") throws -> [Int] { [] }
+
+func test2(v: Int!) -> [Any]! { nil }
+func test2(v: Int!, other: String = "") throws -> [Int] { [] }
+
+func performTest(v: Int!) {
+  guard let _ = test1(v: v) as? [Int] else { // Ok
+    return
+  }
+
+  guard let _ = test2(v: v) as? [Int] else {
+    // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+    // expected-warning@-2 {{conditional cast from '[Int]' to '[Int]' always succeeds}}
+    return
+  }
+}


### PR DESCRIPTION
They form a follow-up disjunction to determine whether force unwrap is necessary and `getEffectiveType` cannot handle that.

Resolves: rdar://143799118

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
