### PR TITLE
[Dependency Scan] Do not pass clang's `-dwarf-debug-flags` to swift

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1266,6 +1266,9 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
   }
   CI->getFrontendOpts().ModuleMapFiles = FilteredModuleMapFiles;
 
+  // Clear clang debug flags.
+  CI->getCodeGenOpts().DwarfDebugFlags.clear();
+
   return CI->getCC1CommandLine();
 }
 

--- a/test/ScanDependencies/direct-cc1-dwarf-options.swift
+++ b/test/ScanDependencies/direct-cc1-dwarf-options.swift
@@ -1,0 +1,38 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: RC_DEBUG_OPTIONS=1 %target-swift-frontend -scan-dependencies -o %t/deps.json -I %t \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -g -file-compilation-dir %t -Xcc -ferror-limit=1 \
+// RUN:   %t/test.swift -module-name Test -swift-version 5 -experimental-clang-importer-direct-cc1-scan
+// RUN: %FileCheck %s --check-prefix CHECK-DIRECT-CC1-SCAN --input-file=%t/deps.json
+
+// CHECK-DIRECT-CC1-SCAN-NOT: -dwarf-debug-flags
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd
+
+// RUN: %{python} %S/../CAS/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/map.json\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -module-name Test -O @%t/MyApp.cmd %t/test.swift -parse-stdlib \
+// RUN:   -g -c -o %t/test.o -debug-info-store-invocation
+
+// RUN: %llvm-dwarfdump %t/test.o --recurse-depth=0 | %FileCheck %s --check-prefix=FLAGS
+// FLAGS: DW_AT_APPLE_flags
+// FLAGS-SAME: -target
+
+//--- A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func a() { }
+
+//--- test.swift
+import A
+func test() {}


### PR DESCRIPTION
When turning on directCC1 scanning, swift will ask clang driver to expand all cc1 flags and pass that explicitly on command-line. In such case, if `RC_DEBUG_OPTIONS` env is set on darwin platform, it will cause clang driver to encode all the options it gets and pass those clang driver options as a cc1 options `-dwarf-debug-flags`.

After the change, swift scanner will no longer generate a long `-Xcc -dwarf-debug-flag -Xcc <long list of flags>` for later compilation. Losing such information in DWARF doesn't affect swift debugging. It will instead, make command-line a lot shorter, save spaces in swift binary module, and make swift caching build more reliable.

rdar://144267483

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
