### PR TITLE
The SWIFT_DUMP_ACCESSIBLE_FUNCTIONS flag must be a bool, not a string

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -128,7 +128,7 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'legacy' (Legacy behavior), "
          " 'swift6' (Swift 6.0+ behavior)")
 
-VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, string, "",
+VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
          "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "
          "These are used to obtain function pointers from accessible function "
          "record names, e.g. by the Distributed runtime to invoke distributed "


### PR DESCRIPTION
The flag is intended to be a bool; and the `""` was treated as true, resulting in debug logging (once, but anyway), of distributed function state when it should not be enabled.

Resolves rdar://144203699