### PR TITLE
AST: Begin refactoring AvailabilitySpec to support custom domains

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -654,12 +654,12 @@ BridgedSourceRange
 BridgedAvailabilitySpec_getVersionRange(BridgedAvailabilitySpec spec);
 
 SWIFT_NAME("BridgedPlatformVersionConstraintAvailabilitySpec.createParsed(_:"
-           "platform:platformLoc:version:runtimeVersion:versionRange:)")
+           "platform:platformLoc:version:versionRange:)")
 BridgedPlatformVersionConstraintAvailabilitySpec
 BridgedPlatformVersionConstraintAvailabilitySpec_createParsed(
     BridgedASTContext cContext, BridgedPlatformKind cPlatform,
     BridgedSourceLoc cPlatformLoc, BridgedVersionTuple cVersion,
-    BridgedVersionTuple cRuntimeVersion, BridgedSourceRange cVersionSrcRange);
+    BridgedSourceRange cVersionSrcRange);
 
 SWIFT_NAME("BridgedPlatformAgnosticVersionConstraintAvailabilitySpec."
            "createParsed(_:kind:nameLoc:version:versionRange:)")

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -75,20 +75,6 @@ class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
 
   llvm::VersionTuple Version;
 
-  // For macOS Big Sur, we canonicalize 10.16 to 11.0 for compile-time
-  // checking since clang canonicalizes availability markup. However, to
-  // support Beta versions of macOS Big Sur where the OS
-  // reports 10.16 at run time, we need to compare against 10.16,
-  //
-  // This means for:
-  //
-  // if #available(macOS 10.16, *) { ... }
-  //
-  // we need to keep around both a canonical version for use in compile-time
-  // checks and an uncanonicalized version for the version to actually codegen
-  // with.
-  llvm::VersionTuple RuntimeVersion;
-
   SourceRange VersionSrcRange;
 
   // Location of the macro expanded to create this spec.
@@ -98,13 +84,10 @@ public:
   PlatformVersionConstraintAvailabilitySpec(PlatformKind Platform,
                                             SourceLoc PlatformLoc,
                                             llvm::VersionTuple Version,
-                                            llvm::VersionTuple RuntimeVersion,
                                             SourceRange VersionSrcRange)
-    : AvailabilitySpec(AvailabilitySpecKind::PlatformVersionConstraint),
-      Platform(Platform),
-      PlatformLoc(PlatformLoc), Version(Version),
-      RuntimeVersion(RuntimeVersion),
-      VersionSrcRange(VersionSrcRange) {}
+      : AvailabilitySpec(AvailabilitySpecKind::PlatformVersionConstraint),
+        Platform(Platform), PlatformLoc(PlatformLoc), Version(Version),
+        VersionSrcRange(VersionSrcRange) {}
 
   /// The required platform.
   PlatformKind getPlatform() const { return Platform; }
@@ -116,13 +99,13 @@ public:
   bool isUnrecognizedPlatform() const { return Platform == PlatformKind::none; }
 
   // The platform version to compare against.
-  llvm::VersionTuple getVersion() const { return Version; }
+  llvm::VersionTuple getVersion() const;
   SourceRange getVersionSrcRange() const { return VersionSrcRange; }
 
   // The version to be used in codegen for version comparisons at run time.
   // This is required to support beta versions of macOS Big Sur that
   // report 10.16 at run time.
-  llvm::VersionTuple getRuntimeVersion() const { return RuntimeVersion; }
+  llvm::VersionTuple getRuntimeVersion() const;
 
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_CONST_TYPE_INFO_H
 
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include <memory>

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -20,7 +20,6 @@
 #include "swift/AST/ASTAllocated.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/AvailabilityRange.h"
