### PR TITLE
[Backtracing] Uncached(Local|Remote)MemoryReader only exists on macOS and Linux.

### DIFF
--- a/stdlib/public/RuntimeModule/CachingMemoryReader.swift
+++ b/stdlib/public/RuntimeModule/CachingMemoryReader.swift
@@ -96,6 +96,7 @@ extension CachingMemoryReader where Reader == UncachedMemserverMemoryReader {
 }
 #endif
 
+#if os(Linux) || os(macOS)
 @_spi(MemoryReaders)
 public typealias RemoteMemoryReader = CachingMemoryReader<UncachedRemoteMemoryReader>
 
@@ -119,3 +120,4 @@ extension CachingMemoryReader where Reader == UncachedLocalMemoryReader {
     self.init(for: UncachedLocalMemoryReader())
   }
 }
+#endif // os(Linux) || os(macOS)


### PR DESCRIPTION
There's no support for this type on anything other than macOS and Linux right now.

rdar://143865183
