### PR TITLE
Implement FreeBSD Crash Handler

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -572,6 +572,9 @@ swift_auth_code_function(T value, unsigned extra) {
 #elif defined(__linux__) && (defined(__aarch64__) || defined(__x86_64__))
 #  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 1
 #  define SWIFT_BACKTRACE_SECTION "swift5_backtrace"
+#elif defined(__FreeBSD__) && (defined(__aarch64__) || defined(__x86_64__))
+#  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 1
+#  define SWIFT_BACKTRACE_SECTION "swift5_backtrace"
 #else
 #  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 0
 #endif

--- a/include/swift/Runtime/CrashInfo.h
+++ b/include/swift/Runtime/CrashInfo.h
@@ -45,13 +45,13 @@ struct CrashInfo {
   // Points to the mcontext_t structure for the crashing thread; other
   // threads' contexts can be recovered using Mach APIs later.
   uint64_t mctx;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
   // The head of the thread list; points at a "struct thread" (see below).
   uint64_t thread_list;
 #endif
 };
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 
 // A memory server request packet.
 struct memserver_req {

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -12,10 +12,18 @@
 #
 #  The Runtime module isn't the runtime itself; that lives in libswiftCore;
 #  rather, it's a high level Swift interface to things
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+set(swift_runtime_link_libraries
+  swiftCore
+  swift_Concurrency
+  util
+)
+else()
 set(swift_runtime_link_libraries
   swiftCore
   swift_Concurrency
 )
+endif()
 
 set(concurrency)
 if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
@@ -44,6 +52,7 @@ set(RUNTIME_SOURCES
   ImageMap.swift
   ImageMap+Darwin.swift
   ImageMap+Linux.swift
+  ImageMap+FreeBSD.swift
   ImageSource.swift
   Libc.swift
   LimitSequence.swift
@@ -126,5 +135,5 @@ add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STD
   INSTALL_IN_COMPONENT stdlib
   MACCATALYST_BUILD_FLAVOR "zippered"
 
-  TARGET_SDKS OSX LINUX LINUX_STATIC
+  TARGET_SDKS OSX LINUX LINUX_STATIC FREEBSD
 )

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -317,6 +317,36 @@ extension arm_gprs {
   public static func fromHostMContext(_ mcontext: Any) -> HostContext {
     return X86_64Context(with: mcontext as! mcontext_t)
   }
+  #elseif os(FreeBSD) && arch(x86_64)
+  init(with mctx: mcontext_t) {
+    gprs.setR(X86_64Register.rax.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rax)))
+    gprs.setR(X86_64Register.rbx.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rbx)))
+    gprs.setR(X86_64Register.rcx.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rcx)))
+    gprs.setR(X86_64Register.rdx.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rdx)))
+    gprs.setR(X86_64Register.rdi.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rdi)))
+    gprs.setR(X86_64Register.rsi.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rsi)))
+    gprs.setR(X86_64Register.rbp.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rbp)))
+    gprs.setR(X86_64Register.rsp.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_rsp)))
+    gprs.setR(X86_64Register.r8.rawValue,  to: UInt64(bitPattern: Int64(mctx.mc_r8)))
+    gprs.setR(X86_64Register.r9.rawValue,  to: UInt64(bitPattern: Int64(mctx.mc_r9)))
+    gprs.setR(X86_64Register.r10.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r10)))
+    gprs.setR(X86_64Register.r11.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r11)))
+    gprs.setR(X86_64Register.r12.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r12)))
+    gprs.setR(X86_64Register.r13.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r13)))
+    gprs.setR(X86_64Register.r14.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r14)))
+    gprs.setR(X86_64Register.r15.rawValue, to: UInt64(bitPattern: Int64(mctx.mc_r15)))
+    gprs.rip = UInt64(bitPattern: Int64(mctx.mc_rip))
+    gprs.rflags = UInt64(bitPattern: Int64(mctx.mc_rflags))
+    gprs.cs = UInt16(mctx.mc_cs)
+    gprs.fs = UInt16(mctx.mc_fs)
+    gprs.gs = UInt16(mctx.mc_gs)
+    gprs.valid = 0x1fffff
+  }
+
+  public static func fromHostMContext(_ mcontext: Any) -> HostContext {
+    return X86_64Context(with: mcontext as! mcontext_t)
+  }
+
   #endif
 
   #if os(Windows) || !SWIFT_ASM_AVAILABLE

