### PR TITLE
[Compatibility50] Silence warning about taking the address of objc_setHook_getClass.

### DIFF
--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -112,7 +112,7 @@ static void installGetClassHook_untrusted() {
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
-  if (objc_setHook_getClass) {
+  if (&objc_setHook_getClass) {
     objc_setHook_getClass(getObjCClassByMangledName_untrusted,
                           &OldGetClassHook);
   }


### PR DESCRIPTION
Add a & so the compiler doesn't think it always evaluates to true.

rdar://144465537