### PR TITLE
Sema: Loosen more available than enclosing extension diagnostic

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1437,8 +1437,13 @@ public:
 
   /// Returns the active platform-specific `@available` attribute that should be
   /// used to determine the platform introduction version of the decl.
+  ///
+  /// If the declaration does not have a platform introduction attribute of its
+  /// own and is a member of an extension then the platform introduction
+  /// attribute attached to the extension will be returned instead unless \p
+  /// checkExtension is false.
   std::optional<SemanticAvailableAttr>
-  getAvailableAttrForPlatformIntroduction() const;
+  getAvailableAttrForPlatformIntroduction(bool checkExtension = true) const;
 
   /// Returns true if the declaration is deprecated at the current deployment
   /// target.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -793,7 +793,7 @@ AvailabilityRange AvailabilityInference::annotatedAvailableRangeForAttr(
 }
 
 std::optional<SemanticAvailableAttr>
-Decl::getAvailableAttrForPlatformIntroduction() const {
+Decl::getAvailableAttrForPlatformIntroduction(bool checkExtension) const {
   if (auto attr = getDeclAvailableAttrForPlatformIntroduction(this))
     return attr;
 
@@ -804,6 +804,8 @@ Decl::getAvailableAttrForPlatformIntroduction() const {
   // if the declaration does not have an explicit @available attribute
   // itself. This check relies on the fact that we cannot have nested
   // extensions.
+  if (!checkExtension)
+    return std::nullopt;
 
   if (auto parent =
           AvailabilityInference::parentDeclForInferredAvailability(this)) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2338,7 +2338,8 @@ static Decl *getEnclosingDeclForDecl(Decl *D) {
 
 static std::optional<std::pair<SemanticAvailableAttr, const Decl *>>
 getSemanticAvailableRangeDeclAndAttr(const Decl *decl) {
-  if (auto attr = decl->getAvailableAttrForPlatformIntroduction())
+  if (auto attr = decl->getAvailableAttrForPlatformIntroduction(
+          /*checkExtension=*/false))
     return std::make_pair(*attr, decl);
 
   if (auto *parent =
@@ -2466,12 +2467,6 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
           // Members of extensions of nominal types with available ranges were
           // not diagnosed previously, so only emit a warning in that case.
           if (isa<ExtensionDecl>(DC->getTopmostDeclarationDeclContext()))
-            limit = DiagnosticBehavior::Warning;
-        } else if (enclosingAttr.getPlatform() != attr->getPlatform()) {
-          // Downgrade to a warning when the limiting attribute is for a more
-          // specific platform.
-          if (inheritsAvailabilityFromPlatform(enclosingAttr.getPlatform(),
-                                               attr->getPlatform()))
             limit = DiagnosticBehavior::Warning;
         }
         diagnose(D->isImplicit() ? enclosingDecl->getLoc()

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1184,9 +1184,14 @@ extension ClassToExtend : ProtocolAvailableOn51 {
 }
 
 @available(OSX, introduced: 51)
-extension ClassToExtend { // expected-note {{enclosing scope requires availability of macOS 51 or newer}}
+extension ClassToExtend { // expected-note 2 {{enclosing scope requires availability of macOS 51 or newer}}
   @available(OSX, introduced: 10.9) // expected-error {{instance method cannot be more available than enclosing scope}}
   func extensionMethod10_9() { }
+
+  struct Nested {
+    @available(OSX, introduced: 10.9) // expected-warning {{instance method cannot be more available than enclosing scope}}
+    func nestedTypeMethod10_9() { }
+  }
 }
 
 func usePotentiallyUnavailableExtension() {

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -167,8 +167,8 @@ public extension AvailableOnMacCatalyst { } // ok
 
 @available(iOS, introduced: 14.0)
 @available(macCatalyst, introduced: 14.5)
-public struct AvailableLaterOnMacCatalyst { // expected-note {{enclosing scope requires availability of Mac Catalyst 14.5 or newer}}
-  @available(iOS, introduced: 14.0) // expected-warning {{instance method cannot be more available than enclosing scope}}
+public struct AvailableLaterOnMacCatalyst { // expected-note 2 {{enclosing scope requires availability of Mac Catalyst 14.5 or newer}}
+  @available(iOS, introduced: 14.0) // expected-error {{instance method cannot be more available than enclosing scope}}
   func iOSOnly() { }
 
   @available(macCatalyst, introduced: 14.5)
@@ -177,4 +177,43 @@ public struct AvailableLaterOnMacCatalyst { // expected-note {{enclosing scope r
   @available(iOS, introduced: 14.0)
   @available(macCatalyst, introduced: 14.5)
   func iOSAndMacCatalyst() { }
+
+  struct Nested {
+    @available(iOS, introduced: 14.0) // expected-error {{instance method cannot be more available than enclosing scope}}
+    func iOSOnlyNested() { }
+
+    @available(macCatalyst, introduced: 14.5)
+    func macCatalystOnlyNested() { }
+
+    @available(iOS, introduced: 14.0)
+    @available(macCatalyst, introduced: 14.5)
+    func iOSAndMacCatalystNested() { }
+  }
+}
+
+@available(iOS, introduced: 14.0)
+@available(macCatalyst, introduced: 14.5)
+extension AvailableLaterOnMacCatalyst { // expected-note 2 {{enclosing scope requires availability of Mac Catalyst 14.5 or newer}}
+  @available(iOS, introduced: 14.0) // expected-error {{instance method cannot be more available than enclosing scope}}
+  func iOSOnlyInExtension() { }
+
+  @available(macCatalyst, introduced: 14.5)
+  func macCatalystOnlyInExtension() { }
+
+  @available(iOS, introduced: 14.0)
+  @available(macCatalyst, introduced: 14.5)
+  func iOSAndMacCatalystInExtension() { }
+
+  struct NestedInExtension {
+    @available(iOS, introduced: 14.0) // expected-warning {{instance method cannot be more available than enclosing scope}}
+    func iOSOnlyNestedInExtension() { }
+
+    @available(macCatalyst, introduced: 14.5)
+    func macCatalystOnlyNestedInExtension() { }
+
+    @available(iOS, introduced: 14.0)
+    @available(macCatalyst, introduced: 14.5)
+    func iOSAndMacCatalystNestedInExtension() { }
+  }
+
 }


### PR DESCRIPTION
When diagnosing a declaration that is more available than its context, to preserve source compatibility we need to downgrade the diagnostic to a warning when the outermost declaration is an extension. This logic regressed with https://github.com/swiftlang/swift/pull/77950 and my earlier attempt to fix this (https://github.com/swiftlang/swift/pull/78832) misidentified what had regressed.

Really resolves rdar://143423070.
