### PR TITLE
[Parse] Adjust assertions for ParsingFlags::PoundIfAllActive mode

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1503,7 +1503,11 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         continue;
 
       // Extract the parsed expression as the result.
-      assert(activeElements.size() == 1 && activeElements[0].is<Expr *>());
+      assert(activeElements.size() == 1 ||
+             SF.getParsingOptions().contains(
+                 SourceFile::ParsingFlags::PoundIfAllActive));
+      // FIXME: 'PoundIfAllActive' mode should keep all the parsed AST nodes.
+      assert(activeElements[0].is<Expr *>());
       auto expr = activeElements[0].get<Expr *>();
       ParserStatus status(ICD);
       auto charRange = Lexer::getCharSourceRangeFromSourceRange(

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -184,3 +184,20 @@ class A {
   @IBAction @objc func foo(a: Int) {}
   #endif
 }
+
+func testPostfixIfConfig() {
+  foo
+  #if FLAG1
+    .flag1
+    #if FLAG2
+      .flag2
+    #elseif FLAG3
+      .flag3
+    #else
+      .else1
+    #endif
+    .flag1Tail
+  #else
+    .else2
+  #endif
+}

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2930,
+  key.length: 3126,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1669,6 +1669,17 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "testPostfixIfConfig()",
+      key.offset: 2931,
+      key.length: 194,
+      key.nameoffset: 2936,
+      key.namelength: 21,
+      key.bodyoffset: 2959,
+      key.bodylength: 165
     }
   ],
   key.diagnostics: [

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2930,
+  key.length: 3126,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1669,6 +1669,17 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "testPostfixIfConfig()",
+      key.offset: 2931,
+      key.length: 194,
+      key.nameoffset: 2936,
+      key.namelength: 21,
+      key.bodyoffset: 2959,
+      key.bodylength: 165
     }
   ],
   key.diagnostics: [

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2930,
+  key.length: 3126,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1669,6 +1669,17 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "testPostfixIfConfig()",
+      key.offset: 2931,
+      key.length: 194,
+      key.nameoffset: 2936,
+      key.namelength: 21,
+      key.bodyoffset: 2959,
+      key.bodylength: 165
     }
   ],
   key.diagnostics: [


### PR DESCRIPTION
In this mode, multiple #if clauses are active. For now, just use the first clause as the result.
