### PR TITLE
IRGen: Fix DenseMap interior pointer invalidation bug in IRGenSILFunction::visitEndApply.

### DIFF
--- a/test/AutoDiff/validation-test/modify_accessor.swift
+++ b/test/AutoDiff/validation-test/modify_accessor.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar144216380
-
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Fixes rdar://144216380.