### PR TITLE
[Dependency Scanning] Support loading scanner cache state for caching

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -232,8 +232,14 @@ REMARK(remark_scanner_invalidate_upstream, none,
        "Incremental module scan: Dependency info for module '%0' invalidated due to an out-of-date"
        " dependency.", (StringRef))
 
-REMARK(remark_cache_reuse_disabled_with_cas, none,
-       "Incremental module scan: Re-using serialized module scanning dependency cache disabled in Caching build", ())
+REMARK(remark_scanner_invalidate_configuration, none,
+       "Incremental module scan: Dependency info for module '%0' invalidated due to wrong configuration.", (StringRef))
+
+REMARK(remark_scanner_invalidate_cas_error, none,
+       "Incremental module scan: Dependency info for module '%0' invalidated due to cas error: %1", (StringRef, StringRef))
+
+REMARK(remark_scanner_invalidate_missing_cas, none,
+       "Incremental module scan: Dependency info for module '%0' invalidated due to missing CAS input '%1'.", (StringRef, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: custom attribute diagnostics

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1117,6 +1117,8 @@ public:
     return Mapper->mapToString(Path);
   }
 
+  bool hasCAS() const { return (bool)CAS; }
+
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
 

--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -14,18 +14,24 @@
 #define SWIFT_DEPENDENCY_SCANDEPENDENCIES_H
 
 #include "swift-c/DependencyScan/DependencyScan.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/StringSet.h"
-#include "llvm/Support/Error.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Chrono.h"
+#include "llvm/Support/ErrorOr.h"
+#include <unordered_set>
 
 namespace llvm {
 class StringSaver;
-}
+namespace vfs {
+class FileSystem;
+} // namespace vfs
+} // namespace llvm
 
 namespace swift {
 
 class CompilerInvocation;
 class CompilerInstance;
+class DiagnosticEngine;
 class ModuleDependenciesCache;
 struct ModuleDependencyID;
 struct ModuleDependencyIDHash;

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -1819,6 +1819,7 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
                           .CASBridgingHeaderIncludeTreeRootID);
         addIdentifier(swiftTextDeps->moduleCacheKey);
         addIdentifier(swiftTextDeps->userModuleVersion);
+        addIdentifier(swiftTextDeps->moduleCacheKey);
         break;
       }
       case swift::ModuleDependencyKind::SwiftBinary: {
@@ -1831,6 +1832,7 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
         addIdentifier(swiftBinDeps->headerImport);
         addIdentifier(swiftBinDeps->definingModuleInterfacePath);
         addIdentifier(swiftBinDeps->userModuleVersion);
+        addIdentifier(swiftBinDeps->moduleCacheKey);
         addStringArray(moduleID,
                        ModuleIdentifierArrayKind::HeaderInputModuleDependencies,
                        clangHeaderDependencyNames);
@@ -1872,6 +1874,7 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
             swiftSourceDeps->textualModuleDetails.CASFileSystemRootID);
         addIdentifier(swiftSourceDeps->chainedBridgingHeaderPath);
         addIdentifier(swiftSourceDeps->chainedBridgingHeaderContent);
