### PR TITLE
[ASTGen] Generate AvailableAttr

### DIFF
--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ArgumentList.h"
+#include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/IfConfigClauseRangeInfo.h"
@@ -234,6 +235,14 @@ swift::DeclAttributes BridgedDeclAttributes::unbridged() const {
   swift::DeclAttributes attrs;
   attrs.setRawAttributeChain(chain.unbridged());
   return attrs;
+}
+
+BridgedAvailabilityDomain::BridgedAvailabilityDomain(
+    swift::AvailabilityDomain domain)
+    : opaque(domain.getOpaqueValue()) {}
+
+swift::AvailabilityDomain BridgedAvailabilityDomain::unbridged() const {
+  return swift::AvailabilityDomain::fromOpaque(opaque);
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -87,6 +87,11 @@ AST_BRIDGING_WRAPPER_NULLABLE(CustomAttributeInitializer)
 AST_BRIDGING_WRAPPER_NONNULL(TypeAttributes)
 AST_BRIDGING_WRAPPER_NONNULL(CustomAttribute)
 AST_BRIDGING_WRAPPER_NULLABLE(ArgumentList)
+AST_BRIDGING_WRAPPER_NULLABLE(AvailabilitySpec)
+AST_BRIDGING_WRAPPER_NULLABLE(PlatformVersionConstraintAvailabilitySpec)
+AST_BRIDGING_WRAPPER_NULLABLE(PlatformAgnosticVersionConstraintAvailabilitySpec)
+AST_BRIDGING_WRAPPER_NULLABLE(OtherPlatformAvailabilitySpec)
+AST_BRIDGING_WRAPPER_NONNULL(AvailabilityMacroMap)
 
 // Non-AST types to generate wrappers for.
 AST_BRIDGING_WRAPPER_NULLABLE(DiagnosticEngine)

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -996,11 +996,8 @@ public:
     return getMultiPayloadEnumTagSinglePayloadAvailability();
   }
 
-  /// Cache of the availability macros parsed from the command line arguments.
-  ///
-  /// This is an implementation detail, access via
-  /// \c Parser::parseAllAvailabilityMacroArguments.
-  AvailabilityMacroMap &getAvailabilityMacroCache() const;
+  /// Availability macros parsed from the command line arguments.
+  const AvailabilityMacroMap &getAvailabilityMacroMap() const;
 
   /// Test support utility for loading a platform remap file
   /// in case an SDK is not specified to the compilation.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -112,12 +112,6 @@ private:
 
   AvailabilityDomain(Storage storage) : storage(storage) {};
 
