### PR TITLE
ClangImporter: enable test, fix typo

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -560,7 +560,7 @@ void GetWindowsFileMappings(
       fileMapping.redirectedFiles.emplace_back(std::string(VCToolsInjection),
                                                AuxiliaryFile);
 
-    // Because we wish to be backwrds compatible with older Visual Studio
+    // Because we wish to be backwards compatible with older Visual Studio
     // releases, we inject empty headers which allow us to have definitions for
     // modules referencing headers which may not exist. We stub out the headers
     // with empty files to allow a single module definition to work across

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -5,9 +5,6 @@
 
 // REQUIRES: executable_test
 
-// TODO: test failed in Windows PR testing: rdar://144384453
-// UNSUPPORTED: OS=windows-msvc
-
 import StdlibUnittest
 import CxxStdlib
 import StdStringView


### PR DESCRIPTION
Enable one of the previously disabled tests on Windows and take the opportunity to fix an associated typo.