--- a/stdlib/public/RuntimeModule/ImageMap+FreeBSD.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+FreeBSD.swift
@@ -1,0 +1,128 @@
+//===--- ImageMap+FreeBSD.swift --------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  FreeBSD specifics for ImageMap capture.
+//
+//===----------------------------------------------------------------------===//
+
+#if os(FreeBSD)
+
+import Swift
+
+internal import FreeBSD
+
+internal import BacktracingImpl.ImageFormats.Elf
+internal import BacktracingImpl.OS.FreeBSD
+
+fileprivate func readOSRelease() -> [String:String]? {
+  let result: String? = withUnsafeTemporaryAllocation(of: CChar.self, capacity: 256) { buffer in
+    let mib = [CTL_KERN, KERN_OSRELEASE]
+    var len: Int = 256
+    return mib.withUnsafeBufferPointer { mibp in
+      withUnsafeMutablePointer(to: &len) {
+        let result = sysctl(mibp.baseAddress, 2, buffer.baseAddress!, $0, nil, 0)
+        guard result != -1 else { return nil }
+        return String(cString: buffer.baseAddress!)
+      }
+    }
+  }
+
+  return result == nil ? nil : ["VERSION": result!]
+}
+
+extension ImageMap {
+
+  private static var platform = {
+    "FreeBSD"
+  }()
+
+  private struct AddressRange {
+    var low: Address = 0
+    var high: Address = 0
+  }
+
+  @_specialize(exported: true, kind: full, where M == UnsafeLocalMemoryReader)
+  @_specialize(exported: true, kind: full, where M == RemoteMemoryReader)
+  @_specialize(exported: true, kind: full, where M == LocalMemoryReader)
+  @_spi(Internal)
+  public static func capture<M: MemoryReader>(
+    using reader: M,
+    forProcess pid: Int? = nil
+  ) -> ImageMap {
+    var images: [Image] = []
+
+    let wordSize: WordSize
+
+    #if arch(x86_64) || arch(arm64) || arch(arm64_32)
+    wordSize = .sixtyFourBit
+    #elseif arch(i386) || arch(arm)
+    wordSize = .thirtyTwoBit
+    #endif
+
+    var vmmapCount: Int32 = 0
+    let cEntries = kinfo_getvmmap(Int32(pid ?? -1), &vmmapCount)
+    let entries = Array(UnsafeBufferPointer<kinfo_vmentry>(start: cEntries, count: Int(vmmapCount)))
+    free(cEntries)
+
+    var mappedFiles: [(String, AddressRange)] = []
+    for entry in entries {
+      if entry.kve_type == KVME_TYPE_VNODE {
+        let range = AddressRange(low: entry.kve_start, high: entry.kve_end)
+        let pathname: String = withUnsafePointer(to: entry.kve_path) { ptr in
+          let charptr =  UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+          return String(cString: charptr)
+        }
+
+        mappedFiles.append((pathname, range))
+      }
+    }
+
+    // Look at each mapped file to see if it's an ELF image
+    for (path, range) in mappedFiles {
+      // Extract the filename from path
+      let name: String
+      if let slashIndex = path.lastIndex(of: "/") {
+        name = String(path.suffix(from: path.index(after: slashIndex)))
+      } else {
+        name = String(path)
+      }
+
+      // Inspect the image and extract the UUID and end of text
+      guard let (endOfText, uuid) = getElfImageInfo(
+              at: M.Address(exactly: range.low)!,
+              using: reader
+            ) else {
+        // Not an ELF image
+        continue
+      }
+
+      let image = Image(name: String(name),
+                        path: String(path),
+                        uniqueID: uuid,
+                        baseAddress: range.low,
+                        endOfText: Address(endOfText))
+
+      images.append(image)
+    }
+
+    images.sort(by: { $0.baseAddress < $1.baseAddress })
+
+    return ImageMap(
+      platform: ImageMap.platform,
+      images: images,
+      wordSize: wordSize
+    )
+  }
+
+}
+
+#endif // os(FreeBSD)

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -182,7 +182,7 @@ public struct UncachedLocalMemoryReader: MemoryReader {
 }
 #endif
 
-#if os(Linux)
+#if os(Linux) || os(FreeBSD)
 @_spi(MemoryReaders) public struct POSIXError: Error {
   var errno: CInt
 }

--- a/stdlib/public/RuntimeModule/Runtime.swift
+++ b/stdlib/public/RuntimeModule/Runtime.swift
@@ -21,7 +21,7 @@ internal import BacktracingImpl.Runtime
 
 typealias CrashInfo = swift.runtime.backtrace.CrashInfo
 
-#if os(Linux)
+#if os(Linux) || os(FreeBSD)
 typealias memserver_req = swift.runtime.backtrace.memserver_req
 typealias memserver_resp = swift.runtime.backtrace.memserver_resp
 typealias thread = swift.runtime.backtrace.thread

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -34,6 +34,7 @@ set(BACKTRACING_SOURCES
   main.swift
   AnsiColor.swift
   TargetMacOS.swift
+  TargetFreeBSD.swift
   TargetLinux.swift
   Themes.swift
   Utils.swift
@@ -58,6 +59,7 @@ add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
   SWIFT_MODULE_DEPENDS_WINDOWS      ${wincrt_sdk}
   SWIFT_MODULE_DEPENDS_LINUX        ${glibc}
   SWIFT_MODULE_DEPENDS_LINUX_STATIC ${musl}
+  SWIFT_MODULE_DEPENDS_FREEBSD      ${glibc}
 
   DEPLOYMENT_VERSION_OSX ${osx_deployment_target}
 
@@ -66,7 +68,7 @@ add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
     ${BACKTRACING_COMPILE_FLAGS}
     -parse-as-library
 
-  TARGET_SDKS OSX LINUX)
+  TARGET_SDKS OSX LINUX FREEBSD)
 
 set(static_target_sdks)
 if(SWIFT_BUILD_STATIC_STDLIB)

