### PR TITLE
Fix miscompilations for debugger because of resilience

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -6009,6 +6009,14 @@ bool IRGenModule::hasResilientMetadata(ClassDecl *D,
     return false;
   }
 
+  // Because the debugger can extend non public types outside of their module, 
+  // also check that "D" is *not* resilient  from the module that contains 
+  // "asViewedFromRootClass".
+  if (Context.LangOpts.DebuggerSupport && asViewedFromRootClass &&
+      !D->hasResilientMetadata(asViewedFromRootClass->getModuleContext(),
+                               expansion))
+    return false;
+
   return D->hasResilientMetadata(getSwiftModule(), expansion);
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -8390,9 +8390,17 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
 
   auto methodType = i->getType().castTo<SILFunctionType>();
 
+  AccessLevel methodAccess = method.getDecl()->getEffectiveAccess();
   auto *classDecl = cast<ClassDecl>(method.getDecl()->getDeclContext());
   bool shouldUseDispatchThunk = false;
-  if (IGM.hasResilientMetadata(classDecl, ResilienceExpansion::Maximal)) {
+  // Because typechecking for the debugger has more lax rules, check the access
+  // level of the getter to decide whether to use a dispatch thunk for the
+  // debugger.
+  bool shouldUseDispatchThunkIfInDebugger =
+      !classDecl->getASTContext().LangOpts.DebuggerSupport ||
+      methodAccess == AccessLevel::Public;
+  if (IGM.hasResilientMetadata(classDecl, ResilienceExpansion::Maximal) &&
+      shouldUseDispatchThunkIfInDebugger) {
     shouldUseDispatchThunk = true;
   } else if (IGM.getOptions().VirtualFunctionElimination) {
     // For VFE, use a thunk if the target class is in another module. This


### PR DESCRIPTION
Explanation: This patch fixes two instances of the compiler embedded in LLDB miscompiling code for expression evaluation, because of a combination of the debugger's access to private types and resilience, which would cause the generated code to access fields indirectly through resilience functions that were never emitted.
Scope: IRGen of code for LLDB
Issues:  rdar://137876089
Original PRs: https://github.com/swiftlang/swift/pull/78728
Risk: Low (only affects IRGen when compiling for LLDB).
Testing: swift ci testing
Reviewers: @adrian-prantl  

