### PR TITLE
Runtime: correct homing module for `swift_coroFrameAlloc`

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2099,7 +2099,7 @@ FUNCTION(Free, c, free, C_CC, AlwaysAvailable,
          NO_ATTRS,
          EFFECT(Deallocating),
          UNKNOWN_MEMEFFECTS)
-FUNCTION(CoroFrameAlloc, c, swift_coroFrameAlloc, C_CC, AlwaysAvailable,
+FUNCTION(CoroFrameAlloc, Swift, swift_coroFrameAlloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy, Int64Ty),
          NO_ATTRS,


### PR DESCRIPTION
This function is part of the Swift standard library, not the *C* standard library. Correct the library name for the module to ensure that it is properly exported.