### PR TITLE
 TypeResolution: Map `any` constraint into context before checking validity

### DIFF
--- a/test/type/explicit_existential_type_parameter_constraint.swift
+++ b/test/type/explicit_existential_type_parameter_constraint.swift
@@ -1,0 +1,50 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple -enable-upcoming-feature ExistentialAny
+
+// REQUIRES: swift_feature_ExistentialAny
+
+do {
+  protocol P {
+    typealias PAlias = P
+    
+    func f() -> any PAlias
+    func g<T>(_: T) -> any PAlias
+  }
+}
+do {
+  protocol P {
+    associatedtype A
+    
+    func f1() -> any A
+    // expected-error@-1:18 {{'any' has no effect on type parameter 'Self.A'}}
+    
+    typealias Alias = A
+    
+    func f2() -> any Alias
+    // expected-error@-1:18 {{'any' has no effect on type parameter 'Self.Alias' (aka 'Self.A')}}
+  }
+}
+do {
+  protocol P {
+    associatedtype A where A == Int
+    
+    func f1() -> any A
+    // expected-error@-1:18 {{'any' has no effect on concrete type 'Int'}}
+    func g1<T>(_: T) -> any A
+    // expected-error@-1:25 {{'any' has no effect on concrete type 'Int'}}
+    
+    typealias Alias = A
+    
+    func f2() -> any Alias
+    // expected-error@-1:18 {{'any' has no effect on concrete type 'Self.Alias' (aka 'Int')}}
+    func g2<T>(_: T) -> any Alias
+    // expected-error@-1:25 {{'any' has no effect on concrete type 'Self.Alias' (aka 'Int')}}
+  }
+}
+do {
+  protocol P {
+    associatedtype A where A == Invalid
+    // expected-error@-1 {{cannot find type 'Invalid' in scope}}
+    
+    func f() -> any A
+  }
+}


### PR DESCRIPTION
* In the structural stage, let the constaint type be if it is a type parameter. We do not have enough information to prove it invalid.
* In the interface stage, first map the constraint type into context, and only then proceed to validation.