-  static AvailabilityDomain fromOpaque(void *opaque) {
-    return AvailabilityDomain(Storage::getFromOpaqueValue(opaque));
-  }
-
-  void *getOpaqueValue() const { return storage.getOpaqueValue(); }
-
   std::optional<InlineDomain> getInlineDomain() const {
     return storage.is<InlineDomainPtr>()
                ? static_cast<std::optional<InlineDomain>>(
@@ -160,6 +154,12 @@ public:
   /// Returns the built-in availability domain identified by the given string.
   static std::optional<AvailabilityDomain>
   builtinDomainForString(StringRef string, const DeclContext *declContext);
+
+  static AvailabilityDomain fromOpaque(void *opaque) {
+    return AvailabilityDomain(Storage::getFromOpaqueValue(opaque));
+  }
+
+  void *getOpaqueValue() const { return storage.getOpaqueValue(); }
 
   Kind getKind() const {
     if (auto inlineDomain = getInlineDomain())

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -25,6 +25,7 @@
 namespace swift {
 
 struct ASTNode;
+class AvailabilityMacroMap;
 
 /// Report that a request of the given kind is being evaluated, so it
 /// can be recorded by the stats reporter.
@@ -191,6 +192,30 @@ private:
       Evaluator &evaluator, SourceFile *SF, SourceRange conditionRange,
       bool shouldEvaluate) const;
 };
+
+/// Parse the '-define-availability' arguments.
+class AvailabilityMacroArgumentsRequest
+    : public SimpleRequest<AvailabilityMacroArgumentsRequest,
+                           AvailabilityMacroMap *(ASTContext *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  AvailabilityMacroMap *evaluate(Evaluator &evaluator, ASTContext *ctx) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+
+  // Source location.
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+};
+
+void simple_display(llvm::raw_ostream &out, const ASTContext *state);
 
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -34,3 +34,6 @@ SWIFT_REQUEST(Parse, ExportedSourceFileRequest,
 SWIFT_REQUEST(Parse, EvaluateIfConditionRequest,
               (std::pair<bool, bool>)(SourceFile *, SourceRange, bool), Uncached,
               NoLocationInfo)
+SWIFT_REQUEST(Parse, AvailabilityMacroArgumentsRequest,
+              (AvailabilityMacroMap *)(ASTContext *), Cached,
+              NoLocationInfo)

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -78,6 +78,7 @@
 namespace llvm {
 class raw_ostream;
 class StringRef;
+class VersionTuple;
 } // end namespace llvm
 
 namespace swift {
@@ -163,10 +164,13 @@ public:
 
 SWIFT_NAME("getter:BridgedArrayRef.data(self:)")
 BRIDGED_INLINE
-const void *_Nullable BridgedArrayRef_data(BridgedArrayRef arr);
+const void *_Nullable BridgedArrayRef_data(const BridgedArrayRef arr);
 
 SWIFT_NAME("getter:BridgedArrayRef.count(self:)")
-BRIDGED_INLINE SwiftInt BridgedArrayRef_count(BridgedArrayRef arr);
+BRIDGED_INLINE SwiftInt BridgedArrayRef_count(const BridgedArrayRef arr);
+
+SWIFT_NAME("getter:BridgedArrayRef.isEmpty(self:)")
+BRIDGED_INLINE bool BridgedArrayRef_isEmpty(const BridgedArrayRef arr);
 
 //===----------------------------------------------------------------------===//
 // MARK: Data
@@ -460,6 +464,44 @@ struct BridgedVirtualFile {
   BridgedStringRef Name;
   ptrdiff_t LineOffset;
   size_t NamePosition;
+};
+
+//===----------------------------------------------------------------------===//
+// MARK: VersionTuple
+//===----------------------------------------------------------------------===//
+
+struct BridgedVersionTuple {
+  unsigned Major : 32;
+
+  unsigned Minor : 31;
+  unsigned HasMinor : 1;
+
+  unsigned Subminor : 31;
+  unsigned HasSubminor : 1;
+
+  unsigned Build : 31;
+  unsigned HasBuild : 1;
+
+  BridgedVersionTuple()
+      : Major(0), Minor(0), HasMinor(false), Subminor(0), HasSubminor(false),
+        Build(0), HasBuild(false) {}
+  BridgedVersionTuple(unsigned Major)
+      : Major(Major), Minor(0), HasMinor(false), Subminor(0),
+        HasSubminor(false), Build(0), HasBuild(false) {}
+  BridgedVersionTuple(unsigned Major, unsigned Minor)
+      : Major(Major), Minor(Minor), HasMinor(true), Subminor(0),
+        HasSubminor(false), Build(0), HasBuild(false) {}
+  BridgedVersionTuple(unsigned Major, unsigned Minor, unsigned Subminor)
+      : Major(Major), Minor(Minor), HasMinor(true), Subminor(Subminor),
+        HasSubminor(true), Build(0), HasBuild(false) {}
+  BridgedVersionTuple(unsigned Major, unsigned Minor, unsigned Subminor,
+                      unsigned Build)
+      : Major(Major), Minor(Minor), HasMinor(true), Subminor(Subminor),
+        HasSubminor(true), Build(Build), HasBuild(true) {}
+
+  BridgedVersionTuple(llvm::VersionTuple);
+
+  llvm::VersionTuple unbridged() const;
 };
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -14,6 +14,8 @@
 #define SWIFT_BASIC_BASICBRIDGINGIMPL_H
 
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/SourceLoc.h"
+#include "llvm/ADT/StringRef.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -21,12 +23,16 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 // MARK: BridgedArrayRef
 //===----------------------------------------------------------------------===//
 
-const void *_Nullable BridgedArrayRef_data(BridgedArrayRef arr) {
+const void *_Nullable BridgedArrayRef_data(const BridgedArrayRef arr) {
   return arr.Data;
 }
 
-SwiftInt BridgedArrayRef_count(BridgedArrayRef arr) {
+SwiftInt BridgedArrayRef_count(const BridgedArrayRef arr) {
   return static_cast<SwiftInt>(arr.Length);
+}
+
+bool BridgedArrayRef_isEmpty(const BridgedArrayRef arr) {
+  return arr.Length == 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -111,6 +111,14 @@ swift_ASTGen_virtualFiles(void *_Nonnull sourceFile,
 void swift_ASTGen_freeBridgedVirtualFiles(
     BridgedVirtualFile *_Nullable virtualFiles, size_t numFiles);
 
+bool swift_ASTGen_parseAvailabilityMacroDefinition(
+    BridgedASTContext ctx, BridgedDeclContext dc, BridgedDiagnosticEngine diags,
+    BridgedStringRef buffer,
+    BridgedAvailabilityMacroDefinition *_Nonnull outPtr);
+
+void swift_ASTGen_freeAvailabilityMacroDefinition(
+    BridgedAvailabilityMacroDefinition *_Nonnull definition);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2047,21 +2047,13 @@ public:
   ParserStatus
   parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs);
 
-  /// Parse the availability macros definitions passed as arguments.
-  AvailabilityMacroMap &parseAllAvailabilityMacroArguments();
-
-  /// Result of parsing an availability macro definition.
-  struct AvailabilityMacroDefinition {
-    StringRef Name;
-    llvm::VersionTuple Version;
-    SmallVector<AvailabilitySpec *, 4> Specs;
-  };
-
   /// Parse an availability macro definition from a command line argument.
-  /// This function should be called on a Parser set up on the command line
+  /// This function should only be called on a Parser set up on the command line
   /// argument code.
   ParserStatus
-  parseAvailabilityMacroDefinition(AvailabilityMacroDefinition &Result);
+  parseAvailabilityMacroDefinition(std::string &Name,
+                                   llvm::VersionTuple &Version,
+                                   SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   ParserResult<AvailabilitySpec> parseAvailabilitySpec();
   ParserResult<PlatformVersionConstraintAvailabilitySpec>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -427,9 +427,6 @@ struct ASTContext::Implementation {
   /// Singleton used to cache the import graph.
   swift::namelookup::ImportCache TheImportCache;
 
-  /// Cache of availability macros parsed from the command line.
-  AvailabilityMacroMap TheAvailabilityMacroCache;
-
   /// The module loader used to load Clang modules.
   ClangModuleLoader *TheClangModuleLoader = nullptr;
 
@@ -2297,8 +2294,10 @@ swift::namelookup::ImportCache &ASTContext::getImportCache() const {
   return getImpl().TheImportCache;
 }
 
-AvailabilityMacroMap &ASTContext::getAvailabilityMacroCache() const {
-  return getImpl().TheAvailabilityMacroCache;
+const AvailabilityMacroMap &ASTContext::getAvailabilityMacroMap() const {
+  auto *ctx = const_cast<ASTContext *>(this);
+  return *evaluateOrFatal(ctx->evaluator,
+                          AvailabilityMacroArgumentsRequest{ctx});
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4885,8 +4885,12 @@ public:
   void visitAvailableAttr(AvailableAttr *Attr, Label label) {
     printCommon(Attr, "available_attr", label);
 
-    if (auto domain = Attr->getCachedDomain())
-      printField(domain->getNameForAttributePrinting(), Label::always("platform"));
+    if (auto domain = Attr->getCachedDomain()) {
+      printField(domain->getNameForAttributePrinting(),
+                 Label::always("domain"));
+    } else {
+      printField(*Attr->getDomainString(), Label::always("domainString"));
+    }
 
     switch (Attr->getKind()) {
     case swift::AvailableAttr::Kind::Default:

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -13,6 +13,7 @@
 #include "swift/AST/ASTBridging.h"
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/AvailabilitySpec.h"
 
 using namespace swift;
 
@@ -166,4 +167,10 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
   return cContext.unbridged().canImportModule(
       builder.get(), canImportLoc.unbridged(), version,
       versionKind == CanImportUnderlyingVersion);
+}
+
+BridgedAvailabilityMacroMap
+BridgedASTContext_getAvailabilityMacroMap(BridgedASTContext cContext) {
+  return const_cast<AvailabilityMacroMap *>(
+      &cContext.unbridged().getAvailabilityMacroMap());
 }

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -1,0 +1,178 @@
+//===--- Bridging/AvailabilityBridging.cpp --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTBridging.h"
+#include "swift/AST/AvailabilitySpec.h"
+#include "swift/AST/PlatformKind.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedAvailabilityMacroMap
+//===----------------------------------------------------------------------===//
+
+bool BridgedAvailabilityMacroMap_hasName(BridgedAvailabilityMacroMap map,
+                                         BridgedStringRef name) {
+  return map.unbridged()->hasMacroName(name.unbridged());
+}
+
+bool BridgedAvailabilityMacroMap_hasNameAndVersion(
+    BridgedAvailabilityMacroMap map, BridgedStringRef name,
+    BridgedVersionTuple version) {
+  return map.unbridged()->hasMacroNameVersion(name.unbridged(),
+                                              version.unbridged());
+}
+
+BridgedArrayRef
+BridgedAvailabilityMacroMap_getSpecs(BridgedAvailabilityMacroMap map,
+                                     BridgedStringRef name,
+                                     BridgedVersionTuple version) {
+  return map.unbridged()->getEntry(name.unbridged(), version.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: PlatformKind
+//===----------------------------------------------------------------------===//
+
+BridgedPlatformKind BridgedPlatformKind_fromString(BridgedStringRef cStr) {
+  auto optKind = platformFromString(cStr.unbridged());
+  if (!optKind)
+    return BridgedPlatformKind_None;
+
+  switch (*optKind) {
+  case PlatformKind::none:
+    return BridgedPlatformKind_None;
+#define AVAILABILITY_PLATFORM(X, PrettyName)                                   \
+  case PlatformKind::X:                                                        \
+    return BridgedPlatformKind_##X;
+#include "swift/AST/PlatformKinds.def"
+  }
+}
+
+static PlatformKind unbridge(BridgedPlatformKind platform) {
+  switch (platform) {
+  case BridgedPlatformKind_None:
+    return PlatformKind::none;
+#define AVAILABILITY_PLATFORM(X, PrettyName)                                   \
+  case BridgedPlatformKind_##X:                                                \
+    return PlatformKind::X;
+#include "swift/AST/PlatformKinds.def"
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: AvailabilitySpec
+//===----------------------------------------------------------------------===//
+
+BridgedSourceRange
+BridgedAvailabilitySpec_getSourceRange(BridgedAvailabilitySpec spec) {
+  return spec.unbridged()->getSourceRange();
+}
+
+BridgedAvailabilityDomain
+BridgedAvailabilitySpec_getDomain(BridgedAvailabilitySpec spec) {
+  auto domain = spec.unbridged()->getDomain();
+  if (domain)
+    return *domain;
+  return BridgedAvailabilityDomain();
+}
+
+BridgedVersionTuple
+BridgedAvailabilitySpec_getVersion(BridgedAvailabilitySpec spec) {
+  return spec.unbridged()->getVersion();
+}
+
+BridgedSourceRange
+BridgedAvailabilitySpec_getVersionRange(BridgedAvailabilitySpec spec) {
+  return spec.unbridged()->getVersionSrcRange();
+}
+
+static AvailabilitySpecKind unbridge(BridgedAvailabilitySpecKind kind) {
+  switch (kind) {
+  case BridgedAvailabilitySpecKindPlatformVersionConstraint:
+    return AvailabilitySpecKind::PlatformVersionConstraint;
+  case BridgedAvailabilitySpecKindOtherPlatform:
+    return AvailabilitySpecKind::OtherPlatform;
+  case BridgedAvailabilitySpecKindLanguageVersionConstraint:
+    return AvailabilitySpecKind::LanguageVersionConstraint;
+  case BridgedAvailabilitySpecKindPackageDescriptionVersionConstraint:
+    return AvailabilitySpecKind::PackageDescriptionVersionConstraint;
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+BridgedPlatformVersionConstraintAvailabilitySpec
+BridgedPlatformVersionConstraintAvailabilitySpec_createParsed(
+    BridgedASTContext cContext, BridgedPlatformKind cPlatform,
+    BridgedSourceLoc cPlatformLoc, BridgedVersionTuple cVersion,
+    BridgedVersionTuple cRuntimeVersion, BridgedSourceRange cVersionSrcRange) {
+  return new (cContext.unbridged()) PlatformVersionConstraintAvailabilitySpec(
+      unbridge(cPlatform), cPlatformLoc.unbridged(), cVersion.unbridged(),
+      cRuntimeVersion.unbridged(), cVersionSrcRange.unbridged());
+}
+
+BridgedPlatformAgnosticVersionConstraintAvailabilitySpec
+BridgedPlatformAgnosticVersionConstraintAvailabilitySpec_createParsed(
+    BridgedASTContext cContext, BridgedAvailabilitySpecKind cKind,
+    BridgedSourceLoc cNameLoc, BridgedVersionTuple cVersion,
+    BridgedSourceRange cVersionSrcRange) {
+  return new (cContext.unbridged())
+      PlatformAgnosticVersionConstraintAvailabilitySpec(
+          unbridge(cKind), cNameLoc.unbridged(), cVersion.unbridged(),
+          cVersionSrcRange.unbridged());
+}
+
+BridgedOtherPlatformAvailabilitySpec
+BridgedOtherPlatformAvailabilitySpec_createParsed(BridgedASTContext cContext,
+                                                  BridgedSourceLoc cLoc) {
+  return new (cContext.unbridged())
+      OtherPlatformAvailabilitySpec(cLoc.unbridged());
+}
+
+BridgedAvailabilitySpec
+BridgedPlatformVersionConstraintAvailabilitySpec_asAvailabilitySpec(
+    BridgedPlatformVersionConstraintAvailabilitySpec spec) {
+  return static_cast<AvailabilitySpec *>(spec.unbridged());
+}
+
+BridgedAvailabilitySpec
+BridgedPlatformAgnosticVersionConstraintAvailabilitySpec_asAvailabilitySpec(
+    BridgedPlatformAgnosticVersionConstraintAvailabilitySpec spec) {
+  return static_cast<AvailabilitySpec *>(spec.unbridged());
+}
+
+BridgedAvailabilitySpec BridgedOtherPlatformAvailabilitySpec_asAvailabilitySpec(
+    BridgedOtherPlatformAvailabilitySpec spec) {
+  return static_cast<AvailabilitySpec *>(spec.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: AvailabilityDomain
+//===----------------------------------------------------------------------===//
+
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forUniversal() {
+  return swift::AvailabilityDomain::forUniversal();
+}
+BridgedAvailabilityDomain
+BridgedAvailabilityDomain::forPlatform(BridgedPlatformKind platformKind) {
+  return swift::AvailabilityDomain::forPlatform(unbridge(platformKind));
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forSwiftLanguage() {
+  return swift::AvailabilityDomain::forSwiftLanguage();
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forPackageDescription() {
+  return swift::AvailabilityDomain::forPackageDescription();
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forEmbedded() {
+  return swift::AvailabilityDomain::forEmbedded();
+}

--- a/lib/AST/Bridging/CMakeLists.txt
+++ b/lib/AST/Bridging/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(swiftAST PRIVATE
   ASTContextBridging.cpp
+  AvailabilityBridging.cpp
   DeclAttributeBridging.cpp
   DeclBridging.cpp
   DeclContextBridging.cpp

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -73,6 +73,58 @@ void BridgedDeclAttributes_add(BridgedDeclAttributes *cAttrs,
   *cAttrs = attrs;
 }
 
+static AvailableAttr::Kind unbridge(BridgedAvailableAttrKind value) {
+  switch (value) {
+  case BridgedAvailableAttrKindDefault:
+    return AvailableAttr::Kind::Default;
+  case BridgedAvailableAttrKindDeprecated:
+    return AvailableAttr::Kind::Deprecated;
+  case BridgedAvailableAttrKindUnavailable:
+    return AvailableAttr::Kind::Unavailable;
+  case BridgedAvailableAttrKindNoAsync:
+    return AvailableAttr::Kind::NoAsync;
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+BridgedAvailableAttr BridgedAvailableAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceRange cRange, BridgedAvailabilityDomain cDomain,
+    BridgedSourceLoc cDomainLoc, BridgedAvailableAttrKind cKind,
+    BridgedStringRef cMessage, BridgedStringRef cRenamed,
+    BridgedVersionTuple cIntroduced, BridgedSourceRange cIntroducedRange,
+    BridgedVersionTuple cDeprecated, BridgedSourceRange cDeprecatedRange,
+    BridgedVersionTuple cObsoleted, BridgedSourceRange cObsoletedRange) {
+  return new (cContext.unbridged())
+      AvailableAttr(cAtLoc.unbridged(), cRange.unbridged(), cDomain.unbridged(),
+                    cDomainLoc.unbridged(), unbridge(cKind),
+                    cMessage.unbridged(), cRenamed.unbridged(),
+                    cIntroduced.unbridged(), cIntroducedRange.unbridged(),
+                    cDeprecated.unbridged(), cDeprecatedRange.unbridged(),
+                    cObsoleted.unbridged(), cObsoletedRange.unbridged(),
+                    /*Implicit=*/false,
+                    /*IsSPI=*/false);
+}
+
+BridgedAvailableAttr BridgedAvailableAttr_createParsedStr(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceRange cRange, BridgedStringRef cDomainString,
+    BridgedSourceLoc cDomainLoc, BridgedAvailableAttrKind cKind,
+    BridgedStringRef cMessage, BridgedStringRef cRenamed,
+    BridgedVersionTuple cIntroduced, BridgedSourceRange cIntroducedRange,
+    BridgedVersionTuple cDeprecated, BridgedSourceRange cDeprecatedRange,
+    BridgedVersionTuple cObsoleted, BridgedSourceRange cObsoletedRange) {
+  return new (cContext.unbridged())
+      AvailableAttr(cAtLoc.unbridged(), cRange.unbridged(),
+                    cDomainString.unbridged(), cDomainLoc.unbridged(),
+                    unbridge(cKind), cMessage.unbridged(), cRenamed.unbridged(),
+                    cIntroduced.unbridged(), cIntroducedRange.unbridged(),
+                    cDeprecated.unbridged(), cDeprecatedRange.unbridged(),
+                    cObsoleted.unbridged(), cObsoletedRange.unbridged(),
+                    /*Implicit=*/false,
+                    /*IsSPI=*/false);
+}
+
 static std::optional<AccessLevel> unbridge(BridgedAccessLevel level) {
   switch (level) {
   case BridgedAccessLevelPrivate:

--- a/lib/AST/Bridging/MiscBridging.cpp
+++ b/lib/AST/Bridging/MiscBridging.cpp
@@ -121,4 +121,3 @@ BridgedOwnedString BridgedSubstitutionMap::getDebugDescription() const {
   unbridged().dump(os);
   return BridgedOwnedString(str);
 }
-

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -244,6 +244,15 @@ extension ASTGenVisitor {
     return generateSourceRange(start: start, end: node.lastToken(viewMode: .sourceAccurate)!)
   }
 
+  /// Obtains bridged token source range of a syntax node.
+  @inline(__always)
+  func generateSourceRange(_ node: (some SyntaxProtocol)?) -> BridgedSourceRange {
+    guard let node = node else {
+      return BridgedSourceRange(start: nil, end: nil)
+    }
+    return generateSourceRange(node)
+  }
+
   /// Obtains bridged character source range.
   @inline(__always)
   func generateCharSourceRange(start: AbsolutePosition, length: SourceLength) -> BridgedCharSourceRange {

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -1,0 +1,426 @@
+//===--- Attrs.swift ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ASTBridging
+import BasicBridging
+import SwiftDiagnostics
+import SwiftParserDiagnostics
+import SwiftIfConfig
+@_spi(Compiler) import SwiftParser
+@_spi(RawSyntax) @_spi(Compiler) import SwiftSyntax
+
+extension ASTGenVisitor {
+  /// E.g.:
+  ///   ```
+  ///   @available(macOS 10.12, iOS 13, *)
+  ///   @available(macOS, introduced: 10.12)
+  ///   ```
+  func generateAvailableAttr(attribute node: AttributeSyntax) -> [BridgedAvailableAttr] {
+    guard let args = node.arguments else {
+      self.diagnose(.expectedArgumentsInAttribute(node))
+      return []
+    }
+    guard let args = args.as(AvailabilityArgumentListSyntax.self) else {
+      // TODO: Diagnose.
+      return []
+    }
+
+    // Check if this is "shorthand" syntax.
+    if let firstArg = args.first?.argument {
+      // We need to check availability macros specified by '-define-availability'.
+      let isShorthand: Bool
+      if let firstToken = firstArg.as(TokenSyntax.self), firstToken.rawTokenKind == .identifier, peekAvailabilityMacroName(firstToken.rawText) {
+        //   @available(myFeature, *)
+        isShorthand = true
+      } else if firstArg.is(PlatformVersionSyntax.self) {
+        //   @available(myPlatform 2.7, *)
+        isShorthand = true
+      } else {
+        isShorthand = false
+      }
+      if isShorthand {
+        return self.generateAvailableAttrShorthand(attribute: node)
+      }
+    }
+
+    // E.g.
+    //   @available(macOS, introduced: 10.12, deprecated: 11.2)
+    //   @available(*, unavailable, message: "out of service")
+    if let generated =  self.generateAvailableAttrExtended(attribute: node) {
+      return [generated]
+    }
+    return []
+  }
+
+  func generate(versionTuple node: VersionTupleSyntax?) -> VersionTuple? {
+    guard let node, let tuple = VersionTuple(parsing: node.trimmedDescription) else {
+      return nil
+    }
+    return tuple
+  }
+
+  func generateAvailableAttrShorthand(attribute node: AttributeSyntax) -> [BridgedAvailableAttr] {
+    let atLoc = self.generateSourceLoc(node.atSign)
+    let range = self.generateAttrSourceRange(node)
+    let specs = self.generateAvailabilitySpecList(
+      args: node.arguments!.cast(AvailabilityArgumentListSyntax.self),
+      context: .availableAttr
+    )
+
+    var result: [BridgedAvailableAttr] = []
+    for spec in specs {
+      let domain = spec.domain
+      guard !domain.isNull() else {
+        continue
+      }
+      let attr = BridgedAvailableAttr.createParsed(
+        self.ctx,
+        atLoc: atLoc,
+        range: range,
+        domain: domain,
+        domainLoc: spec.sourceRange.start,
+        kind: .default,
+        message: BridgedStringRef(),
+        renamed: BridgedStringRef(),
+        introduced: spec.version,
+        introducedRange: spec.versionRange,
+        deprecated: BridgedVersionTuple(),
+        deprecatedRange: BridgedSourceRange(),
+        obsoleted: BridgedVersionTuple(),
+        obsoletedRange: BridgedSourceRange()
+      )
+      result.append(attr)
+    }
+    return result
+  }
+
+  func generateAvailableAttrExtended(attribute node: AttributeSyntax) -> BridgedAvailableAttr? {
+    var args = node.arguments!.cast(AvailabilityArgumentListSyntax.self)[...]
+
+    // The platfrom.
+    guard let platformToken = args.popFirst()?.argument.as(TokenSyntax.self) else {
+      // TODO: Diangose
+      fatalError("missing first arg")
+    }
+    let platformStr = platformToken.rawText
+    let platformLoc = self.generateSourceLoc(platformToken)
+
+    // Other arguments can be shuffled.
+    enum Argument: UInt8 {
+      case message
+      case renamed
+      case introduced
+      case deprecated
+      case obsoleted
+      case invalid
+    }
+    var argState = AttrArgumentState<Argument, UInt8>(.invalid)
+    var attrKind: BridgedAvailableAttrKind = .default {
+      willSet {
+        if attrKind != .default {
+          fatalError("resetting attribute kind")
+        }
+      }
+    }
+
+    struct VersionAndRange {
+      let version: VersionTuple
+      let range: BridgedSourceRange
+    }
+
+    var introduced: VersionAndRange? = nil
+    var deprecated: VersionAndRange? = nil
+    var obsoleted: VersionAndRange? = nil
+    var message: BridgedStringRef? = nil
+    var renamed: BridgedStringRef? = nil
+
+    func generateVersion(arg: AvailabilityLabeledArgumentSyntax, into target: inout VersionAndRange?) {
+      guard let versionSytnax = arg.value.as(VersionTupleSyntax.self) else {
+        // TODO: Diagnose
+        fatalError("expected version after introduced, deprecated, or obsoleted")
+      }
+      guard let version = VersionTuple(parsing: versionSytnax.trimmedDescription) else {
+        // TODO: Diagnose
+        fatalError("invalid version string")
+      }
+      if target != nil {
+        // TODO: Diagnose duplicated.
+      }
+
+      target = .init(version: version, range: self.generateSourceRange(versionSytnax))
+    }
+
+    while let arg = args.popFirst() {
+      switch arg.argument {
+      case .availabilityVersionRestriction(_):
+        fatalError("platformVersion in extended args")
+
+      case .token(let arg):
+        // 'deprecated', 'unavailable, 'noasync' changes the mode.
+        switch arg.rawText {
+        case "deprecated":
+          attrKind = .deprecated
+        case "unavailable":
+          attrKind = .unavailable
+        case "noasync":
+          attrKind = .noAsync
+        default:
+          // TODO: Diagnose
+          continue
+        }
+
+      case .availabilityLabeledArgument(let arg):
+        switch arg.label.rawText {
+        case "message":
+          argState.current = .message
+        case "renamed":
+          argState.current = .renamed
+        case "introduced":
+          argState.current = .introduced
+        case "deprecated":
+          argState.current = .deprecated
+        case "obsoleted":
+          argState.current = .obsoleted
+        default:
+          argState.current = .invalid
+        }
+
+        switch argState.current {
+        case .introduced:
+          generateVersion(arg: arg, into: &introduced)
+        case .deprecated:
+          generateVersion(arg: arg, into: &deprecated)
+        case .obsoleted:
+          generateVersion(arg: arg, into: &obsoleted)
+        case .message:
+          guard let literal = arg.value.as(SimpleStringLiteralExprSyntax.self) else {
+            // TODO: Diagnose.
+            fatalError("invalid argument type for 'message:'")
+          }
+          guard let _message = self.generateStringLiteralTextIfNotInterpolated(expr: literal) else {
+            fatalError("invalid literal value")
+          }
+          guard message == nil else {
+            fatalError("duplicated 'message' argument")
+          }
+          message = _message
+        case .renamed:
+          guard let literal = arg.value.as(SimpleStringLiteralExprSyntax.self) else {
+            // TODO: Diagnose.
+            fatalError("invalid argument type for 'renamed:'")
+          }
+          guard let _renamed = self.generateStringLiteralTextIfNotInterpolated(expr: literal) else {
+            fatalError("invalid literal value")
+          }
+          guard renamed == nil else {
+            fatalError("duplicated 'message' argument")
+          }
+          renamed = _renamed
+        case .invalid:
+          // TODO: Diagnose
+          fatalError("invalid labeled argument")
+        }
+      }
+    }
+
+    return BridgedAvailableAttr.createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      domainString: platformStr.bridged,
+      domainLoc: platformLoc,
+      kind: attrKind,
+      message: message ?? BridgedStringRef(),
+      renamed: renamed ?? BridgedStringRef(),
+      introduced: introduced?.version.bridged ?? BridgedVersionTuple(),
+      introducedRange: introduced?.range ?? BridgedSourceRange(),
+      deprecated: deprecated?.version.bridged ?? BridgedVersionTuple(),
+      deprecatedRange: deprecated?.range ?? BridgedSourceRange(),
+      obsoleted: obsoleted?.version.bridged ?? BridgedVersionTuple(),
+      obsoletedRange: obsoleted?.range ?? BridgedSourceRange()
+    )
+  }
+
+  /// Return true if 'name' is an availability macro name.
+  func peekAvailabilityMacroName(_ name: SyntaxText) -> Bool {
+    let map = ctx.availabilityMacroMap
+    return map.has(name: name.bridged)
+  }
+
+  func generate(availabilityMacroDefinition node: AvailabilityMacroDefinitionSyntax) -> BridgedAvailabilityMacroDefinition {
+
+    let name = allocateBridgedString(node.platformVersion.platform.text)
+    let version = self.generate(versionTuple: node.platformVersion.version)
+    let specs = self.generateAvailabilitySpecList(args: node.specs, context: .macro)
+
+    let specsBuffer = UnsafeMutableBufferPointer<BridgedAvailabilitySpec>.allocate(capacity: specs.count)
+    _ = specsBuffer.initialize(from: specs)
+
+    return BridgedAvailabilityMacroDefinition(
+      name: name,
+      version: version?.bridged ?? BridgedVersionTuple(),
+      specs: BridgedArrayRef(data: UnsafeRawPointer(specsBuffer.baseAddress), count: specsBuffer.count)
+    )
+  }
+
+  enum AvailabilitySpecListContext {
+    case availableAttr
+    case macro
+  }
+
+  func generateAvailabilitySpecList(args node: AvailabilityArgumentListSyntax, context: AvailabilitySpecListContext) -> [BridgedAvailabilitySpec] {
+    var result: [BridgedAvailabilitySpec] = []
+
+    func handle(domainNode: TokenSyntax, versionNode: VersionTupleSyntax?) {
+      let nameLoc = self.generateSourceLoc(domainNode)
+      let version = self.generate(versionTuple: versionNode)
+      let versionRange = self.generateSourceRange(versionNode)
+
+      switch domainNode.rawText {
+      case "swift", "_PackageVersion":
+        let kind: BridgedAvailabilitySpecKind = domainNode.rawText == "swift"
+          ? .languageVersionConstraint
+          : .packageDescriptionVersionConstraint
+
+        let spec = BridgedPlatformAgnosticVersionConstraintAvailabilitySpec.createParsed(
+          self.ctx,
+          kind: kind,
+          nameLoc: nameLoc,
+          version: version?.bridged ?? BridgedVersionTuple(),
+          versionRange: versionRange
+        )
+        result.append(spec.asAvailabilitySpec)
+
+      case let name:
+        var macroMatched = false;
+        if context != .macro {
+          // Try expand macro first.
+          let expanded = ctx.availabilityMacroMap.get(
+            name: name.bridged,
+            version: version?.bridged ?? BridgedVersionTuple()
+          )
+          if !expanded.isEmpty {
+            expanded.withElements(ofType: UnsafeRawPointer.self) { buffer in
+              for ptr in buffer {
+                result.append(BridgedAvailabilitySpec(raw: UnsafeMutableRawPointer(mutating: ptr)))
+              }
+            }
+            macroMatched = true
+          }
+        }
+
+        // Was not a macro, it should be a valid platform name.
+        if !macroMatched {
+          let platform = BridgedPlatformKind(from: name.bridged)
+          guard platform != .none else {
+            // TODO: Diagnostics.
+            fatalError("invalid platform kind")
+          }
+          guard let version = version else {
+            // TODO: Diagnostics.
+            fatalError("expected version")
+          }
+          let spec = BridgedPlatformVersionConstraintAvailabilitySpec.createParsed(
+            self.ctx,
+            platform: platform,
+            platformLoc: nameLoc,
+            version: version.bridged,
+            runtimeVersion: version.bridged,
+            versionRange: versionRange
+          )
+          result.append(spec.asAvailabilitySpec)
+        }
+      }
+    }
+
+    for parsed in node {
+      switch parsed.argument {
+      case .token(let tok) where tok.rawText == "*":
+        let spec = BridgedOtherPlatformAvailabilitySpec.createParsed(
+          self.ctx,
+          loc: self.generateSourceLoc(tok)
+        )
+        result.append(spec.asAvailabilitySpec)
+      case .token(let tok):
+        handle(domainNode: tok, versionNode: nil)
+      case .availabilityVersionRestriction(let platformVersion):
+        handle(domainNode: platformVersion.platform, versionNode: platformVersion.version)
+      default:
+        // TODO: Diagnostics.
+        fatalError("invalid argument kind for availability spec")
+      }
+    }
+
+    return result
+  }
+}
+
+/// Parse an argument for '-define-availability' compiler option.
+@_cdecl("swift_ASTGen_parseAvailabilityMacroDefinition")
+func parseAvailabilityMacroDefinition(
+  ctx: BridgedASTContext,
+  dc: BridgedDeclContext,
+  diagEngine: BridgedDiagnosticEngine,
+  buffer: BridgedStringRef,
+  outPtr: UnsafeMutablePointer<BridgedAvailabilityMacroDefinition>
+) -> Bool {
+  let buffer = UnsafeBufferPointer(start: buffer.data, count: buffer.count)
+
+  // Parse.
+  var parser = Parser(buffer)
+  let parsed = AvailabilityMacroDefinitionSyntax.parse(from: &parser)
+
+  // Emit diagnostics.
+  let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: parsed)
+  for diagnostic in diagnostics {
+    emitDiagnostic(
+      diagnosticEngine: diagEngine,
+      sourceFileBuffer: buffer,
+      diagnostic: diagnostic,
+      diagnosticSeverity: diagnostic.diagMessage.severity
+    )
+  }
+  if parsed.hasError {
+    return true
+  }
+
+  // Generate.
+  let config = CompilerBuildConfiguration(ctx: ctx, sourceBuffer: buffer)
+  let configuredRegions = parsed.configuredRegions(in: config)
+
+  // FIXME: 'declContext' and 'configuredRegions' are never used.
+  let generator = ASTGenVisitor(
+    diagnosticEngine: diagEngine,
+    sourceBuffer: buffer,
+    declContext: dc,
+    astContext: ctx,
+    configuredRegions: configuredRegions
+  )
+  let generated = generator.generate(availabilityMacroDefinition: parsed)
+  outPtr.pointee = generated
+  return false
+}
+
+@_cdecl("swift_ASTGen_freeAvailabilityMacroDefinition")
+func freeAvailabilityMacroDefinition(
+  defintion: UnsafeMutablePointer<BridgedAvailabilityMacroDefinition>
+) {
+  freeBridgedString(bridged: defintion.pointee.name)
+
+  let specs = defintion.pointee.specs
+  let specsBuffer = UnsafeMutableBufferPointer(
+    start: UnsafeMutablePointer(mutating: specs.data?.assumingMemoryBound(to: BridgedAvailabilitySpec.self)),
+    count: specs.count
+  )
+  specsBuffer.deinitialize()
+  specsBuffer.deallocate()
+}

--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   ASTGen.swift
   ASTGen+CompilerBuildConfiguration.swift
+  Availability.swift
   Bridge.swift
   CompilerBuildConfiguration.swift
   DeclAttrs.swift

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -497,24 +497,6 @@ extension ASTGenVisitor {
     )
   }
 
-  /// E.g.:
-  ///   ```
-  ///   @available(macOS 10.12, iOS: 13, *)
-  ///   @available(macOS, introduced: 10.12)
-  ///   ```
-  func generateAvailableAttr(attribute node: AttributeSyntax) -> [BridgedAvailableAttr] {
-    guard
-      // `@available` has special argument list syntax.
-      let args = node.arguments?.as(AvailabilityArgumentListSyntax.self)
-    else {
-      // TODO: Diagnose.
-      return []
-    }
-
-    _ = args
-    fatalError("unimplemented")
-  }
-
   /// E.g:
   ///   ```
   ///   @_dynamicReplacement(for: member)
@@ -1859,7 +1841,7 @@ extension ASTGenVisitor {
 }
 
 /// Simpler helper for handling attribute arguments in "generate" functions.
-private struct AttrArgumentState<Flag: RawRepresentable, SeenStorage: FixedWidthInteger> where Flag.RawValue: FixedWidthInteger {
+struct AttrArgumentState<Flag: RawRepresentable, SeenStorage: FixedWidthInteger> where Flag.RawValue: FixedWidthInteger {
   private var seen: SeenStorage = 0
 
   var current: Flag {

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/Assertions.h"
 #include "swift/Basic/BasicBridging.h"
+#include "swift/Basic/Assertions.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/raw_ostream.h"
 
 #ifdef PURE_BRIDGING_MODE
@@ -93,4 +94,31 @@ BridgedCharSourceRangeVector::BridgedCharSourceRangeVector()
 void BridgedCharSourceRangeVector::push_back(BridgedCharSourceRange range) {
   static_cast<std::vector<CharSourceRange> *>(vector)->push_back(
       range.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedVersionTuple
+//===----------------------------------------------------------------------===//
+
+BridgedVersionTuple::BridgedVersionTuple(llvm::VersionTuple version) {
+  if (version.getBuild())
+    *this = BridgedVersionTuple(version.getMajor(), *version.getMinor(),
+                                *version.getSubminor(), *version.getBuild());
+  else if (version.getSubminor())
+    *this = BridgedVersionTuple(version.getMajor(), *version.getMinor(),
+                                *version.getSubminor());
+  else if (version.getMinor())
+    *this = BridgedVersionTuple(version.getMajor(), *version.getMinor());
+  else
+    *this = BridgedVersionTuple(version.getMajor());
+}
+
+llvm::VersionTuple BridgedVersionTuple::unbridged() const {
+  if (HasBuild)
+    return llvm::VersionTuple(Major, Minor, Subminor, Build);
+  if (HasSubminor)
+    return llvm::VersionTuple(Major, Minor, Subminor);
+  if (HasMinor)
+    return llvm::VersionTuple(Major, Minor);
+  return llvm::VersionTuple(Major);
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1434,8 +1434,9 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
   return makeParserResult(Status, result);
 }
 
-ParserStatus
-Parser::parseAvailabilityMacroDefinition(AvailabilityMacroDefinition &Result) {
+ParserStatus Parser::parseAvailabilityMacroDefinition(
+    std::string &Name, llvm::VersionTuple &Version,
+    SmallVectorImpl<AvailabilitySpec *> &Specs) {
 
   // Prime the lexer.
   if (Tok.is(tok::NUM_TOKENS))
@@ -1446,23 +1447,23 @@ Parser::parseAvailabilityMacroDefinition(AvailabilityMacroDefinition &Result) {
     return makeParserError();
   }
 
-  Result.Name = Tok.getText();
+  Name = Tok.getText();
   consumeToken();
 
   if (Tok.isAny(tok::integer_literal, tok::floating_literal)) {
     SourceRange VersionRange;
-    if (parseVersionTuple(Result.Version, VersionRange,
+    if (parseVersionTuple(Version, VersionRange,
                           diag::avail_query_expected_version_number)) {
       return makeParserError();
     }
   }
 
   if (!consumeIf(tok::colon)) {
-    diagnose(Tok, diag::attr_availability_expected_colon_macro, Result.Name);
+    diagnose(Tok, diag::attr_availability_expected_colon_macro, Name);
     return makeParserError();
   }
 
-  return parseAvailabilitySpecList(Result.Specs, AvailabilitySpecSource::Macro);
+  return parseAvailabilitySpecList(Specs, AvailabilitySpecSource::Macro);
 }
 
 ParserStatus

--- a/test/ASTGen/attrs_available.swift
+++ b/test/ASTGen/attrs_available.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -define-availability '_iOS53Aligned:macOS 50.0, iOS 53.0' \
+// RUN:   -define-availability '_iOS54Aligned:macOS 51.0, iOS 54.0' \
+// RUN:   -define-availability '_iOS54:iOS 54.0' \
+// RUN:   -define-availability '_macOS51_0:macOS 51.0' \
+// RUN:   -define-availability '_myProject 1.0:macOS 51.0' \
+// RUN:   -define-availability '_myProject 2.5:macOS 52.5' \
+// RUN: )
+
+// RUN: %target-swift-frontend %s "${COMPILER_ARGS[@]}" -dump-parse \
+// RUN:   -enable-experimental-feature ParserASTGen \
+// RUN:   > %t/astgen.ast.raw
+
+// RUN: %target-swift-frontend %s "${COMPILER_ARGS[@]}" -dump-parse \
+// RUN:   > %t/cpp-parser.ast.raw
+
+// Filter out any addresses in the dump, since they can differ.
+// RUN: sed -E 's#0x[0-9a-fA-F]+#<ADDR>#g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: sed -E 's#0x[0-9a-fA-F]+#<ADDR>#g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
+
+// RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// RUN: %target-typecheck-verify-swift "${COMPILER_ARGS[@]}" \
+// RUN:   -enable-experimental-feature ParserASTGen
+
+// REQUIRES: shell
+// REQUIRES: swift_feature_ParserASTGen
+
+@available(swift 4)
+func testSwift4OrLater() {}
+
+@available(macOS 12, iOS 13.1, *)
+func testShorthandMulti() {}
+
+@available(macOS, unavailable)
+func testUnavailableMacOS() {}
+
+@available(macOS, deprecated: 12.0.5, message: "whatever")
+func testDeprecaed12MacOS() {}
+
+@available(_iOS53Aligned, *)
+func testMacroNameOnly() {}
+
+@available(_myProject 2.5, *)
+func testMacroWithVersion() {}


### PR DESCRIPTION
* Move `AvailabilitySpec` handling logic to AST, so they can be shared between libParse and ASTGen
* Requestify `-define-availability` arguments parsing and parse them with `SwiftParser` according to the `ParserASTGen` feature flag
* Implement `AvailableAttr` generation in ASTGen