### PR TITLE
[Distributed] ban typed throws in distributed funcs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5629,6 +5629,9 @@ ERROR(distributed_actor_func_unsupported_specifier, none,
 ERROR(distributed_actor_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))
+ERROR(distributed_actor_func_typed_throws, none,
+      "cannot declare distributed function with typed throws",
+      ())
 NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",
      (DescriptiveDeclKind))

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -618,6 +618,19 @@ bool CheckDistributedFunctionRequest::evaluate(
     return true;
   }
 
+  // TODO: rdar://136467591 Currently typed throws were not implemented for distributed methods
+  if (func->hasThrows()) {
+    if (auto thrownError = func->getEffectiveThrownErrorType()) {
+      // Basically we only support throwing `any Error` out of a distributed
+      // function because then the effective error thrown by thunk calls naturally
+      // is correct and the same `any Error`
+      if (thrownError.has_value() &&
+          !(*thrownError)->isEqual(C.getErrorExistentialType())) {
+        func->diagnose(diag::distributed_actor_func_typed_throws);
+      }
+    }
+  }
+
   return false;
 }
 

--- a/test/Distributed/distributed_actor_unsupported_typed_throws.swift
+++ b/test/Distributed/distributed_actor_unsupported_typed_throws.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+distributed actor Foo {
+  distributed func alwaysThrows() throws(FooError) { // expected-error{{cannot declare distributed function with typed throws}}
+    throw FooError()
+  }
+}
+
+struct FooError: Codable, Error { }
+struct RemoteInvocationError: Codable, Error { }
+
+func test(foo: Foo) async throws {
+  do {
+    try await foo.alwaysThrows() // actually, this is throws(Error) because network errors etc
+    fatalError("Should not reach here")
+    // FIXME: the following warning is showing why we had to ban typed throws;
+    //        the error type must instead be (FooError | Error (from the distributed thunk))
+    //        rdar://136467591
+  } catch let error as RemoteInvocationError { // expected-warning{{cast from 'FooError' to unrelated type 'RemoteInvocationError' always fails}}
+    print("error = \(error)")
+  }
+}


### PR DESCRIPTION
**Description**: typed throws were never correctly implemented for distributed functions and can lead to incorrect code which claims to throw E, but CAN throw `any Error`. We should ban typed throws on distributed funcs until we properly solve this integration between those two.
**Scope/Impact**: Low, only distributed funcs which declare typed throws -- which always was incorrect.
**Risk:** Low, no known to me code does this.
**Testing**: CI testing
**Reviewed by**: @hborla

**Original PR:** https://github.com/swiftlang/swift/pull/78978/
**Radar:** rdar://136467528