### PR TITLE
[build-script] Disable building and installing the Foundation macros for standalone SDKs (#78782)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2414,6 +2414,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
 
+                if [[ "${BUILD_SWIFT_TOOLS}" == "0" ]]; then
+                    echo "Skipping building Foundation Macros for ${host}, because the host tools are not being built"
+                    continue
+                fi
+
                 if [[ "${SKIP_CLEAN_FOUNDATION}" == "0" ]]
                 then
                   # The Swift project might have been changed, but CMake might
@@ -2561,11 +2566,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     # https://cmake.org/cmake/help/latest/command/find_package.html
                     cmake_options+=(
                         -DCMAKE_FIND_ROOT_PATH:PATH="${CROSS_COMPILE_DEPS_PATH}"
-                    )
-                fi
-                if [[ "${host}" == "android-"* ]]; then
-                    cmake_options+=(
-                        -DCMAKE_HAVE_LIBC_PTHREAD=True
                     )
                 fi
                 ;;
@@ -3011,6 +3011,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 # FIXME: Foundation doesn't build from the script on OS X
                 if [[ ${host} == "macosx"* ]]; then
                     echo "Skipping Foundation on OS X -- Foundation does not build for this platform"
+                    continue
+                fi
+
+                if [[ "${BUILD_SWIFT_TOOLS}" == "0" && "${product}" == "foundation_macros" ]]; then
+                    echo "Skipping installing Foundation Macros for ${host}, because the host tools are not being built"
                     continue
                 fi
 


### PR DESCRIPTION
__Explanation:__ The `--build-swift-tools=0` flag is currently used by a few build presets to disable building and installing the compiler and other host tools, like the Observation macros in this repo. Extend it to also disable building and installing the new Foundation macros, plus remove a CMake flag for Android [that is now directly set in that repo](https://github.com/swiftlang/swift-corelibs-foundation/pull/5151/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR157).

__Scope:__ Only used to build standalone SDKs

__Issue:__ None

__Original PR:__ #78782

__Risk:__ None

__Testing:__ Passed all CI on trunk, plus [on my Android CI for several months now](https://github.com/finagolfin/swift-android-sdk/blob/c3914d8b728e5c473397423ae664e7dd7103a0ac/swift-android.patch#L9)

__Reviewer:__ @jmschonfeld