### PR TITLE
[6.1] test: Add regression test for rdar://91922018

### DIFF
--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -423,3 +423,19 @@ func nestedMetatypeCaller() {
   let t = String.Type.Type.Type.self as (any Q.Type.Type.Type.Type)
   nestedMetatypeCallee(t)
 }
+
+// rdar://91922018
+do {
+  func f<E>(_ c: some Collection<E>) -> some Collection<E> {
+    return c
+  }
+  let c: any Collection<Int>
+  let result = f(c)
+  do {
+    struct G<T> {
+      init(_: T) {}
+    }
+    let t = G(result)
+    let _: G<any Collection<Int>> = t
+  }
+}


### PR DESCRIPTION
  - **Explanation**: We used to not open the existential call argument in this case in 6.0. Probably fixed by #76206.
  - **Scope**: Test suite
  - **Issues**: rdar://91922018
  - **Original PRs**: #79246
  - **Risk**: None
  - **Testing**: Smoke test
  - **Reviewers**: Myself
