### PR TITLE
Sema: Do not drop reference to type paramater if it reduces to `ErrorType`

### DIFF
--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -315,7 +315,8 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
       return GenericParameterReferenceInfo();
     }
 
-    if (auto reducedTy = genericSig.getReducedType(type)) {
+    auto reducedTy = genericSig.getReducedType(type);
+    if (reducedTy && !reducedTy->is<ErrorType>()) {
       if (!reducedTy->isEqual(type)) {
         // Note: origParam becomes openedParam for the recursive call,
         // because concreteTy is written in terms of genericSig and not

--- a/test/decl/protocol/existential_member_access/invalid_type_parameter.swift
+++ b/test/decl/protocol/existential_member_access/invalid_type_parameter.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+// https://github.com/swiftlang/swift/issues/77840
+do {
+  struct G<T> {}
+
+  protocol P {
+    associatedtype A where A == Undefined
+    // expected-error@-1 {{cannot find type 'Undefined' in scope}}
+    associatedtype B where B == G<Undefined>
+    // expected-error@-1 {{cannot find type 'Undefined' in scope}}
+
+    func fooTakesA(_: A)
+    func fooTakesB(_: B)
+
+    func fooReturnsA() -> A
+    func fooReturnsB() -> B
+  }
+
+  let p: any P
+  let _ = p.fooTakesA
+  // expected-error@-1 {{member 'fooTakesA' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
+  let _ = p.fooTakesB
+  // expected-error@-1 {{member 'fooTakesB' cannot be used on value of type 'any P'; consider using a generic constraint instead}}
+  let _ = p.fooReturnsA()
+  let _ = p.fooReturnsB()
+}


### PR DESCRIPTION
Resolves #77840.