### PR TITLE
AST: Platform-specific fixes for `-unavailable-decl-optimization`

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -234,6 +234,11 @@ public:
     return !(*this == other);
   }
 
+  friend bool operator<(const AvailabilityDomain &lhs,
+                        const AvailabilityDomain &rhs) {
+    return lhs.storage.getOpaqueValue() < rhs.storage.getOpaqueValue();
+  }
+
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddPointer(getOpaqueValue());
   }

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -154,10 +154,15 @@ public:
     return AvailabilityDomain(domain);
   }
 
-  /// Returns the most specific platform domain that applies to the compilation
-  /// context.
+  /// Returns the most specific platform domain for the target of the
+  /// compilation context.
   static std::optional<AvailabilityDomain>
   forTargetPlatform(const ASTContext &ctx);
+
+  /// Returns the most specific platform domain for the target variant of the
+  /// compilation context.
+  static std::optional<AvailabilityDomain>
+  forTargetVariantPlatform(const ASTContext &ctx);
 
   /// Returns the built-in availability domain identified by the given string.
   static std::optional<AvailabilityDomain>

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1432,8 +1432,8 @@ public:
   /// Returns the active platform-specific `@available` attribute for this decl.
   /// There may be multiple `@available` attributes that are relevant to the
   /// current platform, but the returned one has the highest priority.
-  std::optional<SemanticAvailableAttr> getActiveAvailableAttrForCurrentPlatform(
-      bool ignoreAppExtensions = false) const;
+  std::optional<SemanticAvailableAttr>
+  getActiveAvailableAttrForCurrentPlatform() const;
 
   /// Returns the active platform-specific `@available` attribute that should be
   /// used to determine the platform introduction version of the decl.
@@ -1479,8 +1479,7 @@ public:
   /// If the decl is always unavailable in the current compilation
   /// context, returns the attribute attached to the decl (or its parent
   /// extension) that makes it unavailable.
-  std::optional<SemanticAvailableAttr>
-  getUnavailableAttr(bool ignoreAppExtensions = false) const;
+  std::optional<SemanticAvailableAttr> getUnavailableAttr() const;
 
   /// Returns true if the decl is effectively always unavailable in the current
   /// compilation context. This query differs from \c isUnavailable() because it

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -83,6 +83,9 @@ bool isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
 /// Returns the target platform for the given language options.
 PlatformKind targetPlatform(const LangOptions &LangOpts);
 
+/// Returns the target variant platform for the given language options.
+PlatformKind targetVariantPlatform(const LangOptions &LangOpts);
+
 /// Returns true when availability attributes from the "parent" platform
 /// should also apply to the "child" platform for declarations without
 /// an explicit attribute for the child.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -642,6 +642,9 @@ availabilityDomainsForABICompatibility(const ASTContext &ctx) {
 
   if (auto targetDomain = AvailabilityDomain::forTargetPlatform(ctx))
     domains.push_back(targetDomain->getABICompatibilityDomain());
+  
+  if (auto variantDomain = AvailabilityDomain::forTargetVariantPlatform(ctx))
+    domains.push_back(variantDomain->getABICompatibilityDomain());
 
   return domains;
 }
