### PR TITLE
test: Add regression test for rdar://91922018

### DIFF
--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -552,3 +552,16 @@ do {
     }
   }
 }
+
+// rdar://91922018
+do {
+  func f<E>(_ c: some Collection<E>) -> some Collection<E> {
+    return c
+  }
+  let c: any Collection<Int>
+  let result = f(c)
+  do {
+    var types = SwiftTypePair(typeOf: result, type2: SwiftType<any Collection<Int>>.self)
+    types.assertTypesAreEqual()
+  }
+}


### PR DESCRIPTION
We used to not open the existential call argument in this case in 6.0. Probably fixed by #76206.