### PR TITLE
Reinstate distributed actor typed throws test with proper availability

### DIFF
--- a/test/Distributed/distributed_actor_typed_throws.swift
+++ b/test/Distributed/distributed_actor_typed_throws.swift
@@ -1,7 +1,5 @@
-// REQUIRES: rdar144229403
-
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -emit-sil -DMAKE_CORRECT %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple %s
+// RUN: %target-swift-frontend -emit-sil -target %target-swift-5.7-abi-triple -DMAKE_CORRECT %s -o - | %FileCheck %s
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency


### PR DESCRIPTION
This test was failing in some configurations due to missing availability. Address it in the same manner as other distributed tests do, by setting a target triple with Swift 5.7.

Fixes rdar://144229403.