-#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/ThrownErrorDestination.h"
@@ -36,6 +35,7 @@ namespace swift {
 class AnyPattern;
 class ASTContext;
 class ASTWalker;
+class AvailabilitySpec;
 class Decl;
 class DeclContext;
 class Evaluator;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -53,7 +53,9 @@ namespace swift {
   class SILParserStateBase;
   class SourceManager;
   class UUID;
-  
+  class PlatformVersionConstraintAvailabilitySpec;
+  class PlatformAgnosticVersionConstraintAvailabilitySpec;
+
   struct EnumElementInfo;
 
   /// Different contexts in which BraceItemList are parsed.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1118,7 +1118,7 @@ namespace {
               printHead("platform_agnostic_version_constraint_"
                         "availability_spec",
                         PatternColor, label);
-              printField(agnostic->isLanguageVersionSpecific()
+              printField(agnostic->getDomain()->isSwiftLanguage()
                              ? "swift"
                              : "package_description",
                          Label::always("kind"));

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -18,6 +18,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityInference.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -116,6 +116,27 @@ SourceRange PlatformAgnosticVersionConstraintAvailabilitySpec::getSourceRange() 
   return SourceRange(PlatformAgnosticNameLoc, VersionSrcRange.End);
 }
 
+llvm::VersionTuple
+PlatformVersionConstraintAvailabilitySpec::getVersion() const {
+  // For macOS Big Sur, we canonicalize 10.16 to 11.0 for compile-time
+  // checking since clang canonicalizes availability markup. However, to
+  // support Beta versions of macOS Big Sur where the OS
+  // reports 10.16 at run time, we need to compare against 10.16,
+  //
+  // This means for:
+  //
+  // if #available(macOS 10.16, *) { ... }
+  //
+  // we need to store the uncanonicalized version for codegen and canonicalize
+  // it as necessary for compile-time checks.
+  return canonicalizePlatformVersion(Platform, Version);
+}
+
+llvm::VersionTuple
+PlatformVersionConstraintAvailabilitySpec::getRuntimeVersion() const {
+  return Version;
+}
+
 void PlatformAgnosticVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                                                       unsigned Indent) const {
   OS.indent(Indent) << '('

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -21,20 +21,6 @@
 
 using namespace swift;
 
-std::optional<PlatformKind> AvailabilitySpec::getPlatform() const {
-  switch (getKind()) {
-  case AvailabilitySpecKind::PlatformVersionConstraint: {
-    auto spec = cast<PlatformVersionConstraintAvailabilitySpec>(this);
-    return spec->getPlatform();
-  }
-  case AvailabilitySpecKind::LanguageVersionConstraint:
-  case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
-  case AvailabilitySpecKind::OtherPlatform:
-    return std::nullopt;
-  }
-  llvm_unreachable("bad AvailabilitySpecKind");
-}
-
 llvm::VersionTuple AvailabilitySpec::getVersion() const {
   switch (getKind()) {
   case AvailabilitySpecKind::PlatformVersionConstraint: {
@@ -77,7 +63,7 @@ void PlatformAgnosticVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
   OS.indent(Indent) << '('
                     << "platform_agnostic_version_constraint_availability_spec"
                     << " kind='"
-                    << (isLanguageVersionSpecific() ?
+                    << (getDomain()->isSwiftLanguage() ?
                          "swift" : "package_description")
                     << "'"
                     << " version='" << getVersion() << "'"

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -21,37 +21,6 @@
 
 using namespace swift;
 
-SourceRange AvailabilitySpec::getSourceRange() const {
-  switch (getKind()) {
-  case AvailabilitySpecKind::PlatformVersionConstraint:
-    return cast<PlatformVersionConstraintAvailabilitySpec>(this)->getSourceRange();
-
- case AvailabilitySpecKind::LanguageVersionConstraint:
- case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
-   return cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(this)->getSourceRange();
-
-  case AvailabilitySpecKind::OtherPlatform:
-    return cast<OtherPlatformAvailabilitySpec>(this)->getSourceRange();
-  }
-  llvm_unreachable("bad AvailabilitySpecKind");
-}
-
-std::optional<AvailabilityDomain> AvailabilitySpec::getDomain() const {
-  switch (getKind()) {
-  case AvailabilitySpecKind::PlatformVersionConstraint: {
-    auto spec = cast<PlatformVersionConstraintAvailabilitySpec>(this);
-    return AvailabilityDomain::forPlatform(spec->getPlatform());
-  }
-  case AvailabilitySpecKind::LanguageVersionConstraint:
-    return AvailabilityDomain::forSwiftLanguage();
-  case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
-    return AvailabilityDomain::forPackageDescription();
-  case AvailabilitySpecKind::OtherPlatform:
-    return std::nullopt;
-  }
-  llvm_unreachable("bad AvailabilitySpecKind");
-}
-
 std::optional<PlatformKind> AvailabilitySpec::getPlatform() const {
   switch (getKind()) {
   case AvailabilitySpecKind::PlatformVersionConstraint: {
@@ -70,38 +39,24 @@ llvm::VersionTuple AvailabilitySpec::getVersion() const {
   switch (getKind()) {
   case AvailabilitySpecKind::PlatformVersionConstraint: {
     auto spec = cast<PlatformVersionConstraintAvailabilitySpec>(this);
-    return spec->getVersion();
+    // For macOS Big Sur, we canonicalize 10.16 to 11.0 for compile-time
+    // checking since clang canonicalizes availability markup. However, to
+    // support Beta versions of macOS Big Sur where the OS
+    // reports 10.16 at run time, we need to compare against 10.16,
+    //
+    // This means for:
+    //
+    // if #available(macOS 10.16, *) { ... }
+    //
+    // we need to store the uncanonicalized version for codegen and canonicalize
+    // it as necessary for compile-time checks.
+    return canonicalizePlatformVersion(spec->getPlatform(), Version);
   }
   case AvailabilitySpecKind::LanguageVersionConstraint:
-  case AvailabilitySpecKind::PackageDescriptionVersionConstraint: {
-    auto spec = cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(this);
-    return spec->getVersion();
-  }
+  case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
   case AvailabilitySpecKind::OtherPlatform:
-    return llvm::VersionTuple();
+    return Version;
   }
-  llvm_unreachable("bad AvailabilitySpecKind");
-}
-
-SourceRange AvailabilitySpec::getVersionSrcRange() const {
-  switch (getKind()) {
-  case AvailabilitySpecKind::PlatformVersionConstraint: {
-    auto spec = cast<PlatformVersionConstraintAvailabilitySpec>(this);
-    return spec->getVersionSrcRange();
-  }
-  case AvailabilitySpecKind::LanguageVersionConstraint:
-  case AvailabilitySpecKind::PackageDescriptionVersionConstraint: {
-    auto spec = cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(this);
-    return spec->getVersionSrcRange();
-  }
-  case AvailabilitySpecKind::OtherPlatform:
-    return SourceRange();
-  }
-  llvm_unreachable("bad AvailabilitySpecKind");
-}
-
-SourceRange PlatformVersionConstraintAvailabilitySpec::getSourceRange() const {
-  return SourceRange(PlatformLoc, VersionSrcRange.End);
 }
 
 void PlatformVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
@@ -110,26 +65,6 @@ void PlatformVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                     << " platform='" << platformString(getPlatform()) << "'"
                     << " version='" << getVersion() << "'"
                     << ')';
-}
-
-SourceRange PlatformAgnosticVersionConstraintAvailabilitySpec::getSourceRange() const {
-  return SourceRange(PlatformAgnosticNameLoc, VersionSrcRange.End);
-}
-
-llvm::VersionTuple
-PlatformVersionConstraintAvailabilitySpec::getVersion() const {
-  // For macOS Big Sur, we canonicalize 10.16 to 11.0 for compile-time
-  // checking since clang canonicalizes availability markup. However, to
-  // support Beta versions of macOS Big Sur where the OS
-  // reports 10.16 at run time, we need to compare against 10.16,
-  //
-  // This means for:
-  //
-  // if #available(macOS 10.16, *) { ... }
-  //
-  // we need to store the uncanonicalized version for codegen and canonicalize
-  // it as necessary for compile-time checks.
-  return canonicalizePlatformVersion(Platform, Version);
 }
 
 llvm::VersionTuple

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -101,10 +101,7 @@ BridgedAvailabilitySpec_getDomain(BridgedAvailabilitySpec spec) {
 
 BridgedPlatformKind
 BridgedAvailabilitySpec_getPlatform(BridgedAvailabilitySpec spec) {
-  auto platform = spec.unbridged()->getPlatform();
-  if (platform)
-    return bridge(*platform);
-  return BridgedPlatformKind_None;
+  return bridge(spec.unbridged()->getPlatform());
 }
 
 BridgedVersionTuple

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -135,10 +135,10 @@ BridgedPlatformVersionConstraintAvailabilitySpec
 BridgedPlatformVersionConstraintAvailabilitySpec_createParsed(
     BridgedASTContext cContext, BridgedPlatformKind cPlatform,
     BridgedSourceLoc cPlatformLoc, BridgedVersionTuple cVersion,
-    BridgedVersionTuple cRuntimeVersion, BridgedSourceRange cVersionSrcRange) {
+    BridgedSourceRange cVersionSrcRange) {
   return new (cContext.unbridged()) PlatformVersionConstraintAvailabilitySpec(
       unbridge(cPlatform), cPlatformLoc.unbridged(), cVersion.unbridged(),
-      cRuntimeVersion.unbridged(), cVersionSrcRange.unbridged());
+      cVersionSrcRange.unbridged());
 }
 
 BridgedPlatformAgnosticVersionConstraintAvailabilitySpec

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Pattern.h"

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -334,7 +334,6 @@ extension ASTGenVisitor {
             platform: platform,
             platformLoc: nameLoc,
             version: version.bridged,
-            runtimeVersion: version.bridged,
             versionRange: versionRange
           )
           result.append(spec.asAvailabilitySpec)

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Assertions.h"

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsParse.h"

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1877,7 +1877,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
       auto Platform = Spec->getPlatform();
       // Since peekAvailabilityMacroName() only matches defined availability
       // macros, we only expect platform specific constraints here.
-      assert(Platform && "Unexpected AvailabilitySpec kind");
+      DEBUG_ASSERT(Platform != PlatformKind::none);
 
       auto Version = Spec->getVersion();
       if (Version.getSubminor().has_value() || Version.getBuild().has_value()) {
@@ -1885,7 +1885,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
                  diag::attr_availability_platform_version_major_minor_only,
                  AttrName);
       }
-      PlatformAndVersions.emplace_back(*Platform, Version);
+      PlatformAndVersions.emplace_back(Platform, Version);
     }
 
     return makeParserSuccess();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3787,11 +3787,7 @@ Parser::parsePlatformVersionConstraintSpec() {
   // Register the platform name as a keyword token.
   TokReceiver->registerTokenKindChange(PlatformLoc, tok::contextual_keyword);
 
-  // Keep the original version around for run-time checks to support
-  // macOS Big Sur betas that report 10.16 at
-  // run time.
-  llvm::VersionTuple RuntimeVersion = Version;
-  Version = canonicalizePlatformVersion(*Platform, Version);
-  return makeParserResult(new (Context) PlatformVersionConstraintAvailabilitySpec(
-      Platform.value(), PlatformLoc, Version, RuntimeVersion, VersionRange));
+  return makeParserResult(
+      new (Context) PlatformVersionConstraintAvailabilitySpec(
+          Platform.value(), PlatformLoc, Version, VersionRange));
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Assertions.h"

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 #include "swift/AST/ParseRequests.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/Module.h"

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1306,24 +1306,25 @@ validateAvailabilitySpecList(Parser &P,
   for (auto *Spec : Specs) {
     RecognizedSpecs.push_back(Spec);
     if (auto *OtherPlatSpec = dyn_cast<OtherPlatformAvailabilitySpec>(Spec)) {
-      OtherPlatformSpecLoc = OtherPlatSpec->getStarLoc();
+      OtherPlatformSpecLoc = OtherPlatSpec->getStartLoc();
       continue;
     }
 
     if (auto *PlatformAgnosticSpec =
          dyn_cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
-      P.diagnose(PlatformAgnosticSpec->getPlatformAgnosticNameLoc(),
+      bool isLanguageVersionSpecific = PlatformAgnosticSpec->getDomain()->isSwiftLanguage();
+      P.diagnose(PlatformAgnosticSpec->getStartLoc(),
                  diag::availability_must_occur_alone,
-                 PlatformAgnosticSpec->isLanguageVersionSpecific() 
-                   ? "swift" 
-                   : "_PackageDescription");
+                 isLanguageVersionSpecific
+                     ? "swift"
+                     : "_PackageDescription");
       continue;
     }
 
     auto *VersionSpec = cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
     // We keep specs for unrecognized platforms around for error recovery
     // during parsing but remove them once parsing is completed.
-    if (VersionSpec->isUnrecognizedPlatform()) {
+    if (!VersionSpec->getDomain().has_value()) {
       RecognizedSpecs.pop_back();
       continue;
     }
@@ -1334,7 +1335,7 @@ validateAvailabilitySpecList(Parser &P,
       // For example, we emit an error for
       /// #available(OSX 10.10, OSX 10.11, *)
       PlatformKind Platform = VersionSpec->getPlatform();
-      P.diagnose(VersionSpec->getPlatformLoc(),
+      P.diagnose(VersionSpec->getStartLoc(),
                  diag::availability_query_repeated_platform,
                  platformString(Platform));
     }
@@ -1404,8 +1405,9 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
   for (auto *Spec : Specs) {
     if (auto *PlatformAgnostic =
           dyn_cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
-      diagnose(PlatformAgnostic->getPlatformAgnosticNameLoc(),
-               PlatformAgnostic->isLanguageVersionSpecific()
+      bool isLanguageVersionSpecific = PlatformAgnostic->getDomain()->isSwiftLanguage();
+      diagnose(PlatformAgnostic->getStartLoc(),
+               isLanguageVersionSpecific
                    ? diag::pound_available_swift_not_allowed
                    : diag::pound_available_package_description_not_allowed,
                getTokenText(MainToken));
@@ -1551,11 +1553,10 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs,
             auto *PlatformSpec =
                 cast<PlatformVersionConstraintAvailabilitySpec>(Previous);
 
-            auto PlatformNameEndLoc =
-              Lexer::getLocForEndOfToken(SourceManager,
-                                         PlatformSpec->getPlatformLoc());
+            auto PlatformNameEndLoc = Lexer::getLocForEndOfToken(
+                SourceManager, PlatformSpec->getStartLoc());
 
-            diagnose(PlatformSpec->getPlatformLoc(),
+            diagnose(PlatformSpec->getStartLoc(),
                      diag::avail_query_meant_introduced)
                 .fixItInsert(PlatformNameEndLoc, ", introduced:");
           }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/Basic/Assertions.h"

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -201,9 +201,7 @@ struct RuntimeVersionCheck {
   Stmt *createEarlyReturnStmt(ASTContext &C) const {
     // platformSpec = "\(attr.platform) \(attr.introduced)"
     auto platformSpec = new (C) PlatformVersionConstraintAvailabilitySpec(
-                            Platform, SourceLoc(),
-                            Version, Version, SourceLoc()
-                        );
+        Platform, SourceLoc(), Version, SourceLoc());
 
     // otherSpec = "*"
     auto otherSpec = new (C) OtherPlatformAvailabilitySpec(SourceLoc());

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -20,6 +20,7 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeChecker.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -21,6 +21,7 @@
 #include "TypeChecker.h"
 #include "swift/AST/ASTBridging.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/AvailabilityScope.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/GenericEnvironment.h"


### PR DESCRIPTION
Hollow out each of the `AvailabilitySpec` subclasses in preparation for adding custom availability domain support to `if #available(...)` queries. `AvailabilitySpec` should eventually become nothing but a bag of parsed details that must be queried via a request to resolve its availability domain, instead of eagerly resolving the domain during parsing. The next step will be to remove the subclasses entirely.