### PR TITLE
[Dependency Scanning] Update Swift Interface Module's Output Path after `vfs` Pruning

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -318,14 +318,6 @@ public:
   void updateCommandLine(const std::vector<std::string> &newCommandLine) {
     textualModuleDetails.buildCommandLine = newCommandLine;
   }
-
-  void updateModuleOutputPath(const std::string &newPath) {
-    const_cast<std::string &>(moduleOutputPath) = newPath;
-  }
-
-  void updateContextHash(const std::string &newContextHash) {
-    const_cast<std::string &>(contextHash) = newContextHash;
-  }
 };
 
 /// Describes the dependencies of a Swift module
@@ -877,20 +869,6 @@ public:
           rootID;
     else
       llvm_unreachable("Unexpected type");
-  }
-
-  void updateModuleOutputPath(const std::string &newPath) {
-    if (isSwiftInterfaceModule())
-      return cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())
-          ->updateModuleOutputPath(newPath);
-    llvm_unreachable("Unexpected type");
-  }
-
-  void updateContextHash(const std::string &newContextHash) {
-    if (isSwiftInterfaceModule())
-      return cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())
-          ->updateContextHash(newContextHash);
-    llvm_unreachable("Unexpected type");
   }
 
   /// Whether explicit input paths of all the module dependencies

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -320,6 +320,14 @@ public:
   void updateCommandLine(const std::vector<std::string> &newCommandLine) {
     textualModuleDetails.buildCommandLine = newCommandLine;
   }
+
+  void updateModuleOutputPath(const std::string &newPath) {
+    const_cast<std::string &>(moduleOutputPath) = newPath;
+  }
+
+  void updateContextHash(const std::string &newContextHash) {
+    const_cast<std::string &>(contextHash) = newContextHash;
+  }
 };
 
 /// Describes the dependencies of a Swift module
@@ -874,6 +882,20 @@ public:
           rootID;
     else
       llvm_unreachable("Unexpected type");
+  }
+
+  void updateModuleOutputPath(const std::string &newPath) {
+    if (isSwiftInterfaceModule())
+      return cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())
+          ->updateModuleOutputPath(newPath);
+    llvm_unreachable("Unexpected type");
+  }
+
+  void updateContextHash(const std::string &newContextHash) {
+    if (isSwiftInterfaceModule())
+      return cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())
+          ->updateContextHash(newContextHash);
+    llvm_unreachable("Unexpected type");
   }
 
   /// Whether explicit input paths of all the module dependencies

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -266,7 +266,7 @@ class SwiftInterfaceModuleDependenciesStorage
     : public ModuleDependencyInfoStorageBase {
 public:
   /// Destination output path
-  const std::string moduleOutputPath;
+  std::string moduleOutputPath;
 
   /// The Swift interface file to be used to generate the module file.
   const std::string swiftInterfaceFile;
@@ -275,7 +275,7 @@ public:
   const std::vector<std::string> compiledModuleCandidates;
 
   /// The hash value that will be used for the generated module
-  const std::string contextHash;
+  std::string contextHash;
 
   /// A flag that indicates this dependency is a framework
   const bool isFramework;
@@ -290,22 +290,20 @@ public:
   const std::string userModuleVersion;
 
   SwiftInterfaceModuleDependenciesStorage(
-      StringRef moduleOutputPath, StringRef swiftInterfaceFile,
+      StringRef swiftInterfaceFile,
       ArrayRef<StringRef> compiledModuleCandidates,
       ArrayRef<ScannerImportStatementInfo> moduleImports,
       ArrayRef<ScannerImportStatementInfo> optionalModuleImports,
       ArrayRef<StringRef> buildCommandLine, ArrayRef<LinkLibrary> linkLibraries,
-      StringRef contextHash, bool isFramework,
-      bool isStatic, StringRef RootID, StringRef moduleCacheKey,
-      StringRef userModuleVersion)
+      bool isFramework, bool isStatic, StringRef RootID,
+      StringRef moduleCacheKey, StringRef userModuleVersion)
       : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftInterface,
                                         moduleImports, optionalModuleImports,
                                         linkLibraries, moduleCacheKey),
-        moduleOutputPath(moduleOutputPath),
         swiftInterfaceFile(swiftInterfaceFile),
         compiledModuleCandidates(compiledModuleCandidates.begin(),
                                  compiledModuleCandidates.end()),
