### PR TITLE
[Threading] Use `tss_dtor_t` and not just `void(*)(void *)`.

### DIFF
--- a/include/swift/Threading/Impl/C11.h
+++ b/include/swift/Threading/Impl/C11.h
@@ -221,7 +221,7 @@ inline void once_impl(once_t &predicate, void (*fn)(void *), void *context) {
 #endif
 
 using tls_key_t = ::tss_t;
-using tls_dtor_t = void (*)(void *);
+using tls_dtor_t = ::tss_dtor_t;
 
 inline bool tls_alloc(tls_key_t &key, tls_dtor_t dtor) {
   return ::tss_create(&key, dtor) == thrd_success;


### PR DESCRIPTION
Although the C11 spec says `tss_dtor_t` is `void(*)(void *)`, there may be modifiers on the former typedef, so we should use it instead of directly writing the type.

rdar://144220714
