### PR TITLE
Add an additional case for clocks to sleep with a wallclock deadline

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1074,7 +1074,8 @@ void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
 
 enum swift_clock_id : int {
   swift_clock_id_continuous = 1,
-  swift_clock_id_suspending = 2
+  swift_clock_id_suspending = 2,
+  swift_clock_id_wall = 3
 };
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -115,7 +115,7 @@ void swift_get_time(
       clock_gettime(CLOCK_REALTIME, &wall);
 #elif defined(_WIN32)
       // This needs to match what swift-corelibs-libdispatch does
-      
+
       static const uint64_t kNTToUNIXBiasAdjustment = 11644473600 * NSEC_PER_SEC;
       // FILETIME is 100-nanosecond intervals since January 1, 1601 (UTC).
       FILETIME ft;
@@ -191,6 +191,20 @@ switch (clock_id) {
 #endif
       *seconds = suspending.tv_sec;
       *nanoseconds = suspending.tv_nsec;
+      return;
+    }
+    case swift_clock_id_wall: {
+      struct timespec wall;
+#if defined(__linux__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__)
+      clock_getres(CLOCK_REALTIME, &wall);
+#elif defined(_WIN32)
+      wall.tv_sec = 0;
+      wall.tv_nsec = 100;
+#else
+#error Missing platform wall time definition
+#endif
+      *seconds = wall.tv_sec;
+      *nanoseconds = wall.tv_nsec;
       return;
     }
   }

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -33,6 +33,10 @@
 
 #include "Error.h"
 
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000ull
+#endif
+
 using namespace swift;
 
 SWIFT_EXPORT_FROM(swift_Concurrency)

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -294,7 +294,8 @@ platform_time(uint64_t nsec) {
 #endif
 
 static inline dispatch_time_t
-clock_and_value_to_time(int clock, long long deadline) {
+clock_and_value_to_time(int clock, long long sec, long long nsec) {
+  uint64_t deadline = sec * NSEC_PER_SEC + nsec;
   uint64_t value = platform_time((uint64_t)deadline);
   if (value >= DISPATCH_TIME_MAX_VALUE) {
     return DISPATCH_TIME_FOREVER;
@@ -304,6 +305,13 @@ clock_and_value_to_time(int clock, long long deadline) {
     return value;
   case swift_clock_id_continuous:
     return value | DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
+  case swift_clock_id_wall: {
+    struct timespec ts = { 
+      .tv_sec = sec,
+      .tv_nsec = nsec
+    };
+    return dispatch_walltime(&ts, 0);
+  }
   }
   __builtin_unreachable();
 }

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -55,6 +55,10 @@
 #include "ExecutorImpl.h"
 #include "TaskPrivate.h"
 
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000ull
+#endif
+
 using namespace swift;
 
 /// The function passed to dispatch_async_f to execute a job.
@@ -310,10 +314,17 @@ clock_and_value_to_time(int clock, long long sec, long long nsec) {
   case swift_clock_id_continuous:
     return value | DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
   case swift_clock_id_wall: {
+#if defined(_WIN32)
+    struct timespec ts = { 
+      .tv_sec = sec,
+      .tv_nsec = static_cast<long>(nsec)
+    };
+#else
     struct timespec ts = { 
       .tv_sec = sec,
       .tv_nsec = nsec
     };
+#endif
     return dispatch_walltime(&ts, 0);
   }
   }


### PR DESCRIPTION
This only modifies the runtime function `swift_task_enqueueGlobalWithDeadline` to take new clock primitive to interoperate with dispatch's wall clock values.