### PR TITLE
[AST/Parse] Initial implementation of `@execution(concurrent | caller)` in type context

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1984,6 +1984,18 @@ BridgedTypeAttribute BridgedTypeAttribute_createIsolated(
     BridgedSourceLoc cLPLoc, BridgedSourceLoc cIsolationLoc,
     BridgedIsolatedTypeAttrIsolationKind cIsolation, BridgedSourceLoc cRPLoc);
 
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedExecutionTypeAttrExecutionKind {
+  BridgedExecutionTypeAttrExecutionKind_Concurrent,
+  BridgedExecutionTypeAttrExecutionKind_Caller
+};
+
+SWIFT_NAME("BridgedTypeAttribute.createExecution(_:atLoc:nameLoc:lpLoc:behaviorLoc:behavior:rpLoc:)")
+BridgedTypeAttribute BridgedTypeAttribute_createExecution(
+    BridgedASTContext cContext,
+    BridgedSourceLoc cAtLoc, BridgedSourceLoc cNameLoc,
+    BridgedSourceLoc cLPLoc, BridgedSourceLoc cBehaviorLoc,
+    BridgedExecutionTypeAttrExecutionKind behavior, BridgedSourceLoc cRPLoc);
+
 //===----------------------------------------------------------------------===//
 // MARK: TypeReprs
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3475,6 +3475,10 @@ protected:
     SWIFT_INLINE_BITFIELD_FULL(IsolatedTypeAttr, TypeAttribute, 8,
       Kind : 8
     );
+
+    SWIFT_INLINE_BITFIELD_FULL(ExecutionTypeAttr, TypeAttribute, 8,
+      Behavior : 8
+    );
   } Bits;
   // clang-format on
 
@@ -3736,6 +3740,28 @@ public:
     return getIsolationKindName(getIsolationKind());
   }
   static const char *getIsolationKindName(IsolationKind kind);
+
+  void printImpl(ASTPrinter &printer, const PrintOptions &options) const;
+};
+
+/// The @execution function type attribute.
+class ExecutionTypeAttr : public SimpleTypeAttrWithArgs<TypeAttrKind::Execution> {
+  SourceLoc BehaviorLoc;
+
+public:
+  ExecutionTypeAttr(SourceLoc atLoc, SourceLoc kwLoc, SourceRange parensRange,
+                    Located<ExecutionKind> behavior)
+      : SimpleTypeAttr(atLoc, kwLoc, parensRange), BehaviorLoc(behavior.Loc) {
+    Bits.ExecutionTypeAttr.Behavior = uint8_t(behavior.Item);
+  }
+
+  ExecutionKind getBehavior() const {
+    return ExecutionKind(Bits.ExecutionTypeAttr.Behavior);
+  }
+
+  SourceLoc getBehaviorLoc() const {
+    return BehaviorLoc;
+  }
 
   void printImpl(ASTPrinter &printer, const PrintOptions &options) const;
 };

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -545,7 +545,6 @@ DECL_ATTR_FEATURE_REQUIREMENT(ABI, ABIAttribute)
 DECL_ATTR(execution, Execution,
   OnFunc | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   166)
