### PR TITLE
[cxx-interop] Support importing static factories as initializers

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3946,6 +3946,11 @@ namespace {
       // FIXME: Poor location info.
       auto nameLoc = Impl.importSourceLoc(decl->getLocation());
 
+      if (auto method = dyn_cast<clang::CXXMethodDecl>(decl);
+          method && method->isStatic() && name.getBaseName().isConstructor()) {
+        return importGlobalAsInitializer(
+            decl, name, dc, importedName.getInitKind(), correctSwiftName);
+      }
       AbstractFunctionDecl *result = nullptr;
       if (auto *ctordecl = dyn_cast<clang::CXXConstructorDecl>(decl)) {
         // Don't import copy constructor or move constructor -- these will be

--- a/test/Interop/Cxx/foreign-reference/Inputs/constructor.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/constructor.h
@@ -1,0 +1,42 @@
+#pragma once
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain")))
+__attribute__((swift_attr("release:release"))) ImportWithCtor {
+  int value = 0;
+  int param1 = 0;
+  int param2 = 0;
+
+  __attribute__((swift_name("init()")))
+  __attribute__((swift_attr("returns_retained")))
+  static ImportWithCtor * _Nonnull create() {
+    return new ImportWithCtor{1};
+  }
+
+  __attribute__((swift_name("init(_:)")))
+  __attribute__((swift_attr("returns_retained")))
+  static ImportWithCtor * _Nonnull create(int x) {
+    return new ImportWithCtor{1, x};
+  }
+
+  __attribute__((swift_name("init(_:_:)")))
+  __attribute__((swift_attr("returns_retained")))
+  static ImportWithCtor * _Nonnull create(int x, int y) {
+    return new ImportWithCtor{1, x, y};
+  }
+
+  __attribute__((swift_name("init(_:_:_:)")))
+  __attribute__((swift_attr("returns_unretained")))
+  static ImportWithCtor * _Nonnull create(int x, int y, int z) {
+    return new ImportWithCtor{0, x, y};
+  }
+};
+
+inline void retain(ImportWithCtor * _Nonnull x) {
+  x->value++;
+}
+
+inline void release(ImportWithCtor * _Nonnull x) {
+  if (!--x->value)
+    delete x;
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -1,3 +1,8 @@
+module Constructor {
+  header "constructor.h"
+  requires cplusplus
+}
+
 module POD {
   header "pod.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/constructor-execution.swift
+++ b/test/Interop/Cxx/foreign-reference/constructor-execution.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking)
+// REQUIRES: executable_test
+
+import Constructor
+import StdlibUnittest
+
+var ForeignRefCtorSuite = TestSuite("ForeignRef Ctor")
+
+ForeignRefCtorSuite.test("ImportStaticFactoryAsInitializer") {
+  let x = ImportWithCtor()
+  expectEqual(x.param1, 0)
+  expectEqual(x.param2, 0)
+  let y = x
+  let z = ImportWithCtor(1)
+  expectEqual(z.param1, 1)
+  expectEqual(z.param2, 0)
+  let z2 = ImportWithCtor(2, 3)
+  expectEqual(z2.param1, 2)
+  expectEqual(z2.param2, 3)
+  let z3 = ImportWithCtor(2, 3, 4)
+  expectEqual(z3.param1, 2)
+  expectEqual(z3.param2, 3)
+}
+
+runAllTests()


### PR DESCRIPTION
This PR adds a feature to import static factory functions returning foreign reference types to be imported as initializers using the SWIFT_NAME annotation.
