### PR TITLE
[6.1] IRGen/loadable_by_address_reg2mem.sil  test requires 64bit

### DIFF
--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -4,6 +4,7 @@
 // UNSUPPORTED: wasm
 // UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
+// REQUIRES: PTRSIZE=64
 
 sil_stage canonical
 


### PR DESCRIPTION
Test case only change. Nothing to integrate.

rdar://142290872
(cherry picked from commit 4062c7e93d88240199e8ac64f21067aa0081effd)