### PR TITLE
swiftpm: Test only running host platform architecture

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1846,6 +1846,7 @@ swift-testing-macros
 install-swift-testing
 install-swift-testing-macros
 
+infer-cross-compile-hosts-on-darwin
 skip-test-swift
 
 [preset: mixin_swiftpm_macos_platform]

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -42,7 +42,14 @@ class SwiftPM(product.Product):
     def should_build(self, host_target):
         return True
 
-    def run_bootstrap_script(self, action, host_target, additional_params=[]):
+    def run_bootstrap_script(
+            self,
+            action,
+            host_target,
+            additional_params=[],
+            *,
+            compile_only_for_running_host_architecture=False,
+    ):
         script_path = os.path.join(
             self.source_dir, 'Utilities', 'bootstrap')
 
@@ -85,7 +92,10 @@ class SwiftPM(product.Product):
             ]
 
         # Pass Cross compile host info
-        if self.has_cross_compile_hosts():
+        if (
+            not compile_only_for_running_host_architecture
+            and self.has_cross_compile_hosts()
+        ):
             if self.is_darwin_host(host_target):
                 helper_cmd += ['--cross-compile-hosts']
                 for cross_compile_host in self.args.cross_compile_hosts:
@@ -114,7 +124,11 @@ class SwiftPM(product.Product):
         return self.args.test_swiftpm
 
     def test(self, host_target):
-        self.run_bootstrap_script('test', host_target)
+        self.run_bootstrap_script(
+            'test',
+            host_target,
+            compile_only_for_running_host_architecture=True,
+        )
 
     def should_clean(self, host_target):
         return self.args.clean_swiftpm


### PR DESCRIPTION
When adding a Swift Testing test to Swift PM repository, the `test` portion of the OSX package pipeline was building against x86_64 and arm64.

Ensure Swift PM testing only runs against the host platform
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
