### PR TITLE
Fix LICM for begin_access/end_access in OSSA

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -890,6 +890,10 @@ void LoopTreeOptimization::analyzeCurrentLoop(
     for (auto &Inst : *BB) {
       if (hasOwnershipOperandsOrResults(&Inst)) {
         checkSideEffects(Inst, sideEffects, sideEffectsInBlock);
+        // Collect fullApplies to be checked in analyzeBeginAccess
+        if (auto fullApply = FullApplySite::isa(&Inst)) {
+          fullApplies.push_back(fullApply);
+        }
         continue;
       }
       switch (Inst.getKind()) {

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1606,3 +1606,36 @@ bb3:
   return %r : $()
 }
 
+sil @foo : $@convention(thin) (@guaranteed { var Int }) -> ()
+
+// CHECK-LABEL: sil [ossa] @test_begin_access : $@convention(thin) (Int) -> () {
+// CHECK: bb2:
+// CHECK: begin_access
+// CHECK: end_access
+// CHECK: bb3
+// CHECK-LABEL: } // end sil function 'test_begin_access'
+sil [ossa] @test_begin_access : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }, var, name "now"
+  %2 = begin_borrow [lexical] [var_decl] %1
+  %3 = project_box %2, 0
+  store %0 to [trivial] %3
+  br bb2
+
+bb1:
+  br bb2
+
+bb2:
+  %7 = function_ref @foo : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %8 = apply %7(%2) : $@convention(thin) (@guaranteed { var Int }) -> ()
+  %9 = begin_access [modify] [dynamic] %3
+  store %0 to [trivial] %9
+  end_access %9
+  cond_br undef, bb3, bb1
+
+bb3:
+  end_borrow %2
+  destroy_value %1
+  %15 = tuple ()
+  return %15
+}


### PR DESCRIPTION
LICM in OSSA is enabled only for instructions involving trvial values.

begin_access/end_access is eligible for LICM in OSSA. However we need to collect applies to check for conflicts.

rdar://143835241