+        addIdentifier(swiftSourceDeps->moduleCacheKey);
         break;
       }
       case swift::ModuleDependencyKind::Clang: {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift-c/DependencyScan/DependencyScan.h"
+#include "swift/AST/DiagnosticsCommon.h"
 #include "swift/Basic/PrettyStackTrace.h"
 
 #include "swift/AST/ASTContext.h"
@@ -1273,32 +1274,27 @@ swift::dependencies::performModuleScan(
   // Load the dependency cache if -reuse-dependency-scan-cache
   // is specified
   if (opts.ReuseDependencyScannerCache) {
-    // For the time being, incremental scanner cache validation
-    // is not compatible with CAS-enabled builds.
-    if (!ctx.CASOpts.EnableCaching) {
-      auto cachePath = opts.SerializedDependencyScannerCachePath;
-      if (opts.EmitDependencyScannerCacheRemarks)
-        ctx.Diags.diagnose(SourceLoc(), diag::remark_reuse_cache, cachePath);
+    auto cachePath = opts.SerializedDependencyScannerCachePath;
+    if (opts.EmitDependencyScannerCacheRemarks)
+      ctx.Diags.diagnose(SourceLoc(), diag::remark_reuse_cache, cachePath);
 
-      llvm::sys::TimePoint<> serializedCacheTimeStamp;
-      bool loadFailure = module_dependency_cache_serialization::
-          readInterModuleDependenciesCache(cachePath, cache,
-                                           serializedCacheTimeStamp);
-      if (opts.EmitDependencyScannerCacheRemarks && loadFailure)
-        ctx.Diags.diagnose(SourceLoc(), diag::warn_scanner_deserialize_failed,
-                           cachePath);
+    llvm::sys::TimePoint<> serializedCacheTimeStamp;
+    bool loadFailure =
+        module_dependency_cache_serialization::readInterModuleDependenciesCache(
+            cachePath, cache, serializedCacheTimeStamp);
+    if (opts.EmitDependencyScannerCacheRemarks && loadFailure)
+      ctx.Diags.diagnose(SourceLoc(), diag::warn_scanner_deserialize_failed,
+                         cachePath);
 
-      if (!loadFailure && opts.ValidatePriorDependencyScannerCache) {
-        auto mainModuleID =
-            ModuleDependencyID{instance.getMainModule()->getNameStr().str(),
-                               ModuleDependencyKind::SwiftSource};
-        incremental::validateInterModuleDependenciesCache(
-            mainModuleID, cache, serializedCacheTimeStamp,
-            *instance.getSourceMgr().getFileSystem(), ctx.Diags,
-            opts.EmitDependencyScannerCacheRemarks);
-      }
-    } else if (opts.EmitDependencyScannerCacheRemarks)
-      ctx.Diags.diagnose(SourceLoc(), diag::remark_cache_reuse_disabled_with_cas);
+    if (!loadFailure && opts.ValidatePriorDependencyScannerCache) {
+      auto mainModuleID =
+          ModuleDependencyID{instance.getMainModule()->getNameStr().str(),
+                             ModuleDependencyKind::SwiftSource};
+      incremental::validateInterModuleDependenciesCache(
+          mainModuleID, cache, serializedCacheTimeStamp,
+          *instance.getSourceMgr().getFileSystem(), ctx.Diags,
+          opts.EmitDependencyScannerCacheRemarks);
+    }
   }
 
   auto scanner = ModuleDependencyScanner(
@@ -1334,7 +1330,7 @@ swift::dependencies::performModuleScan(
 
   // Serialize the dependency cache if -serialize-dependency-scan-cache
   // is specified
-  if (opts.SerializeDependencyScannerCache && !ctx.CASOpts.EnableCaching) {
+  if (opts.SerializeDependencyScannerCache) {
     auto savePath = opts.SerializedDependencyScannerCachePath;
     module_dependency_cache_serialization::writeInterModuleDependenciesCache(
         ctx.Diags, instance.getOutputBackend(), savePath, cache);
@@ -1448,6 +1444,41 @@ bool swift::dependencies::incremental::verifyModuleDependencyUpToDate(
     }
     return true;
   };
+
+  auto verifyCASID = [&cache, &diags, emitRemarks](StringRef moduleName,
+                                                   const std::string &casID) {
+    if (!cache.getScanService().hasCAS()) {
+      // If the wrong cache is passed.
+      if (emitRemarks)
+        diags.diagnose(SourceLoc(),
+                       diag::remark_scanner_invalidate_configuration,
+                       moduleName);
+      return false;
+    }
+    auto &CAS = cache.getScanService().getCAS();
+    auto ID = CAS.parseID(casID);
+    if (!ID) {
+      if (emitRemarks)
+        diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_cas_error,
+                       moduleName, toString(ID.takeError()));
+      return false;
+    }
+    if (!CAS.getReference(*ID)) {
+      if (emitRemarks)
+        diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_missing_cas,
+                       moduleName, casID);
+      return false;
+    }
+    return true;
+  };
+
+  // Check CAS inputs exist
+  if (const auto casID = moduleInfo.getClangIncludeTree())
+    if (!verifyCASID(moduleID.ModuleName, *casID))
+      return false;
+  if (const auto casID = moduleInfo.getCASFSRootID())
+    if (!verifyCASID(moduleID.ModuleName, *casID))
+      return false;
 
   // Check interface file for Swift textual modules
   if (const auto &textualModuleDetails = moduleInfo.getAsSwiftInterfaceModule())

--- a/test/CAS/incremental_scan.swift
+++ b/test/CAS/incremental_scan.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/Swift -cache-compile-job -cas-path %t/cas -no-clang-include-tree -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE --check-prefix=FAILED-LOAD
+
+/// Test reuse
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/Swift -cache-compile-job -cas-path %t/cas -no-clang-include-tree -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE
+
+/// Test invalidation after removing CAS.
+// RUN: rm -rf %t/cas
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/Swift -cache-compile-job -cas-path %t/cas -no-clang-include-tree -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE --check-prefix=INVALIDATE
+
+// REUSE: Incremental module scan: Re-using serialized module scanning dependency cache from:
+// FAILED-LOD: Incremental module scan: Failed to load module scanning dependency cache from
+// INVALIDATE: Incremental module scan: Dependency info for module '{{.*}}' invalidated due to missing CAS input
+// INVALIDATE: Incremental module scan: Dependency info for module '{{.*}}' invalidated due to an out-of-date dependency.
+// REUSE: Incremental module scan: Serializing module scanning dependency cache to
+import E

--- a/test/CAS/no_incremental_scan_for_you.swift
+++ b/test/CAS/no_incremental_scan_for_you.swift
@@ -1,8 +1,0 @@
-// RUN: %empty-directory(%t)
-// RUN: %empty-directory(%t/module-cache)
-
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/Swift -cache-compile-job -cas-path %t/cas -no-clang-include-tree -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache &> %t/clean_scan_output.txt
-// RUN: cat %t/clean_scan_output.txt | %FileCheck %s
-
-// CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache disabled in Caching build
-import E


### PR DESCRIPTION
Teach scanner cache loader to validate the CAS contents when validating dependency graph loaded.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
