### PR TITLE
[embedded] Add a CMake setting for building Embedded Swift stdlib for custom target triples

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -152,6 +152,9 @@ option(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING
       "Enable build of the embedded Swift standard library and runtime for cross-compiling targets"
       FALSE)
 
+set(SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES "" CACHE STRING
+    "List of extra target triples to build the embedded Swift standard library for")
+
 if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND (NOT SWIFT_HOST_VARIANT STREQUAL "linux") AND (NOT SWIFT_HOST_VARIANT STREQUAL "windows"))
   set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
 elseif(BOOTSTRAPPING_MODE STREQUAL "OFF")
@@ -249,6 +252,24 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     )
   endif()
 endif()
+
+foreach(triple ${SWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES})
+  if(triple STREQUAL "")
+    continue()
+  endif()
+
+  string(REGEX REPLACE "-" ";" list "${triple}")
+  list(GET list 0 arch)
+  list(GET list 1 vendor)
+  list(GET list 2 os)
+  string(REGEX REPLACE "[0-9]+(\\.[0-9]+)+" " " mod "${triple}")
+
+  list(FILTER EMBEDDED_STDLIB_TARGET_TRIPLES EXCLUDE REGEX " ${mod} ")
+
+  list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+    "${arch} ${mod} ${triple}"
+  )
+endforeach()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(triples)


### PR DESCRIPTION
No change to the default build, but this new setting is useful for e.g. orchestrating multiple builds of the stdlib from the outside and specifying which target triples to build externally.