### PR TITLE
Fix typo in code comment for clarity

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -190,7 +190,7 @@ ManagedValue
 SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
                                                  ManagedValue optional,
                                                  bool isImplicitUnwrap) {
-  // Generate code to the optional is present, and if not, abort with a message
+  // Generate code to check if the optional is present, and if not, abort with a message
   // (provided by the stdlib).
   SILBasicBlock *contBB = createBasicBlock();
   SILBasicBlock *failBB = createBasicBlock();

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -39,7 +39,7 @@ class SolverStep;
 class ComponentStep;
 
 /// Represents available states which every
-/// given step could be in during it's lifetime.
+/// given step could be in during its lifetime.
 enum class StepState { Setup, Ready, Running, Suspended, Done };
 
 /// Represents result of the step execution,


### PR DESCRIPTION
### Description of Changes

This pull request fixes typos in code comments. The changes are minor and do not affect the functionality of the code. The modified files are `lib/SILGen/SILGenConvert.cpp` and `lib/Sema/CSStep.h`.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured that my changes do not introduce any new warnings or errors
- [x] I have verified that the code compiles and runs correctly
- [x] I have reviewed the comments and documentation for accuracy

### Breaking Changes

N/A

### Related Issues

N/A

### Additional Notes

N/A