### PR TITLE
AST/Sema: Continue adopting AvailabilityConstraint

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -703,23 +703,6 @@ public:
   }
 };
 
-/// Determine the result of comparing an availability attribute to a specific
-/// platform or language version.
-enum class AvailableVersionComparison {
-  /// The entity is guaranteed to be available.
-  Available,
-
-  /// The entity is never available.
-  Unavailable,
-
-  /// The entity might be unavailable at runtime, because it was introduced
-  /// after the requested minimum platform version.
-  PotentiallyUnavailable,
-
-  /// The entity has been obsoleted.
-  Obsoleted,
-};
-
 /// Defines the @available attribute.
 class AvailableAttr : public DeclAttribute {
 public:
@@ -3377,12 +3360,6 @@ public:
   /// version for swift version-specific availability kind, PackageDescription
   /// version for PackageDescription version-specific availability.
   llvm::VersionTuple getActiveVersion(const ASTContext &ctx) const;
-
-  /// Compare this attribute's version information against the platform or
-  /// language version (assuming the this attribute pertains to the active
-  /// platform).
-  AvailableVersionComparison
-  getVersionAvailability(const ASTContext &ctx) const;
 
   /// Returns true if this attribute is considered active in the current
   /// compilation context.

--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -22,6 +22,7 @@
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/OptionSet.h"
 
 namespace swift {
 
@@ -165,12 +166,22 @@ public:
   const_iterator end() const { return constraints.end(); }
 };
 
+enum class AvailabilityConstraintFlag : uint8_t {
+  /// By default, the availability constraints for the members of extensions
+  /// include the constraints for `@available` attributes that were written on
+  /// the enclosing extension, since these members can be referred to without
+  /// referencing the extension. When this flag is specified, though, only the
+  /// attributes directly attached to the declaration are considered.
+  SkipEnclosingExtension = 1 << 0,
+};
+using AvailabilityConstraintFlags = OptionSet<AvailabilityConstraintFlag>;
+
 /// Returns the set of availability constraints that restrict use of \p decl
 /// when it is referenced from the given context. In other words, it is the
 /// collection of of `@available` attributes with unsatisfied conditions.
-DeclAvailabilityConstraints
-getAvailabilityConstraintsForDecl(const Decl *decl,
-                                  const AvailabilityContext &context);
+DeclAvailabilityConstraints getAvailabilityConstraintsForDecl(
+    const Decl *decl, const AvailabilityContext &context,
+    AvailabilityConstraintFlags flags = std::nullopt);
 } // end namespace swift
 
 #endif

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -24,7 +24,7 @@ PlatformKind AvailabilityConstraint::getPlatform() const {
 
 std::optional<AvailabilityRange>
 AvailabilityConstraint::getRequiredNewerAvailabilityRange(
-    ASTContext &ctx) const {
+    const ASTContext &ctx) const {
   switch (getReason()) {
   case Reason::UnconditionallyUnavailable:
   case Reason::Obsoleted:
@@ -35,13 +35,86 @@ AvailabilityConstraint::getRequiredNewerAvailabilityRange(
   }
 }
 
-bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
+bool AvailabilityConstraint::isActiveForRuntimeQueries(
+    const ASTContext &ctx) const {
   if (getAttr().getPlatform() == PlatformKind::none)
     return true;
 
   return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
                                  /*forTargetVariant=*/false,
                                  /*forRuntimeQuery=*/true);
+}
+
+static bool constraintIsStronger(const AvailabilityConstraint &lhs,
+                                 const AvailabilityConstraint &rhs) {
+  DEBUG_ASSERT(lhs.getDomain() == rhs.getDomain());
+
+  // If the constraints have matching domains but different reasons, the
+  // constraint with the lowest reason is "strongest".
+  if (lhs.getReason() != rhs.getReason())
+    return lhs.getReason() < rhs.getReason();
+
+  switch (lhs.getReason()) {
+  case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
+    // Just keep the first.
+    return false;
+
+  case AvailabilityConstraint::Reason::Obsoleted:
+    // Pick the earliest obsoleted version.
+    return *lhs.getAttr().getObsoleted() < *rhs.getAttr().getObsoleted();
+
+  case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+  case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+    // Pick the latest introduced version.
+    return *lhs.getAttr().getIntroduced() > *rhs.getAttr().getIntroduced();
+  }
+}
+
+void addConstraint(llvm::SmallVector<AvailabilityConstraint, 4> &constraints,
+                   const AvailabilityConstraint &constraint,
+                   const ASTContext &ctx) {
+
+  auto iter = llvm::find_if(
+      constraints, [&constraint](AvailabilityConstraint &existing) {
+        return constraint.getDomain() == existing.getDomain();
+      });
+
+  // There's no existing constraint for the same domain so just add it.
+  if (iter == constraints.end()) {
+    constraints.emplace_back(constraint);
+    return;
+  }
+
+  if (constraintIsStronger(constraint, *iter)) {
+    constraints.erase(iter);
+    constraints.emplace_back(constraint);
+  }
+}
+
+std::optional<AvailabilityConstraint>
+DeclAvailabilityConstraints::getPrimaryConstraint() const {
+  std::optional<AvailabilityConstraint> result;
+
+  auto isStrongerConstraint = [](const AvailabilityConstraint &lhs,
+                                 const AvailabilityConstraint &rhs) {
+    // Constraint reasons are defined in descending order of strength.
+    if (lhs.getReason() != rhs.getReason())
+      return lhs.getReason() < rhs.getReason();
+
+    // Pick the constraint from the broader domain.
+    if (lhs.getDomain() != rhs.getDomain())
+      return rhs.getDomain().contains(lhs.getDomain());
+    
+    return false;
+  };
+
+  // Pick the strongest constraint.
+  for (auto const &constraint : constraints) {
+    if (!result || isStrongerConstraint(constraint, *result))
+      result.emplace(constraint);
+  }
+
+  return result;
 }
 
 static bool
@@ -65,13 +138,12 @@ isInsideCompatibleUnavailableDeclaration(const Decl *decl,
   return context.containsUnavailableDomain(domain);
 }
 
-std::optional<AvailabilityConstraint>
-swift::getAvailabilityConstraintForAttr(const Decl *decl,
-                                        const SemanticAvailableAttr &attr,
-                                        const AvailabilityContext &context) {
-  if (isInsideCompatibleUnavailableDeclaration(decl, attr, context))
-    return std::nullopt;
-
+/// Returns the `AvailabilityConstraint` that describes how \p attr restricts
+/// use of \p decl in \p context or `std::nullopt` if there is no restriction.
+static std::optional<AvailabilityConstraint>
+getAvailabilityConstraintForAttr(const Decl *decl,
+                                 const SemanticAvailableAttr &attr,
+                                 const AvailabilityContext &context) {
   if (attr.isUnconditionallyUnavailable())
     return AvailabilityConstraint::unconditionallyUnavailable(attr);
 
@@ -128,10 +200,10 @@ activePlatformDomainForDecl(const Decl *decl) {
   return activeDomain;
 }
 
-static void
-getAvailabilityConstraintsForDecl(DeclAvailabilityConstraints &constraints,
-                                  const Decl *decl,
-                                  const AvailabilityContext &context) {
+static void getAvailabilityConstraintsForDecl(
+    llvm::SmallVector<AvailabilityConstraint, 4> &constraints, const Decl *decl,
+    const AvailabilityContext &context) {
+  auto &ctx = decl->getASTContext();
   auto activePlatformDomain = activePlatformDomainForDecl(decl);
 
   for (auto attr :
@@ -141,20 +213,27 @@ getAvailabilityConstraintsForDecl(DeclAvailabilityConstraints &constraints,
         !activePlatformDomain->contains(domain))
       continue;
 
-    if (auto constraint =
-            swift::getAvailabilityConstraintForAttr(decl, attr, context))
-      constraints.addConstraint(*constraint);
+    if (auto constraint = getAvailabilityConstraintForAttr(decl, attr, context))
+      addConstraint(constraints, *constraint, ctx);
   }
+
+  // After resolving constraints, remove any constraints that indicate the
+  // declaration is unconditionally unavailable in a domain for which
+  // the context is already unavailable.
+  llvm::erase_if(constraints, [&](const AvailabilityConstraint &constraint) {
+    return isInsideCompatibleUnavailableDeclaration(decl, constraint.getAttr(),
+                                                    context);
+  });
 }
 
 DeclAvailabilityConstraints
 swift::getAvailabilityConstraintsForDecl(const Decl *decl,
                                          const AvailabilityContext &context) {
-  DeclAvailabilityConstraints constraints;
+  llvm::SmallVector<AvailabilityConstraint, 4> constraints;
 
   // Generic parameters are always available.
   if (isa<GenericTypeParamDecl>(decl))
-    return constraints;
+    return DeclAvailabilityConstraints();
 
   decl = abstractSyntaxDeclForAvailableAttribute(decl);
 

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -228,7 +228,8 @@ static void getAvailabilityConstraintsForDecl(
 
 DeclAvailabilityConstraints
 swift::getAvailabilityConstraintsForDecl(const Decl *decl,
-                                         const AvailabilityContext &context) {
+                                         const AvailabilityContext &context,
+                                         AvailabilityConstraintFlags flags) {
   llvm::SmallVector<AvailabilityConstraint, 4> constraints;
 
   // Generic parameters are always available.
@@ -238,6 +239,9 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
   decl = abstractSyntaxDeclForAvailableAttribute(decl);
 
   getAvailabilityConstraintsForDecl(constraints, decl, context);
+
+  if (flags.contains(AvailabilityConstraintFlag::SkipEnclosingExtension))
+    return constraints;
 
   // If decl is an extension member, query the attributes of the extension, too.
   //

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -202,7 +202,10 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
   bool isConstrained = false;
 
   Info info{storage->info};
-  auto constraints = swift::getAvailabilityConstraintsForDecl(decl, *this);
+  AvailabilityConstraintFlags flags =
+      AvailabilityConstraintFlag::SkipEnclosingExtension;
+  auto constraints =
+      swift::getAvailabilityConstraintsForDecl(decl, *this, flags);
   isConstrained |= info.constrainWith(constraints, decl->getASTContext());
   isConstrained |= CONSTRAIN_BOOL(info.IsDeprecated, decl->isDeprecated());
   isConstrained |= constrainRange(info.Range, platformRange);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -20,6 +20,7 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeChecker.h"
+#include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -240,8 +241,8 @@ checkAvailability(const EnumElementDecl *elt,
                   AvailabilityContext availabilityContext,
                   std::optional<RuntimeVersionCheck> &versionCheck) {
   auto &C = elt->getASTContext();
-  auto constraint =
-      getUnsatisfiedAvailabilityConstraint(elt, availabilityContext);
+  auto constraint = getAvailabilityConstraintsForDecl(elt, availabilityContext)
+                        .getPrimaryConstraint();
 
   // Is it always available?
   if (!constraint)

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -201,13 +201,6 @@ public:
   /// Get the ExportabilityReason for diagnostics. If this is 'None', there
   /// are no restrictions on referencing unexported declarations.
   std::optional<ExportabilityReason> getExportabilityReason() const;
-
-  /// If \p decl is unconditionally unavailable in this context, and the context
-  /// is not also unavailable in the same way, then this returns the specific
-  /// `@available` attribute that makes the decl unavailable. Otherwise, returns
-  /// nullptr.
-  std::optional<SemanticAvailableAttr>
-  shouldDiagnoseDeclAsUnavailable(const Decl *decl) const;
 };
 
 /// Check if a declaration is exported as part of a module's external interface.

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -251,14 +251,6 @@ void diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
                                        SemanticAvailableAttr attr);
 
 /// Checks whether a declaration should be considered unavailable when referred
-/// to in the given declaration context and availability context and, if so,
-/// returns a result that describes the unsatisfied constraint.
-/// Returns `std::nullopt` if the declaration is available.
-std::optional<AvailabilityConstraint>
-getUnsatisfiedAvailabilityConstraint(const Decl *decl,
-                                     AvailabilityContext availabilityContext);
-
-/// Checks whether a declaration should be considered unavailable when referred
 /// to at the given source location in the given decl context and, if so,
 /// returns a result that describes the unsatisfied constraint.
 /// Returns `std::nullopt` if the declaration is available.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4964,12 +4964,16 @@ static bool diagnoseTypeWitnessAvailability(
   bool shouldError =
       ctx.LangOpts.EffectiveLanguageVersion.isVersionAtLeast(warnBeforeVersion);
 
-  if (auto attr = where.shouldDiagnoseDeclAsUnavailable(witness)) {
+  auto constraint =
+      getAvailabilityConstraintsForDecl(witness, where.getAvailability())
+          .getPrimaryConstraint();
+  if (constraint && constraint->isUnavailable()) {
+    auto attr = constraint->getAttr();
     ctx.addDelayedConformanceDiag(
         conformance, shouldError,
         [witness, assocType, attr](NormalProtocolConformance *conformance) {
           SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
-          EncodedDiagnosticMessage encodedMessage(attr->getMessage());
+          EncodedDiagnosticMessage encodedMessage(attr.getMessage());
           auto &ctx = conformance->getDeclContext()->getASTContext();
           ctx.Diags
               .diagnose(loc, diag::witness_unavailable, witness,

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -140,5 +140,5 @@ class C_50734<@NSApplicationMain T: AnyObject> {} // expected-error {{@NSApplica
 func f6_50734<@discardableResult T>(x: T) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 enum E_50734<@indirect T> {} // expected-error {{'indirect' is a declaration modifier, not an attribute}} expected-error {{'indirect' modifier cannot be applied to this declaration}}
 protocol P {
-  @available(swift, introduced: 4) associatedtype Assoc
+  @available(macOS, introduced: 10.9) associatedtype Assoc
 }

--- a/test/Sema/availability_scopes.swift
+++ b/test/Sema/availability_scopes.swift
@@ -358,7 +358,7 @@ extension SomeEnum {
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=availableMacOS_52
 // CHECK-NEXT: {{^}}      (decl version=50 unavailable=* decl=neverAvailable()
 
 @available(macOS, unavailable)

--- a/test/Sema/availability_scopes.swift
+++ b/test/Sema/availability_scopes.swift
@@ -358,7 +358,7 @@ extension SomeEnum {
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}        (decl version=52 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=availableMacOS_52
 // CHECK-NEXT: {{^}}      (decl version=50 unavailable=* decl=neverAvailable()
 
 @available(macOS, unavailable)

--- a/test/attr/attr_availability_swiftpm_v4.swift
+++ b/test/attr/attr_availability_swiftpm_v4.swift
@@ -37,6 +37,9 @@ func fourPointOh() {}
 @available(_PackageDescription 4)
 class ShortFour {}
 
+@available(_PackageDescription 99)
+func ninetyNine() {} // expected-note {{'ninetyNine()' was introduced in PackageDescription 99}}
+
 shortThree()
 threePointOh()
 threePointOhOnly() // expected-error {{is unavailable}}
@@ -51,6 +54,7 @@ shortFourPointOh()
 four()
 fourPointOh()
 let aa : ShortFour
+ninetyNine() // expected-error {{'ninetyNine()' is unavailable}}
 
 @available(_PackageDescription, introduced: 4.0)
 @available(*, deprecated, message: "test deprecated")
@@ -63,3 +67,15 @@ func shouldBeAlone() {}
 
 @available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}} // expected-error {{'swift' version-availability must be specified alone}}
 func shouldBeAlone2() {} 
+
+@available(*, unavailable, renamed: "shortFour")
+@available(_PackageDescription 3)
+func unconditionallyRenamed() {} // expected-note {{'unconditionallyRenamed()' has been explicitly marked unavailable here}}
+
+unconditionallyRenamed() // expected-error {{'unconditionallyRenamed()' has been renamed to 'shortFour'}}
+
+@available(*, unavailable, renamed: "shortFour")
+@available(_PackageDescription 5)
+func unconditionallyRenamedAndIntroducedLater() {} // expected-note {{'unconditionallyRenamedAndIntroducedLater()' has been explicitly marked unavailable here}}
+
+unconditionallyRenamedAndIntroducedLater() // expected-error {{'unconditionallyRenamedAndIntroducedLater()' has been renamed to 'shortFour'}}

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -533,6 +533,9 @@ func available_func_call_extension_methods(_ e: ExtendMe) { // expected-note {{a
   // expected-note@-1 {{add 'if #available' version check}}
 }
 
+@available(OSX, obsoleted: 10.9)
+struct OSXObsoleted {} // expected-note 2 {{'OSXObsoleted' was obsoleted in macOS 10.9}}
+
 @available(OSX, unavailable)
 @available(OSX, introduced: 99)
 struct OSXUnavailableAndIntroducedInFuture {}
@@ -547,32 +550,33 @@ struct OSXIntroducedInFutureAndUnavailable {}
 @available(OSX, unavailable)
 func osx_unavailable_func(
   _ s1: OSXFutureAvailable,
-  _ s2: OSXUnavailableAndIntroducedInFuture,
-  _ s3: OSXUnavailableAndIntroducedInFutureSameAttribute,
-  _ s4: OSXIntroducedInFutureAndUnavailable,
+  _ s2: OSXObsoleted,
+  _ s3: OSXUnavailableAndIntroducedInFuture,
+  _ s4: OSXUnavailableAndIntroducedInFutureSameAttribute,
+  _ s5: OSXIntroducedInFutureAndUnavailable,
 ) -> (
   OSXFutureAvailable,
+  OSXObsoleted,
   OSXUnavailableAndIntroducedInFuture,
   OSXUnavailableAndIntroducedInFutureSameAttribute,
   OSXIntroducedInFutureAndUnavailable
 ) {
+  // FIXME: [availability] Stop diagnosing potential unavailability or obsoletion in an unavailable context.
   _ = OSXFutureAvailable() // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
-  // FIXME: [availability] The following diagnostic is incorrect
-  _ = OSXUnavailableAndIntroducedInFuture() // expected-error {{'OSXUnavailableAndIntroducedInFuture' is only available in macOS 99 or newer}}
-  // expected-note@-1 {{add 'if #available' version check}}
+  _ = OSXObsoleted() // expected-error {{'OSXObsoleted' is unavailable in macOS}}
+  _ = OSXUnavailableAndIntroducedInFuture()
   _ = OSXUnavailableAndIntroducedInFutureSameAttribute()
   _ = OSXIntroducedInFutureAndUnavailable()
 
   func takesType<T>(_ t: T.Type) {}
   takesType(OSXFutureAvailable.self) // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
-  // FIXME: [availability] The following diagnostic is incorrect
-  takesType(OSXUnavailableAndIntroducedInFuture.self) // expected-error {{'OSXUnavailableAndIntroducedInFuture' is only available in macOS 99 or newer}}
-  // expected-note@-1 {{add 'if #available' version check}}
+  takesType(OSXObsoleted.self) // expected-error {{'OSXObsoleted' is unavailable in macOS}}
+  takesType(OSXUnavailableAndIntroducedInFuture.self)
   takesType(OSXUnavailableAndIntroducedInFutureSameAttribute.self)
   takesType(OSXIntroducedInFutureAndUnavailable.self)
 
-  return (s1, s2, s3, s4)
+  return (s1, s2, s3, s4, s5)
 }
 

--- a/test/decl/ext/objc_implementation_direct_to_storage.swift
+++ b/test/decl/ext/objc_implementation_direct_to_storage.swift
@@ -4,22 +4,20 @@
 
 import objc_implementation_internal
 
+// FIXME: [availability] An implementation that is less available than the interface it implements should be diagnosed
 @available(*, unavailable)
 @objc @implementation extension ObjCPropertyTest {
-  // FIXME: Shouldn't this be on the `@available` above?
-  // expected-note@+1 {{'prop1' has been explicitly marked unavailable here}}
   let prop1: Int32
 
-  // expected-note@+1 2 {{'prop2' has been explicitly marked unavailable here}}
   var prop2: Int32 {
     didSet {
-      _ = prop2 // expected-error {{'prop2' is unavailable}}
+      _ = prop2
     }
   }
 
   override init() {
-    self.prop1 = 1 // expected-error {{'prop1' is unavailable}}
-    self.prop2 = 2 // expected-error {{'prop2' is unavailable}}
+    self.prop1 = 1
+    self.prop2 = 2
     super.init()
   }
 
@@ -27,4 +25,9 @@ import objc_implementation_internal
     _ = self.prop1
     _ = self.prop2
   }
+}
+
+func takesObjCPropertyTest(_ o: ObjCPropertyTest) {
+  _ = o.prop1
+  _ = o.prop2
 }

--- a/test/decl/protocol/associated_type_availability.swift
+++ b/test/decl/protocol/associated_type_availability.swift
@@ -89,6 +89,6 @@ protocol P3 {
   @available(macOS, obsoleted: 12) // expected-error{{associated type cannot be marked unavailable with '@available'}}
   associatedtype A1
 
-  @available(macOS, obsoleted: 99) // FIXME: this should probably be diagnosed
+  @available(macOS, obsoleted: 99)
   associatedtype A2
 }

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -104,6 +104,15 @@ protocol UnavailableAssoc {
   @available(*, unavailable) // expected-error {{associated type cannot be marked unavailable with '@available'}}
   associatedtype A1
 
-  @available(swift, introduced: 99) // expected-error {{associated type cannot be marked unavailable with '@available'}}
+  @available(swift, introduced: 4)
   associatedtype A2
+
+  @available(swift, introduced: 99) // expected-error {{associated type cannot be marked unavailable with '@available'}}
+  associatedtype A3
+
+  @available(swift, obsoleted: 4) // expected-error {{associated type cannot be marked unavailable with '@available'}}
+  associatedtype A4
+
+  @available(swift, obsoleted: 99)
+  associatedtype A5
 }


### PR DESCRIPTION
Builds on top of https://github.com/swiftlang/swift/pull/79249 by reimplementing various availability diagnostics and queries on top of `swift::getAvailabilityConstraintsForDecl()`.