### PR TITLE
[CSOptimizer] A few small performance optimizations

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -125,6 +125,9 @@ static bool isSupportedDisjunction(Constraint *disjunction) {
   // Non-operator disjunctions are supported only if they don't
   // have any generic choices.
   return llvm::all_of(choices, [&](Constraint *choice) {
+    if (choice->isDisabled())
+      return true;
+
     if (choice->getKind() != ConstraintKind::BindOverload)
       return false;
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -299,7 +299,13 @@ static void determineBestChoicesInContext(
     if (applicableFn.isNull()) {
       auto *locator = disjunction->getLocator();
       if (auto expr = getAsExpr(locator->getAnchor())) {
-        if (auto *parentExpr = cs.getParentExpr(expr)) {
+        auto *parentExpr = cs.getParentExpr(expr);
+        // Look through optional evaluation, so
+        // we can cover expressions like `a?.b + 2`.
+        if (isExpr<OptionalEvaluationExpr>(parentExpr))
+          parentExpr = cs.getParentExpr(parentExpr);
+
+        if (parentExpr) {
           // If this is a chained member reference or a direct operator
           // argument it could be prioritized since it helps to establish
           // context for other calls i.e. `(a.)b + 2` if `a` and/or `b`

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=500
 // REQUIRES: tools-release,no_asan
 
 public class Cookie {


### PR DESCRIPTION
- Disabled overload choices shouldn't be considered when checking whether non-operator disjunction is supported
- Look through `OptionalEvaluationExpr`s when dealing with unapplied disjunctions. Helps with situations like `a?.b + 1`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
