### PR TITLE
[cxx-interop] Prioritize C++ modules over namespaces in interface files

### DIFF
--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -296,11 +296,15 @@ void UnqualifiedLookupFactory::lookUpTopLevelNamesInModuleScopeContext(
     if (Results.empty())
       lookForAModuleWithTheGivenName(DC);
   } else if (inInterface && Results.size() == 1) {
+    // If this was a successful, unambiguous lookup inside an interface file,
+    // check whether we found a C++ namespace, which often collide with C++
+    // module names. In such cases, prefer the module over the namespace in it.
     auto entry = Results[0];
     if (llvm::isa_and_nonnull<clang::NamespaceDecl>(entry.getValueDecl()->getClangDecl())) {
       Results.clear();
       lookForAModuleWithTheGivenName(DC);
       if (Results.empty())
+        // There was no colliding module; return the decl we originally found
         Results.push_back(entry);
     }
   }

--- a/test/Interop/Cxx/modules/cxx-namespace-does-not-shadow-module.swift
+++ b/test/Interop/Cxx/modules/cxx-namespace-does-not-shadow-module.swift
@@ -13,7 +13,7 @@
 // (despite using a mix of C/C++ decls):
 //
 // RUN: %empty-directory(%t/lib)
-// RUN: %target-swift-emit-module-interface(%t/lib/shim.swiftinterface) -cxx-interoperability-mode=default -enable-experimental-feature -AssumeResilientCxxTypes %t/cxxshim.swift -module-name shim -I %t/include
+// RUN: %target-swift-emit-module-interface(%t/lib/shim.swiftinterface) -cxx-interoperability-mode=default %t/cxxshim.swift -module-name shim -I %t/include
 // RUN: %FileCheck %t/cxxshim.swift < %t/lib/shim.swiftinterface
 // RUN: %swift-frontend %t/program.swift -typecheck -verify -cxx-interoperability-mode=default -I %t/include -I %t/lib
 

--- a/test/Interop/Cxx/modules/cxx-namespace-does-not-shadow-module.swift
+++ b/test/Interop/Cxx/modules/cxx-namespace-does-not-shadow-module.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/lib)
+// RUN: %empty-directory(%t/include)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-module-interface(%t/lib/shim.swiftinterface) %t/shim.swift -module-name shim -I %t/include
+// RUN: %FileCheck %t/shim.swift < %t/lib/shim.swiftinterface
+
+// RUN: %swift-frontend %t/program.swift -typecheck -verify -cxx-interoperability-mode=default -I %t/include -I %t/lib
+
+//--- include/module.modulemap
+// A Clang module which will first be compiled in C mode, and then later compiled in C++ mode
+module c2cxx {
+  header "c2cxx.h"
+  export *
+}
+
+//--- include/c2cxx.h
+// A C/C++ header file that defines a namespace with the same name as the module, a common idiom
+#ifndef __C2CXX_NAMESPACE_H
+#define __C2CXX_NAMESPACE_H
+typedef int c2cxx_number;                         // always available and resilient
+#ifdef __cplusplus
+namespace c2cxx { typedef c2cxx_number number; }; // only available in C++
+#endif // __cplusplus
+#endif // __C2CXX_NAMESPACE_H
+
+//--- shim.swift
+// A shim around c2cxx that exposes a c2cxx decl in its module interface
+import c2cxx
+public func shimId(_ n: c2cxx_number) -> c2cxx_number { return n }
+// CHECK: public func shimId(_ n: c2cxx.c2cxx_number) -> c2cxx.c2cxx_number
+
+//--- program.swift
+// Uses the shim and causes it to be (re)built from its interface
+import shim
+func numberwang() -> Bool { return shimId(42) == 42 }


### PR DESCRIPTION
In Swift, there is currently no way to refer to a module that has been shadowed by a top-level declaration. This is a problem in Swift module interfaces, which fully (<sup>*</sup>most) qualifies identifiers, e.g., `modulename.member`. If there is another top-level declaration named `modulename`, `modulename.member` will resolve the first component to that declaration rather than to the module; attempting to look up `member` in the declaration will lead to a missing member error (or resolve to the wrong member if the declaration happens to also define `member`).

<sup>*</sup>_One exception is within the body of `@inlinable` functions, which are splatted in interface files almost exactly as written by the user (i.e., usually unqualified). This is also why it is potentially dangerous to attempt any fix that assumes all module interface identifiers are fully qualified._

This problem is more pronounced with C++ interop, where naming a namespace the same as the module is a fairly common idiom (e.g., `os`, and `simd`). Worse, this problem is difficult to detect ahead of time---i.e., when a module interface is being generated---because the module might originally be compiled without C++ interop, where header guards prevent the C++ namespace from being defined. The problem only arises when the module is later recompiled from its interface with C++ interop (in fact, the module may need to be recompiled _because_ its user is using C++ interop; see #77754).

This patch fixes this issue specifically for C++ namespace/module name collisions, to avoid potential fall-out that may ensue from a broader fix. With this patch, we only favor a module over a colliding member if (1) we are in an interface file, and (2) the member is a namespace.

It should be possible to drop condition (2) if we can ensure _all_ identifiers are fully-qualified in interface files, but that is not currently the case. That would also fix this issue for _Swift_ modules whose name conflicts with one of its members'.

Related:

- #43510 tracks the design and implementation of a language feature to explicitly refer to modules in _user-written_ source code. The issue addressed by this patch is specific to _compiler-generated_ module interface files.
- #78634 works around this issue for the `os` module.
- #78676 attempted to work around this issue for the `simd` module, but that caused other problems; #78852 reverted it.

rdar://143352205