### PR TITLE
Sema: Fix generic type alias resolution edge case

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6136,6 +6136,8 @@ Type TypeChecker::substMemberTypeWithBase(TypeDecl *member,
     // Cope with the presence of unbound generic types, which are ill-formed
     // at this point but break the invariants of getContextSubstitutionMap().
     if (baseTy->hasUnboundGenericType()) {
+      memberType = memberType->getReducedType(aliasDecl->getGenericSignature());
+
       if (memberType->hasTypeParameter())
         return ErrorType::get(memberType);
 

--- a/test/decl/typealias/fully_constrained.swift
+++ b/test/decl/typealias/fully_constrained.swift
@@ -3,22 +3,23 @@
 struct OtherGeneric<U> {}
 
 struct Generic<T> {
-  // FIXME: Should work with 'T' as well
   typealias NonGeneric = Int where T == Int
+  typealias FakeGeneric = T where T == Int
 
   typealias Unbound = OtherGeneric where T == Int
   typealias Generic = OtherGeneric where T == Int
 }
 
 extension Generic where T == Int {
-  // FIXME: Should work with 'T' as well
   typealias NonGenericInExtension = Int
+  typealias FakeGenericInExtension = T
 
   typealias UnboundInExtension = OtherGeneric
   typealias GenericInExtension = OtherGeneric
 }
 
 func use(_: Generic.NonGeneric,
+         _: Generic.FakeGeneric,
          _: Generic.Unbound<String>,
          _: Generic.Generic<String>,
          _: Generic.NonGenericInExtension,
@@ -28,16 +29,20 @@ func use(_: Generic.NonGeneric,
   // FIXME: Get these working too
 #if false
   let _ = Generic.NonGeneric.self
+  let _ = Generic.FakeGeneric.self
   let _ = Generic.Unbound<String>.self
   let _ = Generic.Generic<String>.self
 
   let _ = Generic.NonGenericInExtension.self
+  let _ = Generic.FakeGenericInExtension.self
   let _ = Generic.UnboundInExtension<String>.self
   let _ = Generic.GenericInExtension<String>.self
+#endif
 
   let _: Generic.NonGeneric = 123
+  let _: Generic.FakeGeneric = 123
   let _: Generic.NonGenericInExtension = 123
-#endif
+  let _: Generic.FakeGenericInExtension = 123
 
   let _: Generic.Unbound = OtherGeneric<String>()
   let _: Generic.Generic = OtherGeneric<String>()
@@ -48,11 +53,13 @@ func use(_: Generic.NonGeneric,
 
 struct Use {
   let a1: Generic.NonGeneric
-  let b1: Generic.Unbound<String>
-  let c1: Generic.Generic<String>
+  let b1: Generic.FakeGeneric
+  let c1: Generic.Unbound<String>
+  let d1: Generic.Generic<String>
   let a2: Generic.NonGenericInExtension
-  let b2: Generic.UnboundInExtension<String>
-  let c2: Generic.GenericInExtension<String>
+  let b2: Generic.FakeGenericInExtension
+  let c2: Generic.UnboundInExtension<String>
+  let d2: Generic.GenericInExtension<String>
 }
 
 extension Generic.NonGeneric {}


### PR DESCRIPTION
If a type alias in generic context fixes all outer generic parameters to concrete types, we allow the type alias to be referenced without specifying the generic arguments of its parent type.

However, we need to reduce the underlying type in case it was written in terms of the (fully concrete) generic parameters.

Fixes rdar://problem/143707820.