### PR TITLE
Concurrency: Use `std::bit_cast` over ignoring `-Wcast-function-type-mismatch`

### DIFF
--- a/include/swift/Runtime/STLCompatibility.h
+++ b/include/swift/Runtime/STLCompatibility.h
@@ -1,4 +1,4 @@
-//===---- STLCompatibility.h - Runtime C++ Compatibiltiy Stubs --*- C++ -*-===//
+//===---- STLCompatibility.h - Runtime C++ Compatibility Stubs --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1973,7 +1973,6 @@ private:
       auto *ClassTy = BaseTy->castTo<BoundGenericClassType>();
       auto *Decl = ClassTy->getDecl();
       auto L = getFileAndLocation(Decl);
-      unsigned FwdDeclLine = 0;
 
       return createSpecializedStructOrClassType(ClassTy, Decl, Scope, L.File,
                                                 L.Line, SizeInBits, AlignInBits,


### PR DESCRIPTION
Building on https://github.com/swiftlang/swift/pull/78985, use `std::bit_cast` consistently wherever Clang had been emitting `-Wcast-function-type-mismatch` warnings, instead of ignoring the diagnostic.