### PR TITLE
Serialization: Report deserialization remarks from lookup services

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -830,7 +830,7 @@ ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
       } else {
         if (!getContext().LangOpts.EnableDeserializationRecovery)
           fatal(mem.takeError());
-        consumeError(mem.takeError());
+        diagnoseAndConsumeError(mem.takeError());
       }
     }
   }
@@ -860,7 +860,7 @@ void ModuleFile::lookupClassMember(ImportPath::Access accessPath,
         if (!declOrError) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(declOrError.takeError());
-          consumeError(declOrError.takeError());
+          diagnoseAndConsumeError(declOrError.takeError());
           continue;
         }
 
@@ -878,7 +878,7 @@ void ModuleFile::lookupClassMember(ImportPath::Access accessPath,
         if (!declOrError) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(declOrError.takeError());
-          consumeError(declOrError.takeError());
+          diagnoseAndConsumeError(declOrError.takeError());
           continue;
         }
 
@@ -902,7 +902,7 @@ void ModuleFile::lookupClassMember(ImportPath::Access accessPath,
     if (!declOrError) {
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(declOrError.takeError());
-      consumeError(declOrError.takeError());
+      diagnoseAndConsumeError(declOrError.takeError());
       continue;
     }
 
@@ -975,7 +975,7 @@ void ModuleFile::lookupObjCMethods(
     // Deserialize the method and add it to the list.
     auto declOrError = getDeclChecked(std::get<2>(result));
     if (!declOrError) {
-        consumeError(declOrError.takeError());
+        diagnoseAndConsumeError(declOrError.takeError());
         continue;
     }
 
@@ -1002,13 +1002,16 @@ void ModuleFile::getTopLevelDecls(
       if (declOrError.errorIsA<DeclAttributesDidNotMatch>()) {
         // Decl rejected by matchAttributes, ignore it.
         assert(matchAttributes);
-        consumeError(declOrError.takeError());
+
+        // We don't diagnose DeclAttributesDidNotMatch at the moment but
+        // let's use the diagnose consume variant for consistency.
+        diagnoseAndConsumeError(declOrError.takeError());
         continue;
       }
 
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(declOrError.takeError());
-      consumeError(declOrError.takeError());
+      diagnoseAndConsumeError(declOrError.takeError());
       continue;
     }
     if (!ABIRoleInfo(declOrError.get()).providesAPI()) // FIXME: flags
@@ -1024,7 +1027,7 @@ void ModuleFile::getExportedPrespecializations(
     if (!declOrError) {
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(declOrError.takeError());
-      consumeError(declOrError.takeError());
+      diagnoseAndConsumeError(declOrError.takeError());
       continue;
     }
     results.push_back(declOrError.get());

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -36,6 +36,12 @@
 // CHECK-MOVED: note: could not deserialize type for 'foo()'
 // CHECK-MOVED: error: cannot find 'foo' in scope
 
+// CHECK-MOVED: remark: reference to type 'BrokenType' broken by a context change; 'BrokenType' was expected to be in 'A'
+// CHECK-MOVED: note: could not deserialize type for 'init(t:)'
+
+// CHECK-MOVED: remark: reference to type 'BrokenType' broken by a context change; 'BrokenType' was expected to be in 'A'
+// CHECK-MOVED: note: could not deserialize type for 'member()'
+
 /// Move A to the SDK, triggering a different note about layering.
 // RUN: mv %t/A.swiftmodule %t/sdk/A.swiftmodule
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
@@ -80,7 +86,18 @@ public func foo() -> BrokenType {
     fatalError()
 }
 
+public class StableType {
+    public init() {}
+    public convenience init(t: BrokenType) { self.init() }
+    public func member() -> BrokenType { fatalError() }
+}
+
 //--- Client.swift
 import LibWithXRef
 
 foo()
+
+let s = StableType()
+s.member()
+
+let s2 = StableType(42)

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -1,20 +1,20 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/sdk)
-// RUN: split-file %s %t
+// RUN: split-file %s %t --leading-lines
 
 /// Compile two library modules A and A_related, and a middle library LibWithXRef with a reference to a type in A.
 // RUN: %target-swift-frontend %t/LibOriginal.swift -emit-module-path %t/A.swiftmodule -module-name A -I %t
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
 // RUN: %target-swift-frontend %t/LibWithXRef.swift -emit-module-path %t/sdk/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -swift-version 5 -enable-library-evolution
 
-/// Move MyType from A to A_related, triggering most notes.
+/// Move BrokenType from A to A_related, triggering most notes.
 // RUN: %target-swift-frontend %t/EmptyOverlay.swift -emit-module-path %t/A.swiftmodule -module-name A -I %t
 // RUN: %target-swift-frontend %t/LibOriginal.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related -I %t
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk -swift-version 4 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-MOVED %s
 
 /// Main error downgraded to a remark.
-// CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
+// CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'BrokenType' broken by a context change; 'BrokenType' was expected to be in 'A', but now a candidate is found only in 'A_related'
 
 /// Contextual notes about the modules involved.
 // CHECK-MOVED: note: the type was expected to be found in module 'A' at '
@@ -32,7 +32,7 @@
 // CHECK-MOVED-SAME: LibWithXRef.swiftmodule'
 // CHECK-MOVED: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
 // CHECK-MOVED: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
-// CHECK-MOVED: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
+// CHECK-MOVED: note: the type 'BrokenType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
 // CHECK-MOVED: note: could not deserialize type for 'foo()'
 // CHECK-MOVED: error: cannot find 'foo' in scope
 
@@ -68,7 +68,7 @@ void foo() {}
 //--- LibOriginal.swift
 @_exported import A
 
-public struct MyType {
+public struct BrokenType {
     public init() {}
 }
 
@@ -76,7 +76,7 @@ public struct MyType {
 import A
 import A_related
 
-public func foo() -> MyType {
+public func foo() -> BrokenType {
     fatalError()
 }
 


### PR DESCRIPTION
Update the lookup services to prints remarks on deserialization errors attributed to broken modules. The remarks are controlled by the flag `-Rmodule-recovery` and were already active for most of the AST deserialization logic.

Now that `Deserialization.cpp` and `ModuleFile.cpp` consumes are updated to use `diagnoseAndConsumeError` instead of `consumerError`, all the AST deserialization logic should be covered by the remarks. The remaining calls to `consumeError` should only be for lower level issues like format errors that are not handled by the remarks.