### PR TITLE
SimplifyKeyPath: insert the correct destroy operation for an operand of a removed keypath

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
@@ -19,7 +19,11 @@ extension KeyPathInst : OnoneSimplifyable {
         let builder = Builder(after: self, context)
         for operand in self.operands {
           if !operand.value.type.isTrivial(in: parentFunction) {
-            builder.createDestroyValue(operand: operand.value)
+            if operand.value.type.isAddress {
+              builder.createDestroyAddr(address: operand.value)
+            } else {
+              builder.createDestroyValue(operand: operand.value)
+            }
           }
         }
       }

--- a/test/SILOptimizer/simplify_keypath_resilient.swift
+++ b/test/SILOptimizer/simplify_keypath_resilient.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -primary-file %s -enable-library-evolution -emit-sil | %FileCheck %s
+
+public enum E: Hashable {
+  case e
+}
+
+public struct S {
+  public var dict: [E: Int] = [:]
+}
+
+// Check that the keypath simplification does not crash when inserting a compensating destroy.
+
+// CHECK-LABEL: sil @$s26simplify_keypath_resilient6testityyF :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function '$s26simplify_keypath_resilient6testityyF'
+@inlinable
+public func testit() {
+  let _ = \S.dict[.e]
+}
+
+


### PR DESCRIPTION
If the operand is an address, we need to use `destroy_addr` and not `destroy_value`.

Fixes a compiler crash.
rdar://144662171
