### PR TITLE
Fix mutable_span_bounds_check_tests.swift on iOS: REQUIRES: OS=macosx

### DIFF
--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -8,6 +8,9 @@
 // REQUIRES: swift_feature_Span
 // REQUIRES: swift_feature_AllowUnsafeAttribute
 
+// In Inputs/SpanExtras.swift we have @available(macOS 9999, *):
+// REQUIRES: OS=macosx
+
 import SpanExtras
 
 // Bounds check should be eliminated


### PR DESCRIPTION
This test fails on iOS and blocks PR testing:
```
swift-PR-macos/branch-main/swift/test/SILOptimizer/Inputs/SpanExtras.swift:172:11: error: 'Span' is only available in iOS 9999 or newer
 170 | 
 171 | @available(macOS 9999, *)
 172 | extension Span where Element: ~Copyable {
     | |         `- error: 'Span' is only available in iOS 9999 or newer
     | `- note: add @available attribute to enclosing extension
```