### PR TITLE
[Parser] Include all AST nodes from every #if region in ParserUnit

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -98,6 +98,9 @@ public:
 
     /// Validate the new SwiftSyntax parser diagnostics.
     ValidateNewParserDiagnostics = 1 << 6,
+
+    /// Consider every #if ... #endif region active.
+    PoundIfAllActive = 1 << 7,
   };
   using ParsingOptions = OptionSet<ParsingFlags>;
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -834,6 +834,11 @@ Result Parser::parseIfConfigRaw(
       // determined solely by which block has the completion token.
       !ideInspectionClauseLoc.isValid();
 
+  // For constructing syntactic structures, we need AST nodes even for
+  // non-active regions.
+  bool allActive = SF.getParsingOptions().contains(
+      SourceFile::ParsingFlags::PoundIfAllActive);
+
   bool foundActive = false;
   bool isVersionCondition = false;
   CharSourceRange activeBodyRange;
@@ -892,6 +897,9 @@ Result Parser::parseIfConfigRaw(
     // Treat the region containing code completion token as "active".
     if (ideInspectionClauseLoc.isValid() && !foundActive)
       isActive = (ClauseLoc == ideInspectionClauseLoc);
+
+    if (allActive)
+      isActive = true;
 
     foundActive |= isActive;
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -381,7 +381,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                             IsFollowingGuard);
 
             if (IsActive)
-              activeElements = std::move(elements);
+              activeElements.append(elements);
           });
       if (IfConfigResult.hasCodeCompletion() && isIDEInspectionFirstPass()) {
         consumeDecl(BeginParserPosition, IsTopLevel);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1145,6 +1145,7 @@ struct ParserUnit::Implementation {
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);
     parsingOpts |= ParsingFlags::DisableDelayedBodies;
     parsingOpts |= ParsingFlags::DisablePoundIfEvaluation;
+    parsingOpts |= ParsingFlags::PoundIfAllActive;
 
     auto *M = ModuleDecl::createEmpty(Ctx.getIdentifier(ModuleName), Ctx);
     SF = new (Ctx) SourceFile(*M, SFKind, BufferID, parsingOpts);

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -1,5 +1,326 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s -D CONF | %FileCheck %s
 
+// CHECK: <kw>var</kw> f : <type>Int</type>
+var f : Int
+
+// CHECK: <#kw>#if</#kw> os(macOS)
+#if os(macOS)
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x : <type>Int</type>
+  var x : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x : <type>Float</type>
+  var x : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  var x2 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  var x3 : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  var x3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  var x4 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  var y1 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  var y1 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  var y1 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  var y2 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  var y2 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  var y2 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  var y3 : Int
+// CHECK: <#kw>#elseif</#kw> CONF
+#elseif CONF
+  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  var y3 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  var y3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <kw>var</kw> l : <type>Int</type>
+var l : Int
+
+// CHECK: <kw>class</kw> C1 {
+class C1 {
+  // CHECK: <kw>var</kw> f : <type>Int</type>
+  var f : Int
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x : <type>Int</type>
+  var x : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x : <type>Float</type>
+  var x : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  var x2 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  var x3 : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  var x3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  var x4 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  var y1 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  var y1 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  var y1 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  var y2 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  var y2 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  var y2 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  var y3 : Int
+// CHECK: <#kw>#elseif</#kw> CONF
+#elseif CONF
+  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  var y3 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  var y3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+  // CHECK: <kw>var</kw> l : <type>Int</type>
+  var l : Int
+}
+
+// CHECK: <kw>func</kw> test1() {
+func test1() {
+  // CHECK: <kw>var</kw> f : <type>Int</type>
+  var f : Int
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x : <type>Int</type>
+  var x : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x : <type>Float</type>
+  var x : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  var x2 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  var x3 : Int
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  var x3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  var x4 : Int
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> CONF
+#if CONF
+  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  var y1 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  var y1 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  var y1 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  var y2 : Int
+// CHECK: <#kw>#elseif</#kw> BAZ
+#elseif BAZ
+  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  var y2 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  var y2 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+// CHECK: <#kw>#if</#kw> !CONF
+#if !CONF
+  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  var y3 : Int
+// CHECK: <#kw>#elseif</#kw> CONF
+#elseif CONF
+  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  var y3 : String
+// CHECK: <#kw>#else</#kw>
+#else
+  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  var y3 : Float
+// CHECK: <#kw>#endif</#kw>
+#endif
+
+  // CHECK: <kw>var</kw> l : <type>Int</type>
+  var l : Int
+}
+
+// CHECK: <kw>class</kw> C2 {
+class C2 {
+  // CHECK: <#kw>#if</#kw> os(iOS)
+  #if os(iOS)
+  // CHECK: <kw>func</kw> foo() {}
+  func foo() {}
+  #endif
+}
+
+class NestedPoundIf {
+// CHECK: <kw>class</kw> NestedPoundIf {
+    func foo1() {
+// CHECK: <kw>func</kw> foo1() {
+        #if os(macOS)
+// CHECK: <#kw>#if</#kw> os(macOS)
+          var a = 1
+// CHECK: <kw>var</kw> a = <int>1</int>
+            #if USE_METAL
+// CHECK: <#kw>#if</#kw> USE_METAL
+              var b = 2
+// CHECK: <kw>var</kw> b = <int>2</int>
+              #if os(iOS)
+// CHECK: <#kw>#if</#kw> os(iOS)
+                var c = 3
+// CHECK: <kw>var</kw> c = <int>3</int>
+              #else
+// CHECK: <#kw>#else</#kw>
+                var c = 3
+// CHECK: <kw>var</kw> c = <int>3</int>
+              #endif
+// CHECK: <#kw>#endif</#kw>
+            #else
+// CHECK: <#kw>#else</#kw>
+              var b = 2
+// CHECK: <kw>var</kw> b = <int>2</int>
+            #endif
+// CHECK: <#kw>#endif</#kw>
+           #else
+// CHECK: <#kw>#else</#kw>
+            var a = 1
+// CHECK: <kw>var</kw> a = <int>1</int>
+        #endif
+// CHECK: <#kw>#endif</#kw>
+    }
+    func foo2() {}
+// CHECK: <kw>func</kw> foo2() {}
+    func foo3() {}
+// CHECK: <kw>func</kw> foo3() {}
+}
+
 // CHECK: <#kw>#error</#kw>(<str>"Error"</str>)
 #error("Error")
 // CHECK: <#kw>#warning</#kw>(<str>"Warning"</str>)

--- a/test/IDE/coloring_unclosed_hash_if.swift
+++ b/test/IDE/coloring_unclosed_hash_if.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
+
+// CHECK: <#kw>#if</#kw> d
+// CHECK-NEXT: <kw>func</kw> bar() {
+// CHECK-NEXT: <#kw>#if</#kw> d
+// CHECK-NEXT: }
+// CHECK-NEXT: <kw>func</kw> foo() {}
+
+#if d
+func bar() {
+  #if d
+}
+func foo() {}

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -147,11 +147,13 @@ braced2(x: {<#T##() -> Void#>}, y: Int)
 // CHECK-NEXT:  }, y: Int)
 
 braced3({
+  #if true
   <#T##() -> Int#>
+  #endif
 })
 // CHECK:      braced3 {
-// CHECK-NEXT:      <#code#>
-// CHECK-NEXT:  }
+// CHECK-NEXT:   <#code#>
+// CHECK-NEXT: }
 
 func returnTrailing() -> Int {
   return withtrail(<#T##() -> ()#>)
@@ -254,6 +256,17 @@ func activeWithTrailing() {
   // CHECK: forEach {
   // CHECK-NEXT: <#code#>
 }
+#if false
+func inactive() {
+  foo(<#T##value: Foo##Foo#>)
+  // CHECK: foo(Foo)
+}
+func inactiveWithTrailing() {
+  forEach(<#T##() -> ()#>)
+  // CHECK: forEach {
+  // CHECK-NEXT: <#code#>
+}
+#endif
 
 expandClosureWithInternalParameterNames {
   withtrail(<#T##callback: (Int, Int) -> Bool##(_ a: Int, _ b: Int) -> Bool#>)

--- a/test/SourceKit/CodeFormat/indent-pound-if.swift
+++ b/test/SourceKit/CodeFormat/indent-pound-if.swift
@@ -35,7 +35,7 @@ print(false)
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "#else"
-// CHECK: key.sourcetext: "let i = 3"
-// CHECK: key.sourcetext: "func b () {"
+// CHECK: key.sourcetext: "        let i = 3"
+// CHECK: key.sourcetext: "    func b () {"
 // CHECK: key.sourcetext: "#elseif os(OSX)"
-// CHECK: key.sourcetext: "func b () {"
+// CHECK: key.sourcetext: "    func b () {"

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1429,6 +1429,106 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2496,
+      key.length: 36,
+      key.nameoffset: 2506,
+      key.namelength: 6,
+      key.bodyoffset: 2514,
+      key.bodylength: 17,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2517,
+          key.length: 13,
+          key.nameoffset: 2522,
+          key.namelength: 5,
+          key.bodyoffset: 2529,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2534,
+      key.length: 53,
+      key.nameoffset: 2544,
+      key.namelength: 5,
+      key.bodyoffset: 2551,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2554,
+          key.length: 31,
+          key.nameoffset: 2560,
+          key.namelength: 5,
+          key.bodyoffset: 2567,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2572,
+              key.length: 9,
+              key.nameoffset: 2572,
+              key.namelength: 6,
+              key.bodyoffset: 2580,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2596,
+      key.length: 55,
+      key.nameoffset: 2606,
+      key.namelength: 6,
+      key.bodyoffset: 2614,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2589,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2617,
+          key.length: 32,
+          key.nameoffset: 2623,
+          key.namelength: 6,
+          key.bodyoffset: 2631,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2636,
+              key.length: 9,
+              key.nameoffset: 2636,
+              key.namelength: 6,
+              key.bodyoffset: 2644,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.protocol,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "BarProtocol",
@@ -1479,6 +1579,50 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "MyProtocol",
+      key.offset: 2780,
+      key.length: 71,
+      key.nameoffset: 2789,
+      key.namelength: 10,
+      key.bodyoffset: 2819,
+      key.bodylength: 31,
+      key.inheritedtypes: [
+        {
+          key.name: "NSObjectProtocol"
+        }
+      ],
+      key.attributes: [
+        {
+          key.offset: 2774,
+          key.length: 5,
+          key.attribute: source.decl.attribute.objc
+        }
+      ],
+      key.elements: [
+        {
+          key.kind: source.lang.swift.structure.elem.typeref,
+          key.offset: 2801,
+          key.length: 16
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "thing",
+          key.offset: 2824,
+          key.length: 25,
+          key.typename: "NSObject",
+          key.nameoffset: 2828,
+          key.namelength: 5,
+          key.bodyoffset: 2845,
+          key.bodylength: 3
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.class,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "A",
@@ -1487,7 +1631,44 @@
       key.nameoffset: 2866,
       key.namelength: 1,
       key.bodyoffset: 2869,
-      key.bodylength: 59
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2899,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2904,
+          key.namelength: 11,
+          key.bodyoffset: 2917,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2893,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2883,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2908,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2908,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     }
   ],
   key.diagnostics: [

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1429,6 +1429,106 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2496,
+      key.length: 36,
+      key.nameoffset: 2506,
+      key.namelength: 6,
+      key.bodyoffset: 2514,
+      key.bodylength: 17,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2517,
+          key.length: 13,
+          key.nameoffset: 2522,
+          key.namelength: 5,
+          key.bodyoffset: 2529,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2534,
+      key.length: 53,
+      key.nameoffset: 2544,
+      key.namelength: 5,
+      key.bodyoffset: 2551,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2554,
+          key.length: 31,
+          key.nameoffset: 2560,
+          key.namelength: 5,
+          key.bodyoffset: 2567,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2572,
+              key.length: 9,
+              key.nameoffset: 2572,
+              key.namelength: 6,
+              key.bodyoffset: 2580,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2596,
+      key.length: 55,
+      key.nameoffset: 2606,
+      key.namelength: 6,
+      key.bodyoffset: 2614,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2589,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2617,
+          key.length: 32,
+          key.nameoffset: 2623,
+          key.namelength: 6,
+          key.bodyoffset: 2631,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2636,
+              key.length: 9,
+              key.nameoffset: 2636,
+              key.namelength: 6,
+              key.bodyoffset: 2644,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.protocol,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "BarProtocol",
@@ -1479,6 +1579,50 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "MyProtocol",
+      key.offset: 2780,
+      key.length: 71,
+      key.nameoffset: 2789,
+      key.namelength: 10,
+      key.bodyoffset: 2819,
+      key.bodylength: 31,
+      key.inheritedtypes: [
+        {
+          key.name: "NSObjectProtocol"
+        }
+      ],
+      key.attributes: [
+        {
+          key.offset: 2774,
+          key.length: 5,
+          key.attribute: source.decl.attribute.objc
+        }
+      ],
+      key.elements: [
+        {
+          key.kind: source.lang.swift.structure.elem.typeref,
+          key.offset: 2801,
+          key.length: 16
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "thing",
+          key.offset: 2824,
+          key.length: 25,
+          key.typename: "NSObject",
+          key.nameoffset: 2828,
+          key.namelength: 5,
+          key.bodyoffset: 2845,
+          key.bodylength: 3
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.class,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "A",
@@ -1487,7 +1631,44 @@
       key.nameoffset: 2866,
       key.namelength: 1,
       key.bodyoffset: 2869,
-      key.bodylength: 59
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2899,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2904,
+          key.namelength: 11,
+          key.bodyoffset: 2917,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2893,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2883,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2908,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2908,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     }
   ],
   key.diagnostics: [

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1429,6 +1429,106 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2496,
+      key.length: 36,
+      key.nameoffset: 2506,
+      key.namelength: 6,
+      key.bodyoffset: 2514,
+      key.bodylength: 17,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2517,
+          key.length: 13,
+          key.nameoffset: 2522,
+          key.namelength: 5,
+          key.bodyoffset: 2529,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2534,
+      key.length: 53,
+      key.nameoffset: 2544,
+      key.namelength: 5,
+      key.bodyoffset: 2551,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2554,
+          key.length: 31,
+          key.nameoffset: 2560,
+          key.namelength: 5,
+          key.bodyoffset: 2567,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2572,
+              key.length: 9,
+              key.nameoffset: 2572,
+              key.namelength: 6,
+              key.bodyoffset: 2580,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2596,
+      key.length: 55,
+      key.nameoffset: 2606,
+      key.namelength: 6,
+      key.bodyoffset: 2614,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2589,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2617,
+          key.length: 32,
+          key.nameoffset: 2623,
+          key.namelength: 6,
+          key.bodyoffset: 2631,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2636,
+              key.length: 9,
+              key.nameoffset: 2636,
+              key.namelength: 6,
+              key.bodyoffset: 2644,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.protocol,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "BarProtocol",
@@ -1479,6 +1579,50 @@
       ]
     },
     {
+      key.kind: source.lang.swift.decl.protocol,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "MyProtocol",
+      key.offset: 2780,
+      key.length: 71,
+      key.nameoffset: 2789,
+      key.namelength: 10,
+      key.bodyoffset: 2819,
+      key.bodylength: 31,
+      key.inheritedtypes: [
+        {
+          key.name: "NSObjectProtocol"
+        }
+      ],
+      key.attributes: [
+        {
+          key.offset: 2774,
+          key.length: 5,
+          key.attribute: source.decl.attribute.objc
+        }
+      ],
+      key.elements: [
+        {
+          key.kind: source.lang.swift.structure.elem.typeref,
+          key.offset: 2801,
+          key.length: 16
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "thing",
+          key.offset: 2824,
+          key.length: 25,
+          key.typename: "NSObject",
+          key.nameoffset: 2828,
+          key.namelength: 5,
+          key.bodyoffset: 2845,
+          key.bodylength: 3
+        }
+      ]
+    },
+    {
       key.kind: source.lang.swift.decl.class,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "A",
@@ -1487,7 +1631,44 @@
       key.nameoffset: 2866,
       key.namelength: 1,
       key.bodyoffset: 2869,
-      key.bodylength: 59
+      key.bodylength: 59,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "foo(a:)",
+          key.offset: 2899,
+          key.length: 19,
+          key.selector_name: "fooWithA:",
+          key.nameoffset: 2904,
+          key.namelength: 11,
+          key.bodyoffset: 2917,
+          key.bodylength: 0,
+          key.attributes: [
+            {
+              key.offset: 2893,
+              key.length: 5,
+              key.attribute: source.decl.attribute.objc.name
+            },
+            {
+              key.offset: 2883,
+              key.length: 9,
+              key.attribute: source.decl.attribute.ibaction
+            }
+          ],
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "a",
+              key.offset: 2908,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 2908,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     }
   ],
   key.diagnostics: [

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -79,7 +79,7 @@
       key.length: 1
     },
     {
-      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
       key.offset: 153,
       key.length: 3
     },
@@ -99,7 +99,7 @@
       key.length: 1
     },
     {
-      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
       key.offset: 171,
       key.length: 5
     },


### PR DESCRIPTION
'ParserUnit' is used for analyzing syntax structures _mainly_ in SourceKit.

Since we removed IfConfigDecl from AST, ParserUnit didn't inclue any AST in #if ... #endif regions even for active region because it used to consider all inactive. Instead, consider every region "active" and include all the AST nodes.

rdar://117387631
