### PR TITLE
[ConstraintSystem] Store declaration context in which application constraint occurs

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -582,7 +582,7 @@ public:
   static Constraint *createApplicableFunction(
       ConstraintSystem &cs, Type argumentFnType, Type calleeType,
       std::optional<TrailingClosureMatching> trailingClosureMatching,
-      ConstraintLocator *locator);
+      DeclContext *useDC, ConstraintLocator *locator);
 
   static Constraint *createSyntacticElement(ConstraintSystem &cs,
                                               ASTNode node,

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -380,10 +380,6 @@ class Constraint final : public llvm::ilist_node<Constraint>,
   /// The kind of function reference, for member references.
   unsigned TheFunctionRefInfo : 3;
 
-  /// The trailing closure matching for an applicable function constraint,
-  /// if any. 0 = None, 1 = Forward, 2 = Backward.
-  unsigned trailingClosureMatching : 2;
-
   union {
     struct {
       /// The first type.
@@ -439,6 +435,21 @@ class Constraint final : public llvm::ilist_node<Constraint>,
       /// Identifies whether result of this node is unused.
       bool IsDiscarded;
     } SyntacticElement;
+
+    struct {
+      /// The function type that is being applied where parameters
+      /// represent argument types passed to callee and result type
+      /// represents result type of the application.
+      FunctionType *AppliedFn;
+      /// The type being called, primarily a function type, but could
+      /// be a metatype, a tuple or a nominal type.
+      Type Callee;
+      /// The trailing closure matching for an applicable function constraint,
+      /// if any. 0 = None, 1 = Forward, 2 = Backward.
+      unsigned TrailingClosureMatching : 2;
+      /// The declaration context in which the application appears.
+      DeclContext *UseDC;
+    } Apply;
   };
 
   /// The locator that describes where in the expression this
@@ -492,6 +503,11 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
   /// Construct a closure body element constraint.
   Constraint(ASTNode node, ContextualTypeInfo context, bool isDiscarded,
+             ConstraintLocator *locator,
+             SmallPtrSetImpl<TypeVariableType *> &typeVars);
+
+  Constraint(FunctionType *appliedFn, Type calleeType,
+             unsigned trailingClosureMatching, DeclContext *useDC,
              ConstraintLocator *locator,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
@@ -580,7 +596,7 @@ public:
 
   /// Create a new Applicable Function constraint.
   static Constraint *createApplicableFunction(
-      ConstraintSystem &cs, Type argumentFnType, Type calleeType,
+      ConstraintSystem &cs, FunctionType *argumentFnType, Type calleeType,
       std::optional<TrailingClosureMatching> trailingClosureMatching,
       DeclContext *useDC, ConstraintLocator *locator);
 
@@ -739,6 +755,9 @@ public:
     case ConstraintKind::SyntacticElement:
       llvm_unreachable("closure body element constraint has no type operands");
 
+    case ConstraintKind::ApplicableFunction:
+      return Apply.AppliedFn;
+
     default:
       return Types.First;
     }
@@ -757,6 +776,9 @@ public:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueWitness:
       return Member.Second;
+
+    case ConstraintKind::ApplicableFunction:
+      return Apply.Callee;
 
     default:
       return Types.Second;
@@ -849,6 +871,21 @@ public:
            Kind == ConstraintKind::UnresolvedValueMember ||
            Kind == ConstraintKind::ValueWitness);
     return Member.UseDC;
