### PR TITLE
[embedded] Add an experimental -Xfrontend -mergeable-symbols to allow linking multiple .o modules in Embedded Swift

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -460,6 +460,8 @@ public:
   /// Internalize symbols (static library) - do not export any public symbols.
   unsigned InternalizeSymbols : 1;
 
+  unsigned MergeableSymbols : 1;
+
   /// Emit a section with references to class_ro_t* in generic class patterns.
   unsigned EmitGenericRODatas : 1;
 
@@ -589,6 +591,7 @@ public:
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
+        MergeableSymbols(false),
         EmitGenericRODatas(true), NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -56,10 +56,15 @@ public:
   /// be promoted to public external. Used by the LLDB expression evaluator.
   bool ForcePublicDecls;
 
+  /// When true, allows duplicate external and hidden declarations by marking
+  /// them as linkonce / weak.
+  bool MergeableSymbols;
+
   explicit UniversalLinkageInfo(IRGenModule &IGM);
 
   UniversalLinkageInfo(const llvm::Triple &triple, bool hasMultipleIGMs,
-                       bool forcePublicDecls, bool isStaticLibrary);
+                       bool forcePublicDecls, bool isStaticLibrary,
+                       bool mergeableSymbols);
 
   /// In case of multiple llvm modules (in multi-threaded compilation) all
   /// private decls must be visible from other files.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -763,6 +763,10 @@ def conditional_runtime_records : Flag<["-"], "conditional-runtime-records">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Allow removal of runtime metadata records (public types, protocol conformances) based on whether they're used or unused">;
 
+def mergeable_symbols : Flag<["-"], "mergeable-symbols">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Emit symbol definitions as mergeable (linkonce_odr)">;
+
 def disable_preallocated_instantiation_caches : Flag<["-"], "disable-preallocated-instantiation-caches">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Avoid preallocating metadata instantiation caches in globals">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3551,6 +3551,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.InternalizeSymbols = FrontendOpts.Static;
 
+  if (Args.hasArg(OPT_mergeable_symbols)) {
+    Opts.MergeableSymbols = true;
+  }
+
   if (Args.hasArg(OPT_disable_preallocated_instantiation_caches)) {
     Opts.NoPreallocatedInstantiationCaches = true;
   }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -82,16 +82,19 @@ bool swift::irgen::useDllStorage(const llvm::Triple &triple) {
 UniversalLinkageInfo::UniversalLinkageInfo(IRGenModule &IGM)
     : UniversalLinkageInfo(IGM.Triple, IGM.IRGen.hasMultipleIGMs(),
                            IGM.IRGen.Opts.ForcePublicLinkage,
-                           IGM.IRGen.Opts.InternalizeSymbols) {}
+                           IGM.IRGen.Opts.InternalizeSymbols,
+                           IGM.IRGen.Opts.MergeableSymbols) {}
 
 UniversalLinkageInfo::UniversalLinkageInfo(const llvm::Triple &triple,
                                            bool hasMultipleIGMs,
                                            bool forcePublicDecls,
-                                           bool isStaticLibrary)
+                                           bool isStaticLibrary,
+                                           bool mergeableSymbols)
     : IsELFObject(triple.isOSBinFormatELF()),
       IsMSVCEnvironment(triple.isWindowsMSVCEnvironment()),
       UseDLLStorage(useDllStorage(triple)), Internalize(isStaticLibrary),
-      HasMultipleIGMs(hasMultipleIGMs), ForcePublicDecls(forcePublicDecls) {}
+      HasMultipleIGMs(hasMultipleIGMs), ForcePublicDecls(forcePublicDecls),
+      MergeableSymbols(mergeableSymbols) {}
 
 LinkEntity LinkEntity::forSILGlobalVariable(SILGlobalVariable *G,
                                             IRGenModule &IGM) {

--- a/lib/IRGen/TBDGenVisitor.h
+++ b/lib/IRGen/TBDGenVisitor.h
@@ -126,7 +126,7 @@ public:
                 APIRecorder &recorder)
       : DataLayoutDescription(dataLayoutString),
         UniversalLinkInfo(target, opts.HasMultipleIGMs, /*forcePublic*/ false,
-                          /*static=*/false),
+                          /*static=*/false, /*mergeableSymbols*/false),
         SwiftModule(swiftModule), Opts(opts), recorder(recorder),
         previousInstallNameMap(parsePreviousModuleInstallNameMap()) {}
 

--- a/test/embedded/linkage-linkonce-odr.swift
+++ b/test/embedded/linkage-linkonce-odr.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -mergeable-symbols -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -mergeable-symbols -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
+// RUN: %target-clang %t/a.o %t/MyModule.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+public func module_func() {
+  print("module_func")
+}
+
+public func module_generic_func<T: CustomStringConvertible>(t: T) {
+  print("module_generic_func: \(t)")
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+func test() {
+  module_func()
+  module_generic_func(t: 42)
+}
+
+test()
+
+// CHECK: module_func
+// CHECK: module_generic_func: 42


### PR DESCRIPTION
Note: This isn't a "solution" yet, just adding an experimental flag for further evaluation and experiments.

**Problem:** In Embedded Swift, we link other modules' content at the SIL level, i.e. we bring in (deserialize) definitions of functions from other modules when used, including from the standard library. We have to do that to support monomorphization (including vtable specialization and wtable de-virtualization). This changes the linkage model of Embedded Swift significantly -- concretely, we expect that only the "leaf" client module actually produces a .o file with code, and that this .o file is not linked with any other Swift code. This imposes some surprising behavior and restrictions on users, for example the "duplicate symbol" issue reported here: https://forums.swift.org/t/embedded-wasm-and-swiftpm-dependencies-duplicate-symbol-issue/72180.

There is a couple high-level options how to improve the situation:
1. Switch to, or offer as an option, a traditional linkage model, where each library produces a .o/.a file, the user is responsible for linking the right separately compiled libraries. This has the tradeoff that libraries distributed with the toolchain (concretely, the stdlib) would need to be prebuilt for concrete ABIs and would no longer allow customizing codegen options via -Xcc flags on the client side.
2. Make symbol definitions "linkonce_odr", to allow linking multiple separately compiled modules together, even if they end up deserializing and compiling the same functions from a library (e.g. `swift_retain` from the stdlib). This would make the linker essentially just pick one of the definitions at random, assuming they are equivalent.
3. Internalize the dependent symbols via some mechanism like adding an extra name to the mangling, or by deserializing under a different name (per client module), or similar.

I think that all these options are worth exploring further. This PR implements option (2) under a flag, but it's not meant as a solution, but rather as a step allowing further explorations and experimentation.

CC @eeckstein 