### PR TITLE
Runtimes: use the static module constructor in swiftCore

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -306,7 +306,8 @@ target_link_libraries(swiftCore
     swiftDemangling
     swiftShims
     swiftStdlibStubs
-    swiftThreading)
+    swiftThreading
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt$<$<PLATFORM_ID:Windows>:T>>)
 target_link_options(swiftCore PRIVATE
   -nostartfiles)
 if(NOT POLICY CMP0157)


### PR DESCRIPTION
Use the static module constructor for swiftCore on Windows as the runtime functions are internal to the module. This fixes the last linker warning that we see with the standard library build when building dynamically. More importantly, this allows building swiftCore as a DLL with the new build system on Windows as we now treat any linker warnings as errors.