### PR TITLE
[Sema]Set IsSending flag to subscript.getter if needed

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10607,6 +10607,9 @@ AccessorDecl *AccessorDecl::createParsed(
       // The cloned parameter is implicit.
       param->setImplicit();
 
+      if (subscriptParam->isSending())
+        param->setSending();
+
       newParams.push_back(param);
     }
   }

--- a/test/Concurrency/sending_witness_subscript.swift
+++ b/test/Concurrency/sending_witness_subscript.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 %s -o /dev/null -verify
+
+class NonSendableKlass {}
+
+protocol P {
+  subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { get }
+}
+
+struct S: P {
+  subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { NonSendableKlass() }
+}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Resolves https://github.com/swiftlang/swift/issues/79041

When using the sending keyword in a subscript parameter through protocol conformance, an assertion failure occurs when emitting SIL.

For example, run the following code with `swift -frontend -emit-sil -swift-version 6`:

```swift
class NonSendable {}
protocol P {
    subscript(_: sending NonSendable) -> Bool { get }
}

struct S: P {
    subscript(_: sending NonSendable) -> Bool { true }
}
```

It triggers the following assertion failure:

```
sil_witness_table hidden S: P module main {
  method #P.subscript!getter: <Self where Self : P> (Self) -> (Assertion failed: (flags.isSending() && "Only valid when sending is enabled"), function printParameterFlags, file ASTPrinter.cpp, line 3759.
```

It appears we need to add a flag when the subscript parameter includes the sending keyword.