### PR TITLE
[NFC] OSSACanonicalizeOwned: Simplify Def definition.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -340,7 +340,6 @@ private:
       llvm_unreachable("covered switch");
     }
   };
-  friend llvm::DenseMapInfo<Def>;
 
   /// The defs derived from currentDef whose uses are added to liveness.
   SmallVector<Def, 8> discoveredDefs;

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -97,7 +97,6 @@
 #define SWIFT_SILOPTIMIZER_UTILS_CANONICALOSSALIFETIME_H
 
 #include "swift/Basic/SmallPtrSetVector.h"
-#include "swift/Basic/TaggedUnion.h"
 #include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
@@ -279,66 +278,24 @@ private:
   /// outside the pruned liveness at the time it is discovered.
   llvm::SmallPtrSet<DebugValueInst *, 8> debugValues;
 
-  class Def {
-    struct Root {
-      SILValue value;
-    };
-    struct Copy {
-      CopyValueInst *cvi;
-    };
-    struct BorrowedFrom {
-      BorrowedFromInst *bfi;
-    };
-    struct Reborrow {
-      SILArgument *argument;
-    };
-    using Payload = TaggedUnion<Root, Copy, BorrowedFrom, Reborrow>;
-    Payload payload;
-    Def(Payload payload) : payload(payload) {}
-
-  public:
-    enum class Kind {
+  struct Def {
+    enum Kind {
       Root,
       Copy,
       BorrowedFrom,
       Reborrow,
     };
-    Kind getKind() const {
-      if (payload.isa<Root>()) {
-        return Kind::Root;
-      }
-      if (payload.isa<Copy>()) {
-        return Kind::Copy;
-      }
-      if (payload.isa<BorrowedFrom>()) {
-        return Kind::BorrowedFrom;
-      }
-      assert(payload.isa<Reborrow>());
-      return Kind::Reborrow;
-    }
-    operator Kind() const { return getKind(); }
-    bool operator==(Def rhs) const {
-      return getKind() == rhs.getKind() && getValue() == rhs.getValue();
-    }
-    static Def root(SILValue value) { return {Root{value}}; }
-    static Def copy(CopyValueInst *cvi) { return {Copy{cvi}}; }
+    const Kind kind;
+    const SILValue value;
+    static Def root(SILValue value) { return {Root, value}; }
+    static Def copy(CopyValueInst *cvi) { return {Copy, cvi}; }
     static Def borrowedFrom(BorrowedFromInst *bfi) {
-      return {BorrowedFrom{bfi}};
+      return {BorrowedFrom, bfi};
     }
-    static Def reborrow(SILArgument *argument) { return {Reborrow{argument}}; }
-    SILValue getValue() const {
-      switch (*this) {
-      case Kind::Root:
-        return payload.get<Root>().value;
-      case Kind::Copy:
-        return payload.get<Copy>().cvi;
-      case Kind::BorrowedFrom:
-        return payload.get<BorrowedFrom>().bfi;
-      case Kind::Reborrow:
-        return payload.get<Reborrow>().argument;
-      }
-      llvm_unreachable("covered switch");
-    }
+    static Def reborrow(SILArgument *argument) { return {Reborrow, argument}; }
+
+  private:
+    Def(Kind kind, SILValue value) : kind(kind), value(value) {}
   };
 
   /// The defs derived from currentDef whose uses are added to liveness.

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -135,7 +135,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
   SmallVector<unsigned, 8> indexWorklist;
   ValueSet visitedDefs(getCurrentDef()->getFunction());
   auto addDefToWorklist = [&](Def def) {
-    if (!visitedDefs.insert(def.getValue()))
+    if (!visitedDefs.insert(def.value))
       return;
     discoveredDefs.push_back(def);
     indexWorklist.push_back(discoveredDefs.size() - 1);
@@ -154,25 +154,25 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
   while (!indexWorklist.empty()) {
     auto index = indexWorklist.pop_back_val();
     auto def = discoveredDefs[index];
-    auto value = def.getValue();
+    auto value = def.value;
     LLVM_DEBUG(llvm::dbgs() << "  Uses of value:\n";
                value->print(llvm::dbgs()));
 
     for (Operand *use : value->getUses()) {
       LLVM_DEBUG(llvm::dbgs() << "    Use:\n";
                  use->getUser()->print(llvm::dbgs()));
-      
+
       auto *user = use->getUser();
       // Recurse through copies.
       if (auto *copy = dyn_cast<CopyValueInst>(user)) {
         // Don't recurse through copies of borrowed-froms or reborrows.
-        switch (def) {
-        case Def::Kind::Root:
-        case Def::Kind::Copy:
+        switch (def.kind) {
+        case Def::Root:
+        case Def::Copy:
           addDefToWorklist(Def::copy(copy));
           break;
-        case Def::Kind::Reborrow:
-        case Def::Kind::BorrowedFrom:
+        case Def::Reborrow:
+        case Def::BorrowedFrom:
           break;
         }
         continue;
@@ -1251,15 +1251,15 @@ void CanonicalizeOSSALifetime::rewriteCopies(
 
   // Perform a def-use traversal, visiting each use operand.
   for (auto def : discoveredDefs) {
-    switch (def) {
-    case Def::Kind::BorrowedFrom:
-    case Def::Kind::Reborrow:
+    switch (def.kind) {
+    case Def::BorrowedFrom:
+    case Def::Reborrow:
       // Direct uses of these defs never need to be rewritten.  Being guaranteed
       // values, none of their direct uses consume an owned value.
-      assert(def.getValue()->getOwnershipKind() == OwnershipKind::Guaranteed);
+      assert(def.value->getOwnershipKind() == OwnershipKind::Guaranteed);
       break;
-    case Def::Kind::Root: {
-      SILValue value = def.getValue();
+    case Def::Root: {
+      SILValue value = def.value;
       for (auto useIter = value->use_begin(), endIter = value->use_end();
            useIter != endIter;) {
         Operand *use = *useIter++;
@@ -1269,8 +1269,8 @@ void CanonicalizeOSSALifetime::rewriteCopies(
       }
       break;
     }
-    case Def::Kind::Copy: {
-      SILValue value = def.getValue();
+    case Def::Copy: {
+      SILValue value = def.value;
       CopyValueInst *srcCopy = cast<CopyValueInst>(value);
       // Recurse through copies while replacing their uses.
       Operand *reusedCopyOp = nullptr;


### PR DESCRIPTION
It's sufficient just to have a struct with a kind and a value.  There aren't any cases where the payload's original type benefits from being statically preserved--they're only ever obtained as `SILValue`s.  Keep the type safety by way of constructors.
