### PR TITLE
[6.1] Sema: Partially revert existential opening fix

### DIFF
--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -259,11 +259,22 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
   if (auto *pack = type->getAs<PackType>()) {
     auto info = GenericParameterReferenceInfo();
 
-    for (auto arg : pack->getElementTypes()) {
-      info |= findGenericParameterReferencesRec(
-          genericSig, origParam, openedParam, arg,
-          TypePosition::Invariant, /*canBeCovariantResult=*/false);
-    }
+    // FIXME: Source compatibility remedy to allow existential opening in
+    // the following case:
+    // ```
+    // protocol P {}
+    // struct S<each T> {}
+    // func foo<T: P>(_: T, _: S<T>? = nil) {}
+    // let p: any P
+    // foo(p)
+    // ```
+    //
+    // for (auto arg : pack->getElementTypes()) {
+    //   info |= findGenericParameterReferencesRec(
+    //       genericSig, origParam, openedParam, arg,
+    //       TypePosition::Invariant, /*canBeCovariantResult=*/false);
+    // }
+    (void)pack;
 
     return info;
   }

--- a/test/Constraints/opened_existentials_default_arg.swift
+++ b/test/Constraints/opened_existentials_default_arg.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+do {
+  protocol P {}
+  struct S<each T> {}
+
+  func foo<T: P>(_: T, _: Optional<S<T>> = nil) {}
+
+  let p: any P
+  foo(p) // OK
+}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1038,19 +1038,6 @@ func bar(a: any HasSameShape) -> (Int, String) {
   a.foo(t: 1, u: "hi")
 }
 
-// Make sure we look through a pack type when evaluating the variance of the result
-struct Variadic<each A> {}
-
-protocol VariadicResult {
-  associatedtype A
-  func foo() -> Variadic<A>
-}
-
-func variadicResult(a: any VariadicResult) {
-  a.foo()
-  // expected-error@-1 {{member 'foo' cannot be used on value of type 'any VariadicResult'; consider using a generic constraint instead}}
-}
-
 // Pack expansions are invariant
 struct Pair<X, Y> {}
 

--- a/validation-test/compiler_crashers_2/existential-member-access-invariant-pack-type.swift
+++ b/validation-test/compiler_crashers_2/existential-member-access-invariant-pack-type.swift
@@ -1,0 +1,12 @@
+// RUN: not --crash %target-swift-frontend -typecheck -target %target-swift-5.9-abi-triple %s
+
+struct Variadic<each A> {}
+
+protocol VariadicResult {
+  associatedtype A
+  func foo() -> Variadic<A>
+}
+
+func variadicResult(a: any VariadicResult) {
+  a.foo()
+}


### PR DESCRIPTION
- **Explanation**: Selectively revert 36683a804c6829dc58aed151793a8c5ef72f64a9 to resolve a source compatibility regression. See inline comment for use case. We are going to consider acknowledging this use case in the rules in a future release.
- **Scope**: Implicit existential opening + invariant generic parameter references in pack types.
- **Issues**: rdar://141962317
- **Original PRs**: #79404
- **Risk**: Low
- **Testing**: Regression test included.
- **Reviewers**: @hborla