### PR TITLE
SIL: Fix type lowering of 'unowned T' where 'T' is a type parameter

### DIFF
--- a/test/SILGen/unowned-class-bound-generic-parameter.swift
+++ b/test/SILGen/unowned-class-bound-generic-parameter.swift
@@ -21,3 +21,17 @@ func makeGenericClosureWithNativeClass2<T>(t: T) where T : ClassProtocol, T : Ba
 }
 
 // CHECK-LABEL: sil private [ossa] @$s4main34makeGenericClosureWithNativeClass21tyx_tAA9BaseClassCRbzAA0I8ProtocolRzlFyycfU_ : $@convention(thin) <T where T : BaseClass, T : ClassProtocol> (@guaranteed @sil_unowned T) -> () {
+
+// https://github.com/swiftlang/swift/issues/79244
+
+struct Wrapper<T: AnyObject> {
+  unowned var t: T
+}
+
+func f1<T: AnyObject>(t: T) {
+  _ = { Wrapper(t: t) }
+}
+
+func f2<T: AnyObject, U: AnyObject>(u: U, tt: Array<Wrapper<T>>) {
+  _ = tt.map { _ in Wrapper(t: u) }
+}


### PR DESCRIPTION
The abstraction pattern's generic signature does not describe the substituted type, and it may not be present at all.

Fixes https://github.com/swiftlang/swift/issues/79244.