### PR TITLE
Parse/Sema: Consolidate diagnostics for unexpected versions

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1579,10 +1579,6 @@ ERROR(attr_availability_expected_equal,none,
 ERROR(attr_availability_expected_version,none,
       "expected version number in '%0' attribute", (StringRef))
 
-WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
-      "unexpected version number in '%0' attribute for non-specific platform "
-      "'*'", (StringRef))
-
 WARNING(attr_availability_wildcard_ignored,none,
         "* as platform name has no effect in '%0' attribute", (StringRef))
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -546,26 +546,6 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   if (AnyArgumentInvalid)
     return nullptr;
 
-  // Warn if any version is specified with the universal domain ('*').
-  bool SomeVersion = (!Introduced.empty() ||
-                      !Deprecated.empty() ||
-                      !Obsoleted.empty());
-  if (Platform == "*" && SomeVersion) {
-    auto diag = diagnose(AttrLoc,
-        diag::attr_availability_nonspecific_platform_unexpected_version,
-        AttrName);
-    if (!Introduced.empty())
-      diag.fixItRemove(SourceRange(Introduced.DelimiterLoc,
-                                   Introduced.Range.End));
-    if (!Deprecated.empty())
-      diag.fixItRemove(SourceRange(Deprecated.DelimiterLoc,
-                                   Deprecated.Range.End));
-    if (!Obsoleted.empty())
-      diag.fixItRemove(SourceRange(Obsoleted.DelimiterLoc,
-                                   Obsoleted.Range.End));
-    return nullptr;
-  }
-
   auto Attr = new (Context) AvailableAttr(
       AtLoc, SourceRange(AttrLoc, Tok.getLoc()), Platform, PlatformLoc,
       AttrKind, Message, Renamed, Introduced.Version, Introduced.Range,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8404,9 +8404,7 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   bool hasVersionSpec =
       (introducedVersion || deprecatedVersion || obsoletedVersion);
 
-  // FIXME: [availability] For the universal domain, this is currently
-  // diagnosed during parsing. That diagnostic should be subsumed by this one.
-  if (!domain->isVersioned() && hasVersionSpec && !domain->isUniversal()) {
+  if (!domain->isVersioned() && hasVersionSpec) {
     SourceRange versionSourceRange;
     if (introducedVersion)
       versionSourceRange = semanticAttr.getIntroducedSourceRange();

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -33,15 +33,15 @@ func twoShorthandsFollowedByDeprecated() {}
 // Missing/wrong warning message for '*' or 'swift' platform.
 
 @available(*, deprecated: 4.2)
-// expected-warning@-1 {{unexpected version number in 'available' attribute for non-specific platform '*'}} {{25-30=}}
+// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
 func allPlatformsDeprecatedVersion() {}
 
 @available(*, deprecated, obsoleted: 4.2)
-// expected-warning@-1 {{unexpected version number in 'available' attribute for non-specific platform '*'}} {{36-41=}}
+// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
 func allPlatformsDeprecatedAndObsoleted() {}
 
 @available(*, introduced: 4.0, deprecated: 4.1, obsoleted: 4.2)
-// expected-warning@-1 {{unexpected version number in 'available' attribute for non-specific platform '*'}} {{25-30=}} {{42-47=}} {{58-63=}}
+// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
 func allPlatformsDeprecatedAndObsoleted2() {}
 
 @available(swift, unavailable)


### PR DESCRIPTION
Since resolving the domain of an `@available` attribute is done during type checking now, diagnostics about unexpected versions for a domain need to be emitted at that point instead of during parsing. It doesn't make sense to maintain the special version of this diagnostic that is emitted during parsing for the universal availability domain only.

Builds on https://github.com/swiftlang/swift/pull/79070 and depends on https://github.com/swiftlang/sourcekit-lsp/pull/1962.