### PR TITLE
[Backtracing] Support redirection to a named file.

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import Darwin.C
+import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -143,6 +143,34 @@ internal func spawn(_ path: String, args: [String]) throws {
 
 #endif // os(macOS)
 
+internal func isDir(_ path: String) -> Bool {
+  var st = stat()
+  guard stat(path, &st) == 0 else {
+    return false
+  }
+  return (st.st_mode & S_IFMT) == S_IFDIR
+}
+
+internal func exists(_ path: String) -> Bool {
+  var st = stat()
+  guard stat(path, &st) == 0 else {
+    return false
+  }
+  return true
+}
+
+extension Sequence {
+  /// Return the first element in a Sequence.
+  ///
+  /// This is not, in general, a safe thing to do, because the sequence might
+  /// not be restartable.  For the cases where we're using it here, it's OK
+  /// though.
+  public var unsafeFirst: Element? {
+    var iterator = makeIterator()
+    return iterator.next()
+  }
+}
+
 struct CFileStream: TextOutputStream {
   var fp: UnsafeMutablePointer<FILE>
 
@@ -152,6 +180,10 @@ struct CFileStream: TextOutputStream {
 
   public func flush() {
     fflush(fp)
+  }
+
+  public func close() {
+    fclose(fp)
   }
 }
 

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -159,18 +159,6 @@ internal func exists(_ path: String) -> Bool {
   return true
 }
 
-extension Sequence {
-  /// Return the first element in a Sequence.
-  ///
-  /// This is not, in general, a safe thing to do, because the sequence might
-  /// not be restartable.  For the cases where we're using it here, it's OK
-  /// though.
-  public var unsafeFirst: Element? {
-    var iterator = makeIterator()
-    return iterator.next()
-  }
-}
-
 struct CFileStream: TextOutputStream {
   var fp: UnsafeMutablePointer<FILE>
 

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -56,6 +56,7 @@ internal struct SwiftBacktrace {
   enum OutputTo {
     case stdout
     case stderr
+    case file
   }
 
   enum Symbolication {
@@ -81,6 +82,7 @@ internal struct SwiftBacktrace {
     var cache = true
     var outputTo: OutputTo = .stdout
     var symbolicate: Symbolication = .full
+    var outputPath: String = "/tmp"
   }
 
   static var args = Arguments()
@@ -97,15 +99,10 @@ internal struct SwiftBacktrace {
     }
   }
 
-  static var outputStream: CFileStream {
-    switch args.outputTo {
-      case .stdout: return standardOutput
-      case .stderr: return standardError
-    }
-  }
+  static var outputStream: CFileStream? = nil
 
   static func write(_ string: String, flush: Bool = false) {
-    var stream = outputStream
+    var stream = outputStream!
 
     print(string, terminator: "", to: &stream)
     if flush {
@@ -114,7 +111,7 @@ internal struct SwiftBacktrace {
   }
 
   static func writeln(_ string: String, flush: Bool = false) {
-    var stream = outputStream
+    var stream = outputStream!
 
     print(string, to: &stream)
     if flush {
@@ -207,6 +204,10 @@ Generate a backtrace for the parent process.
 
 --output-to <stream>    Set which output stream to use.  Options are "stdout"
 -o <stream>             and "stderr".  The default is "stdout".
+
+                        Alternatively, you may specify a file path here.  If
+                        the path points to a directory, a unique filename will
+                        be generated automatically.
 
 --crashinfo <addr>
 -a <addr>               Provide a pointer to a platform specific CrashInfo
@@ -405,10 +406,8 @@ Generate a backtrace for the parent process.
             case "stderr":
               args.outputTo = .stderr
             default:
-              print("swift-backtrace: unknown output-to setting '\(v)'",
-                    to: &standardError)
-              usage()
-              exit(1)
+              args.outputTo = .file
+              args.outputPath = v
           }
         } else {
           print("swift-backtrace: missing output-to value",
@@ -538,6 +537,69 @@ Generate a backtrace for the parent process.
                       symbolicate: args.symbolicate)
 
       currentThread = target!.crashingThreadNdx
+    }
+
+    // Set up the output stream
+    var didOpenOutput = false
+    switch args.outputTo {
+      case .stdout:
+        outputStream = standardOutput
+      case .stderr:
+        outputStream = standardError
+      case .file:
+        if isDir(args.outputPath) {
+          // If the output path is a directory, generate a filename
+          let name = target!.name
+          let pid = target!.pid
+          var now = timespec()
+
+          if clock_gettime(CLOCK_REALTIME, &now) != 0 {
+            now.tv_sec = time(nil)
+            now.tv_nsec = 0
+          }
+
+          var filename =
+            "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec).log"
+
+          var fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
+          var ndx = 1
+          while fd < 0 && errno == EEXIST {
+            ndx += 1
+            filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).log"
+            fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
+          }
+
+          if fd < 0 {
+            print("swift-backtrace: unable to create \(filename) for writing",
+                  to: &standardError)
+            outputStream = standardError
+          }
+
+          if let cFile = fdopen(fd, "wt") {
+            didOpenOutput = true
+            outputStream = CFileStream(fp: cFile)
+          } else {
+            close(fd)
+            unlink(filename)
+
+            print("swift-backtrace: unable to fdopen \(filename) for writing",
+                  to: &standardError)
+            outputStream = standardError
+          }
+        } else if let cFile = fopen(args.outputPath, "wt") {
+          didOpenOutput = true
+          outputStream = CFileStream(fp: cFile)
+        } else {
+          print("swift-backtrace: unable to open \(args.outputPath) for writing",
+                to: &standardError)
+
+          outputStream = standardError
+        }
+    }
+    defer {
+      if didOpenOutput {
+        outputStream!.close()
+      }
     }
 
     printCrashLog()
@@ -707,11 +769,18 @@ Generate a backtrace for the parent process.
       description = "Program crashed: \(target.signalDescription) at \(hex(target.faultAddress))"
     }
 
-    // Clear (or complete) the message written by the crash handler
-    if args.color {
-      write("\r\u{1b}[0K")
+    // Clear (or complete) the message written by the crash handler; this
+    // is always on stdout or stderr, even if you specify a file for output.
+    var handlerOut: CFileStream
+    if args.outputTo == .stdout {
+      handlerOut = standardOutput
     } else {
-      write(" done ***\n\n")
+      handlerOut = standardError
+    }
+    if args.color {
+      print("\r\u{1b}[0K", terminator: "", to: &handlerOut)
+    } else {
+      print(" done ***\n\n", terminator: "", to: &handlerOut)
     }
 
     writeln(theme.crashReason(description))
@@ -837,7 +906,7 @@ Generate a backtrace for the parent process.
     }
 
     while true {
-      outputStream.flush()
+      outputStream!.flush()
       write(theme.prompt(">>> "), flush: true)
       guard let input = readLine() else {
         print("")

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -563,8 +563,10 @@ Generate a backtrace for the parent process.
 
           var fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
           var ndx = 1
-          while fd < 0 && errno == EEXIST {
-            ndx += 1
+          while fd < 0 && (errno == EEXIST || errno == EINTR) {
+            if errno != EINTR {
+              ndx += 1
+            }
             filename = "\(args.outputPath)/\(name)-\(pid)-\(now.tv_sec).\(now.tv_nsec)-\(ndx).log"
             fd = open(filename, O_RDWR|O_CREAT|O_EXCL, 0o644)
           }

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -137,6 +137,9 @@ SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
 
   // swiftBacktracePath
   NULL,
+
+  // outputPath
+  NULL,
 };
 
 }
@@ -175,6 +178,14 @@ static_assert((SWIFT_BACKTRACE_ENVIRONMENT_SIZE % SWIFT_PAGE_SIZE) == 0,
               "page size.  If it isn't, you'll get weird crashes in other "
               "code because we'll protect more than just the buffer.");
 
+// And the output path
+#define SWIFT_BACKTRACE_OUTPUT_PATH_SIZE 16384
+
+static_assert((SWIFT_BACKTRACE_OUTPUT_PATH_SIZE % SWIFT_PAGE_SIZE) == 0,
+              "The output path buffer must be a multiple of the system "
+              "page size.  If it isn't, you'll get weird crashes in other "
+              "code because we'll protect more than just the buffer.");
+
 #if _WIN32
 #pragma section(SWIFT_BACKTRACE_SECTION, read, write)
 
@@ -186,6 +197,8 @@ __declspec(allocate(SWIFT_BACKTRACE_SECTION)) WCHAR swiftBacktracePath[SWIFT_BAC
 
 __declspec(allocate(SWIFT_BACKTRACE_SECTION)) CHAR swiftBacktraceEnv[SWIFT_BACKTRACE_ENVIRONMENT_SIZE];
 
+__declspec(allocate(SWIFT_BACKTRACE_SECTION)) CHAR swiftBacktraceOutputPath[SWIFT_BACKTRACE_OUTPUT_PATH_SIZE];
+
 #elif defined(__linux__) || TARGET_OS_OSX
 
 #if defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
@@ -195,6 +208,9 @@ char swiftBacktracePath[SWIFT_BACKTRACE_BUFFER_SIZE] __attribute__((section(SWIF
 #endif // !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH
 
 char swiftBacktraceEnv[SWIFT_BACKTRACE_ENVIRONMENT_SIZE] __attribute__((section(SWIFT_BACKTRACE_SECTION), aligned(SWIFT_PAGE_SIZE)));
+
+char swiftBacktraceOutputPath[SWIFT_BACKTRACE_OUTPUT_PATH_SIZE] __attribute__((section(SWIFT_BACKTRACE_SECTION), aligned(SWIFT_PAGE_SIZE)));
+
 #endif // defined(__linux__) || TARGET_OS_OSX
 
 void _swift_backtraceSetupEnvironment();
@@ -284,6 +300,16 @@ bool isPrivileged() {
 #elif _WIN32
 bool isPrivileged() {
   return false;
+}
+#endif
+
+#if _WIN32
+bool writeProtectMemory(void *ptr, size_t size) {
+  return !!VirtualProtect(ptr, size, PAGE_READONLY, NULL);
+}
+#else
+bool writeProtectMemory(void *ptr, size_t size) {
+  return mprotect(ptr, size, PROT_READ) == 0;
 }
 #endif
 
@@ -383,6 +409,30 @@ BacktraceInitializer::BacktraceInitializer() {
       _swift_backtraceSettings.preset = Preset::Full;
   }
 
+  if (_swift_backtraceSettings.outputTo == OutputTo::File) {
+    size_t len = strlen(_swift_backtraceSettings.outputPath);
+    if (len > SWIFT_BACKTRACE_OUTPUT_PATH_SIZE - 1) {
+      swift::warning(0,
+                     "swift runtime: backtracer output path too long; output "
+                     "path setting will be ignored.\n");
+      _swift_backtraceSettings.outputTo = OutputTo::Auto;
+    } else {
+      memcpy(swiftBacktraceOutputPath,
+             _swift_backtraceSettings.outputPath,
+             len + 1);
+
+#if PROTECT_BACKTRACE_SETTINGS
+      if (!writeProtectMemory(swiftBacktraceOutputPath,
+                              sizeof(swiftBacktraceOutputPath))) {
+        swift::warning(0,
+                       "swift runtime: unable to protect backtracer output "
+                       "path; path setting will be ignored.\n");
+        _swift_backtraceSettings.outputTo = OutputTo::Auto;
+      }
+#endif
+    }
+  }
+
   if (_swift_backtraceSettings.outputTo == OutputTo::Auto) {
     if (_swift_backtraceSettings.interactive == OnOffTty::On)
       _swift_backtraceSettings.outputTo = OutputTo::Stdout;
@@ -397,10 +447,10 @@ BacktraceInitializer::BacktraceInitializer() {
     // attacker to overwrite the path and then cause a crash to get us to
     // execute an arbitrary file.
 
-#if _WIN32
     if (_swift_backtraceSettings.algorithm == UnwindAlgorithm::Auto)
       _swift_backtraceSettings.algorithm = UnwindAlgorithm::Precise;
 
+#if _WIN32
 #if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
     int len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                                     _swift_backtraceSettings.swiftBacktracePath, -1,
@@ -412,33 +462,10 @@ BacktraceInitializer::BacktraceInitializer() {
                      "swift-backtrace: %08lx; disabling backtracing.\n",
                      ::GetLastError());
       _swift_backtraceSettings.enabled = OnOffTty::Off;
-    } else if (!VirtualProtect(swiftBacktracePath,
-                               sizeof(swiftBacktracePath),
-                               PAGE_READONLY,
-                               NULL)) {
-      swift::warning(0,
-                     "swift runtime: unable to protect path to "
-                     "swift-backtrace: %08lx; disabling backtracing.\n",
-                     ::GetLastError());
-      _swift_backtraceSettings.enabled = OnOffTty::Off;
     }
 #endif // !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
 
-    _swift_backtraceSetupEnvironment();
-
-    if (!VirtualProtect(swiftBacktraceEnv,
-                        sizeof(swiftBacktraceEnv),
-                        PAGE_READONLY,
-                        NULL)) {
-      swift::warning(0,
-                     "swift runtime: unable to protect environment "
-                     "for swift-backtrace: %08lx; disabling backtracing.\n",
-                     ::GetLastError());
-      _swift_backtraceSettings.enabled = OnOffTty::Off;
-    }
-#else
-    if (_swift_backtraceSettings.algorithm == UnwindAlgorithm::Auto)
-      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Precise;
+#else // !_WIN32
 
 #if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
     size_t len = strlen(_swift_backtraceSettings.swiftBacktracePath);
@@ -451,38 +478,35 @@ BacktraceInitializer::BacktraceInitializer() {
       memcpy(swiftBacktracePath,
              _swift_backtraceSettings.swiftBacktracePath,
              len + 1);
-
-#if PROTECT_BACKTRACE_SETTINGS
-      if (mprotect(swiftBacktracePath,
-                   sizeof(swiftBacktracePath),
-                   PROT_READ) < 0) {
-        swift::warning(0,
-                       "swift runtime: unable to protect path to "
-                       "swift-backtrace at %p: %d; disabling backtracing.\n",
-                       swiftBacktracePath,
-                       errno);
-        _swift_backtraceSettings.enabled = OnOffTty::Off;
-      }
-#endif // PROTECT_BACKTRACE_SETTINGS
     }
 #endif // !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
+
+#endif // !_WIN32
 
     _swift_backtraceSetupEnvironment();
 
 #if PROTECT_BACKTRACE_SETTINGS
-    if (mprotect(swiftBacktraceEnv,
-                 sizeof(swiftBacktraceEnv),
-                 PROT_READ) < 0) {
+#if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
+    if (!writeProtectMemory(swiftBacktracePath,
+                            sizeof(swiftBacktracePath))) {
         swift::warning(0,
-                       "swift runtime: unable to protect environment for "
-                       "swift-backtrace at %p: %d; disabling backtracing.\n",
-                       swiftBacktraceEnv,
-                       errno);
+                       "swift runtime: unable to protect path to "
+                       "swift-backtrace at %p; disabling backtracing.\n",
+                       swiftBacktracePath);
         _swift_backtraceSettings.enabled = OnOffTty::Off;
     }
-#endif // PROTECT_BACKTRACE_SETTINGS
+#endif
+    if (!writeProtectMemory(swiftBacktraceEnv,
+                            sizeof(swiftBacktraceEnv))) {
+      swift::warning(0,
+                     "swift runtime: unable to protect environment "
+                     "for swift-backtrace at %p; disabling backtracing.\n",
+                     swiftBacktraceEnv);
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    }
+#endif
 
-#endif // !_WIN32
+
   }
 
   if (_swift_backtraceSettings.enabled == OnOffTty::On) {
@@ -990,23 +1014,197 @@ _swift_backtrace_demangle(const char *mangledName,
   return nullptr;
 }
 
+namespace {
+
+char addr_buf[18];
+char timeout_buf[22];
+char limit_buf[22];
+char top_buf[22];
+const char *backtracer_argv[] = {
+  "swift-backtrace",            // 0
+  "--unwind",                   // 1
+  "precise",                    // 2
+  "--demangle",                 // 3
+  "true",                       // 4
+  "--interactive",              // 5
+  "true",                       // 6
+  "--color",                    // 7
+  "true",                       // 8
+  "--timeout",                  // 9
+  timeout_buf,                  // 10
+  "--preset",                   // 11
+  "friendly",                   // 12
+  "--crashinfo",                // 13
+  addr_buf,                     // 14
+  "--threads",                  // 15
+  "preset",                     // 16
+  "--registers",                // 17
+  "preset",                     // 18
+  "--images",                   // 19
+  "preset",                     // 20
+  "--limit",                    // 21
+  limit_buf,                    // 22
+  "--top",                      // 23
+  top_buf,                      // 24
+  "--sanitize",                 // 25
+  "preset",                     // 26
+  "--cache",                    // 27
+  "true",                       // 28
+  "--output-to",                // 29
+  "stdout",                     // 30
+  "--symbolicate",              // 31
+  "full",                       // 32
+  NULL
+};
+
+const char *
+trueOrFalse(bool b) {
+  return b ? "true" : "false";
+}
+
+const char *
+trueOrFalse(OnOffTty oot) {
+  return trueOrFalse(oot == OnOffTty::On);
+}
+
+} // namespace
+
 // N.B. THIS FUNCTION MUST BE SAFE TO USE FROM A CRASH HANDLER.  On Linux
 // and macOS, that means it must be async-signal-safe.  On Windows, there
 // isn't an equivalent notion but a similar restriction applies.
 SWIFT_RUNTIME_STDLIB_INTERNAL bool
 #ifdef __linux__
-_swift_spawnBacktracer(const ArgChar * const *argv, int memserver_fd)
+_swift_spawnBacktracer(CrashInfo *crashInfo, int memserver_fd)
 #else
-_swift_spawnBacktracer(const ArgChar * const *argv)
+_swift_spawnBacktracer(CrashInfo *crashInfo)
 #endif
 {
 #if !SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
   return false;
 #elif TARGET_OS_OSX || TARGET_OS_MACCATALYST || defined(__linux__)
+  // Set-up the backtracer's command line arguments
+  switch (_swift_backtraceSettings.algorithm) {
+  case UnwindAlgorithm::Fast:
+    backtracer_argv[2] = "fast";
+    break;
+  default:
+    backtracer_argv[2] = "precise";
+    break;
+  }
+
+  // (The TTY option has already been handled at this point, so these are
+  //  all either "On" or "Off".)
+  backtracer_argv[4] = trueOrFalse(_swift_backtraceSettings.demangle);
+  backtracer_argv[6] = trueOrFalse(_swift_backtraceSettings.interactive);
+  backtracer_argv[8] = trueOrFalse(_swift_backtraceSettings.color);
+
+  switch (_swift_backtraceSettings.threads) {
+  case ThreadsToShow::Preset:
+    backtracer_argv[16] = "preset";
+    break;
+  case ThreadsToShow::All:
+    backtracer_argv[16] = "all";
+    break;
+  case ThreadsToShow::Crashed:
+    backtracer_argv[16] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.registers) {
+  case RegistersToShow::Preset:
+    backtracer_argv[18] = "preset";
+    break;
+  case RegistersToShow::None:
+    backtracer_argv[18] = "none";
+    break;
+  case RegistersToShow::All:
+    backtracer_argv[18] = "all";
+    break;
+  case RegistersToShow::Crashed:
+    backtracer_argv[18] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.images) {
+  case ImagesToShow::Preset:
+    backtracer_argv[20] = "preset";
+    break;
+  case ImagesToShow::None:
+    backtracer_argv[20] = "none";
+    break;
+  case ImagesToShow::All:
+    backtracer_argv[20] = "all";
+    break;
+  case ImagesToShow::Mentioned:
+    backtracer_argv[20] = "mentioned";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.preset) {
+  case Preset::Friendly:
+    backtracer_argv[12] = "friendly";
+    break;
+  case Preset::Medium:
+    backtracer_argv[12] = "medium";
+    break;
+  default:
+    backtracer_argv[12] = "full";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.sanitize) {
+  case SanitizePaths::Preset:
+    backtracer_argv[26] = "preset";
+    break;
+  case SanitizePaths::Off:
+    backtracer_argv[26] = "false";
+    break;
+  case SanitizePaths::On:
+    backtracer_argv[26] = "true";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.outputTo) {
+  case OutputTo::Stdout:
+    backtracer_argv[30] = "stdout";
+    break;
+  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
+  case OutputTo::Stderr:
+    backtracer_argv[30] = "stderr";
+    break;
+  case OutputTo::File:
+    backtracer_argv[30] = swiftBacktraceOutputPath;
+    break;
+  }
+
+  backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
+
+  switch (_swift_backtraceSettings.symbolicate) {
+  case Symbolication::Off:
+    backtracer_argv[32] = "off";
+    break;
+  case Symbolication::Fast:
+    backtracer_argv[32] = "fast";
+    break;
+  case Symbolication::Full:
+    backtracer_argv[32] = "full";
+    break;
+  }
+
+  _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
+
+  if (_swift_backtraceSettings.limit < 0)
+    std::strcpy(limit_buf, "none");
+  else
+    _swift_formatUnsigned(_swift_backtraceSettings.limit, limit_buf);
+
+  _swift_formatUnsigned(_swift_backtraceSettings.top, top_buf);
+  _swift_formatAddress(crashInfo, addr_buf);
+
+  // Set-up the environment array
   pid_t child;
   const char *env[BACKTRACE_MAX_ENV_VARS + 1];
 
-  // Set-up the environment array
   const char *ptr = swiftBacktraceEnv;
   unsigned nEnv = 0;
   while (*ptr && nEnv < lengthof(env) - 1) {
@@ -1019,12 +1217,12 @@ _swift_spawnBacktracer(const ArgChar * const *argv)
   // posix_spawn() et al use char * const * is for compatibility.
 #ifdef __linux__
   int ret = safe_spawn(&child, swiftBacktracePath, memserver_fd,
-                       const_cast<char * const *>(argv),
+                       const_cast<char * const *>(backtracer_argv),
                        const_cast<char * const *>(env));
 #else
   int ret = posix_spawn(&child, swiftBacktracePath,
                         nullptr, nullptr,
-                        const_cast<char * const *>(argv),
+                        const_cast<char * const *>(backtracer_argv),
                         const_cast<char * const *>(env));
 #endif
   if (ret < 0)

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -94,6 +94,7 @@ enum class OutputTo {
   Auto = -1,
   Stdout = 0,
   Stderr = 2,
+  File = 3
 };
 
 enum class Symbolication {
@@ -120,6 +121,7 @@ struct BacktraceSettings {
   OutputTo         outputTo;
   Symbolication    symbolicate;
   const char      *swiftBacktracePath;
+  const char      *outputPath;
 };
 
 SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings;

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -18,6 +18,7 @@
 #define SWIFT_RUNTIME_BACKTRACE_UTILS_H
 
 #include "swift/Runtime/Config.h"
+#include "swift/Runtime/Backtrace.h"
 #include "swift/shims/Visibility.h"
 
 #include <inttypes.h>
@@ -133,9 +134,10 @@ inline bool _swift_backtrace_isEnabled() {
 SWIFT_RUNTIME_STDLIB_INTERNAL ErrorCode _swift_installCrashHandler();
 
 #ifdef __linux__
-SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(const ArgChar * const *argv, int memserver_fd);
+SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(CrashInfo *crashInfo,
+                                                          int memserver_fd);
 #else
-SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(const ArgChar * const *argv);
+SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(CrashInfo *crashInfo);
 #endif
 
 SWIFT_RUNTIME_STDLIB_INTERNAL void _swift_displayCrashMessage(int signum, const void *pc);

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -264,10 +264,10 @@ handle_fatal_signal(int signum,
   if (!run_backtracer(fd)) {
     const char *message = _swift_backtraceSettings.color == OnOffTty::On
       ? " failed\n\n" : " failed ***\n\n";
-    if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
-      write(STDERR_FILENO, message, strlen(message));
-    else
+    if (_swift_backtraceSettings.outputTo == OutputTo::Stdout)
       write(STDOUT_FILENO, message, strlen(message));
+    else
+      write(STDERR_FILENO, message, strlen(message));
   }
 
 #if !MEMSERVER_USE_PROCESS
@@ -930,6 +930,9 @@ run_backtracer(int memserver_fd)
   case OutputTo::Stderr:
     backtracer_argv[30] = "stderr";
     break;
+  case OutputTo::File:
+    backtracer_argv[30] = _swift_backtraceSettings.outputPath;
+    break;
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
@@ -963,4 +966,3 @@ run_backtracer(int memserver_fd)
 } // namespace
 
 #endif // __linux__
-

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -76,7 +76,6 @@ uint32_t currently_paused();
 void wait_paused(uint32_t expected, const struct timespec *timeout);
 int  memserver_start();
 int  memserver_entry(void *);
-bool run_backtracer(int fd);
 
 ssize_t safe_read(int fd, void *buf, size_t len) {
   uint8_t *ptr = (uint8_t *)buf;
@@ -261,7 +260,7 @@ handle_fatal_signal(int signum,
   _swift_displayCrashMessage(signum, pc);
 
   // Actually start the backtracer
-  if (!run_backtracer(fd)) {
+  if (!_swift_spawnBacktracer(&crashInfo, fd)) {
     const char *message = _swift_backtraceSettings.color == OnOffTty::On
       ? " failed\n\n" : " failed ***\n\n";
     if (_swift_backtraceSettings.outputTo == OutputTo::Stdout)
@@ -782,185 +781,6 @@ memserver_entry(void *dummy __attribute__((unused))) {
  fail:
   close(fd);
   return result;
-}
-
-// .. Starting the backtracer ..................................................
-
-char addr_buf[18];
-char timeout_buf[22];
-char limit_buf[22];
-char top_buf[22];
-const char *backtracer_argv[] = {
-  "swift-backtrace",            // 0
-  "--unwind",                   // 1
-  "precise",                    // 2
-  "--demangle",                 // 3
-  "true",                       // 4
-  "--interactive",              // 5
-  "true",                       // 6
-  "--color",                    // 7
-  "true",                       // 8
-  "--timeout",                  // 9
-  timeout_buf,                  // 10
-  "--preset",                   // 11
-  "friendly",                   // 12
-  "--crashinfo",                // 13
-  addr_buf,                     // 14
-  "--threads",                  // 15
-  "preset",                     // 16
-  "--registers",                // 17
-  "preset",                     // 18
-  "--images",                   // 19
-  "preset",                     // 20
-  "--limit",                    // 21
-  limit_buf,                    // 22
-  "--top",                      // 23
-  top_buf,                      // 24
-  "--sanitize",                 // 25
-  "preset",                     // 26
-  "--cache",                    // 27
-  "true",                       // 28
-  "--output-to",                // 29
-  "stdout",                     // 30
-  "--symbolicate",              // 31
-  "full",                       // 32
-  NULL
-};
-
-const char *
-trueOrFalse(bool b) {
-  return b ? "true" : "false";
-}
-
-const char *
-trueOrFalse(OnOffTty oot) {
-  return trueOrFalse(oot == OnOffTty::On);
-}
-
-bool
-run_backtracer(int memserver_fd)
-{
-  // Set-up the backtracer's command line arguments
-  switch (_swift_backtraceSettings.algorithm) {
-  case UnwindAlgorithm::Fast:
-    backtracer_argv[2] = "fast";
-    break;
-  default:
-    backtracer_argv[2] = "precise";
-    break;
-  }
-
-  // (The TTY option has already been handled at this point, so these are
-  //  all either "On" or "Off".)
-  backtracer_argv[4] = trueOrFalse(_swift_backtraceSettings.demangle);
-  backtracer_argv[6] = trueOrFalse(_swift_backtraceSettings.interactive);
-  backtracer_argv[8] = trueOrFalse(_swift_backtraceSettings.color);
-
-  switch (_swift_backtraceSettings.threads) {
-  case ThreadsToShow::Preset:
-    backtracer_argv[16] = "preset";
-    break;
-  case ThreadsToShow::All:
-    backtracer_argv[16] = "all";
-    break;
-  case ThreadsToShow::Crashed:
-    backtracer_argv[16] = "crashed";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.registers) {
-  case RegistersToShow::Preset:
-    backtracer_argv[18] = "preset";
-    break;
-  case RegistersToShow::None:
-    backtracer_argv[18] = "none";
-    break;
-  case RegistersToShow::All:
-    backtracer_argv[18] = "all";
-    break;
-  case RegistersToShow::Crashed:
-    backtracer_argv[18] = "crashed";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.images) {
-  case ImagesToShow::Preset:
-    backtracer_argv[20] = "preset";
-    break;
-  case ImagesToShow::None:
-    backtracer_argv[20] = "none";
-    break;
-  case ImagesToShow::All:
-    backtracer_argv[20] = "all";
-    break;
-  case ImagesToShow::Mentioned:
-    backtracer_argv[20] = "mentioned";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.preset) {
-  case Preset::Friendly:
-    backtracer_argv[12] = "friendly";
-    break;
-  case Preset::Medium:
-    backtracer_argv[12] = "medium";
-    break;
-  default:
-    backtracer_argv[12] = "full";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.sanitize) {
-  case SanitizePaths::Preset:
-    backtracer_argv[26] = "preset";
-    break;
-  case SanitizePaths::Off:
-    backtracer_argv[26] = "false";
-    break;
-  case SanitizePaths::On:
-    backtracer_argv[26] = "true";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.outputTo) {
-  case OutputTo::Stdout:
-    backtracer_argv[30] = "stdout";
-    break;
-  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
-  case OutputTo::Stderr:
-    backtracer_argv[30] = "stderr";
-    break;
-  case OutputTo::File:
-    backtracer_argv[30] = _swift_backtraceSettings.outputPath;
-    break;
-  }
-
-  backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
-
-  switch (_swift_backtraceSettings.symbolicate) {
-  case Symbolication::Off:
-    backtracer_argv[32] = "off";
-    break;
-  case Symbolication::Fast:
-    backtracer_argv[32] = "fast";
-    break;
-  case Symbolication::Full:
-    backtracer_argv[32] = "full";
-    break;
-  }
-
-  _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
-
-  if (_swift_backtraceSettings.limit < 0)
-    std::strcpy(limit_buf, "none");
-  else
-    _swift_formatUnsigned(_swift_backtraceSettings.limit, limit_buf);
-
-  _swift_formatUnsigned(_swift_backtraceSettings.top, top_buf);
-  _swift_formatAddress(&crashInfo, addr_buf);
-
-  // Actually execute it
-  return _swift_spawnBacktracer(backtracer_argv, memserver_fd);
 }
 
 } // namespace

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -415,6 +415,9 @@ run_backtracer()
   case OutputTo::Stderr:
     backtracer_argv[30] = "stderr";
     break;
+  case OutputTo::File:
+    backtracer_argv[30] = _swift_backtraceSettings.outputPath;
+    break;
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
@@ -450,4 +453,3 @@ run_backtracer()
 #endif // TARGET_OS_OSX || TARGET_OS_MACCATALYST
 
 #endif // __APPLE__
-

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -57,7 +57,6 @@ namespace {
 void handle_fatal_signal(int signum, siginfo_t *pinfo, void *uctx);
 void suspend_other_threads();
 void resume_other_threads();
-bool run_backtracer(void);
 
 CrashInfo crashInfo;
 
@@ -255,7 +254,7 @@ handle_fatal_signal(int signum,
 
   /* Start the backtracer; this will suspend the process, so there's no need
      to try to suspend other threads from here. */
-  if (!run_backtracer()) {
+  if (!_swift_spawnBacktracer(&crashInfo)) {
     const char *message = _swift_backtraceSettings.color == OnOffTty::On
       ? " failed\n\n" : " failed ***\n\n";
     if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
@@ -269,183 +268,6 @@ handle_fatal_signal(int signum,
 
   // Restore errno and exit (to crash)
   errno = old_err;
-}
-
-char addr_buf[18];
-char timeout_buf[22];
-char limit_buf[22];
-char top_buf[22];
-const char *backtracer_argv[] = {
-  "swift-backtrace",            // 0
-  "--unwind",                   // 1
-  "precise",                    // 2
-  "--demangle",                 // 3
-  "true",                       // 4
-  "--interactive",              // 5
-  "true",                       // 6
-  "--color",                    // 7
-  "true",                       // 8
-  "--timeout",                  // 9
-  timeout_buf,                  // 10
-  "--preset",                   // 11
-  "friendly",                   // 12
-  "--crashinfo",                // 13
-  addr_buf,                     // 14
-  "--threads",                  // 15
-  "preset",                     // 16
-  "--registers",                // 17
-  "preset",                     // 18
-  "--images",                   // 19
-  "preset",                     // 20
-  "--limit",                    // 21
-  limit_buf,                    // 22
-  "--top",                      // 23
-  top_buf,                      // 24
-  "--sanitize",                 // 25
-  "preset",                     // 26
-  "--cache",                    // 27
-  "true",                       // 28
-  "--output-to",                // 29
-  "stdout",                     // 30
-  "--symbolicate",              // 31
-  "true",                       // 32
-  NULL
-};
-
-const char *
-trueOrFalse(bool b) {
-  return b ? "true" : "false";
-}
-
-const char *
-trueOrFalse(OnOffTty oot) {
-  return trueOrFalse(oot == OnOffTty::On);
-}
-
-bool
-run_backtracer()
-{
-  // Set-up the backtracer's command line arguments
-  switch (_swift_backtraceSettings.algorithm) {
-  case UnwindAlgorithm::Fast:
-    backtracer_argv[2] = "fast";
-    break;
-  default:
-    backtracer_argv[2] = "precise";
-    break;
-  }
-
-  // (The TTY option has already been handled at this point, so these are
-  //  all either "On" or "Off".)
-  backtracer_argv[4] = trueOrFalse(_swift_backtraceSettings.demangle);
-  backtracer_argv[6] = trueOrFalse(_swift_backtraceSettings.interactive);
-  backtracer_argv[8] = trueOrFalse(_swift_backtraceSettings.color);
-
-  switch (_swift_backtraceSettings.threads) {
-  case ThreadsToShow::Preset:
-    backtracer_argv[16] = "preset";
-    break;
-  case ThreadsToShow::All:
-    backtracer_argv[16] = "all";
-    break;
-  case ThreadsToShow::Crashed:
-    backtracer_argv[16] = "crashed";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.registers) {
-  case RegistersToShow::Preset:
-    backtracer_argv[18] = "preset";
-    break;
-  case RegistersToShow::None:
-    backtracer_argv[18] = "none";
-    break;
-  case RegistersToShow::All:
-    backtracer_argv[18] = "all";
-    break;
-  case RegistersToShow::Crashed:
-    backtracer_argv[18] = "crashed";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.images) {
-  case ImagesToShow::Preset:
-    backtracer_argv[20] = "preset";
-    break;
-  case ImagesToShow::None:
-    backtracer_argv[20] = "none";
-    break;
-  case ImagesToShow::All:
-    backtracer_argv[20] = "all";
-    break;
-  case ImagesToShow::Mentioned:
-    backtracer_argv[20] = "mentioned";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.preset) {
-  case Preset::Friendly:
-    backtracer_argv[12] = "friendly";
-    break;
-  case Preset::Medium:
-    backtracer_argv[12] = "medium";
-    break;
-  default:
-    backtracer_argv[12] = "full";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.sanitize) {
-  case SanitizePaths::Preset:
-    backtracer_argv[26] = "preset";
-    break;
-  case SanitizePaths::Off:
-    backtracer_argv[26] = "false";
-    break;
-  case SanitizePaths::On:
-    backtracer_argv[26] = "true";
-    break;
-  }
-
-  switch (_swift_backtraceSettings.outputTo) {
-  case OutputTo::Stdout:
-    backtracer_argv[30] = "stdout";
-    break;
-  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
-  case OutputTo::Stderr:
-    backtracer_argv[30] = "stderr";
-    break;
-  case OutputTo::File:
-    backtracer_argv[30] = _swift_backtraceSettings.outputPath;
-    break;
-  }
-
-  backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
-
-  switch (_swift_backtraceSettings.symbolicate) {
-  case Symbolication::Off:
-    backtracer_argv[32] = "off";
-    break;
-  case Symbolication::Fast:
-    backtracer_argv[32] = "fast";
-    break;
-  case Symbolication::Full:
-    backtracer_argv[32] = "full";
-    break;
-  }
-
-  _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
-
-  if (_swift_backtraceSettings.limit < 0)
-    std::strcpy(limit_buf, "none");
-  else
-    _swift_formatUnsigned(_swift_backtraceSettings.limit, limit_buf);
-
-  _swift_formatUnsigned(_swift_backtraceSettings.top, top_buf);
-  _swift_formatAddress(&crashInfo, addr_buf);
-
-  // Actually execute it
-  return _swift_spawnBacktracer(backtracer_argv);
 }
 
 } // namespace

--- a/test/Backtracing/CrashOutputFile.swift
+++ b/test/Backtracing/CrashOutputFile.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/crashlogs)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/CrashOutputFile
+// RUN: %target-codesign %t/CrashOutputFile
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crash.log %target-run %t/CrashOutputFile 2>&1 || true) && cat %t/crash.log | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=%t/crashlogs %target-run %t/CrashOutputFile 2>&1 || true) && cat %t/crashlogs/* | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to crash")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct CrashOutputFile {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK: Thread 0 {{(".*" )?}}crashed:
+
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:34:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:28:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:24:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:20:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:16:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static CrashOutputFile.main() + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift:40:5
+// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static CrashOutputFile.$main() + {{[0-9]+}} in CrashOutputFile at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashOutputFile at {{.*}}/CrashOutputFile.swift
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{([0-9a-f]+|<no build ID>)}}{{ +}}CrashOutputFile{{ +}}{{.*}}/CrashOutputFile


### PR DESCRIPTION
Add the ability to specify a filename or directory name as the output-to setting in `SWIFT_BACKTRACE`.  If the option is set to a directory name, generate a unique filename in that directory using the process name, process ID and timestamp.

rdar://136977833
