### PR TITLE
Remove FreeBSD version from swiftmodule triple

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -427,7 +427,7 @@ macro(configure_sdk_unix name architectures)
         string(REGEX REPLACE "[-].*" "" freebsd_system_version ${CMAKE_SYSTEM_VERSION})
         message(STATUS "FreeBSD Version: ${freebsd_system_version}")
 
-        set(SWIFT_SDK_FREEBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-freebsd${freebsd_system_version}")
+        set(SWIFT_SDK_FREEBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-freebsd")
       elseif("${prefix}" STREQUAL "OPENBSD")
         if(NOT arch STREQUAL "x86_64" AND NOT arch STREQUAL "aarch64")
           message(FATAL_ERROR "unsupported arch for OpenBSD: ${arch}")

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -414,6 +414,10 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
                         triple.getOSName(), environment);
   }
 
+  if (triple.isOSFreeBSD()) {
+    return swift::getUnversionedTriple(triple);
+  }
+
   // Other platforms get no normalization.
   return triple;
 }


### PR DESCRIPTION
Do not include FreeBSD version in the swift sdk triple. This makes https://github.com/swiftlang/swift-build/pull/12 easier.

~~Although technically different versions of FreeBSD does not guarantee ABI stability across major versions~~ FreeBSD guarantees user land ABI stability across major version, toolchain are shipping per OS version anyway, so it shouldn't affect user in any meaningful way. (each major release will likely have a separate toolchain).

This also have the additional benefit that the swift toolchain will not break and complain about not finding the correct swiftmodule across minor updates (which ABI stability is preserved across)