### PR TITLE
AST: Introduce `AvailabilityContext::containsUnavailableDomain()`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -87,12 +87,17 @@ public:
   /// Constrain with another `AvailabilityContext`.
   void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);
 
-  /// Constrain with the availability attributes of `decl`.
-  void constrainWithDecl(const Decl *decl);
-
   /// Constrain the platform availability range with `platformRange`.
   void constrainWithPlatformRange(const AvailabilityRange &platformRange,
                                   ASTContext &ctx);
+
+  /// Constrain the context by adding \p domain to the set of unavailable
+  /// domains.
+  void constrainWithUnavailableDomain(AvailabilityDomain domain,
+                                      ASTContext &ctx);
+
+  /// Constrain with the availability attributes of `decl`.
+  void constrainWithDecl(const Decl *decl);
 
   /// Constrain with the availability attributes of `decl`, intersecting the
   /// platform range of `decl` with `platformRange`.

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -74,12 +74,11 @@ public:
   /// availability context, starting at its introduction version.
   AvailabilityRange getPlatformRange() const;
 
-  /// Returns the broadest AvailabilityDomain that is unavailable in this
-  /// context.
-  std::optional<AvailabilityDomain> getUnavailableDomain() const;
+  /// Returns true if this context contains any unavailable domains.
+  bool isUnavailable() const;
 
-  /// Returns true if this context is unavailable.
-  bool isUnavailable() const { return getUnavailableDomain().has_value(); }
+  /// Returns true if \p domain is unavailable in this context.
+  bool containsUnavailableDomain(AvailabilityDomain domain) const;
 
   /// Returns true if this context is deprecated on the current platform.
   bool isDeprecated() const;

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -155,10 +155,6 @@ void AvailabilityContext::constrainWithContext(const AvailabilityContext &other,
   storage = Storage::get(info, ctx);
 }
 
