### PR TITLE
 [cxx-interop] Import non-public inherited members

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -202,10 +202,18 @@ public:
   /// Imports a clang decl directly, rather than looking up its name.
   virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
 
-  /// Imports a clang decl from a base class, cloning it for \param newContext
-  /// if it wasn't cloned for this specific context before.
-  virtual ValueDecl *importBaseMemberDecl(ValueDecl *decl,
-                                          DeclContext *newContext) = 0;
+  /// Clones an imported \param decl from its base class to its derived class
+  /// \param newContext where it is inherited. Its access level is determined
+  /// with respect to \param inheritance, which signifies whether \param decl
+  /// was inherited via C++ public/protected/private inheritance.
+  ///
+  /// This function uses a cache so that it is idempotent; successive
+  /// invocations will only generate one cloned ValueDecl (and all return
+  /// a pointer to it). Returns a NULL pointer upon failure.
+  virtual ValueDecl *
+  importBaseMemberDecl(ValueDecl *decl,
+                       DeclContext *newContext,
+                       clang::AccessSpecifier inheritance) = 0;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -658,7 +658,8 @@ public:
   Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
 
   ValueDecl *importBaseMemberDecl(ValueDecl *decl,
-                                  DeclContext *newContext) override;
+                                  DeclContext *newContext,
+                                  clang::AccessSpecifier inheritance) override;
 
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -24,6 +24,7 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
@@ -132,25 +133,33 @@ private:
 };
 
 /// The input type for a record member lookup request.
+///
+/// These lookups may be requested recursively in the case of inheritance,
+/// for which we separately keep track of the derived class where we started
+/// looking (startDecl) and the access level for the current inheritance.
 struct ClangRecordMemberLookupDescriptor final {
-  NominalTypeDecl *recordDecl;
-  NominalTypeDecl *inheritingDecl;
-  DeclName name;
+  NominalTypeDecl *recordDecl;        // Where we are currently looking
+  NominalTypeDecl *inheritingDecl;    // Where we started looking from
+  DeclName name;                      // What we are looking for
+  clang::AccessSpecifier inheritance; // public/protected/private inheritance
+                                      // (clang::AS_none means no inheritance)
 
   ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name)
-      : recordDecl(recordDecl), inheritingDecl(recordDecl), name(name) {
+      : recordDecl(recordDecl), inheritingDecl(recordDecl), name(name),
+        inheritance(clang::AS_none) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
   }
 
   friend llvm::hash_code
   hash_value(const ClangRecordMemberLookupDescriptor &desc) {
-    return llvm::hash_combine(desc.name, desc.recordDecl, desc.inheritingDecl);
+    return llvm::hash_combine(desc.name, desc.recordDecl, desc.inheritingDecl, desc.inheritance);
   }
 
   friend bool operator==(const ClangRecordMemberLookupDescriptor &lhs,
                          const ClangRecordMemberLookupDescriptor &rhs) {
     return lhs.name == rhs.name && lhs.recordDecl == rhs.recordDecl &&
-           lhs.inheritingDecl == rhs.inheritingDecl;
+           lhs.inheritingDecl == rhs.inheritingDecl &&
+           lhs.inheritance == rhs.inheritance;
   }
 
   friend bool operator!=(const ClangRecordMemberLookupDescriptor &lhs,
@@ -163,11 +172,15 @@ private:
 
   // This private constructor should only be used in ClangRecordMemberLookup,
   // for recursively traversing base classes that inheritingDecl inherites from.
-  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name,
-                                    NominalTypeDecl *inheritingDecl)
-      : recordDecl(recordDecl), inheritingDecl(inheritingDecl), name(name) {
+  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl,
+                                    DeclName name,
+                                    NominalTypeDecl *inheritingDecl,
+                                    clang::AccessSpecifier inheritance)
+      : recordDecl(recordDecl), inheritingDecl(inheritingDecl), name(name),
+        inheritance(inheritance) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
     assert(isa<clang::CXXRecordDecl>(inheritingDecl->getClangDecl()));
+    assert(inheritance != clang::AS_none && "");
     assert(recordDecl != inheritingDecl &&
            "recursive calls should lookup elsewhere");
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6223,6 +6223,11 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
 
       auto memberClangDecl = namedMember->getClangDecl();
 
+      // Skip this base class member if it isn't from recordDecl; this happens
+      // when this member was inherited.
+      if (memberClangDecl != recordDecl->getClangDecl())
+        continue;
+
       // Skip this base class if this is a case of nested private inheritance.
       //
       // BUG: private base class members should be inherited but inaccessible.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -36,6 +36,7 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
