### PR TITLE
util: Add -Variant param to build.ps1 for building Asserts | NoAsserts.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -927,8 +927,8 @@ function Fetch-Dependencies {
   }
 }
 
-function Get-PinnedToolchainToolsDir() {
-  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache", "toolchains", "$PinnedToolchain", "LocalApp", "Programs", "Swift", "Toolchains")
+function Get-PinnedToolchainTool() {
+  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$PinnedToolchain", "LocalApp", "Programs", "Swift", "Toolchains")
   $VariantToolchainPath = [IO.Path]::Combine($ToolchainsRoot, "$(Get-PinnedToolchainVersion)+$PinnedToolchainVariant", "usr", "bin")
 
   # NOTE: Add a workaround for the main snapshots that inadvertently used the

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -929,7 +929,6 @@ function Fetch-Dependencies {
 
 function Get-PinnedToolchainToolsDir() {
   $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$PinnedToolchain", "LocalApp", "Programs", "Swift", "Toolchains")
-  $VariantToolchainPath = [IO.Path]::Combine($ToolchainsRoot, "$(Get-PinnedToolchainVersion)+$PinnedToolchainVariant", "usr", "bin")
 
   # NOTE: Add a workaround for the main snapshots that inadvertently used the
   # wrong version when they were built. This allows use of the nightly snapshot
@@ -941,6 +940,8 @@ function Get-PinnedToolchainToolsDir() {
       }
     }
   }
+
+  $VariantToolchainPath = [IO.Path]::Combine($ToolchainsRoot, "$(Get-PinnedToolchainVersion)+$PinnedToolchainVariant", "usr", "bin")
 
   if (Test-Path $VariantToolchainPath) {
     return $VariantToolchainPath

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -927,7 +927,7 @@ function Fetch-Dependencies {
   }
 }
 
-function Get-PinnedToolchainTool() {
+function Get-PinnedToolchainToolsDir() {
   $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$PinnedToolchain", "LocalApp", "Programs", "Swift", "Toolchains")
   $VariantToolchainPath = [IO.Path]::Combine($ToolchainsRoot, "$(Get-PinnedToolchainVersion)+$PinnedToolchainVariant", "usr", "bin")
 


### PR DESCRIPTION
To facilitate building asserting and non-asserting variants of the toolchain, introduce `-Variant` so callers can specify. 
