### PR TITLE
🍒 Linux: don't link libicu in static executables, as it is no longer built separately

### DIFF
--- a/stdlib/public/Resources/linux/static-executable-args.lnk
+++ b/stdlib/public/Resources/linux/static-executable-args.lnk
@@ -9,9 +9,6 @@
 -ldispatch
 -lBlocksRuntime
 -lpthread
--licui18nswift
--licuucswift
--licudataswift
 -ldl
 -lstdc++
 -lm


### PR DESCRIPTION
This was dropped in #40340.

(cherry picked from commit abe922506528c21cb45a0fe16621532e7c9a8a89)

Fixes Issue #79153 on 6.1