### PR TITLE
FrontendTool: print the compiler configuration

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1091,6 +1091,8 @@ static bool printSwiftVersion(const CompilerInvocation &Invocation) {
                << '\n';
   llvm::outs() << "Target: " << Invocation.getLangOptions().Target.str()
                << '\n';
+  if (!llvm::cl::getCompilerBuildConfig().empty())
+    llvm::cl::printBuildConfig(llvm::outs());
   return false;
 }
 


### PR DESCRIPTION
This adds the compiler configuration to the output similar to clang. This will allow us to identify the compiler build type, e.g.

```
Swift version 6.2-dev (LLVM 47665e034aa6f27, Swift 2b3e5dac59b8632)
Target: x86_64-unknown-windows-msvc
Build config: +unoptimized,+assertions,+expensive-checks,+asan,+hwasan,+msan,+ubsan
```