-        contextHash(contextHash), isFramework(isFramework), isStatic(isStatic),
+        isFramework(isFramework), isStatic(isStatic),
         textualModuleDetails(buildCommandLine, RootID),
         userModuleVersion(userModuleVersion) {}
 
@@ -593,21 +591,18 @@ public:
   /// Describe the module dependencies for a Swift module that can be
   /// built from a Swift interface file (\c .swiftinterface).
   static ModuleDependencyInfo forSwiftInterfaceModule(
-      StringRef moduleOutputPath, StringRef swiftInterfaceFile,
-      ArrayRef<StringRef> compiledCandidates, ArrayRef<StringRef> buildCommands,
+      StringRef swiftInterfaceFile, ArrayRef<StringRef> compiledCandidates,
+      ArrayRef<StringRef> buildCommands,
       ArrayRef<ScannerImportStatementInfo> moduleImports,
       ArrayRef<ScannerImportStatementInfo> optionalModuleImports,
-      ArrayRef<LinkLibrary> linkLibraries,
-      StringRef contextHash, bool isFramework, bool isStatic,
+      ArrayRef<LinkLibrary> linkLibraries, bool isFramework, bool isStatic,
       StringRef CASFileSystemRootID, StringRef moduleCacheKey,
       StringRef userModuleVersion) {
     return ModuleDependencyInfo(
         std::make_unique<SwiftInterfaceModuleDependenciesStorage>(
-            moduleOutputPath, swiftInterfaceFile, compiledCandidates,
-            moduleImports, optionalModuleImports,
-            buildCommands, linkLibraries, contextHash,
-            isFramework, isStatic, CASFileSystemRootID, moduleCacheKey,
-            userModuleVersion));
+            swiftInterfaceFile, compiledCandidates, moduleImports,
+            optionalModuleImports, buildCommands, linkLibraries, isFramework,
+            isStatic, CASFileSystemRootID, moduleCacheKey, userModuleVersion));
   }
 
   /// Describe the module dependencies for a serialized or parsed Swift module.
@@ -1004,6 +999,9 @@ public:
 
   /// Set the chained bridging header buffer.
   void setChainedBridgingHeaderBuffer(StringRef path, StringRef buffer);
+
+  /// Set the output path and the context hash.
+  void setOutputPathAndHash(StringRef outputPath, StringRef hash);
 
   /// Collect a map from a secondary module name to a list of cross-import
   /// overlays, when this current module serves as the primary module.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -639,7 +639,7 @@ struct SwiftInterfaceInfo {
 /// then prune the extra args, and finally obtain expandedName again.
 /// Pruning always happens before the first time we call getExpandedName().
 /// Therefore it is correct to calculate expandedName only once.
-class InterfaceModuleNameExpander {
+class InterfaceModuleOutputPathResolver {
 public:
   using ArgListTy = std::vector<std::string>;
   struct ResultTy {
@@ -660,19 +660,19 @@ private:
   // and see pruneExtraArgs to see how it can be updated.
   ArgListTy extraArgs;
 
-  std::unique_ptr<ResultTy> expandedName;
+  std::unique_ptr<ResultTy> resolvedOutputPath;
 
   std::string getHash();
 
 public:
-  InterfaceModuleNameExpander(const StringRef moduleName,
-                              const StringRef interfacePath,
-                              const StringRef sdkPath,
-                              const CompilerInvocation &CI)
+  InterfaceModuleOutputPathResolver(const StringRef moduleName,
+                                    const StringRef interfacePath,
+                                    const StringRef sdkPath,
+                                    const CompilerInvocation &CI)
       : moduleName(moduleName), interfacePath(interfacePath), sdkPath(sdkPath),
         CI(CI), extraArgs(CI.getClangImporterOptions()
                               .getReducedExtraArgsForSwiftModuleDependency()) {}
-  ResultTy getExpandedName();
+  ResultTy getOutputPath();
   void pruneExtraArgs(std::function<void(ArgListTy &)> filter);
 };
 
@@ -751,7 +751,7 @@ public:
   ~InterfaceSubContextDelegateImpl() = default;
 
   /// includes a hash of relevant key data.
-  InterfaceModuleNameExpander::ResultTy
+  InterfaceModuleOutputPathResolver::ResultTy
   getCachedOutputPath(StringRef moduleName, StringRef interfacePath,
                       StringRef sdkPath);
 };

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -710,6 +710,41 @@ public:
                                     StringRef &CacheHash);
   std::string getCacheHash(StringRef useInterfacePath, StringRef sdkPath);
 };
