### PR TITLE
[test] [6.1] temporarily disable two Cxx tests on Windows because they fail in PR testing

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -4,6 +4,9 @@
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
 
+// TODO: test failed in Windows PR testing: rdar://144384453
+// UNSUPPORTED: OS=windows-msvc
+
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: executable_test
 
+// TODO: test failed in Windows PR testing: rdar://144384453
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import CxxStdlib
 import StdStringView


### PR DESCRIPTION
This is a cherry-pick of https://github.com/swiftlang/swift/pull/79214

rdar://144384453