@@ -706,13 +709,6 @@ static bool isUnavailableForAllABICompatiblePlatforms(const Decl *decl) {
   
   // Verify that there aren't any explicitly available descendant domains.
   if (availableDescendantDomains.size() > 0)
-    return false;
-
-  // FIXME: [availability] Support zippered frameworks (rdar://125371621)
-  // If we have a target variant (e.g. we're building a zippered macOS
-  // framework) then the decl is only unreachable if it is unavailable for both
-  // the primary target and the target variant.
-  if (decl->getASTContext().LangOpts.TargetVariant.has_value())
     return false;
 
   return true;

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -19,6 +19,15 @@
 using namespace swift;
 
 std::optional<AvailabilityDomain>
+AvailabilityDomain::forTargetPlatform(const ASTContext &ctx) {
+  auto platform = swift::targetPlatform(ctx.LangOpts);
+  if (platform == PlatformKind::none)
+    return std::nullopt;
+
+  return forPlatform(platform);
+}
+
+std::optional<AvailabilityDomain>
 AvailabilityDomain::builtinDomainForString(StringRef string,
                                            const DeclContext *declContext) {
   // This parameter is used in downstream forks, do not remove.
@@ -134,6 +143,20 @@ bool AvailabilityDomain::contains(const AvailabilityDomain &other) const {
   case Kind::Custom:
     return getCustomDomain() == other.getCustomDomain();
   }
+}
+
+AvailabilityDomain AvailabilityDomain::getABICompatibilityDomain() const {
+  if (!isPlatform())
+    return *this;
+
+  auto iOSDomain = AvailabilityDomain::forPlatform(PlatformKind::iOS);
+  if (iOSDomain.contains(*this))
+    return iOSDomain;
+
+  if (auto basePlatform = basePlatformForExtensionPlatform(getPlatformKind()))
+    return AvailabilityDomain::forPlatform(*basePlatform);
+
+  return *this;
 }
 
 CustomAvailabilityDomain::CustomAvailabilityDomain(Identifier name,

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -28,6 +28,15 @@ AvailabilityDomain::forTargetPlatform(const ASTContext &ctx) {
 }
 
 std::optional<AvailabilityDomain>
+AvailabilityDomain::forTargetVariantPlatform(const ASTContext &ctx) {
+  auto platform = swift::targetVariantPlatform(ctx.LangOpts);
+  if (platform == PlatformKind::none)
+    return std::nullopt;
+
+  return forPlatform(platform);
+}
+
+std::optional<AvailabilityDomain>
 AvailabilityDomain::builtinDomainForString(StringRef string,
                                            const DeclContext *declContext) {
   // This parameter is used in downstream forks, do not remove.

--- a/test/Concurrency/isolation_macro_availability.swift
+++ b/test/Concurrency/isolation_macro_availability.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: swift_swift_parser
-// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
 
 // rdar://126118470
 // UNSUPPORTED: CPU=arm64e

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -44,6 +44,13 @@ public func unavailableOnMacOSExtensionFunc() {}
 @available(macOSApplicationExtension, unavailable) // FIXME: Seems like this should be diagnosed as redundant
 public func unavailableOnMacOSAndMacOSExtensionFunc() {}
 
+// CHECK-LABEL:     sil{{.*}}@$s4Test33availableOnMacOSExtensionOnlyFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test33availableOnMacOSExtensionOnlyFuncyyF'
+@available(macOS, unavailable)
+@available(macOSApplicationExtension, introduced: 10.9)
+public func availableOnMacOSExtensionOnlyFunc() {}
+
 // CHECK-LABEL:     sil{{.*}}@$s4Test20unavailableOniOSFuncyyF
 // CHECK-NOT:         _diagnoseUnavailableCodeReached
 // CHECK:           } // end sil function '$s4Test20unavailableOniOSFuncyyF'

--- a/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
@@ -21,16 +21,15 @@ public func unavailableOnMacOSFunc() {}
 @available(iOS, unavailable)
 public func unavailableOniOSFunc() {}
 
-// FIXME: This function should diagnose (rdar://125930716)
 // CHECK-LABEL:     sil{{.*}}@$s4Test28unavailableOnMacCatalystFuncyyF
 // CHECK-NOT:         _diagnoseUnavailableCodeReached
 // CHECK:           } // end sil function '$s4Test28unavailableOnMacCatalystFuncyyF'
 @available(macCatalyst, unavailable)
 public func unavailableOnMacCatalystFunc() {}
 
-// FIXME: This function should diagnose (rdar://125930716)
 // CHECK-LABEL:     sil{{.*}}@$s4Test28unavailableOnMacOSAndiOSFuncyyF
-// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:           } // end sil function '$s4Test28unavailableOnMacOSAndiOSFuncyyF'
 @available(macOS, unavailable)
 @available(iOS, unavailable)
@@ -43,7 +42,7 @@ public struct UnavailableOniOS {
   // CHECK:           } // end sil function '$s4Test16UnavailableOniOSV15availableMethodyyF'
   public func availableMethod() {}
 
-  // FIXME: This function should diagnose (rdar://125930716)
+  // FIXME: [availability] This method should diagnose
   // CHECK-LABEL:     sil{{.*}}@$s4Test16UnavailableOniOSV24unavailableOnMacOSMethodyyF
   // CHECK-NOT:         _diagnoseUnavailableCodeReached
   // CHECK:           } // end sil function '$s4Test16UnavailableOniOSV24unavailableOnMacOSMethodyyF'

--- a/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -target arm64-apple-xros1.0 | %FileCheck %s --check-prefixes=CHECK
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=none -target arm64-apple-xros1.0 | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target arm64-apple-xros1.0 | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target arm64-apple-xros1.0 -application-extension | %FileCheck %s --check-prefixes=CHECK
 
 // REQUIRES: OS=xros
 
@@ -14,7 +14,8 @@ public func visionOSUnavailable() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test14iOSUnavailableAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:       } // end sil function '$s4Test14iOSUnavailableAA1SVyF'
 @available(iOS, unavailable)
 public func iOSUnavailable() -> S {
@@ -39,12 +40,32 @@ public func iOSUnavailableVisionOSAvailable() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test25iOSAndVisionOSUnavailableAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:       } // end sil function '$s4Test25iOSAndVisionOSUnavailableAA1SVyF'
 @available(iOS, unavailable)
 @available(visionOS, unavailable)
 public func iOSAndVisionOSUnavailable() -> S {
-  // FIXME: This function should be optimized (rdar://116742214)
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test20iOSAppExtensionsOnlyAA1SVyF
+// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK:       } // end sil function '$s4Test20iOSAppExtensionsOnlyAA1SVyF'
+@available(iOS, unavailable)
+@available(visionOS, unavailable)
+@available(iOSApplicationExtension, introduced: 1.0)
+public func iOSAppExtensionsOnly() -> S {
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test25visionOSAppExtensionsOnlyAA1SVyF
+// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK:       } // end sil function '$s4Test25visionOSAppExtensionsOnlyAA1SVyF'
+@available(iOS, unavailable)
+@available(visionOS, unavailable)
+@available(visionOSApplicationExtension, introduced: 1.0)
+public func visionOSAppExtensionsOnly() -> S {
   return S()
 }
 
@@ -58,11 +79,11 @@ public struct UnavailableOnVisionOS {
   }
 
   // CHECK-LABEL: sil{{.*}}@$s4Test21UnavailableOnVisionOSV022iOSUnavailableInheritsdF0AA1SVyF
-  // CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+  // CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+  // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
   // CHECK:       } // end sil function '$s4Test21UnavailableOnVisionOSV022iOSUnavailableInheritsdF0AA1SVyF'
   @available(iOS, unavailable)
   public func iOSUnavailableInheritsVisionOSUnavailable() -> S {
-    // FIXME: This function should be optimized (rdar://116742214)
     return S()
   }
 }

--- a/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
@@ -47,12 +47,10 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      index_a = 2
   // CHECK-NEXT:    case .unavailableMacCatalyst:
   // CHECK-NEXT:      index_a = 3
-  // FIXME: This case should diagnose (rdar://125930716)
   // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:      index_a = 4
-  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
   // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
-  // CHECK-NEXT:      index_a = 5
+  // CHECK-NEXT:      index_a = 4
   // CHECK-NEXT:    }
   // CHECK-NEXT:    var index_b: Int
   // CHECK-NEXT:    switch b {
@@ -66,12 +64,10 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      index_b = 2
   // CHECK-NEXT:    case .unavailableMacCatalyst:
   // CHECK-NEXT:      index_b = 3
-  // FIXME: This case should diagnose (rdar://125930716)
   // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:      index_b = 4
-  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
   // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
-  // CHECK-NEXT:      index_b = 5
+  // CHECK-NEXT:      index_b = 4
   // CHECK-NEXT:    }
   // CHECK-NEXT:    return index_a == index_b
   // CHECK-NEXT:  }
@@ -89,12 +85,10 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      discriminator = 2
   // CHECK-NEXT:    case .unavailableMacCatalyst:
   // CHECK-NEXT:      discriminator = 3
-  // FIXME: This case should diagnose (rdar://125930716)
   // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:      discriminator = 4
-  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
   // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
-  // CHECK-NEXT:      discriminator = 5
+  // CHECK-NEXT:      discriminator = 4
   // CHECK-NEXT:    }
   // CHECK-NEXT:    hasher.combine(discriminator)
   // CHECK-NEXT:  }

--- a/test/embedded/availability-code-removal.swift
+++ b/test/embedded/availability-code-removal.swift
@@ -7,8 +7,9 @@
 // - (2) unavailable function bodies is removed in embedded Swift,
 // - (3) the test() function is not reported by the existential checker.
 
-// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib  -wmo | %FileCheck %s --check-prefix CHECK-A
-// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -wmo | %FileCheck %s --check-prefix CHECK-B
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -wmo | %FileCheck %s --check-prefix CHECK-NONEMBEDDED
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -wmo | %FileCheck %s --check-prefix CHECK-EMBEDDED
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-EMBEDDED
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
@@ -21,5 +22,5 @@ public func test() -> any Player {
   Concrete() // no error because we're in unavailable-in-embedded context
 }
 
-// CHECK-A: $s4main4testAA6Player_pyF
-// CHECK-B-NOT: $e4main4testAA6Player_pyF
+// CHECK-NONEMBEDDED: $s4main4testAA6Player_pyF
+// CHECK-EMBEDDED-NOT: $e4main4testAA6Player_pyF

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -30,7 +30,7 @@ static AvailabilityRange getAvailabilityRange(unsigned major, unsigned minor) {
 class AvailabilityContextTest : public ::testing::Test {
 public:
   const TestContext defaultTestContext{
-      DoNotDeclareOptionalTypes, llvm::Triple("x86_64", "apple", "macosx10.9")};
+      llvm::Triple("x86_64", "apple", "macosx10.9")};
 
   struct {
     const AvailabilityDomain universal = AvailabilityDomain::forUniversal();

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TestContext.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
+using namespace swift::unittest;
 
 class AvailabilityDomainLattice : public ::testing::Test {
 public:
@@ -126,4 +128,48 @@ TEST_F(AvailabilityDomainLattice, Contains) {
   EXPECT_FALSE(visionOSAppExt.contains(macCatalystAppExt));
   EXPECT_FALSE(visionOSAppExt.contains(macOS));
   EXPECT_FALSE(visionOSAppExt.contains(macOSAppExt));
+}
+
+TEST_F(AvailabilityDomainLattice, ABICompatibilityDomain) {
+  EXPECT_EQ(Universal.getABICompatibilityDomain(), Universal);
+  EXPECT_EQ(Swift.getABICompatibilityDomain(), Swift);
+  EXPECT_EQ(Package.getABICompatibilityDomain(), Package);
+  EXPECT_EQ(Embedded.getABICompatibilityDomain(), Embedded);
+  EXPECT_EQ(macOS.getABICompatibilityDomain(), macOS);
+  EXPECT_EQ(macOSAppExt.getABICompatibilityDomain(), macOS);
+  EXPECT_EQ(iOS.getABICompatibilityDomain(), iOS);
+  EXPECT_EQ(iOSAppExt.getABICompatibilityDomain(), iOS);
+  EXPECT_EQ(macCatalyst.getABICompatibilityDomain(), iOS);
+  EXPECT_EQ(macCatalystAppExt.getABICompatibilityDomain(), iOS);
+  EXPECT_EQ(visionOS.getABICompatibilityDomain(), iOS);
+  EXPECT_EQ(visionOSAppExt.getABICompatibilityDomain(), iOS);
+}
+
+TEST(AvailabilityDomain, TargetPlatform) {
+  using namespace llvm;
+
+  struct TargetToPlatformKind {
+    Triple target;
+    PlatformKind platformKind;
+  };
+  TargetToPlatformKind tests[] = {
+      {Triple("x86_64", "apple", "macosx10.15"), PlatformKind::macOS},
+      {Triple("arm64", "apple", "ios13"), PlatformKind::iOS},
+      {Triple("arm64_32", "apple", "watchos8"), PlatformKind::watchOS},
+      {Triple("x86_64", "apple", "ios14", "macabi"), PlatformKind::macCatalyst},
+      {Triple("x86_64", "unknown", "windows", "msvc"), PlatformKind::none},
+      {Triple("x86_64", "unknown", "linux", "gnu"), PlatformKind::none},
+  };
+
+  for (TargetToPlatformKind test : tests) {
+    TestContext context{test.target};
+    auto domain = AvailabilityDomain::forTargetPlatform(context.Ctx);
+    if (test.platformKind != PlatformKind::none) {
+      EXPECT_TRUE(domain);
+      if (domain)
+        EXPECT_TRUE(domain->getPlatformKind() == test.platformKind);
+    } else {
+      EXPECT_FALSE(domain);
+    }
+  }
 }

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -71,19 +71,59 @@ TEST_F(AvailabilityDomainLattice, Contains) {
   EXPECT_FALSE(macOS.contains(macCatalyst));
   EXPECT_FALSE(macCatalyst.contains(macOS));
 
-  // Additionally, iOS is the ABI platform for both macCatalyst and visionOS and
-  // thus the iOS domain contains those domains.
+  // iOS is the ABI platform for macCatalyst and visionOS, so it contain those
+  // domains.
   EXPECT_TRUE(iOS.contains(iOS));
   EXPECT_TRUE(iOS.contains(iOSAppExt));
-  EXPECT_FALSE(iOSAppExt.contains(iOS));
   EXPECT_TRUE(iOS.contains(macCatalyst));
-  EXPECT_FALSE(macCatalyst.contains(iOS));
   EXPECT_TRUE(iOS.contains(macCatalystAppExt));
-  EXPECT_FALSE(macCatalystAppExt.contains(iOS));
   EXPECT_TRUE(iOS.contains(visionOS));
-  EXPECT_FALSE(visionOS.contains(iOS));
   EXPECT_TRUE(iOS.contains(visionOSAppExt));
-  EXPECT_FALSE(visionOSAppExt.contains(iOS));
   EXPECT_FALSE(iOS.contains(macOS));
   EXPECT_FALSE(iOS.contains(macOSAppExt));
+
+  EXPECT_TRUE(iOSAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(iOSAppExt.contains(iOS));
+  EXPECT_FALSE(iOSAppExt.contains(macCatalyst));
+  EXPECT_TRUE(iOSAppExt.contains(macCatalystAppExt));
+  EXPECT_FALSE(iOSAppExt.contains(visionOS));
+  EXPECT_TRUE(iOSAppExt.contains(visionOSAppExt));
+  EXPECT_FALSE(iOSAppExt.contains(macOS));
+  EXPECT_FALSE(iOSAppExt.contains(macOSAppExt));
+
+  EXPECT_TRUE(macCatalyst.contains(macCatalyst));
+  EXPECT_TRUE(macCatalyst.contains(macCatalystAppExt));
+  EXPECT_FALSE(macCatalyst.contains(iOS));
+  EXPECT_FALSE(macCatalyst.contains(iOSAppExt));
+  EXPECT_FALSE(macCatalyst.contains(visionOS));
+  EXPECT_FALSE(macCatalyst.contains(visionOSAppExt));
+  EXPECT_FALSE(macCatalyst.contains(macOS));
+  EXPECT_FALSE(macCatalyst.contains(macOSAppExt));
+
+  EXPECT_TRUE(macCatalystAppExt.contains(macCatalystAppExt));
+  EXPECT_FALSE(macCatalystAppExt.contains(macCatalyst));
+  EXPECT_FALSE(macCatalystAppExt.contains(iOS));
+  EXPECT_FALSE(macCatalystAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.contains(visionOS));
+  EXPECT_FALSE(macCatalystAppExt.contains(visionOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.contains(macOS));
+  EXPECT_FALSE(macCatalystAppExt.contains(macOSAppExt));
+
+  EXPECT_TRUE(visionOS.contains(visionOS));
+  EXPECT_TRUE(visionOS.contains(visionOSAppExt));
+  EXPECT_FALSE(visionOS.contains(iOS));
+  EXPECT_FALSE(visionOS.contains(iOSAppExt));
+  EXPECT_FALSE(visionOS.contains(macCatalyst));
+  EXPECT_FALSE(visionOS.contains(macCatalystAppExt));
+  EXPECT_FALSE(visionOS.contains(macOS));
+  EXPECT_FALSE(visionOS.contains(macOSAppExt));
+
+  EXPECT_TRUE(visionOSAppExt.contains(visionOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.contains(visionOS));
+  EXPECT_FALSE(visionOSAppExt.contains(iOS));
+  EXPECT_FALSE(visionOSAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.contains(macCatalyst));
+  EXPECT_FALSE(visionOSAppExt.contains(macCatalystAppExt));
+  EXPECT_FALSE(visionOSAppExt.contains(macOS));
+  EXPECT_FALSE(visionOSAppExt.contains(macOSAppExt));
 }

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -61,6 +61,9 @@ public:
       ShouldDeclareOptionalTypes optionals = DoNotDeclareOptionalTypes,
       llvm::Triple target = llvm::Triple(llvm::sys::getProcessTriple()));
 
+  TestContext(llvm::Triple target)
+      : TestContext(DoNotDeclareOptionalTypes, target) {};
+
   template <typename Nominal>
   typename std::enable_if<!std::is_same<Nominal, swift::ClassDecl>::value,
                           Nominal *>::type


### PR DESCRIPTION
Add support for `-unavailable-decl-optimization` on visionOS and on macOS for zippered libraries. It was previously disabled because of the complexity of correctly handling ABI compatibility with iOS in these contexts. The algorithm for determining whether a declaration is unreachable at runtime due to unavailability has been rewritten to account for platforms with ABI compatible ancestor platforms.

Resolves rdar://116742214 and rdar://125930716.