### PR TITLE
IRGen: Replace retail_value_addr implementation by destroy_addr's

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5399,18 +5399,14 @@ void IRGenSILFunction::visitRetainValueInst(swift::RetainValueInst *i) {
 void IRGenSILFunction::visitRetainValueAddrInst(swift::RetainValueAddrInst *i) {
   SILValue operandValue = i->getOperand();
   assert(!operandValue->getType().isMoveOnly());
-  Address addr = getLoweredAddress(operandValue);
-  SILType addrTy = operandValue->getType();
-  SILType objectT = addrTy.getObjectType();
-  llvm::Type *llvmType = addr.getAddress()->getType();
-  const TypeInfo &addrTI = getTypeInfo(addrTy);
-  auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;
-  auto *outlinedF = cast<llvm::Function>(
-      IGM.getOrCreateRetainFunction(addrTI, objectT, llvmType, atomicity));
-  llvm::Value *args[] = {addr.getAddress()};
-  llvm::CallInst *call =
-      Builder.CreateCall(outlinedF->getFunctionType(), outlinedF, args);
-  call->setCallingConv(IGM.DefaultCC);
+
+  auto objTy = operandValue->getType().getObjectType();
+  const TypeInfo &type = getTypeInfo(objTy);
+  auto stackAddr = type.allocateStack(*this, objTy, "retain.value.addr.tmp");
+  Address src = getLoweredAddress(operandValue);
+  type.initializeWithCopy(*this, stackAddr.getAddress(), src,
+                          operandValue->getType(), false);
+  type.deallocateStack(*this, stackAddr, operandValue->getType());
 }
 
 void IRGenSILFunction::visitCopyValueInst(swift::CopyValueInst *i) {
@@ -5489,15 +5485,10 @@ void IRGenSILFunction::visitReleaseValueInst(swift::ReleaseValueInst *i) {
 void IRGenSILFunction::visitReleaseValueAddrInst(
     swift::ReleaseValueAddrInst *i) {
   SILValue operandValue = i->getOperand();
-  Address addr = getLoweredAddress(operandValue);
   SILType addrTy = operandValue->getType();
-  SILType objectT = addrTy.getObjectType();
-  if (tryEmitDestroyUsingDeinit(*this, addr, addrTy)) {
-    return;
-  }
   const TypeInfo &addrTI = getTypeInfo(addrTy);
-  auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;
-  addrTI.callOutlinedRelease(*this, addr, objectT, atomicity);
+  Address base = getLoweredAddress(operandValue);
+  addrTI.destroy(*this, base, addrTy, false /*isOutlined*/);
 }
 
 void IRGenSILFunction::visitDestroyValueInst(swift::DestroyValueInst *i) {

--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -21,7 +21,6 @@ public struct BigStruct {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(ptr noalias nocapture dereferenceable({{.*}}) #0 {
 // CHECK-NEXT: entry
-// CHECK-NEXT: call ptr @"$s15big_types_tests9BigStructVWOs"(ptr %0)
 // CHECK-NEXT: ret void
 sil @testDestroyValue : $@convention(thin) (@owned BigStruct) -> ()  {
 entry(%x : $BigStruct):

--- a/test/IRGen/moveonly_deinit.sil
+++ b/test/IRGen/moveonly_deinit.sil
@@ -209,7 +209,7 @@ entry(%b : $*MOEnum):
 
 // CHECK-LABEL: define{{.*}}@destroy_combo_struct_value(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:   call {{.*}} @[[COMBO_STRUCT_OUTLINED_DESTROY:"\$.*13MOComboStructVWOs"]](
+// CHECK-NEXT:   call {{.*}} @[[COMBO_STRUCT_OUTLINED_DESTROY:"\$.*13MOComboStructVWOh"]](
 // CHECK-NEXT:   ret void
 sil @destroy_combo_struct_value : $@convention(thin) (@owned MOComboStruct) -> () {
 entry(%b : $MOComboStruct):

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -177,7 +177,7 @@ public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
 // CHECK-SAME:      ptr{{.*}} %0,
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
-// CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOs"(
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOh"(
 // CHECK-SAME:        ptr %0,
 // CHECK-SAME:        ptr %T)
 // CHECK:       }
@@ -185,8 +185,8 @@ public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
 // Verify that the outlined release function takes the metadata for the
 // move-only-with-deinit type InnerDeinitingReleasableNC<T> and passes it along
 // to that deinit.
-// $s24moveonly_value_functions9OuterNC_1VyxGlWOs ---> outlined release of moveonly_value_functions.OuterNC_2<A>
-// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOs"(
+// $s24moveonly_value_functions9OuterNC_1VyxGlWOh ---> outlined destroy of moveonly_value_functions.OuterNC_2<A>
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOh"(
 // CHECK-SAME:      ptr %0,
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
@@ -298,24 +298,15 @@ public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<
 //           :      ptr noalias nocapture dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
-// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOs"(
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T)
 // CHECK:       }
-// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOs"(
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOh"(
 // CHECK-SAME:      ptr %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
-// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOe"(
-//            :       i64 %2, 
-//            :       i64 %4, 
-//            :       i64 %6, 
-//            :       i64 %8, 
-//            :       i64 %10, 
-//            :       i64 %12, 
-//            :       i64 %14, 
-//            :       i64 %16, 
-//            :       ptr %T)
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingReleasableNCVfD"(
 // CHECK:       }
 public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<T>) {}
 
@@ -400,23 +391,15 @@ public func takeOuterMultiPayloadNC_2<T>(_ e: consuming OuterMultiPayloadNC_2<T>
 //           :      ptr noalias nocapture dereferenceable(64) %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
-// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOs"(
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T)
 // CHECK:       }
-// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOs"(
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOh"(
 // CHECK-SAME:      ptr %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOe"(
-//           :        i64 %2, 
-//           :        i64 %4, 
-//           :        i64 %6, 
-//           :        i64 %8, 
-//           :        i64 %10, 
-//           :        i64 %12, 
-//           :        i64 %14, 
-//           :        i64 %16, 
 // CHECK-SAME:        ptr %T)
 // CHECK:       }
 public func takeOuterMultiPayloadNC_3<T>(_ e: consuming OuterMultiPayloadNC_3<T>) {}

--- a/test/IRGen/variadic_generic_outlining.sil
+++ b/test/IRGen/variadic_generic_outlining.sil
@@ -45,3 +45,31 @@ bb3:
   %ret = tuple ()
   return %ret : $()
 }
+
+sil hidden @test_outlining_retain_release_addr : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat Wrapper<each T>}) -> @pack_out Pack{repeat Wrapper<each T>} {
+bb0(%0 : $*Pack{repeat Wrapper<each T>}, %1 : $*Pack{repeat Wrapper<each T>}):
+  %zero = integer_literal $Builtin.Word, 0
+  %one = integer_literal $Builtin.Word, 1
+  %len = pack_length $Pack{repeat each T}
+  br bb1(%zero : $Builtin.Word)
+
+bb1(%idx : $Builtin.Word):
+  %done = builtin "cmp_eq_Word"(%idx : $Builtin.Word, %len : $Builtin.Word) : $Builtin.Int1 // user: %10
+  cond_br %done, bb3, bb2
+
+bb2:
+  %pi = dynamic_pack_index %idx of $Pack{repeat Wrapper<each T>}
+  %opening = open_pack_element %pi of <each T> at <Pack{repeat each T}>, shape $T, uuid "31FF306C-BF88-11ED-A03F-ACDE48001123"
+  %in = pack_element_get %pi of %0 : $*Pack{repeat Wrapper<each T>} as $*Wrapper<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001123") T>
+  %out = pack_element_get %pi of %1 : $*Pack{repeat Wrapper<each T>} as $*Wrapper<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001123") T>
+  // Make sure that these don't crash.
+  retain_value_addr %in : $*Wrapper<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001123") T>
+  release_value_addr %in : $*Wrapper<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001123") T>
+  copy_addr %in to [init] %out : $*Wrapper<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001123") T>
+  %next = builtin "add_Word"(%idx : $Builtin.Word, %one : $Builtin.Word) : $Builtin.Word
+  br bb1(%next : $Builtin.Word)
+
+bb3:
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
We can't always use an outlined function, destroy_addr's implementation already handles cases where this is true (such as opened archetypes).

rdar://143456806