### PR TITLE
[Backtracing] Local|RemoteMemoryReader only exists on macOS and Linux.

### DIFF
--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -1879,7 +1879,9 @@ typealias Elf64Image = ElfImage<Elf64Traits>
 /// Test if there is a valid ELF image at the specified address; if there is,
 /// extract the address range for the text segment and the UUID, if any.
 @_specialize(kind: full, where R == UnsafeLocalMemoryReader)
+#if os(macOS) || os(Linux)
 @_specialize(kind: full, where R == RemoteMemoryReader)
+#endif
 #if os(Linux)
 @_specialize(kind: full, where R == MemserverMemoryReader)
 #endif
@@ -1915,8 +1917,10 @@ func getElfImageInfo<R: MemoryReader>(at address: R.Address,
 
 @_specialize(kind: full, where R == UnsafeLocalMemoryReader, Traits == Elf32Traits)
 @_specialize(kind: full, where R == UnsafeLocalMemoryReader, Traits == Elf64Traits)
+#if os(macOS) || os(Linux)
 @_specialize(kind: full, where R == RemoteMemoryReader, Traits == Elf32Traits)
 @_specialize(kind: full, where R == RemoteMemoryReader, Traits == Elf64Traits)
+#endif
 #if os(Linux)
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf32Traits)
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf64Traits)

--- a/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
+++ b/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
@@ -36,7 +36,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   var reader: MemoryReader
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
@@ -77,7 +79,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   }
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
@@ -114,7 +118,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   }
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
@@ -129,7 +135,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   }
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
@@ -138,7 +146,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   }
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
@@ -155,7 +165,9 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   }
 
   @_specialize(exported: true, kind: full, where C == HostContext, M == UnsafeLocalMemoryReader)
+  #if os(macOS) || os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == RemoteMemoryReader)
+  #endif
   #if os(Linux)
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif


### PR DESCRIPTION
When fixing the previous problem, I should have realised that this would cascade; the `@_specialize` annotations refer to the cached versions of the types, and those are now turned off except on macOS and Linux because they rely on the uncached versions, which are only available on macOS and Linux.

rdar://144023438
