### PR TITLE
github: add myself as a CODEOWNER for include/swift/Runtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,7 +97,7 @@
 /include/swift/Parse/                              @ahoppen @bnbarham @CodaFi @DougGregor @hamishknight @rintaro
 /include/swift/PrintAsClang                        @zoecarver @hyp @egorzhdan @Xazax-hun
 /include/swift/Refactoring                         @ahoppen @bnbarham @hamishknight @rintaro
-/include/swift/Runtime/                            @rjmccall
+/include/swift/Runtime/                            @rjmccall @compnerd
 /include/swift/SIL/                                @jckarter
 /include/swift/SIL/*Coverage*                      @ahoppen @bnbarham @hamishknight @rintaro
 /include/swift/SIL/*DebugInfo*                     @adrian-prantl


### PR DESCRIPTION
The declarations for the well-known function entries for the Swift runtime have direct impact on the Swift runtime implementation for Windows. Add myself as a CODEOWNER to provide notifications of any changes that may impact platform support.