### PR TITLE
SIL: Fix memory behavior of mark_dependence

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -253,6 +253,12 @@ struct AliasAnalysis {
     case let storeBorrow as StoreBorrowInst:
       return memLoc.mayAlias(with: storeBorrow.destination, self) ? .init(write: true) : .noEffects
 
+    case let mdi as MarkDependenceInst:
+      if mdi.base.type.isAddress && memLoc.mayAlias(with: mdi.base, self) {
+        return .init(read: true)
+      }
+      return .noEffects
+
     case let copy as SourceDestAddrInstruction:
       let mayRead = memLoc.mayAlias(with: copy.source, self)
       let mayWrite = memLoc.mayAlias(with: copy.destination, self)

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
@@ -74,6 +74,7 @@ private extension Instruction {
          is CopyAddrInst,
          is BuiltinInst,
          is StoreBorrowInst,
+         is MarkDependenceInst,
          is DebugValueInst:
       return true
     default:

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1081,6 +1081,12 @@ MemoryBehavior SILInstruction::getMemoryBehavior() const {
     llvm_unreachable("Covered switch isn't covered?!");
   }
   
+  if (auto *mdi = dyn_cast<MarkDependenceInst>(this)) {
+    if (mdi->getBase()->getType().isAddress())
+      return MemoryBehavior::MayRead;
+    return MemoryBehavior::None;
+  }
+  
   // TODO: An UncheckedTakeEnumDataAddr instruction has no memory behavior if
   // it is nondestructive. Setting this currently causes LICM to miscompile
   // because access paths do not account for enum projections.

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2829,6 +2829,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::EndLifetimeInst:
   case SILInstructionKind::ExistentialMetatypeInst:
   case SILInstructionKind::FixLifetimeInst:
+  case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::GlobalAddrInst:
   case SILInstructionKind::HasSymbolInst:
   case SILInstructionKind::HopToExecutorInst:

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -181,10 +181,10 @@ collectLoads(Operand *addressUse, CopyAddrInst *originalCopy,
   }
   case SILInstructionKind::MarkDependenceInst: {
     auto mdi = cast<MarkDependenceInst>(user);
-    // If the user is the base operand of the MarkDependenceInst we can return
-    // true, because this would be the end of this dataflow chain
     if (mdi->getBase() == address) {
-      return true;
+      // We want to keep the original lifetime of the base. If we would eliminate
+      // the base alloc_stack, we risk to insert a destroy_addr too early.
+      return false;
     }
     // If the user is the value operand of the MarkDependenceInst we have to
     // transitively explore its uses until we reach a load or return false

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -510,6 +510,18 @@ bb0(%0 :  $*T):
   return %res : $()
 }
 
+sil [ossa] @test_non_escaping_closure_with_mark_dependence : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $T
+  %func = function_ref @closure : $@convention(thin) (@in_guaranteed T) -> ()
+  %pa = partial_apply [callee_guaranteed] [on_stack] %func(%0) : $@convention(thin) (@in_guaranteed T) -> ()
+  %pa1 = mark_dependence %pa on %0
+  destroy_value %pa1 : $@noescape @callee_guaranteed () -> () 
+  dealloc_stack %0
+  %res = tuple ()
+  return %res : $()
+}
+
 sil [ossa] @test_store_borrow : $@convention(thin) (@guaranteed T) -> () {
 bb0(%0 :  @guaranteed $T):
   %s = alloc_stack $T
@@ -804,5 +816,37 @@ bb2:
 bb3:
   %r = tuple ()
   return %r : $()
+}
+
+sil [ossa] @mark_dependence : $@convention(method) (@owned T, @owned Inner) -> @owned Inner {
+bb0(%0 : @owned $T, %1 : @owned $Inner):
+  %2 = alloc_stack $T
+  store %0 to [init] %2
+  %4 = alloc_stack $Inner
+  store %1 to [init] %4
+  %6 = mark_dependence %4 on %2
+  %7 = begin_access [read] [dynamic] %6
+  %8 = load [take] %7
+  end_access %7
+  dealloc_stack %4
+  destroy_addr %2
+  dealloc_stack %2
+  return %8
+}
+
+sil [ossa] @mark_dependence_uninit_value : $@convention(thin) (@owned T, @owned Inner) -> @owned Inner {
+bb0(%0 : @owned $T, %1 : @owned $Inner):
+  %2 = alloc_stack $T
+  store %0 to [init] %2
+  %4 = alloc_stack $Inner
+  store %1 to [init] %4
+  %6 = mark_dependence %4 on %2
+  %7 = begin_access [read] [dynamic] %6
+  %8 = load [take] %7
+  end_access %7
+  dealloc_stack %4
+  destroy_addr %2
+  dealloc_stack %2
+  return %8
 }
 

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -792,3 +792,20 @@ bb0(%0: $*Inner):
   return %r : $()
 }
 
+// CHECK: SIL memory lifetime failure in @mark_dependence_uninit_base: memory is not initialized, but should be
+sil [ossa] @mark_dependence_uninit_base : $@convention(thin) (@owned T, @owned Inner) -> @owned Inner {
+bb0(%0 : @owned $T, %1 : @owned $Inner):
+  %2 = alloc_stack $T
+  store %0 to [init] %2
+  %4 = alloc_stack $Inner
+  store %1 to [init] %4
+  destroy_addr %2
+  %6 = mark_dependence %4 on %2
+  %7 = begin_access [read] [dynamic] %6
+  %8 = load [take] %7
+  end_access %7
+  dealloc_stack %4
+  dealloc_stack %2
+  return %8
+}
+

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1851,3 +1851,32 @@ bb0(%0 : @owned $CL):
   %3 = tuple ()
   return %3
 }
