### PR TITLE
[test] Remove now unused variables in the lit.cfg for the Android emulator

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1878,22 +1878,9 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
                                            target_specific_module_triple)
     config.variant_triple = re.sub(r'androideabi', 'android', config.variant_triple)
     config.target_cc_options = "-fPIE"
-    def get_architecture_value(**kwargs):
-        result = kwargs[run_cpu]
-        if result is None:
-          if run_cpu.startswith("armv7"):
-            result = kwargs["armv7"]
-          elif run_cpu == "arm64":
-            result = kwards["aarch64"]
-        return result
-
     config.target_cxx_lib = "-lstdc++"
     config.target_pic_opt = "-fPIC"
 
-    ndk_platform_tuple = get_architecture_value(armv7="armeabi-v7a",
-                                                aarch64="arm64-v8a")
-    ndk_platform_triple = get_architecture_value(armv7="arm-linux-androideabi",
-                                                 aarch64="aarch64-linux-android")
     if platform.system() == 'Linux':
         prebuilt_directory = 'linux-x86_64'
     elif platform.system() == 'Darwin':


### PR DESCRIPTION
This should fix [the new community Android x86_64 CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-24.04-android-build/) from @marcprux.

Fixes #63907