### PR TITLE
build-script-impl: propagate `--verbose-build` to nested CMake builds

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -552,6 +552,11 @@ class BuildScriptInvocation(object):
                 impl_env["HOST_VARIABLE_{}__{}".format(
                     host_target.replace("-", "_"), name)] = value
 
+        if args.verbose_build:
+            # This ensures all CMake builds (including the ones
+            # called with `ExternalProject`) have verbose output
+            impl_env["VERBOSE"] = "1"
+
         return (impl_env, impl_args)
 
     def compute_host_specific_variables(self):


### PR DESCRIPTION
The main goal of this change is to ensure that the new build of the stdlib matches the same level of verbosity of the compiler build that spawned it.

For now I'm not matching this behaviour to the regular CMake build products (which would be needed if want to target external projects configured in LLVM).

Addresses rdar://144256800