### PR TITLE
DestroyHoisting: visit begin_borrows which don't have an end_borrow in dead-end blocks.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
@@ -188,6 +188,15 @@ private extension InstructionRange {
     }
     defer { visitor.deinitialize() }
 
+    // This is important to visit begin_borrows which don't have an end_borrow in dead-end blocks.
+    // TODO: we can remove this once we have complete lifetimes.
+    visitor.innerScopeHandler = {
+      if let inst = $0.definingInstruction {
+        liverange.insert(inst)
+      }
+      return .continueWalk
+    }
+
     _ = visitor.visitUses()
     self = liverange
   }

--- a/test/SILOptimizer/destroy-hoisting.sil
+++ b/test/SILOptimizer/destroy-hoisting.sil
@@ -370,3 +370,28 @@ bb0(%0 : @owned $Klass):
   %r = tuple ()
   return %r
 }
+
+// CHECK-LABEL: sil [ossa] @borrow_in_deadend_block :
+// CHECK:       bb1:
+// CHECK-NEXT:    destroy_value %1
+// CHECK-NEXT:    destroy_value %2
+// CHECK:       } // end sil function 'borrow_in_deadend_block'
+sil [ossa] @borrow_in_deadend_block : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0
+  %2 = copy_value %1
+  %3 = begin_borrow %1
+  end_borrow %3
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  destroy_value %2
+  %8 = tuple ()
+  return %8
+
+bb2:
+  %10 = begin_borrow %1
+  unreachable
+}
+


### PR DESCRIPTION
This makes sure that incomplete lifetimes are handled correctly.

Fixes an ownership violation.
rdar://144065326
