### PR TITLE
[6.1] The SWIFT_DUMP_ACCESSIBLE_FUNCTIONS flag must be a bool, not a string

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -128,7 +128,7 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'legacy' (Legacy behavior), "
          " 'swift6' (Swift 6.0+ behavior)")
 
-VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, string, "",
+VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
          "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "
          "These are used to obtain function pointers from accessible function "
          "record names, e.g. by the Distributed runtime to invoke distributed "


### PR DESCRIPTION
**Description**: This flag is used in an if condition to only conditionally log some debug information (swift_once) for Distributed. Since it was a string, it was wrongly always "true" and the debug logging has happened always. This fixes the flag to be a bool and stops accidentally logging debug information.
**Scope/Impact**: Any Distributed adopter making a remote call.
**Risk:** Low, trivial fix to correct type of flag. No compatibility impact.
**Testing**: Manually verified the debug logging is not present
**Reviewed by**: @xedin 

**Original PR:** https://github.com/swiftlang/swift/pull/79147
**Radar:** rdar://144203699