### PR TITLE
[Sema]Coerce to rvalue when withoutActuallyEscaping receives an lvalue argument

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8217,7 +8217,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         // Resolve into a MakeTemporarilyEscapableExpr.
         auto *args = apply->getArgs();
         assert(args->size() == 2 && "should have two arguments");
-        auto *nonescaping = args->getExpr(0);
+        auto *nonescaping = cs.coerceToRValue(args->getExpr(0));
         auto *body = args->getExpr(1);
         auto bodyTy = cs.getType(body)->getWithoutSpecifierType();
         auto bodyFnTy = bodyTy->castTo<FunctionType>();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8217,7 +8217,18 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         // Resolve into a MakeTemporarilyEscapableExpr.
         auto *args = apply->getArgs();
         assert(args->size() == 2 && "should have two arguments");
-        auto *nonescaping = cs.coerceToRValue(args->getExpr(0));
+
+        auto appliedWrappers =
+            solution.getAppliedPropertyWrappers(calleeLocator.getAnchor());
+        auto fnType = cs.getType(fn)->getAs<FunctionType>();
+        args = coerceCallArguments(
+            args, fnType, declRef, apply,
+            locator.withPathElement(ConstraintLocator::ApplyArgument),
+            appliedWrappers);
+        if (!args)
+          return nullptr;
+
+        auto *nonescaping = args->getExpr(0);
         auto *body = args->getExpr(1);
         auto bodyTy = cs.getType(body)->getWithoutSpecifierType();
         auto bodyFnTy = bodyTy->castTo<FunctionType>();

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2214,7 +2214,7 @@ isInvalidPartialApplication(ConstraintSystem &cs,
 /// the full opened type and the reference's type.
 static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     ConstraintSystem &CS, ConstraintLocator *locator,
-    DeclTypeCheckingSemantics semantics) {
+    DeclTypeCheckingSemantics semantics, DeclContext *useDC) {
   switch (semantics) {
   case DeclTypeCheckingSemantics::Normal:
     llvm_unreachable("Decl does not have special type checking semantics!");
@@ -2261,10 +2261,11 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         CS.getConstraintLocator(locator, ConstraintLocator::ThrownErrorType),
         0);
     FunctionType::Param arg(escapeClosure);
+    bool isAsync = CS.isAsynchronousContext(useDC);
     auto bodyClosure = FunctionType::get(arg, result,
                                          FunctionType::ExtInfoBuilder()
                                              .withNoEscape(true)
-                                             .withAsync(true)
+                                             .withAsync(isAsync)
                                              .withThrows(true, thrownError)
                                              .build());
     FunctionType::Param args[] = {
@@ -2275,7 +2276,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto refType = FunctionType::get(args, result,
                                      FunctionType::ExtInfoBuilder()
                                          .withNoEscape(false)
-                                         .withAsync(true)
+                                         .withAsync(isAsync)
                                          .withThrows(true, thrownError)
                                          .build());
     return {refType, refType, refType, refType, Type()};
@@ -2370,7 +2371,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     DeclReferenceType declRefType;
     if (semantics != DeclTypeCheckingSemantics::Normal) {
       declRefType = getTypeOfReferenceWithSpecialTypeCheckingSemantics(
-          *this, locator, semantics);
+          *this, locator, semantics, useDC);
     } else if (auto baseTy = choice.getBaseType()) {
       // Retrieve the type of a reference to the specific declaration choice.
       assert(!baseTy->hasTypeParameter());

--- a/test/Constraints/without_actually_escaping.swift
+++ b/test/Constraints/without_actually_escaping.swift
@@ -61,7 +61,7 @@ func rethrowThroughWAE(_ zz: (Int, Int, Int) throws -> Int, _ value: Int) throws
 }
 
 let _: ((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> () = withoutActuallyEscaping(_:do:)
-// expected-error@-1 {{invalid conversion from 'async' function of type '((Int) -> Int, (@escaping (Int) -> Int) async -> ()) async -> ()' to synchronous function type '((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> ()'}}
+// expected-error@-1 {{cannot convert value of type '((Swift.Int) -> Swift.Int, (@escaping (Swift.Int) -> Swift.Int) -> ()) -> ()' to specified type '((Swift.Int) -> Swift.Int, (@escaping (Swift.Int) -> Swift.Int) -> ()) -> ()'}}
 
 
 // Failing to propagate @noescape into non-single-expression

--- a/test/Sema/without_actually_escaping.swift
+++ b/test/Sema/without_actually_escaping.swift
@@ -1,0 +1,66 @@
+// RUN: %target-typecheck-verify-swift
+
+func noEscapeWAE(f: () -> Void) {
+  withoutActuallyEscaping(f) { $0() }  
+}
+
+func escapingWAE(f: @escaping () -> Void) {
+  withoutActuallyEscaping(f) { $0() }  
+}
+
+func inoutWAE(f: inout () -> Void) {
+  withoutActuallyEscaping(f) { $0() }  
+}
+
+func rethrowThroughInoutWAE(f: inout () throws -> Void) throws {
+  try withoutActuallyEscaping(f) { try $0() }  
+}
+
+func consumingWAE(f: consuming @escaping () -> Void) {
+  withoutActuallyEscaping(f) { $0() }  
+}
+
+func rethrowThroughConsumingWAE(f: consuming @escaping () throws -> Void) throws {
+  try withoutActuallyEscaping(f) { try $0() }  
+}
+
+func sendingEscapingAsyncWAE(f: sending @escaping () async -> Void) async {
+  await withoutActuallyEscaping(f) { await $0() }  
+}
+
+func rethrowThroughSendingEscapingAsyncWAE(f: sending @escaping () async throws -> Void) async throws {
+  try await withoutActuallyEscaping(f) { try await $0() }  
+}
+
+func sendingNoEscapeAsyncWAE(f: sending () async -> Void) async {
+  await withoutActuallyEscaping(f) { await $0() }  
+}
+
+func rethrowThroughSendingNoEscapeAsyncWAE(f: sending () async throws -> Void) async throws {
+  try await withoutActuallyEscaping(f) { try await $0() }  
+}
+
+func passNoEscapeClosureViaVarWAE(f: () -> Void) {
+  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  withoutActuallyEscaping(x) { $0() }
+}
+
+func passEscapingClosureViaVarWAE(f: @escaping () -> Void) {
+  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  withoutActuallyEscaping(x) { $0() }
+}
+
+func passInoutClosureViaVarWAE(f: inout () -> Void) {
+  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  withoutActuallyEscaping(x) { $0() }
+}
+
+func passConsumingClosureViaVarWAE(f: consuming @escaping () -> Void) {
+  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  withoutActuallyEscaping(x) { $0() }
+}
+
+func passSendingClosureViaVarWAE(f: consuming @escaping () -> Void) {
+  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  withoutActuallyEscaping(x) { $0() }
+}

--- a/test/Sema/without_actually_escaping.swift
+++ b/test/Sema/without_actually_escaping.swift
@@ -41,26 +41,31 @@ func rethrowThroughSendingNoEscapeAsyncWAE(f: sending () async throws -> Void) a
 }
 
 func passNoEscapeClosureViaVarWAE(f: () -> Void) {
-  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  var x = f
   withoutActuallyEscaping(x) { $0() }
+  x = {}
 }
 
 func passEscapingClosureViaVarWAE(f: @escaping () -> Void) {
-  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  var x = f
   withoutActuallyEscaping(x) { $0() }
+  x = {}
 }
 
 func passInoutClosureViaVarWAE(f: inout () -> Void) {
-  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  var x = f
   withoutActuallyEscaping(x) { $0() }
+  x = {}
 }
 
 func passConsumingClosureViaVarWAE(f: consuming @escaping () -> Void) {
-  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  var x = f
   withoutActuallyEscaping(x) { $0() }
+  x = {}
 }
 
 func passSendingClosureViaVarWAE(f: consuming @escaping () -> Void) {
-  var x = f // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+  var x = f
   withoutActuallyEscaping(x) { $0() }
+  x = {}
 }


### PR DESCRIPTION
Resolves #79078 

When `withoutActuallyEscaping` receives an lvalue argument, the compiler crashed since `FunctionType` is expected as the type of `NonescapingClosureValue`, but  in the case of lvalue, it has the type `LValueType`. Then, `closureFnTy` is null and aborted.

```c++
 auto closureFnTy =
          E->getNonescapingClosureValue()->getType()->getAs<FunctionType>();
```
https://github.com/swiftlang/swift/blob/main/lib/AST/ASTVerifier.cpp#L2353


It could be an lvalue when the argument is `inout`, `consuming`, `sending`.


If I understand correctly, the `body` parameter of `withoutActuallyEscaping` expects an rvalue. I also referred to the below comment.

```
// Proceed with a "WithoutActuallyEscaping" operation. The body closure
// receives a copy of the argument closure that is temporarily made
// @escaping.
```
https://github.com/swiftlang/swift/blob/main/lib/Sema/TypeOfReference.cpp#L2245

Given this, it seems we need to coerce the lvalue to an rvalue.

--

Regarding [this](https://github.com/swiftlang/swift/pull/79238#discussion_r1947546038), we always set `withAsync(true)` in the case of `withoutActuallyEscaping` (https://github.com/swiftlang/swift/blob/main/lib/Sema/TypeOfReference.cpp#L2278). As a result, the async version gets selected by the ConstraintSystem even when it's not async.

```
---Solution---
Fixed score: [sync-in-asynchronous(s), weight: 17, impact: 1]
Type variables:
  $T0 as Void @ locator@0x127053000 [DiscardAssignment@79078.swift:4:5]
  $T1 as (@escaping () async -> Void, (@escaping () async -> Void) async -> Void) async -> Void @ locator@0x127053068 [DeclRef@79078.swift:4:15]
  $T2 as () async -> Void @ locator@0x1270530b0 [DeclRef@79078.swift:4:15 → function argument]
  $T3 as () async -> Void @ locator@0x1270530b0 [DeclRef@79078.swift:4:15 → function argument]

Overload choices:
  locator@0x127053068 [DeclRef@79078.swift:4:15] with Swift.(file).withoutActuallyEscaping(_:do:) as withoutActuallyEscaping: ($T2, ($T3) async throws($T5) -> $T4) async throws($T5) -> $T4
```
https://github.com/swiftlang/swift/blob/main/lib/Sema/CSSimplify.cpp#L1919

However, I believe this approach is incorrect when the declaration is not in an async context. Therefore, it is necessary to check whether the context is asynchronous or not.