-void AvailabilityContext::constrainWithDecl(const Decl *decl) {
-  constrainWithDeclAndPlatformRange(decl, AvailabilityRange::alwaysAvailable());
-}
-
 void AvailabilityContext::constrainWithPlatformRange(
     const AvailabilityRange &platformRange, ASTContext &ctx) {
 
@@ -167,6 +163,19 @@ void AvailabilityContext::constrainWithPlatformRange(
     return;
 
   storage = Storage::get(info, ctx);
+}
+
+void AvailabilityContext::constrainWithUnavailableDomain(
+    AvailabilityDomain domain, ASTContext &ctx) {
+  Info info{storage->info};
+  if (!info.constrainUnavailability(domain))
+    return;
+
+  storage = Storage::get(info, ctx);
+}
+
+void AvailabilityContext::constrainWithDecl(const Decl *decl) {
+  constrainWithDeclAndPlatformRange(decl, AvailabilityRange::alwaysAvailable());
 }
 
 void AvailabilityContext::constrainWithDeclAndPlatformRange(

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -133,9 +133,16 @@ AvailabilityRange AvailabilityContext::getPlatformRange() const {
   return storage->info.Range;
 }
 
-std::optional<AvailabilityDomain>
-AvailabilityContext::getUnavailableDomain() const {
-  return storage->info.UnavailableDomain;
+bool AvailabilityContext::isUnavailable() const {
+  return storage->info.UnavailableDomain.has_value();
+}
+
+bool AvailabilityContext::containsUnavailableDomain(
+    AvailabilityDomain domain) const {
+  if (auto unavailableDomain = storage->info.UnavailableDomain)
+    return unavailableDomain->contains(domain);
+
+  return false;
 }
 
 bool AvailabilityContext::isDeprecated() const {
@@ -212,7 +219,7 @@ stringForAvailability(const AvailabilityRange &availability) {
 void AvailabilityContext::print(llvm::raw_ostream &os) const {
   os << "version=" << stringForAvailability(getPlatformRange());
 
-  if (auto unavailableDomain = getUnavailableDomain())
+  if (auto unavailableDomain = storage->info.UnavailableDomain)
     os << " unavailable=" << unavailableDomain->getNameForAttributePrinting();
 
   if (isDeprecated())

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -349,8 +349,7 @@ static bool computeContainedByDeploymentTarget(AvailabilityScope *scope,
 static bool isInsideCompatibleUnavailableDeclaration(
     const Decl *D, AvailabilityContext availabilityContext,
     const SemanticAvailableAttr &attr) {
-  auto contextDomain = availabilityContext.getUnavailableDomain();
-  if (!contextDomain)
+  if (!availabilityContext.isUnavailable())
     return false;
 
   if (!attr.isUnconditionallyUnavailable())
@@ -364,7 +363,7 @@ static bool isInsideCompatibleUnavailableDeclaration(
       return false;
   }
 
-  return contextDomain->contains(declDomain);
+  return availabilityContext.containsUnavailableDomain(declDomain);
 }
 
 std::optional<SemanticAvailableAttr>

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -75,6 +75,9 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
 
   auto macOS10_9 = AvailabilityContext::forDeploymentTarget(ctx);
   EXPECT_FALSE(macOS10_9.isUnavailable());
+  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.macOS));
+  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.macOSAppExt));
+  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.universal));
 
   // Constrain the deployment target context by adding unavailability on macOS.
   // The resulting context should be a new context that is less available than
@@ -82,7 +85,10 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
   auto unavailableOnMacOS = macOS10_9;
   unavailableOnMacOS.constrainWithUnavailableDomain(domains.macOS, ctx);
   EXPECT_TRUE(unavailableOnMacOS.isUnavailable());
-  // FIXME: [availability] query unavailable domains
+  EXPECT_TRUE(unavailableOnMacOS.containsUnavailableDomain(domains.macOS));
+  EXPECT_TRUE(
+      unavailableOnMacOS.containsUnavailableDomain(domains.macOSAppExt));
+  EXPECT_FALSE(unavailableOnMacOS.containsUnavailableDomain(domains.universal));
   EXPECT_NE(unavailableOnMacOS, macOS10_9);
   EXPECT_TRUE(unavailableOnMacOS.isContainedIn(macOS10_9));
   EXPECT_FALSE(macOS10_9.isContainedIn(unavailableOnMacOS));
@@ -106,7 +112,11 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
   auto unavailableUniversally = unavailableOnMacOS;
   unavailableUniversally.constrainWithUnavailableDomain(domains.universal, ctx);
   EXPECT_TRUE(unavailableUniversally.isUnavailable());
-  // FIXME: [availability] query unavailable domains
+  EXPECT_TRUE(unavailableUniversally.containsUnavailableDomain(domains.macOS));
+  EXPECT_TRUE(
+      unavailableUniversally.containsUnavailableDomain(domains.macOSAppExt));
+  EXPECT_TRUE(
+      unavailableUniversally.containsUnavailableDomain(domains.universal));
   EXPECT_NE(unavailableUniversally, unavailableOnMacOS);
   EXPECT_TRUE(unavailableUniversally.isContainedIn(unavailableOnMacOS));
   EXPECT_TRUE(unavailableUniversally.isContainedIn(macOS10_9));

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -1,0 +1,115 @@
+//===--- AvailabilityContextTests.cpp - Tests for AvailabilityContext -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestContext.h"
+#include "swift/AST/AvailabilityContext.h"
+#include "llvm/TargetParser/Triple.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+static llvm::VersionTuple getPlatformIntro(const AvailabilityContext &context) {
+  return context.getPlatformRange().getRawVersionRange().getLowerEndpoint();
+}
+
+static AvailabilityRange getAvailabilityRange(unsigned major, unsigned minor) {
+  return AvailabilityRange(
+      VersionRange::allGTE(llvm::VersionTuple(major, minor)));
+}
+
+class AvailabilityContextTest : public ::testing::Test {
+public:
+  const TestContext defaultTestContext{
+      DoNotDeclareOptionalTypes, llvm::Triple("x86_64", "apple", "macosx10.9")};
+
+  struct {
+    const AvailabilityDomain universal = AvailabilityDomain::forUniversal();
+    const AvailabilityDomain macOS =
+        AvailabilityDomain::forPlatform(PlatformKind::macOS);
+    const AvailabilityDomain macOSAppExt = AvailabilityDomain::forPlatform(
+        PlatformKind::macOSApplicationExtension);
+  } domains;
+};
+
+TEST_F(AvailabilityContextTest, PlatformIntroduction) {
+  auto &ctx = defaultTestContext.Ctx;
+
+  auto macOS10_9 = AvailabilityContext::forDeploymentTarget(ctx);
+  EXPECT_EQ(getPlatformIntro(macOS10_9), llvm::VersionTuple(10, 9));
+
+  // Attempt to constrain the macOS version to >= 10.8. Since the context is
+  // already >= 10.9, this should have no effect.
+  auto macOS10_8 = macOS10_9;
+  macOS10_8.constrainWithPlatformRange(getAvailabilityRange(10, 8), ctx);
+  EXPECT_EQ(macOS10_8, macOS10_9);
+
+  // Attempt to constrain the macOS version to >= 10.9. Since the context is
+  // already >= 10.9, this should have no effect.
+  auto stillMacOS10_9 = macOS10_9;
+  stillMacOS10_9.constrainWithPlatformRange(getAvailabilityRange(10, 9), ctx);
+  EXPECT_EQ(stillMacOS10_9, macOS10_9);
+
+  // Constrain the the macOS version to >= 10.10 instead. The resulting context
+  // should be a new context that is less available than the deployment target
+  // context (a.k.a. "contained by").
+  auto macOS10_10 = macOS10_9;
+  macOS10_10.constrainWithPlatformRange(getAvailabilityRange(10, 10), ctx);
+  EXPECT_EQ(getPlatformIntro(macOS10_10), llvm::VersionTuple(10, 10));
+  EXPECT_NE(macOS10_9, macOS10_10);
+  EXPECT_TRUE(macOS10_10.isContainedIn(macOS10_9));
+  EXPECT_FALSE(macOS10_9.isContainedIn(macOS10_10));
+}
+
+TEST_F(AvailabilityContextTest, UnavailableDomains) {
+  auto &ctx = defaultTestContext.Ctx;
+
+  auto macOS10_9 = AvailabilityContext::forDeploymentTarget(ctx);
+  EXPECT_FALSE(macOS10_9.isUnavailable());
+
+  // Constrain the deployment target context by adding unavailability on macOS.
+  // The resulting context should be a new context that is less available than
+  // the deployment target context (a.k.a. "contained by").
+  auto unavailableOnMacOS = macOS10_9;
+  unavailableOnMacOS.constrainWithUnavailableDomain(domains.macOS, ctx);
+  EXPECT_TRUE(unavailableOnMacOS.isUnavailable());
+  // FIXME: [availability] query unavailable domains
+  EXPECT_NE(unavailableOnMacOS, macOS10_9);
+  EXPECT_TRUE(unavailableOnMacOS.isContainedIn(macOS10_9));
+  EXPECT_FALSE(macOS10_9.isContainedIn(unavailableOnMacOS));
+
+  // Constraining a context that is already unavailable on macOS by adding
+  // unavailability on macOS should have no effect.
+  auto stillUnavailableOnMacOS = unavailableOnMacOS;
+  stillUnavailableOnMacOS.constrainWithUnavailableDomain(domains.macOS, ctx);
+  EXPECT_EQ(unavailableOnMacOS, stillUnavailableOnMacOS);
+
+  // Constraining unavailability on macOS application extensions should also
+  // have no effect.
+  auto unavailableInAppExt = unavailableOnMacOS;
+  unavailableInAppExt.constrainWithUnavailableDomain(domains.macOSAppExt, ctx);
+  EXPECT_EQ(unavailableOnMacOS, unavailableInAppExt);
+
+  // FIXME: [availability] Test adding unavailability for an independent domain.
+
+  // Constraining the context to be universally unavailable should create a
+  // new context that contains the context that was unavailable on macOS only.
+  auto unavailableUniversally = unavailableOnMacOS;
+  unavailableUniversally.constrainWithUnavailableDomain(domains.universal, ctx);
+  EXPECT_TRUE(unavailableUniversally.isUnavailable());
+  // FIXME: [availability] query unavailable domains
+  EXPECT_NE(unavailableUniversally, unavailableOnMacOS);
+  EXPECT_TRUE(unavailableUniversally.isContainedIn(unavailableOnMacOS));
+  EXPECT_TRUE(unavailableUniversally.isContainedIn(macOS10_9));
+  EXPECT_FALSE(unavailableOnMacOS.isContainedIn(unavailableUniversally));
+  EXPECT_FALSE(macOS10_9.isContainedIn(unavailableUniversally));
+}

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -1,3 +1,15 @@
+//===--- AvailabilityDomainTests.cpp - Tests for AvailabilityDomain -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 #include "swift/AST/AvailabilityDomain.h"
 #include "gtest/gtest.h"
 

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
   ASTDumperTests.cpp
   ASTWalkerTests.cpp
