### PR TITLE
[Dependency Scanning] Ignore `-ffile-compilation-dir` when Determining Swift Module Variants

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -734,10 +734,11 @@ namespace {
         "-working-directory=",
         "-working-directory"};
 
-  constexpr std::array<std::string_view, 15>
+  constexpr std::array<std::string_view, 16>
       knownClangDependencyIgnorablePrefiexes = {"-I",
                                                 "-F",
                                                 "-fmodule-map-file=",
+                                                "-ffile-compilation-dir",
                                                 "-iquote",
                                                 "-idirafter",
                                                 "-iframeworkwithsysroot",

--- a/test/ScanDependencies/eliminate_unused_vfs.swift
+++ b/test/ScanDependencies/eliminate_unused_vfs.swift
@@ -6,7 +6,7 @@
 
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders|g" %t/overlay_template.yaml > %t/overlay.yaml
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 //--- overlay_template.yaml
@@ -54,6 +54,7 @@ import F
 // CHECK: "-compile-module-from-interface"
 // CHECK-NOT: "-ivfsoverlay",
 // CHECK-NOT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NOT: "-ffile-compilation-dir={{.*}}"
 // CHECK: ],
 
 /// --------Clang module F


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Currently, the Swift dependency scanner knows about a fixed list of `clang` command line options it can ignore when computing a Swift module's cache hash. This PR adds `-ffile-compilation-dir` since it is not necessary for the Swift module to vary when the only difference in the relevant command line arguments is a different `-ffile-compilation-dir`. 

rdar://144256093