--- a/stdlib/public/libexec/swift-backtrace/TargetFreeBSD.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetFreeBSD.swift
@@ -1,0 +1,314 @@
+//===--- TargetFreeBSD.swift - Represents a process we are inspecting -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines `Target`, which represents the process we are inspecting.
+//  This is the FreeBSD version.
+//
+//===----------------------------------------------------------------------===//
+
+#if os(FreeBSD)
+
+#if canImport(FreeBSD)
+import FreeBSD
+#endif
+
+import Runtime
+@_spi(Internal) import Runtime
+@_spi(Contexts) import Runtime
+@_spi(MemoryReaders) import Runtime
+@_spi(Utils) import Runtime
+
+enum SomeBacktrace {
+  case raw(Backtrace)
+  case symbolicated(SymbolicatedBacktrace)
+}
+
+struct TargetThread {
+  typealias ThreadID = pid_t
+
+  var id: ThreadID
+  var context: HostContext?
+  var name: String
+  var backtrace: SomeBacktrace
+}
+
+class Target {
+  typealias Address = UInt64
+
+  var pid: pid_t
+  var name: String
+  var signal: UInt64
+  var faultAddress: Address
+  var crashingThread: TargetThread.ThreadID
+
+  var images: ImageMap
+
+  var threads: [TargetThread] = []
+  var threadsInfo: [kinfo_proc] = []
+  var crashingThreadNdx: Int = -1
+
+  var signalName: String {
+    switch signal {
+      case UInt64(SIGQUIT): return "SIGQUIT"
+      case UInt64(SIGABRT): return "SIGABRT"
+      case UInt64(SIGBUS):  return "SIGBUS"
+      case UInt64(SIGFPE): return "SIGFPE"
+      case UInt64(SIGILL): return "SIGILL"
+      case UInt64(SIGSEGV): return "SIGSEGV"
+      case UInt64(SIGTRAP): return "SIGTRAP"
+      default: return "\(signal)"
+    }
+  }
+
+  var signalDescription: String {
+    switch signal {
+      case UInt64(SIGQUIT): return "Terminated"
+      case UInt64(SIGABRT): return "Aborted"
+      case UInt64(SIGBUS): return "Bus error"
+      case UInt64(SIGFPE): return "Floating point exception"
+      case UInt64(SIGILL): return "Illegal instruction"
+      case UInt64(SIGSEGV): return "Bad pointer dereference"
+      case UInt64(SIGTRAP): return "System trap"
+      default:
+        return "Signal \(signal)"
+    }
+  }
+
+  var reader: CachingMemoryReader<MemserverMemoryReader>
+
+  /// Get the name of a thread
+  private func getThreadName(tid: Int64) -> String {
+    guard
+      let info = threadsInfo.first(where: { $0.ki_tid == tid }),
+      info.ki_tdname.0 != 0
+    else { return String(tid, radix: 16) }
+
+    var tdname = info.ki_tdname
+    var moretdname = info.ki_moretdname
+
+    let name = withUnsafePointer(to: &tdname) {
+      String(cString: UnsafeRawPointer($0)!.assumingMemoryBound(to: CChar.self))
+    }
+    let morename = withUnsafePointer(to: &moretdname) {
+      String(cString: UnsafeRawPointer($0)!.assumingMemoryBound(to: CChar.self))
+    }
+
+    return name + morename
+  }
+
+  init(crashInfoAddr: UInt64, limit: Int?, top: Int, cache: Bool,
+       symbolicate: SwiftBacktrace.Symbolication) {
+    // fd #4 is reserved for the memory server
+    let memserverFd: CInt = 4
+
+    pid = getppid()
+    reader = CachingMemoryReader(for: MemserverMemoryReader(fd: memserverFd))
+
+    let crashInfo: CrashInfo
+    do {
+      crashInfo = try reader.fetch(from: crashInfoAddr, as: CrashInfo.self)
+    } catch {
+      print("swift-backtrace: unable to fetch crash info.")
+      exit(1)
+    }
+
+    crashingThread = TargetThread.ThreadID(crashInfo.crashing_thread)
+    signal = crashInfo.signal
+    faultAddress = crashInfo.fault_address
+
+    images = ImageMap.capture(using: reader, forProcess: Int(pid))
+
+    var threadsInfo = [kinfo_proc]()
+
+    for i in 0..<crashInfo.kinfo_proc_count {
+      do {
+        let offset = i * UInt64(MemoryLayout<kinfo_proc>.size)
+        let info = try reader.fetch(from: crashInfo.kinfo_proc_list + offset,
+                                    as: kinfo_proc.self)
+        threadsInfo.append(info)
+      } catch {
+        print("swift-backtrace: unable to fetch kinfo.")
+        exit(1)
+      }
+    }
+
+    self.threadsInfo = threadsInfo
+
+    if let firstThread = threadsInfo.first {
+      var comm = firstThread.ki_comm
+      name = withUnsafePointer(to: &comm) {
+        String(cString: UnsafeRawPointer($0)!.assumingMemoryBound(to: CChar.self))
+      }
+    } else {
+      name = ""
+    }
+
+    do {
+      try fetchThreads(threadListHead: Address(crashInfo.thread_list),
+                       limit: limit, top: top, cache: cache,
+                       symbolicate: symbolicate)
+    } catch {
+      print("swift-backtrace: failed to fetch thread information: \(error)")
+      exit(1)
+    }
+  }
+
+  /// Fetch information about all of the process's threads; the crash_info
+  /// structure contains a linked list of thread ucontexts, which may not
+  /// include every thread.  In particular, if a thread was stuck in an
+  /// uninterruptible wait, we won't have a ucontext for it.
+  func fetchThreads(
+    threadListHead: Address,
+    limit: Int?, top: Int, cache: Bool,
+    symbolicate: SwiftBacktrace.Symbolication
+  ) throws {
+    var next = threadListHead
+
+    while next != 0 {
+      let t = try reader.fetch(from: next, as: thread.self)
+
+      next = t.next
+
+      guard let ucontext
+              = try? reader.fetch(from: t.uctx, as: ucontext_t.self) else {
+	// This can happen if a thread is in an uninterruptible wait
+        continue
+      }
+
+      let context = HostContext.fromHostMContext(ucontext.uc_mcontext)
+      let backtrace = try Backtrace.capture(from: context,
+                                            using: reader,
+                                            images: images,
+                                            algorithm: .auto,
+                                            limit: limit,
+                                            offset: 0,
+                                            top: top)
+
+      let shouldSymbolicate: Bool
+      var options: Backtrace.SymbolicationOptions
+      switch symbolicate {
+        case .off:
+          shouldSymbolicate = false
+          options = []
+        case .fast:
+          shouldSymbolicate = true
+          options = [ .showSourceLocations ]
+        case .full:
+          shouldSymbolicate = true
+          options = [ .showInlineFrames, .showSourceLocations ]
+      }
+
+      if cache {
+        options.insert(.useSymbolCache)
+      }
+
+      if shouldSymbolicate {
+        guard let symbolicated = backtrace.symbolicated(
+                with: images,
+                options: options
+              ) else {
+          print("unable to symbolicate backtrace for thread \(t.tid)")
+          exit(1)
+        }
+
+        threads.append(TargetThread(id: TargetThread.ThreadID(t.tid),
+                                    context: context,
+                                    name: getThreadName(tid: t.tid),
+                                    backtrace: .symbolicated(symbolicated)))
+      } else {
+        threads.append(TargetThread(id: TargetThread.ThreadID(t.tid),
+                                    context: context,
+                                    name: getThreadName(tid: t.tid),
+                                    backtrace: .raw(backtrace)))
+      }
+    }
+
+    // Sort the threads by thread ID; the main thread always sorts
+    // lower than any other.
+    threads.sort {
+      return $0.id == pid || ($1.id != pid && $0.id < $1.id)
+    }
+
+    // Find the crashing thread index
+    if let ndx = threads.firstIndex(where: { $0.id == crashingThread }) {
+      crashingThreadNdx = ndx
+    } else {
+      print("unable to find the crashing thread")
+      exit(1)
+    }
+  }
+
+  func redoBacktraces(
+    limit: Int?, top: Int, cache: Bool,
+    symbolicate: SwiftBacktrace.Symbolication
+  ) {
+    for (ndx, thread) in threads.enumerated() {
+      guard let context = thread.context else {
+        continue
+      }
+
+      guard let backtrace = try? Backtrace.capture(from: context,
+                                                   using: reader,
+                                                   images: images,
+                                                   algorithm: .auto,
+                                                   limit: limit,
+                                                   offset: 0,
+                                                   top: top) else {
+        print("unable to capture backtrace from context for thread \(ndx)")
+        continue
+      }
+
+      let shouldSymbolicate: Bool
+      var options: Backtrace.SymbolicationOptions
+      switch symbolicate {
+        case .off:
+          shouldSymbolicate = false
+          options = []
+        case .fast:
+          shouldSymbolicate = true
+          options = [ .showSourceLocations ]
+        case .full:
+          shouldSymbolicate = true
+          options = [ .showInlineFrames, .showSourceLocations ]
+      }
+
+      if cache {
+        options.insert(.useSymbolCache)
+      }
+
+      if shouldSymbolicate {
+        guard let symbolicated = backtrace.symbolicated(
+                with: images,
+                options: options
+              ) else {
+          print("unable to symbolicate backtrace from context for thread \(ndx)")
+          continue
+        }
+
+        threads[ndx].backtrace = .symbolicated(symbolicated)
+      } else {
+        threads[ndx].backtrace = .raw(backtrace)
+      }
+    }
+  }
+
+  func withDebugger(_ body: () -> ()) throws {
+    print("""
+            From another shell, please run
+
+            lldb --attach-pid \(pid) -o c
+            """)
+    body()
+  }
+}
+
+#endif // os(FreeBSD)

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -30,7 +30,7 @@ internal import BacktracingImpl.Runtime
 
 typealias CrashInfo = swift.runtime.backtrace.CrashInfo
 
