### PR TITLE
[cxx-interop] Do not codegen zero-sized fields

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1451,6 +1451,7 @@ private:
   /// Place the next struct field at its appropriate offset.
   void addStructField(const clang::FieldDecl *clangField,
                       VarDecl *swiftField, const clang::ASTRecordLayout &layout) {
+    bool isZeroSized = clangField->isZeroSize(ClangContext);
     unsigned fieldOffset = layout.getFieldOffset(clangField->getFieldIndex());
     assert(!clangField->isBitField());
     Size offset( SubobjectAdjustment.getValue() + fieldOffset / 8);
@@ -1460,12 +1461,12 @@ private:
       auto &fieldTI = cast<FixedTypeInfo>(IGM.getTypeInfo(
           SwiftType.getFieldType(swiftField, IGM.getSILModule(),
                                  IGM.getMaximalTypeExpansionContext())));
-      addField(swiftField, offset, fieldTI);
+      addField(swiftField, offset, fieldTI, isZeroSized);
       return;
     }
 
     // Otherwise, add it as an opaque blob.
-    auto fieldSize = ClangContext.getTypeSizeInChars(clangField->getType());
+    auto fieldSize = isZeroSized ? clang::CharUnits::Zero() : ClangContext.getTypeSizeInChars(clangField->getType());
     return addOpaqueField(offset, Size(fieldSize.getQuantity()));
   }
 
@@ -1491,23 +1492,23 @@ private:
     if (fieldSize.isZero()) return;
 
     auto &opaqueTI = IGM.getOpaqueStorageTypeInfo(fieldSize, Alignment(1));
-    addField(nullptr, offset, opaqueTI);
+    addField(nullptr, offset, opaqueTI, false);
   }
 
   /// Add storage for an (optional) Swift field at the given offset.
   void addField(VarDecl *swiftField, Size offset,
-                const FixedTypeInfo &fieldType) {
-    assert(offset >= NextOffset && "adding fields out of order");
+                const FixedTypeInfo &fieldType, bool isZeroSized) {
+    assert(isZeroSized || offset >= NextOffset && "adding fields out of order");
 
     // Add a padding field if required.
-    if (offset != NextOffset)
+    if (!isZeroSized && offset != NextOffset)
       addPaddingField(offset);
 
-    addFieldInfo(swiftField, fieldType);
+    addFieldInfo(swiftField, fieldType, isZeroSized);
   }
 
   /// Add information to track a value field at the current offset.
-  void addFieldInfo(VarDecl *swiftField, const FixedTypeInfo &fieldType) {
+  void addFieldInfo(VarDecl *swiftField, const FixedTypeInfo &fieldType, bool isZeroSized) {
     bool isLoadableField = isa<LoadableTypeInfo>(fieldType);
     unsigned explosionSize = 0;
     if (isLoadableField)
@@ -1517,11 +1518,15 @@ private:
     unsigned explosionEnd = NextExplosionIndex;
 
     ElementLayout layout = ElementLayout::getIncomplete(fieldType);
-    auto isEmpty = fieldType.isKnownEmpty(ResilienceExpansion::Maximal);
-    if (isEmpty)
-      layout.completeEmptyTailAllocatedCType(
-          fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal), NextOffset);
-    else
+    auto isEmpty = isZeroSized || fieldType.isKnownEmpty(ResilienceExpansion::Maximal);
+    if (isEmpty) {
+      if (isZeroSized)
+        layout.completeEmpty(
+            fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal), NextOffset);
+      else
+        layout.completeEmptyTailAllocatedCType(
+            fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal), NextOffset);
+    } else
       layout.completeFixed(fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal),
                            NextOffset, LLVMFields.size());
 

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -6,4 +6,26 @@ public:
   const int const_member = 23;
 };
 
+struct Empty {
+  using type = int;
+  int getNum() const { return 42; }
+};
+
+struct HasZeroSizedField {
+  int a;
+  [[no_unique_address]] Empty b;
+  short c;
+  [[no_unique_address]] Empty d;
+  int* e;
+  [[no_unique_address]] Empty f;
+
+  int get_a() const { return a; }
+  short get_c() const { return c; }
+  void set_c(short c) { this->c = c; }
+};
+
+inline int takesZeroSizedInCpp(HasZeroSizedField x) {
+  return x.a;
+}
+
 #endif

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import MemberVariables
+
+var FieldsTestSuite = TestSuite("Generating code with zero sized fields")
+
+func takeTypeWithZeroSizedMember(_ x: HasZeroSizedField) {}
+
+FieldsTestSuite.test("Zero sized field") {
+  var s = HasZeroSizedField()
+  s.a = 5
+  s.set_c(7)
+  takeTypeWithZeroSizedMember(s)
+  let s2 = s
+  let myInt : Empty.type = 6
+  expectEqual(s.a, 5)
+  expectEqual(s.a, s.get_a())
+  expectEqual(s2.c, 7)
+  expectEqual(s2.c, s2.get_c())
+  expectEqual(takesZeroSizedInCpp(s2), 5)
+  expectEqual(s.b.getNum(), 42)
+}
+
+runAllTests()


### PR DESCRIPTION
Zero sized fields are messing up the offset calculations when we import C++ fields to Swift. We assume that the size of the field is determined by the type of the field. This is not true for fields marked with no_unique_address. Those fields can have 0 size while the sizeof(decltype(field)) is still 1.

rdar://143907490
