### PR TITLE
[BridgingHeader] Fix auto-chaining when only dependency has bridging header

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -286,7 +286,7 @@ public:
 
   /// If set, the header provided in ImplicitObjCHeaderPath will be rewritten
   /// by the Clang importer as part of semantic analysis.
-  bool SerializeBridgingHeader = false;
+  bool ModuleHasBridgingHeader = false;
 
   /// Indicates whether or not the frontend should print statistics upon
   /// termination.

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -901,7 +901,7 @@ void ArgsToFrontendOptionsConverter::computeImportObjCHeaderOptions() {
       Opts.ImplicitObjCHeaderPath = A->getValue();
     // If `-import-object-header` is used, it means the module has a direct
     // bridging header dependency and it can be serialized into binary module.
-    Opts.SerializeBridgingHeader |= true;
+    Opts.ModuleHasBridgingHeader |= true;
   }
   if (const Arg *A = Args.getLastArgNoClaim(OPT_import_pch))
     Opts.ImplicitObjCPCHPath = A->getValue();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -196,7 +196,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.DocOutputPath = outs.ModuleDocOutputPath;
   serializationOpts.SourceInfoOutputPath = outs.ModuleSourceInfoOutputPath;
   serializationOpts.GroupInfoPath = opts.GroupInfoPath.c_str();
-  if (opts.SerializeBridgingHeader && !outs.ModuleOutputPath.empty())
+  if (opts.ModuleHasBridgingHeader && !outs.ModuleOutputPath.empty())
     serializationOpts.SerializeBridgingHeader = true;
   // For batch mode, emit empty header path as placeholder.
   if (serializationOpts.SerializeBridgingHeader &&
@@ -1302,10 +1302,12 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
   }
 
   imports.ShouldImportUnderlyingModule = frontendOpts.ImportUnderlyingModule;
-  if (frontendOpts.ImplicitObjCPCHPath.empty())
-    imports.BridgingHeaderPath = frontendOpts.ImplicitObjCHeaderPath;
-  else
-    imports.BridgingHeaderPath = frontendOpts.ImplicitObjCPCHPath;
+  if (frontendOpts.ModuleHasBridgingHeader) {
+    if (frontendOpts.ImplicitObjCPCHPath.empty())
+      imports.BridgingHeaderPath = frontendOpts.ImplicitObjCHeaderPath;
+    else
+      imports.BridgingHeaderPath = frontendOpts.ImplicitObjCPCHPath;
+  }
   return imports;
 }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4524,6 +4524,9 @@ int main(int argc, char *argv[]) {
     options::ImportObjCHeader;
   InitInvok.getClangImporterOptions().BridgingHeader =
     options::ImportObjCHeader;
+  if (!options::ImportObjCHeader.empty())
+    InitInvok.getFrontendOptions().ModuleHasBridgingHeader = true;
+
   InitInvok.getLangOptions().EnableAccessControl =
     !options::DisableAccessControl;
   InitInvok.getLangOptions().EnableDeserializationSafety =


### PR DESCRIPTION
When enable bridging header auto chaining, it is possible for the compilation to have a PCH file input for the bridging header from a binary swift module dependency. In this case, we should not report a bridging header for current module as bridging header can be leaking out through swiftinterface file.

To fully distinguish the PCH files passed in through different situation, here are the situations:
* If no chaining is used, only `-import-objc-header` option is used and it can be used to pass either a header file or a PCH file depending if GeneratePCH job is requested or not.
* If chaining is enabled, `-import-objc-header` is only used to pass the header file and `-import-pch` is used to pass PCH file. Chaining mode requires PCH generation if bridging header is used.

rdar://144623388

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
