### PR TITLE
Add verbosity when building swiftpm

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -118,7 +118,14 @@ class SwiftPM(product.Product):
         shell.call(helper_cmd)
 
     def build(self, host_target):
-        self.run_bootstrap_script('build', host_target, ["--reconfigure"])
+        self.run_bootstrap_script(
+            'build',
+            host_target,
+            additional_params=[
+                "--reconfigure",
+                "--verbose",
+            ],
+        )
 
     def should_test(self, host_target):
         return self.args.test_swiftpm
@@ -128,6 +135,9 @@ class SwiftPM(product.Product):
             'test',
             host_target,
             compile_only_for_running_host_architecture=True,
+            additional_params=[
+                '--verbose'
+            ]
         )
 
     def should_clean(self, host_target):
@@ -144,6 +154,7 @@ class SwiftPM(product.Product):
         install_prefix = install_destdir + self.args.install_prefix
 
         self.run_bootstrap_script('install', host_target, [
+            '--verbose',
             '--prefix', install_prefix
         ])
 


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

There have been cases where CI build failures on Linux did not have sufficient logs when it failed during a Swift PM build/test.  Augment the Swift PM build/test by enabling verbosity!