### PR TITLE
[embedded] Explicitly recognize riscv32 as a valid arch conditional

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -100,6 +100,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationArches[] =
   "powerpc64le",
   "s390x",
   "wasm32",
+  "riscv32",
   "riscv64",
   "avr"
 };
@@ -539,6 +540,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::ArchType::wasm32:
     addPlatformConditionValue(PlatformConditionKind::Arch, "wasm32");
+    break;
+  case llvm::Triple::ArchType::riscv32:
+    addPlatformConditionValue(PlatformConditionKind::Arch, "riscv32");
     break;
   case llvm::Triple::ArchType::riscv64:
     addPlatformConditionValue(PlatformConditionKind::Arch, "riscv64");


### PR DESCRIPTION
We already build and support riscv32 (see e.g. the ESP32 Matter examples) in Embedded Swift, this just explicitly recognizes the arch name "riscv32" in conditional compilation. This removes a warning, and avoid relying on the "unknown architecture" fallback.