### PR TITLE
[6.1] [stdlib] Add Comparable conformance to WordPair

### DIFF
--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -183,6 +183,16 @@ extension WordPair: Hashable {
   }
 }
 
+@available(SwiftStdlib 6.2, *)
+extension WordPair: Comparable {
+  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public static func <(lhs: WordPair, rhs: WordPair) -> Bool {
+    (lhs.first, lhs.second) < (rhs.first, rhs.second)
+  }
+}
+
 @available(SwiftStdlib 6.0, *)
 @_unavailableInEmbedded
 extension WordPair: CustomStringConvertible {

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -183,9 +183,9 @@ extension WordPair: Hashable {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftStdlib 6.1, *)
 extension WordPair: Comparable {
-  @available(SwiftStdlib 6.2, *)
+  @available(SwiftStdlib 6.1, *)
   @_alwaysEmitIntoClient
   @_transparent
   public static func <(lhs: WordPair, rhs: WordPair) -> Bool {

--- a/test/abi/macOS/arm64/synchronization.swift
+++ b/test/abi/macOS/arm64/synchronization.swift
@@ -698,3 +698,6 @@ Added: _$s15Synchronization20AtomicUpdateOrderingV22sequentiallyConsistentACvpZM
 Added: _$s15Synchronization20AtomicUpdateOrderingV7relaxedACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9acquiringACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9releasingACvpZMV
+
+// WordPair to Comparable conformance
+Added: _$s15Synchronization8WordPairVSLAAMc

--- a/test/abi/macOS/x86_64/synchronization.swift
+++ b/test/abi/macOS/x86_64/synchronization.swift
@@ -692,3 +692,6 @@ Added: _$s15Synchronization20AtomicUpdateOrderingV22sequentiallyConsistentACvpZM
 Added: _$s15Synchronization20AtomicUpdateOrderingV7relaxedACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9acquiringACvpZMV
 Added: _$s15Synchronization20AtomicUpdateOrderingV9releasingACvpZMV
+
+// WordPair to Comparable conformance
+Added: _$s15Synchronization8WordPairVSLAAMc

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -49,4 +49,22 @@ suite.test("basics") {
 
 } // if #available(SwiftStdlib 6.0, *)
 
+if #available(SwiftStdlib 6.2, *) {
+suite.test("comparable") {
+  let c0 = WordPair(first: 0, second: 0)
+  let c1 = WordPair(first: 1, second: 0)
+  let c2 = WordPair(first: 2, second: 0)
+  let c3 = WordPair(first: 0, second: 1)
+  let c4 = WordPair(first: 1, second: 2)
+  let c5 = WordPair(first: 2, second: 1)
+  expectFalse(c0 < c0)
+  expectTrue(c0 < c1)
+  expectTrue(c0 < c2)
+  expectTrue(c0 < c3)
+  expectFalse(c1 < c0)
+  expectTrue(c4 < c5)
+  expectFalse(c5 < c4)
+}
+} // if #available(SwiftStdlib 6.2, *)
+
 runAllTests()

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -49,7 +49,7 @@ suite.test("basics") {
 
 } // if #available(SwiftStdlib 6.0, *)
 
-if #available(SwiftStdlib 6.2, *) {
+if #available(SwiftStdlib 6.1, *) {
 suite.test("comparable") {
   let c0 = WordPair(first: 0, second: 0)
   let c1 = WordPair(first: 1, second: 0)

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -65,6 +65,6 @@ suite.test("comparable") {
   expectTrue(c4 < c5)
   expectFalse(c5 < c4)
 }
-} // if #available(SwiftStdlib 6.2, *)
+} // if #available(SwiftStdlib 6.1, *)
 
 runAllTests()


### PR DESCRIPTION
* **Explanation**: We forgot to include this conformance in the initial `WordPair` PR, so this patch adds it with a newer availability than the type.
* **Scope**: Folks trying to compare 2 different `WordPair` instances.
* **Original** **PR**: https://github.com/swiftlang/swift/pull/78857
* **Reviewer**: @glessard 
* **Issue**: N/A
* **Risk**: Very Low, just an additive change.
* **Testing**: Added tests.