+
+// CHECK-LABEL: @test_mark_dependence
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %3 = mark_dependence %1 : $*C on %2 : $C
+// CHECK-NEXT:    %0 = argument of bb0 : $*C
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #3.
+// CHECK-NEXT:      %4 = mark_dependence %2 : $C on %0 : $*C
+// CHECK-NEXT:    %0 = argument of bb0 : $*C
+// CHECK-NEXT:    r=1,w=0
+// CHECK:       PAIR #4.
+// CHECK-NEXT:      %4 = mark_dependence %2 : $C on %0 : $*C
+// CHECK-NEXT:    %1 = argument of bb0 : $*C
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #7.
+// CHECK-NEXT:      %5 = mark_dependence %1 : $*C on %0 : $*C
+// CHECK-NEXT:    %0 = argument of bb0 : $*C
+// CHECK-NEXT:    r=1,w=0
+// CHECK:       PAIR #8.
+// CHECK-NEXT:      %5 = mark_dependence %1 : $*C on %0 : $*C
+// CHECK-NEXT:    %1 = argument of bb0 : $*C
+// CHECK-NEXT:    r=0,w=0
+sil [ossa] @test_mark_dependence : $@convention(thin) (@in_guaranteed C, @in_guaranteed C, @owned C) -> @owned C {
+bb0(%0 : $*C, %1 : $*C, %2 : @owned $C):
+  %3 = mark_dependence %1 on %2
+  %4 = mark_dependence %2 on %0
+  %5 = mark_dependence %1 on %0
+  return %4
+}

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -216,11 +216,12 @@ bb3:
 }
 
 // Ensure no assert fires while handling lifetime end of partial_apply
-sil [ossa] @testPartialApplyStack2 : $@convention(thin) (@guaranteed C) -> () {
-bb0(%0 : @guaranteed $C):
+sil [ossa] @testPartialApplyStack2 : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
   specify_test "ossa_lifetime_completion @instruction[1] availability"
   %2 = alloc_stack $C
   %3 = copy_value %0 : $C
+  store %0 to [init] %2
   %4 = begin_borrow %3 : $C
   %5 = function_ref @foo : $@convention(thin) (@guaranteed C) -> ()
   %6 = partial_apply [callee_guaranteed] [on_stack] %5(%4) : $@convention(thin) (@guaranteed C) -> ()
@@ -228,6 +229,7 @@ bb0(%0 : @guaranteed $C):
   destroy_value %7 : $@noescape @callee_guaranteed () -> ()
   end_borrow %4 : $C
   destroy_value %3 : $C
+  destroy_addr %2 : $*C
   dealloc_stack %2 : $*C
   %12 = tuple ()
   return %12 : $()

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -812,7 +812,7 @@ bb0(%0 : $*Klass, %1 : $*Klass, %2 : @owned $Klass):
 // CHECK: load
 // CHECK-NOT: load
 // CHECK-LABEL: } // end sil function 'redundant_load_mark_dependence'
-sil [ossa] @redundant_load_mark_dependence : $@convention(thin) (@inout Klass, @guaranteed Builtin.NativeObject) -> @owned (Klass, Klass) {
+sil [ossa] @redundant_load_mark_dependence : $@convention(thin) (@in Klass, @guaranteed Builtin.NativeObject) -> @owned (Klass, Klass) {
 bb0(%0 : $*Klass, %1 : @guaranteed $Builtin.NativeObject):
   %2 = mark_dependence %0 : $*Klass on %1 : $Builtin.NativeObject
   %4 = load [copy] %2 : $*Klass

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -34,6 +34,8 @@ sil @unknown : $@convention(thin) () -> ()
 sil @load_string : $@convention(thin) (@in_guaranteed String) -> String
 sil @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
 sil @consume : $@convention(thin) (@owned C) -> ()
+sil @createKlass : $@convention(thin) () -> @owned Klass
+sil @initC : $@convention(thin) () -> @out C
 
 sil @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
@@ -802,3 +804,26 @@ bb0(%0 : $C):
   dealloc_stack %2
   return %5
 }
+
+// CHECK-LABEL: sil [ossa] @dont_shrink_lifetime_of_mark_dependence_base
+// CHECK:         copy_addr
+// CHECK:         apply
+// CHECK:       } // end sil function 'dont_shrink_lifetime_of_mark_dependence_base'
+sil [ossa] @dont_shrink_lifetime_of_mark_dependence_base : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $C
+  %1 = function_ref @initC : $@convention(thin) () -> @out C
+  %2 = apply %1(%0) : $@convention(thin) () -> @out C
+  %3 = alloc_stack [var_decl] $C, let, name "a"
+  copy_addr [take] %0 to [init] %3
+  %5 = function_ref @createKlass : $@convention(thin) () -> @owned Klass
+  %6 = apply %5() : $@convention(thin) () -> @owned Klass
+  %7 = mark_dependence [nonescaping] %6 on %3
+  destroy_value %7
+  destroy_addr %3
+  dealloc_stack %3
+  dealloc_stack %0
+  %12 = tuple ()
+  return %12
+}
+


### PR DESCRIPTION
If the base value of a `mark_dependence` is an address, that memory location must be initialized at the `mark_dependence`.
This requires that the `mark_dependence` is considered to read from the base address.

Also, verify that the base value is initialized in the MemoryLifetimeVerifier.
The check is not perfect, because it only checks that the base operand is alive _at_ the mark_dependence. Ideally it should check that the base operand is alive during the whole lifetime of the value operand.

The verification uncovered a problem in TempRValueOptimization which is fixed by not optimizing copies to `mark_dependence` base values.