### PR TITLE
AST: Split `AvailabilityConstraint` classifications into separate `Reason` and `Kind` enums

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -33,12 +33,12 @@ class Decl;
 /// certain context.
 class AvailabilityConstraint {
 public:
-  enum class Kind {
+  enum class Reason {
     /// The declaration is referenced in a context in which it is generally
     /// unavailable. For example, a reference to a declaration that is
     /// unavailable on macOS from a context that may execute on macOS has this
     /// constraint.
-    AlwaysUnavailable,
+    UnconditionallyUnavailable,
 
     /// The declaration is referenced in a context in which it is considered
     /// obsolete. For example, a reference to a declaration that is obsolete in
@@ -46,10 +46,10 @@ public:
     /// constraint.
     Obsoleted,
 
-    /// The declaration is only available in a different version. For example,
+    /// The declaration is only available in a later version. For example,
     /// the declaration might only be introduced in the Swift 6 language mode
     /// while the module is being compiled in the Swift 5 language mode.
-    RequiresVersion,
+    IntroducedInLaterVersion,
 
     /// The declaration is referenced in a context that does not have an
     /// adequate minimum version constraint. For example, a reference to a
@@ -58,37 +58,39 @@ public:
     /// kind of constraint can be satisfied by tightening the minimum
     /// version of the context with `if #available(...)` or by adding or
     /// adjusting an `@available` attribute.
-    IntroducedInNewerVersion,
+    IntroducedInLaterDynamicVersion,
   };
 
 private:
-  llvm::PointerIntPair<SemanticAvailableAttr, 2, Kind> attrAndKind;
+  llvm::PointerIntPair<SemanticAvailableAttr, 2, Reason> attrAndReason;
 
-  AvailabilityConstraint(Kind kind, SemanticAvailableAttr attr)
-      : attrAndKind(attr, kind) {};
+  AvailabilityConstraint(Reason reason, SemanticAvailableAttr attr)
+      : attrAndReason(attr, reason) {};
 
 public:
   static AvailabilityConstraint
-  forAlwaysUnavailable(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Kind::AlwaysUnavailable, attr);
+  unconditionallyUnavailable(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::UnconditionallyUnavailable, attr);
   }
 
-  static AvailabilityConstraint forObsoleted(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Kind::Obsoleted, attr);
-  }
-
-  static AvailabilityConstraint forRequiresVersion(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Kind::RequiresVersion, attr);
+  static AvailabilityConstraint obsoleted(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::Obsoleted, attr);
   }
 
   static AvailabilityConstraint
-  forIntroducedInNewerVersion(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Kind::IntroducedInNewerVersion, attr);
+  introducedInLaterVersion(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::IntroducedInLaterVersion, attr);
   }
 
-  Kind getKind() const { return attrAndKind.getInt(); }
+  static AvailabilityConstraint
+  introducedInLaterDynamicVersion(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::IntroducedInLaterDynamicVersion,
+                                  attr);
+  }
+
+  Reason getReason() const { return attrAndReason.getInt(); }
   SemanticAvailableAttr getAttr() const {
-    return static_cast<SemanticAvailableAttr>(attrAndKind.getPointer());
+    return static_cast<SemanticAvailableAttr>(attrAndReason.getPointer());
   }
 
   /// Returns the domain that the constraint applies to.

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -35,17 +35,6 @@ AvailabilityConstraint::getRequiredNewerAvailabilityRange(
   }
 }
 