-DECL_ATTR_FEATURE_REQUIREMENT(Execution, NonIsolatedAsyncInheritsIsolationFromContext)
 
 LAST_DECL_ATTR(Execution)
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1683,6 +1683,14 @@ ERROR(attr_isolated_expected_rparen,none,
 ERROR(attr_isolated_expected_kind,none,
       "expected 'any' as the isolation kind", ())
 
+ERROR(attr_execution_expected_lparen,none,
+      "expected '(' after '@execution'",
+      ())
+ERROR(attr_execution_expected_rparen,none,
+      "expected ')' after execution behavior", ())
+ERROR(attr_execution_expected_kind,none,
+      "expected 'concurrent' or 'caller' as the execution behavior", ())
+
 ERROR(attr_private_import_expected_rparen,none,
       "expected ')' after function name for @_private", ())
 ERROR(attr_private_import_expected_sourcefile, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8257,9 +8257,13 @@ ERROR(attr_abi_incompatible_with_silgen_name,none,
 // MARK: @execution Attribute
 //===----------------------------------------------------------------------===//
 
-ERROR(attr_execution_concurrent_only_on_async,none,
-      "cannot use '@execution(concurrent)' on non-async %kind0",
+ERROR(attr_execution_only_on_async,none,
+      "cannot use '@execution' on non-async %kind0",
       (ValueDecl *))
+
+ERROR(attr_execution_type_attr_only_on_async,none,
+      "cannot use '@execution' on non-async function type",
+      ())
 
 ERROR(attr_execution_concurrent_incompatible_isolated_parameter,none,
       "cannot use '@execution(concurrent)' on %kind0 because it has "
@@ -8275,6 +8279,19 @@ ERROR(attr_execution_concurrent_incompatible_with_nonisolated,none,
       "cannot use '@execution(concurrent)' and 'nonisolated' on the same %0 "
       "because they serve the same purpose",
       (ValueDecl *))
+
+ERROR(attr_execution_concurrent_type_attr_incompatible_with_global_isolation,none,
+      "cannot use '@execution(concurrent)' because function type is "
+      "isolated to global actor %0",
+      (Type))
+
+ERROR(attr_execution_concurrent_type_attr_incompatible_with_isolated_param,none,
+      "cannot use '@execution(concurrent)' together with isolated parameter",
+      ())
+
+ERROR(attr_execution_concurrent_type_attr_incompatible_with_isolated_any,none,
+      "cannot use '@execution(concurrent)' together with @isolated(any)",
+      ())
 
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/include/swift/AST/TypeAttr.def
+++ b/include/swift/AST/TypeAttr.def
@@ -66,6 +66,7 @@ SIMPLE_TYPE_ATTR(_noMetadata, NoMetadata)
 TYPE_ATTR(_opaqueReturnTypeOf, OpaqueReturnTypeOf)
 TYPE_ATTR(isolated, Isolated)
 SIMPLE_TYPE_ATTR(_addressable, Addressable)
+TYPE_ATTR(execution, Execution)
 
 // SIL-specific attributes
 SIMPLE_SIL_TYPE_ATTR(async, Async)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -303,6 +303,23 @@ void IsolatedTypeAttr::printImpl(ASTPrinter &printer,
   printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
 }
 
+void ExecutionTypeAttr::printImpl(ASTPrinter &printer,
+                                  const PrintOptions &options) const {
+  printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
+  printer.printAttrName("@execution");
+  printer << "(";
+  switch (getBehavior()) {
+  case ExecutionKind::Concurrent:
+    printer << "concurrent";
+    break;
+  case ExecutionKind::Caller:
+    printer << "caller";
+    break;
+  }
+  printer << ")";
+  printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
+}
+
 /// Given a name like "inline", return the decl attribute ID that corresponds
 /// to it.  Note that this is a many-to-one mapping, and that the identifier
 /// passed in may only be the first portion of the attribute (e.g. in the case

--- a/lib/AST/Bridging/TypeAttributeBridging.cpp
+++ b/lib/AST/Bridging/TypeAttributeBridging.cpp
@@ -91,3 +91,23 @@ BridgedTypeAttribute BridgedTypeAttribute_createIsolated(
                        {cLPLoc.unbridged(), cRPLoc.unbridged()},
                        {isolationKind, cIsolationLoc.unbridged()});
 }
+
+BridgedTypeAttribute BridgedTypeAttribute_createExecution(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceLoc cNameLoc, BridgedSourceLoc cLPLoc,
+    BridgedSourceLoc cBehaviorLoc,
+    BridgedExecutionTypeAttrExecutionKind behavior, BridgedSourceLoc cRPLoc) {
+  auto behaviorKind = [=] {
+    switch (behavior) {
+    case BridgedExecutionTypeAttrExecutionKind_Concurrent:
+      return ExecutionKind::Concurrent;
+    case BridgedExecutionTypeAttrExecutionKind_Caller:
+      return ExecutionKind::Caller;
+    }
+    llvm_unreachable("bad kind");
+  }();
+  return new (cContext.unbridged())
+      ExecutionTypeAttr(cAtLoc.unbridged(), cNameLoc.unbridged(),
+                        {cLPLoc.unbridged(), cRPLoc.unbridged()},
+                        {behaviorKind, cBehaviorLoc.unbridged()});
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4788,6 +4788,50 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
+  case TypeAttrKind::Execution: {
+    SourceLoc lpLoc = Tok.getLoc(), behaviorLoc, rpLoc;
+    if (!consumeIfNotAtStartOfLine(tok::l_paren)) {
+      if (!justChecking) {
+        diagnose(Tok, diag::attr_execution_expected_lparen);
+        // TODO: should we suggest removing the `@`?
+      }
+      return makeParserError();
+    }
+
+    bool invalid = false;
+    std::optional<ExecutionKind> behavior;
+    if (isIdentifier(Tok, "concurrent")) {
+      behaviorLoc = consumeToken(tok::identifier);
+      behavior = ExecutionKind::Concurrent;
+    } else if (isIdentifier(Tok, "caller")) {
+      behaviorLoc = consumeToken(tok::identifier);
+      behavior = ExecutionKind::Caller;
+    } else {
+      if (!justChecking) {
+        diagnose(Tok, diag::attr_execution_expected_kind);
+      }
+      invalid = true;
+      consumeIf(tok::identifier);
+    }
+
+    if (justChecking && !Tok.is(tok::r_paren))
+      return makeParserError();
+    if (parseMatchingToken(tok::r_paren, rpLoc,
+                           diag::attr_execution_expected_rparen,
+                           lpLoc))
+      return makeParserError();
+
+    if (invalid)
+      return makeParserError();
+    assert(behavior);
+
+    if (!justChecking) {
+      result = new (Context) ExecutionTypeAttr(AtLoc, attrLoc, {lpLoc, rpLoc},
+                                               {*behavior, behaviorLoc});
+    }
+    return makeParserSuccess();
+  }
+
   case TypeAttrKind::Opened: {
     // Parse the opened existential ID string in parens
     SourceLoc beginLoc = Tok.getLoc(), idLoc, endLoc;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -259,8 +259,7 @@ public:
       return;
 
     if (!F->hasAsync()) {
-      diagnoseAndRemoveAttr(attr, diag::attr_execution_concurrent_only_on_async,
-                            F);
+      diagnoseAndRemoveAttr(attr, diag::attr_execution_only_on_async, F);
       return;
     }
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -251,6 +251,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-DAG: Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
 // ON_METHOD-DAG: Keyword/None:                       lifetime[#Func Attribute#]; name=lifetime
+// ON_METHOD-DAG: Keyword/None:                       execution[#Func Attribute#]; name=execution
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -325,6 +326,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
 // ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // ON_MEMBER_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
+// ON_MEMBER_LAST-DAG: Keyword/None:                       execution[#Declaration Attribute#]; name=execution
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -397,6 +399,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // KEYWORD_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
+// KEYWORD_LAST-DAG: Keyword/None:                       execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyGenericPropertyWrapper[#Property Wrapper#]; name=MyGenericPropertyWrapper

--- a/test/IDE/complete_decl_attribute_feature_requirement.swift
+++ b/test/IDE/complete_decl_attribute_feature_requirement.swift
@@ -7,8 +7,7 @@
 
 // RUN: %batch-code-completion -filecheck-additional-suffix _DISABLED
 // RUN: %batch-code-completion -filecheck-additional-suffix _ENABLED \
-// RUN:        -enable-experimental-feature ABIAttribute \
-// RUN:        -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+// RUN:        -enable-experimental-feature ABIAttribute
 
 // NOTE: Please do not include the ", N items" after "Begin completions". The
 // item count creates needless merge conflicts given that an "End completions"
@@ -18,18 +17,14 @@
 
 // KEYWORD2:              Begin completions
 // KEYWORD2_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
-// KEYWORD2_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // KEYWORD2_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD2_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD2:              End completions
 
 @#^KEYWORD3^# class C {}
 
 // KEYWORD3:              Begin completions
 // KEYWORD3_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD3_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD3_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3:              End completions
 
 @#^KEYWORD3_2?check=KEYWORD3^#IB class C2 {}
@@ -38,60 +33,46 @@
 @#^KEYWORD4^# enum E {}
 // KEYWORD4:              Begin completions
 // KEYWORD4_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD4_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD4_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4:              End completions
 
 @#^KEYWORD5^# struct S{}
 // KEYWORD5:              Begin completions
 // KEYWORD5_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD5_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// KEYWORD5_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5:              End completions
 
 @#^ON_GLOBALVAR^# var globalVar
 // ON_GLOBALVAR:              Begin completions
 // ON_GLOBALVAR_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
-// ON_GLOBALVAR_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR:              End completions
 
 struct _S {
   @#^ON_INIT^# init()
 // ON_INIT:              Begin completions
 // ON_INIT_ENABLED-DAG:  Keyword/None:              abi[#Constructor Attribute#]; name=abi
-// ON_INIT_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_INIT_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT:              End completions
 
   @#^ON_PROPERTY^# var foo
 // ON_PROPERTY:              Begin completions
 // ON_PROPERTY_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
-// ON_PROPERTY_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_PROPERTY_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY:              End completions
 
   @#^ON_METHOD^# private
   func foo()
 // ON_METHOD:              Begin completions
 // ON_METHOD_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
-// ON_METHOD_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // ON_METHOD_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_METHOD_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_METHOD:              End completions
 
 
   func bar(@#^ON_PARAM_1?check=ON_PARAM^#)
 // ON_PARAM:              Begin completions
 // ON_PARAM_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_PARAM_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_PARAM_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM:              End completions
 
   func bar(
@@ -114,9 +95,7 @@ struct _S {
   @#^ON_MEMBER_LAST^#
 // ON_MEMBER_LAST:              Begin completions
 // ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
-// ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_MEMBER_LAST:              End completions
 }
 
@@ -128,9 +107,7 @@ func takeClosure(_: () -> Void) {
 // IN_CLOSURE:              Begin completions
 // FIXME: Not valid in this position (but CompletionLookup can't tell that)
 // IN_CLOSURE_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
-// IN_CLOSURE_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // IN_CLOSURE_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
-// IN_CLOSURE_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // IN_CLOSURE:              End completions
 
 @#^KEYWORD_INDEPENDENT_1?check=KEYWORD_LAST^#
@@ -146,7 +123,5 @@ func dummy2() {}
 
 // KEYWORD_LAST:              Begin completions
 // KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
-// KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST_DISABLED-NOT: Keyword/None:              abi[#Declaration Attribute#]; name=abi
-// KEYWORD_LAST_DISABLED-NOT: Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST:              End completions

--- a/test/Parse/execution.swift
+++ b/test/Parse/execution.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+typealias F = @execution(concurrent) () async -> Void
+
+typealias E = @execution(concurrent) () -> Void
+// expected-error@-1 {{cannot use '@execution' on non-async function type}}
+
+func test1(_: @execution(caller) (Int...) async -> Void) {}
+func test2(_: @execution(concurrent) (Int...) async -> Void) {}
+
+func test_err1(_: @execution(concurrent) @MainActor () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution(concurrent)' because function type is isolated to global actor 'MainActor'}}
+
+func test_err2(_: @execution(concurrent) @isolated(any) () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution(concurrent)' together with @isolated(any)}}
+
+func test_err3(_: @execution(concurrent) (isolated (any Actor)?) async -> Void) {}
+// expected-error@-1 {{cannot use '@execution(concurrent)' together with isolated parameter}}
+
+func test_err4(_: @execution (Int) -> Void) {}
+// expected-error@-1 {{expected 'concurrent' or 'caller' as the execution behavior}}
+// expected-error@-2 {{expected parameter type following ':'}}
+
+func test_err5(_: @execution( () async -> Void) {}
+// expected-error@-1 {{expected 'concurrent' or 'caller' as the execution behavior}}
+// expected-note@-2 {{to match this opening '('}}
+// expected-error@-3 {{expected ')' after execution behavior}}
+
+func test_err6(_: @execution(hello) () async -> Void) {}
+// expected-error@-1 {{expected 'concurrent' or 'caller' as the execution behavior}}
+
+func test_err7(_: @execution(hello () async -> Void) {}
+// expected-error@-1 {{expected 'concurrent' or 'caller' as the execution behavior}}
+// expected-note@-2 {{to match this opening '('}}
+// expected-error@-3 {{expected ')' after execution behavior}}
+
+func test_err8(_: @execution(concurrent) Int) {} // expected-error {{attribute does not apply to type}}
+
+do {
+  let _ = [@execution(caller) () async -> Void]()
+  let _ = [@execution(caller) () -> Void]()
+  // expected-error@-1 {{cannot use '@execution' on non-async function type}}
+}
+

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -9,10 +9,10 @@
 // expected-error@-1 {{duplicate attribute}} expected-note@-1 {{attribute already specified here}}
 
 @execution(concurrent) func nonAsync1() {}
-// expected-error@-1 {{cannot use '@execution(concurrent)' on non-async global function 'nonAsync1()'}}
+// expected-error@-1 {{cannot use '@execution' on non-async global function 'nonAsync1()'}}
 
 @execution(caller) func nonAsync2() {}
-// expected-error@-1 {{cannot use '@execution(concurrent)' on non-async global function 'nonAsync2()'}}
+// expected-error@-1 {{cannot use '@execution' on non-async global function 'nonAsync2()'}}
 
 @execution(concurrent) func testGlobal() async {} // Ok
 
@@ -21,7 +21,7 @@ struct Test {
   // expected-error@-1 {{@execution(concurrent) may only be used on 'func' declarations}}
 
   @execution(concurrent) func member() {}
-  // expected-error@-1 {{cannot use '@execution(concurrent)' on non-async instance method 'member()'}}
+  // expected-error@-1 {{cannot use '@execution' on non-async instance method 'member()'}}
 
   @execution(concurrent) func member() async {} // Ok
 

--- a/test/attr/feature_requirement.swift
+++ b/test/attr/feature_requirement.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -disable-experimental-parser-round-trip -verify-additional-prefix disabled-
-// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute
 
 // REQUIRES: asserts
 
@@ -13,13 +13,4 @@ func fn() {}  // expected-disabled-error@-1 {{'abi' attribute is only valid when
   #error("does have @abi")  // expected-enabled-error {{does have @abi}}
 #else
   #error("doesn't have @abi")  // expected-disabled-error {{doesn't have @abi}}
-#endif
-
-@execution(concurrent) func testExecutionAttr() async {}
-// expected-disabled-error@-1 {{'execution(concurrent)' attribute is only valid when experimental feature NonIsolatedAsyncInheritsIsolationFromContext is enabled}}
-
-#if hasAttribute(execution)
-  #error("does have @execution") // expected-enabled-error {{does have @execution}}
-#else
-  #error("doesn't have @execution") // expected-disabled-error {{doesn't have @execution}}
 #endif


### PR DESCRIPTION
Implements parsing, ASTBridging and validation of the `@execution` attribute in type context.

Next up is to decide what to do with `FunctionTypeIsolation` and adjust the solver to handle new conversions.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
