### PR TITLE
Serialization: Protect `maybeReadGenericParams` against errors

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -507,7 +507,7 @@ private:
   ///
   /// If the record at the cursor is not a generic param list, returns null
   /// without moving the cursor.
-  GenericParamList *maybeReadGenericParams(DeclContext *DC);
+  llvm::Expected<GenericParamList *> maybeReadGenericParams(DeclContext *DC);
 
   /// Reads a set of requirements from \c DeclTypeCursor.
   void deserializeGenericRequirements(ArrayRef<uint64_t> scratch,


### PR DESCRIPTION
Update signature and implementation of `maybeReadGenericParams` to pass up errors to the callers. Also update all of its callers to pass that error further up.

rdar://126582124