-#if os(Linux)
+#if os(Linux) || os(FreeBSD)
 typealias thread = swift.runtime.backtrace.thread
 #endif
 

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if (os(macOS) || os(Linux)) && (arch(x86_64) || arch(arm64))
+#if (os(macOS) || os(Linux) || os(FreeBSD)) && (arch(x86_64) || arch(arm64))
 
 #if canImport(Darwin)
 import Darwin
@@ -613,7 +613,7 @@ Generate a backtrace for the parent process.
     }
   }
 
-  #if os(Linux) || os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(Linux) || os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD)
   static func setRawMode() -> termios {
     var oldAttrs = termios()
     tcgetattr(0, &oldAttrs)
@@ -621,6 +621,8 @@ Generate a backtrace for the parent process.
     var newAttrs = oldAttrs
 
     #if os(Linux)
+    newAttrs.c_lflag &= ~UInt32(ICANON | ECHO)
+    #elseif os(FreeBSD)
     newAttrs.c_lflag &= ~UInt32(ICANON | ECHO)
     #else
     newAttrs.c_lflag &= ~UInt(ICANON | ECHO)

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -130,7 +130,7 @@ inline bool _swift_backtrace_isEnabled() {
 
 SWIFT_RUNTIME_STDLIB_INTERNAL ErrorCode _swift_installCrashHandler();
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(const ArgChar * const *argv, int memserver_fd);
 #else
 SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(const ArgChar * const *argv);

--- a/stdlib/public/runtime/CrashHandlerFreeBSD.cpp
+++ b/stdlib/public/runtime/CrashHandlerFreeBSD.cpp
@@ -1,0 +1,676 @@
+//===--- CrashHandlerFreeBSD.cpp - Swift crash handler for FreeBSD ------- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The FreeBSD crash handler implementation.
+//
+// We use signal handling rather than trying to use Mach exceptions here,
+// because the latter would entail running a separate Mach server thread, and
+// creates a much greater risk of interfering with the system wide Crash
+// Reporter, which is a no-no.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/thr.h>
+#include <sys/ucontext.h>
+#include <sys/user.h>
+#include <sys/umtx.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <pthread_np.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "swift/Runtime/Backtrace.h"
+
+#include <cstring>
+
+#include "BacktracePrivate.h"
+
+#ifndef lengthof
+#define lengthof(x)     (sizeof(x) / sizeof(x[0]))
+#endif
+
+using namespace swift::runtime::backtrace;
+
+namespace {
+
+void handle_fatal_signal(int signum, siginfo_t *pinfo, void *uctx);
+const struct kinfo_proc *suspend_other_threads(struct swift::runtime::backtrace::thread *, size_t*);
+void resume_other_threads();
+bool run_backtracer(int);
+
+int memserver_start();
+void* memserver_entry(void *fd);
+
+ssize_t safe_read(int fd, void *buf, size_t len) {
+  uint8_t *ptr = (uint8_t *)buf;
+  uint8_t *end = ptr + len;
+  ssize_t total = 0;
+
+  while (ptr < end) {
+    ssize_t ret;
+    do {
+      ret = read(fd, buf, len);
+    } while (ret < 0 && errno == EINTR);
+    if (ret < 0)
+      return ret;
+    total += ret;
+    ptr += ret;
+    len -= ret;
+  }
+
+  return total;
+}
+
+ssize_t safe_write(int fd, const void *buf, size_t len) {
+  const uint8_t *ptr = (const uint8_t *)buf;
+  const uint8_t *end = ptr + len;
+  ssize_t total = 0;
+
+  while (ptr < end) {
+    ssize_t ret;
+    do {
+      ret = write(fd, buf, len);
+    } while (ret < 0 && errno == EINTR);
+    if (ret < 0)
+      return ret;
+    total += ret;
+    ptr += ret;
+    len -= ret;
+  }
+
+  return total;
+}
+
+CrashInfo crashInfo;
+
+const int signalsToHandle[] = {
+  SIGQUIT,
+  SIGABRT,
+  SIGBUS,
+  SIGFPE,
+  SIGILL,
+  SIGSEGV,
+  SIGTRAP
+};
+
+} // namespace
+
+namespace swift {
+namespace runtime {
+namespace backtrace {
+
+SWIFT_RUNTIME_STDLIB_INTERNAL int
+_swift_installCrashHandler()
+{
+  stack_t ss;
+
+  // See if an alternate signal stack already exists
+  if (sigaltstack(NULL, &ss) < 0)
+    return errno;
+
+  if (ss.ss_sp == 0) {
+    // No, so set one up
+    ss.ss_flags = 0;
+    ss.ss_size = SIGSTKSZ;
+    ss.ss_sp = mmap(0, ss.ss_size, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (ss.ss_sp == MAP_FAILED)
+      return errno;
+
+    if (sigaltstack(&ss, NULL) < 0)
+      return errno;
+  }
+
+  // Now register signal handlers
+  struct sigaction sa;
+
+  sigfillset(&sa.sa_mask);
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n) {
+    sigdelset(&sa.sa_mask, signalsToHandle[n]);
+  }
+
+  sa.sa_handler = NULL;
+  sa.sa_flags = SA_ONSTACK | SA_SIGINFO | SA_NODEFER;
+  sa.sa_sigaction = handle_fatal_signal;
+
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n) {
+    struct sigaction osa;
+
+    // See if a signal handler for this signal is already installed
+    if (sigaction(signalsToHandle[n], NULL, &osa) < 0)
+      return errno;
+
+    if (osa.sa_handler == SIG_DFL) {
+      // No, so install ours
+      if (sigaction(signalsToHandle[n], &sa, NULL) < 0)
+        return errno;
+    }
+  }
+
+  return 0;
+}
+
+} // namespace backtrace
+} // namespace runtime
+} // namespace swift
+
+namespace {
+
+uint32_t threads_paused = 0;
+
+void
+warn(const char *str) {
+  write(STDERR_FILENO, str, strlen(str));
+}
+
+size_t _getpagesize()
+{
+  int mib[] = {CTL_HW, HW_PAGESIZE};
+  size_t page_size = 0, size_size = sizeof(page_size);
+  if (sysctl(mib, 2, &page_size, &size_size, NULL, 0) == -1) {
+    page_size = 4096;
+  }
+  return page_size;
+}
+
+int foreach_other_thread_kinfo(pid_t pid,
+                               long tid,
+                               const struct kinfo_proc ** kpp,
+                               size_t *threads_count,
+                               int (*perform)(const struct kinfo_proc* const))
+{
+  struct kinfo_proc *kp = NULL;
+  size_t page_size = _getpagesize();
+  size_t len = 0, count = 0, map_size = 0, sum = 0;
+  int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID | KERN_PROC_INC_THREAD, pid};
+
+  if (sysctl(mib, 4, NULL, &len, NULL, 0) == -1) {
+    return -1;
+  }
+
+  count = len / sizeof(struct kinfo_proc);
+  map_size = ((len / page_size) + (len % page_size ? 1 : 0)) * page_size;
+  kp = static_cast<struct kinfo_proc*>(mmap(NULL, map_size,
+                                            PROT_READ|PROT_WRITE,
+                                            MAP_PRIVATE|MAP_ANON, -1, 0));
+
+  if (sysctl(mib, 4, kp, &len, NULL, 0) == -1) {
+    munmap(kp, map_size);
+    return -1;
+  }
+
+  *kpp = kp;
+  *threads_count = count;
+
+  for (unsigned i = 0; i < count; ++i) {
+    if (kp[i].ki_tid != tid) {
+      if (perform(&kp[i]) != -1) {
+        sum++;
+      }
+    }
+  }
+
+  return sum;
+}
+
+void
+reset_threads(struct swift::runtime::backtrace::thread *first) {
+  __atomic_store_n(&crashInfo.thread_list, (uint64_t)first, __ATOMIC_RELEASE);
+}
+
+void
+add_thread(struct swift::runtime::backtrace::thread *thread) {
+  uint64_t next = __atomic_load_n(&crashInfo.thread_list, __ATOMIC_ACQUIRE);
+  do {
+    thread->next = next;
+  } while (!__atomic_compare_exchange_n(&crashInfo.thread_list, &next,
+                                        (uint64_t)thread,
+                                        false,
+                                        __ATOMIC_RELEASE, __ATOMIC_ACQUIRE));
+}
+
+void
+pause_thread(int signum __attribute__((unused)),
+             siginfo_t *pinfo __attribute__((unused)),
+             void *uctx)
+{
+  int old_err = errno;
+  long tid;
+  thr_self(&tid);
+
+  struct swift::runtime::backtrace::thread self = {  0, (int64_t)tid, (uint64_t)uctx };
+  add_thread(&self);
+
+  __atomic_fetch_add(&threads_paused, 1, __ATOMIC_RELEASE);
+  _umtx_op(&threads_paused, UMTX_OP_WAKE, 1, NULL, NULL);
+  thr_suspend(NULL);
+  errno = old_err;
+}
+
+void
+wait_paused(uint32_t expected, const struct timespec *timeout)
+{
+  uint32_t current;
+  do {
+    current = __atomic_load_n(&threads_paused, __ATOMIC_ACQUIRE);
+    if (current == expected)
+      return;
+  } while (!_umtx_op(&threads_paused, UMTX_OP_WAIT, current,
+                     const_cast<struct timespec*>(timeout), NULL));
+}
+
+const struct kinfo_proc *
+suspend_other_threads(struct swift::runtime::backtrace::thread* self, size_t *count)
+{
+  unsigned max_loops = 15;
+  struct sigaction sa, sa_old_prof, sa_old_usr1, sa_old_usr2;
+  pid_t pid = getpid();
+  long tid;
+  thr_self(&tid);
+
+  const struct kinfo_proc *kpp = nullptr;
+
+  reset_threads(self);
+
+  sigfillset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sa.sa_handler = NULL;
+  sa.sa_sigaction = pause_thread;
+
+  sigaction(SIGPROF, &sa, &sa_old_prof);
+  sigaction(SIGUSR1, &sa, &sa_old_usr1);
+  sigaction(SIGUSR2, &sa, &sa_old_usr2);
+
+  do {
+    int pending = foreach_other_thread_kinfo(pid, tid, &kpp, count, [](auto ki) {
+      sigset_t sigmask = ki->ki_sigmask;
+      int sig = !sigismember(&sigmask, SIGUSR1) ? SIGUSR1
+              : !sigismember(&sigmask, SIGUSR2) ? SIGUSR2
+              : !sigismember(&sigmask, SIGPROF) ? SIGPROF
+              : -1;
+      if (sig != -1) {
+        thr_kill(ki->ki_tid, sig);
+        return 0;
+      } else {
+        warn("swift-runtime: failed to suspend thread ");
+        warn(ki->ki_tdname);
+        warn(" while processing a crash; backtraces will be missing "
+            "information\n");
+        return -1;
+      }
+    });
+
+    if (pending) {
+      struct timespec timeout = { .tv_sec = 2, .tv_nsec = 0 };
+      wait_paused(pending, &timeout);
+    } else {
+      break;
+    }
+  } while (max_loops--);
+
+  sigaction(SIGPROF, &sa_old_prof, NULL);
+  sigaction(SIGUSR1, &sa_old_usr1, NULL);
+  sigaction(SIGUSR2, &sa_old_usr2, NULL);
+
+  return kpp;
+}
+
+void
+resume_other_threads()
+{
+  pthread_resume_all_np();
+}
+void
+reset_signal(int signum)
+{
+  struct sigaction sa;
+  sa.sa_handler = SIG_DFL;
+  sa.sa_flags = 0;
+  sigemptyset(&sa.sa_mask);
+
+  sigaction(signum, &sa, NULL);
+}
+
+void
+handle_fatal_signal(int signum,
+                    siginfo_t *pinfo,
+                    void *uctx)
+{
+  int old_err = errno;
+  long cur_thread;
+  size_t threads_count = 0;
+
+  thr_self(&cur_thread);
+
+  struct swift::runtime::backtrace::thread self = { 0, (int64_t)cur_thread, (uint64_t)uctx };
+
+  // Prevent this from exploding if more than one thread gets here at once
+  const struct kinfo_proc *kp = suspend_other_threads(&self, &threads_count);
+
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n)
+    signal(signalsToHandle[n], SIG_DFL);
+
+  crashInfo.crashing_thread = cur_thread;
+  crashInfo.signal = signum;
+  crashInfo.fault_address = (uint64_t)(uintptr_t)pinfo->si_addr;
+  crashInfo.kinfo_proc_list = (uint64_t)(uintptr_t)kp;
+  crashInfo.kinfo_proc_count = (uint64_t)threads_count;
+
+  int fd = memserver_start();
+
+  void *pc = 0;
+  ucontext_t *ctx = (ucontext_t *)uctx;
+
+#if defined(__x86_64__)
+  pc = (void *)ctx->uc_mcontext.mc_rip;
+#elif defined(__aarch64__) || defined(__arm64__)
+  pc = (void *)ctx->uc_mcontext.mc_gpregs.gp_x[15]
+#endif
+
+  _swift_displayCrashMessage(signum, pc);
+  if (!run_backtracer(fd)) {
+    const char *message = _swift_backtraceSettings.color == OnOffTty::On
+      ? " failed\n\n" : " failed ***\n\n";
+    if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
+      write(STDERR_FILENO, message, strlen(message));
+    else
+      write(STDOUT_FILENO, message, strlen(message));
+  }
+  reset_signal(SIGSEGV);
+  reset_signal(SIGBUS);
+
+  // Restart the other threads
+  resume_other_threads();
+
+  // Restore errno and exit (to crash)
+  errno = old_err;
+}
+
+char memserver_buffer[4096];
+sigjmp_buf memserver_fault_buf;
+
+int
+memserver_start()
+{
+  int ret;
+  int fds[2];
+  pthread_t thread;
+  ret = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+  if (ret < 0)
+    return ret;
+  // XXX: pthread_create is not async-signal-safe
+  ret = pthread_create(&thread, NULL, memserver_entry, (void *)(intptr_t)fds[0]);
+  if (ret < 0) {
+    close(fds[0]);
+    close(fds[1]);
+    return ret;
+  }
+  return fds[1];
+}
+
+
+void
+memserver_fault(int sig) {
+  (void)sig;
+  siglongjmp(memserver_fault_buf, -1);
+}
+
+ssize_t __attribute__((noinline))
+memserver_read(void *to, const void *from, size_t len) {
+  if (!sigsetjmp(memserver_fault_buf, 1)) {
+    memcpy(to, from, len);
+    return len;
+  } else {
+    return -1;
+  }
+}
+
+void*
+memserver_entry(void *fdp) {
+  int fd = (int)(intptr_t)fdp;
+  int result = -1;
+
+  struct sigaction sa;
+  sigfillset(&sa.sa_mask);
+  sa.sa_handler = memserver_fault;
+  sa.sa_flags = SA_NODEFER;
+  sigaction(SIGSEGV, &sa, NULL);
+  sigaction(SIGBUS, &sa, NULL);
+
+  for (;;) {
+    struct memserver_req req;
+    ssize_t ret;
+
+    ret = safe_read(fd, &req, sizeof(req));
+    if (ret != sizeof(req))
+      break;
+
+    uint64_t addr = req.addr;
+    uint64_t bytes = req.len;
+
+    while (bytes) {
+      uint64_t todo = (bytes < sizeof(memserver_buffer)
+                       ? bytes : sizeof(memserver_buffer));
+      ret = memserver_read(memserver_buffer, (void *)addr, (size_t)todo);
+      struct memserver_resp resp;
+
+      resp.addr = addr;
+      resp.len = ret;
+      ret = safe_write(fd, &resp, sizeof(resp));
+      if (ret != sizeof(resp))
+        goto fail;
+
+      if (resp.len < 0)
+        break;
+      ret = safe_write(fd, memserver_buffer, resp.len);
+      if (ret != resp.len)
+        goto fail;
+
+      addr += resp.len;
+      bytes -= resp.len;
+    }
+  }
+
+  result = 0;
+
+fail:
+  close(fd);
+
+  return nullptr;
+}
+
+char addr_buf[18];
+char timeout_buf[22];
+char limit_buf[22];
+char top_buf[22];
+const char *backtracer_argv[] = {
+  "swift-backtrace",            // 0
+  "--unwind",                   // 1
+  "precise",                    // 2
+  "--demangle",                 // 3
+  "true",                       // 4
+  "--interactive",              // 5
+  "true",                       // 6
+  "--color",                    // 7
+  "true",                       // 8
+  "--timeout",                  // 9
+  timeout_buf,                  // 10
+  "--preset",                   // 11
+  "friendly",                   // 12
+  "--crashinfo",                // 13
+  addr_buf,                     // 14
+  "--threads",                  // 15
+  "preset",                     // 16
+  "--registers",                // 17
+  "preset",                     // 18
+  "--images",                   // 19
+  "preset",                     // 20
+  "--limit",                    // 21
+  limit_buf,                    // 22
+  "--top",                      // 23
+  top_buf,                      // 24
+  "--sanitize",                 // 25
+  "preset",                     // 26
+  "--cache",                    // 27
+  "true",                       // 28
+  "--output-to",                // 29
+  "stdout",                     // 30
+  "--symbolicate",              // 31
+  "true",                       // 32
+  NULL
+};
+
+const char *
+trueOrFalse(bool b) {
+  return b ? "true" : "false";
+}
+
+const char *
+trueOrFalse(OnOffTty oot) {
+  return trueOrFalse(oot == OnOffTty::On);
+}
+
+bool
+run_backtracer(int memserver_fd)
+{
+  // Set-up the backtracer's command line arguments
+  switch (_swift_backtraceSettings.algorithm) {
+  case UnwindAlgorithm::Fast:
+    backtracer_argv[2] = "fast";
+    break;
+  default:
+    backtracer_argv[2] = "precise";
+    break;
+  }
+
+  // (The TTY option has already been handled at this point, so these are
+  //  all either "On" or "Off".)
+  backtracer_argv[4] = trueOrFalse(_swift_backtraceSettings.demangle);
+  backtracer_argv[6] = trueOrFalse(_swift_backtraceSettings.interactive);
+  backtracer_argv[8] = trueOrFalse(_swift_backtraceSettings.color);
+
+  switch (_swift_backtraceSettings.threads) {
+  case ThreadsToShow::Preset:
+    backtracer_argv[16] = "preset";
+    break;
+  case ThreadsToShow::All:
+    backtracer_argv[16] = "all";
+    break;
+  case ThreadsToShow::Crashed:
+    backtracer_argv[16] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.registers) {
+  case RegistersToShow::Preset:
+    backtracer_argv[18] = "preset";
+    break;
+  case RegistersToShow::None:
+    backtracer_argv[18] = "none";
+    break;
+  case RegistersToShow::All:
+    backtracer_argv[18] = "all";
+    break;
+  case RegistersToShow::Crashed:
+    backtracer_argv[18] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.images) {
+  case ImagesToShow::Preset:
+    backtracer_argv[20] = "preset";
+    break;
+  case ImagesToShow::None:
+    backtracer_argv[20] = "none";
+    break;
+  case ImagesToShow::All:
+    backtracer_argv[20] = "all";
+    break;
+  case ImagesToShow::Mentioned:
+    backtracer_argv[20] = "mentioned";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.preset) {
+  case Preset::Friendly:
+    backtracer_argv[12] = "friendly";
+    break;
+  case Preset::Medium:
+    backtracer_argv[12] = "medium";
+    break;
+  default:
+    backtracer_argv[12] = "full";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.sanitize) {
+  case SanitizePaths::Preset:
+    backtracer_argv[26] = "preset";
+    break;
+  case SanitizePaths::Off:
+    backtracer_argv[26] = "false";
+    break;
+  case SanitizePaths::On:
+    backtracer_argv[26] = "true";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.outputTo) {
+  case OutputTo::Stdout:
+    backtracer_argv[30] = "stdout";
+    break;
+  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
+  case OutputTo::Stderr:
+    backtracer_argv[30] = "stderr";
+    break;
+  }
+
+  backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
+
+  switch (_swift_backtraceSettings.symbolicate) {
+  case Symbolication::Off:
+    backtracer_argv[32] = "off";
+    break;
+  case Symbolication::Fast:
+    backtracer_argv[32] = "fast";
+    break;
+  case Symbolication::Full:
+    backtracer_argv[32] = "full";
+    break;
+  }
+
+  _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
+
+  if (_swift_backtraceSettings.limit < 0)
+    std::strcpy(limit_buf, "none");
+  else
+    _swift_formatUnsigned(_swift_backtraceSettings.limit, limit_buf);
+
+  _swift_formatUnsigned(_swift_backtraceSettings.top, top_buf);
+  _swift_formatAddress(&crashInfo, addr_buf);
+
+  // Actually execute it
+  return _swift_spawnBacktracer(backtracer_argv, memserver_fd);
+}
+
+} // namespace
+
+#endif // __FreeBSD__


### PR DESCRIPTION
This implements Crash Handler for x86_64 FreeBSD. The implementation is similar to Linux, and base on `memserver`.

The FreeBSD implementation differs the Linux one in a few ways:
1. On crash, the fatal signal handler uses `sysctl(3)` instead of reading `/proc/self` to gather a snapshot of the current threads info and find the signal mask of all threads.   This snapshot is also stored to `CrashInfo` for `swift-backtrace` to recover various metadata such as thread name without reading `/proc/*`

2. Instead of holding a lock, this implementation utilize `thr_suspend` to suspend the threads, and `pthread_resume_all_np` to resume all threads.

3. The `swift-backtrace` utility read from `sysctl(3)` to determine the imagemap instead of reading /proc.

This is currently tested on x86_64 FreeBSD:
- [x] Reading registers value
- [x] Reading remote memory
- [x] Listing the image map
- ⚠️ backtrace symbolization (only C functions are symbolized)
