### PR TITLE
@safe functions, properties, and subscripts "cover" certain unsafe arguments

### DIFF
--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -171,8 +171,7 @@ func testMyArray(ints: MyArray<Int>) {
     let bufferCopy = unsafe buffer
     _ = unsafe bufferCopy
 
-    // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-    print(buffer.safeCount) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+    print(buffer.safeCount)
     unsafe print(buffer.baseAddress!)
   }
 }

--- a/test/Unsafe/safe_argument_suppression.swift
+++ b/test/Unsafe/safe_argument_suppression.swift
@@ -1,0 +1,53 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -print-diagnostic-groups
+
+// REQUIRES: swift_feature_AllowUnsafeAttribute
+// REQUIRES: swift_feature_WarnUnsafe
+
+@unsafe
+class NotSafe {
+  @safe var okay: Int { 0 }
+
+  @safe var safeSelf: NotSafe { unsafe self }
+
+  @safe func memberFunc(_: NotSafe) { }
+
+  @safe subscript(ns: NotSafe) -> Int { 5 }
+
+  @safe static func doStatically(_: NotSafe.Type) { }
+  
+  @safe static subscript(ns: NotSafe) -> Int { 5 }
+
+  @safe init(_: NotSafe) { }
+
+  func stillUnsafe() { }
+}
+
+@unsafe
+class NotSafeSubclass: NotSafe {
+}
+
+@safe func okayFunc(_ ns: NotSafe) { }
+
+@safe func testImpliedSafety(ns: NotSafe) {
+  _ = ns.okay
+  _ = ns.safeSelf.okay
+  ns.memberFunc(ns)
+  okayFunc(ns)
+  _ = ns[ns]
+
+  _ = NotSafe(ns)
+  _ = NotSafe[ns]
+  NotSafe.doStatically(NotSafe.self)
+
+  ns.stillUnsafe() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe' [Unsafe]}}
+  // expected-note@-1{{reference to parameter 'ns' involves unsafe type 'NotSafe'}}
+  // expected-note@-2{{reference to unsafe instance method 'stillUnsafe()'}}
+}
+
+@safe func testImpliedSafetySubclass(ns: NotSafeSubclass) {
+  _ = ns.okay
+  _ = ns.safeSelf.okay
+  ns.memberFunc(ns)
+  okayFunc(ns)
+  _ = ns[ns]
+}


### PR DESCRIPTION
When calling an explicitly-@safe function or subscript, or accessing an explicitly-@safe property, the direct arguments to that operation can be considered safe if they are references to local variables or are references to types.

This brings the implementation in line with the recent adjustments to the proposal within the review.
