### PR TITLE
[cxx-interop] Modularize __msvc_string_view on Windows

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -563,12 +563,18 @@ void GetWindowsFileMappings(
     // __msvc_bit_utils.hpp was added in a recent VS 2022 version. It has to be
     // referenced from the modulemap directly to avoid modularization errors.
     // Older VS versions might not have it. Let's inject an empty header file if
-    // it isn't available.
-    llvm::sys::path::remove_filename(VCToolsInjection);
-    llvm::sys::path::append(VCToolsInjection, "__msvc_bit_utils.hpp");
-    if (!llvm::sys::fs::exists(VCToolsInjection))
-      fileMapping.overridenFiles.emplace_back(std::string(VCToolsInjection),
-                                              "");
+    // it isn't available. Same applies to a few more headers.
+    ArrayRef<StringRef> headersToInjectIfAbsent = {
+        "__msvc_bit_utils.hpp",
+        "__msvc_string_view.hpp",
+    };
+    for (auto headerToInject : headersToInjectIfAbsent) {
+      llvm::sys::path::remove_filename(VCToolsInjection);
+      llvm::sys::path::append(VCToolsInjection, headerToInject);
+      if (!llvm::sys::fs::exists(VCToolsInjection))
+        fileMapping.overridenFiles.emplace_back(std::string(VCToolsInjection),
+                                                "");
+    }
   }
 }
 } // namespace

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -707,6 +707,11 @@ module std [system] {
       export *
     }
 
+    explicit module __msvc_string_view {
+      header "__msvc_string_view.hpp"
+      export *
+    }
+
     explicit module xatomic {
       header "xatomic.h"
       export *

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -5,9 +5,6 @@
 
 // REQUIRES: executable_test
 
-// TODO: test failed in Windows PR testing: rdar://144384453
-// UNSUPPORTED: OS=windows-msvc
-
 import StdlibUnittest
 import CxxStdlib
 import StdStringView


### PR DESCRIPTION
`__msvc_string_view.hpp` header was added in a recent MSVC version. It should be referenced directly from the STL modulemap to make sure it doesn't get hijacked by an unexpected Clang module that happened to be processed first by Clang.

This fixes a test failure that started triggering in CI after MSVC version upgrade:
```
C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\test\Interop\Cxx\stdlib/Inputs\std-string-view.h:3:13: error: missing '#include <__msvc_string_view.hpp>'; 'string_view' must be declared before it is used
```

This is similar to 16e7cbea.

rdar://144385377

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