+  AvailabilityContextTests.cpp
   AvailabilityDomainTests.cpp
   IndexSubsetTests.cpp
   DiagnosticBehaviorTests.cpp

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -33,8 +33,10 @@ static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
   return decl;
 }
 
-TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
-    : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
+TestContext::TestContext(ShouldDeclareOptionalTypes optionals,
+                         llvm::Triple target)
+    : TestContextBase(target),
+      Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                            ClangImporterOpts, SymbolGraphOpts, CASOpts,
                            SerializationOpts, SourceMgr, Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -40,8 +40,8 @@ public:
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 
-  TestContextBase() : Diags(SourceMgr) {
-    LangOpts.Target = llvm::Triple(llvm::sys::getProcessTriple());
+  TestContextBase(llvm::Triple target) : Diags(SourceMgr) {
+    LangOpts.Target = target;
   }
 };
 
@@ -57,7 +57,9 @@ class TestContext : public TestContextBase {
 public:
   ASTContext &Ctx;
 
-  TestContext(ShouldDeclareOptionalTypes optionals = DoNotDeclareOptionalTypes);
+  TestContext(
+      ShouldDeclareOptionalTypes optionals = DoNotDeclareOptionalTypes,
+      llvm::Triple target = llvm::Triple(llvm::sys::getProcessTriple()));
 
   template <typename Nominal>
   typename std::enable_if<!std::is_same<Nominal, swift::ClassDecl>::value,


### PR DESCRIPTION
The new query replaces `AvailabilityContext::getUnavailableDomain()`, which is going away because there may be multiple unavailable domains in a single availability context.

Also, add some tests for `AvailabilityContext` to the `SwiftASTTests` target.

NFC.