### PR TITLE
[SIL] Check if our original type is opaque before getting getting FixedArray element type

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3067,14 +3067,8 @@ bool TypeConverter::visitAggregateLeaves(
                            origTy.getPackExpansionPatternType(),
                            field, index);
       } else if (auto array = dyn_cast<BuiltinFixedArrayType>(ty)) {
-        auto origEltTy = AbstractionPattern::getOpaque();
-
-        if (auto origBFA = origTy.getAs<BuiltinFixedArrayType>()) {
-          origEltTy = AbstractionPattern(origTy.getGenericSignatureOrNull(),
-                                         origBFA->getElementType());
-        }
-
-        insertIntoWorklist(array->getElementType(), origEltTy, field, index);
+        insertIntoWorklist(array->getElementType(),
+                           AbstractionPattern::getOpaque(), field, index);
       } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
         for (auto *structField : decl->getStoredProperties()) {
           auto subMap = ty->getContextSubstitutionMap();

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3067,12 +3067,14 @@ bool TypeConverter::visitAggregateLeaves(
                            origTy.getPackExpansionPatternType(),
                            field, index);
       } else if (auto array = dyn_cast<BuiltinFixedArrayType>(ty)) {
-        auto origBFA = origTy.getAs<BuiltinFixedArrayType>();
-        insertIntoWorklist(
-            array->getElementType(),
-            AbstractionPattern(origTy.getGenericSignatureOrNull(),
-                               origBFA->getElementType()),
-            field, index);
+        auto origEltTy = AbstractionPattern::getOpaque();
+
+        if (auto origBFA = origTy.getAs<BuiltinFixedArrayType>()) {
+          origEltTy = AbstractionPattern(origTy.getGenericSignatureOrNull(),
+                                         origBFA->getElementType());
+        }
+
+        insertIntoWorklist(array->getElementType(), origEltTy, field, index);
       } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
         for (auto *structField : decl->getStoredProperties()) {
           auto subMap = ty->getContextSubstitutionMap();

--- a/test/SIL/bitwise_copyable.swift
+++ b/test/SIL/bitwise_copyable.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-frontend                         \
+// RUN:     %s                                         \
+// RUN:     -emit-sil                                  \
+// RUN:     -enable-experimental-feature ValueGenerics \
+// RUN:     -enable-builtin-module \
+// RUN:     -disable-availability-checking \
+// RUN:     -O
+
+// REQUIRES: swift_feature_ValueGenerics
+
+// Force verification of TypeLowering's isTrivial.
+
+import Builtin
+
+@frozen
+public struct Vector<let Count: Int, Element: ~Copyable>: ~Copyable {
+    private var storage: Builtin.FixedArray<Count, Element>
+
+    public init(_ valueForIndex: (Int) -> Element) {
+        storage = Builtin.emplace { rawPointer in
+            let base = UnsafeMutablePointer<Element>(rawPointer)
+            for i in 0..<Count {
+                (base + i).initialize(to: valueForIndex(i))
+            }
+        }
+    }
+
+    public subscript(i: Int) -> Element {
+        _read {
+            assert(i >= 0 && i < Count)
+            let rawPointer = Builtin.addressOfBorrow(self)
+            let base = UnsafePointer<Element>(rawPointer)
+            yield ((base + i).pointee)
+        }
+
+        _modify {
+            assert(i >= 0 && i < Count)
+            let rawPointer = Builtin.addressof(&self)
+            let base = UnsafeMutablePointer<Element>(rawPointer)
+            yield (&(base + i).pointee)
+        }
+    }
+}
+extension Vector: Copyable where Element: Copyable {
+    public init(repeating value: Element) {
+        self.init { _ in value }
+    }
+}
+extension Vector: BitwiseCopyable where Element: BitwiseCopyable {}
+
+func main() {
+    var v = Vector<4, String>(repeating: "x") // OK
+    //v[0] = 1
+    //v[1] = 2
+    //v[2] = 3
+    //v[3] = 4
+    print("break here")
+}
+main()


### PR DESCRIPTION
If the original type passed to `visitAggregateLeaves` is completely opaque, then we can can't get it as a `Builtin.FixedArray`. Check if that's the case and if so just pass an opaque abstraction pattern as the original element type.

Resolves: rdar://139531227