### PR TITLE
Enable loop rotate when the header is exiting

### DIFF
--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -1,11 +1,10 @@
-// RUN: %target-sil-opt -loop-rotate -update-borrowed-from -looprotate-single-block-loop=true %s | %FileCheck %s
+// RUN: %target-sil-opt -loop-rotate -update-borrowed-from -looprotate-single-block-loop=true -looprotate-infinite-budget %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin
 import Swift
 
 class Klass {
-
 }
 
 struct BoxStruct {
@@ -244,3 +243,39 @@ bb8:
 bb9:
   unreachable
 }
+
+sil @foo : $@convention(thin) (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+
+sil [ossa] @looprotate_ownership_results : $@convention(thin) (Int32, @guaranteed Klass) -> Int32 {
+bb0(%0 : $Int32, %1 : @guaranteed $Klass):
+  %2 = struct_extract %0, #Int32._value
+  %3 = integer_literal $Builtin.Int32, 0
+  br bb1(%2, %3)
+
+bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32):
+  %7 = function_ref @foo : $@convention(thin) (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+  %8 = thin_to_thick_function %7 to $@noescape @callee_guaranteed (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+  %9 = convert_function %8 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error any Error) for <UInt64, UInt64>, forwarding: @owned 
+  destroy_value %9
+  %11 = struct $Int32 (%6)
+  %12 = builtin "cmp_eq_Word"(%6, %2) : $Builtin.Int1
+  cond_br %12, bb3, bb2
+
+bb2:
+  %14 = integer_literal $Builtin.Int32, 1
+  %15 = integer_literal $Builtin.Int1, -1
+  %16 = builtin "sadd_with_overflow_Word"(%6, %14, %15) : $(Builtin.Int32, Builtin.Int1)
+  %17 = tuple_extract %16, 0
+  %18 = enum $Optional<Int32>, #Optional.some!enumelt, %11
+  %19 = unchecked_enum_data %18, #Optional.some!enumelt
+  %20 = struct_extract %19, #Int32._value
+  %21 = integer_literal $Builtin.Int1, -1
+  %22 = builtin "sadd_with_overflow_Word"(%5, %20, %21) : $(Builtin.Int32, Builtin.Int1)
+  %23 = tuple_extract %22, 0
+  br bb1(%23, %17)
+
+bb3:
+  %25 = struct $Int32 (%5)
+  return %25
+}
+

--- a/test/SILOptimizer/looprotate_ossa.sil
+++ b/test/SILOptimizer/looprotate_ossa.sil
@@ -85,16 +85,13 @@ bb3:
   return %23 : $Int32
 }
 
-// CHECK-LABEL: sil [ossa] @dont_rotate_multi_exit_loop :
-// CHECK:       bb1({{.*}}):
-// CHECK:         cond_br %{{.*}}, bb4, bb2
-// CHECK:       bb2:
-// CHECK:         cond_br undef, bb3, bb5
-// CHECK:       bb6:
-// CHECK:         return
-// CHECK-NOT:   bb7
-// CHECK:       } // end sil function 'dont_rotate_multi_exit_loop'
-sil [ossa] @dont_rotate_multi_exit_loop : $@convention(thin) (Int32, @owned Bar) -> Int32 {
+// CHECK-LABEL: sil [ossa] @rotate_multi_exit_loop :
+// CHECK:  [[METH1:%.*]] = class_method {{.*}} : $Bar, #Bar.foo : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> ()
+// CHECK:  apply [[METH1]]({{.*}}) : $@convention(method) (@guaranteed Bar) -> ()
+// CHECK:  [[METH2:%.*]] = class_method {{.*}} : $Bar, #Bar.foo : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> ()
+// CHECK:  apply [[METH2]]({{.*}}) : $@convention(method) (@guaranteed Bar) -> ()
+// CHECK:  } // end sil function 'rotate_multi_exit_loop'
+sil [ossa] @rotate_multi_exit_loop : $@convention(thin) (Int32, @owned Bar) -> Int32 {
 bb0(%0 : $Int32, %25: @owned $Bar):
   %1 = struct_extract %0 : $Int32, #Int32._value
   %2 = integer_literal $Builtin.Int32, 0

--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -130,7 +130,7 @@ public func span_bubble_sort(_ span: inout MutableSpan<Int>) {
 }
 
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests6sortedySb10SpanExtras07MutableG0VySiGF : 
-// CHECK-SIL: bb4:
+// CHECK-SIL: bb4({{.*}}):
 // CHECK-SIL: cond_fail {{.*}}, "precondition failure"
 // CHECK-SIL: cond_fail {{.*}}, "precondition failure"
 // CHECK-SIL: cond_br

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -244,7 +244,7 @@ public func span_element_sum(_ v: Span<Int>, _ i: Int) -> Int {
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF : 
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF'
 public func span_search<T : Equatable>(_ v: Span<T>, _ elem: T) -> Int? {
@@ -261,7 +261,7 @@ public func span_search<T : Equatable>(_ v: Span<T>, _ elem: T) -> Int? {
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A11_search_splySiSgs4SpanVySiG_SitF : 
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A11_search_splySiSgs4SpanVySiG_SitF'
 public func span_search_spl(_ v: Span<Int>, _ elem: Int) -> Int? {


### PR DESCRIPTION
This was recently disabled but turns out to be an important case for loops with early exits.

Also fix a LoopRotate bug in ossa where an instruction producing an ownership result was hoisted, but its destroys were duplicated causing ownership errors. 