### PR TITLE
[concurrency] Introduce concurrent, swap its meaning with nonisolated and make nonisolated caller inheriting isolation.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -203,13 +203,9 @@ public:
     return (kind == Concurrent) || (kind == ConcurrentUnsafe);
   }
 
-  bool isConcurrentUnsafe() const { return kind == ConcurrentUnsafe; }
-
   bool isNonisolated() const {
     return (kind == Nonisolated) || (kind == NonisolatedUnsafe);
   }
-
-  bool isNonisolatedUnsafe() const { return kind == NonisolatedUnsafe; }
 
   bool isUnsafe() const {
     return kind == NonisolatedUnsafe || kind == ConcurrentUnsafe;

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -80,11 +80,6 @@ public:
     /// The actor isolation iss statically erased, as for a call to
     /// an isolated(any) function.  This is not possible for declarations.
     Erased,
-    /// Inherits isolation from the caller of the given function.
-    ///
-    /// DISCUSSION: This is used for nonisolated asynchronous functions that we
-    /// want to inherit from their context the context's actor isolation.
-    CallerIsolationInheriting,
     /// The declaration is explicitly specified to be not isolated to any actor,
     /// meaning that it can be used from any actor but is also unable to
     /// refer to the isolated state of any given actor.
@@ -107,7 +102,7 @@ private:
     Type globalActor;
     void *pointer;
   };
-  unsigned kind : 4;
+  unsigned kind : 3;
   unsigned isolatedByPreconcurrency : 1;
 
   /// Set to true if this was parsed from SIL.
@@ -139,12 +134,6 @@ public:
 
   static ActorIsolation forConcurrent(bool unsafe) {
     return ActorIsolation(unsafe ? ConcurrentUnsafe : Concurrent);
-  }
-
-  static ActorIsolation forCallerIsolationInheriting() {
-    // NOTE: We do not use parameter indices since the parameter is implicit
-    // from the perspective of the AST.
-    return ActorIsolation(CallerIsolationInheriting);
   }
 
   static ActorIsolation forActorInstanceSelf(ValueDecl *decl);
@@ -194,9 +183,6 @@ public:
                   std::optional<ActorIsolation>(ActorIsolation::GlobalActor))
             .Case("global_actor_unsafe",
                   std::optional<ActorIsolation>(ActorIsolation::GlobalActor))