+#include "clang/Basic/Specifiers.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/AST/DeclVisitor.h"
@@ -690,7 +691,9 @@ public:
 
   bool isDefaultArgSafeToImport(const clang::ParmVarDecl *param);
 
-  ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext);
+  ValueDecl *importBaseMemberDecl(ValueDecl *decl,
+                                  DeclContext *newContext,
+                                  clang::AccessSpecifier inheritance);
 
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
 
@@ -1636,7 +1639,8 @@ private:
   loadAllMembersOfObjcContainer(Decl *D,
                                 const clang::ObjCContainerDecl *objcContainer);
   void loadAllMembersOfRecordDecl(NominalTypeDecl *swiftDecl,
-                                  const clang::RecordDecl *clangRecord);
+                                  const clang::RecordDecl *clangRecord,
+                                  clang::AccessSpecifier inheritance);
 
   void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
                            Decl *D, DeclContext *DC,

--- a/test/Interop/Cxx/class/access/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/access/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module NonPublicInheritance {
+    requires cplusplus
+    header "non-public-inheritance.h"
+}

--- a/test/Interop/Cxx/class/access/Inputs/non-public-inheritance.h
+++ b/test/Interop/Cxx/class/access/Inputs/non-public-inheritance.h
@@ -1,0 +1,37 @@
+#ifndef NON_PUBLIC_INHERTIANCE_H
+#define NON_PUBLIC_INHERTIANCE_H
+
+// TODO: dependent on private_fileid feature
+// #define BLESS __attribute__((__swift_attr__("private_fileid:main/blessed.swift")))
+#define BLESS
+
+const int PUBL_RETURN_VAL = 1;
+const int PROT_RETURN_VAL = 2;
+const int PRIV_RETURN_VAL = 3;
+
+class BLESS Base {
+public:
+  int publ(void) const { return PUBL_RETURN_VAL; }
+protected:
+  int prot(void) const { return PROT_RETURN_VAL; }
+private:
+  int priv(void) const { return PRIV_RETURN_VAL; }
+};
+
+class BLESS PublBase : public    Base {};
+class BLESS ProtBase : protected Base {};
+class BLESS PrivBase : private   Base {};
+
+class BLESS PublPublBase : public    PublBase {};
+class BLESS ProtPublBase : protected PublBase {};
+class BLESS PrivPublBase : private   PublBase {};
+
+class BLESS PublProtBase : public    ProtBase {};
+class BLESS ProtProtBase : protected ProtBase {};
+class BLESS PrivProtBase : private   ProtBase {};
+
+class BLESS PublPrivBase : public    PrivBase {};
+class BLESS ProtPrivBase : protected PrivBase {};
+class BLESS PrivPrivBase : private   PrivBase {};
+
+#endif /* NON_PUBLIC_INHERTIANCE_H */

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -1,0 +1,120 @@
+// Test that all accessible inherited methods can be called.
+//
+// Note that this test isn't very meaningful until we are allowed to access
+// non-public members (those are the TODOs). It is checked in for now as
+// a placeholder (and it _does_ at least ensure that things haven't gone
+// horribly wrong).
+//
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import NonPublicInheritance
+
+var Tests = TestSuite("NonPublicInheritance")
+Tests.test("Base") { Base().ext() }
+Tests.test("PublBase") { PublBase().ext() }
+Tests.test("ProtBase") { ProtBase().ext() }
+Tests.test("PrivBase") { PrivBase().ext() }
+Tests.test("PublPublBase") { PublPublBase().ext() }
+Tests.test("ProtPublBase") { ProtPublBase().ext() }
+Tests.test("PrivPublBase") { PrivPublBase().ext() }
+Tests.test("PublProtBase") { PublProtBase().ext() }
+Tests.test("ProtProtBase") { ProtProtBase().ext() }
+Tests.test("PrivProtBase") { PrivProtBase().ext() }
+Tests.test("PublPrivBase") { PublPrivBase().ext() }
+Tests.test("ProtPrivBase") { ProtPrivBase().ext() }
+Tests.test("PrivPrivBase") { PrivPrivBase().ext() }
+
+extension Base {
+    func ext() {
+        expectEqual(publ(), PUBL_RETURN_VAL)
+        // TODO: prot()
+        // TODO: priv()
+    }
+}
+
+extension PublBase {
+    func ext() {
+        expectEqual(publ(), PUBL_RETURN_VAL)
+        // TODO: prot()
+    }
+}
+
+extension PublPublBase {
+    func ext() {
+        expectEqual(publ(), PUBL_RETURN_VAL)
+        // TODO: prot()
+    }
+}
+
+extension ProtPublBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension PrivPublBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension ProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+
+extension PublProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension ProtProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension PrivProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension PrivBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+    }
+}
+
+extension PublPrivBase {
+    func ext() {
+      // Nothing to test (nothing is accessible)
+    }
+}
+
+extension ProtPrivBase {
+    func ext() {
+      // Nothing to test (nothing is accessible)
+    }
+}
+
+extension PrivPrivBase {
+    func ext() {
+      // Nothing to test (nothing is accessible)
+    }
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK:      public struct Base {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   public func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT:   private func priv() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PublBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   public func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct ProtBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PrivBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PublPublBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   public func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct ProtPublBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PrivPublBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PublProtBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct ProtProtBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PrivProtBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publ() -> Int32
+// CHECK-NEXT:   private func prot() -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PublPrivBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct ProtPrivBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct PrivPrivBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT: }
+

--- a/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
@@ -1,0 +1,182 @@
+//--- blessed.swift
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
+
+import NonPublicInheritance
+
+// Extensions of each class test whether we correctly modeled *which* members
+// get inherited, but do not tell us whether they were inherited with the right
+// access permissions.
+//
+// Global functions (i.e., not in extensions) tell us whether those members were
+// inherited with the correct Swift access level (i.e., public vs private).
+
+extension Base {
+    func ext() {
+        publ()
+        // TODO: prot()
+        // TODO: priv()
+    }
+}
+func fBase(v: Base) {
+    v.publ()
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{'priv' is inaccessible due to 'private' protection level}}
+}
+
+extension PublBase {
+    func ext() {
+        publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPublBase(v: PublBase) {
+    v.publ()
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'PublBase' has no member 'priv'}}
+}
+
+extension PublPublBase {
+    func ext() {
+        publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPublPublBase(v: PublPublBase) {
+        v.publ()
+        v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+        v.priv() // expected-error {{value of type 'PublPublBase' has no member 'priv'}}
+}
+
+extension ProtPublBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fProtPublBase(v: ProtPublBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'ProtPublBase' has no member 'priv'}}
+}
+
+extension PrivPublBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPrivPublBase(v: PrivPublBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'PrivPublBase' has no member 'priv'}}
+}
+
+extension ProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fProtBase(v: ProtBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'ProtBase' has no member 'priv'}}
+}
+
+
+extension PublProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPublProtBase(v: PublProtBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'PublProtBase' has no member 'priv'}}
+}
+
+extension ProtProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fProtProtBase(v: ProtProtBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'ProtProtBase' has no member 'priv'}}
+}
+
+extension PrivProtBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPrivProtBase(v: PrivProtBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'PrivProtBase' has no member 'priv'}}
+}
+
+extension PrivBase {
+    func ext() {
+        // TODO: publ()
+        // TODO: prot()
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPrivBase(v: PrivBase) {
+    v.publ() // expected-error {{'publ' is inaccessible due to 'private' protection level}}
+    v.prot() // expected-error {{'prot' is inaccessible due to 'private' protection level}}
+    v.priv() // expected-error {{value of type 'PrivBase' has no member 'priv'}}
+}
+
+extension PublPrivBase {
+    func ext() {
+        publ() // expected-error {{cannot find 'publ' in scope}}
+        prot() // expected-error {{cannot find 'prot' in scope}}
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPublPrivBase(v: PublPrivBase) {
+    v.publ() // expected-error {{value of type 'PublPrivBase' has no member 'publ'}}
+    v.prot() // expected-error {{value of type 'PublPrivBase' has no member 'prot'}}
+    v.priv() // expected-error {{value of type 'PublPrivBase' has no member 'priv'}}
+}
+
+extension ProtPrivBase {
+    func ext() {
+        publ() // expected-error {{cannot find 'publ' in scope}}
+        prot() // expected-error {{cannot find 'prot' in scope}}
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fProtPrivBase(v: ProtPrivBase) {
+    v.publ() // expected-error {{value of type 'ProtPrivBase' has no member 'publ'}}
+    v.prot() // expected-error {{value of type 'ProtPrivBase' has no member 'prot'}}
+    v.priv() // expected-error {{value of type 'ProtPrivBase' has no member 'priv'}}
+}
+
+extension PrivPrivBase {
+    func ext() {
+        publ() // expected-error {{cannot find 'publ' in scope}}
+        prot() // expected-error {{cannot find 'prot' in scope}}
+        priv() // expected-error {{cannot find 'priv' in scope}}
+    }
+}
+func fPrivPrivBase(v: PrivPrivBase) {
+    v.publ() // expected-error {{value of type 'PrivPrivBase' has no member 'publ'}}
+    v.prot() // expected-error {{value of type 'PrivPrivBase' has no member 'prot'}}
+    v.priv() // expected-error {{value of type 'PrivPrivBase' has no member 'priv'}}
+}

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -1,123 +1,227 @@
-// RUN: %target-swift-ide-test -print-module -print-implicit-attrs -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -print-implicit-attrs -print-access -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK:      struct NonTrivial {
-// CHECK-NEXT:   init()
+// CHECK:      public struct NonTrivial {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func inNonTrivial() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct Base {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct Base {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func rvalueThisInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func rvalueThisInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func templateInBase<T>(_ t: T) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func templateInBase<T>(_ t: T) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   static func staticInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public static func staticInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
+// CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct OtherBase {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct OtherBase {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct Derived {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct Derived {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func inDerived() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodDifferentSignature(_ x: Int32) -> Int32
+// CHECK-NEXT:   public func sameMethodDifferentSignature(_ x: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
+// CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct DerivedFromDerived {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct DerivedFromDerived {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func topLevel() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   public func topLevel() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func inDerived() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodDifferentSignature(_ x: Int32) -> Int32
+// CHECK-NEXT:   public func sameMethodDifferentSignature(_ x: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
+// CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
+// CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct DerivedFromNonTrivial {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct DerivedFromNonTrivial {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func inNonTrivial() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct PrivatelyInherited {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct PrivatelyInherited {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
+// CHECK-NEXT:   private mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) private func pure() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT: }
 
-// CHECK-NEXT: struct ProtectedInherited {
-// CHECK-NEXT:   init()
+// CHECK-NEXT: public struct ProtectedInherited {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
+// CHECK-NEXT:   private mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) private func pure() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   private func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT: }
+
+// CHECK-NEXT: public struct EmptyBaseClass {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func inBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct DerivedFromEmptyBaseClass {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   public var a: Int32
+// CHECK-NEXT:   public var b: Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func inBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT: }
+
+// CHECK-NEXT: @discardableResult
+// CHECK-NEXT: public func getCopyCounter() -> UnsafeMutablePointer<Int32>
+// CHECK-NEXT: public struct CopyTrackedBaseClass {
+// CHECK-NEXT:   public init(_ x: Int32)
+// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
+// CHECK-NEXT:   @_transparent public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func getXMut() -> Int32
+// CHECK-NEXT:   private var x: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct CopyTrackedDerivedClass {
+// CHECK-NEXT:   public init(_ x: Int32)
+// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
+// CHECK-NEXT:   @_transparent public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getDerivedX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func getXMut() -> Int32
+// CHECK-NEXT:   private var x: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct NonEmptyBase {
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getY() -> Int32
+// CHECK-NEXT:   private var y: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct CopyTrackedDerivedDerivedClass {
+// CHECK-NEXT:   public init(_ x: Int32)
+// CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
+// CHECK-NEXT:   @_transparent public init()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getY() -> Int32
+// CHECK-NEXT:   private var y: Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getDerivedX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func getXMut() -> Int32
+// CHECK-NEXT:   private var x: Int32
+// CHECK-NEXT: }
+

--- a/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
@@ -6,11 +6,11 @@ import UsingBaseMembers
 
 let a = PublicBasePrivateInheritance()
 let _ = a.publicGetter()
-a.notExposed() // expected-error {{value of type 'PublicBasePrivateInheritance' has no member 'notExposed'}}
+a.notExposed() // expected-error {{'notExposed' is inaccessible due to 'private' protection level}}
 
 let b = PublicBaseProtectedInheritance()
 let _ = b.publicGetter()
-b.notExposed() // expected-error {{value of type 'PublicBaseProtectedInheritance' has no member 'notExposed'}}
+b.notExposed() // expected-error {{'notExposed' is inaccessible due to 'private' protection level}}
 
 let _ = UsingBaseConstructorWithParam(566 as Int32)
 let _ = UsingBaseConstructorWithParam(566 as UInt32)


### PR DESCRIPTION
This patch is follow-up work from #78942 and concurrent with #79093.
It imports non-public members, which were previously not being imported.
Once #79093 (`SWIFT_PRIVATE_FILEID`) is merged in, these inherited members
will be available within certain Swift extensions.