### PR TITLE
Sema: More accurate undo() of PotentialBindings::retract()

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -224,14 +224,6 @@ struct PotentialBindings {
   /// The set of potential bindings.
   llvm::SmallVector<PotentialBinding, 4> Bindings;
 
-  /// The set of unique literal protocol requirements placed on this
-  /// type variable or inferred transitively through subtype chains.
-  ///
-  /// Note that ordering is important when it comes to bindings, we'd
-  /// like to add any "direct" default types first to attempt them
-  /// before transitive ones.
-  llvm::SmallPtrSet<Constraint *, 2> Literals;
-
   /// The set of constraints which would be used to infer default types.
   llvm::SmallPtrSet<Constraint *, 2> Defaults;
 
@@ -258,8 +250,6 @@ struct PotentialBindings {
   llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> EquivalentTo;
 
   void addDefault(Constraint *constraint);
-
-  void addLiteral(Constraint *constraint);
 
   /// Add a potential binding to the list of bindings,
   /// coalescing supertype bounds when we are able to compute the meet.
@@ -386,7 +376,14 @@ public:
   /// The set of protocol conformance requirements placed on this type variable.
   llvm::SmallVector<Constraint *, 4> Protocols;
 
+  /// The set of unique literal protocol requirements placed on this
+  /// type variable or inferred transitively through subtype chains.
+  ///
+  /// Note that ordering is important when it comes to bindings, we'd
+  /// like to add any "direct" default types first to attempt them
+  /// before transitive ones.
   llvm::SmallMapVector<ProtocolDecl *, LiteralRequirement, 2> Literals;
+
   llvm::SmallDenseMap<CanType, Constraint *, 2> Defaults;
 
   /// The set of transitive protocol requirements inferred through

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -224,9 +224,6 @@ struct PotentialBindings {
   /// The set of potential bindings.
   llvm::SmallVector<PotentialBinding, 4> Bindings;
 
-  /// The set of protocol requirements placed on this type variable.
-  llvm::SmallVector<Constraint *, 4> Protocols;
-
   /// The set of unique literal protocol requirements placed on this
   /// type variable or inferred transitively through subtype chains.
   ///
@@ -385,6 +382,10 @@ class BindingSet {
 
 public:
   swift::SmallSetVector<PotentialBinding, 4> Bindings;
+
+  /// The set of protocol conformance requirements placed on this type variable.
+  llvm::SmallVector<Constraint *, 4> Protocols;
+
   llvm::SmallMapVector<ProtocolDecl *, LiteralRequirement, 2> Literals;
   llvm::SmallDenseMap<CanType, Constraint *, 2> Defaults;
 
@@ -499,7 +500,7 @@ public:
   }
 
   ArrayRef<Constraint *> getConformanceRequirements() const {
-    return Info.Protocols;
+    return Protocols;
   }
 
   unsigned getNumViableLiteralBindings() const;

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -71,15 +71,12 @@ enum class LiteralBindingKind : uint8_t {
 /// along with information that can be used to construct related
 /// bindings, e.g., the supertypes of a given type.
 struct PotentialBinding {
-  friend class BindingSet;
-
   /// The type to which the type variable can be bound.
   Type BindingType;
 
   /// The kind of bindings permitted.
   AllowedBindingKind Kind;
 
-protected:
   /// The source of the type information.
   ///
   /// Determines whether this binding represents a "hole" in
@@ -91,7 +88,6 @@ protected:
                    PointerUnion<Constraint *, ConstraintLocator *> source)
       : BindingType(type), Kind(kind), BindingSource(source) {}
 
-public:
   PotentialBinding(Type type, AllowedBindingKind kind, Constraint *source)
       : PotentialBinding(
             type, kind,

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -233,18 +233,17 @@ struct PotentialBindings {
   /// bindings (contained in the binding type e.g. `Foo<$T0>`), or
   /// reachable through subtype/conversion  relationship e.g.
   /// `$T0 subtype of $T1` or `$T0 arg conversion $T1`.
-  llvm::SmallDenseSet<std::pair<TypeVariableType *, Constraint *>, 2>
-      AdjacentVars;
-
-  ASTNode AssociatedCodeCompletionToken = ASTNode();
+  llvm::SmallVector<std::pair<TypeVariableType *, Constraint *>, 2> AdjacentVars;
 
   /// A set of all not-yet-resolved type variables this type variable
   /// is a subtype of, supertype of or is equivalent to. This is used
   /// to determine ordering inside of a chain of subtypes to help infer
   /// transitive bindings  and protocol requirements.
-  llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> SubtypeOf;
-  llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> SupertypeOf;
-  llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> EquivalentTo;
+  llvm::SmallVector<std::pair<TypeVariableType *, Constraint *>, 4> SubtypeOf;
+  llvm::SmallVector<std::pair<TypeVariableType *, Constraint *>, 4> SupertypeOf;
+  llvm::SmallVector<std::pair<TypeVariableType *, Constraint *>, 4> EquivalentTo;
+
+  ASTNode AssociatedCodeCompletionToken = ASTNode();
 
   /// Add a potential binding to the list of bindings,
   /// coalescing supertype bounds when we are able to compute the meet.

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -219,7 +219,7 @@ private:
 
 struct PotentialBindings {
   /// The set of all constraints that have been added via infer().
-  llvm::SmallPtrSet<Constraint *, 2> Constraints;
+  llvm::SmallSetVector<Constraint *, 2> Constraints;
 
   /// The set of potential bindings.
   llvm::SmallVector<PotentialBinding, 4> Bindings;
@@ -393,20 +393,7 @@ public:
   std::optional<llvm::SmallPtrSet<Constraint *, 4>> TransitiveProtocols;
 
   BindingSet(ConstraintSystem &CS, TypeVariableType *TypeVar,
-             const PotentialBindings &info)
-      : CS(CS), TypeVar(TypeVar), Info(info) {
-    for (const auto &binding : info.Bindings)
-      addBinding(binding, /*isTransitive=*/false);
-
-    for (auto *literal : info.Literals)
-      addLiteralRequirement(literal);
-
-    for (auto *constraint : info.Defaults)
-      addDefault(constraint);
-
-    for (auto &entry : info.AdjacentVars)
-      AdjacentVars.insert(entry.first);
-  }
+             const PotentialBindings &info);
 
   ConstraintSystem &getConstraintSystem() const { return CS; }
 

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -224,9 +224,6 @@ struct PotentialBindings {
   /// The set of potential bindings.
   llvm::SmallVector<PotentialBinding, 4> Bindings;
 
-  /// The set of constraints which would be used to infer default types.
-  llvm::SmallPtrSet<Constraint *, 2> Defaults;
-
   /// The set of constraints which delay attempting this type variable.
   llvm::TinyPtrVector<Constraint *> DelayedBy;
 
@@ -248,8 +245,6 @@ struct PotentialBindings {
   llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> SubtypeOf;
   llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> SupertypeOf;
   llvm::SmallSetVector<std::pair<TypeVariableType *, Constraint *>, 4> EquivalentTo;
-
-  void addDefault(Constraint *constraint);
 
   /// Add a potential binding to the list of bindings,
   /// coalescing supertype bounds when we are able to compute the meet.

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -38,6 +38,10 @@
 #define GRAPH_NODE_CHANGE(Name) CHANGE(Name)
 #endif
 
+#ifndef BINDING_RELATION_CHANGE
+#define BINDING_RELATION_CHANGE(Name) CHANGE(Name)
+#endif
+
 #ifndef SCORE_CHANGE
 #define SCORE_CHANGE(Name) CHANGE(Name)
 #endif
@@ -73,6 +77,12 @@ GRAPH_NODE_CHANGE(AddedConstraint)
 GRAPH_NODE_CHANGE(RemovedConstraint)
 GRAPH_NODE_CHANGE(InferredBindings)
 GRAPH_NODE_CHANGE(RetractedBindings)
+GRAPH_NODE_CHANGE(RetractedDelayedBy)
+
+BINDING_RELATION_CHANGE(RetractedAdjacentVar)
+BINDING_RELATION_CHANGE(RetractedSubtypeOf)
+BINDING_RELATION_CHANGE(RetractedSupertypeOf)
+BINDING_RELATION_CHANGE(RetractedEquivalentTo)
 
 SCORE_CHANGE(IncreasedScore)
 SCORE_CHANGE(DecreasedScore)
@@ -96,14 +106,16 @@ CHANGE(RecordedPotentialThrowSite)
 CHANGE(RecordedIsolatedParam)
 CHANGE(RecordedKeyPath)
 CHANGE(RetiredConstraint)
+CHANGE(RetractedBinding)
 
-LAST_CHANGE(RetiredConstraint)
+LAST_CHANGE(RetractedBinding)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE
 #undef CLOSURE_CHANGE
 #undef CONSTRAINT_CHANGE
 #undef GRAPH_NODE_CHANGE
+#undef BINDING_RELATION_CHANGE
 #undef SCORE_CHANGE
 #undef LAST_CHANGE
 #undef CHANGE

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -38,6 +38,10 @@ namespace constraints {
 class Constraint;
 struct SyntacticElementTargetKey;
 
+namespace inference {
+struct PotentialBinding;
+}
+
 class SolverTrail {
 public:
 
@@ -90,6 +94,12 @@ public:
       } Relation;
 
       struct {
+        TypeVariableType *TypeVar;
+        TypeVariableType *OtherTypeVar;
+        Constraint *Constraint;
+      } BindingRelation;
+
+      struct {
         /// The type variable being updated.
         TypeVariableType *TypeVar;
 
@@ -128,6 +138,15 @@ public:
         Constraint *Constraint;
       } Retiree;
 
+      struct {
+        TypeVariableType *TypeVar;
+
+        /// These two fields together with 'Options' above store the contents
+        /// of a PotentialBinding.
+        Type BindingType;
+        PointerUnion<Constraint *, ConstraintLocator *> BindingSource;
+      } Binding;
+
       ConstraintFix *TheFix;
       ConstraintLocator *TheLocator;
       PackExpansionType *TheExpansion;
@@ -155,6 +174,9 @@ public:
 #define SCORE_CHANGE(Name) static Change Name(ScoreKind kind, unsigned value);
 #define GRAPH_NODE_CHANGE(Name) static Change Name(TypeVariableType *typeVar, \
                                                    Constraint *constraint);
+#define BINDING_RELATION_CHANGE(Name) static Change Name(TypeVariableType *typeVar, \
+                                                         TypeVariableType *otherTypeVar, \
+                                                         Constraint *constraint);
 #include "swift/Sema/CSTrail.def"
 
     /// Create a change that added a type variable.
@@ -225,6 +247,11 @@ public:
     /// Create a change that removed a constraint from the inactive constraint list.
     static Change RetiredConstraint(llvm::ilist<Constraint>::iterator where,
                                     Constraint *constraint);
+
+    /// Create a change that removed a binding from a type variable's potential
+    /// bindings.
+    static Change RetractedBinding(TypeVariableType *typeVar,
+                                   inference::PotentialBinding binding);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -448,11 +448,6 @@ private:
   void unrelateTypeVariables(TypeVariableType *typeVar,
                              TypeVariableType *otherTypeVar);
 
-  /// Infer bindings from the given constraint.
-  ///
-  /// Note that this it only meant to be called by SolverTrail::Change::undo().
-  void inferBindings(TypeVariableType *typeVar, Constraint *constraint);
-
   /// Retract bindings from the given constraint.
   ///
   /// Note that this it only meant to be called by SolverTrail::Change::undo().

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1918,7 +1918,7 @@ void PotentialBindings::infer(ConstraintSystem &CS,
     return;
 
   // Record the change, if there are active scopes.
-  if (CS.solverState && !CS.solverState->Trail.isUndoActive())
+  if (CS.solverState)
     CS.recordChange(SolverTrail::Change::InferredBindings(TypeVar, constraint));
 
   switch (constraint->getKind()) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -540,11 +540,6 @@ void ConstraintGraph::unrelateTypeVariables(TypeVariableType *typeVar,
   node.removeReference(otherTypeVar);
 }
 
-void ConstraintGraph::inferBindings(TypeVariableType *typeVar,
-                                    Constraint *constraint) {
-  (*this)[typeVar].getPotentialBindings().infer(CS, typeVar, constraint);
-}
-
 void ConstraintGraph::retractBindings(TypeVariableType *typeVar,
                                       Constraint *constraint) {
   (*this)[typeVar].getPotentialBindings().retract(CS, typeVar, constraint);

--- a/test/Constraints/rdar143474242.swift
+++ b/test/Constraints/rdar143474242.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+extension Collection {
+  func myMap<T>(_: (Self.Element) -> T) -> [T] { fatalError() }
+}
+
+protocol SignedInteger {}
+
+extension SignedInteger {
+  init<T: BinaryFloatingPoint>(_: T) { fatalError() }
+  init<T: BinaryInteger>(_: T) { fatalError() }
+}
+
+struct Int32: SignedInteger {
+  init(_: String) {}
+}
+
+func test() {
+  let _: [(Int32, Float)] = (0..<1).myMap { (Int32($0), 0.0) }
+}

--- a/test/Sema/issue-46000.swift
+++ b/test/Sema/issue-46000.swift
@@ -11,7 +11,7 @@ struct Data {}
 extension DispatchData {
   func asFoundationData<T>(execute: (Data) throws -> T) rethrows -> T {
     return try withUnsafeBytes { (ptr: UnsafePointer<Int8>) -> Void in
-      // expected-error@-1 {{declared closure result 'Void' is incompatible with contextual type 'T'}}
+      // expected-error@-1 {{cannot convert return expression of type 'Void' to return type 'T'}}
       let data = Data()
       return try execute(data) // expected-error {{cannot convert value of type 'T' to closure result type 'Void'}}
     }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -274,7 +274,8 @@ func associatedTypeIdentity() {
   sameType(gary(candace()).r_out(), gary(candace()).r_out())
   sameType(gary(doug()).r_out(), gary(doug()).r_out())
   sameType(gary(doug()).r_out(), gary(candace()).r_out())
-  // expected-error@-1:39 {{cannot convert value of type 'some R' (result of 'candace()') to expected argument type 'some R' (result of 'doug()')}}
+  // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}
+  // expected-error@-2 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}
 }
 
 func redeclaration() -> some P { return 0 } // expected-note 2{{previously declared}}


### PR DESCRIPTION
Consider this series of events:

- We bind a fixed type to a type variable
- This activates some constraints that mention this type variable
- Some of those constraints are solved
- The solved constraints are retracted

When we retract the solved constraints, we call `PotentialBindings::retract()` and record a change. Previously, when we undo this change, we would call `PotentialBindings::infer()`. However, `infer()` is not always the opposite of `retract()`, because it calls `simplifyType()`. To avoid this order dependency, have `retract()` record exactly what was removed in a series of individual changes.

This fixes a regression from https://github.com/swiftlang/swift/pull/77174.

There are a couple of diagnostic changes, and in fact the same diagnostics also changed in https://github.com/swiftlang/swift/pull/77174.

This PR also simplifies `PotentialBindings` a bit. The `Protocols`, `Literals`, and `Defaults` fields weren't really needed because we can easily reconstruct this information when we build the `BindingSet`. Also, a few other fields that used to be `*Set` types are now `SmallVector` instead, because we don't insert duplicate elements by construction so there's no need for the additional overhead of hashing here.

Fixes rdar://problem/143474242.