### PR TITLE
Concurrency: silence some unused variable warnings

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -151,9 +151,9 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
+#if defined(__APPLE__) && !defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
 static constexpr size_t dispatchQueueCooperativeFlag = 4;
-
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__APPLE__)
+#else
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -307,6 +307,7 @@ bool swift::addStatusRecord(AsyncTask *task, TaskStatusRecord *newRecord,
     // Wait for any active lock to be released.
     if (oldStatus.isStatusRecordLocked()) {
       bool selfLocked = waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus);
+      static_cast<void>(selfLocked);
       assert(!selfLocked);
     }
 
@@ -368,6 +369,7 @@ static void removeStatusRecordLocked(ActiveTaskStatus status, TaskStatusRecord *
     }
     cur = next;
   }
+  static_cast<void>(removedRecord);
   assert(removedRecord);
 }
 


### PR DESCRIPTION
This cleans up some warnings from the unused variables. The variables were referenced by `assert` cases only.