### PR TITLE
[cxx-interop] Workaround deserialization crash with `std::string` initializer

### DIFF
--- a/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
@@ -2,6 +2,10 @@
 #include <functional>
 #include <string>
 
+inline std::string __swift_interopMakeString(const char* begin, size_t count) {
+  return std::string(begin, count);
+}
+
 /// Used for std::string conformance to Swift.Hashable
 typedef std::hash<std::string> __swift_interopHashOfString;
 inline std::size_t __swift_interopComputeHashOfString(const std::string &str) {

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -22,14 +22,7 @@ extension std.string {
   @_alwaysEmitIntoClient
   public init(_ string: String) {
     self = string.withCString(encodedAs: UTF8.self) { buffer in
-#if os(Windows)
-      // Use the 2 parameter constructor.
-      // The MSVC standard library has a enable_if template guard
-      // on the 3 parameter constructor, and thus it's not imported into Swift.
-      std.string(buffer, string.utf8.count)
-#else
-      std.string(buffer, string.utf8.count, .init())
-#endif
+      __swift_interopMakeString(buffer, string.utf8.count)
     }
   }
 


### PR DESCRIPTION
rdar://144404267

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
