### PR TITLE
IRGen: Annotate LLVM IR of condfail with the condfail's message

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -490,6 +490,8 @@ public:
 
   unsigned ConditionalRuntimeRecords : 1;
 
+  unsigned AnnotateCondFailMessage : 1;
+
   unsigned InternalizeAtLink : 1;
 
   /// Internalize symbols (static library) - do not export any public symbols.
@@ -634,6 +636,7 @@ public:
         DisableStandardSubstitutionsInReflectionMangling(false),
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
+        AnnotateCondFailMessage(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
         MergeableSymbols(false), EmitGenericRODatas(true),
         NoPreallocatedInstantiationCaches(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1175,6 +1175,12 @@ def enable_arm64_corocc : Flag<["-"], "enable-arm64-corocc">,
 def disable_arm64_corocc : Flag<["-"], "disable-arm64-corocc">,
   HelpText<"Don't use swiftcorocc for yield_once_2 routines on arm64 variants.">;
 
+def enable_cond_fail_message_annotation : Flag<["-"], "enable-cond-fail-message-annotation">,
+  HelpText<"Enable large loadable types register to memory pass">;
+
+def disable_cond_fail_message_annotation : Flag<["-"], "dissable-cond-fail-message-annotation">,
+  HelpText<"Disable large loadable types register to memory pass">;
+
 let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOptionIgnorable] in {
   def enable_pack_metadata_stack_promotion :
     Joined<["-"], "enable-pack-metadata-stack-promotion=">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3764,6 +3764,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.EnableLayoutStringValueWitnessesInstantiation = Args.hasFlag(OPT_enable_layout_string_value_witnesses_instantiation,
                                       OPT_disable_layout_string_value_witnesses_instantiation,
                                       Opts.EnableLayoutStringValueWitnessesInstantiation);
+  Opts.AnnotateCondFailMessage =
+      Args.hasFlag(OPT_enable_cond_fail_message_annotation,
+                   OPT_disable_cond_fail_message_annotation,
+                   Opts.AnnotateCondFailMessage);
+
 
   if (Opts.EnableLayoutStringValueWitnessesInstantiation &&
       !Opts.EnableLayoutStringValueWitnesses) {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -94,6 +94,11 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/DCE.h"
 
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/LLVMRemarkStreamer.h"
+#include "llvm/Support/ToolOutputFile.h"
+
 #include <thread>
 
 #if HAVE_UNISTD_H
@@ -598,6 +603,38 @@ static void countStatsPostIRGen(UnifiedStatsReporter &Stats,
   }
 }
 
+namespace {
+  class SwiftDiagnosticHandler final : public llvm::DiagnosticHandler {
+
+  public:
+    SwiftDiagnosticHandler(const IRGenOptions &Opts) : IRGenOpts(Opts) {}
+
+    bool handleDiagnostics(const llvm::DiagnosticInfo &DI) override {
+      return true;
+    }
+
+    bool isAnalysisRemarkEnabled(StringRef PassName) const override {
+      return IRGenOpts.AnnotateCondFailMessage &&
+        PassName == "annotation-remarks";
+    }
+    bool isMissedOptRemarkEnabled(StringRef PassName) const override {
+      return IRGenOpts.AnnotateCondFailMessage &&
+        PassName == "annotation-remarks";
+    }
+    bool isPassedOptRemarkEnabled(StringRef PassName) const override {
+      return IRGenOpts.AnnotateCondFailMessage &&
+        PassName == "annotation-remarks";
+    }
+
+    bool isAnyRemarkEnabled() const override {
+      return IRGenOpts.AnnotateCondFailMessage;
+    }
+
+  private:
+    const IRGenOptions &IRGenOpts;
+  };
+}
+
 /// Run the LLVM passes. In multi-threaded compilation this will be done for
 /// multiple LLVM modules in parallel.
 bool swift::performLLVM(const IRGenOptions &Opts,
@@ -666,6 +703,32 @@ bool swift::performLLVM(const IRGenOptions &Opts,
     assert(Opts.OutputKind == IRGenOutputKind::Module && "no output specified");
   }
 
+  std::string OptRemarksRecordFile;
+  if (Opts.AnnotateCondFailMessage && !OutputFilename.empty()) {
+    OptRemarksRecordFile = std::string(OutputFilename);
+    OptRemarksRecordFile.append(".opt.yaml");
+  }
+
+  auto &Ctxt = Module->getContext();
+  std::unique_ptr<llvm::DiagnosticHandler> OldDiagnosticHandler =
+          Ctxt.getDiagnosticHandler();
+  Ctxt.setDiagnosticHandler(std::make_unique<SwiftDiagnosticHandler>(Opts));
+
+  llvm::Expected<std::unique_ptr<llvm::ToolOutputFile>> OptRecordFileOrErr =
+    setupLLVMOptimizationRemarks(Ctxt, OptRemarksRecordFile.c_str(), "annotation-remarks", "yaml",
+                                 false/*RemarksWithHotness*/,
+                                 0/*RemarksHotnessThreshold*/);
+
+  if (Error E = OptRecordFileOrErr.takeError()) {
+    diagnoseSync(Diags, DiagMutex, SourceLoc(), diag::error_opening_output,
+                 StringRef(OptRemarksRecordFile.c_str()),
+                 toString(std::move(E)));
+    return true;
+  }
+
+  std::unique_ptr<llvm::ToolOutputFile> OptRecordFile =
+    std::move(*OptRecordFileOrErr);
+
   performLLVMOptimizations(Opts, Diags, DiagMutex, Module, TargetMachine,
                            OutputFile ? &OutputFile->getOS() : nullptr);
 
@@ -695,9 +758,15 @@ bool swift::performLLVM(const IRGenOptions &Opts,
     }
   }
 
-  return compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags,
+  auto res = compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags,
                              *OutputFile, DiagMutex,
                              CASIDFile ? CASIDFile.get() : nullptr);
+  if (OptRecordFile)
+    OptRecordFile->keep();
+
+  Ctxt.setDiagnosticHandler(std::move(OldDiagnosticHandler));
+
+  return res;
 }
 
 bool swift::compileAndWriteLLVM(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -8249,8 +8249,11 @@ void IRGenSILFunction::visitCondFailInst(swift::CondFailInst *i) {
 
   llvm::BasicBlock *failBB = llvm::BasicBlock::Create(IGM.getLLVMContext());
   llvm::BasicBlock *contBB = llvm::BasicBlock::Create(IGM.getLLVMContext());
-  Builder.CreateCondBr(expectedCond, failBB, contBB);
-    
+  auto br = Builder.CreateCondBr(expectedCond, failBB, contBB);
+
+  if (IGM.getOptions().AnnotateCondFailMessage && !i->getMessage().empty())
+    br->addAnnotationMetadata(i->getMessage());
+
   Builder.SetInsertPoint(&CurFn->back());
   Builder.emitBlock(failBB);
   if (IGM.DebugInfo)

--- a/test/IRGen/annotated_cond_fail.swift
+++ b/test/IRGen/annotated_cond_fail.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -module-name A -enable-cond-fail-message-annotation -primary-file %s -O -emit-ir | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: PTRSIZE=64
+
+public func test(_ a: [Int], _ i: Int) -> Int {
+    return a[i + 1]
+}
+
+// CHECK: define{{.*}} swiftcc i64 @"$s1A4testySiSaySiG_SitF"(ptr{{.*}} %0, i64 %1)
+
+// CHECK:  [[ADD:%.*]] = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %1, i64 1)
+// CHECK:  [[IDX:%.*]] = extractvalue { i64, i1 } [[ADD]], 0
+// CHECK:  [[OVERFLOW:%.*]] = extractvalue { i64, i1 } [[ADD]], 1
+// CHECK:  br i1 [[OVERFLOW]], {{.*}}!annotation ![[ARITH_OVERFLOW:[0-9]+]]
+
+// CHECK:  [[C0:%.*]] = icmp slt i64 [[IDX]], 0
+// CHECK:  br i1 [[C0]], {{.*}}!annotation ![[ARRAY_INDEX_OUT_OF_BOUNDS:[0-9]+]]
+
+// CHECK:  [[SIZE_ADDR:%.*]] = getelementptr
+// CHECK:  [[SIZE:%.*]] = load i64, ptr [[SIZE_ADDR]]
+// CHECK:  [[C1:%.*]] = icmp ult i64 [[IDX]], [[SIZE]]
+// CHECK:  br i1 [[C1]], {{.*}}!annotation ![[ARRAY_INDEX_OUT_OF_BOUNDS]]
+
+
+// CHECK-DAG: ![[ARITH_OVERFLOW]] = !{!"arithmetic overflow"}
+// CHECK-DAG: ![[ARRAY_INDEX_OUT_OF_BOUNDS]] = !{!"Index out of range"}


### PR DESCRIPTION
`-Xfrontend -enable-cond-fail-message-annotation`
LLVM IR produced by the Swift compiler will add the `annotation`
metadata attribute to the branch instruction generated for cond_fail
builtins.