### PR TITLE
Basic: query the target pointer width from clang

### DIFF
--- a/include/swift/Basic/TargetInfo.h
+++ b/include/swift/Basic/TargetInfo.h
@@ -33,7 +33,8 @@ namespace targetinfo {
 void printTargetInfo(const CompilerInvocation &invocation,
                      llvm::raw_ostream &out);
 
-void printTripleInfo(const llvm::Triple &triple,
+void printTripleInfo(const CompilerInvocation &invocation,
+                     const llvm::Triple &triple,
                      std::optional<llvm::VersionTuple> runtimeVersion,
                      llvm::raw_ostream &out);
 } // namespace targetinfo

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -97,6 +97,7 @@ _swift_gyb_target_sources(swiftBasic PRIVATE
     UnicodeExtendedGraphemeClusters.cpp.gyb)
 
 target_include_directories(swiftBasic PRIVATE
+  clangBasic
   ${UUID_INCLUDE})
 
 target_link_libraries(swiftBasic PUBLIC

--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -16,6 +16,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "swift/Frontend/Frontend.h"
 
+#include "clang/Basic/TargetInfo.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -52,9 +53,11 @@ static void printCompatibilityLibrary(
   printedAny = true;
 }
 
+namespace swift {
+namespace targetinfo {
 /// Print information about the selected target in JSON.
-void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
-                                 llvm::raw_ostream &out) {
+void printTargetInfo(const CompilerInvocation &invocation,
+                     llvm::raw_ostream &out) {
   out << "{\n";
 
   // Compiler version, as produced by --version.
@@ -67,12 +70,12 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
     invocation.getIRGenOptions().AutolinkRuntimeCompatibilityLibraryVersion;
   auto &langOpts = invocation.getLangOptions();
   out << "  \"target\": ";
-  printTripleInfo(langOpts.Target, runtimeVersion, out);
+  printTripleInfo(invocation, langOpts.Target, runtimeVersion, out);
   out << ",\n";
 
   if (auto &variant = langOpts.TargetVariant) {
     out << "  \"targetVariant\": ";
-    printTripleInfo(*variant, runtimeVersion, out);
+    printTripleInfo(invocation, *variant, runtimeVersion, out);
     out << ",\n";
   }
 
@@ -112,9 +115,10 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
 }
 
 // Print information about the target triple in JSON.
-void targetinfo::printTripleInfo(
-    const llvm::Triple &triple,
-    std::optional<llvm::VersionTuple> runtimeVersion, llvm::raw_ostream &out) {
+void printTripleInfo(const CompilerInvocation &invocation,
+                     const llvm::Triple &triple,
+                     std::optional<llvm::VersionTuple> runtimeVersion,
+                     llvm::raw_ostream &out) {
   out << "{\n";
 
   out << "    \"triple\": \"";
@@ -130,7 +134,21 @@ void targetinfo::printTripleInfo(
   out << "\",\n";
 
   out << "    \"platform\": \"" << getPlatformNameForTriple(triple) << "\",\n";
-  out << "    \"arch\": \"" << swift::getMajorArchitectureName(triple) << "\",\n";
+  out << "    \"arch\": \"" << swift::getMajorArchitectureName(triple)
+      << "\",\n";
+
+  clang::DiagnosticsEngine DE{new clang::DiagnosticIDs(),
+                              new clang::DiagnosticOptions(),
+                              new clang::IgnoringDiagConsumer()};
+  std::shared_ptr<clang::TargetOptions> TO =
+      std::make_shared<clang::TargetOptions>();
+  TO->Triple = triple.str();
+  clang::TargetInfo *TI = clang::TargetInfo::CreateTargetInfo(DE, TO);
+  out << "    \"pointerWidthInBits\": "
+      << TI->getPointerWidth(clang::LangAS::Default) << ",\n";
+  out << "    \"pointerWidthInBytes\": "
+      << TI->getPointerWidth(clang::LangAS::Default) / TI->getCharWidth()
+      << ",\n";
 
   if (runtimeVersion) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";
@@ -140,15 +158,14 @@ void targetinfo::printTripleInfo(
     // Compatibility libraries that need to be linked.
     out << "    \"compatibilityLibraries\": [";
     bool printedAnyCompatibilityLibrary = false;
-    #define BACK_DEPLOYMENT_LIB(Version, Filter, LibraryName, ForceLoad)   \
-      printCompatibilityLibrary(                                           \
-        *runtimeVersion, llvm::VersionTuple Version, #Filter, LibraryName, \
-        ForceLoad, printedAnyCompatibilityLibrary, out);
-    #include "swift/Frontend/BackDeploymentLibs.def"
+#define BACK_DEPLOYMENT_LIB(Version, Filter, LibraryName, ForceLoad)           \
+  printCompatibilityLibrary(*runtimeVersion, llvm::VersionTuple Version,       \
+                            #Filter, LibraryName, ForceLoad,                   \
+                            printedAnyCompatibilityLibrary, out);
+#include "swift/Frontend/BackDeploymentLibs.def"
 
-    if (printedAnyCompatibilityLibrary) {
+    if (printedAnyCompatibilityLibrary)
       out << "\n   ";
-    }
     out << " ],\n";
   } else {
     out << "    \"compatibilityLibraries\": [ ],\n";
@@ -160,3 +177,5 @@ void targetinfo::printTripleInfo(
 
   out << "  }";
 }
+} // namespace targetinfo
+} // namespace swift

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -16,6 +16,9 @@
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
+// RUN: %swift_frontend_plain -target thumbv7-unknown-windows-msvc -print-target-info | %FileCheck -check-prefix CHECK-PTR-SIZE-32 %s
+// RUN: %swift_frontend_plain -target aarch64-unknown-windows-msvc -print-target-info | %FileCheck -check-prefix CHECK-PTR-SIZE-64 %s
+
 // CHECK-IOS:   "compilerVersion": "{{.*}}Swift version
 
 // CHECK-IOS:   "target": {
@@ -107,3 +110,15 @@
 // CHECK-IOS-SIM:     "swiftRuntimeCompatibilityVersion": "5.0",
 // CHECK-IOS-SIM:     "librariesRequireRPath": true
 // CHECK-IOS-SIM:   }
+
+// CHECK-PTR-SIZE-32: "target": {
+// CHECK-PTR-SIZE-32:   "triple": "thumbv7-unknown-windows-msvc",
+// CHECK-PTR-SIZE-32:   "pointerWidthInBits": 32,
+// CHECK-PTR-SIZE-32:   "pointerWidthInBytes": 4,
+// CHECK-PTR-SIZE-32: }
+
+// CHECK-PTR-SIZE-64: "target": {
+// CHECK-PTR-SIZE-64:   "triple": "aarch64-unknown-windows-msvc",
+// CHECK-PTR-SIZE-64:   "pointerWidthInBits": 64,
+// CHECK-PTR-SIZE-64:   "pointerWidthInBytes": 8,
+// CHECK-PTR-SIZE-64: }


### PR DESCRIPTION
Use the `clang::TargetInfo` to query the target pointer size for the given triple. This is meant to enable us to properly determine `CMAKE_SIZEOF_VOID_P`.