### PR TITLE
Fix typo, refine formatting in `EmbeddedSwift/UserManual.md`

### DIFF
--- a/docs/EmbeddedSwift/UserManual.md
+++ b/docs/EmbeddedSwift/UserManual.md
@@ -126,7 +126,7 @@ _swift_stdlib_isLinkingConsonant
 _swift_stdlib_nfd_decompositions
 ```
 
-To resolve this, link in the libswiftUnicodeDataTables.a that's in Swift toolchain's resource directory (`lib/swift/`) under the target triple that you're using:
+To resolve this, link in the `libswiftUnicodeDataTables.a` that's in Swift toolchain's resource directory (`lib/swift/`) under the target triple that you're using:
 
 ```bash
 $ swiftc <inputs> -target armv6m-none-none-eabi -enable-experimental-feature Embedded -wmo -c -o output.o
@@ -138,17 +138,17 @@ $ ld ... -o binary output.o $(dirname `which swiftc`)/../lib/swift/embedded/armv
 - Comparing String objects for equality
 - Sorting Strings
 - Using String's hash values, and in particular using String as dictionary keys
-- Using String's .count property
-- Using Unicode-aware string processing APIs (.split(), iterating characters, indexing)
-- Using Unicode-aware conversion String APIs (.uppercased(), .lowercased(), etc.)
+- Using String's `.count` property
+- Using Unicode-aware string processing APIs (`.split()`, iterating characters, indexing)
+- Using Unicode-aware conversion String APIs (`.uppercased()`, `.lowercased()`, etc.)
 
 **For contrast, unicode data tables are *not required for* (list not exhaustive):**
 
 - Using StaticString
 - Creating, concatenating, string interpolating, and printing String objects
-- Using .utf8, .utf16, and .unicodeScalars views of strings, including their .count property, using them as dictionary keys
+- Using `.utf8`, `.utf16`, and `.unicodeScalars` views of strings, including their .count property, using them as dictionary keys
 
-Manually linking libUnicodeDataTables.a is required for several reasons, including acknowledging that the data tables are desirable: Since they have a non-negligible size, it's useful to be aware that you are using them.
+Manually linking `libswiftUnicodeDataTables.a` is required for several reasons, including acknowledging that the data tables are desirable: Since they have a non-negligible size, it's useful to be aware that you are using them.
 
 ## Conditionalizing compilation for Embedded Swift
 


### PR DESCRIPTION
The document should refer to `libswiftUnicodeDataTables.a`, not `libUnicodeDataTables.a`, as the latter doesn't exist.
