### PR TITLE
[CS] Avoid penalizing holes for placeholder vars for completion

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2879,6 +2879,40 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
   return std::nullopt;
 }
 
+static bool shouldIgnoreHoleForCodeCompletion(ConstraintSystem &cs,
+                                              TypeVariableType *typeVar,
+                                              ConstraintLocator *srcLocator) {
+  if (!cs.isForCodeCompletion())
+    return false;
+  
+  // Don't penalize solutions with unresolved generics.
+  if (typeVar->getImpl().getGenericParameter())
+    return true;
+
+  // Don't penalize solutions if we couldn't determine the type of the code
+  // completion token. We still want to examine the surrounding types in
+  // that case.
+  if (typeVar->getImpl().isCodeCompletionToken())
+    return true;
+
+  // Don't penalize solutions with holes due to missing arguments after the
+  // code completion position.
+  auto argLoc = srcLocator->findLast<LocatorPathElt::SynthesizedArgument>();
+  if (argLoc && argLoc->isAfterCodeCompletionLoc())
+    return true;
+
+  // Don't penalize solutions that have holes for ignored arguments.
+  if (cs.hasArgumentsIgnoredForCodeCompletion()) {
+    // Avoid simplifying the locator if the constraint system didn't ignore
+    // any arguments.
+    auto argExpr = simplifyLocatorToAnchor(typeVar->getImpl().getLocator());
+    if (cs.isArgumentIgnoredForCodeCompletion(argExpr.dyn_cast<Expr *>())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   auto type = Binding.BindingType;
   auto *srcLocator = Binding.getLocator();
@@ -2934,33 +2968,9 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   }
 
   auto reportHole = [&]() {
-    if (cs.isForCodeCompletion()) {
-      // Don't penalize solutions with unresolved generics.
-      if (TypeVar->getImpl().getGenericParameter())
-        return false;
-
-      // Don't penalize solutions if we couldn't determine the type of the code
-      // completion token. We still want to examine the surrounding types in
-      // that case.
-      if (TypeVar->getImpl().isCodeCompletionToken())
-        return false;
-
-      // Don't penalize solutions with holes due to missing arguments after the
-      // code completion position.
-      auto argLoc = srcLocator->findLast<LocatorPathElt::SynthesizedArgument>();
-      if (argLoc && argLoc->isAfterCodeCompletionLoc())
-        return false;
-
-      // Don't penalize solutions that have holes for ignored arguments.
-      if (cs.hasArgumentsIgnoredForCodeCompletion()) {
-        // Avoid simplifying the locator if the constraint system didn't ignore
-        // any arguments.
-        auto argExpr = simplifyLocatorToAnchor(TypeVar->getImpl().getLocator());
-        if (cs.isArgumentIgnoredForCodeCompletion(argExpr.dyn_cast<Expr *>())) {
-          return false;
-        }
-      }
-    }
+    if (shouldIgnoreHoleForCodeCompletion(cs, TypeVar, srcLocator))
+      return false;
+    
     // Reflect in the score that this type variable couldn't be
     // resolved and had to be bound to a placeholder "hole" type.
     cs.increaseScore(SK_Hole, srcLocator);

--- a/test/IDE/issue-79213.swift
+++ b/test/IDE/issue-79213.swift
@@ -1,0 +1,38 @@
+// RUN: %batch-code-completion
+
+protocol View {}
+
+struct EmptyView: View {}
+struct Either<T: View, U: View>: View {}
+struct Tuple<T>: View {}
+extension Optional: View where Wrapped: View {}
+
+@resultBuilder
+struct ViewBuilder {
+  static func buildBlock() -> EmptyView { .init() }
+  static func buildBlock<T: View>(_ x: T) -> T { x }
+  @_disfavoredOverload static func buildBlock<each T: View>(
+    _ x: repeat each T
+  ) -> Tuple<(repeat each T)> { .init() }
+  static func buildEither<T, U>(first component: T) -> Either<T, U> { .init() }
+  static func buildEither<T, U>(second component: U) -> Either<T, U> { .init() }
+  static func buildIf<T: View>(_ x: T?) -> T? { x }
+}
+
+struct R {
+  var bar: Bool
+}
+
+func baz<R>(@ViewBuilder _ fn: () -> R) {}
+
+// https://github.com/swiftlang/swift/issues/79213 - Make sure we get a result here.
+func foo(_ x: R, _ b: Bool) {
+  baz {
+    if b {
+      EmptyView()
+    } else if b {
+      if x.#^COMPLETE^# {}
+      // COMPLETE: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: bar[#Bool#]; name=bar
+    }
+  }
+}


### PR DESCRIPTION
When doing completion in a result builder, we avoid solving unrelated expressions by replacing them with unbound placeholder variables. Avoid penalizing assigning holes to these placeholders, since otherwise we can end up unnecessarily exploring the entire solution space, and bailing due to too complex.

Resolves #79213
rdar://144382123