### PR TITLE
TypeResolution: Stop resolving unqualified protocol type aliases to `DependentMemberType` in structural stage

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1127,11 +1127,6 @@ Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
                                               /*packElementOpener*/ nullptr)
           .resolveType(underlyingTypeRepr);
 
-  // Don't build a generic siganture for a protocol extension, because this
-  // request might be evaluated while building a protocol requirement signature.
-  if (parentDC->getSelfProtocolDecl())
-    return result;
-
   Type parent;
   if (parentDC->isTypeContext())
     parent = parentDC->getSelfInterfaceType();

--- a/test/type/explicit_existential_protocol_typealias.swift
+++ b/test/type/explicit_existential_protocol_typealias.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple -enable-upcoming-feature ExistentialAny
+
+// REQUIRES: swift_feature_ExistentialAny
+
+protocol P {
+  typealias PAlias1 = P
+
+  func f1() -> any PAlias1
+  func g1<T>(_: T) -> any PAlias1
+}
+extension P {
+  typealias PAlias2 = P
+
+  func f2() -> any PAlias2 {}
+  func g2<T>(_: T) -> any PAlias2 {}
+}


### PR DESCRIPTION
This workaround is no longer needed because `TypeAliasType` is now modeled using generic arguments vs. a substitution map. Previously, computing the substitution map in `StructuralTypeRequest` to construct the resulting `TypeAliasType` could cause a request cycle around generic signature computation.
