### PR TITLE
[Distributed] Improve coverage for field order of synthesized dist actor fields

### DIFF
--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -99,17 +99,6 @@ bool addNonIsolatedToSynthesized(NominalTypeDecl *nominal, ValueDecl *value);
 void applyInferredSPIAccessControlAttr(Decl *decl, const Decl *inferredFromDecl,
                                        ASTContext &ctx);
 
-/// Asserts that the synthesized fields appear in the expected order.
-///
-/// The `id` and `actorSystem` MUST be the first two fields of a distributed
-/// actor, because we assume their location in IRGen, and also when we allocate
-/// a distributed remote actor, we're able to allocate memory ONLY for those and
-/// without allocating any of the storage for the actor's properties.
-///         [id, actorSystem, unownedExecutor]
-/// followed by the executor fields for a default distributed actor.
-void assertRequiredSynthesizedPropertyOrder(ASTContext &Context,
-                                            NominalTypeDecl *nominal);
-
 } // end namespace swift
 
 #endif

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -857,8 +857,10 @@ void swift::assertRequiredSynthesizedPropertyOrder(ASTContext &Context,
           }
           if (idIdx + actorSystemIdx + unownedExecutorIdx >= 0 + 1 + 2) {
             // we have found all the necessary fields, let's assert their order
-            assert(idIdx < actorSystemIdx < unownedExecutorIdx &&
-                   "order of fields MUST be exact.");
+            assert(idIdx < actorSystemIdx &&
+                   "order of fields MUST be exact. id must be before actorSystem");
+            assert(actorSystemIdx < unownedExecutorIdx &&
+                   "order of fields MUST be exact. actorSystem must be before unownedExecutor");
           }
         }
       }

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -1036,43 +1036,6 @@ addDistributedActorCodableConformance(
 /******************************************************************************/
 /******************************************************************************/
 
-void swift::assertRequiredSynthesizedPropertyOrder(ASTContext &Context,
-                                                   NominalTypeDecl *nominal) {
-#ifndef NDEBUG
-  if (nominal->getDistributedActorIDProperty()) {
-    if (nominal->getDistributedActorSystemProperty()) {
-      if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
-        if (classDecl->getUnownedExecutorProperty()) {
-          int idIdx, actorSystemIdx, unownedExecutorIdx = 0;
-          int idx = 0;
-          for (auto member : nominal->getMembers()) {
-            if (auto binding = dyn_cast<PatternBindingDecl>(member)) {
-              if (binding->getSingleVar()->getName() == Context.Id_id) {
-                idIdx = idx;
-              } else if (binding->getSingleVar()->getName() ==
-                         Context.Id_actorSystem) {
-                actorSystemIdx = idx;
-              } else if (binding->getSingleVar()->getName() ==
-                         Context.Id_unownedExecutor) {
-                unownedExecutorIdx = idx;
-              }
-              idx += 1;
-            }
-          }
-          if (idIdx + actorSystemIdx + unownedExecutorIdx >= 0 + 1 + 2) {
-            // we have found all the necessary fields, let's assert their order
-            // FIXME: This assertion was not asserting what it is designed to
-            // assert and more work is needed to make it pass.
-//            assert(idIdx < actorSystemIdx < unownedExecutorIdx &&
-//                   "order of fields MUST be exact.");
-          }
-        }
-      }
-    }
-  }
-#endif
-}
-
 static bool canSynthesizeDistributedThunk(AbstractFunctionDecl *distributedTarget) {
   // `distributed` protocol requirements are allowed without additional checks.
   if (isa<ProtocolDecl>(distributedTarget->getDeclContext()))

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -733,14 +733,10 @@ static ValueDecl *deriveDistributedActor_unownedExecutor(DerivedConformance &der
 
 ValueDecl *DerivedConformance::deriveDistributedActor(ValueDecl *requirement) {
   if (auto var = dyn_cast<VarDecl>(requirement)) {
-    ValueDecl *derivedValue = nullptr;
     if (var->getName() == Context.Id_unownedExecutor)
-      derivedValue = deriveDistributedActor_unownedExecutor(*this);
+      return deriveDistributedActor_unownedExecutor(*this);
 
-    if (derivedValue) {
-      assertRequiredSynthesizedPropertyOrder(Context, Nominal);
-    }
-    return derivedValue;
+    return nullptr;
   }
 
   if (auto func = dyn_cast<FuncDecl>(requirement)) {

--- a/test/Distributed/distributed_actor_field_order.swift
+++ b/test/Distributed/distributed_actor_field_order.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -disable-availability-checking -module-name field_order | %FileCheck %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// Verifies the stored-property layout of a distributed actor.
+//
+// The runtime relies on this exact field order: 'swift_distributedActor_remote_initialize'
+// trims the allocation of a 'remote' proxy at the offset of the first user-defined
+// stored property.
+//
+// Field order MUST be: $defaultActor, id, actorSystem, <user properties...>
+
+import Distributed
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+public distributed actor WithUserFields {
+  var first: Int = 1
+  var second: String = ""
+}
+
+// The synthesized fields come first, in this order, before any user property.
+// CHECK-LABEL: @"$s11field_order14WithUserFieldsC2id11Distributed19LocalTestingActorIDVvpWvd" =
+// CHECK: @"$s11field_order14WithUserFieldsC11actorSystem{{.*}}vpWvd" =
+// CHECK: @"$s11field_order14WithUserFieldsC5firstSivpWvd" =
+// CHECK: @"$s11field_order14WithUserFieldsC6secondSSvpWvd" =
+
+public distributed actor WithoutUserFields {
+}
+
+// Even with no user properties the synthesized fields are present.
+// CHECK-LABEL: @"$s11field_order17WithoutUserFieldsC2id11Distributed19LocalTestingActorIDVvpWvd" =
+// CHECK: @"$s11field_order17WithoutUserFieldsC11actorSystem{{.*}}vpWvd" =
+
+public distributed actor CustomExecutorActor {
+  var first: Int = 1
+
+  public nonisolated var unownedExecutor: UnownedSerialExecutor {
+    MainActor.sharedUnownedExecutor
+  }
+}
+
+// A distributed actor with a custom executor is not a default actor, so it has no
+// '$defaultActor' storage. 'id' and 'actorSystem' still come first, and
+// 'unownedExecutor' is computed, so it contributes no field of its own.
+// CHECK-LABEL: @"$s11field_order19CustomExecutorActorC2id11Distributed012LocalTestingE2IDVvpWvd" =
+// CHECK: @"$s11field_order19CustomExecutorActorC11actorSystem{{.*}}vpWvd" =
+// CHECK: @"$s11field_order19CustomExecutorActorC5firstSivpWvd" =

--- a/validation-test/compiler_crashers_fixed/DerivedConformance-deriveDistributedActor-7459ef.swift
+++ b/validation-test/compiler_crashers_fixed/DerivedConformance-deriveDistributedActor-7459ef.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::DerivedConformance::deriveDistributedActor(swift::ValueDecl*)","signatureNext":"ConformanceChecker::resolveWitnessViaDerivation"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 // REQUIRES: OS=macosx
 import Distributed typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem distributed actor a{c, b


### PR DESCRIPTION
The assertion in Sema wasn't really correct, nor the best place to do it. Instead let's just have a test in IRGen that actors's fields are produced the right way -- they MUST have this specific order as remote references depend on this for memory safety.