### PR TITLE
utils: rename `Foundation` to `DynamicFoundation`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -426,7 +426,7 @@ enum TargetComponent {
   LLVM
   Runtime
   Dispatch
-  Foundation
+  DynamicFoundation
   XCTest
   Testing
   ClangBuiltins
@@ -2122,7 +2122,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
     }
   } else {
     $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
-    $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
+    $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch DynamicFoundation
     $ShortArch = $Arch.LLVMName
 
     Isolate-EnvVars {
@@ -2215,7 +2215,7 @@ function Build-FoundationMacros() {
 
 function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
   $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
-  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
+  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch DynamicFoundation
   $XCTestBinaryCache = Get-TargetProjectBinaryCache $Arch XCTest
 
   Isolate-EnvVars {
@@ -2254,7 +2254,7 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
 function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
   $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
-  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
+  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch DynamicFoundation
   $SwiftTestingBinaryCache = Get-TargetProjectBinaryCache $Arch Testing
 
   Isolate-EnvVars {


### PR DESCRIPTION
The smoke test for the new runtime builds also serves as a static runtime build test. Rename the `Foundation` product to `DynamicFoundation` to permit the introduction of a `StaticFoundation` to fit into the static SDK build.