### PR TITLE
[ASTDumper] Write inherited types correctly.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1859,6 +1859,10 @@ public:
     assert(!IsSuppressed && "setting suppressed again!?");
     IsSuppressed = true;
   }
+
+  void dump(raw_ostream &os) const;
+
+  SWIFT_DEBUG_DUMP;
 };
 
 /// A wrapper for the collection of inherited types for either a `TypeDecl` or

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -624,6 +624,16 @@ static StringRef getDumpString(ExecutionKind kind) {
     return "caller";
   }
 }
+static StringRef getDumpString(ExplicitSafety safety) {
+  switch (safety) {
+  case ExplicitSafety::Unspecified:
+    return "unspecified";
+  case ExplicitSafety::Safe:
+    return "safe";
+  case ExplicitSafety::Unsafe:
+    return "unsafe";
+  }
+}
 static StringRef getDumpString(StringRef s) {
   return s;
 }
@@ -1924,16 +1934,38 @@ namespace {
     }
 
     void printInherited(InheritedTypes Inherited) {
-      printStringListField(Inherited.getEntries(), [&](InheritedEntry Super) {
-        if (Writer.isParsable()) {
-          return typeUSR(Super.getType());
-        } else {
-          std::string value;
-          llvm::raw_string_ostream SOS(value);
-          Super.getType().print(SOS);
-          return value;
-        }
-      }, Label::always("inherits"), /*delimiter=*/ ", ");
+      if (Writer.isParsable()) {
+        printList(
+            Inherited.getEntries(),
+            [&](InheritedEntry Super, Label label) {
+              printRecArbitrary(
+                  [&](Label label) {
+                    printHead("inherited_entry", FieldLabelColor, label);
+                    printTypeField(Super.getType(), Label::always("type"));
+                    printFlag(Super.isPreconcurrency(), "preconcurrency");
+                    printFlag(Super.isRetroactive(), "retroactive");
+                    printFlag(Super.isSuppressed(), "suppressed");
+                    printFlag(Super.isUnchecked(), "unchecked");
+                    if (Super.getExplicitSafety() !=
+                        ExplicitSafety::Unspecified)
+                      printField(Super.getExplicitSafety(),
+                                 Label::always("safety"));
+                    printFoot();
+                  },
+                  label);
+            },
+            Label::always("inherits"));
+      } else {
+        printStringListField(
+            Inherited.getEntries(),
+            [&](InheritedEntry Super) {
+              std::string value;
+              llvm::raw_string_ostream SOS(value);
+              Super.dump(SOS);
+              return value;
+            },
+            Label::always("inherits"), /*delimiter=*/", ");
+      }
     }
 
     void printImportPath(ImportDecl *ID, Label label) {
@@ -6504,3 +6536,19 @@ void SILResultInfo::dump() const {
   print(llvm::errs());
   llvm::errs() << '\n';
 }
+
+void InheritedEntry::dump(llvm::raw_ostream &os) const {
+  if (isPreconcurrency())
+    os << "@preconcurrency ";
+  if (isRetroactive())
+    os << "@retroactive ";
+  if (isUnchecked())
+    os << "@unchecked ";
+  if (getExplicitSafety() != ExplicitSafety::Unspecified)
+    os << '@' << getDumpString(getExplicitSafety()) << ' ';
+  if (isSuppressed())
+    os << "~";
+  getType().print(os);
+}
+
+void InheritedEntry::dump() const { dump(llvm::errs()); }


### PR DESCRIPTION
ASTDumper was never updated to print extra conformance information, like suppression, preconcurrency, etc. In default mode, we print it as a comma-delimited list of source-like strings. In JSON mode, we print objects containing flags.
