### PR TITLE
[DebugInfo]Generate call-site information in swift

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -296,6 +296,10 @@ public:
   /// indexing info.
   PathRemapper FilePrefixMap;
 
+  /// Indicates whether or not the frontend should generate callsite information
+  /// in the debug info.
+  bool DebugCallsiteInfo = false;
+
   /// What level of debug info to generate.
   IRGenDebugInfoLevel DebugInfoLevel : 2;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2191,6 +2191,10 @@ def cas_backend: Flag<["-"], "cas-backend">,
   Flags<[FrontendOption, NoDriverOption]>,
   HelpText<"Enable using CASBackend for object file output">;
 
+def debug_callsite_info: Flag<["-"], "debug-callsite-info">,
+  Flags<[FrontendOption, NoDriverOption]>,
+  HelpText<"Generate callsite information in debug info">;
+
 def cas_backend_mode: Joined<["-"], "cas-backend-mode=">,
   Flags<[FrontendOption, NoDriverOption]>,
   HelpText<"CASBackendMode for output kind">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3681,6 +3681,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.UseCASBackend |= Args.hasArg(OPT_cas_backend);
   Opts.EmitCASIDFile |= Args.hasArg(OPT_cas_emit_casid_file);
 
+  Opts.DebugCallsiteInfo |= Args.hasArg(OPT_debug_callsite_info);
+
   return false;
 }
 

--- a/test/DebugInfo/call-site-info.swift
+++ b/test/DebugInfo/call-site-info.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -debug-callsite-info -emit-ir -parse-as-library -g -O -module-name S %s -o - | %FileCheck %s
+// CHECK: {{[0-9]+}} = distinct !DISubprogram(name: "f", linkageName: {{.*}}, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: !{{[0-9]+}}, scopeLine: {{[0-9]+}}, flags: DIFlagAllCallsDescribed
+// CHECK: {{[0-9]+}} = distinct !DISubprogram(linkageName: {{.*}}, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, type: !{{[0-9]+}}, flags: {{.*}} DIFlagAllCallsDescribed
+
+public struct S {
+  public func f() {}
+}


### PR DESCRIPTION
This patch adds the frontend flag `gen-callsite-info` which adds support for emitting the flag `llvm::DINode::FlagAllCallsDescribed` when generating LLVM IR from the Swift compiler to get call-site information for swift source code.

This will help disambiguate merged functions produced by function deduplication in the linker.

