### PR TITLE
Fix indexing crasher with implicit objcImpl inits

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -858,6 +858,8 @@ public:
     return LastDeclAndKind.getInt();
   }
 
+  SourceRange getBraces() const;
+
   bool hasUnparsedMembers() const;
 
   void setDeserializedMembers(bool deserialized) { DeserializedMembers = deserialized; }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -919,6 +919,18 @@ ASTContext &IterableDeclContext::getASTContext() const {
   return getDecl()->getASTContext();
 }
 
+SourceRange IterableDeclContext::getBraces() const {
+  switch (getIterableContextKind()) {
+  case IterableDeclContextKind::NominalTypeDecl:
+    return cast<NominalTypeDecl>(this)->getBraces();
+    break;
+
+  case IterableDeclContextKind::ExtensionDecl:
+    return cast<ExtensionDecl>(this)->getBraces();
+    break;
+  }
+}
+
 DeclRange IterableDeclContext::getCurrentMembersWithoutLoading() const {
   return DeclRange(FirstDeclAndLazyMembers.getPointer(), nullptr);
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -818,16 +818,16 @@ createDesignatedInitOverride(ClassDecl *classDecl,
 
   // Create the initializer declaration, inheriting the name,
   // failability, and throws from the superclass initializer.
-  auto implCtx = classDecl->getImplementationContext()->getAsGenericContext();
+  auto implCtx = classDecl->getImplementationContext();
   auto ctor = new (ctx) ConstructorDecl(
-      superclassCtor->getName(), classDecl->getBraces().Start,
+      superclassCtor->getName(), implCtx->getBraces().Start,
       superclassCtor->isFailable(),
       /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/superclassCtor->hasAsync(),
       /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/superclassCtor->hasThrows(),
       /*ThrowsLoc=*/SourceLoc(), TypeLoc::withoutLoc(thrownType), bodyParams,
-      genericParams, implCtx,
+      genericParams, implCtx->getAsGenericContext(),
       /*LifetimeDependentTypeRepr*/ nullptr);
 
   ctor->setImplicit();

--- a/test/Index/index_objc_impl.swift
+++ b/test/Index/index_objc_impl.swift
@@ -4,11 +4,14 @@
 // RUN: %empty-directory(%t/mods)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -o %t/mods %t/ObjcImpl.swift -import-objc-header %t/objc_impl.h -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
+// We use `-index-store-path` to exercise a code path that used to crash; we
+// aren't checking its output.
+// RUN: %target-swift-frontend -emit-module -o %t/mods %t/ObjcImpl.swift -import-objc-header %t/objc_impl.h -target %target-stable-abi-triple -disable-objc-attr-requires-foundation-module -index-store-path %t/index-store
 // RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print ObjcImpl -source-filename none -I %t/mods -target %target-stable-abi-triple | %FileCheck %s
 
 //--- objc_impl.h
 @interface NSObject
+- (instancetype)init;
 @end
 
 @interface ObjCClass : NSObject
@@ -20,5 +23,8 @@
 // CHECK: class/Swift | ObjCClass | c:objc(cs)ObjCClass | Ref
 @_objcImplementation public extension ObjCClass {
   // CHECK: instance-property/Swift | someObjCDeclaredVar | c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
-  @objc var someObjCDeclaredVar: CInt
+  @objc var someObjCDeclaredVar: CInt = 1
+
+  // Implicitly synthesized `override init()`:
+  // CHECK: constructor/Swift | init() | c:@CM@ObjcImpl@@objc(cs)ObjCClass(im)init | Def
 }


### PR DESCRIPTION
Implicit initializers are given a source location within the type they belong to. This works poorly for `@objc @implementation` classes, because the class they belong to is imported and so those SourceLocs are in a different source buffer from the extension they’re inside, breaking an invariant enforced by index-while-building features.

Fix these SourceLocs to come from the implementation context, so they’ll come from the extension for an objcImpl class and the type itself otherwise.