### PR TITLE
git: ignore in files in the Runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ Runtimes/**/*.yaml
 Runtimes/**/*.inc
 Runtimes/**/*.json
 Runtimes/**/*.modulemap
+Runtimes/**/*.in


### PR DESCRIPTION
We include some template files in the runtime build and we should not commit those as we currently are using `Resync.cmake` to synchronise the directory.