### PR TITLE
Prevent shadowing of unavailable member impls

### DIFF
--- a/test/decl/ext/Inputs/objc_implementation_internal.h
+++ b/test/decl/ext/Inputs/objc_implementation_internal.h
@@ -6,3 +6,13 @@
 
 @end
 
+@interface ObjCPropertyTest : NSObject
+
+@property (readonly) int prop1;
+@property (readwrite) int prop2;
+
+- (instancetype)init;
+
+- (void)doSomething;
+
+@end

--- a/test/decl/ext/objc_implementation_direct_to_storage.swift
+++ b/test/decl/ext/objc_implementation_direct_to_storage.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -debug-diagnostic-names
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_ObjCImplementation
+
+import objc_implementation_internal
+
+@available(*, unavailable)
+@objc @implementation extension ObjCPropertyTest {
+  // FIXME: Shouldn't this be on the `@available` above?
+  // expected-note@+1 {{'prop1' has been explicitly marked unavailable here}}
+  let prop1: Int32
+
+  // expected-note@+1 2 {{'prop2' has been explicitly marked unavailable here}}
+  var prop2: Int32 {
+    didSet {
+      _ = prop2 // expected-error {{'prop2' is unavailable}}
+    }
+  }
+
+  override init() {
+    self.prop1 = 1 // expected-error {{'prop1' is unavailable}}
+    self.prop2 = 2 // expected-error {{'prop2' is unavailable}}
+    super.init()
+  }
+
+  func doSomething() {
+    _ = self.prop1
+    _ = self.prop2
+  }
+}


### PR DESCRIPTION
Typically, access control denies access to member implementations, so the imported interface decl will be used instead. However, in contexts that permit direct access to stored properties—such as accessors, inits, and deinits—their member implementations are accessible; the compiler then relies on a shadowing rule favoring Swift decls over ObjC decls to eliminate the imported interface decl.

However, there are many rules that are higher-priority than the Swift vs. ObjC decls one. In particular, a recent change to availability checking in #77886 caused a higher-priority rule to begin eliminating member implementations which belonged to unavailable extensions. This caused regressions in projects using `@objc @implementation` with classes that are unavailable in Mac Catalyst.

Introduce a fairly high-priority shadowing rule that favors a member implementation over its interface when both are present (i.e. when direct access to storage is permitted).

Fixes rdar://143582383.