### PR TITLE
🍒 [6.1] [ASTDumper] Some followups from the initial JSON PR and macro dumping improvements.

### DIFF
--- a/include/swift/AST/ASTDumper.h
+++ b/include/swift/AST/ASTDumper.h
@@ -1,0 +1,41 @@
+//===--- ASTDumper.h - Swift AST Dumper flags -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines types that are used to control the level of detail printed
+// by the AST dumper.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_AST_DUMPER_H
+#define SWIFT_AST_AST_DUMPER_H
+
+namespace swift {
+
+/// Describes the nature of requests that should be kicked off, if any, to
+/// compute members and top-level decls when dumping an AST.
+enum class ASTDumpMemberLoading {
+  /// Dump cached members if available; if they are not, do not kick off any
+  /// parsing or type-checking requests.
+  None,
+
+  /// Dump parsed members, kicking off a parsing request if necessary to compute
+  /// them, but not performing additional type-checking.
+  Parsed,
+
+  /// Dump all fully-type checked members, kicking off any requests necessary to
+  /// compute them.
+  TypeChecked,
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_AST_DUMPER_H

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_SOURCEFILE_H
 #define SWIFT_AST_SOURCEFILE_H
 
+#include "swift/AST/ASTDumper.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/IfConfigClauseRangeInfo.h"
@@ -20,9 +21,9 @@
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/STLExtras.h"
 
 namespace swift {
 
@@ -675,10 +676,12 @@ public:
   }
 
   SWIFT_DEBUG_DUMP;
-  void dump(raw_ostream &os, bool parseIfNeeded = false) const;
+  void
+  dump(raw_ostream &os,
+       ASTDumpMemberLoading memberLoading = ASTDumpMemberLoading::None) const;
 
   /// Dumps this source file's AST in JSON format to the given output stream.
-  void dumpJSON(raw_ostream &os) const;
+  void dumpJSON(raw_ostream &os, ASTDumpMemberLoading memberLoading) const;
 
   /// Pretty-print the contents of this source file.
   ///

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -23,6 +23,7 @@
 #include "swift/FrontendTool/FrontendTool.h"
 #include "Dependencies.h"
 #include "TBD.h"
+#include "swift/AST/ASTDumper.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
@@ -463,20 +464,21 @@ getPrimaryOrMainSourceFile(const CompilerInstance &Instance) {
 
 /// Dumps the AST of all available primary source files. If corresponding output
 /// files were specified, use them; otherwise, dump the AST to stdout.
-static bool dumpAST(CompilerInstance &Instance) {
+static bool dumpAST(CompilerInstance &Instance,
+                    ASTDumpMemberLoading memberLoading) {
   const FrontendOptions &opts = Instance.getInvocation().getFrontendOptions();
   auto dumpAST = [&](SourceFile *SF, raw_ostream &out) {
     switch (opts.DumpASTFormat) {
     case FrontendOptions::ASTFormat::Default:
-      SF->dump(out, /*parseIfNeeded*/ true);
+      SF->dump(out, memberLoading);
       break;
     case FrontendOptions::ASTFormat::JSON:
-      SF->dumpJSON(out);
+      SF->dumpJSON(out, memberLoading);
       break;
     case FrontendOptions::ASTFormat::JSONZlib:
       std::string jsonText;
       llvm::raw_string_ostream jsonTextStream(jsonText);
-      SF->dumpJSON(jsonTextStream);
+      SF->dumpJSON(jsonTextStream, memberLoading);
 
       SmallVector<uint8_t, 0> compressed;
       llvm::compression::zlib::compress(llvm::arrayRefFromStringRef(jsonText),
@@ -1232,12 +1234,14 @@ static bool performAction(CompilerInstance &Instance,
 
   // MARK: Actions that Dump
   case FrontendOptions::ActionType::DumpParse:
-    return dumpAST(Instance);
+    return dumpAST(Instance, ASTDumpMemberLoading::Parsed);
   case FrontendOptions::ActionType::DumpAST:
     return withSemanticAnalysis(
-        Instance, observer, [](CompilerInstance &Instance) {
-          return dumpAST(Instance);
-        }, /*runDespiteErrors=*/true);
+        Instance, observer,
+        [](CompilerInstance &Instance) {
+          return dumpAST(Instance, ASTDumpMemberLoading::TypeChecked);
+        },
+        /*runDespiteErrors=*/true);
   case FrontendOptions::ActionType::PrintAST:
     return withSemanticAnalysis(
         Instance, observer, [](CompilerInstance &Instance) {

--- a/test/Concurrency/async_main_resolution.swift
+++ b/test/Concurrency/async_main_resolution.swift
@@ -62,12 +62,12 @@ extension MainProtocol {
 @main struct MyMain : AsyncMainProtocol {}
 #endif
 
-// CHECK-IS-SYNC-LABEL: "MyMain" interface type="MyMain.Type"
-// CHECK-IS-SYNC: (func_decl implicit "$main()" interface type="(MyMain.Type) -> () -> ()"
+// CHECK-IS-SYNC-LABEL: "MyMain" interface_type="MyMain.Type"
+// CHECK-IS-SYNC: (func_decl implicit "$main()" interface_type="(MyMain.Type) -> () -> ()"
 // CHECK-IS-SYNC:       (declref_expr implicit type="(MyMain.Type) -> () -> ()"
 
-// CHECK-IS-ASYNC-LABEL: "MyMain" interface type="MyMain.Type"
-// CHECK-IS-ASYNC: (func_decl implicit "$main()" interface type="(MyMain.Type) -> () async -> ()"
+// CHECK-IS-ASYNC-LABEL: "MyMain" interface_type="MyMain.Type"
+// CHECK-IS-ASYNC: (func_decl implicit "$main()" interface_type="(MyMain.Type) -> () async -> ()"
 // CHECK-IS-ASYNC:       (declref_expr implicit type="(MyMain.Type) -> () async -> ()"
 
 // CHECK-IS-ERROR1: error: 'MyMain' is annotated with @main and must provide a main static function of type {{\(\) -> Void or \(\) throws -> Void|\(\) -> Void, \(\) throws -> Void, \(\) async -> Void, or \(\) async throws -> Void}}

--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -9,7 +9,7 @@ extension Error {
 }
 
 func test(seq: any AsyncSequence) async {
-  // CHECK: "error" interface type="any Error"
+  // CHECK: "error" interface_type="any Error"
   do {
     for try await _ in seq { }
   } catch {

--- a/test/Concurrency/where_clause_main_resolution.swift
+++ b/test/Concurrency/where_clause_main_resolution.swift
@@ -22,22 +22,22 @@ protocol App {
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}}
 // CHECK-NOT: where
 // CHECK-NEXT: (func_decl range={{\[}}[[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE:[0-9]+]]:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "main()"
-// CHECK-SAME: interface type="<Self where Self : App> (Self.Type) -> () async -> ()"
+// CHECK-SAME: interface_type="<Self where Self : App> (Self.Type) -> () async -> ()"
 
 extension App where Configuration == Config1 {
-// CHECK-CONFIG1: (func_decl implicit "$main()" interface type="(MainType.Type) -> () -> ()"
+// CHECK-CONFIG1: (func_decl implicit "$main()" interface_type="(MainType.Type) -> () -> ()"
 // CHECK-CONFIG1: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() { }
 }
 
 extension App where Configuration == Config2 {
-// CHECK-CONFIG2: (func_decl implicit "$main()" interface type="(MainType.Type) -> () async -> ()"
+// CHECK-CONFIG2: (func_decl implicit "$main()" interface_type="(MainType.Type) -> () async -> ()"
 // CHECK-CONFIG2: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() async { }
 }
 
 extension App where Configuration == Config3 {
-// CHECK-CONFIG3-ASYNC: (func_decl implicit "$main()" interface type="(MainType.Type) -> () async -> ()"
+// CHECK-CONFIG3-ASYNC: (func_decl implicit "$main()" interface_type="(MainType.Type) -> () async -> ()"
 // CHECK-CONFIG3-ASYNC: [[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE]]
 }
 

--- a/test/Constraints/nil-coalescing-favoring.swift
+++ b/test/Constraints/nil-coalescing-favoring.swift
@@ -6,7 +6,7 @@ struct B {
 
 struct A {
   init(_ other: B) {}
-  // CHECK: constructor_decl{{.*}}interface type="(A.Type) -> (B?) -> A"
+  // CHECK: constructor_decl{{.*}}interface_type="(A.Type) -> (B?) -> A"
   init(_ other: B?) {
     // CHECK: dot_syntax_call_expr type="(B) -> A"
     self.init(other ?? ._none)

--- a/test/Constraints/result_builder_switch_with_vars.swift
+++ b/test/Constraints/result_builder_switch_with_vars.swift
@@ -49,8 +49,8 @@ func tuplify<T>(@TupleBuilder body: (E) throws -> T) rethrows {
 tuplify {
   switch $0 {
   // CHECK: (case_body_variables
-  // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type="String" let readImpl=stored immutable)
-  // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type="Int" let readImpl=stored immutable)
+  // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface_type="String" let readImpl=stored immutable)
+  // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface_type="Int" let readImpl=stored immutable)
   case let .test(a, b):
     a
     b
@@ -58,8 +58,8 @@ tuplify {
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type="String" let readImpl=stored immutable)
-    // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type="Int" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface_type="String" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface_type="Int" let readImpl=stored immutable)
   case .test(let a, let b):
     a
     b
@@ -67,21 +67,21 @@ tuplify {
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface_type="(a: String, b: Int)" let readImpl=stored immutable)
   case let .test((value)):
     value.a
   }
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface_type="(a: String, b: Int)" let readImpl=stored immutable)
   case let .test(value):
     value.a
   }
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface_type="(a: String, b: Int)" let readImpl=stored immutable)
   case .test(let value):
     value.a
   }

--- a/test/DWARFImporter/basic.swift
+++ b/test/DWARFImporter/basic.swift
@@ -27,10 +27,10 @@ import ObjCModule
 
 let pureSwift = Int32(42)
 // FAIL-NOT:  var_decl
-// CHECK:     var_decl "pureSwift" {{.*}} type="Int32"
-// SWIFTONLY: var_decl "pureSwift" {{.*}} type="Int32" 
+// CHECK:     var_decl "pureSwift"{{.*}} interface_type="Int32"
+// SWIFTONLY: var_decl "pureSwift"{{.*}} interface_type="Int32" 
 
 let point = Point(x: 1, y: 2)
-// CHECK:     var_decl "point" {{.*}} type="Point"
+// CHECK:     var_decl "point"{{.*}} interface_type="Point"
 // SWIFTONLY-NOT: var_decl "point"
 

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -27,9 +27,9 @@ distributed actor DefaultWorker {
 }
 
 // Check DefaultWorker, the DefaultActor version of the synthesis:
-// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type="DefaultWorker.Type" access=internal non_resilient distributed actor
+// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface_type="DefaultWorker.Type" access=internal non_resilient distributed actor
 // The unowned executor property:
-// CHECK:    (var_decl implicit "unownedExecutor" interface type="UnownedSerialExecutor" access=internal final readImpl=getter immutable
+// CHECK:    (var_decl implicit "unownedExecutor" interface_type="UnownedSerialExecutor" access=internal final readImpl=getter immutable
 
 // We guard the rest of the body; we only return a default executor if the actor is local:
 // CHECK:       (guard_stmt implicit

--- a/test/Frontend/Inputs/json_ast_macro_definitions.swift
+++ b/test/Frontend/Inputs/json_ast_macro_definitions.swift
@@ -17,3 +17,32 @@ struct MemberInjectingMacro: MemberMacro {
     return [member]
   }
 }
+
+struct PeerInjectingMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf decl: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let peer: DeclSyntax =
+      """
+      struct FixedNamePeer {}
+      """
+
+    return [peer]
+  }
+}
+
+struct FreestandingInjectingMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let peer: DeclSyntax =
+      """
+      struct FixedNameFreestander {}
+      """
+
+    return [peer]
+  }
+}

--- a/test/Frontend/Inputs/json_ast_macro_library.swift
+++ b/test/Frontend/Inputs/json_ast_macro_library.swift
@@ -1,2 +1,8 @@
 @attached(member, names: named(_macroInjectedMember))
 public macro InjectMember() = #externalMacro(module: "MacroDefinition", type: "MemberInjectingMacro")
+
+@attached(peer, names: named(FixedNamePeer))
+public macro InjectPeer() = #externalMacro(module: "MacroDefinition", type: "PeerInjectingMacro")
+
+@freestanding(declaration, names: named(FixedNameFreestander))
+public macro injectFreestanding() = #externalMacro(module: "MacroDefinition", type: "FreestandingInjectingMacro")

--- a/test/Frontend/ast-dump-json-macros.swift
+++ b/test/Frontend/ast-dump-json-macros.swift
@@ -14,7 +14,41 @@ import json_ast_macro_library
 struct X {
     var y: Int
 }
-
-// CHECK:      "_kind":"pattern_binding_decl"
+// CHECK:      "_kind":"struct_decl",
+// CHECK-SAME: "usr":"s:4main1XV",
+// CHECK-SAME: "_kind":"custom_attr",
+// CHECK-SAME: "macro":{"_kind":"decl_ref","base_name":"InjectMember","decl_usr":"s:22json_ast_macro_library12InjectMemberyycfm","type_usr":"$syycD"}
+// CHECK-SAME: "_kind":"pattern_binding_decl"
 // CHECK-SAME: "buffer_id":"@__swiftmacro_4main1X12InjectMemberfMm_.swift"
 // CHECK-SAME: "name":"_macroInjectedMember"
+
+struct Z {
+    #injectFreestanding
+}
+// NOTE: For freestanding members (as opposed to top-level), we get the expanded
+// decl before we see the MacroExpansionDecl.
+// CHECK-SAME: "_kind":"struct_decl",
+// CHECK-SAME: "usr":"s:4main1ZV20FixedNameFreestanderV",
+// CHECK-SAME: "buffer_id":"@__swiftmacro_4main0033astdumpjsonmacrosswift_GwAFheaeGafMX{{[0-9]+}}_{{[0-9]+}}_33_{{[0-9A-F]+}}Ll18injectFreestandingfMf_.swift"
+// CHECK-SAME: "_kind":"macro_expansion_decl",
+// CHECK-SAME: "auxiliary_decl_usrs":["s:4main1ZV20FixedNameFreestanderV"]
+// CHECK-SAME: "macro":{"_kind":"decl_ref","base_name":"injectFreestanding","decl_usr":"s:22json_ast_macro_library18injectFreestandingyycfm","type_usr":"$syycD"}
+
+@InjectPeer
+struct ThisWillBePeered {}
+// CHECK-SAME: "_kind":"struct_decl",
+// CHECK-SAME: "usr":"s:4main16ThisWillBePeeredV",
+// CHECK-SAME: "auxiliary_decl_usrs":["s:4main13FixedNamePeerV"],
+// CHECK-SAME: "_kind":"custom_attr",
+// CHECK-SAME: "macro":{"_kind":"decl_ref","base_name":"InjectPeer","decl_usr":"s:22json_ast_macro_library10InjectPeeryycfm","type_usr":"$syycD"}
+// CHECK-SAME: "_kind":"struct_decl",
+// CHECK-SAME: "usr":"s:4main13FixedNamePeerV",
+// CHECK-SAME: "buffer_id":"@__swiftmacro_4main16ThisWillBePeered10InjectPeerfMp_.swift"
+
+#injectFreestanding
+// CHECK-SAME: "_kind":"macro_expansion_decl",
+// CHECK-SAME: "auxiliary_decl_usrs":["s:4main20FixedNameFreestanderV"],
+// CHECK-SAME: "macro":{"_kind":"decl_ref","base_name":"injectFreestanding","decl_usr":"s:22json_ast_macro_library18injectFreestandingyycfm","type_usr":"$syycD"}
+// CHECK-SAME: "_kind":"struct_decl",
+// CHECK-SAME: "usr":"s:4main20FixedNameFreestanderV",
+// CHECK-SAME: "buffer_id":"@__swiftmacro_4main0033astdumpjsonmacrosswift_GwAFheaeGafMX{{[0-9]+}}_{{[0-9]+}}_33_{{[0-9A-F]+}}Ll18injectFreestandingfMf_.swift"

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -55,7 +55,7 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrusive.
-// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface_type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
 // CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T -> Int)]" function_ref=unapplied))

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -7,7 +7,7 @@ struct MyBase {
   }
 }
 
-// CHECK-AST: (func_decl implicit "$main()" interface type="(MyBase.Type) -> () throws -> ()" access=internal static
+// CHECK-AST: (func_decl implicit "$main()" interface_type="(MyBase.Type) -> () throws -> ()" access=internal static
 // CHECK-AST-NEXT:  (parameter "self")
 // CHECK-AST-NEXT:  (parameter_list)
 // CHECK-AST-NEXT:  (brace_stmt implicit

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -7,21 +7,21 @@
 // Public types with @frozen are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type="Point.Type" access=public non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type="Point.Type" access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Point" interface_type="Point.Type" access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface_type="Point.Type" access=public non_resilient
 @frozen public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type="FixedPoint.Type" access=public non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type="FixedPoint.Type" access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface_type="FixedPoint.Type" access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface_type="FixedPoint.Type" access=public non_resilient
 @_fixed_layout public struct FixedPoint {
   // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type="ChooseYourOwnAdventure.Type" access=public non_resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type="ChooseYourOwnAdventure.Type" access=public non_resilient
+// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface_type="ChooseYourOwnAdventure.Type" access=public non_resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface_type="ChooseYourOwnAdventure.Type" access=public non_resilient
 @frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
@@ -31,23 +31,23 @@
 // Public types are resilient when -enable-library-evolution is on
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Size" interface type="Size.Type" access=public resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type="Size.Type" access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Size" interface_type="Size.Type" access=public resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface_type="Size.Type" access=public non_resilient
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type="UsableFromInlineStruct.Type" access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type="UsableFromInlineStruct.Type" access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface_type="UsableFromInlineStruct.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface_type="UsableFromInlineStruct.Type" access=internal non_resilient
 @frozen @usableFromInline struct UsableFromInlineStruct {}
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface_type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface_type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
 @_fixed_layout @usableFromInline struct UsableFromInlineFixedStruct {}
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
 
-// RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type="TaxCredit.Type" access=public resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type="TaxCredit.Type" access=public non_resilient
+// RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface_type="TaxCredit.Type" access=public resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface_type="TaxCredit.Type" access=public non_resilient
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -57,8 +57,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type="Rectangle.Type" access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type="Rectangle.Type" access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface_type="Rectangle.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface_type="Rectangle.Type" access=internal non_resilient
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -2,19 +2,19 @@
 
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface_type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" interface type="Int" access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" interface_type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" interface type="Int" access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" interface_type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
@@ -22,7 +22,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface_type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
@@ -34,7 +34,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface_type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
@@ -46,7 +46,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface_type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
@@ -58,7 +58,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface_type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
@@ -70,7 +70,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "storedWithObserver" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
+  // CHECK: (var_decl {{.*}} "storedWithObserver" interface_type="Int" access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
   // CHECK: (accessor_decl {{.*}}access=private dynamic didSet for="storedWithObserver"
   // CHECK: (accessor_decl {{.*}}access=internal dynamic get for="storedWithObserver"
   // CHECK: (accessor_decl {{.*}}access=internal set for="storedWithObserver"
@@ -136,19 +136,19 @@ struct Strukt {
 
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface_type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" interface type="Int" access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" interface_type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" interface type="Int" access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" interface_type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
@@ -156,7 +156,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface_type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
@@ -168,7 +168,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface_type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
@@ -180,7 +180,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface_type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
@@ -192,7 +192,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface_type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
@@ -285,12 +285,12 @@ class Klass {
 class SubKlass : Klass {
 
   // CHECK: (class_decl {{.*}} "SubKlass"
-  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface type="(SubKlass) -> (Int) -> Int" access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface_type="(SubKlass) -> (Int) -> Int" access=internal {{.*}} dynamic
   override dynamic func aMethod(arg: Int) -> Int {
    return 23
   }
 
-  // CHECK: (func_decl {{.*}} "anotherMethod()" interface type="(SubKlass) -> () -> Int" access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "anotherMethod()" interface_type="(SubKlass) -> () -> Int" access=internal {{.*}} dynamic
   override dynamic func anotherMethod() -> Int {
    return 23
   }

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
-// CHECK: func_decl{{.*}}"clone()" interface type="(Android) -> () -> Self"
+// CHECK: func_decl{{.*}}"clone()" interface_type="(Android) -> () -> Self"
 
 class Android {
   func clone() -> Self {

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,7 +2,7 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" "<T>" interface type="<T> (t: T, x: AnyObject) -> ()"
+// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" "<T>" interface_type="<T> (t: T, x: AnyObject) -> ()"
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
@@ -20,13 +20,13 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl{{.*}}"innerGeneric(u:)" "<U>" interface type="<T, U> (u: U) -> ()" {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" "<U>" interface_type="<T, U> (u: U) -> ()" {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
-  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type="<T> (tt: TT) -> ()" {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface_type="<T> (tt: TT) -> ()" {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
   // CHECK: closure_expr type="(TT) -> ()" {{.*}} captures=(<generic> )

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -15,7 +15,7 @@ guard let x = Optional(0) else { fatalError() }
 // CHECK: (top_level_code_decl
 _ = 0 // intervening code
 
-// CHECK-LABEL: (func_decl{{.*}}"function()" interface type="() -> ()" access=internal captures=(x<direct>)
+// CHECK-LABEL: (func_decl{{.*}}"function()" interface_type="() -> ()" access=internal captures=(x<direct>)
 func function() {
   _ = x
 }
@@ -39,7 +39,7 @@ let closureCapture: () -> Void = { [x] in
 }
 
 // CHECK-LABEL: (defer_stmt
-// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type="() -> ()" access=fileprivate captures=(x<direct><noescape>)
+// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface_type="() -> ()" access=fileprivate captures=(x<direct><noescape>)
 defer {
   _ = x
 }


### PR DESCRIPTION
  - **Explanation**: AST dump improvements (mostly JSON focused): ensure that all macro expansions are dumped, print a macro expansion's decl ref (instead of the nonexistent type); change `interface type` label to `interface_type`.

  - **Scope**: Only affects `-dump-ast` output; does not impact how code is compiled and should not break code.

  - **Issues**: None.

  - **Original PRs**: https://github.com/swiftlang/swift/pull/79059

  - **Risk**: Low; only affects `-dump-ast`.

  - **Testing**: Added lit tests to account for the new changes.

  - **Reviewers**: @hamishknight 