### PR TITLE
stdlib: add a missing fixLifetime in `withVaList`

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -159,7 +159,9 @@ public func withVaList<R>(_ args: [CVarArg],
   for a in args {
     builder.append(a)
   }
-  return _withVaList(builder, body)
+  let result = _withVaList(builder, body)
+  _fixLifetime(args)
+  return result
 }
 
 /// Invoke `body` with a C `va_list` argument derived from `builder`.


### PR DESCRIPTION
If this function is inlined, the optimizer can shrink the lifetime of the `args` parameter. This would deallocate the passed arguments (e.g. `NSString`s) before the are used in the closure.

This problem showed up in the `TestNSString.test_initializeWithFormat4` swift-corelibs-foundation test (on linux) when enabling OSSA modules (https://github.com/swiftlang/swift/pull/78939)