### PR TITLE
SILOptimizer: address C5030

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2979,7 +2979,7 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
             LLVM_DEBUG(llvm::dbgs() << "    Also a def block; skipping!\n");
             continue;
           }
-          [[clang::fallthrough]];
+          LLVM_FALLTHROUGH;
         }
         case IsLive::LiveWithin:
           if (isLive == IsLive::LiveWithin)


### PR DESCRIPTION
```
swift\lib\SILOptimizer\Mandatory\MoveOnlyAddressCheckerUtils.cpp(2981): warning C5030: attribute [[clang::fallthrough]] is not recognized
```

Replace the use of `clang::fallthrough` with `LLVM_FALLTHROUGH` which
properly uses the C++ standard spelling (`[[fallthrough]]`) depending on
the compiler version.