+
+class InterfaceModuleNameExpander {
+public:
+  using ArgListTy = std::vector<std::string>;
+  struct ResultTy {
+    llvm::SmallString<256> outputPath;
+
+    // Hash points to a segment of outputPath.
+    StringRef hash;
+  };
+
+private:
+  const StringRef moduleName;
+  const StringRef interfacePath;
+  const StringRef sdkPath;
+  const CompilerInvocation &CI;
+  ArgListTy extraArgs;
+
+  ResultTy expandedName;
+
+  bool expanded = false;
+
+  std::string getHash();
+
+public:
+  InterfaceModuleNameExpander(const StringRef moduleName,
+                              const StringRef interfacePath,
+                              const StringRef sdkPath,
+                              const CompilerInvocation &CI)
+      : moduleName(moduleName), interfacePath(interfacePath), sdkPath(sdkPath),
+        CI(CI), extraArgs(CI.getClangImporterOptions()
+                              .getReducedExtraArgsForSwiftModuleDependency()) {}
+  ResultTy getExpandedName();
+  void pruneExtraArgs(std::function<void(ArgListTy &)> filter);
+};
 }
 
 #endif

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -628,6 +628,17 @@ struct SwiftInterfaceInfo {
   std::optional<version::Version> CompilerToolsVersion;
 };
 
