### PR TITLE
[concurrency] Implement serialization for execution(caller)/execution(concurrent).

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1649,9 +1649,7 @@ private:
     // If we are an async function that is unspecified or nonisolated, insert an
     // isolated parameter if NonIsolatedAsyncInheritsIsolationFromContext is
     // enabled.
-    if (TC.Context.LangOpts.hasFeature(
-            Feature::NonIsolatedAsyncInheritsIsolationFromContext) &&
-        IsolationInfo &&
+    if (IsolationInfo &&
         IsolationInfo->getKind() == ActorIsolation::CallerIsolationInheriting &&
         extInfoBuilder.isAsync()) {
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -74,17 +74,18 @@ setExpectedExecutorForParameterIsolation(SILGenFunction &SGF,
   // If we have caller isolation inheriting... just grab from our isolated
   // argument.
   if (actorIsolation.getKind() == ActorIsolation::CallerIsolationInheriting) {
-    if (auto *isolatedArg = SGF.F.maybeGetIsolatedArgument()) {
-      ManagedValue isolatedMV;
-      if (isolatedArg->getOwnershipKind() == OwnershipKind::Guaranteed) {
-        isolatedMV = ManagedValue::forBorrowedRValue(isolatedArg);
-      } else {
-        isolatedMV = ManagedValue::forUnmanagedOwnedValue(isolatedArg);
-      }
-
-      SGF.ExpectedExecutor.set(SGF.emitLoadActorExecutor(loc, isolatedMV));
-      return;
+    auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
+    assert(isolatedArg &&
+           "Caller Isolation Inheriting without isolated parameter");
+    ManagedValue isolatedMV;
+    if (isolatedArg->getOwnershipKind() == OwnershipKind::Guaranteed) {
+      isolatedMV = ManagedValue::forBorrowedRValue(isolatedArg);
+    } else {
+      isolatedMV = ManagedValue::forUnmanagedOwnedValue(isolatedArg);
     }
+
+    SGF.ExpectedExecutor.set(SGF.emitLoadActorExecutor(loc, isolatedMV));
+    return;
   }
 
   llvm_unreachable("Unhandled case?!");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -265,16 +265,6 @@ public:
 
     switch (attr->getBehavior()) {
     case ExecutionKind::Concurrent: {
-      // 'concurrent' doesn't work with explicit `nonisolated`
-      if (F->hasExplicitIsolationAttribute()) {
-        if (F->getAttrs().hasAttribute<NonisolatedAttr>()) {
-          diagnoseAndRemoveAttr(
-              attr,
-              diag::attr_execution_concurrent_incompatible_with_nonisolated, F);
-          return;
-        }
-      }
-
       auto parameters = F->getParameters();
       if (!parameters)
         return;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5523,6 +5523,83 @@ static void addAttributesForActorIsolation(ValueDecl *value,
     }
 }
 
+/// Determine the default isolation and isolation source for this declaration,
+/// which may still be overridden by other inference rules.
+static std::tuple<InferredActorIsolation, ValueDecl *,
+                  std::optional<ActorIsolation>>
+computeDefaultInferredActorIsolation(ValueDecl *value) {
+  auto &ctx = value->getASTContext();
+
+  // If we are supposed to infer main actor isolation by default for entities
+  // within our module, make our default isolation main actor.
+  if (ctx.LangOpts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated) &&
+      value->getModuleContext() == ctx.MainModule) {
+
+    // Default global actor isolation does not apply to any declarations
+    // within actors and distributed actors.
+    bool inActorContext = false;
+    auto *dc = value->getInnermostDeclContext();
+    while (dc && !inActorContext) {
+      if (auto *nominal = dc->getSelfNominalTypeDecl()) {
+        inActorContext = nominal->isAnyActor();
+      }
+      dc = dc->getParent();
+    }
+
+    if (!inActorContext) {
+      // FIXME: deinit should be implicitly MainActor too.
+      if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
+          isa<AbstractStorageDecl>(value) || isa<FuncDecl>(value) ||
+          isa<ConstructorDecl>(value)) {
+        return {{ActorIsolation::forMainActor(ctx), {}}, nullptr, {}};
+      }
+    }
+  }
+
+  // If we have an async function... by default we inherit isolation.
+  if (ctx.LangOpts.hasFeature(
+          Feature::NonIsolatedAsyncInheritsIsolationFromContext)) {
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(value);
+        func && func->hasAsync() &&
+        func->getModuleContext() == ctx.MainModule) {
+      return {
+          {ActorIsolation::forCallerIsolationInheriting(), {}}, nullptr, {}};
+    }
+  }
+
+  if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
+    // A @Sendable function is assumed to be actor-independent.
+    if (func->isSendable()) {
+      return {
+          {ActorIsolation::forNonisolated(/*unsafe=*/false), {}}, nullptr, {}};
+    }
+  }
+
+  // When no other isolation applies, an actor's non-async init is independent
+  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl())
+    if (nominal->isAnyActor())
+      if (auto ctor = dyn_cast<ConstructorDecl>(value))
+        if (!ctor->hasAsync())
+          return {{ActorIsolation::forNonisolated(/*unsafe=*/false), {}},
+                  nullptr,
+                  {}};
+
+  // Look for and remember the overridden declaration's isolation.
+  if (auto *overriddenValue = value->getOverriddenDeclOrSuperDeinit()) {
+    // Use the overridden decl's isolation as the default isolation for this
+    // decl.
+    auto isolation = getOverriddenIsolationFor(value);
+    return {{isolation,
+             IsolationSource(overriddenValue, IsolationSource::Override)},
+            overriddenValue,
+            isolation}; // use the overridden decl's iso as the default
+                        // isolation for this decl.
+  }
+
+  // We did not find anything special, return unspecified.
+  return {{ActorIsolation::forUnspecified(), {}}, nullptr, {}};
+}
+
 InferredActorIsolation ActorIsolationRequest::evaluate(
     Evaluator &evaluator, ValueDecl *value) const {
   // If this declaration has actor-isolated "self", it's isolated to that
@@ -5566,7 +5643,7 @@ InferredActorIsolation ActorIsolationRequest::evaluate(
     value->getAttrs().add(preconcurrency);
   }
 
-  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) {
+  if (auto *fd = dyn_cast<FuncDecl>(value)) {
     // Main.main() and Main.$main are implicitly MainActor-protected.
     // Any other isolation is an error.
     std::optional<ActorIsolation> mainIsolation =
@@ -5599,74 +5676,11 @@ InferredActorIsolation ActorIsolationRequest::evaluate(
             IsolationSource(/*source*/ nullptr, IsolationSource::Explicit)};
   }
 
-  // Determine the default isolation for this declaration, which may still be
-  // overridden by other inference rules.
-  ActorIsolation defaultIsolation = ActorIsolation::forUnspecified();
-  IsolationSource defaultIsolationSource;
-
-  // If we are supposed to infer main actor isolation by default for entities
-  // within our module, make our default isolation main actor.
-  if (ctx.LangOpts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated) &&
-      value->getModuleContext() == ctx.MainModule) {
-
-    // Default global actor isolation does not apply to any declarations
-    // within actors and distributed actors.
-    bool inActorContext = false;
-    auto *dc = value->getInnermostDeclContext();
-    while (dc && !inActorContext) {
-      if (auto *nominal = dc->getSelfNominalTypeDecl()) {
-        inActorContext = nominal->isAnyActor();
-      }
-      dc = dc->getParent();
-    }
-
-    if (!inActorContext) {
-      // FIXME: deinit should be implicitly MainActor too.
-      if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
-          isa<AbstractStorageDecl>(value) || isa<FuncDecl>(value) ||
-          isa<ConstructorDecl>(value)) {
-        defaultIsolation = ActorIsolation::forMainActor(ctx);
-      }
-    }
-  }
-
-  // If we have an async function... by default we inherit isolation.
-  if (ctx.LangOpts.hasFeature(
-          Feature::NonIsolatedAsyncInheritsIsolationFromContext)) {
-    if (auto *func = dyn_cast<AbstractFunctionDecl>(value);
-        func && func->hasAsync() &&
-        func->getModuleContext() == ctx.MainModule) {
-      defaultIsolation = ActorIsolation::forCallerIsolationInheriting();
-    }
-  }
-
-  if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
-    // A @Sendable function is assumed to be actor-independent.
-    if (func->isSendable()) {
-      defaultIsolation = ActorIsolation::forNonisolated(/*unsafe=*/false);
-    }
-  }
-
-  // When no other isolation applies, an actor's non-async init is independent
-  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl())
-    if (nominal->isAnyActor())
-      if (auto ctor = dyn_cast<ConstructorDecl>(value))
-        if (!ctor->hasAsync())
-          defaultIsolation = ActorIsolation::forNonisolated(/*unsafe=*/false);
-
-  // Look for and remember the overridden declaration's isolation.
-  std::optional<ActorIsolation> overriddenIso;
-  ValueDecl *overriddenValue = value->getOverriddenDeclOrSuperDeinit();
-  if (overriddenValue) {
-    // use the overridden decl's iso as the default isolation for this decl.
-    defaultIsolation = getOverriddenIsolationFor(value);
-    defaultIsolationSource =
-        IsolationSource(overriddenValue, IsolationSource::Override);
-    overriddenIso = defaultIsolation;
-  }
-
-  // NOTE: After this point, the default has been set. Only touch the default
-  // isolation above this point since code below assumes it is now constant.
+  InferredActorIsolation defaultIsolation;
+  ValueDecl *overriddenValue;
+  std::optional<ActorIsolation> overridenIsolation;
+  std::tie(defaultIsolation, overriddenValue, overridenIsolation) =
+      computeDefaultInferredActorIsolation(value);
 
   // Function used when returning an inferred isolation.
   auto inferredIsolation = [&](ActorIsolation inferred,
@@ -5677,16 +5691,17 @@ InferredActorIsolation ActorIsolationRequest::evaluate(
       // if the inferred isolation is not valid, then carry-over the overridden
       // declaration's isolation as this decl's inferred isolation.
       switch (validOverrideIsolation(value, inferred, overriddenValue,
-                                     *overriddenIso)) {
+                                     *overridenIsolation)) {
       case OverrideIsolationResult::Allowed:
       case OverrideIsolationResult::Sendable:
         break;
 
       case OverrideIsolationResult::Disallowed:
-        if (overriddenValue->hasClangNode() && overriddenIso->isUnspecified()) {
-          inferred = overriddenIso->withPreconcurrency(true);
+        if (overriddenValue->hasClangNode() &&
+            overridenIsolation->isUnspecified()) {
+          inferred = overridenIsolation->withPreconcurrency(true);
         } else {
-          inferred = *overriddenIso;
+          inferred = *overridenIsolation;
         }
         break;
       }
@@ -5944,7 +5959,7 @@ InferredActorIsolation ActorIsolationRequest::evaluate(
   }
 
   // Default isolation for this member.
-  return {defaultIsolation, defaultIsolationSource};
+  return defaultIsolation;
 }
 
 bool HasIsolatedSelfRequest::evaluate(

--- a/test/SILGen/execution_attr.swift
+++ b/test/SILGen/execution_attr.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+
+// Validate that both with and without the experimental flag we properly codegen
+// execution(caller) and execution(concurrent).
+
+// CHECK-LABEL: // executionCaller()
+// CHECK-NEXT: // Isolation: caller_isolation_inheriting
+// CHECK-NEXT: sil hidden [ossa] @$s14execution_attr0A6CalleryyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> () {
+@execution(caller)
+func executionCaller() async {}
+
+// CHECK-LABEL: // executionConcurrent()
+// CHECK: // Isolation: nonisolated
+// CHECK: sil hidden [ossa] @$s14execution_attr0A10ConcurrentyyYaF : $@convention(thin) @async () -> () {
+@execution(concurrent)
+func executionConcurrent() async {}

--- a/test/Serialization/Inputs/caller_inheriting_isolation.swift
+++ b/test/Serialization/Inputs/caller_inheriting_isolation.swift
@@ -1,0 +1,47 @@
+
+public func unspecifiedAsync<T>(_ t: T) async {
+}
+
+@execution(caller)
+public func unspecifiedAsyncCaller<T>(_ t: T) async {
+}
+
+@execution(concurrent)
+public func unspecifiedAsyncConcurrent<T>(_ t: T) async {
+}
+
+nonisolated public func nonisolatedAsync<T>(_ t: T) async {
+}
+
+@execution(caller)
+nonisolated public func nonisolatedAsyncCaller<T>(_ t: T) async {
+}
+
+@execution(concurrent)
+nonisolated public func nonisolatedAsyncConcurrent<T>(_ t: T) async {
+}
+
+public struct S {
+  public init() {}
+  public func unspecifiedAsync<T>(_ t: T) async {
+  }
+
+  @execution(caller)
+  public func unspecifiedAsyncCaller<T>(_ t: T) async {
+  }
+
+  @execution(concurrent)
+  public func unspecifiedAsyncConcurrent<T>(_ t: T) async {
+  }
+
+  nonisolated public func nonisolatedAsync<T>(_ t: T) async {
+  }
+
+  @execution(caller)
+  nonisolated public func nonisolatedAsyncCaller<T>(_ t: T) async {
+  }
+
+  @execution(concurrent)
+  nonisolated public func nonisolatedAsyncConcurrent<T>(_ t: T) async {
+  }
+}

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -1,0 +1,227 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+
+// RUN: %target-swift-frontend -module-name main -I %t %s -emit-sil -o - | %FileCheck %s
+
+// RUN: %target-swift-frontend -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -module-name main -I %t %s -emit-sil -verify -swift-version 6
+
+// REQUIRES: asserts
+// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+
+import WithFeature
+import WithoutFeature
+
+class NonSendable {}
+
+actor A {
+  var ns = NonSendable()
+
+  // CHECK-LABEL: // unspecifiedAsync<A>(_:)
+  // CHECK-NEXT: // Isolation: caller_isolation_inheriting
+  // CHECK-NEXT: sil @$s11WithFeature16unspecifiedAsyncyyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test1() async {
+    // If unspecifiedAsync does not inherit the isolation of A, then we will get
+    // an error.
+    await WithFeature.unspecifiedAsync(ns)
+  }
+
+  // CHECK-LABEL: // unspecifiedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s11WithFeature26unspecifiedAsyncConcurrentyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test1a() async {
+    await WithFeature.unspecifiedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // unspecifiedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature22unspecifiedAsyncCalleryyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test1b() async {
+    await WithFeature.unspecifiedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // unspecifiedAsync<A>(_:)
+  // CHECK: // Isolation: unspecified
+  // CHECK: sil @$s14WithoutFeature16unspecifiedAsyncyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test2() async {
+    await WithoutFeature.unspecifiedAsync(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // unspecifiedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature26unspecifiedAsyncConcurrentyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test2a() async {
+    // If unspecifiedAsync does not inherit the isolation of A, then we will get
+    // an error.
+    await WithoutFeature.unspecifiedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // unspecifiedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s14WithoutFeature22unspecifiedAsyncCalleryyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test2b() async {
+    await WithoutFeature.unspecifiedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // nonisolatedAsync<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature16nonisolatedAsyncyyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test3() async {
+    await WithFeature.nonisolatedAsync(ns)
+  }
+
+  // CHECK-LABEL: // nonisolatedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s11WithFeature26nonisolatedAsyncConcurrentyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test3a() async {
+    await WithFeature.nonisolatedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // nonisolatedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature22nonisolatedAsyncCalleryyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test3b() async {
+    await WithFeature.nonisolatedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // nonisolatedAsync<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature16nonisolatedAsyncyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test4() async {
+    await WithoutFeature.nonisolatedAsync(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // nonisolatedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature26nonisolatedAsyncConcurrentyyxYalF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  func test4a() async {
+    await WithoutFeature.nonisolatedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // nonisolatedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s14WithoutFeature22nonisolatedAsyncCalleryyxYalF : $@convention(thin) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0) -> ()
+  func test4b() async {
+    await WithoutFeature.nonisolatedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsync<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature1SV16unspecifiedAsyncyyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test5() async {
+    let s = WithFeature.S()
+    await s.unspecifiedAsync(ns)
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s11WithFeature1SV26unspecifiedAsyncConcurrentyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test5a() async {
+    let s = WithFeature.S()
+    await s.unspecifiedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature1SV22unspecifiedAsyncCalleryyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test5b() async {
+    let s = WithFeature.S()
+    await s.unspecifiedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsync<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature1SV16nonisolatedAsyncyyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test6() async {
+    let s = WithFeature.S()
+    await s.nonisolatedAsync(ns)
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s11WithFeature1SV26nonisolatedAsyncConcurrentyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test6a() async {
+    let s = WithFeature.S()
+    await s.nonisolatedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s11WithFeature1SV22nonisolatedAsyncCalleryyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test6b() async {
+    let s = WithFeature.S()
+    await s.nonisolatedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsync<A>(_:)
+  // CHECK: // Isolation: unspecified
+  // CHECK: sil @$s14WithoutFeature1SV16unspecifiedAsyncyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test7() async {
+    let s = WithoutFeature.S()
+    await s.unspecifiedAsync(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature1SV26unspecifiedAsyncConcurrentyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test7a() async {
+    let s = WithoutFeature.S()
+    await s.unspecifiedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.unspecifiedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s14WithoutFeature1SV22unspecifiedAsyncCalleryyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test7b() async {
+    let s = WithoutFeature.S()
+    await s.unspecifiedAsyncCaller(ns)
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsync<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature1SV16nonisolatedAsyncyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test8() async {
+    let s = WithoutFeature.S()
+    await s.nonisolatedAsync(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsyncConcurrent<A>(_:)
+  // CHECK: // Isolation: nonisolated
+  // CHECK: sil @$s14WithoutFeature1SV26nonisolatedAsyncConcurrentyyxYalF : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, S) -> ()
+  func test8a() async {
+    let s = WithoutFeature.S()
+    await s.nonisolatedAsyncConcurrent(ns)
+    // expected-error @-1 {{sending 'self.ns' risks causing data races}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+  }
+
+  // CHECK-LABEL: // S.nonisolatedAsyncCaller<A>(_:)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil @$s14WithoutFeature1SV22nonisolatedAsyncCalleryyxYalF : $@convention(method) @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @in_guaranteed τ_0_0, S) -> ()
+  func test8b() async {
+    let s = WithoutFeature.S()
+    await s.nonisolatedAsyncCaller(ns)
+  }
+}

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -42,7 +42,6 @@ do {
 
 struct TestAttributeCollisions {
   @execution(concurrent) nonisolated func testNonIsolated() async {}
-  // expected-error@-1 {{cannot use '@execution(concurrent)' and 'nonisolated' on the same 'testNonIsolated()' because they serve the same purpose}}
 
   @execution(concurrent) func test(arg: isolated MainActor) async {}
   // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}


### PR DESCRIPTION
This PR implements serialization for execution(caller)/execution(concurrent).

It also does a few other small changes as well:

1. I allow for nonisolated and execution(concurrent) to be used together.
2. I noticed that we were not handling @execution(caller) correctly when the enabling flag was disabled. I fixed the issue and added some tests to validate that things keep working with and without the flag (which just changes the default for nonisolated).
3. I also recommitted the inferred default actor computation that I removed when I reverted the nonisolated -> concurrent rename (which I did to just make the revert easier).

rdar://142790023