### PR TITLE
Be sure to clear `@isolated(any)` from the constant function type

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2030,7 +2030,8 @@ static void
 lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
                               CanGenericSignature genericSig,
                               TypeExpansionContext expansion,
-                              SmallVectorImpl<SILParameterInfo> &inputs) {
+                              SmallVectorImpl<SILParameterInfo> &inputs,
+                              SILExtInfoBuilder &extInfo) {
 
   // If the function is a closure being converted to an @isolated(any) type,
   // add the implicit isolation parameter.
@@ -2039,6 +2040,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto isolationTy = SILType::getOpaqueIsolationType(TC.Context);
       inputs.push_back({isolationTy.getASTType(),
                         ParameterConvention::Direct_Guaranteed});
+      extInfo = extInfo.withErasedIsolation(false);
     }
   }
 
@@ -2573,7 +2575,7 @@ static CanSILFunctionType getSILFunctionType(
     // don't need to keep its capture types opaque.
     lowerCaptureContextParameters(TC, *constant, genericSig,
                                   TC.getCaptureTypeExpansionContext(*constant),
-                                  inputs);
+                                  inputs, extInfoBuilder);
   }
   
   auto calleeConvention = ParameterConvention::Direct_Unowned;

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -247,6 +247,7 @@ actor MyActor {
 func asyncAction() async {}
 
 func takeAsyncIsolatedAny(fn: @escaping @isolated(any) @Sendable () async -> ()) {}
+func takeAsyncIsolatedAnyAutoclosure(_: @autoclosure @isolated(any) () async -> Void) async {}
 func takeInheritingAsyncIsolatedAny(@_inheritActorContext fn: @escaping @isolated(any) @Sendable () async -> ()) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test0A28EraseAsyncNonIsolatedClosureyyF
@@ -324,6 +325,17 @@ func testEraseInheritingAsyncMainActorClosure() {
   takeInheritingAsyncIsolatedAny {
     await asyncAction()
   }
+}
+
+// rdar://142636640
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A30EraseAsyncMainActorAutoclosureyyYaF
+// CHECK:         [[CLOSURE_FN:%.*]] = function_ref @$s4test0A30EraseAsyncMainActorAutoclosureyyYaFyyYaYAXEfu_ : $@convention(thin) @async (@guaranteed Optional<any Actor>) -> ()
+// CHECK-NEXT:    metatype $@thick MainActor.Type
+// CHECK-NEXT:    // function_ref static MainActor.shared.getter
+//   ...followed by the standard "get the main actor instance" stuff
+@MainActor
+func testEraseAsyncMainActorAutoclosure() async {
+  await takeAsyncIsolatedAnyAutoclosure(await asyncAction())
 }
 
 // Define a global actor that doesn't use Self as its instance type


### PR DESCRIPTION
I'm not completely sure why this code pattern triggers this --- or really, why other code patterns don't --- but it's easy to fix.

Fixes rdar://142636640