### PR TITLE
AST: Begin consolidating availability constraint queries

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -26,6 +26,8 @@
 namespace swift {
 
 class ASTContext;
+class AvailabilityContext;
+class Decl;
 
 /// Represents the reason a declaration could be considered unavailable in a
 /// certain context.
@@ -110,6 +112,37 @@ public:
   bool isActiveForRuntimeQueries(ASTContext &ctx) const;
 };
 
+/// Represents a set of availability constraints that restrict use of a
+/// declaration in a particular context.
+class DeclAvailabilityConstraints {
+  using Storage = llvm::SmallVector<AvailabilityConstraint, 4>;
+  Storage constraints;
+
+public:
+  DeclAvailabilityConstraints() {}
+
+  void addConstraint(const AvailabilityConstraint &constraint) {
+    constraints.emplace_back(constraint);
+  }
+
+  using const_iterator = Storage::const_iterator;
+  const_iterator begin() const { return constraints.begin(); }
+  const_iterator end() const { return constraints.end(); }
+};
+
+/// Returns the `AvailabilityConstraint` that describes how \p attr restricts
+/// use of \p decl in \p context or `std::nullopt` if there is no restriction.
+std::optional<AvailabilityConstraint>
+getAvailabilityConstraintForAttr(const Decl *decl,
+                                 const SemanticAvailableAttr &attr,
+                                 const AvailabilityContext &context);
+
+/// Returns the set of availability constraints that restrict use of \p decl
+/// when it is referenced from the given context. In other words, it is the
+/// collection of of `@available` attributes with unsatisfied conditions.
+DeclAvailabilityConstraints
+getAvailabilityConstraintsForDecl(const Decl *decl,
+                                  const AvailabilityContext &context);
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_AVAILABILITY_CONSTRAINT_H
 #define SWIFT_AST_AVAILABILITY_CONSTRAINT_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/PlatformKind.h"
