### PR TITLE
[IRGen] Emit a pointer from nominal type descriptor to concrete metadata.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3880,6 +3880,13 @@ struct TargetCanonicalSpecializedMetadatasCachingOnceToken {
 };
 
 template <typename Runtime>
+struct TargetSingletonMetadataPointer {
+  TargetRelativeDirectPointer<Runtime, TargetMetadata<Runtime>,
+                              /*Nullable*/ false>
+      metadata;
+};
+
+template <typename Runtime>
 class swift_ptrauth_struct_context_descriptor(TypeContextDescriptor)
     TargetTypeContextDescriptor : public TargetContextDescriptor<Runtime> {
 public:
@@ -3931,7 +3938,15 @@ public:
   }
 
   bool hasCanonicalMetadataPrespecializations() const {
-    return getTypeContextDescriptorFlags().hasCanonicalMetadataPrespecializations();
+    return this->isGeneric() &&
+           getTypeContextDescriptorFlags()
+               .hasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer();
+  }
+
+  bool hasSingletonMetadataPointer() const {
+    return !this->isGeneric() &&
+           getTypeContextDescriptorFlags()
+               .hasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer();
   }
 
   bool hasLayoutString() const {
@@ -4123,7 +4138,8 @@ class swift_ptrauth_struct_context_descriptor(ClassDescriptor)
                               TargetCanonicalSpecializedMetadatasListEntry<Runtime>,
                               TargetCanonicalSpecializedMetadataAccessorsListEntry<Runtime>,
                               TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>,
-                              InvertibleProtocolSet> {
+                              InvertibleProtocolSet,
+                              TargetSingletonMetadataPointer<Runtime>> {
 private:
   using TrailingGenericContextObjects =
     swift::TrailingGenericContextObjects<TargetClassDescriptor<Runtime>,
@@ -4140,7 +4156,8 @@ private:
                                          TargetCanonicalSpecializedMetadatasListEntry<Runtime>,
                                          TargetCanonicalSpecializedMetadataAccessorsListEntry<Runtime>,
                                          TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>,
-                                         InvertibleProtocolSet>;
+                                         InvertibleProtocolSet,
+                                         TargetSingletonMetadataPointer<Runtime>>;
 
   using TrailingObjects =
     typename TrailingGenericContextObjects::TrailingObjects;
@@ -4170,6 +4187,7 @@ public:
       TargetCanonicalSpecializedMetadataAccessorsListEntry<Runtime>;
   using MetadataCachingOnceToken =
       TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>;
+  using SingletonMetadataPointer = TargetSingletonMetadataPointer<Runtime>;
 
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredPointerDifference = typename Runtime::StoredPointerDifference;
@@ -4309,6 +4327,10 @@ private:
 
   size_t numTrailingObjects(OverloadToken<MetadataCachingOnceToken>) const {
     return this->hasCanonicalMetadataPrespecializations() ? 1 : 0;
+  }
+
+  size_t numTrailingObjects(OverloadToken<SingletonMetadataPointer>) const {
+    return this->hasSingletonMetadataPointer() ? 1 : 0;
   }
 
 public:
@@ -4490,6 +4512,14 @@ public:
     return box->token.get();
   }
 
+  TargetMetadata<Runtime> *getSingletonMetadata() const {
+    if (!this->hasSingletonMetadataInitialization())
+      return nullptr;
+
+    auto box = this->template getTrailingObjects<SingletonMetadataPointer>();
+    return box->token.get();
+  }
+
   /// Retrieve the set of protocols that are inverted by this type's
   /// primary definition.
   ///
@@ -4537,7 +4567,8 @@ class swift_ptrauth_struct_context_descriptor(StructDescriptor)
                             TargetCanonicalSpecializedMetadatasListCount<Runtime>,
                             TargetCanonicalSpecializedMetadatasListEntry<Runtime>,
                             TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>,
-                            InvertibleProtocolSet> {
+                            InvertibleProtocolSet,
+                            TargetSingletonMetadataPointer<Runtime>> {
 public:
   using ForeignMetadataInitialization =
     TargetForeignMetadataInitialization<Runtime>;
@@ -4551,6 +4582,7 @@ public:
     TargetCanonicalSpecializedMetadatasListEntry<Runtime>;
   using MetadataCachingOnceToken =
       TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>;
+  using SingletonMetadataPointer = TargetSingletonMetadataPointer<Runtime>;
 
 private:
   using TrailingGenericContextObjects =
@@ -4561,7 +4593,8 @@ private:
                                            MetadataListCount,
                                            MetadataListEntry,
                                            MetadataCachingOnceToken,
-                                           InvertibleProtocolSet>;
+                                           InvertibleProtocolSet,
+                                           TargetSingletonMetadataPointer<Runtime>>;
 
   using TrailingObjects =
     typename TrailingGenericContextObjects::TrailingObjects;
@@ -4593,6 +4626,10 @@ private:
 
   size_t numTrailingObjects(OverloadToken<MetadataCachingOnceToken>) const {
     return this->hasCanonicalMetadataPrespecializations() ? 1 : 0;
+  }
+
+  size_t numTrailingObjects(OverloadToken<SingletonMetadataPointer>) const {
+    return this->hasSingletonMetadataPointer() ? 1 : 0;
   }
 
 public:
@@ -4648,6 +4685,14 @@ public:
     return box->token.get();
   }
 
+  TargetMetadata<Runtime> *getSingletonMetadata() const {
+    if (!this->hasSingletonMetadataInitialization())
+      return nullptr;
+
+    auto box = this->template getTrailingObjects<SingletonMetadataPointer>();
+    return box->token.get();
+  }
+
   /// Retrieve the set of protocols that are inverted by this type's
   /// primary definition.
   ///
@@ -4684,7 +4729,8 @@ class swift_ptrauth_struct_context_descriptor(EnumDescriptor)
                             TargetCanonicalSpecializedMetadatasListCount<Runtime>,
                             TargetCanonicalSpecializedMetadatasListEntry<Runtime>,
                             TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>,
-                            InvertibleProtocolSet> {
+                            InvertibleProtocolSet,
+                            TargetSingletonMetadataPointer<Runtime>> {
 public:
   using SingletonMetadataInitialization =
     TargetSingletonMetadataInitialization<Runtime>;
@@ -4698,6 +4744,7 @@ public:
     TargetCanonicalSpecializedMetadatasListEntry<Runtime>;
   using MetadataCachingOnceToken =
       TargetCanonicalSpecializedMetadatasCachingOnceToken<Runtime>;
+  using SingletonMetadataPointer = TargetSingletonMetadataPointer<Runtime>;
 
 private:
   using TrailingGenericContextObjects =
@@ -4708,7 +4755,8 @@ private:
                                         MetadataListCount,
                                         MetadataListEntry, 
                                         MetadataCachingOnceToken,
-                                        InvertibleProtocolSet>;
+                                        InvertibleProtocolSet,
+                                        TargetSingletonMetadataPointer<Runtime>>;
 
   using TrailingObjects =
     typename TrailingGenericContextObjects::TrailingObjects;
@@ -4740,6 +4788,10 @@ private:
 
   size_t numTrailingObjects(OverloadToken<MetadataCachingOnceToken>) const {
     return this->hasCanonicalMetadataPrespecializations() ? 1 : 0;
+  }
+
+  size_t numTrailingObjects(OverloadToken<SingletonMetadataPointer>) const {
+    return this->hasSingletonMetadataPointer() ? 1 : 0;
   }
 
 public:
@@ -4806,6 +4858,14 @@ public:
       return nullptr;
     }
     auto box = this->template getTrailingObjects<MetadataCachingOnceToken>();
+    return box->token.get();
+  }
+
+  TargetMetadata<Runtime> *getSingletonMetadata() const {
+    if (!this->hasSingletonMetadataInitialization())
+      return nullptr;
+
+    auto box = this->template getTrailingObjects<SingletonMetadataPointer>();
     return box->token.get();
   }
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1861,9 +1861,10 @@ class TypeContextDescriptorFlags : public FlagSet<uint16_t> {
     /// Meaningful for all type-descriptor kinds.
     HasImportInfo = 2,
 
-    /// Set if the type descriptor has a pointer to a list of canonical
-    /// prespecializations.
-    HasCanonicalMetadataPrespecializations = 3,
+    /// Set if the generic type descriptor has a pointer to a list of canonical
+    /// prespecializations, or the non-generic type descriptor has a pointer to
+    /// its singleton metadata.
+    HasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer = 3,
 
     /// Set if the metadata contains a pointer to a layout string
     HasLayoutString = 4,
@@ -1948,7 +1949,10 @@ public:
 
   FLAGSET_DEFINE_FLAG_ACCESSORS(HasImportInfo, hasImportInfo, setHasImportInfo)
 
-  FLAGSET_DEFINE_FLAG_ACCESSORS(HasCanonicalMetadataPrespecializations, hasCanonicalMetadataPrespecializations, setHasCanonicalMetadataPrespecializations)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(
+      HasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer,
+      hasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer,
+      setHasCanonicalMetadataPrespecializationsOrSingletonMetadataPointer)
 
   FLAGSET_DEFINE_FLAG_ACCESSORS(HasLayoutString,
                                 hasLayoutString,

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -398,6 +398,10 @@ public:
   /// arguments.
   unsigned PrespecializeGenericMetadata : 1;
 
+  /// Emit pointers to the corresponding type metadata in non-public non-generic
+  /// type descriptors.
+  unsigned EmitSingletonMetadataPointers : 1;
+
   /// The path to load legacy type layouts from.
   StringRef ReadLegacyTypeInfoPath;
 
@@ -576,7 +580,8 @@ public:
         LazyInitializeProtocolConformances(false),
         IndirectAsyncFunctionPointer(false),
         CompactAbsoluteFunctionPointer(false), DisableLegacyTypeInfo(false),
-        PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),
+        PrespecializeGenericMetadata(false),
+        EmitSingletonMetadataPointers(false), UseIncrementalLLVMCodeGen(true),
         UseTypeLayoutValueHandling(true), ForceStructTypeLayouts(false),
         EnableLargeLoadableTypesReg2Mem(true),
         EnableLayoutStringValueWitnesses(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1102,6 +1102,10 @@ def prespecialize_generic_metadata : Flag<["-"], "prespecialize-generic-metadata
    HelpText<"Statically specialize metadata for generic types at types that "
             "are known to be used in source.">;
 
+def emit_singleton_metadata_pointer : Flag<["-"], "emit-singleton-metadata-pointer">,
+   HelpText<"Emit a pointer to the corresponding type metadata into non-public "
+            "non-generic type descriptors.">;
+
 def read_legacy_type_info_path_EQ : Joined<["-"], "read-legacy-type-info-path=">,
   HelpText<"Read legacy type layout from the given path instead of default path">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3436,6 +3436,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.PrespecializeGenericMetadata = true;
   }
 
+  if (Args.hasArg(OPT_emit_singleton_metadata_pointer)) {
+    Opts.EmitSingletonMetadataPointers = true;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_read_legacy_type_info_path_EQ)) {
     Opts.ReadLegacyTypeInfoPath = A->getValue();
   }

--- a/test/IRGen/emit-singleton-metadata-pointer.swift
+++ b/test/IRGen/emit-singleton-metadata-pointer.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -emit-singleton-metadata-pointer | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-vendor --dump-input=always
+
+// CHECK: @"$s4main23PrivateNongenericStructVMn" =
+// CHECK-SAME: hidden constant <{ i32, i32, i32, i32, i32, i32, i32, i32 }>
+// -- flags: struct, unique, has singleton metadata pointer
+// CHECK-SAME: <{ i32 524369,
+// -- 32-bit relative pointer to metadata
+// CHECK-64-SAME: i32 trunc (i64 sub (i64 ptrtoint (ptr getelementptr inbounds (<{ {{.*}} }>, ptr @"$s4main23PrivateNongenericStructVMf", i32 0, i32 2) to i64)
+// CHECK-32-SAME: i32 sub (i32 ptrtoint (ptr getelementptr inbounds (<{ {{.*}} }>, ptr @"$s4main23PrivateNongenericStructVMf", i32 0, i32 2) to i32)
+
+internal struct PrivateNongenericStruct {}


### PR DESCRIPTION
This allows external tools to locate the metadata pointer without needing to call the accessor function.

This is only useful for non-generic types, so we borrow the HasCanonicalMetadataPrespecializations flag to indicate the presence of this pointer on non-generic types, and it continues to indicate the presence of prespecializations for generic types.

Only emit this pointer for internal/private types with no runtime initialization. Public type metadata can be found with the symbol, and it's not useful for types that require runtime initialization.

rdar://144640722