-            .Case("caller_isolation_inheriting",
-                  std::optional<ActorIsolation>(
-                      ActorIsolation::CallerIsolationInheriting))
             .Case("concurrent",
                   std::optional<ActorIsolation>(ActorIsolation::Concurrent))
             .Case("concurrent_unsafe", std::optional<ActorIsolation>(
@@ -255,7 +241,6 @@ public:
     case Unspecified:
     case Nonisolated:
     case NonisolatedUnsafe:
-    case CallerIsolationInheriting:
     case Concurrent:
     case ConcurrentUnsafe:
       return false;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3844,10 +3844,15 @@ public:
     switch (auto isolation = E->getActorIsolation()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::ConcurrentUnsafe:
       break;
 
     case ActorIsolation::Nonisolated:
       printFlag(true, "nonisolated", CapturesColor);
+      break;
+
+    case ActorIsolation::Concurrent:
+      printFlag(true, "concurrent", CapturesColor);
       break;
 
     case ActorIsolation::Erased:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3859,10 +3859,6 @@ public:
       printFlag(true, "dynamically_isolated", CapturesColor);
       break;
 
-    case ActorIsolation::CallerIsolationInheriting:
-      printFlag(true, "isolated_to_caller_isolation", CapturesColor);
-      break;
-
     case ActorIsolation::ActorInstance:
       printReferencedDeclWithContextField(isolation.getActorInstance(),
                                           Label::always("actor_isolated"),

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -39,7 +39,10 @@ ActorIsolation::ActorIsolation(Kind kind, Expr *actor, unsigned parameterIndex)
 
 ActorIsolation::ActorIsolation(Kind kind, Type globalActor)
     : globalActor(globalActor), kind(kind), isolatedByPreconcurrency(false),
-      silParsed(false), parameterIndex(0) {}
+      silParsed(false), parameterIndex(0) {
+  assert((silParsed || globalActor) &&
+         "If we are not sil parsed, global actor must be a real type");
+}
 
 ActorIsolation
 ActorIsolation::forActorInstanceParameter(Expr *actor,
@@ -49,7 +52,7 @@ ActorIsolation::forActorInstanceParameter(Expr *actor,
   // An isolated value of `nil` is statically nonisolated.
   // FIXME: Also allow 'Optional.none'
   if (isa<NilLiteralExpr>(actor))
-    return ActorIsolation::forNonisolated(/*unsafe*/ false);
+    return ActorIsolation::forConcurrent(/*unsafe*/ false);
 
   // An isolated value of `<global actor type>.shared` is statically
   // global actor isolated.
@@ -164,6 +167,8 @@ bool ActorIsolation::isEqual(const ActorIsolation &lhs,
   switch (lhs.getKind()) {
   case Nonisolated:
   case NonisolatedUnsafe:
+  case Concurrent:
+  case ConcurrentUnsafe:
   case Unspecified:
     return true;
 

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -165,8 +165,6 @@ bool ActorIsolation::isEqual(const ActorIsolation &lhs,
     return false;
 
   switch (lhs.getKind()) {
-  case Nonisolated:
-  case NonisolatedUnsafe:
   case Concurrent:
   case ConcurrentUnsafe:
   case Unspecified:
@@ -179,7 +177,8 @@ bool ActorIsolation::isEqual(const ActorIsolation &lhs,
     // to answer.
     return false;
 
-  case CallerIsolationInheriting:
+  case Nonisolated:
+  case NonisolatedUnsafe:
     // This returns false for the same reason as erased. The caller has to check
     // against the actual caller isolation.
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2757,6 +2757,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
         switch (isolation) {
           case ActorIsolation::Unspecified:
           case ActorIsolation::NonisolatedUnsafe:
+          case ActorIsolation::ConcurrentUnsafe:
             break;
 
           case ActorIsolation::GlobalActor:
@@ -2768,6 +2769,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
           case ActorIsolation::CallerIsolationInheriting:
           case ActorIsolation::ActorInstance:
           case ActorIsolation::Nonisolated:
+          case ActorIsolation::Concurrent:
           case ActorIsolation::Erased: // really can't happen
             return true;
         }
@@ -11458,6 +11460,8 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
       case ActorIsolation::NonisolatedUnsafe:
+      case ActorIsolation::Concurrent:
+      case ActorIsolation::ConcurrentUnsafe:
       case ActorIsolation::GlobalActor:
       case ActorIsolation::Erased:
       case ActorIsolation::CallerIsolationInheriting:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2766,7 +2766,6 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
 
             return true;
 
-          case ActorIsolation::CallerIsolationInheriting:
           case ActorIsolation::ActorInstance:
           case ActorIsolation::Nonisolated:
           case ActorIsolation::Concurrent:
@@ -11464,7 +11463,6 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
       case ActorIsolation::ConcurrentUnsafe:
       case ActorIsolation::GlobalActor:
       case ActorIsolation::Erased:
-      case ActorIsolation::CallerIsolationInheriting:
         return false;
 
       case ActorIsolation::ActorInstance:

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1856,7 +1856,6 @@ SourceLoc MacroDefinitionRequest::getNearestLoc() const {
 
 bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
-  case CallerIsolationInheriting:
   case ActorInstance:
   case Nonisolated:
   case NonisolatedUnsafe:
@@ -1874,7 +1873,6 @@ bool ActorIsolation::requiresSubstitution() const {
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
-  case CallerIsolationInheriting:
   case Nonisolated:
   case NonisolatedUnsafe:
   case Concurrent:
@@ -1895,11 +1893,6 @@ void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
   switch (*this) {
   case ActorIsolation::ActorInstance:
     os << "actor" << (asNoun ? " isolation" : "-isolated");
-    break;
-
-  case ActorIsolation::CallerIsolationInheriting:
-    os << "caller isolation inheriting"
-       << (asNoun ? " isolation" : "-isolated");
     break;
 
   case ActorIsolation::GlobalActor: {
@@ -1940,9 +1933,6 @@ void ActorIsolation::print(llvm::raw_ostream &os) const {
       os << ". name: '" << vd->getBaseIdentifier() << "'";
     }
     return;
-  case CallerIsolationInheriting:
-    os << "caller_isolation_inheriting";
-    return;
   case Nonisolated:
     os << "nonisolated";
     return;
@@ -1972,9 +1962,6 @@ void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
     return;
   case ActorInstance:
     os << "actor_instance";
-    return;
-  case CallerIsolationInheriting:
-    os << "caller_isolation_inheriting";
     return;
   case Nonisolated:
     os << "nonisolated";
@@ -2025,10 +2012,6 @@ void swift::simple_display(
       } else {
         out << state.getActor()->getName();
       }
-      break;
-
-    case ActorIsolation::CallerIsolationInheriting:
-      out << "isolated to isolation of caller";
       break;
 
     case ActorIsolation::Nonisolated:

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1860,6 +1860,8 @@ bool ActorIsolation::requiresSubstitution() const {
   case ActorInstance:
   case Nonisolated:
   case NonisolatedUnsafe:
+  case Concurrent:
+  case ConcurrentUnsafe:
   case Unspecified:
     return false;
 
@@ -1875,6 +1877,8 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   case CallerIsolationInheriting:
   case Nonisolated:
   case NonisolatedUnsafe:
+  case Concurrent:
+  case ConcurrentUnsafe:
   case Unspecified:
     return *this;
 
@@ -1912,11 +1916,13 @@ void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
     os << "@isolated(any)";
     break;
 
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:
     os << "nonisolated";
-    if (*this == ActorIsolation::NonisolatedUnsafe) {
+    if (isUnsafe()) {
       os << "(unsafe)";
     }
     break;
@@ -1942,6 +1948,12 @@ void ActorIsolation::print(llvm::raw_ostream &os) const {
     return;
   case NonisolatedUnsafe:
     os << "nonisolated_unsafe";
+    return;
+  case Concurrent:
+    os << "concurrent";
+    return;
+  case ConcurrentUnsafe:
+    os << "concurrent_unsafe";
     return;
   case GlobalActor:
     os << "global_actor. type: " << getGlobalActor();
@@ -1969,6 +1981,12 @@ void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
     return;
   case NonisolatedUnsafe:
     os << "nonisolated_unsafe";
+    return;
+  case Concurrent:
+    os << "concurrent";
+    return;
+  case ConcurrentUnsafe:
+    os << "concurrent_unsafe";
     return;
   case GlobalActor:
     os << "global_actor";
@@ -2015,8 +2033,10 @@ void swift::simple_display(
 
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::Concurrent:
+    case ActorIsolation::ConcurrentUnsafe:
       out << "nonisolated";
-      if (state == ActorIsolation::NonisolatedUnsafe) {
+      if (state.isUnsafe()) {
         out << "(unsafe)";
       }
       break;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -830,7 +830,6 @@ void CompletionLookup::analyzeActorIsolation(
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Concurrent:
   case ActorIsolation::ConcurrentUnsafe:
-  case ActorIsolation::CallerIsolationInheriting:
     return;
   }
 }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -827,8 +827,10 @@ void CompletionLookup::analyzeActorIsolation(
     break;
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
     return;
   }
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2530,12 +2530,12 @@ static CanSILFunctionType getSILFunctionType(
     std::optional<ActorIsolation> actorIsolation;
     if (constant) {
       if (constant->kind == SILDeclRef::Kind::Deallocator) {
-        actorIsolation = ActorIsolation::forNonisolated(false);
+        actorIsolation = ActorIsolation::forConcurrent(false);
       } else if (auto *decl = constant->getAbstractFunctionDecl();
                  decl && decl->getExecutionBehavior().has_value()) {
         switch (*decl->getExecutionBehavior()) {
         case ExecutionKind::Concurrent:
-          actorIsolation = ActorIsolation::forNonisolated(false /*unsafe*/);
+          actorIsolation = ActorIsolation::forConcurrent(false /*unsafe*/);
           break;
         case ExecutionKind::Caller:
           actorIsolation = ActorIsolation::forCallerIsolationInheriting();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1651,8 +1651,7 @@ private:
     // enabled.
     if (TC.Context.LangOpts.hasFeature(
             Feature::NonIsolatedAsyncInheritsIsolationFromContext) &&
-        IsolationInfo &&
-        IsolationInfo->getKind() == ActorIsolation::CallerIsolationInheriting &&
+        IsolationInfo && IsolationInfo->isNonisolated() &&
         extInfoBuilder.isAsync()) {
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);
       auto actorType =
@@ -2538,7 +2537,7 @@ static CanSILFunctionType getSILFunctionType(
           actorIsolation = ActorIsolation::forConcurrent(false /*unsafe*/);
           break;
         case ExecutionKind::Caller:
-          actorIsolation = ActorIsolation::forCallerIsolationInheriting();
+          actorIsolation = ActorIsolation::forNonisolated(false /*unsafe*/);
           break;
         }
       } else {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -735,7 +735,7 @@ static ActorIsolation getActorIsolationForFunction(SILFunction &fn) {
     if (constant.kind == SILDeclRef::Kind::Deallocator) {
       // Deallocating destructor is always nonisolated. Isolation of the deinit
       // applies only to isolated deallocator and destroyer.
-      return ActorIsolation::forNonisolated(false);
+      return ActorIsolation::forConcurrent(false);
     }
 
     // If we have actor isolation for our constant, put the isolation onto the

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3104,8 +3104,10 @@ done:
 
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
-      case ActorIsolation::CallerIsolationInheriting:
       case ActorIsolation::NonisolatedUnsafe:
+      case ActorIsolation::Concurrent:
+      case ActorIsolation::ConcurrentUnsafe:
+      case ActorIsolation::CallerIsolationInheriting:
         llvm_unreachable("Not isolated");
       }
 
@@ -5832,8 +5834,10 @@ RValue SILGenFunction::emitApply(
 
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
-    case ActorIsolation::CallerIsolationInheriting:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::Concurrent:
+    case ActorIsolation::ConcurrentUnsafe:
+    case ActorIsolation::CallerIsolationInheriting:
       llvm_unreachable("Not isolated");
       break;
     }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3107,7 +3107,6 @@ done:
       case ActorIsolation::NonisolatedUnsafe:
       case ActorIsolation::Concurrent:
       case ActorIsolation::ConcurrentUnsafe:
-      case ActorIsolation::CallerIsolationInheriting:
         llvm_unreachable("Not isolated");
       }
 
@@ -5837,7 +5836,6 @@ RValue SILGenFunction::emitApply(
     case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::Concurrent:
     case ActorIsolation::ConcurrentUnsafe:
-    case ActorIsolation::CallerIsolationInheriting:
       llvm_unreachable("Not isolated");
       break;
     }

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -106,6 +106,8 @@ void SILGenFunction::emitExpectedExecutorProlog() {
           // the instance properties of the class.
           return false;
 
+        case ActorIsolation::Concurrent:
+        case ActorIsolation::ConcurrentUnsafe:
         case ActorIsolation::Nonisolated:
         case ActorIsolation::NonisolatedUnsafe:
         case ActorIsolation::Unspecified:
@@ -165,6 +167,8 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::Concurrent:
+    case ActorIsolation::ConcurrentUnsafe:
       break;
 
     case ActorIsolation::Erased:
@@ -205,8 +209,10 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
-    case ActorIsolation::CallerIsolationInheriting:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::Concurrent:
+    case ActorIsolation::ConcurrentUnsafe:
+    case ActorIsolation::CallerIsolationInheriting:
       break;
 
     case ActorIsolation::Erased:
@@ -633,8 +639,10 @@ SILGenFunction::emitClosureIsolation(SILLocation loc, SILDeclRef constant,
   switch (isolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
     return emitNonIsolatedIsolation(loc);
 
   case ActorIsolation::Erased:
@@ -685,8 +693,10 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
   switch (isolation.getKind()) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
     return std::nullopt;
 
   case ActorIsolation::Erased:
@@ -716,6 +726,8 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
       });
   if (isolation != ActorIsolation::Nonisolated &&
       isolation != ActorIsolation::NonisolatedUnsafe &&
+      isolation != ActorIsolation::Concurrent &&
+      isolation != ActorIsolation::ConcurrentUnsafe &&
       isolation != ActorIsolation::Unspecified) {
     // TODO: Explicit hop with no hop-back should only be allowed in nonisolated
     // async functions. But it needs work for any closure passed to

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -603,6 +603,8 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
   case ActorIsolation::GlobalActor:
   case ActorIsolation::CallerIsolationInheriting:
     return false;
@@ -1558,6 +1560,8 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
+    case ActorIsolation::Concurrent:
+    case ActorIsolation::ConcurrentUnsafe:
     case ActorIsolation::CallerIsolationInheriting:
       break;
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -606,7 +606,6 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   case ActorIsolation::Concurrent:
   case ActorIsolation::ConcurrentUnsafe:
   case ActorIsolation::GlobalActor:
-  case ActorIsolation::CallerIsolationInheriting:
     return false;
   }
 }
@@ -1562,7 +1561,6 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::Concurrent:
     case ActorIsolation::ConcurrentUnsafe:
-    case ActorIsolation::CallerIsolationInheriting:
       break;
 
     case ActorIsolation::Erased:

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1097,8 +1097,10 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
         switch (actorIsolation) {
         case ActorIsolation::Unspecified:
         case ActorIsolation::Nonisolated:
-        case ActorIsolation::CallerIsolationInheriting:
         case ActorIsolation::NonisolatedUnsafe:
+        case ActorIsolation::Concurrent:
+        case ActorIsolation::ConcurrentUnsafe:
+        case ActorIsolation::CallerIsolationInheriting:
         case ActorIsolation::ActorInstance:
           break;
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1100,7 +1100,6 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
         case ActorIsolation::NonisolatedUnsafe:
         case ActorIsolation::Concurrent:
         case ActorIsolation::ConcurrentUnsafe:
-        case ActorIsolation::CallerIsolationInheriting:
         case ActorIsolation::ActorInstance:
           break;
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2430,7 +2430,7 @@ public:
         // locations (which is how we grab our AST information).
         !(applyExpr && applyExpr->getIsolationCrossing()
                            ->getCalleeIsolation()
-                           .isNonisolated());
+                           .isConcurrent());
 
     for (auto result : applyResults) {
       if (auto value = tryToTrackValue(result)) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1070,7 +1070,6 @@ void LifetimeChecker::injectActorHops() {
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Concurrent:
   case ActorIsolation::ConcurrentUnsafe:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::GlobalActor:
     return;
   }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1067,8 +1067,10 @@ void LifetimeChecker::injectActorHops() {
 
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::GlobalActor:
     return;
   }

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -12,18 +12,17 @@
 
 #define DEBUG_TYPE "flow-isolation"
 
-#include "llvm/Support/WithColor.h"
-#include "swift/AST/Expr.h"
-#include "swift/AST/ActorIsolation.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/Expr.h"
 #include "swift/Basic/Assertions.h"
-#include "swift/Sema/Concurrency.h"
 #include "swift/SIL/ApplySite.h"
-#include "swift/SIL/BitDataflow.h"
 #include "swift/SIL/BasicBlockBits.h"
-#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/BitDataflow.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/Sema/Concurrency.h"
+#include "llvm/Support/WithColor.h"
 
 using namespace swift;
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -96,7 +96,7 @@ public:
       if (auto *mri = dyn_cast<MemberRefExpr>(expr)) {
         if (mri->hasDecl()) {
           auto isolation = swift::getActorIsolation(mri->getDecl().getDecl());
-          if (isolation.isConcurrentUnsafe())
+          if (isolation.isUnsafe())
             return true;
         }
       }
@@ -485,16 +485,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     if (nomDecl->isAnyActor())
       return SILIsolationInfo::getActorInstanceIsolated(rei, rei->getOperand(),
                                                         nomDecl)
-          .withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
+          .withUnsafeNonIsolated(varIsolation.isUnsafe());
 
     if (auto isolation = swift::getActorIsolation(nomDecl)) {
       assert(isolation.isGlobalActor());
       return SILIsolationInfo::getGlobalActorIsolated(
                  rei, isolation.getGlobalActor())
-          .withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
+          .withUnsafeNonIsolated(varIsolation.isUnsafe());
     }
 
-    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isUnsafe());
   }
 
   // Check if we have a global_addr inst.
@@ -507,7 +507,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               ga, isolation.getGlobalActor());
         }
 
-        if (isolation.isConcurrentUnsafe()) {
+        if (isolation.isUnsafe()) {
           return SILIsolationInfo::getDisconnected(
               true /*is nonisolated(unsafe)*/);
         }
@@ -544,7 +544,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       }
 
       // Then check if we have something that is nonisolated unsafe.
-      if (isolation.isConcurrentUnsafe()) {
+      if (isolation.isUnsafe()) {
         // First check if our function_ref is a method of a global actor
         // isolated type. In such a case, we create a global actor isolated
         // nonisolated(unsafe) so that if we assign the value to another
@@ -623,7 +623,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             // Check if we have a global actor and handle it appropriately.
             if (isolation.getKind() == ActorIsolation::GlobalActor) {
               bool localNonIsolatedUnsafe =
-                  isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
+                  isNonIsolatedUnsafe | isolation.isUnsafe();
               return SILIsolationInfo::getGlobalActorIsolated(
                          cmi, isolation.getGlobalActor())
                   .withUnsafeNonIsolated(localNonIsolatedUnsafe);
@@ -633,7 +633,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             if (isolation.getKind() != ActorIsolation::ActorInstance &&
                 isolation.isActorInstanceForSelfParameter()) {
               bool localNonIsolatedUnsafe =
-                  isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
+                  isNonIsolatedUnsafe | isolation.isUnsafe();
               return SILIsolationInfo::getActorInstanceIsolated(
                          cmi, cmi->getOperand(),
                          cmi->getOperand()
@@ -650,7 +650,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               // Check if we have a global actor and handle it appropriately.
               if (isolation.getKind() == ActorIsolation::GlobalActor) {
                 bool localNonIsolatedUnsafe =
-                    isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
+                    isNonIsolatedUnsafe | isolation.isUnsafe();
                 return SILIsolationInfo::getGlobalActorIsolated(
                            cmi, isolation.getGlobalActor())
                     .withUnsafeNonIsolated(localNonIsolatedUnsafe);
@@ -660,7 +660,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               if (isolation.getKind() != ActorIsolation::ActorInstance &&
                   isolation.isActorInstanceForSelfParameter()) {
                 bool localNonIsolatedUnsafe =
-                    isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
+                    isNonIsolatedUnsafe | isolation.isUnsafe();
                 return SILIsolationInfo::getActorInstanceIsolated(
                            cmi, cmi->getOperand(),
                            cmi->getOperand()
@@ -683,16 +683,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     auto varIsolation = swift::getActorIsolation(sei->getField());
     if (auto isolation =
             SILIsolationInfo::getGlobalActorIsolated(sei, sei->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
-    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
+      return isolation.withUnsafeNonIsolated(varIsolation.isUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isUnsafe());
   }
 
   if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
     auto varIsolation = swift::getActorIsolation(seai->getField());
     if (auto isolation = SILIsolationInfo::getGlobalActorIsolated(
             seai, seai->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
-    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
+      return isolation.withUnsafeNonIsolated(varIsolation.isUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isUnsafe());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -96,7 +96,7 @@ public:
       if (auto *mri = dyn_cast<MemberRefExpr>(expr)) {
         if (mri->hasDecl()) {
           auto isolation = swift::getActorIsolation(mri->getDecl().getDecl());
-          if (isolation.isNonisolatedUnsafe())
+          if (isolation.isConcurrentUnsafe())
             return true;
         }
       }
@@ -485,17 +485,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     if (nomDecl->isAnyActor())
       return SILIsolationInfo::getActorInstanceIsolated(rei, rei->getOperand(),
                                                         nomDecl)
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+          .withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
 
     if (auto isolation = swift::getActorIsolation(nomDecl)) {
       assert(isolation.isGlobalActor());
       return SILIsolationInfo::getGlobalActorIsolated(
                  rei, isolation.getGlobalActor())
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+          .withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
     }
 
-    return SILIsolationInfo::getDisconnected(
-        varIsolation.isNonisolatedUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
   }
 
   // Check if we have a global_addr inst.
@@ -508,7 +507,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               ga, isolation.getGlobalActor());
         }
 
-        if (isolation.isNonisolatedUnsafe()) {
+        if (isolation.isConcurrentUnsafe()) {
           return SILIsolationInfo::getDisconnected(
               true /*is nonisolated(unsafe)*/);
         }
@@ -545,7 +544,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       }
 
       // Then check if we have something that is nonisolated unsafe.
-      if (isolation.isNonisolatedUnsafe()) {
+      if (isolation.isConcurrentUnsafe()) {
         // First check if our function_ref is a method of a global actor
         // isolated type. In such a case, we create a global actor isolated
         // nonisolated(unsafe) so that if we assign the value to another
@@ -624,7 +623,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             // Check if we have a global actor and handle it appropriately.
             if (isolation.getKind() == ActorIsolation::GlobalActor) {
               bool localNonIsolatedUnsafe =
-                  isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+                  isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
               return SILIsolationInfo::getGlobalActorIsolated(
                          cmi, isolation.getGlobalActor())
                   .withUnsafeNonIsolated(localNonIsolatedUnsafe);
@@ -634,7 +633,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             if (isolation.getKind() != ActorIsolation::ActorInstance &&
                 isolation.isActorInstanceForSelfParameter()) {
               bool localNonIsolatedUnsafe =
-                  isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+                  isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
               return SILIsolationInfo::getActorInstanceIsolated(
                          cmi, cmi->getOperand(),
                          cmi->getOperand()
@@ -651,7 +650,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               // Check if we have a global actor and handle it appropriately.
               if (isolation.getKind() == ActorIsolation::GlobalActor) {
                 bool localNonIsolatedUnsafe =
-                    isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+                    isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
                 return SILIsolationInfo::getGlobalActorIsolated(
                            cmi, isolation.getGlobalActor())
                     .withUnsafeNonIsolated(localNonIsolatedUnsafe);
@@ -661,7 +660,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               if (isolation.getKind() != ActorIsolation::ActorInstance &&
                   isolation.isActorInstanceForSelfParameter()) {
                 bool localNonIsolatedUnsafe =
-                    isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+                    isNonIsolatedUnsafe | isolation.isConcurrentUnsafe();
                 return SILIsolationInfo::getActorInstanceIsolated(
                            cmi, cmi->getOperand(),
                            cmi->getOperand()
@@ -684,20 +683,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     auto varIsolation = swift::getActorIsolation(sei->getField());
     if (auto isolation =
             SILIsolationInfo::getGlobalActorIsolated(sei, sei->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(
-          varIsolation.isNonisolatedUnsafe());
-    return SILIsolationInfo::getDisconnected(
-        varIsolation.isNonisolatedUnsafe());
+      return isolation.withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
   }
 
   if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
     auto varIsolation = swift::getActorIsolation(seai->getField());
     if (auto isolation = SILIsolationInfo::getGlobalActorIsolated(
             seai, seai->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(
-          varIsolation.isNonisolatedUnsafe());
-    return SILIsolationInfo::getDisconnected(
-        varIsolation.isNonisolatedUnsafe());
+      return isolation.withUnsafeNonIsolated(varIsolation.isConcurrentUnsafe());
+    return SILIsolationInfo::getDisconnected(varIsolation.isConcurrentUnsafe());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.
@@ -775,7 +770,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     if (asi->isFromVarDecl()) {
       if (auto *varDecl = asi->getLoc().getAsASTNode<VarDecl>()) {
         auto isolation = swift::getActorIsolation(varDecl);
-        if (isolation.getKind() == ActorIsolation::NonisolatedUnsafe) {
+        if (isolation.isUnsafe()) {
           return SILIsolationInfo::getDisconnected(
               true /*is nonisolated(unsafe)*/);
         }
@@ -795,7 +790,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
         if (auto *dbg = dyn_cast<DebugValueInst>(debugInfo->getUser())) {
           if (auto *varDecl = dbg->getLoc().getAsASTNode<VarDecl>()) {
             auto isolation = swift::getActorIsolation(varDecl);
-            if (isolation.getKind() == ActorIsolation::NonisolatedUnsafe) {
+            if (isolation.isUnsafe()) {
               return SILIsolationInfo::getDisconnected(
                   true /*is nonisolated(unsafe)*/);
             }
@@ -816,7 +811,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   // caused by the actor instances not matching.
   if (ApplyExpr *apply = inst->getLoc().getAsASTNode<ApplyExpr>()) {
     if (auto crossing = apply->getIsolationCrossing()) {
-      if (crossing->getCalleeIsolation().isNonisolated()) {
+      if (crossing->getCalleeIsolation().isConcurrent()) {
         return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5111,7 +5111,6 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       case ActorIsolation::NonisolatedUnsafe:
       case ActorIsolation::Concurrent:
       case ActorIsolation::ConcurrentUnsafe:
-      case ActorIsolation::CallerIsolationInheriting:
         break;
 
       case ActorIsolation::Erased:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5108,8 +5108,10 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       switch (getActorIsolation(storage)) {
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
-      case ActorIsolation::CallerIsolationInheriting:
       case ActorIsolation::NonisolatedUnsafe:
+      case ActorIsolation::Concurrent:
+      case ActorIsolation::ConcurrentUnsafe:
+      case ActorIsolation::CallerIsolationInheriting:
         break;
 
       case ActorIsolation::Erased:

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -505,8 +505,10 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     llvm_unreachable("decl cannot have dynamic isolation");
 
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::Unspecified:
     return false;
   }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -508,7 +508,6 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Concurrent:
   case ActorIsolation::ConcurrentUnsafe:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::Unspecified:
     return false;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -104,7 +104,6 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Concurrent:
   case ActorIsolation::ConcurrentUnsafe:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -101,8 +101,10 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
 
   case ActorIsolation::GlobalActor:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Concurrent:
+  case ActorIsolation::ConcurrentUnsafe:
+  case ActorIsolation::CallerIsolationInheriting:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -164,7 +164,7 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
 static bool isReferenceToNonisolatedUnsafe(ValueDecl *decl) {
   auto isolation = getActorIsolationForReference(
       decl, decl->getDeclContext());
-  if (!isolation.isNonisolated())
+  if (!isolation.isConcurrent())
     return false;
 
   auto attr = decl->getAttrs().getAttribute<NonisolatedAttr>();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -495,7 +495,6 @@ getActualActorIsolationKind(uint8_t raw) {
   CASE(NonisolatedUnsafe)
   CASE(Concurrent)
   CASE(ConcurrentUnsafe)
-  CASE(CallerIsolationInheriting)
   CASE(GlobalActor)
   CASE(Erased)
 #undef CASE
@@ -4073,15 +4072,19 @@ public:
       ActorIsolation isolation;
       switch (isoKind) {
       case ActorIsolation::Unspecified:
-      case ActorIsolation::Nonisolated:
-      case ActorIsolation::NonisolatedUnsafe:
-      case ActorIsolation::Concurrent:
-      case ActorIsolation::ConcurrentUnsafe:
         isolation = ActorIsolation::forUnspecified();
         break;
-
-      case ActorIsolation::CallerIsolationInheriting:
-        isolation = ActorIsolation::forCallerIsolationInheriting();
+      case ActorIsolation::Concurrent:
+        isolation = ActorIsolation::forConcurrent(false);
+        break;
+      case ActorIsolation::ConcurrentUnsafe:
+        isolation = ActorIsolation::forConcurrent(true);
+        break;
+      case ActorIsolation::Nonisolated:
+        isolation = ActorIsolation::forNonisolated(false);
+        break;
+      case ActorIsolation::NonisolatedUnsafe:
+        isolation = ActorIsolation::forNonisolated(true);
         break;
 
       case ActorIsolation::Erased:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -492,8 +492,10 @@ getActualActorIsolationKind(uint8_t raw) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
-  CASE(CallerIsolationInheriting)
   CASE(NonisolatedUnsafe)
+  CASE(Concurrent)
+  CASE(ConcurrentUnsafe)
+  CASE(CallerIsolationInheriting)
   CASE(GlobalActor)
   CASE(Erased)
 #undef CASE
@@ -4073,6 +4075,8 @@ public:
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
       case ActorIsolation::NonisolatedUnsafe:
+      case ActorIsolation::Concurrent:
+      case ActorIsolation::ConcurrentUnsafe:
         isolation = ActorIsolation::forUnspecified();
         break;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -564,7 +564,6 @@ enum class ActorIsolation : uint8_t {
   GlobalActor,
   GlobalActorUnsafe,
   Erased,
-  CallerIsolationInheriting,
   Concurrent,
   ConcurrentUnsafe,
 };

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 917; // ossa serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 918; // concurrent
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -565,6 +565,8 @@ enum class ActorIsolation : uint8_t {
   GlobalActorUnsafe,
   Erased,
   CallerIsolationInheriting,
+  Concurrent,
+  ConcurrentUnsafe,
 };
 using ActorIsolationField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1554,7 +1554,6 @@ getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
   CASE(NonisolatedUnsafe)
   CASE(Concurrent)
   CASE(ConcurrentUnsafe)
-  CASE(CallerIsolationInheriting)
   CASE(GlobalActor)
   CASE(Erased)
 #undef CASE

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1551,8 +1551,10 @@ getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
-  CASE(CallerIsolationInheriting)
   CASE(NonisolatedUnsafe)
+  CASE(Concurrent)
+  CASE(ConcurrentUnsafe)
+  CASE(CallerIsolationInheriting)
   CASE(GlobalActor)
   CASE(Erased)
 #undef CASE

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -10,22 +10,22 @@
 class Klass {
   // Implicit deinit
   // CHECK: // Klass.deinit
-  // CHECK-NEXT: // Isolation: unspecified
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject {
 
   // Implicit deallocating deinit
   // CHECK: // Klass.__deallocating_deinit
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfD : $@convention(method) (@owned Klass) -> () {
 
   // Implicit allocating init
   // CHECK: // Klass.__allocating_init()
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [exact_self_class] [ossa] @$s16assume_mainactor5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass {
 
   // Implicit designated init
   // CHECK: // Klass.init()
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass {
 }
 
@@ -44,7 +44,7 @@ struct StructContainingKlass {
   var k = Klass()
 
   // CHECK: // StructContainingKlass.init()
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor21StructContainingKlassVACycfC : $@convention(method) (@thin StructContainingKlass.Type) -> @owned StructContainingKlass {
 }
 
@@ -64,7 +64,7 @@ struct NonIsolatedStructContainingKlass {
   var k = Klass()
 
   // CHECK: // NonIsolatedStructContainingKlass.init()
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor32NonIsolatedStructContainingKlassVACycfC : $@convention(method) (@thin NonIsolatedStructContainingKlass.Type) -> @owned NonIsolatedStructContainingKlass {
 }
 
@@ -79,7 +79,7 @@ actor CustomActor {
 func unspecifiedAsync<T>(_ t: T) async {}
 
 // CHECK: // nonisolatedAsync<A>(_:)
-// CHECK-NEXT: // Isolation: nonisolated
+// CHECK-NEXT: // Isolation: concurrent
 // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor16nonisolatedAsyncyyxYalF : $@convention(thin) @async <T> (@in_guaranteed T) -> () {
 nonisolated func nonisolatedAsync<T>(_ t: T) async {}
 
@@ -152,7 +152,7 @@ func unspecifiedFunctionTest3() async {
 }
 
 // CHECK: // nonisolatedFunctionTest()
-// CHECK-NEXT: // Isolation: nonisolated
+// CHECK-NEXT: // Isolation: concurrent
 // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor23nonisolatedFunctionTestyyYaF : $@convention(thin) @async () -> () {
 nonisolated func nonisolatedFunctionTest() async {
   let k = NonIsolatedStructContainingKlass()
@@ -189,12 +189,12 @@ actor MyActor {
 
   // Implicit deinit
   // CHECK: // MyActor.deinit
-  // CHECK-NEXT: // Isolation: unspecified
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorCfd : $@convention(method) (@guaranteed MyActor) -> @owned Builtin.NativeObject {
 
   // Non-async init should be nonisolated
   // CHECK: // MyActor.init()
-  // CHECK-NEXT: // Isolation: nonisolated
+  // CHECK-NEXT: // Isolation: concurrent
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorCACycfc : $@convention(method) (@owned MyActor) -> @owned MyActor {
 }
 

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -10,7 +10,7 @@
 class Klass {
   // Implicit deinit
   // CHECK: // Klass.deinit
-  // CHECK-NEXT: // Isolation: concurrent
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject {
 
   // Implicit deallocating deinit
@@ -189,7 +189,7 @@ actor MyActor {
 
   // Implicit deinit
   // CHECK: // MyActor.deinit
-  // CHECK-NEXT: // Isolation: concurrent
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor7MyActorCfd : $@convention(method) (@guaranteed MyActor) -> @owned Builtin.NativeObject {
 
   // Non-async init should be nonisolated

--- a/test/Concurrency/attr_execution.swift
+++ b/test/Concurrency/attr_execution.swift
@@ -5,7 +5,7 @@
 
 
 // CHECK-LABEL: // concurrentTest()
-// CHECK: // Isolation: nonisolated
+// CHECK: // Isolation: concurrent
 // CHECK: sil hidden [ossa] @$s14attr_execution14concurrentTestyyYaF : $@convention(thin) @async () -> () {
 @execution(concurrent)
 func concurrentTest() async {}

--- a/test/Concurrency/attr_execution.swift
+++ b/test/Concurrency/attr_execution.swift
@@ -11,7 +11,7 @@
 func concurrentTest() async {}
 
 // CHECK-LABEL: // callerTest()
-// CHECK: // Isolation: caller_isolation_inheriting
+// CHECK: // Isolation: nonisolated
 // CHECK: sil hidden [ossa] @$s14attr_execution10callerTestyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 @execution(caller)
 func callerTest() async {}

--- a/test/Concurrency/deinit_isolation.swift
+++ b/test/Concurrency/deinit_isolation.swift
@@ -27,7 +27,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: BaseWithNonisolatedDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation25BaseWithNonisolatedDeinitCfZ
 // CHECK-SYMB: // BaseWithNonisolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation25BaseWithNonisolatedDeinitCfD : $@convention(method) (@owned BaseWithNonisolatedDeinit) -> () {
 class BaseWithNonisolatedDeinit {}
 
@@ -38,7 +38,7 @@ class BaseWithNonisolatedDeinit {}
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation34BaseWithDeinitIsolatedOnFirstActorCfZ : $@convention(thin) (@owned BaseWithDeinitIsolatedOnFirstActor) -> () {
 // CHECK-SYMB: BaseWithDeinitIsolatedOnFirstActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation34BaseWithDeinitIsolatedOnFirstActorCfD : $@convention(method) (@owned BaseWithDeinitIsolatedOnFirstActor) -> () {
 class BaseWithDeinitIsolatedOnFirstActor {
     @FirstActor deinit {} // expected-note 3{{overridden declaration is here}}
@@ -57,7 +57,7 @@ class BaseIsolatedOnSecondActor {}
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation35BaseWithDeinitIsolatedOnSecondActorCfZ : $@convention(thin) (@owned BaseWithDeinitIsolatedOnSecondActor) -> () {
 // CHECK-SYMB: BaseWithDeinitIsolatedOnSecondActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation35BaseWithDeinitIsolatedOnSecondActorCfD : $@convention(method) (@owned BaseWithDeinitIsolatedOnSecondActor) -> () {
 class BaseWithDeinitIsolatedOnSecondActor {
     @SecondActor deinit {} // expected-note 3{{overridden declaration is here}}
@@ -71,7 +71,7 @@ class BaseWithDeinitIsolatedOnSecondActor {
 // CHECK-SYMB-NOT: ImplicitDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation19ImplicitDeinitActorCfZ
 // CHECK-SYMB: // ImplicitDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation19ImplicitDeinitActorCfD : $@convention(method) (@owned ImplicitDeinitActor) -> () {
 actor ImplicitDeinitActor {
     // nonisolated deinit
@@ -83,7 +83,7 @@ actor ImplicitDeinitActor {
 // CHECK-SYMB-NOT: DefaultDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation18DefaultDeinitActorCfZ
 // CHECK-SYMB: // DefaultDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation18DefaultDeinitActorCfD : $@convention(method) (@owned DefaultDeinitActor) -> () {
 actor DefaultDeinitActor {
     // self-isolated deinit
@@ -101,7 +101,7 @@ actor DefaultDeinitActor {
 // CHECK-SYMB-NEXT: // Isolation: actor_instance. name: 'self'
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation21PropagatedDeinitActorCfZ : $@convention(thin) (@owned PropagatedDeinitActor) -> () {
 // CHECK-SYMB: // PropagatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation21PropagatedDeinitActorCfD : $@convention(method) (@owned PropagatedDeinitActor) -> () {
 actor PropagatedDeinitActor {
     // self-isolated deinit
@@ -118,7 +118,7 @@ actor PropagatedDeinitActor {
 // CHECK-SYMB-NOT: NonisolatedDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation22NonisolatedDeinitActorCfZ
 // CHECK-SYMB: // NonisolatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation22NonisolatedDeinitActorCfD : $@convention(method) (@owned NonisolatedDeinitActor) -> () {
 actor NonisolatedDeinitActor {
     // nonisolated deinit
@@ -136,7 +136,7 @@ actor NonisolatedDeinitActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation19IsolatedDeinitActorCfZ : $@convention(thin) (@owned IsolatedDeinitActor) -> () {
 // CHECK-SYMB: // IsolatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation19IsolatedDeinitActorCfD : $@convention(method) (@owned IsolatedDeinitActor) -> () {
 actor IsolatedDeinitActor {
     // FirstActor-isolated deinit
@@ -154,7 +154,7 @@ actor IsolatedDeinitActor {
 // CHECK-SYMB-NOT: ImplicitDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation14ImplicitDeinitCfZ
 // CHECK-SYMB: // ImplicitDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation14ImplicitDeinitCfD : $@convention(method) (@owned ImplicitDeinit) -> () {
 @FirstActor
 class ImplicitDeinit {
@@ -167,7 +167,7 @@ class ImplicitDeinit {
 // CHECK-SYMB-NOT: DefaultDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation13DefaultDeinitCfZ
 // CHECK-SYMB: // DefaultDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation13DefaultDeinitCfD : $@convention(method) (@owned DefaultDeinit) -> () {
 @FirstActor
 class DefaultDeinit {
@@ -185,7 +185,7 @@ class DefaultDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation16PropagatedDeinitCfZ : $@convention(thin) (@owned PropagatedDeinit) -> () {
 // CHECK-SYMB: // PropagatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation16PropagatedDeinitCfD : $@convention(method) (@owned PropagatedDeinit) -> () {
 @FirstActor
 class PropagatedDeinit {
@@ -207,7 +207,7 @@ class BadPropagatedDeinit {
 // CHECK-SYMB-NOT: NonisolatedDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation17NonisolatedDeinitCfZ
 // CHECK-SYMB: // NonisolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation17NonisolatedDeinitCfD : $@convention(method) (@owned NonisolatedDeinit) -> () {
 @FirstActor
 class NonisolatedDeinit {
@@ -226,7 +226,7 @@ class NonisolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation14IsolatedDeinitCfZ : $@convention(thin) (@owned IsolatedDeinit) -> () {
 // CHECK-SYMB: // IsolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation14IsolatedDeinitCfD : $@convention(method) (@owned IsolatedDeinit) -> () {
 class IsolatedDeinit {
     // FirstActor-isolated deinit
@@ -242,7 +242,7 @@ class IsolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation23DifferentIsolatedDeinitCfZ : $@convention(thin) (@owned DifferentIsolatedDeinit) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation23DifferentIsolatedDeinitCfD : $@convention(method) (@owned DifferentIsolatedDeinit) -> () {
 @FirstActor
 class DifferentIsolatedDeinit {
@@ -262,7 +262,7 @@ class DifferentIsolatedDeinit {
 // CHECK-SYMB-NOT: ImplicitDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation32ImplicitDeinitInheritNonisolatedCfZ
 // CHECK-SYMB: // ImplicitDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation32ImplicitDeinitInheritNonisolatedCfD : $@convention(method) (@owned ImplicitDeinitInheritNonisolated) -> () {
 @FirstActor
 class ImplicitDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -275,7 +275,7 @@ class ImplicitDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NOT: // DefaultDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: sil hidden [ossa] @$s16deinit_isolation31DefaultDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned DefaultDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // DefaultDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation31DefaultDeinitInheritNonisolatedCfD : $@convention(method) (@owned DefaultDeinitInheritNonisolated) -> () {
 @FirstActor
 class DefaultDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -300,7 +300,7 @@ class BadPropagatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation34PropagatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned PropagatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // PropagatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation34PropagatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned PropagatedDeinitInheritNonisolated) -> () {
 @FirstActor
 class PropagatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -316,7 +316,7 @@ class PropagatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NOT: NonisolatedDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s16deinit_isolation024NonisolatedDeinitInheritC0CfZ
 // CHECK-SYMB: // NonisolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation024NonisolatedDeinitInheritC0CfD : $@convention(method) (@owned NonisolatedDeinitInheritNonisolated) -> () {
 @FirstActor
 class NonisolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -335,7 +335,7 @@ class NonisolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation32IsolatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned IsolatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // IsolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation32IsolatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned IsolatedDeinitInheritNonisolated) -> () {
 class IsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // FirstActor-isolated deinit
@@ -351,7 +351,7 @@ class IsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation41DifferentIsolatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned DifferentIsolatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation41DifferentIsolatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned DifferentIsolatedDeinitInheritNonisolated) -> () {
 @FirstActor
 class DifferentIsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -372,7 +372,7 @@ class DifferentIsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation30ImplicitDeinitInheritIsolated1CfZ : $@convention(thin) (@owned ImplicitDeinitInheritIsolated1) -> () {
 // CHECK-SYMB: // ImplicitDeinitInheritIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation30ImplicitDeinitInheritIsolated1CfD : $@convention(method) (@owned ImplicitDeinitInheritIsolated1) -> () {
 @FirstActor
 class ImplicitDeinitInheritIsolated1: BaseWithDeinitIsolatedOnFirstActor {
@@ -404,7 +404,7 @@ class BadPropagatedDeinitIsolated: BaseWithDeinitIsolatedOnFirstActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation29GoodPropagatedDeinitIsolated1CfZ : $@convention(thin) (@owned GoodPropagatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // GoodPropagatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation29GoodPropagatedDeinitIsolated1CfD : $@convention(method) (@owned GoodPropagatedDeinitIsolated1) -> () {
 class GoodPropagatedDeinitIsolated1: BaseIsolatedOnFirstActor {
     isolated deinit {
@@ -419,7 +419,7 @@ class GoodPropagatedDeinitIsolated1: BaseIsolatedOnFirstActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation25PropagatedDeinitIsolated1CfZ : $@convention(thin) (@owned PropagatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // PropagatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa]  @$s16deinit_isolation25PropagatedDeinitIsolated1CfD : $@convention(method) (@owned PropagatedDeinitIsolated1) -> () {
 @FirstActor
 class PropagatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
@@ -446,7 +446,7 @@ class NonisolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation23IsolatedDeinitIsolated1CfZ : $@convention(thin) (@owned IsolatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // IsolatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation23IsolatedDeinitIsolated1CfD : $@convention(method) (@owned IsolatedDeinitIsolated1) -> () {
 class IsolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // FirstActor-isolated deinit
@@ -474,7 +474,7 @@ class DifferentIsolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation30ImplicitDeinitInheritIsolated2CfZ : $@convention(thin) (@owned ImplicitDeinitInheritIsolated2) -> () {
 // CHECK-SYMB: // ImplicitDeinitInheritIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation30ImplicitDeinitInheritIsolated2CfD : $@convention(method) (@owned ImplicitDeinitInheritIsolated2) -> () {
 @FirstActor
 class ImplicitDeinitInheritIsolated2: BaseWithDeinitIsolatedOnSecondActor {
@@ -488,7 +488,7 @@ class ImplicitDeinitInheritIsolated2: BaseWithDeinitIsolatedOnSecondActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation29GoodPropagatedDeinitIsolated2CfZ : $@convention(thin) (@owned GoodPropagatedDeinitIsolated2) -> () {
 // CHECK-SYMB: // GoodPropagatedDeinitIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation29GoodPropagatedDeinitIsolated2CfD : $@convention(method) (@owned GoodPropagatedDeinitIsolated2) -> () {
 class GoodPropagatedDeinitIsolated2: BaseIsolatedOnSecondActor {
     isolated deinit {
@@ -534,7 +534,7 @@ class IsolatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation32DifferentIsolatedDeinitIsolated2CfZ : $@convention(thin) (@owned DifferentIsolatedDeinitIsolated2) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinitIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation32DifferentIsolatedDeinitIsolated2CfD : $@convention(method) (@owned DifferentIsolatedDeinitIsolated2) -> () {
 @FirstActor
 class DifferentIsolatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -35,7 +35,7 @@ func isolatedFunc() {} // expected-note 15{{calls to global function 'isolatedFu
 // CHECK-SYMB-NOT: ProbeImplicit_RoundtripNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test34ProbeImplicit_RoundtripNonisolatedCfZ
 // CHECK-SYMB: // ProbeImplicit_RoundtripNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test34ProbeImplicit_RoundtripNonisolatedCfD : $@convention(method) (@owned ProbeImplicit_RoundtripNonisolated) -> () {
 class ProbeImplicit_RoundtripNonisolated: RoundtripNonisolated {}
 
@@ -45,7 +45,7 @@ class ProbeImplicit_RoundtripNonisolated: RoundtripNonisolated {}
 // CHECK-SYMB-NOT: ProbeDefault_RoundtripNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test33ProbeDefault_RoundtripNonisolatedCfZ
 // CHECK-SYMB: // ProbeDefault_RoundtripNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test33ProbeDefault_RoundtripNonisolatedCfD : $@convention(method) (@owned ProbeDefault_RoundtripNonisolated) -> () {
 class ProbeDefault_RoundtripNonisolated: RoundtripNonisolated {
     deinit {
@@ -70,7 +70,7 @@ class ProbeIsolated_RoundtripNonisolated: RoundtripNonisolated {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: AnotherActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test32ProbeGlobal_RoundtripNonisolatedCfZ : $@convention(thin) (@owned ProbeGlobal_RoundtripNonisolated) -> () {
 // CHECK-SYMB: // ProbeGlobal_RoundtripNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test32ProbeGlobal_RoundtripNonisolatedCfD : $@convention(method) (@owned ProbeGlobal_RoundtripNonisolated) -> () {
 class ProbeGlobal_RoundtripNonisolated: RoundtripNonisolated {
     @AnotherActor deinit {
@@ -90,7 +90,7 @@ class ProbeGlobal_RoundtripNonisolated: RoundtripNonisolated {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test31ProbeImplicit_RoundtripIsolatedCfZ : $@convention(thin) (@owned ProbeImplicit_RoundtripIsolated) -> () {
 // CHECK-SYMB: // ProbeImplicit_RoundtripIsolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test31ProbeImplicit_RoundtripIsolatedCfD : $@convention(method) (@owned ProbeImplicit_RoundtripIsolated) -> () {
 class ProbeImplicit_RoundtripIsolated: RoundtripIsolated {}
 
@@ -115,7 +115,7 @@ class ProbeIsolated_RoundtripIsolated: RoundtripIsolated {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test29ProbeGlobal_RoundtripIsolatedCfZ : $@convention(thin) (@owned ProbeGlobal_RoundtripIsolated) -> () {
 // CHECK-SYMB: // ProbeGlobal_RoundtripIsolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test29ProbeGlobal_RoundtripIsolatedCfD : $@convention(method) (@owned ProbeGlobal_RoundtripIsolated) -> () {
 class ProbeGlobal_RoundtripIsolated: RoundtripIsolated {
 #if !SILGEN
@@ -133,7 +133,7 @@ class ProbeGlobal_RoundtripIsolated: RoundtripIsolated {
 // CHECK-SYMB-NOT: ProbeImplicit_BaseNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test29ProbeImplicit_BaseNonisolatedCfZ
 // CHECK-SYMB: // ProbeImplicit_BaseNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test29ProbeImplicit_BaseNonisolatedCfD : $@convention(method) (@owned ProbeImplicit_BaseNonisolated) -> () {
 class ProbeImplicit_BaseNonisolated: BaseNonisolated {}
 
@@ -143,7 +143,7 @@ class ProbeImplicit_BaseNonisolated: BaseNonisolated {}
 // CHECK-SYMB-NOT: ProbeDefault_BaseNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test28ProbeDefault_BaseNonisolatedCfZ
 // CHECK-SYMB: // ProbeDefault_BaseNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test28ProbeDefault_BaseNonisolatedCfD : $@convention(method) (@owned ProbeDefault_BaseNonisolated) -> () {
 class ProbeDefault_BaseNonisolated: BaseNonisolated {
     deinit {
@@ -168,7 +168,7 @@ class ProbeIsolated_BaseNonisolated: BaseNonisolated {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: AnotherActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test27ProbeGlobal_BaseNonisolatedCfZ : $@convention(thin) (@owned ProbeGlobal_BaseNonisolated) -> () {
 // CHECK-SYMB: // ProbeGlobal_BaseNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test27ProbeGlobal_BaseNonisolatedCfD : $@convention(method) (@owned ProbeGlobal_BaseNonisolated) -> () {
 class ProbeGlobal_BaseNonisolated: BaseNonisolated {
     @AnotherActor deinit {
@@ -186,7 +186,7 @@ class ProbeGlobal_BaseNonisolated: BaseNonisolated {
 // CHECK-SYMB-NOT: ProbeImplicit_DerivedNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test32ProbeImplicit_DerivedNonisolatedCfZ
 // CHECK-SYMB: // ProbeImplicit_DerivedNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test32ProbeImplicit_DerivedNonisolatedCfD : $@convention(method) (@owned ProbeImplicit_DerivedNonisolated) -> () {
 class ProbeImplicit_DerivedNonisolated: DerivedNonisolated {}
 
@@ -196,7 +196,7 @@ class ProbeImplicit_DerivedNonisolated: DerivedNonisolated {}
 // CHECK-SYMB-NOT: ProbeDefault_DerivedNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test31ProbeDefault_DerivedNonisolatedCfZ
 // CHECK-SYMB: // ProbeDefault_DerivedNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test31ProbeDefault_DerivedNonisolatedCfD : $@convention(method) (@owned ProbeDefault_DerivedNonisolated) -> () {
 class ProbeDefault_DerivedNonisolated: DerivedNonisolated {
     deinit {
@@ -221,7 +221,7 @@ class ProbeIsolated_DerivedNonisolated: DerivedNonisolated {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: AnotherActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test30ProbeGlobal_DerivedNonisolatedCfZ : $@convention(thin) (@owned ProbeGlobal_DerivedNonisolated) -> () {
 // CHECK-SYMB: // ProbeGlobal_DerivedNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test30ProbeGlobal_DerivedNonisolatedCfD : $@convention(method) (@owned ProbeGlobal_DerivedNonisolated) -> () {
 class ProbeGlobal_DerivedNonisolated: DerivedNonisolated {
     @AnotherActor deinit {
@@ -239,7 +239,7 @@ class ProbeGlobal_DerivedNonisolated: DerivedNonisolated {
 // CHECK-SYMB-NOT: ProbeImplicit_BaseIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test31ProbeImplicit_BaseIsolatedClassCfZ
 // CHECK-SYMB: // ProbeImplicit_BaseIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test31ProbeImplicit_BaseIsolatedClassCfD : $@convention(method) (@owned ProbeImplicit_BaseIsolatedClass) -> () {
 class ProbeImplicit_BaseIsolatedClass: BaseIsolatedClass {}
 
@@ -249,7 +249,7 @@ class ProbeImplicit_BaseIsolatedClass: BaseIsolatedClass {}
 // CHECK-SYMB-NOT: ProbeDefault_BaseIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test30ProbeDefault_BaseIsolatedClassCfZ
 // CHECK-SYMB: // ProbeDefault_BaseIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test30ProbeDefault_BaseIsolatedClassCfD : $@convention(method) (@owned ProbeDefault_BaseIsolatedClass) -> () {
 class ProbeDefault_BaseIsolatedClass: BaseIsolatedClass {
     deinit {
@@ -266,7 +266,7 @@ class ProbeDefault_BaseIsolatedClass: BaseIsolatedClass {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test018ProbeIsolated_BaseC5ClassCfZ : $@convention(thin) (@owned ProbeIsolated_BaseIsolatedClass) -> () {
 // CHECK-SYMB: // ProbeIsolated_BaseIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test018ProbeIsolated_BaseC5ClassCfD : $@convention(method) (@owned ProbeIsolated_BaseIsolatedClass) -> () {
 class ProbeIsolated_BaseIsolatedClass: BaseIsolatedClass {
     isolated deinit {
@@ -281,7 +281,7 @@ class ProbeIsolated_BaseIsolatedClass: BaseIsolatedClass {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: AnotherActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test29ProbeGlobal_BaseIsolatedClassCfZ : $@convention(thin) (@owned ProbeGlobal_BaseIsolatedClass) -> () {
 // CHECK-SYMB: // ProbeGlobal_BaseIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test29ProbeGlobal_BaseIsolatedClassCfD : $@convention(method) (@owned ProbeGlobal_BaseIsolatedClass) -> () {
 class ProbeGlobal_BaseIsolatedClass: BaseIsolatedClass {
     @AnotherActor deinit {
@@ -299,7 +299,7 @@ class ProbeGlobal_BaseIsolatedClass: BaseIsolatedClass {
 // CHECK-SYMB-NOT: ProbeImplicit_DerivedIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test34ProbeImplicit_DerivedIsolatedClassCfZ
 // CHECK-SYMB: // ProbeImplicit_DerivedIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test34ProbeImplicit_DerivedIsolatedClassCfD : $@convention(method) (@owned ProbeImplicit_DerivedIsolatedClass) -> () {
 class ProbeImplicit_DerivedIsolatedClass: DerivedIsolatedClass {}
 
@@ -309,7 +309,7 @@ class ProbeImplicit_DerivedIsolatedClass: DerivedIsolatedClass {}
 // CHECK-SYMB-NOT: ProbeDefault_DerivedIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test33ProbeDefault_DerivedIsolatedClassCfZ
 // CHECK-SYMB: // ProbeDefault_DerivedIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test33ProbeDefault_DerivedIsolatedClassCfD : $@convention(method) (@owned ProbeDefault_DerivedIsolatedClass) -> () {
 class ProbeDefault_DerivedIsolatedClass: DerivedIsolatedClass {
     deinit {
@@ -326,7 +326,7 @@ class ProbeDefault_DerivedIsolatedClass: DerivedIsolatedClass {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test021ProbeIsolated_DerivedC5ClassCfZ : $@convention(thin) (@owned ProbeIsolated_DerivedIsolatedClass) -> () {
 // CHECK-SYMB: // ProbeIsolated_DerivedIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test021ProbeIsolated_DerivedC5ClassCfD : $@convention(method) (@owned ProbeIsolated_DerivedIsolatedClass) -> () {
 class ProbeIsolated_DerivedIsolatedClass: DerivedIsolatedClass {
     isolated deinit {
@@ -341,7 +341,7 @@ class ProbeIsolated_DerivedIsolatedClass: DerivedIsolatedClass {
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: AnotherActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test32ProbeGlobal_DerivedIsolatedClassCfZ : $@convention(thin) (@owned ProbeGlobal_DerivedIsolatedClass) -> () {
 // CHECK-SYMB: // ProbeGlobal_DerivedIsolatedClass.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test32ProbeGlobal_DerivedIsolatedClassCfD : $@convention(method) (@owned ProbeGlobal_DerivedIsolatedClass) -> () {
 class ProbeGlobal_DerivedIsolatedClass: DerivedIsolatedClass {
     @AnotherActor deinit {
@@ -363,7 +363,7 @@ class ProbeGlobal_DerivedIsolatedClass: DerivedIsolatedClass {
 // CHECK-SYMB-NOT: ProbeImplicit_BaseIsolatedDealloc.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test33ProbeImplicit_BaseIsolatedDeallocCfZ
 // CHECK-SYMB: // ProbeImplicit_BaseIsolatedDealloc.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test33ProbeImplicit_BaseIsolatedDeallocCfD : $@convention(method) (@owned ProbeImplicit_BaseIsolatedDealloc) -> () {
 class ProbeImplicit_BaseIsolatedDealloc: BaseIsolatedDealloc {}
 
@@ -389,7 +389,7 @@ class ProbeIsolated_BaseIsolatedDealloc: BaseIsolatedDealloc {
 // CHECK-SYMB-NOT: ProbeGlobal_BaseIsolatedDealloc.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test31ProbeGlobal_BaseIsolatedDeallocCfZ
 // CHECK-SYMB: // ProbeGlobal_BaseIsolatedDealloc.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test31ProbeGlobal_BaseIsolatedDeallocCfD : $@convention(method) (@owned ProbeGlobal_BaseIsolatedDealloc) -> () {
 class ProbeGlobal_BaseIsolatedDealloc: BaseIsolatedDealloc {
 #if !SILGEN
@@ -408,7 +408,7 @@ class ProbeGlobal_BaseIsolatedDealloc: BaseIsolatedDealloc {
 // CHECK-SYMB-NOT: ProbeImplicit_DerivedIsolatedDealloc.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test36ProbeImplicit_DerivedIsolatedDeallocCfZ
 // CHECK-SYMB: // ProbeImplicit_DerivedIsolatedDealloc.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test36ProbeImplicit_DerivedIsolatedDeallocCfD : $@convention(method) (@owned ProbeImplicit_DerivedIsolatedDealloc) -> () {
 class ProbeImplicit_DerivedIsolatedDealloc: DerivedIsolatedDealloc {}
 
@@ -434,7 +434,7 @@ class ProbeIsolated_DerivedIsolatedDealloc: DerivedIsolatedDealloc {
 // CHECK-SYMB-NOT: ProbeGlobal_DerivedIsolatedDealloc.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test34ProbeGlobal_DerivedIsolatedDeallocCfZ
 // CHECK-SYMB: // ProbeGlobal_DerivedIsolatedDealloc.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test34ProbeGlobal_DerivedIsolatedDeallocCfD : $@convention(method) (@owned ProbeGlobal_DerivedIsolatedDealloc) -> () {
 class ProbeGlobal_DerivedIsolatedDealloc: DerivedIsolatedDealloc {
 #if !SILGEN
@@ -452,7 +452,7 @@ class ProbeGlobal_DerivedIsolatedDealloc: DerivedIsolatedDealloc {
 // CHECK-SYMB-NOT: ProbeImplicit_DeallocIsolatedFromProtocol.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test41ProbeImplicit_DeallocIsolatedFromProtocolCfZ
 // CHECK-SYMB: // ProbeImplicit_DeallocIsolatedFromProtocol.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test41ProbeImplicit_DeallocIsolatedFromProtocolCfD : $@convention(method) (@owned ProbeImplicit_DeallocIsolatedFromProtocol) -> () {
 class ProbeImplicit_DeallocIsolatedFromProtocol: DeallocIsolatedFromProtocol {}
 
@@ -466,7 +466,7 @@ class ProbeGlobal_DeallocIsolatedFromProtocol: DeallocIsolatedFromProtocol {
 // CHECK-SYMB-NOT: ProbeImplicit_DeallocIsolatedFromCategory.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test41ProbeImplicit_DeallocIsolatedFromCategoryCfZ
 // CHECK-SYMB: // ProbeImplicit_DeallocIsolatedFromCategory.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test41ProbeImplicit_DeallocIsolatedFromCategoryCfD : $@convention(method) (@owned ProbeImplicit_DeallocIsolatedFromCategory) -> () {
 class ProbeImplicit_DeallocIsolatedFromCategory: DeallocIsolatedFromCategory {}
 
@@ -480,7 +480,7 @@ class ProbeGlobal_DeallocIsolatedFromCategory: DeallocIsolatedFromCategory {
 // CHECK-SYMB-NOT: ProbeImplicit_DeallocIsolatedFromExtension.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s4test42ProbeImplicit_DeallocIsolatedFromExtensionCfZ
 // CHECK-SYMB: // ProbeImplicit_DeallocIsolatedFromExtension.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test42ProbeImplicit_DeallocIsolatedFromExtensionCfD : $@convention(method) (@owned ProbeImplicit_DeallocIsolatedFromExtension) -> () {
 class ProbeImplicit_DeallocIsolatedFromExtension: DeallocIsolatedFromExtension {}
 

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -27,7 +27,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: BaseWithNonisolatedDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc25BaseWithNonisolatedDeinitCfZ
 // CHECK-SYMB: // BaseWithNonisolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc25BaseWithNonisolatedDeinitCfD : $@convention(method) (@owned BaseWithNonisolatedDeinit) -> () {
 @objc class BaseWithNonisolatedDeinit : NSObject {}
 
@@ -38,7 +38,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc34BaseWithDeinitIsolatedOnFirstActorCfZ : $@convention(thin) (@owned BaseWithDeinitIsolatedOnFirstActor) -> () {
 // CHECK-SYMB: BaseWithDeinitIsolatedOnFirstActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc34BaseWithDeinitIsolatedOnFirstActorCfD : $@convention(method) (@owned BaseWithDeinitIsolatedOnFirstActor) -> () {
 @objc class BaseWithDeinitIsolatedOnFirstActor : NSObject {
     @FirstActor deinit {} // expected-note 3{{overridden declaration is here}}
@@ -57,7 +57,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc35BaseWithDeinitIsolatedOnSecondActorCfZ : $@convention(thin) (@owned BaseWithDeinitIsolatedOnSecondActor) -> () {
 // CHECK-SYMB: BaseWithDeinitIsolatedOnSecondActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc35BaseWithDeinitIsolatedOnSecondActorCfD : $@convention(method) (@owned BaseWithDeinitIsolatedOnSecondActor) -> () {
 @objc class BaseWithDeinitIsolatedOnSecondActor: NSObject {
     @SecondActor deinit {} // expected-note 3{{overridden declaration is here}}
@@ -71,7 +71,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: ImplicitDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc19ImplicitDeinitActorCfZ
 // CHECK-SYMB: // ImplicitDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc19ImplicitDeinitActorCfD : $@convention(method) (@owned ImplicitDeinitActor) -> () {
 @objc actor ImplicitDeinitActor : NSObject {
     // nonisolated deinit
@@ -83,7 +83,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: DefaultDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc18DefaultDeinitActorCfZ
 // CHECK-SYMB: // DefaultDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc18DefaultDeinitActorCfD : $@convention(method) (@owned DefaultDeinitActor) -> () {
 @objc actor DefaultDeinitActor : NSObject {
     // self-isolated deinit
@@ -101,7 +101,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: actor_instance. name: 'self'
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc21PropagatedDeinitActorCfZ : $@convention(thin) (@owned PropagatedDeinitActor) -> () {
 // CHECK-SYMB: // PropagatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc21PropagatedDeinitActorCfD : $@convention(method) (@owned PropagatedDeinitActor) -> () {
 @objc actor PropagatedDeinitActor : NSObject {
     // self-isolated deinit
@@ -118,7 +118,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: NonisolatedDeinitActor.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc22NonisolatedDeinitActorCfZ
 // CHECK-SYMB: // NonisolatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc22NonisolatedDeinitActorCfD : $@convention(method) (@owned NonisolatedDeinitActor) -> () {
 @objc actor NonisolatedDeinitActor : NSObject {
     // nonisolated deinit
@@ -136,7 +136,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc19IsolatedDeinitActorCfZ : $@convention(thin) (@owned IsolatedDeinitActor) -> () {
 // CHECK-SYMB: // IsolatedDeinitActor.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc19IsolatedDeinitActorCfD : $@convention(method) (@owned IsolatedDeinitActor) -> () {
 @objc actor IsolatedDeinitActor : NSObject {
     // FirstActor-isolated deinit
@@ -154,7 +154,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: ImplicitDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc14ImplicitDeinitCfZ
 // CHECK-SYMB: // ImplicitDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc14ImplicitDeinitCfD : $@convention(method) (@owned ImplicitDeinit) -> () {
 @FirstActor
 @objc class ImplicitDeinit : NSObject {
@@ -167,7 +167,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: DefaultDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc13DefaultDeinitCfZ
 // CHECK-SYMB: // DefaultDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc13DefaultDeinitCfD : $@convention(method) (@owned DefaultDeinit) -> () {
 @FirstActor
 @objc class DefaultDeinit: NSObject {
@@ -185,7 +185,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc16PropagatedDeinitCfZ : $@convention(thin) (@owned PropagatedDeinit) -> () {
 // CHECK-SYMB: // PropagatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc16PropagatedDeinitCfD : $@convention(method) (@owned PropagatedDeinit) -> () {
 @FirstActor
 @objc class PropagatedDeinit: NSObject {
@@ -207,7 +207,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: NonisolatedDeinit.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc17NonisolatedDeinitCfZ
 // CHECK-SYMB: // NonisolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc17NonisolatedDeinitCfD : $@convention(method) (@owned NonisolatedDeinit) -> () {
 @FirstActor
 @objc class NonisolatedDeinit : NSObject {
@@ -226,7 +226,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc14IsolatedDeinitCfZ : $@convention(thin) (@owned IsolatedDeinit) -> () {
 // CHECK-SYMB: // IsolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc14IsolatedDeinitCfD : $@convention(method) (@owned IsolatedDeinit) -> () {
 @objc class IsolatedDeinit : NSObject {
     // FirstActor-isolated deinit
@@ -242,7 +242,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc23DifferentIsolatedDeinitCfZ : $@convention(thin) (@owned DifferentIsolatedDeinit) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinit.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc23DifferentIsolatedDeinitCfD : $@convention(method) (@owned DifferentIsolatedDeinit) -> () {
 @FirstActor
 @objc class DifferentIsolatedDeinit : NSObject {
@@ -262,7 +262,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: ImplicitDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc32ImplicitDeinitInheritNonisolatedCfZ
 // CHECK-SYMB: // ImplicitDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc32ImplicitDeinitInheritNonisolatedCfD : $@convention(method) (@owned ImplicitDeinitInheritNonisolated) -> () {
 @FirstActor
 @objc class ImplicitDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -275,7 +275,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: // DefaultDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: sil hidden [ossa] @$s21deinit_isolation_objc31DefaultDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned DefaultDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // DefaultDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc31DefaultDeinitInheritNonisolatedCfD : $@convention(method) (@owned DefaultDeinitInheritNonisolated) -> () {
 @FirstActor
 @objc class DefaultDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -300,7 +300,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc34PropagatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned PropagatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // PropagatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc34PropagatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned PropagatedDeinitInheritNonisolated) -> () {
 @FirstActor
 @objc class PropagatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -316,7 +316,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NOT: NonisolatedDeinitInheritNonisolated.__isolated_deallocating_deinit
 // CHECK-SYMB-NOT: @$s21deinit_isolation_objc024NonisolatedDeinitInheritD0CfZ
 // CHECK-SYMB: // NonisolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc024NonisolatedDeinitInheritD0CfD : $@convention(method) (@owned NonisolatedDeinitInheritNonisolated) -> () {
 @FirstActor
 @objc class NonisolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -335,7 +335,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc32IsolatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned IsolatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // IsolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc32IsolatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned IsolatedDeinitInheritNonisolated) -> () {
 @objc class IsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // FirstActor-isolated deinit
@@ -351,7 +351,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc41DifferentIsolatedDeinitInheritNonisolatedCfZ : $@convention(thin) (@owned DifferentIsolatedDeinitInheritNonisolated) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinitInheritNonisolated.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc41DifferentIsolatedDeinitInheritNonisolatedCfD : $@convention(method) (@owned DifferentIsolatedDeinitInheritNonisolated) -> () {
 @FirstActor
 @objc class DifferentIsolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
@@ -372,7 +372,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc30ImplicitDeinitInheritIsolated1CfZ : $@convention(thin) (@owned ImplicitDeinitInheritIsolated1) -> () {
 // CHECK-SYMB: // ImplicitDeinitInheritIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc30ImplicitDeinitInheritIsolated1CfD : $@convention(method) (@owned ImplicitDeinitInheritIsolated1) -> () {
 @FirstActor
 @objc class ImplicitDeinitInheritIsolated1: BaseWithDeinitIsolatedOnFirstActor {
@@ -402,7 +402,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc29GoodPropagatedDeinitIsolated1CfZ : $@convention(thin) (@owned GoodPropagatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // GoodPropagatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc29GoodPropagatedDeinitIsolated1CfD : $@convention(method) (@owned GoodPropagatedDeinitIsolated1) -> () {
 @objc class GoodPropagatedDeinitIsolated1: BaseIsolatedOnFirstActor {
     isolated deinit {
@@ -417,7 +417,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc25PropagatedDeinitIsolated1CfZ : $@convention(thin) (@owned PropagatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // PropagatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa]  @$s21deinit_isolation_objc25PropagatedDeinitIsolated1CfD : $@convention(method) (@owned PropagatedDeinitIsolated1) -> () {
 @FirstActor
 @objc class PropagatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
@@ -444,7 +444,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: FirstActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc23IsolatedDeinitIsolated1CfZ : $@convention(thin) (@owned IsolatedDeinitIsolated1) -> () {
 // CHECK-SYMB: // IsolatedDeinitIsolated1.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc23IsolatedDeinitIsolated1CfD : $@convention(method) (@owned IsolatedDeinitIsolated1) -> () {
 @objc class IsolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // FirstActor-isolated deinit
@@ -472,7 +472,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc30ImplicitDeinitInheritIsolated2CfZ : $@convention(thin) (@owned ImplicitDeinitInheritIsolated2) -> () {
 // CHECK-SYMB: // ImplicitDeinitInheritIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc30ImplicitDeinitInheritIsolated2CfD : $@convention(method) (@owned ImplicitDeinitInheritIsolated2) -> () {
 @FirstActor
 @objc class ImplicitDeinitInheritIsolated2: BaseWithDeinitIsolatedOnSecondActor {
@@ -486,7 +486,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc29GoodPropagatedDeinitIsolated2CfZ : $@convention(thin) (@owned GoodPropagatedDeinitIsolated2) -> () {
 // CHECK-SYMB: // GoodPropagatedDeinitIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc29GoodPropagatedDeinitIsolated2CfD : $@convention(method) (@owned GoodPropagatedDeinitIsolated2) -> () {
 @objc class GoodPropagatedDeinitIsolated2: BaseIsolatedOnSecondActor {
     isolated deinit {
@@ -532,7 +532,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: SecondActor
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc32DifferentIsolatedDeinitIsolated2CfZ : $@convention(thin) (@owned DifferentIsolatedDeinitIsolated2) -> () {
 // CHECK-SYMB: // DifferentIsolatedDeinitIsolated2.__deallocating_deinit
-// CHECK-SYMB-NEXT: // Isolation: nonisolated
+// CHECK-SYMB-NEXT: // Isolation: concurrent
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc32DifferentIsolatedDeinitIsolated2CfD : $@convention(method) (@owned DifferentIsolatedDeinitIsolated2) -> () {
 @FirstActor
 @objc class DifferentIsolatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -130,11 +130,11 @@ func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
     normalAcceptsClosure { }
 
     // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeSyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     normalAcceptsSendingClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeSyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     normalAcceptsSendableClosure { }
 }
 
@@ -168,11 +168,11 @@ func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await normalGlobalActorAcceptsSendingClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await normalGlobalActorAcceptsSendableClosure { }
 }
 
@@ -209,11 +209,11 @@ func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
     normalAcceptsAsyncClosure { }
 
     // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     normalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     normalAcceptsSendableAsyncClosure { }
 }
 
@@ -244,11 +244,11 @@ func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await normalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await normalGlobalActorAcceptsSendableAsyncClosure { }
 }
 
@@ -285,11 +285,11 @@ func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalAcceptsSendingClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalAcceptsSendableClosure { }
 }
 
@@ -324,11 +324,11 @@ func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalGlobalActorAcceptsSendingClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalGlobalActorAcceptsSendableClosure { }
 }
 
@@ -367,11 +367,11 @@ func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalAcceptsSendableAsyncClosure { }
 }
 
@@ -410,11 +410,11 @@ func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
     // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     await asyncNormalGlobalActorAcceptsSendableAsyncClosure { }
 }
 
@@ -456,11 +456,11 @@ extension MyActor {
         normalAcceptsClosure { print(self) }
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerSyncNormal_CalleeSyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         normalAcceptsSendingClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeSyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         normalAcceptsSendableClosure { print(self) }
     }
 
@@ -493,11 +493,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await normalGlobalActorAcceptsSendingClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await normalGlobalActorAcceptsSendableClosure { print(self) }
     }
 
@@ -537,11 +537,11 @@ extension MyActor {
         normalAcceptsAsyncClosure { print(self) }
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         normalAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         normalAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -570,11 +570,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsAsyncClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await normalGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await normalGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -612,11 +612,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalAcceptsSendingClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalAcceptsSendableClosure { print(self) }
     }
 
@@ -650,11 +650,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalGlobalActorAcceptsSendingClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalGlobalActorAcceptsSendableClosure { print(self) }
     }
 
@@ -695,11 +695,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -736,11 +736,11 @@ extension MyActor {
         // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsAsyncClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: concurrent
         await asyncNormalGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }
 

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -67,14 +67,14 @@ escaping({ $0 })
 // CHECK-AST:        (declref_expr type="(@escaping (Int) -> Int) -> ()"
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=0 nonisolated escaping single_expression
+// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=0 concurrent escaping single_expression
 
 func nonescaping(_: (Int) -> Int) {}
 nonescaping({ $0 })
 // CHECK-AST:        (declref_expr type="((Int) -> Int) -> ()"
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=1 nonisolated single_expression
+// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=1 concurrent single_expression
 
 // CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
 struct MyStruct {}

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -489,7 +489,7 @@ func testNoescape() {
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: closure #1 () -> () in functions.testNoescape() -> ()
-// CHECK-NEXT: Isolation: nonisolated
+// CHECK-NEXT: Isolation: concurrent
 // CHECK-NEXT: sil private [ossa] @$s9functions12testNoescapeyyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 
@@ -510,9 +510,9 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden [ossa] @$s9functions13testNoescape2yyF : $@convention(thin) () -> () {
 
 // CHECK: // closure #1 () -> () in functions.testNoescape2() -> ()
-// CHECK-NEXT: Isolation: nonisolated
+// CHECK-NEXT: Isolation: concurrent
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 // CHECK: // closure #1 () -> () in closure #1 () -> () in functions.testNoescape2() -> ()
-// CHECK-NEXT: Isolation: nonisolated
+// CHECK-NEXT: Isolation: concurrent
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_yycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {

--- a/test/SILGen/nonisolated_inherits_isolation.swift
+++ b/test/SILGen/nonisolated_inherits_isolation.swift
@@ -18,7 +18,7 @@ func unspecifiedAsyncUse(_ t: NonSendableKlass) async {}
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: // nonisolatedAsync()
-// CHECK-NEXT: Isolation: caller_isolation_inheriting
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation0A5AsyncyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>):
 // CHECK:   hop_to_executor [[ACTOR]]
@@ -28,7 +28,7 @@ nonisolated func nonisolatedAsync() async {}
 func unspecifiedAsyncCallee() async {}
 
 // CHECK-LABEL: // unspecifiedAsync()
-// CHECK-NEXT: Isolation: caller_isolation_inheriting
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation16unspecifiedAsyncyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Optional<any Actor>):
 // CHECK:   hop_to_executor [[ACTOR]]
@@ -52,7 +52,7 @@ struct NonisolatedStruct {
   // Do apply it to sync initializers.
   //
   // CHECK-LABEL: // NonisolatedStruct.init(asynchronous:)
-  // CHECK-NEXT: // Isolation: caller_isolation_inheriting
+  // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation17NonisolatedStructV12asynchronousACyt_tYacfC : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @thin NonisolatedStruct.Type) -> NonisolatedStruct {
   // CHECK: } // end sil function '$s30nonisolated_inherits_isolation17NonisolatedStructV12asynchronousACyt_tYacfC'
   init(asynchronous: ()) async {}
@@ -62,14 +62,14 @@ struct NonisolatedStruct {
 
   // But do apply it to async methods.
   // CHECK-LABEL: // NonisolatedStruct.asyncMethod()
-  // CHECK-NEXT: // Isolation: caller_isolation_inheriting
+  // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation17NonisolatedStructV11asyncMethodyyYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, NonisolatedStruct) -> () {
   // CHECK: } // end sil function '$s30nonisolated_inherits_isolation17NonisolatedStructV11asyncMethodyyYaF'
   func asyncMethod() async {}
 }
 
 // CHECK-LABEL: // useNonisolatedStruct()
-// CHECK-NEXT: // Isolation: caller_isolation_inheriting
+// CHECK-NEXT: // Isolation: nonisolated
 // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation20useNonisolatedStructyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 // CHECK: bb0([[ACTOR:%.*]] :
 // CHECK:   hop_to_executor [[ACTOR]]
@@ -89,7 +89,7 @@ func useNonisolatedStruct() async {
 }
 
 // CHECK-LABEL: // useNonisolatedStruct2()
-// CHECK-NEXT: // Isolation: caller_isolation_inheriting
+// CHECK-NEXT: // Isolation: nonisolated
 // CHECK-NEXT: sil hidden [ossa] @$s30nonisolated_inherits_isolation21useNonisolatedStruct2yyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
 // CHECK: bb0([[ACTOR:%.*]] :
 // CHECK:   hop_to_executor [[ACTOR]]

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -62,7 +62,7 @@ extension Enum: Codable where T: Codable {}
 
 extension NoValues: CaseIterable {}
 // CHECK-LABEL: // static NoValues.allCases.getter
-// CHECK-NEXT: // Isolation: nonisolated
+// CHECK-NEXT: // Isolation: concurrent
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum8NoValuesO8allCasesSayACGvgZ : $@convention(method) (@thin NoValues.Type) -> @owned Array<NoValues> {
 
 extension NoValues: Codable {}

--- a/test/SILOptimizer/moveonly_raw_layout.swift
+++ b/test/SILOptimizer/moveonly_raw_layout.swift
@@ -30,7 +30,7 @@ struct Lock: ~Copyable {
     }
 
     // CHECK-LABEL: // Lock.deinit
-    // CHECK-NEXT: // Isolation: nonisolated
+    // CHECK-NEXT: // Isolation: concurrent
     // CHECK-NEXT: sil{{.*}} @[[DEINIT:\$.*4LockV.*fD]] :
     deinit {
         // CHECK-NOT: destroy_addr

--- a/test/Sema/property_wrappers.swift
+++ b/test/Sema/property_wrappers.swift
@@ -70,8 +70,8 @@ public class W_58201<Value> {
 struct S1_58201 {
   // CHECK:      argument_list implicit labels="wrappedValue:"
   // CHECK-NEXT:   argument label="wrappedValue"
-  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool?" discriminator=0 nonisolated captures=(<opaque_value> ) escaping
-  // CHECK:            autoclosure_expr implicit type="() -> Bool?" discriminator=1 nonisolated escaping
+  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool?" discriminator=0 concurrent captures=(<opaque_value> ) escaping
+  // CHECK:            autoclosure_expr implicit type="() -> Bool?" discriminator=1 concurrent escaping
   @W_58201 var a: Bool?
 }
 
@@ -79,8 +79,8 @@ struct S1_58201 {
 struct S2_58201 {
   // CHECK:      argument_list implicit labels="wrappedValue:"
   // CHECK-NEXT:   argument label="wrappedValue"
-  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+2]]:26 range=[{{.+}}] discriminator=0 nonisolated captures=(<opaque_value> ) escaping
-  // CHECK:            autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+1]]:26 range=[{{.+}}] discriminator=1 nonisolated escaping
+  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+2]]:26 range=[{{.+}}] discriminator=0 concurrent captures=(<opaque_value> ) escaping
+  // CHECK:            autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+1]]:26 range=[{{.+}}] discriminator=1 concurrent escaping
   @W_58201 var b: Bool = false
 }
 

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -4,7 +4,7 @@
 
 class Android {
   func clone() -> Self {
-    // CHECK: closure_expr type="() -> Self" {{.*}} discriminator=0 nonisolated captures=(<dynamic_self> self<direct>)
+    // CHECK: closure_expr type="() -> Self" {{.*}} discriminator=0 concurrent captures=(<dynamic_self> self<direct>)
     let fn = { return self }
     return fn()
   }

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -6,16 +6,16 @@ func doSomething<T>(_ t: T) {}
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=0 nonisolated captures=(<generic> t<direct>) escaping single_expression
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=0 concurrent captures=(<generic> t<direct>) escaping single_expression
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
-  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=1 nonisolated captures=(x<direct>) escaping single_expression
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=1 concurrent captures=(x<direct>) escaping single_expression
   _ = { doSomething(x) }
 
   // Special case -- closure captures outer generic parameter, but it does not
   // appear as the type of any expression
-  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=2 nonisolated captures=(<generic> x<direct>)
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=2 concurrent captures=(<generic> x<direct>)
   _ = { if x is T {} }
 
   // Nested generic functions always capture outer generic parameters, even if

--- a/test/expr/capture/nested.swift
+++ b/test/expr/capture/nested.swift
@@ -2,9 +2,9 @@
 
 // CHECK: func_decl{{.*}}"foo2(_:)"
 func foo2(_ x: Int) -> (Int) -> (Int) -> Int {
-  // CHECK: closure_expr type="(Int) -> (Int) -> Int" {{.*}} discriminator=0 nonisolated captures=(x)
+  // CHECK: closure_expr type="(Int) -> (Int) -> Int" {{.*}} discriminator=0 concurrent captures=(x)
   return {(bar: Int) -> (Int) -> Int in
-    // CHECK: closure_expr type="(Int) -> Int" {{.*}} discriminator=0 nonisolated captures=(x<direct>, bar<direct>)
+    // CHECK: closure_expr type="(Int) -> Int" {{.*}} discriminator=0 concurrent captures=(x<direct>, bar<direct>)
     return {(bas: Int) -> Int in
       return x + bar + bas
     }


### PR DESCRIPTION
Just a refactoring to make the semantics line up.