-bool AvailabilityConstraint::isConditionallySatisfiable() const {
-  switch (getReason()) {
-  case Reason::UnconditionallyUnavailable:
-  case Reason::Obsoleted:
-  case Reason::IntroducedInLaterVersion:
-    return false;
-  case Reason::IntroducedInLaterDynamicVersion:
-    return true;
-  }
-}
-
 bool AvailabilityConstraint::isActiveForRuntimeQueries(ASTContext &ctx) const {
   if (getAttr().getPlatform() == PlatformKind::none)
     return true;

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -25,23 +25,23 @@ PlatformKind AvailabilityConstraint::getPlatform() const {
 std::optional<AvailabilityRange>
 AvailabilityConstraint::getRequiredNewerAvailabilityRange(
     ASTContext &ctx) const {
-  switch (getKind()) {
-  case Kind::AlwaysUnavailable:
-  case Kind::RequiresVersion:
-  case Kind::Obsoleted:
+  switch (getReason()) {
+  case Reason::UnconditionallyUnavailable:
+  case Reason::Obsoleted:
+  case Reason::IntroducedInLaterVersion:
     return std::nullopt;
-  case Kind::IntroducedInNewerVersion:
+  case Reason::IntroducedInLaterDynamicVersion:
     return getAttr().getIntroducedRange(ctx);
   }
 }
 
 bool AvailabilityConstraint::isConditionallySatisfiable() const {
-  switch (getKind()) {
-  case Kind::AlwaysUnavailable:
-  case Kind::RequiresVersion:
-  case Kind::Obsoleted:
+  switch (getReason()) {
+  case Reason::UnconditionallyUnavailable:
+  case Reason::Obsoleted:
+  case Reason::IntroducedInLaterVersion:
     return false;
-  case Kind::IntroducedInNewerVersion:
+  case Reason::IntroducedInLaterDynamicVersion:
     return true;
   }
 }
@@ -84,7 +84,7 @@ swift::getAvailabilityConstraintForAttr(const Decl *decl,
     return std::nullopt;
 
   if (attr.isUnconditionallyUnavailable())
-    return AvailabilityConstraint::forAlwaysUnavailable(attr);
+    return AvailabilityConstraint::unconditionallyUnavailable(attr);
 
   auto &ctx = decl->getASTContext();
   auto deploymentVersion = attr.getActiveVersion(ctx);
@@ -101,16 +101,16 @@ swift::getAvailabilityConstraintForAttr(const Decl *decl,
   }
 
   if (obsoletedVersion && *obsoletedVersion <= deploymentVersion)
-    return AvailabilityConstraint::forObsoleted(attr);
+    return AvailabilityConstraint::obsoleted(attr);
 
   AvailabilityRange introducedRange = attr.getIntroducedRange(ctx);
 
   // FIXME: [availability] Expand this to cover custom versioned domains
   if (attr.isPlatformSpecific()) {
     if (!context.getPlatformRange().isContainedIn(introducedRange))
-      return AvailabilityConstraint::forIntroducedInNewerVersion(attr);
+      return AvailabilityConstraint::introducedInLaterDynamicVersion(attr);
   } else if (!deploymentRange.isContainedIn(introducedRange)) {
-    return AvailabilityConstraint::forRequiresVersion(attr);
+    return AvailabilityConstraint::introducedInLaterVersion(attr);
   }
 
   return std::nullopt;

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -71,13 +71,13 @@ bool AvailabilityContext::Info::constrainWith(
   for (auto constraint : constraints) {
     auto attr = constraint.getAttr();
     auto domain = attr.getDomain();
-    switch (constraint.getKind()) {
-    case AvailabilityConstraint::Kind::AlwaysUnavailable:
-    case AvailabilityConstraint::Kind::Obsoleted:
-    case AvailabilityConstraint::Kind::RequiresVersion:
+    switch (constraint.getReason()) {
+    case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
+    case AvailabilityConstraint::Reason::Obsoleted:
+    case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
       isConstrained |= constrainUnavailability(domain);
       break;
-    case AvailabilityConstraint::Kind::IntroducedInNewerVersion:
+    case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
       // FIXME: [availability] Support versioning for other kinds of domains.
       DEBUG_ASSERT(domain.isPlatform());
       if (domain.isPlatform())

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2467,7 +2467,7 @@ private:
 
       auto constraint = getUnsatisfiedAvailabilityConstraint(
           nominal, context.getAsDeclContext(), loc);
-      if (constraint && constraint->isConditionallySatisfiable()) {
+      if (constraint && constraint->isPotentiallyAvailable()) {
         auto &ctx = getASTContext();
         ctx.Diags.diagnose(loc,
                            diag::result_builder_missing_limited_availability,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4918,11 +4918,11 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   // If the setter is unavailable, then the keypath ought to be read-only
   // in this context.
   if (auto setter = storage->getOpaqueAccessor(AccessorKind::Set)) {
-    // FIXME: Fully unavailable setters should cause the key path to be
-    // readonly too.
+    // FIXME: [availability] Fully unavailable setters should cause the key path
+    // to be readonly too.
     auto constraint =
         getUnsatisfiedAvailabilityConstraint(setter, DC, referenceLoc);
-    if (constraint && constraint->isConditionallySatisfiable())
+    if (constraint && constraint->isPotentiallyAvailable())
       return true;
   }
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -247,14 +247,14 @@ checkAvailability(const EnumElementDecl *elt,
   if (!constraint)
     return true;
 
+  // Is it never available?
+  if (constraint->isUnavailable())
+    return false;
+
   // Some constraints are active for type checking but can't translate to
   // runtime restrictions.
   if (!constraint->isActiveForRuntimeQueries(C))
     return true;
-
-  // Is it never available?
-  if (!constraint->isConditionallySatisfiable())
-    return false;
 
   // It's conditionally available; create a version constraint and return true.
   auto platform = constraint->getPlatform();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3031,7 +3031,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
                                     const ExportContext &where,
                                     bool warnIfConformanceUnavailablePreSwift6,
                                     bool preconcurrency) {
-  if (constraint.isConditionallySatisfiable())
+  if (!constraint.isUnavailable())
     return false;
 
   // Invertible protocols are never unavailable.
@@ -3464,7 +3464,7 @@ bool diagnoseExplicitUnavailability(
     const ExportContext &Where, DeclAvailabilityFlags Flags,
     llvm::function_ref<void(InFlightDiagnostic &, StringRef)>
         attachRenameFixIts) {
-  if (constraint.isConditionallySatisfiable())
+  if (!constraint.isUnavailable())
     return false;
 
   auto Attr = constraint.getAttr();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3013,12 +3013,12 @@ bool shouldHideDomainNameForConstraintDiagnostic(
 
   case AvailabilityDomain::Kind::PackageDescription:
   case AvailabilityDomain::Kind::SwiftLanguage:
-    switch (constraint.getKind()) {
-    case AvailabilityConstraint::Kind::AlwaysUnavailable:
-    case AvailabilityConstraint::Kind::IntroducedInNewerVersion:
+    switch (constraint.getReason()) {
+    case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
+    case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
       return false;
-    case AvailabilityConstraint::Kind::RequiresVersion:
-    case AvailabilityConstraint::Kind::Obsoleted:
+    case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+    case AvailabilityConstraint::Reason::Obsoleted:
       return true;
     }
   }
@@ -3062,24 +3062,24 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
       .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
       .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
 
-  switch (constraint.getKind()) {
-  case AvailabilityConstraint::Kind::AlwaysUnavailable:
+  switch (constraint.getReason()) {
+  case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
     diags
         .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
                   proto)
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Kind::RequiresVersion:
+  case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
                    type, proto, versionedPlatform, *attr.getIntroduced());
     break;
-  case AvailabilityConstraint::Kind::Obsoleted:
+  case AvailabilityConstraint::Reason::Obsoleted:
     diags
         .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
                   versionedPlatform, *attr.getObsoleted())
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Kind::IntroducedInNewerVersion:
+  case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
     llvm_unreachable("unexpected constraint");
   }
   return true;
@@ -3108,12 +3108,12 @@ swift::getUnsatisfiedAvailabilityConstraint(
       if ((attr->isSwiftLanguageModeSpecific() ||
            attr->isPackageDescriptionVersionSpecific()) &&
           attr->getIntroduced().has_value())
-        return AvailabilityConstraint::forRequiresVersion(*attr);
+        return AvailabilityConstraint::introducedInLaterVersion(*attr);
 
-      return AvailabilityConstraint::forAlwaysUnavailable(*attr);
+      return AvailabilityConstraint::unconditionallyUnavailable(*attr);
 
     case AvailableVersionComparison::Obsoleted:
-      return AvailabilityConstraint::forObsoleted(*attr);
+      return AvailabilityConstraint::obsoleted(*attr);
     }
   }
 
@@ -3121,7 +3121,8 @@ swift::getUnsatisfiedAvailabilityConstraint(
   if (auto rangeAttr = decl->getAvailableAttrForPlatformIntroduction()) {
     auto range = rangeAttr->getIntroducedRange(ctx);
     if (!availabilityContext.getPlatformRange().isContainedIn(range))
-      return AvailabilityConstraint::forIntroducedInNewerVersion(*rangeAttr);
+      return AvailabilityConstraint::introducedInLaterDynamicVersion(
+          *rangeAttr);
   }
 
   return std::nullopt;
@@ -3527,24 +3528,24 @@ bool diagnoseExplicitUnavailability(
   }
 
   auto sourceRange = Attr.getParsedAttr()->getRange();
-  switch (constraint.getKind()) {
-  case AvailabilityConstraint::Kind::AlwaysUnavailable:
+  switch (constraint.getReason()) {
+  case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
     diags.diagnose(D, diag::availability_marked_unavailable, D)
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Kind::RequiresVersion:
+  case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
     diags
         .diagnose(D, diag::availability_introduced_in_version, D,
                   versionedPlatform, *Attr.getIntroduced())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Kind::Obsoleted:
+  case AvailabilityConstraint::Reason::Obsoleted:
     diags
         .diagnose(D, diag::availability_obsoleted, D, versionedPlatform,
                   *Attr.getObsoleted())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Kind::IntroducedInNewerVersion:
+  case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
     llvm_unreachable("unexpected constraint");
     break;
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -41,7 +41,7 @@ static EnumElementDecl *extractEnumElement(DeclContext *DC, SourceLoc UseLoc,
   if (auto constraint =
           getUnsatisfiedAvailabilityConstraint(constant, DC, UseLoc)) {
     // Only diagnose explicit unavailability.
-    if (!constraint->isConditionallySatisfiable())
+    if (constraint->isUnavailable())
       diagnoseDeclAvailability(constant, UseLoc, nullptr,
                                ExportContext::forFunctionBody(DC, UseLoc));
   }

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -532,3 +532,47 @@ func available_func_call_extension_methods(_ e: ExtendMe) { // expected-note {{a
   e.osx_app_extension_extension_osx_future_method() // expected-error {{'osx_app_extension_extension_osx_future_method()' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 }
+
+@available(OSX, unavailable)
+@available(OSX, introduced: 99)
+struct OSXUnavailableAndIntroducedInFuture {}
+
+@available(OSX, unavailable, introduced: 99)
+struct OSXUnavailableAndIntroducedInFutureSameAttribute {}
+
+@available(OSX, introduced: 99)
+@available(OSX, unavailable)
+struct OSXIntroducedInFutureAndUnavailable {}
+
+@available(OSX, unavailable)
+func osx_unavailable_func(
+  _ s1: OSXFutureAvailable,
+  _ s2: OSXUnavailableAndIntroducedInFuture,
+  _ s3: OSXUnavailableAndIntroducedInFutureSameAttribute,
+  _ s4: OSXIntroducedInFutureAndUnavailable,
+) -> (
+  OSXFutureAvailable,
+  OSXUnavailableAndIntroducedInFuture,
+  OSXUnavailableAndIntroducedInFutureSameAttribute,
+  OSXIntroducedInFutureAndUnavailable
+) {
+  _ = OSXFutureAvailable() // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  // FIXME: [availability] The following diagnostic is incorrect
+  _ = OSXUnavailableAndIntroducedInFuture() // expected-error {{'OSXUnavailableAndIntroducedInFuture' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  _ = OSXUnavailableAndIntroducedInFutureSameAttribute()
+  _ = OSXIntroducedInFutureAndUnavailable()
+
+  func takesType<T>(_ t: T.Type) {}
+  takesType(OSXFutureAvailable.self) // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  // FIXME: [availability] The following diagnostic is incorrect
+  takesType(OSXUnavailableAndIntroducedInFuture.self) // expected-error {{'OSXUnavailableAndIntroducedInFuture' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  takesType(OSXUnavailableAndIntroducedInFutureSameAttribute.self)
+  takesType(OSXIntroducedInFutureAndUnavailable.self)
+
+  return (s1, s2, s3, s4)
+}
+


### PR DESCRIPTION
Some uses of `AvailabilityConstraint` only care what kind of constraint it is (whether it represents "unavailability" or just "potential unavailability") and other uses care about exactly what caused the constraint. Introduce a distinction between the reason for the constraint and the kind of constraint it is.