### PR TITLE
[Backtracing] Add missing CxxStdlib dependency.

### DIFF
--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -11,7 +11,10 @@
 #===------------------------------------------------------------------------===#
 #
 #  The Runtime module isn't the runtime itself; that lives in libswiftCore;
-#  rather, it's a high level Swift interface to things
+#  rather, it's a high level Swift interface to things in the runtime.
+#
+#===------------------------------------------------------------------------===#
+
 set(swift_runtime_link_libraries
   swiftCore
   swift_Concurrency
@@ -20,6 +23,11 @@ set(swift_runtime_link_libraries
 set(concurrency)
 if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
   set(concurrency _Concurrency)
+endif()
+
+set(cxxstdlib_overlay)
+if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
+  set(cxxstdlib_overlay CxxStdlib)
 endif()
 
 set(RUNTIME_SOURCES
@@ -90,7 +98,7 @@ set(LLVM_OPTIONAL_SOURCES
 add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ${RUNTIME_SOURCES}
 
-  SWIFT_MODULE_DEPENDS ${concurrency}
+  SWIFT_MODULE_DEPENDS ${concurrency} ${cxxstdlib_overlay}
 
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc


### PR DESCRIPTION
To do this we also need to fix AddSwiftStdlib because if you set the `INSTALL_WITH_SHARED` flag, the CMake scripts don't make a target with the `-static` suffix, but AddSwiftStdlib also assumes that it should dad `-static` to any module dependencies when building a static library.
