### PR TITLE
[Concurrency] Two isolation inference changes for default isolation mode.

### DIFF
--- a/test/Concurrency/Runtime/unspecified_is_main_actor.swift
+++ b/test/Concurrency/Runtime/unspecified_is_main_actor.swift
@@ -76,7 +76,9 @@ tests.test("checkIfOnMainQueue crashes off the main queue 2") { @CustomActor () 
 class Klass {}
 
 struct MainActorIsolated {
-  init() {}
+  init() {
+    checkIfOnMainQueue()
+  }
 
   func test() async {
     checkIfOnMainQueue()
@@ -84,7 +86,7 @@ struct MainActorIsolated {
 };
 
 tests.test("callNominalType") { @CustomActor () -> () in
-  let x = MainActorIsolated()
+  let x = await MainActorIsolated()
   // We would crash without hopping here.
   await x.test()
 }

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -10,7 +10,7 @@
 class Klass {
   // Implicit deinit
   // CHECK: // Klass.deinit
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject {
 
   // Implicit deallocating deinit
@@ -163,7 +163,7 @@ nonisolated func nonisolatedFunctionTest() async {
 
 actor MyActor {
   // CHECK: // variable initialization expression of MyActor.k
-  // CHECK-NEXT: // Isolation: actor_instance
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor7MyActorC1kAA5KlassCvpfi : $@convention(thin) () -> @owned Klass {
 
   // CHECK: // MyActor.k.getter
@@ -175,9 +175,21 @@ actor MyActor {
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor7MyActorC1kAA5KlassCvs : $@convention(method) (@owned Klass, @sil_isolated @guaranteed MyActor) -> () {
   var k = Klass()
 
+  // CHECK: // static MyActor.f()
+  // CHECK-NEXT: // Isolation: unspecified
+  // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorC1fyyFZ : $@convention(method) (@thick MyActor.Type) -> ()
+  static func f() {}
+
+  struct Nested {
+    // CHECK: // MyActor.Nested.f()
+    // CHECK-NEXT: // Isolation: unspecified
+    // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorC6NestedV1fyyF : $@convention(method) (MyActor.Nested) -> ()
+    func f() {}
+  }
+
   // Implicit deinit
   // CHECK: // MyActor.deinit
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorCfd : $@convention(method) (@guaranteed MyActor) -> @owned Builtin.NativeObject {
 
   // Non-async init should be nonisolated

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -51,7 +51,7 @@ func unspecifiedFunctionTest2() async {
 }
 
 nonisolated func nonisolatedFunctionTest() async {
-  let k = StructContainingKlass()
+  let k = await StructContainingKlass()
   await unspecifiedAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
   await nonisolatedAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
   await mainActorAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
@@ -66,7 +66,7 @@ func testTask() async {
 
 func testTaskDetached() async {
   Task.detached {
-    let k = Klass(getDataFromSocket())
+    let k = await Klass(getDataFromSocket())
     // Have to pop back onto the main thread to do something.
     await k.doSomething()
   }


### PR DESCRIPTION
1. Non-actor initializers should participate in custom default isolation inference. Otherwise, they will not be able to touch the type's stored properties to initialize them if those properties have the default isolation inferred.
2. All declarations inside actors and distributed actors do not participate in default isolation inference; they remain unspecified, so the existing isolation inference rules apply.