### PR TITLE
[ClangImporter][Tests] clang doesn't support the empty string as a path argument

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -937,20 +937,24 @@ importer::addCommonInvocationArguments(
   }
 
   for (const auto &framepath : searchPathOpts.getFrameworkSearchPaths()) {
-    if (framepath.IsSystem) {
-      invocationArgStrs.push_back("-iframework");
-      invocationArgStrs.push_back(framepath.Path);
-    } else {
-      invocationArgStrs.push_back("-F" + framepath.Path);
+    if (!framepath.Path.empty()) {
+      if (framepath.IsSystem) {
+        invocationArgStrs.push_back("-iframework");
+        invocationArgStrs.push_back(framepath.Path);
+      } else {
+        invocationArgStrs.push_back("-F" + framepath.Path);
+      }
     }
   }
 
   for (const auto &path : searchPathOpts.getImportSearchPaths()) {
-    if (path.IsSystem) {
-      invocationArgStrs.push_back("-isystem");
-      invocationArgStrs.push_back(path.Path);
-    } else {
-      invocationArgStrs.push_back("-I" + path.Path);
+    if (!path.Path.empty()) {
+      if (path.IsSystem) {
+        invocationArgStrs.push_back("-isystem");
+        invocationArgStrs.push_back(path.Path);
+      } else {
+        invocationArgStrs.push_back("-I" + path.Path);
+      }
     }
   }
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2928,10 +2928,12 @@ config.substitutions.insert(0, ('%platform-sdk-overlay-dir', platform_sdk_overla
 config.substitutions.insert(0, ('%platform-dylib-dir', platform_dylib_dir))
 config.substitutions.insert(0, ('%test-resource-dir', test_resource_dir))
 
-if run_vendor != 'apple':
-    extra_frameworks_dir = ''
+if run_vendor == 'apple':
+    extra_frameworks_search_path = '-F %r' % extra_frameworks_dir
+else:
+    extra_frameworks_search_path = ''
     extra_platform_search_paths = ''
-config.substitutions.append(('%xcode-extra-frameworks-dir', extra_frameworks_dir))
+config.substitutions.append(('%xcode-extra-frameworks-search-path', extra_frameworks_search_path))
 config.substitutions.append(('%xcode-extra-platform-search-paths', extra_platform_search_paths))
 
 config.substitutions.append(('%target-swiftmodule-name', target_specific_module_triple + '.swiftmodule'))

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -3,14 +3,12 @@
 # RUN:     %swift_src_root \
 # RUN:     %target-sil-opt -sdk %sdk -enable-sil-verify-all \
 # RUN:       -F %sdk/System/Library/PrivateFrameworks \
-# RUN:       -F "%xcode-extra-frameworks-dir"
+# RUN:       %xcode-extra-frameworks-search-path
 
 # REQUIRES: rdar143050566
 # REQUIRES: long_test
 # REQUIRES: nonexecutable_test
 
-# rdar://142441042
-# UNSUPPORTED: OS=linux-gnu
 
 import os
 import subprocess


### PR DESCRIPTION
SIL/verify_all_overlays.py is passing `-F ""` on non-Apple platforms. Swift handles that kind of, but clang doesn't support it and will get argument parsing errors. It's a pathological case, so fix SIL/verify_all_overlays.py to not do that, but also add a failsafe in ClangImporter to not pass on empty paths.

rdar://142441042