### PR TITLE
Fix misuse of `CMAKE_SIZEOF_VOID_P` in testing

### DIFF
--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
 // RUN: %empty-directory(%t)
-// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/NumericParsing.swift
+// RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/NumericParsing.swift
 // RUN: %line-directive %t/NumericParsing.swift -- %target-build-swift %t/NumericParsing.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out
@@ -19,7 +19,7 @@
 %{
 from SwiftIntTypes import all_integer_types
 
-word_bits = int(CMAKE_SIZEOF_VOID_P)
+word_bits = int(WORD_BITS)
 
 def maskOfWidth(n):
   return (1 << n) - 1

--- a/test/stdlib/NumericParsing2.swift.gyb
+++ b/test/stdlib/NumericParsing2.swift.gyb
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
 // RUN: %empty-directory(%t)
-// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/NumericParsing.swift
+// RUN: %gyb %s -o %t/NumericParsing.swift
 // RUN: %line-directive %t/NumericParsing.swift -- %target-build-swift %t/NumericParsing.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out

--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteFP.swift
+// RUN: %gyb %s -o %t/SIMDConcreteFP.swift
 // RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-build-swift %t/SIMDConcreteFP.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-run %t/a.out

--- a/test/stdlib/SIMDConcreteIntegers.swift.gyb
+++ b/test/stdlib/SIMDConcreteIntegers.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteIntegers.swift
+// RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/SIMDConcreteIntegers.swift
 // RUN: %line-directive %t/SIMDConcreteIntegers.swift -- %target-build-swift %t/SIMDConcreteIntegers.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/SIMDConcreteIntegers.swift -- %target-run %t/a.out
@@ -21,7 +21,7 @@ import StdlibUnittest
 
 %{
 from SwiftIntTypes import all_integer_types
-word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+word_bits = int(WORD_BITS)
 storagescalarCounts = [2,4,8,16,32,64]
 vectorscalarCounts = storagescalarCounts + [3]
 }%

--- a/test/stdlib/SIMDConcreteMasks.swift.gyb
+++ b/test/stdlib/SIMDConcreteMasks.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteMasks.swift
+// RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/SIMDConcreteMasks.swift
 // RUN: %line-directive %t/SIMDConcreteMasks.swift -- %target-build-swift %t/SIMDConcreteMasks.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/SIMDConcreteMasks.swift -- %target-run %t/a.out
@@ -21,7 +21,7 @@ import StdlibUnittest
 
 %{
 from SwiftIntTypes import all_integer_types
-word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+word_bits = int(WORD_BITS)
 storagescalarCounts = [2,4,8,16,32,64]
 vectorscalarCounts = storagescalarCounts + [3]
 }%


### PR DESCRIPTION
# Motivation

There are a few instances of misuse of `CMAKE_SIZEOF_VOID_P` in test files. This flag is intended to [represent the **byte** size of a word](https://github.com/swiftlang/swift/blob/69a77d8f09dcb2625e29d7371c732926e4701a0d/Runtimes/Core/cmake/modules/PlatformInfo.cmake#L2-L3), but we mistakenly pass `%target-ptrsize` (which is **bits** size of a word) to it.

Fortunately, it does not seem to affect the test results. However, we should fix this to prevent similar mistakes in the future.

# Solution

Use `WORD_BITS` instead.

# Alternative Considered

`-DCMAKE_SIZEOF_VOID_P=$((%target-ptrsize/8))` works too but it seems we used the value to making bits representation of word (it's redundant), it would be better to use `WORD_BITS` in these situation (especially in testing files).

```swift
word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
```