+/// A small helper class that expands the module name to a full output path
+/// with context hash.
+/// The cannonical way to use this class is the following:
+/// 1. Create an instance through the constructor.
+/// 2. Optional: prune the extra args if necessary.
+/// 3. Obtain the expanded name that contains a full path, and a hash.
+/// expandedName is computed only once, and never updated.
+/// Currently, there is no use case where we first obtain expandedName,
+/// then prune the extra args, and finally obtain expandedName again.
+/// Pruning always happens before the first time we call getExpandedName().
+/// Therefore it is correct to calculate expandedName only once.
 class InterfaceModuleNameExpander {
 public:
   using ArgListTy = std::vector<std::string>;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -638,7 +638,7 @@ struct ResultTy {
 
 using ArgListTy = std::vector<std::string>;
 
-void getOutputPath(ResultTy &outputPath, const StringRef &moduleName,
+void setOutputPath(ResultTy &outputPath, const StringRef &moduleName,
                    const StringRef &interfacePath, const StringRef &sdkPath,
                    const CompilerInvocation &CI, const ArgListTy &extraArgs);
 } // namespace SwiftInterfaceModuleOutputPathResolution

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -465,6 +465,21 @@ void ModuleDependencyInfo::addSourceFile(StringRef sourceFile) {
   }
 }
 
+void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
+                                                StringRef hash) {
+  switch (getKind()) {
+  case swift::ModuleDependencyKind::SwiftInterface: {
+    auto swiftInterfaceStorage =
+        cast<SwiftInterfaceModuleDependenciesStorage>(storage.get());
+    swiftInterfaceStorage->moduleOutputPath = outputPath.str();
+    swiftInterfaceStorage->contextHash = hash.str();
+    break;
+  }
+  default:
+    llvm_unreachable("Unexpected dependency kind");
+  }
+}
+
 SwiftDependencyScanningService::SwiftDependencyScanningService() {
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -585,12 +585,12 @@ bool ModuleDependenciesCacheDeserializer::readGraph(
 
       // Form the dependencies storage object
       auto moduleDep = ModuleDependencyInfo::forSwiftInterfaceModule(
-          outputModulePath.value(), optionalSwiftInterfaceFile.value(),
-          compiledCandidatesRefs, buildCommandRefs, importStatements,
-          optionalImportStatements, linkLibraries, *contextHash,
-          isFramework, isStatic, *rootFileSystemID, *moduleCacheKey,
-          *userModuleVersion);
+          optionalSwiftInterfaceFile.value(), compiledCandidatesRefs,
+          buildCommandRefs, importStatements, optionalImportStatements,
+          linkLibraries, isFramework, isStatic, *rootFileSystemID,
+          *moduleCacheKey, *userModuleVersion);
 
+      moduleDep.setOutputPathAndHash(*outputModulePath, *contextHash);
       addCommonDependencyInfo(moduleDep);
       addSwiftCommonDependencyInfo(moduleDep);
       addSwiftTextualDependencyInfo(

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -211,10 +211,16 @@ private:
     if (resolvingDepInfo.isSwiftPlaceholderModule())
       return llvm::Error::success();
 
+    if (outputPathResolver) {
+      auto resolvedPath = outputPathResolver->getOutputPath();
+      depInfo.setOutputPathAndHash(resolvedPath.outputPath.str().str(),
+                                   resolvedPath.hash.str());
+    }
+
     // Add macros.
     for (auto &macro : macros)
-      depInfo.addMacroDependency(
-          macro.first(), macro.second.LibraryPath, macro.second.ExecutablePath);
+      depInfo.addMacroDependency(macro.first(), macro.second.LibraryPath,
+                                 macro.second.ExecutablePath);
 
     for (auto &macro : depInfo.getMacroDependencies()) {
       std::string arg = macro.second.LibraryPath + "#" +
@@ -228,18 +234,11 @@ private:
       return err;
 
     if (!bridgingHeaderBuildCmd.empty())
-      depInfo.updateBridgingHeaderCommandLine(
-          bridgingHeaderBuildCmd);
+      depInfo.updateBridgingHeaderCommandLine(bridgingHeaderBuildCmd);
     if (!resolvingDepInfo.isSwiftBinaryModule()) {
       depInfo.updateCommandLine(commandline);
       if (auto err = updateModuleCacheKey(depInfo))
         return err;
-    }
-
-    if (outputPathResolver) {
-      auto expandedName = outputPathResolver->getOutputPath();
-      depInfo.updateModuleOutputPath(expandedName.outputPath.c_str());
-      depInfo.updateContextHash(expandedName.hash.str());
     }
 
     return llvm::Error::success();

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -422,14 +422,13 @@ private:
     const auto &CI = instance.getInvocation();
 
     SwiftInterfaceModuleOutputPathResolution::ArgListTy extraArgsList;
-    const SwiftInterfaceModuleOutputPathResolution::ArgListTy
-        &clangImpporterOptions =
-            CI.getClangImporterOptions()
-                .getReducedExtraArgsForSwiftModuleDependency();
+    const auto &clangImporterOptions =
+        CI.getClangImporterOptions()
+            .getReducedExtraArgsForSwiftModuleDependency();
 
     skip = 0;
-    for (auto it = clangImpporterOptions.begin(),
-              end = clangImpporterOptions.end();
+    for (auto it = clangImporterOptions.begin(),
+              end = clangImporterOptions.end();
          it != end; it++) {
       if (skip) {
         skip = 0;
@@ -449,7 +448,7 @@ private:
     auto swiftTextualDeps = resolvingDepInfo.getAsSwiftInterfaceModule();
     auto &interfacePath = swiftTextualDeps->swiftInterfaceFile;
     auto sdkPath = instance.getASTContext().SearchPathOpts.getSDKPath();
-    SwiftInterfaceModuleOutputPathResolution::getOutputPath(
+    SwiftInterfaceModuleOutputPathResolution::setOutputPath(
         outputPath, moduleID.ModuleName, interfacePath, sdkPath, CI,
         extraArgsList);
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -445,7 +445,7 @@ private:
 
         newArgs.push_back(*it);
       }
-      args = newArgs;
+      args = std::move(newArgs);
       return;
     };
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -180,6 +180,9 @@ public:
 
     pruneUnusedVFSOverlay();
 
+    // It is necessary to update the command line to take
+    // the pruned unused VFS overlay into account before remapping the
+    // command line.
     if (resolvingDepInfo.isSwiftInterfaceModule())
       updateSwiftInterfaceCommandLine();
 
@@ -453,13 +456,14 @@ private:
   }
 
   void updateSwiftInterfaceCommandLine() {
-    // The command line needs upadte once we prune the unused VFS overlays.
+    // The command line needs update once we prune the unused VFS overlays.
     // The update consists of two steps.
-    // 1. Recompute the output path, which includes the module hash.
+    // 1. Obtain the output path, which includes the module hash that takes the
+    // VFS pruning into account.
     // 2. Update `-o `'s value on the command line with the new output path.
 
     assert(nameExpander && "Can only update if we hae a nameExpander.");
-    auto expandedName = nameExpander->getExpandedName();
+    const auto &expandedName = nameExpander->getExpandedName();
 
     StringRef outputName = expandedName.outputPath.str();
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1098,11 +1098,9 @@ class ModuleInterfaceLoaderImpl {
         requiresOSSAModules);
 
     // Compute the output path if we're loading or emitting a cached module.
-    llvm::SmallString<256> cachedOutputPath;
-    StringRef CacheHash;
-    astDelegate.computeCachedOutputPath(moduleName, interfacePath,
-                                        ctx.SearchPathOpts.getSDKPath(),
-                                        cachedOutputPath, CacheHash);
+    auto expandedName = astDelegate.getCachedOutputPath(
+        moduleName, interfacePath, ctx.SearchPathOpts.getSDKPath());
+    auto &cachedOutputPath = expandedName.outputPath;
 
     // Try to find the right module for this interface, either alongside it,
     // in the cache, or in the prebuilt cache.
@@ -2007,110 +2005,13 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
 
 /// Calculate an output filename in \p genericSubInvocation's cache path that
 /// includes a hash of relevant key data.
-StringRef InterfaceSubContextDelegateImpl::computeCachedOutputPath(
-                             StringRef moduleName,
-                             StringRef useInterfacePath,
-                             StringRef sdkPath,
-                             llvm::SmallString<256> &OutPath,
-                             StringRef &CacheHash) {
-  OutPath = genericSubInvocation.getClangModuleCachePath();
-  llvm::sys::path::append(OutPath, moduleName);
-  OutPath.append("-");
-  auto hashStart = OutPath.size();
-  OutPath.append(getCacheHash(useInterfacePath, sdkPath));
-  CacheHash = OutPath.str().substr(hashStart);
-  OutPath.append(".");
-  auto OutExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
-  OutPath.append(OutExt);
-  return OutPath.str();
-}
-
-/// Construct a cache key for the .swiftmodule being generated. There is a
-/// balance to be struck here between things that go in the cache key and
-/// things that go in the "up to date" check of the cache entry. We want to
-/// avoid fighting over a single cache entry too much when (say) running
-/// different compiler versions on the same machine or different inputs
-/// that happen to have the same short module name, so we will disambiguate
-/// those in the key. But we want to invalidate and rebuild a cache entry
-/// -- rather than making a new one and potentially filling up the cache
-/// with dead entries -- when other factors change, such as the contents of
-/// the .swiftinterface input or its dependencies.
-std::string
-InterfaceSubContextDelegateImpl::getCacheHash(StringRef useInterfacePath,
-                                              StringRef sdkPath) {
-  // When doing dependency scanning for explicit module, use strict context hash
-  // to ensure sound module hash.
-  bool useStrictCacheHash =
-      genericSubInvocation.getFrontendOptions().RequestedAction ==
-      FrontendOptions::ActionType::ScanDependencies;
-
-  // Include the normalized target triple when not using strict hash.
-  // Otherwise, use the full target to ensure soundness of the hash. In
-  // practice, .swiftinterface files will be in target-specific subdirectories
-  // and would have target-specific pieces #if'd out. However, it doesn't hurt
-  // to include it, and it guards against mistakenly reusing cached modules
-  // across targets. Note that this normalization explicitly doesn't include the
-  // minimum deployment target (e.g. the '12.0' in 'ios12.0').
-  auto targetToHash = useStrictCacheHash
-                          ? genericSubInvocation.getLangOptions().Target
-                          : getTargetSpecificModuleTriple(
-                                genericSubInvocation.getLangOptions().Target);
-
-  std::string sdkBuildVersion = getSDKBuildVersion(sdkPath);
-  const auto ExtraArgs = genericSubInvocation.getClangImporterOptions()
-                             .getReducedExtraArgsForSwiftModuleDependency();
-
-  llvm::hash_code H = hash_combine(
-      // Start with the compiler version (which will be either tag names or
-      // revs). Explicitly don't pass in the "effective" language version --
-      // this would mean modules built in different -swift-version modes would
-      // rebuild their dependencies.
-      swift::version::getSwiftFullVersion(),
-
-      // Simplest representation of input "identity" (not content) is just a
-      // pathname, and probably all we can get from the VFS in this regard
-      // anyways.
-      useInterfacePath,
-
-      // The target triple to hash.
-      targetToHash.str(),
-
-      // The SDK path is going to affect how this module is imported, so
-      // include it.
-      genericSubInvocation.getSDKPath(),
-
-      // The SDK build version may identify differences in headers
-      // that affects references serialized in the cached file.
-      sdkBuildVersion,
-
-      // Applying the distribution channel of the current compiler enables
-      // different compilers to share a module cache location.
-      version::getCurrentCompilerChannel(),
-
-      // Whether or not we're tracking system dependencies affects the
-      // invalidation behavior of this cache item.
-      genericSubInvocation.getFrontendOptions().shouldTrackSystemDependencies(),
-
-      // Whether or not caching is enabled affects if the instance is able to
-      // correctly load the dependencies.
-      genericSubInvocation.getCASOptions().getModuleScanningHashComponents(),
-
-      // Clang ExtraArgs that affects how clang types are imported into swift
-      // module.
-      llvm::hash_combine_range(ExtraArgs.begin(), ExtraArgs.end()),
-
-      /// Application extension.
-      unsigned(
-          genericSubInvocation.getLangOptions().EnableAppExtensionRestrictions),
-
-      // Whether or not OSSA modules are enabled.
-      //
-      // If OSSA modules are enabled, we use a separate namespace of modules to
-      // ensure that we compile all swift interface files with the option set.
-      unsigned(genericSubInvocation.getSILOptions().EnableOSSAModules)
-      );
-
-  return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);
+InterfaceModuleNameExpander::ResultTy
+InterfaceSubContextDelegateImpl::getCachedOutputPath(StringRef moduleName,
+                                                     StringRef interfacePath,
+                                                     StringRef sdkPath) {
+  InterfaceModuleNameExpander expander(moduleName, interfacePath, sdkPath,
+                                       genericSubInvocation);
+  return expander.getExpandedName();
 }
 
 std::error_code
@@ -2189,13 +2090,11 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   }
 
   // Calculate output path of the module.
-  llvm::SmallString<256> buffer;
-  StringRef CacheHash;
-  auto hashedOutput = computeCachedOutputPath(moduleName, interfacePath,
-                                              sdkPath, buffer, CacheHash);
+  auto expandedName = getCachedOutputPath(moduleName, interfacePath, sdkPath);
+
   // If no specific output path is given, use the hashed output path.
   if (outputPath.empty()) {
-    outputPath = hashedOutput;
+    outputPath = expandedName.outputPath;
   }
 
   // Configure the outputs in front-end options. There must be an equal number of
@@ -2249,7 +2148,7 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   }
 
   info.BuildArguments = BuildArgs;
-  info.Hash = CacheHash;
+  info.Hash = expandedName.hash;
 
   // Run the action under the sub compiler instance.
   return action(info);
@@ -2846,26 +2745,45 @@ std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
 
 InterfaceModuleNameExpander::ResultTy
 InterfaceModuleNameExpander::getExpandedName() {
-  // Expand the name once, and reuse later.
-  if (!expanded) {
-    auto &outputPath = expandedName.outputPath;
+  if (!expandedName) {
+    expandedName = std::make_unique<ResultTy>();
+    auto &outputPath = expandedName->outputPath;
     outputPath = CI.getClangModuleCachePath();
     llvm::sys::path::append(outputPath, moduleName);
     outputPath.append("-");
     auto hashStart = outputPath.size();
     outputPath.append(getHash());
-    expandedName.hash = outputPath.str().substr(hashStart);
+    expandedName->hash = outputPath.str().substr(hashStart);
     outputPath.append(".");
     auto outExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
     outputPath.append(outExt);
-    expanded = true;
   }
-  return expandedName;
+  return *expandedName;
 }
 
+/// Construct a key for the .swiftmodule being generated. There is a
+/// balance to be struck here between things that go in the cache key and
+/// things that go in the "up to date" check of the cache entry. We want to
+/// avoid fighting over a single cache entry too much when (say) running
+/// different compiler versions on the same machine or different inputs
+/// that happen to have the same short module name, so we will disambiguate
+/// those in the key. But we want to invalidate and rebuild a cache entry
+/// -- rather than making a new one and potentially filling up the cache
+/// with dead entries -- when other factors change, such as the contents of
+/// the .swiftinterface input or its dependencies.
 std::string InterfaceModuleNameExpander::getHash() {
+  // When doing dependency scanning for explicit module, use strict context hash
+  // to ensure sound module hash.
   bool useStrictCacheHash = CI.getFrontendOptions().RequestedAction ==
                             FrontendOptions::ActionType::ScanDependencies;
+
+  // Include the normalized target triple when not using strict hash.
+  // Otherwise, use the full target to ensure soundness of the hash. In
+  // practice, .swiftinterface files will be in target-specific subdirectories
+  // and would have target-specific pieces #if'd out. However, it doesn't hurt
+  // to include it, and it guards against mistakenly reusing cached modules
+  // across targets. Note that this normalization explicitly doesn't include the
+  // minimum deployment target (e.g. the '12.0' in 'ios12.0').
   auto targetToHash =
       useStrictCacheHash
           ? CI.getLangOptions().Target
@@ -2874,12 +2792,50 @@ std::string InterfaceModuleNameExpander::getHash() {
   std::string sdkBuildVersion = getSDKBuildVersion(sdkPath);
 
   llvm::hash_code H = llvm::hash_combine(
-      swift::version::getSwiftFullVersion(), interfacePath, targetToHash.str(),
-      CI.getSDKPath(), sdkBuildVersion, version::getCurrentCompilerChannel(),
+      // Start with the compiler version (which will be either tag names or
+      // revs). Explicitly don't pass in the "effective" language version --
+      // this would mean modules built in different -swift-version modes would
+      // rebuild their dependencies.
+      swift::version::getSwiftFullVersion(),
+
+      // Simplest representation of input "identity" (not content) is just a
+      // pathname, and probably all we can get from the VFS in this regard
+      // anyways.
+      interfacePath,
+
+      // The target triple to hash.
+      targetToHash.str(),
+
+      // The SDK path is going to affect how this module is imported, so
+      // include it.
+      CI.getSDKPath(),
+
+      // The SDK build version may identify differences in headers
+      // that affects references serialized in the cached file.
+      sdkBuildVersion,
+
+      // Applying the distribution channel of the current compiler enables
+      // different compilers to share a module cache location.
+      version::getCurrentCompilerChannel(),
+
+      // Whether or not we're tracking system dependencies affects the
+      // invalidation behavior of this cache item.
       CI.getFrontendOptions().shouldTrackSystemDependencies(),
+
+      // Whether or not caching is enabled affects if the instance is able to
+      // correctly load the dependencies.
       CI.getCASOptions().getModuleScanningHashComponents(),
+
+      // Take care of any extra arguments that should affect the hash.
       llvm::hash_combine_range(extraArgs.begin(), extraArgs.end()),
+
+      // Application extension.
       unsigned(CI.getLangOptions().EnableAppExtensionRestrictions),
+
+      // Whether or not OSSA modules are enabled.
+      //
+      // If OSSA modules are enabled, we use a separate namespace of modules to
+      // ensure that we compile all swift interface files with the option set.
       unsigned(CI.getSILOptions().EnableOSSAModules));
 
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2010,7 +2010,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
 void InterfaceSubContextDelegateImpl::getCachedOutputPath(
     SwiftInterfaceModuleOutputPathResolution::ResultTy &resolvedOutputPath,
     StringRef moduleName, StringRef interfacePath, StringRef sdkPath) {
-  SwiftInterfaceModuleOutputPathResolution::getOutputPath(
+  SwiftInterfaceModuleOutputPathResolution::setOutputPath(
       resolvedOutputPath, moduleName, interfacePath, sdkPath,
       genericSubInvocation,
       genericSubInvocation.getClangImporterOptions()
@@ -2831,7 +2831,7 @@ static std::string getContextHash(const CompilerInvocation &CI,
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);
 }
 
-void getOutputPath(ResultTy &resolvedOutputPath, const StringRef &moduleName,
+void setOutputPath(ResultTy &resolvedOutputPath, const StringRef &moduleName,
                    const StringRef &interfacePath, const StringRef &sdkPath,
                    const CompilerInvocation &CI, const ArgListTy &extraArgs) {
   auto &outputPath = resolvedOutputPath.outputPath;

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -248,9 +248,13 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
         bool isStatic = llvm::find(ArgsRefs, "-static") != ArgsRefs.end();
 
         Result = ModuleDependencyInfo::forSwiftInterfaceModule(
-            outputPathBase.str().str(), InPath, compiledCandidatesRefs,
-            ArgsRefs, {}, {}, linkLibraries, Hash, isFramework,
-            isStatic, {}, /*module-cache-key*/ "", UserModVer);
+            InPath, compiledCandidatesRefs, ArgsRefs, {}, {}, linkLibraries,
+            isFramework, isStatic, {}, /*module-cache-key*/ "", UserModVer);
+
+        // We do NOT need the code below to set output path in the dependency
+        // info because it will be calculated again later. We do not want to
+        // create output paths that do not exist in the end.
+        // Result->setOutputPathAndHash(outputPathBase.str().str(), Hash);
 
         if (Ctx.CASOpts.EnableCaching) {
           std::vector<std::string> clangDependencyFiles;

--- a/test/ScanDependencies/eliminate_unused_vfs.swift
+++ b/test/ScanDependencies/eliminate_unused_vfs.swift
@@ -5,9 +5,16 @@
 // RUN: split-file %s %t
 
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders|g" %t/overlay_template.yaml > %t/overlay.yaml
+// RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders1|g" %t/overlay_template.yaml > %t/overlay1.yaml
 
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
-// RUN: %validate-json %t/deps.json | %FileCheck %s
+// RUN: %validate-json %t/deps.json > %t/validated_deps.json
+// RUN: cat %t/validated_deps.json | %FileCheck %s
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps1.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay1.yaml
+// RUN: %validate-json %t/deps1.json > %t/validated_deps1.json
+// RUN: cat %t/validated_deps.json %t/validated_deps1.json \
+// RUN:   | %FileCheck %s --check-prefix=MOD-HASH
 
 //--- overlay_template.yaml
 {
@@ -61,3 +68,27 @@ import F
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
 // CHECK-NOT: "-ivfsoverlay",
 // CHECK-NOT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+
+/// Check that the dependency swift module hashes are identical when the vfs overlays are ignored.
+// MOD-HASH: "mainModuleName": "deps",
+// MOD-HASH: "linkLibraries": [],
+// MOD-HASH-NEXT: "details": {
+// MOD-HASH-NEXT:   "swift": {
+// MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
+// MOD-HASH:   "commandLine": [
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH:.*]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH:.*]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH:.*]].swiftmodule",
+// MOD-HASH:     ],
+// MOD-HASH: "mainModuleName": "deps1",
+// MOD-HASH: "linkLibraries": [],
+// MOD-HASH: "details": {
+// MOD-HASH-NEXT:   "swift": {
+// MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
+// MOD-HASH:   "commandLine": [
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH]].swiftmodule",
+// MOD-HASH:     ],

--- a/test/ScanDependencies/eliminate_unused_vfs.swift
+++ b/test/ScanDependencies/eliminate_unused_vfs.swift
@@ -6,6 +6,7 @@
 
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders|g" %t/overlay_template.yaml > %t/overlay.yaml
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders1|g" %t/overlay_template.yaml > %t/overlay1.yaml
+// RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders2|g" %t/overlay_template.yaml > %t/overlay2.yaml
 
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
 // RUN: %validate-json %t/deps.json > %t/validated_deps.json
@@ -13,7 +14,9 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps1.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay1.yaml
 // RUN: %validate-json %t/deps1.json > %t/validated_deps1.json
-// RUN: cat %t/validated_deps.json %t/validated_deps1.json \
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache %t/test.swift -o %t/deps2.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -experimental-clang-importer-direct-cc1-scan -file-compilation-dir %t -Xcc -ivfsoverlay -Xcc %t/overlay2.yaml
+// RUN: %validate-json %t/deps2.json > %t/validated_deps2.json
+// RUN: cat %t/validated_deps.json %t/validated_deps1.json %t/validated_deps2.json \
 // RUN:   | %FileCheck %s --check-prefix=MOD-HASH
 
 //--- overlay_template.yaml
@@ -82,6 +85,17 @@ import F
 // MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH:.*]].swiftmodule",
 // MOD-HASH:     ],
 // MOD-HASH: "mainModuleName": "deps1",
+// MOD-HASH: "linkLibraries": [],
+// MOD-HASH: "details": {
+// MOD-HASH-NEXT:   "swift": {
+// MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
+// MOD-HASH:   "commandLine": [
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH]].swiftmodule",
+// MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH]].swiftmodule",
+// MOD-HASH:     ],
+// MOD-HASH: "mainModuleName": "deps2",
 // MOD-HASH: "linkLibraries": [],
 // MOD-HASH: "details": {
 // MOD-HASH-NEXT:   "swift": {


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

This PR teaches the Swift dependency scanner to recompute Swift module interface hashes after `vfs` overlay pruning.

The swift dependency scanner is already aware of unused `vfs` overlays, and removes them from the command line. However, it did not recompute the hashes in the module's full path. The hash still took the unused `vsf` overlay options into account, and led to redundant variants.

This PR implements recalculation of the module output path after the `vfs` pruning, and uses an updated list of commands to compute the module output paths. The command line output is refreshed with the new output path, and the dependency information is updated with the new module output path and the new hash.

rdar://144256093