### PR TITLE
PerformanceInliner: allow inlining of small functions even if the caller block limit is exceeded

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -412,6 +412,11 @@ optimize.sil.specialize.owned2guarantee.never
   Disable function signature optimization which converts an "owned" to a
   "guaranteed" function parameter.
 
+optimize.sil.inline.aggressive
+
+  Inlines into this function more aggressively than it would be done without
+  this attribute.
+
 Availability checks
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -392,16 +392,25 @@ Optimize semantics attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The optimize attribute adds function-specific directives to the optimizer.
-
 The optimize attribute supports the following tags:
 
-sil.specialize.generic.never
+optimize.sil.specialize.generic.never
 
-   The sil optimizer should never create generic specializations of this function. 
+  Disable generic specializations of this function.
 
 optimize.sil.specialize.generic.partial.never
 
-   The sil optimizer should never create generic partial specializations of this function. 
+  Disable create generic partial specializations of this function.
+
+optimize.sil.specialize.generic.size.never
+
+  Disable generic specializations of this function when optimizing for code
+  size (-Osize).
+
+optimize.sil.specialize.owned2guarantee.never
+
+  Disable function signature optimization which converts an "owned" to a
+  "guaranteed" function parameter.
 
 Availability checks
 ~~~~~~~~~~~~~~~~~~~

--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -75,6 +75,8 @@ SEMANTICS_ATTR(OPTIMIZE_SIL_SPECIALIZE_GENERIC_SIZE_NEVER,
           "optimize.sil.specialize.generic.size.never")
 SEMANTICS_ATTR(OPTIMIZE_SIL_SPECIALIZE_OWNED2GUARANTEE_NEVER,
           "optimize.sil.specialize.owned2guarantee.never")
+SEMANTICS_ATTR(OPTIMIZE_SIL_INLINE_AGGRESSIVE,
+          "optimize.sil.inline.aggressive")
 
 // To be used on a nominal type declaration.
 // Assumes that a class (or class references inside a nominal type) are immortal.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1153,7 +1153,8 @@ void SILPerformanceInliner::collectAppliesToInline(
         // but we /do/ inline any inline_always functions remaining.
         if (NumCallerBlocks > OverallCallerBlockLimit &&
             // Still allow inlining of small functions.
-            !hasMaxNumberOfBasicBlocks(Callee, 8)) {
+            !hasMaxNumberOfBasicBlocks(Callee, 8) &&
+            !Caller->hasSemanticsAttr(semantics::OPTIMIZE_SIL_INLINE_AGGRESSIVE)) {
           continue;
         }
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1151,8 +1151,11 @@ void SILPerformanceInliner::collectAppliesToInline(
         // caller block limit at this point. In such a case, we continue. This
         // will ensure that any further non inline always functions are skipped,
         // but we /do/ inline any inline_always functions remaining.
-        if (NumCallerBlocks > OverallCallerBlockLimit)
+        if (NumCallerBlocks > OverallCallerBlockLimit &&
+            // Still allow inlining of small functions.
+            !hasMaxNumberOfBasicBlocks(Callee, 8)) {
           continue;
+        }
 
         // Otherwise, calculate our block weights and determine if we want to
         // inline this.


### PR DESCRIPTION
This can fix performance problems in large functions.

Also add the `@_semantics("optimize.sil.inline.aggressive")`  attribute to enable inlining into large functions. This attribute overrides the limit of maximum number of basic blocks in the caller.

rdar://141320229