@@ -25,7 +26,6 @@
 namespace swift {
 
 class ASTContext;
-class AvailableAttr;
 
 /// Represents the reason a declaration could be considered unavailable in a
 /// certain context.

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -23,6 +23,8 @@
 
 namespace swift {
 
+class DeclAvailabilityConstraints;
+
 /// Summarizes availability the constraints contained by an AvailabilityContext.
 class AvailabilityContext::Info {
 public:
@@ -41,9 +43,11 @@ public:
   /// of adding this constraint.
   bool constrainWith(const Info &other);
 
-  /// Updates each field to reflect the availability of `decl`, if that
-  /// availability is more restrictive. Returns true if any field was updated.
-  bool constrainWith(const Decl *decl);
+  /// Constrains each field using the given constraints if they are more
+  /// restrictive than the current values. Returns true if any field was
+  /// updated.
+  bool constrainWith(const DeclAvailabilityConstraints &constraints,
+                     ASTContext &ctx);
 
   bool constrainUnavailability(std::optional<AvailabilityDomain> domain);
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -16,7 +16,6 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityRange.h"
@@ -65,43 +64,6 @@ AvailabilityRange AvailabilityRange::forInliningTarget(const ASTContext &Ctx) {
 
 AvailabilityRange AvailabilityRange::forRuntimeTarget(const ASTContext &Ctx) {
   return AvailabilityRange(VersionRange::allGTE(Ctx.LangOpts.RuntimeVersion));
-}
-
-PlatformKind AvailabilityConstraint::getPlatform() const {
-  return getAttr().getPlatform();
-}
-
-std::optional<AvailabilityRange>
-AvailabilityConstraint::getRequiredNewerAvailabilityRange(
-    ASTContext &ctx) const {
-  switch (getKind()) {
-  case Kind::AlwaysUnavailable:
-  case Kind::RequiresVersion:
-  case Kind::Obsoleted:
-    return std::nullopt;
-  case Kind::IntroducedInNewerVersion:
-    return getAttr().getIntroducedRange(ctx);
-  }
-}
-
-bool AvailabilityConstraint::isConditionallySatisfiable() const {
-  switch (getKind()) {
-  case Kind::AlwaysUnavailable:
-  case Kind::RequiresVersion:
-  case Kind::Obsoleted:
-    return false;
-  case Kind::IntroducedInNewerVersion:
-    return true;
-  }
-}
-
-bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
-  if (getAttr().getPlatform() == PlatformKind::none)
-    return true;
-
-  return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
-                                 /*forTargetVariant=*/false,
-                                 /*forRuntimeQuery=*/true);
 }
 
 namespace {

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -1,0 +1,53 @@
+//===--- AvailabilityConstraint.cpp - Swift Availability Constraints ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AvailabilityConstraint.h"
+#include "swift/AST/ASTContext.h"
+
+using namespace swift;
+
+PlatformKind AvailabilityConstraint::getPlatform() const {
+  return getAttr().getPlatform();
+}
+
+std::optional<AvailabilityRange>
+AvailabilityConstraint::getRequiredNewerAvailabilityRange(
+    ASTContext &ctx) const {
+  switch (getKind()) {
+  case Kind::AlwaysUnavailable:
+  case Kind::RequiresVersion:
+  case Kind::Obsoleted:
+    return std::nullopt;
+  case Kind::IntroducedInNewerVersion:
+    return getAttr().getIntroducedRange(ctx);
+  }
+}
+
+bool AvailabilityConstraint::isConditionallySatisfiable() const {
+  switch (getKind()) {
+  case Kind::AlwaysUnavailable:
+  case Kind::RequiresVersion:
+  case Kind::Obsoleted:
+    return false;
+  case Kind::IntroducedInNewerVersion:
+    return true;
+  }
+}
+
+bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
+  if (getAttr().getPlatform() == PlatformKind::none)
+    return true;
+
+  return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
+                                 /*forTargetVariant=*/false,
+                                 /*forRuntimeQuery=*/true);
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_host_library(swiftAST STATIC
   Attr.cpp
   AutoDiff.cpp
   Availability.cpp
+  AvailabilityConstraint.cpp
   AvailabilityContext.cpp
   AvailabilityDomain.cpp
   AvailabilityScope.cpp

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -144,26 +144,85 @@ extension X: P {}
 // Test platform inheritance for iOS unavailability.
 // rdar://68597591
 
-@available(iOS, unavailable)
-public struct UnavailableOniOS { } // expected-note 2 {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+func takesAnything<T>(_ t: T) { }
+
+@available(macCatalyst, unavailable)
+struct UnavailableOnMacCatalyst { } // expected-note * {{'UnavailableOnMacCatalyst' has been explicitly marked unavailable here}}
 
 @available(iOS, unavailable)
-func unavailableOniOS(_ p: UnavailableOniOS) { } // ok
-
-func functionUsingAnUnavailableType(_ p: UnavailableOniOS) { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
-
-public extension UnavailableOniOS { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+struct UnavailableOniOS { } // expected-note * {{'UnavailableOniOS' has been explicitly marked unavailable here}}
 
 @available(iOS, unavailable)
-public extension UnavailableOniOS { // ok
-  func someMethod(_ p: UnavailableOniOS) { }
+@available(macCatalyst, introduced: 13.0)
+struct AvailableOnMacCatalystButUnavailableOniOS { }
+
+extension UnavailableOnMacCatalyst { } // expected-error {{'UnavailableOnMacCatalyst' is unavailable in Mac Catalyst}}
+extension UnavailableOniOS { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+extension AvailableOnMacCatalystButUnavailableOniOS { } // ok
+
+@available(macCatalyst, unavailable)
+extension UnavailableOnMacCatalyst {
+  func extensionMethod() {
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+
+  @available(iOS, unavailable)
+  func extensionMethodUnavailableOniOS() {
+    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+
+  @available(iOS, introduced: 15)
+  func extensionMethodIntroducedOniOS() {
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+
+}
+
+@available(iOS, unavailable)
+extension UnavailableOniOS {
+  func extensionMethod() {
+    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+
+  @available(macCatalyst, unavailable)
+  func extensionMethodUnavailableOnMacCatalyst() {
+    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+
+  @available(macCatalyst, introduced: 13.0)
+  func extensionMethodMacCatalystIntroduced() {
+    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
 }
 
 @available(iOS, unavailable)
 @available(macCatalyst, introduced: 13.0)
-public struct AvailableOnMacCatalyst { }
+extension AvailableOnMacCatalystButUnavailableOniOS {
+  func extensionMethod() {
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOnMacCatalyst()) // expected-error {{'UnavailableOnMacCatalyst' is unavailable in Mac Catalyst}}
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
 
-public extension AvailableOnMacCatalyst { } // ok
+  @available(macCatalyst, unavailable)
+  func extensionMethodUnavailableOnMacCatalyst() {
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOnMacCatalyst())
+    takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+  }
+}
 
 @available(iOS, introduced: 14.0)
 @available(macCatalyst, introduced: 14.5)

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -17,7 +17,7 @@ public func unavailable_in_embedded() { }
 
 @available(*, unavailable, message: "always unavailable")
 public func universally_unavailable() { }
-// expected-note@-1 3 {{'universally_unavailable()' has been explicitly marked unavailable here}}
+// expected-note@-1 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unused() { } // no error
@@ -35,12 +35,29 @@ public func has_universally_unavailable_overload(_ s1: S1) { }
 
 public func has_universally_unavailable_overload(_ s2: S2) { }
 
+public struct Available {}
+
+@_unavailableInEmbedded
+extension Available {
+  public func unavailable_in_embedded_method( // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
+    _ uie: UnavailableInEmbedded,
+    _ uu: UniverallyUnavailable,
+    _ a: Available,
+  ) {
+    unavailable_in_embedded()
+    universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+    a.unavailable_in_embedded_method(uie, uu, a)
+  }
+}
+
 public func available(
   _ uie: UnavailableInEmbedded, // expected-error {{'UnavailableInEmbedded' is unavailable: unavailable in embedded Swift}}
-  _ uu: UniverallyUnavailable // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
+  _ uu: UniverallyUnavailable, // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
+  _ a: Available,
 ) {
   unavailable_in_embedded() // expected-error {{'unavailable_in_embedded()' is unavailable: unavailable in embedded Swift}}
   universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a) // expected-error {{'unavailable_in_embedded_method' is unavailable: unavailable in embedded Swift}}
   has_unavailable_in_embedded_overload(.init())
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }
@@ -48,10 +65,12 @@ public func available(
 @_unavailableInEmbedded
 public func also_unavailable_in_embedded(
   _ uie: UnavailableInEmbedded, // OK
-  _ uu: UniverallyUnavailable // OK
+  _ uu: UniverallyUnavailable, // OK
+  _ a: Available,
 ) {
   unavailable_in_embedded() // OK
   universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a)
   has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }
@@ -59,10 +78,12 @@ public func also_unavailable_in_embedded(
 @available(*, unavailable)
 public func also_universally_unavailable(
   _ uie: UnavailableInEmbedded, // OK
-  _ uu: UniverallyUnavailable // OK
+  _ uu: UniverallyUnavailable, // OK
+  _ a: Available,
 ) {
   unavailable_in_embedded()
   universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a)
   has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
   has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
 }


### PR DESCRIPTION
Computing the unsatisfied availability constraints for a declaration when used in a given context is a fundamental building block of availability checking, but the implementation is a bit scattered and hard to share everywhere it's needed. Begin consolidating that logic in `swift::getAvailabilityConstraintsForDecl()` and adopt it when constraining an `AvailabilityContext` with the attributes of a declaration.