### PR TITLE
[6.1] Fix some type issues around handling closures in SendNonSendable

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -434,17 +434,21 @@ public:
     return {};
   }
 
+  static bool isNonSendableType(SILType type, SILFunction *fn) {
+    return isNonSendableType(type.getASTType(), fn);
+  }
+
+  static bool isNonSendableType(SILValue value) {
+    return isNonSendableType(value->getType(), value->getFunction());
+  }
+
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.
   ///
   /// E.x.: Builtin.RawPointer and Builtin.NativeObject
   ///
   /// TODO: Fix the type checker.
-  static bool isNonSendableType(SILType type, SILFunction *fn);
-
-  static bool isNonSendableType(SILValue value) {
-    return isNonSendableType(value->getType(), value->getFunction());
-  }
+  static bool isNonSendableType(CanType type, SILFunction *fn);
 
   bool hasSameIsolation(ActorIsolation actorIsolation) const;
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1215,18 +1215,18 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
 //
 // NOTE: We special case RawPointer and NativeObject to ensure they are
 // treated as non-Sendable and strict checking is applied to it.
-bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
+bool SILIsolationInfo::isNonSendableType(CanType type, SILFunction *fn) {
   // Treat Builtin.NativeObject, Builtin.RawPointer, and Builtin.BridgeObject as
   // non-Sendable.
-  if (type.getASTType()->is<BuiltinNativeObjectType>() ||
-      type.getASTType()->is<BuiltinRawPointerType>() ||
-      type.getASTType()->is<BuiltinBridgeObjectType>()) {
+  if (type->is<BuiltinNativeObjectType>() ||
+      type->is<BuiltinRawPointerType>() ||
+      type->is<BuiltinBridgeObjectType>()) {
     return true;
   }
 
   // Treat Builtin.SILToken as Sendable. It cannot escape from the current
   // function. We should change isSendable to hardwire this.
-  if (type.getASTType()->is<SILTokenType>()) {
+  if (type->is<SILTokenType>()) {
     return false;
   }
 
@@ -1237,12 +1237,17 @@ bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
   // getConcurrencyDiagnosticBehavior could cause us to prevent a
   // "preconcurrency" unneeded diagnostic when just using Sendable values. We
   // only want to trigger that if we analyze a non-Sendable type.
-  if (type.isSendable(fn))
+  if (type->isSendableType())
     return false;
 
   // Grab out behavior. If it is none, then we have a type that we want to treat
   // as non-Sendable.
-  auto behavior = type.getConcurrencyDiagnosticBehavior(fn);
+  auto declRef = fn->getDeclRef();
+  if (!declRef)
+    return true;
+
+  auto *fromDC = declRef.getInnermostDeclContext();
+  auto behavior = type->getConcurrencyDiagnosticBehaviorLimit(fromDC);
   if (!behavior)
     return true;
 


### PR DESCRIPTION
This change fixes a logic error where we were not correctly checking if a type was non-Sendable by converting a potentially not lowered type from the AST to a SILType and then checking non-Sendability with that. Since the type was not lowered in cases where the formal and lowered type of a capture differed, we crashed. Instead, we now perform the check at the CanType level with formal types.

On main, I have completely eliminated this code path by just using a SIL level check (since it also fixed another unrelated issue). This was viewed as too risky for 6.1 (https://github.com/swiftlang/swift/pull/78990), so I went back in and redid it just using types.
Risk: Low
Testing: Added compiler tests.
Issue: rdar://142661388
Reviewer: @xedin 
Original PRs: N/A