### PR TITLE
[build-script] Add an option to force the linker used.

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -644,6 +644,12 @@ def create_argument_parser():
                 '`bootstrapping-with-hostlibs`, `crosscompile`, and '
                 '`crosscompile-with-hostlibs`')
 
+    option('--use-linker', store('use_linker'),
+           choices=['gold', 'lld'],
+           default=None,
+           metavar='USE_LINKER',
+           help='Choose the default linker to use when compiling LLVM/Swift')
+
     # -------------------------------------------------------------------------
     in_group('Host and cross-compilation targets')
 

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -478,6 +478,15 @@ class TestDriverArgumentParser(
         with self.assertRaises(ParserError):
             self.parse_default_args([option_string, '0.0.0.1'])
 
+    def test_option_use_linker(self):
+        option_string = '--use-linker'
+
+        self.parse_default_args([option_string, 'lld'])
+        self.parse_default_args([option_string, 'gold'])
+
+        with self.assertRaises(ParserError):
+            self.parse_default_args([option_string, 'foo'])
+
     def test_option_swift_user_visible_version(self):
         option_string = '--swift-user-visible-version'
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -336,6 +336,7 @@ EXPECTED_DEFAULTS = {
     'xros_all': False,
     'llvm_install_components': defaults.llvm_install_components(),
     'clean_install_destdir': False,
+    'use_linker': None,
 }
 
 
@@ -894,4 +895,5 @@ EXPECTED_OPTIONS = [
     IgnoreOption('--xros-all'),
 
     StrOption('--llvm-install-components'),
+    ChoicesOption('--use-linker', dest='use_linker', choices=['gold', 'lld']),
 ]

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -43,6 +43,9 @@ class LLVM(cmake_product.CMakeProduct):
         # Add the cmake options for compiler version information.
         self.cmake_options.extend(self._version_flags)
 
+        # Add linker flags if specified
+        self.cmake_options.extend(self._use_linker)
+
     @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool
@@ -82,6 +85,12 @@ class LLVM(cmake_product.CMakeProduct):
                 'CLANG_REPOSITORY_STRING',
                 "clang-{}".format(self.args.clang_compiler_version))
         return result
+
+    @property
+    def _use_linker(self):
+        if self.args.use_linker is None:
+            return []
+        return [('CLANG_DEFAULT_LINKER', self.args.use_linker)]
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -46,7 +46,8 @@ class LLVMTestCase(unittest.TestCase):
             compiler_vendor='none',
             clang_compiler_version=None,
             clang_user_visible_version=None,
-            darwin_deployment_version_osx='10.9')
+            darwin_deployment_version_osx='10.9',
+            use_linker=None)
 
         # Setup shell
         shell.dry_run = True
@@ -152,5 +153,37 @@ class LLVMTestCase(unittest.TestCase):
             build_dir='/path/to/build')
         self.assertIn(
             '-DCLANG_REPOSITORY_STRING=clang-2.2.3',
+            llvm.cmake_options
+        )
+
+    def test_use_linker(self):
+        self.args.use_linker = None
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        for s in llvm.cmake_options:
+            self.assertFalse('CLANG_DEFAULT_LINKER' in s)
+
+        self.args.use_linker = 'gold'
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertIn(
+            '-DCLANG_DEFAULT_LINKER=gold',
+            llvm.cmake_options
+        )
+
+        self.args.use_linker = 'lld'
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertIn(
+            '-DCLANG_DEFAULT_LINKER=lld',
             llvm.cmake_options
         )

--- a/utils/swift_build_support/tests/products/test_llvm_linux_cross_compile.py
+++ b/utils/swift_build_support/tests/products/test_llvm_linux_cross_compile.py
@@ -40,7 +40,8 @@ class LLVMLinuxCrossCompileTestCase(unittest.TestCase):
             clang_compiler_version=None,
             clang_user_visible_version=None,
             cross_compile_hosts='linux-aarch64',
-            cross_compile_deps_path='sysroot'
+            cross_compile_deps_path='sysroot',
+            use_linker=None
         )
 
         # Setup shell


### PR DESCRIPTION
I have been doing this using extra-cmake-args/etc... just feels better to have an actual option to do this.

Just did this quickly while waiting for my Linux build to finish that uses extra-cmake-args to set the linker.