+  }
+
+  FunctionType *getAppliedFunctionType() const {
+    assert(Kind == ConstraintKind::ApplicableFunction);
+    return Apply.AppliedFn;
+  }
+
+  Type getCalleeType() const {
+    assert(Kind == ConstraintKind::ApplicableFunction);
+    return Apply.Callee;
+  }
+
+  DeclContext *getApplicationDC() const {
+    assert(Kind == ConstraintKind::ApplicableFunction);
+    return Apply.UseDC;
   }
 
   ASTNode getSyntacticElement() const {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4965,7 +4965,7 @@ private:
 
   /// Attempt to simplify the ApplicableFunction constraint.
   SolutionKind simplifyApplicableFnConstraint(
-      Type type1, Type type2,
+      FunctionType *appliedFn, Type calleeTy,
       std::optional<TrailingClosureMatching> trailingClosureMatching,
       DeclContext *useDC,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3565,6 +3565,11 @@ public:
   void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
                      bool isFavored = false);
 
+  void addApplicationConstraint(
+      FunctionType *appliedFn, Type calleeType,
+      std::optional<TrailingClosureMatching> trailingClosureMatching,
+      DeclContext *useDC, ConstraintLocatorBuilder locator);
+
   /// Add the appropriate constraint for a contextual conversion.
   void addContextualConversionConstraint(Expr *expr, Type conversionType,
                                          ContextualTypePurpose purpose,
@@ -4962,6 +4967,7 @@ private:
   SolutionKind simplifyApplicableFnConstraint(
       Type type1, Type type2,
       std::optional<TrailingClosureMatching> trailingClosureMatching,
+      DeclContext *useDC,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the DynamicCallableApplicableFunction constraint.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -395,10 +395,9 @@ namespace {
 
       // Add the constraint that the index expression's type be convertible
       // to the input type of the subscript operator.
-      CS.addConstraint(ConstraintKind::ApplicableFunction,
-                       FunctionType::get(params, outputTy),
-                       memberTy,
-                       fnLocator);
+      CS.addApplicationConstraint(FunctionType::get(params, outputTy), memberTy,
+                                  /*trailingClosureMatching=*/std::nullopt,
+                                  CurDC, fnLocator);
 
       Type fixedOutputType =
           CS.getFixedTypeRecursive(outputTy, /*wantRValue=*/false);
@@ -721,9 +720,9 @@ namespace {
           CS.getConstraintLocator(expr, ConstraintLocator::FunctionResult),
           TVO_CanBindToNoEscape);
 
-      CS.addConstraint(ConstraintKind::ApplicableFunction,
-                       FunctionType::get(params, resultType), memberType,
-                       fnLoc);
+      CS.addApplicationConstraint(
+          FunctionType::get(params, resultType), memberType,
+          /*trailingClosureMatching=*/std::nullopt, CurDC, fnLoc);
 
       if (constr->isFailable())
         return OptionalType::get(witnessType);
@@ -2545,10 +2544,10 @@ namespace {
       SmallVector<AnyFunctionType::Param, 8> params;
       getMatchingParams(expr->getArgs(), params);
 
-      CS.addConstraint(ConstraintKind::ApplicableFunction,
-                       FunctionType::get(params, resultType, extInfo),
-                       CS.getType(fnExpr),
-        CS.getConstraintLocator(expr, ConstraintLocator::ApplyFunction));
+      CS.addApplicationConstraint(
+          FunctionType::get(params, resultType, extInfo), CS.getType(fnExpr),
+          /*trailingClosureMatching=*/std::nullopt, CurDC,
+          CS.getConstraintLocator(expr, ConstraintLocator::ApplyFunction));
 
       // If we ended up resolving the result type variable to a concrete type,
       // set it as the favored type for this expression.
@@ -3296,10 +3295,11 @@ namespace {
           CS.getConstraintLocator(expr, ConstraintLocator::FunctionResult),
           TVO_CanBindToNoEscape);
 
-      CS.addConstraint(
-          ConstraintKind::ApplicableFunction,
+      CS.addApplicationConstraint(
           FunctionType::get(params, resultType),
           macroRefType,
+          /*trailingClosureMatching=*/std::nullopt,
+          CurDC,
           CS.getConstraintLocator(
             expr, ConstraintLocator::ApplyFunction));
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -87,11 +87,9 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
-  case ConstraintKind::ApplicableFunction:
   case ConstraintKind::DynamicCallableApplicableFunction:
     assert(First->is<FunctionType>()
            && "The left-hand side type should be a function type");
-    trailingClosureMatching = 0;
     break;
 
   case ConstraintKind::ValueMember:
@@ -120,6 +118,10 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
 
   case ConstraintKind::SyntacticElement:
     llvm_unreachable("Syntactic element constraint should use create()");
+
+  case ConstraintKind::ApplicableFunction:
+    llvm_unreachable(
+        "Application constraint should use create()");
   }
 
   std::uninitialized_copy(typeVars.begin(), typeVars.end(),
@@ -284,6 +286,27 @@ Constraint::Constraint(ASTNode node, ContextualTypeInfo context,
       NumTypeVariables(typeVars.size()), SyntacticElement{node, context,
                                                           isDiscarded},
       Locator(locator) {
+  std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
+}
+
+Constraint::Constraint(FunctionType *appliedFn, Type calleeType,
+                       unsigned trailingClosureMatching, DeclContext *useDC,
+                       ConstraintLocator *locator,
+                       SmallPtrSetImpl<TypeVariableType *> &typeVars)
+    : Kind(ConstraintKind::ApplicableFunction), HasFix(false),
+      HasRestriction(false), IsActive(false), IsDisabled(false),
+      IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
+      IsIsolated(false), NumTypeVariables(typeVars.size()), Locator(locator) {
+  assert(appliedFn);
+  assert(calleeType);
+  assert(trailingClosureMatching >= 0 && trailingClosureMatching <= 2);
+  assert(useDC);
+
+  Apply.AppliedFn = appliedFn;
+  Apply.Callee = calleeType;
+  Apply.TrailingClosureMatching = trailingClosureMatching;
+  Apply.UseDC = useDC;
+
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
 }
 
@@ -986,7 +1009,7 @@ Constraint *Constraint::createConjunction(
 }
 
 Constraint *Constraint::createApplicableFunction(
-    ConstraintSystem &cs, Type argumentFnType, Type calleeType,
+    ConstraintSystem &cs, FunctionType *argumentFnType, Type calleeType,
     std::optional<TrailingClosureMatching> trailingClosureMatching,
     DeclContext *useDC, ConstraintLocator *locator) {
   // Collect type variables.
@@ -996,29 +1019,28 @@ Constraint *Constraint::createApplicableFunction(
   if (calleeType->hasTypeVariable())
     calleeType->getTypeVariables(typeVars);
 
-  // Create the constraint.
+  // Encode the trailing closure matching.
+  unsigned rawTrailingClosureMatching = 0;
+  if (trailingClosureMatching) {
+    switch (*trailingClosureMatching) {
+      case TrailingClosureMatching::Forward:
+        rawTrailingClosureMatching = 1;
+        break;
+
+      case TrailingClosureMatching::Backward:
+        rawTrailingClosureMatching = 2;
+        break;
+    }
+  }
+
+    // Create the constraint.
   auto size =
     totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
       typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
-  auto constraint = new (mem) Constraint(
-      ConstraintKind::ApplicableFunction, argumentFnType, calleeType, locator,
-      typeVars);
-
-  // Encode the trailing closure matching.
-  if (trailingClosureMatching) {
-    switch (*trailingClosureMatching) {
-      case TrailingClosureMatching::Forward:
-        constraint->trailingClosureMatching = 1;
-        break;
-
-      case TrailingClosureMatching::Backward:
-        constraint->trailingClosureMatching = 2;
-        break;
-    }
-  } else {
-    constraint->trailingClosureMatching = 0;
-  }
+  auto constraint = new (mem)
+      Constraint(argumentFnType, calleeType, rawTrailingClosureMatching, useDC,
+                 locator, typeVars);
 
   return constraint;
 }
@@ -1051,7 +1073,7 @@ Constraint *Constraint::createSyntacticElement(ConstraintSystem &cs,
 std::optional<TrailingClosureMatching>
 Constraint::getTrailingClosureMatching() const {
   assert(Kind == ConstraintKind::ApplicableFunction);
-  switch (trailingClosureMatching) {
+  switch (Apply.TrailingClosureMatching) {
   case 0:
     return std::nullopt;
   case 1: return TrailingClosureMatching::Forward;

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -988,7 +988,7 @@ Constraint *Constraint::createConjunction(
 Constraint *Constraint::createApplicableFunction(
     ConstraintSystem &cs, Type argumentFnType, Type calleeType,
     std::optional<TrailingClosureMatching> trailingClosureMatching,
-    ConstraintLocator *locator) {
+    DeclContext *useDC, ConstraintLocator *locator) {
   // Collect type variables.
   SmallPtrSet<TypeVariableType *, 4> typeVars;
   if (argumentFnType->hasTypeVariable())

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1933,8 +1933,9 @@ void ConstraintSystem::bindOverloadType(
         {FunctionType::Param(argTy, ctx.Id_dynamicMember)}, resultTy);
 
     ConstraintLocatorBuilder builder(callLoc);
-    addConstraint(ConstraintKind::ApplicableFunction, callerTy, fnTy,
-                  builder.withPathElement(ConstraintLocator::ApplyFunction));
+    addApplicationConstraint(
+        callerTy, fnTy, /*trailingClosureMatching=*/std::nullopt, useDC,
+        builder.withPathElement(ConstraintLocator::ApplyFunction));
 
     if (isExpr<KeyPathExpr>(locator->getAnchor())) {
       auto paramTy = fnTy->getParams()[0].getParameterType();
@@ -2088,8 +2089,9 @@ void ConstraintSystem::bindOverloadType(
       // Add a constraint for the inner application that uses the args of the
       // original call-site, and a fresh type var result equal to the leaf type.
       ConstraintLocatorBuilder kpLocBuilder(keyPathLoc);
-      addConstraint(
-          ConstraintKind::ApplicableFunction, adjustedFnTy, memberTy,
+      addApplicationConstraint(
+          adjustedFnTy, memberTy, /*trailingClosureMatching=*/std::nullopt,
+          useDC,
           kpLocBuilder.withPathElement(ConstraintLocator::ApplyFunction));
 
       addConstraint(ConstraintKind::Equal, subscriptResultTy, leafTy,

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -127,3 +127,98 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
   ASSERT_TRUE(cs.simplifyType(paramTy)->isEqual(getStdlibType("Int")));
   ASSERT_TRUE(cs.simplifyType(resultTy)->isEqual(Context.TheEmptyTupleType));
 }
+
+/// Emulates code like this:
+///
+/// func test(_: (Int) -> Void) {}
+///
+/// test { Double($0) }
+///
+/// To make sure that constructor application sets correct
+/// declaration context for implicit `.init` member.
+TEST_F(SemaTest, TestInitializerUseDCIsSetCorrectlyInClosure) {
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+
+  DeclAttributes closureAttrs;
+
+  // Anonymous closure parameter
+  auto paramName = Context.getIdentifier("0");
+
+  auto *paramDecl =
+      new (Context) ParamDecl(/*specifierLoc=*/SourceLoc(),
+                              /*argumentNameLoc=*/SourceLoc(), paramName,
+                              /*parameterNameLoc=*/SourceLoc(), paramName, DC);
+
+  paramDecl->setSpecifier(ParamSpecifier::Default);
+
+  auto *closure = new (Context) ClosureExpr(
+      closureAttrs,
+      /*bracketRange=*/SourceRange(),
+      /*capturedSelfDecl=*/nullptr, ParameterList::create(Context, {paramDecl}),
+      /*asyncLoc=*/SourceLoc(),
+      /*throwsLoc=*/SourceLoc(),
+      /*thrownType=*/nullptr,
+      /*arrowLoc=*/SourceLoc(),
+      /*inLoc=*/SourceLoc(),
+      /*explicitResultType=*/nullptr,
+      /*parent=*/DC);
+  closure->setDiscriminator(0);
+
+  closure->setImplicit();
+
+  // Double($0)
+  auto initCall = CallExpr::createImplicit(
+      Context, TypeExpr::createImplicit(getStdlibType("Double"), Context),
+      ArgumentList::forImplicitUnlabeled(
+          Context, {new (Context) DeclRefExpr(ConcreteDeclRef(paramDecl),
+                                              /*Loc*/ DeclNameLoc(),
+                                              /*Implicit=*/true)}));
+
+  closure->setBody(BraceStmt::createImplicit(Context, {initCall}));
+
+  auto *closureLoc = cs.getConstraintLocator(closure);
+
+  auto *paramTy = cs.createTypeVariable(
+      cs.getConstraintLocator(closure, LocatorPathElt::TupleElement(0)),
+      /*options=*/TVO_CanBindToInOut);
+
+  auto *resultTy = cs.createTypeVariable(
+      cs.getConstraintLocator(closure, ConstraintLocator::ClosureResult),
+      /*options=*/0);
+
+  auto extInfo = FunctionType::ExtInfo();
+
+  auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
+                                     resultTy, extInfo);
+
+  cs.setClosureType(closure, defaultTy);
+
+  auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
+  cs.setType(closure, closureTy);
+
+  cs.addUnsolvedConstraint(Constraint::create(
+      cs, ConstraintKind::FallbackType, closureTy, defaultTy,
+      cs.getConstraintLocator(closure), /*referencedVars=*/{}));
+
+  auto contextualTy =
+      FunctionType::get({FunctionType::Param(getStdlibType("Int"))},
+                        Context.TheEmptyTupleType, extInfo);
+
+  cs.resolveClosure(closureTy, contextualTy, closureLoc);
+
+  auto &graph = cs.getConstraintGraph();
+
+  for (const auto &component :
+       graph.computeConnectedComponents(cs.getTypeVariables())) {
+    for (auto *constraint : component.getConstraints()) {
+      if (constraint->getKind() != ConstraintKind::Disjunction)
+        continue;
+
+      ASSERT_TRUE(constraint->getLocator()
+                      ->isLastElement<LocatorPathElt::ConstructorMember>());
+
+      for (auto *choice : constraint->getNestedConstraints())
+        ASSERT_EQ(choice->getOverloadUseDC(), closure);
+    }
+  }
+}

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -30,8 +30,8 @@ TEST_F(SemaTest, TestTrailingClosureMatchRecordingForIdenticalFunctions) {
   auto func = FunctionType::get(
       {FunctionType::Param(intType), FunctionType::Param(intType)}, floatType);
 
-  cs.addConstraint(
-      ConstraintKind::ApplicableFunction, func, func,
+  cs.addApplicationConstraint(
+      func, func, /*trailingClosureMatching=*/std::nullopt, DC,
       cs.getConstraintLocator({}, ConstraintLocator::ApplyFunction));
 
   SmallVector<Solution, 2> solutions;


### PR DESCRIPTION
This is required because `ApplicableFunction` constraint can
inject member reference constraints that require a declaration
context.

For example, `_ = { Double(...) }` would now produce a disjunction
for `Double.init` where overload choice declaration contexts point
to the closure instead of the enclosing context.

This addresses a long-standing FIXME in `simplifyApplicableFnConstraint`
and helps with disjunction optimizer because its correctness depends on
correct identification of declaration contexts where applications happen.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
