### PR TITLE
[SUA][Runtime] Define `swift_coroFrameAlloc` function that allocates typed memory

### DIFF
--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -38,6 +38,11 @@ using MallocTypeId = unsigned long long;
 SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 void *swift_slowAllocTyped(size_t bytes, size_t alignMask, MallocTypeId typeId);
 
+// If SWIFT_STDLIB_HAS_MALLOC_TYPE is defined, allocate typed memory.
+// Otherwise, allocate plain memory.
+SWIFT_RUNTIME_EXPORT
+void *swift_coroFrameAlloc(size_t bytes, MallocTypeId typeId);
+
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2099,6 +2099,12 @@ FUNCTION(Free, c, free, C_CC, AlwaysAvailable,
          NO_ATTRS,
          EFFECT(Deallocating),
          UNKNOWN_MEMEFFECTS)
+FUNCTION(CoroFrameAlloc, c, swift_coroFrameAlloc, C_CC, AlwaysAvailable,
+         RETURNS(Int8PtrTy),
+         ARGS(SizeTy, Int64Ty),
+         NO_ATTRS,
+         EFFECT(Allocating),
+         UNKNOWN_MEMEFFECTS)
 
 // void *_Block_copy(void *block);
 FUNCTION(BlockCopy, BlocksRuntime, _Block_copy, C_CC, AlwaysAvailable,

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -120,6 +120,18 @@ void *swift::swift_slowAllocTyped(size_t size, size_t alignMask,
   return swift_slowAlloc(size, alignMask);
 }
 
+void *swift::swift_coroFrameAlloc(size_t size,
+                                  MallocTypeId typeId) {
+#if SWIFT_STDLIB_HAS_MALLOC_TYPE
+  if (__builtin_available(macOS 15, iOS 17, tvOS 17, watchOS 10, *)) {
+    void *p = malloc_type_malloc(size, typeId);
+    if (!p) swift::crash("Could not allocate memory.");
+    return p;
+  }
+#endif
+  return malloc(size);
+}
+
 // Unknown alignment is specified by passing alignMask == ~(size_t(0)), forcing
 // the AlignedFree deallocation path for unknown alignment. The memory
 // deallocated with unknown alignment must have been allocated with either

--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline
@@ -13553,6 +13553,7 @@ _swift_conformsToProtocolCommon
 _swift_copyAuxiliaryExecutablePath
 _swift_copyKeyPathTrivialIndices
 _swift_copyPOD
+_swift_coroFrameAlloc
 _swift_deallocBox
 _swift_deallocClassInstance
 _swift_deallocError

--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
@@ -13648,6 +13648,7 @@ _swift_conformsToProtocolCommon
 _swift_copyAuxiliaryExecutablePath
 _swift_copyKeyPathTrivialIndices
 _swift_copyPOD
+_swift_coroFrameAlloc
 _swift_deallocBox
 _swift_deallocClassInstance
 _swift_deallocError

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline
@@ -13461,6 +13461,7 @@ _swift_conformsToProtocolCommon
 _swift_copyAuxiliaryExecutablePath
 _swift_copyKeyPathTrivialIndices
 _swift_copyPOD
+_swift_coroFrameAlloc
 _swift_deallocBox
 _swift_deallocClassInstance
 _swift_deallocError

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
@@ -13556,6 +13556,7 @@ _swift_conformsToProtocolCommon
 _swift_copyAuxiliaryExecutablePath
 _swift_copyKeyPathTrivialIndices
 _swift_copyPOD
+_swift_coroFrameAlloc
 _swift_deallocBox
 _swift_deallocClassInstance
 _swift_deallocError


### PR DESCRIPTION
Define `swift_coroFrameAlloc` that allocates typed memory if SWIFT_STDLIB_HAS_MALLOC_TYPE is defined. This function will be used by IRGen to emit typed memory allocations for property accessors.

rdar://141235539
