### PR TITLE
CMake: Catalyst Support

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -83,6 +83,7 @@ include(EmitSwiftInterface)
 include(PlatformInfo)
 include(gyb)
 include(ResourceEmbedding)
+include(CatalystSupport)
 
 check_symbol_exists("asl_log" "asl.h" SwiftCore_HAS_ASL)
 check_symbol_exists("dladdr" "dlfcn.h" SwiftCore_HAS_DLADDR)

--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -121,8 +121,5 @@ install(TARGETS swift_Concurrency
   ARCHIVE DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/_Concurrency.swiftmodule"
-  DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/_Concurrency.swiftmodule"
-  RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule")
 emit_swift_interface(swift_Concurrency)
 install_swift_interface(swift_Concurrency)

--- a/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
+++ b/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
@@ -35,9 +35,6 @@ install(TARGETS swiftSwiftOnoneSupport
     ARCHIVE DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport.swiftmodule"
-  DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/SwiftOnoneSupport.swiftmodule"
-  RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule")
 emit_swift_interface(swiftSwiftOnoneSupport)
 install_swift_interface(swiftSwiftOnoneSupport)
 

--- a/Runtimes/Core/cmake/caches/Vendors/Apple/arm64e-MacOSX.cmake
+++ b/Runtimes/Core/cmake/caches/Vendors/Apple/arm64e-MacOSX.cmake
@@ -2,6 +2,10 @@ if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   message(SEND_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET not defined")
 endif()
 
+if(NOT DEFINED SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET)
+  message(WARNING "SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET not defined")
+endif()
+
 set(CMAKE_C_COMPILER_TARGET "arm64e-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
 set(CMAKE_CXX_COMPILER_TARGET "arm64e-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
 set(CMAKE_Swift_COMPILER_TARGET "arm64e-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
@@ -9,8 +13,6 @@ set(CMAKE_Swift_COMPILER_TARGET "arm64e-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGE
 set(SwiftCore_ARCH_SUBDIR arm64e CACHE STRING "")
 set(SwiftCore_PLATFORM_SUBDIR macosx CACHE STRING "")
 
-list(APPEND CMAKE_C_FLAGS "-darwin-target-variant" "arm64e-apple-ios13.1-macabi")
-list(APPEND CMAKE_CXX_FLAGS "-darwin-target-variant" "arm64e-apple-ios13.1-macabi")
-list(APPEND CMAKE_Swift_FLAGS "-target-variant" "arm64e-apple-ios13.1-macabi")
+set(SwiftCore_COMPILER_VARIANT_TARGET "arm64e-apple-ios${SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET}-macabi" CACHE STRING "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/apple-common.cmake")

--- a/Runtimes/Core/cmake/caches/Vendors/Apple/x86_64-MacOSX.cmake
+++ b/Runtimes/Core/cmake/caches/Vendors/Apple/x86_64-MacOSX.cmake
@@ -2,6 +2,10 @@ if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   message(SEND_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET not defined")
 endif()
 
+if(NOT DEFINED SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET)
+  message(WARNING "SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET not defined")
+endif()
+
 set(CMAKE_C_COMPILER_TARGET "x86_64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
 set(CMAKE_CXX_COMPILER_TARGET "x86_64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
 set(CMAKE_Swift_COMPILER_TARGET "x86_64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}" CACHE STRING "")
@@ -9,8 +13,6 @@ set(CMAKE_Swift_COMPILER_TARGET "x86_64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGE
 set(SwiftCore_ARCH_SUBDIR x86_64 CACHE STRING "")
 set(SwiftCore_PLATFORM_SUBDIR macosx CACHE STRING "")
 
-list(APPEND CMAKE_C_FLAGS "-darwin-target-variant" "x86_64-apple-ios13.1-macabi")
-list(APPEND CMAKE_CXX_FLAGS "-darwin-target-variant" "x86_64-apple-ios13.1-macabi")
-list(APPEND CMAKE_Swift_FLAGS "-target-variant" "x86_64-apple-ios13.1-macabi")
+set(SwiftCore_COMPILER_VARIANT_TARGET "x86_64-apple-ios${SwiftCore_TARGET_VARIANT_DEPLOYMENT_TARGET}-macabi" CACHE STRING "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/apple-common.cmake")

--- a/Runtimes/Core/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Core/cmake/modules/CatalystSupport.cmake
@@ -1,0 +1,19 @@
+# Add flags for generating the zippered target variant in the build
+
+if(SwiftCore_COMPILER_VARIANT_TARGET)
+  add_compile_options(
+    "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+
+    # TODO: Remove me once we have a driver with
+    #   https://github.com/swiftlang/swift-driver/pull/1803
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${SwiftCore_COMPILER_VARIANT_TARGET}>")
+
+  add_link_options(
+    "$<$<LINK_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+    "$<$<LINK_LANGUAGE:Swift>:SHELL:-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
+
+    # TODO: Remove me once we have a driver with
+    #   https://github.com/swiftlang/swift-driver/pull/1803
+    "$<$<LINK_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${SwiftCore_COMPILER_VARIANT_TARGET}>")
+endif()

--- a/Runtimes/Core/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Core/cmake/modules/CatalystSupport.cmake
@@ -1,5 +1,8 @@
 # Add flags for generating the zippered target variant in the build
 
+# Initialize `SwiftCore_VARIANT_MODULE_TRIPLE` if the driver is able to emit
+# modules for the target variant.
+
 if(SwiftCore_COMPILER_VARIANT_TARGET)
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${SwiftCore_COMPILER_VARIANT_TARGET}>"
@@ -16,4 +19,20 @@ if(SwiftCore_COMPILER_VARIANT_TARGET)
     # TODO: Remove me once we have a driver with
     #   https://github.com/swiftlang/swift-driver/pull/1803
     "$<$<LINK_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${SwiftCore_COMPILER_VARIANT_TARGET}>")
+
+  # TODO: Once we are guaranteed to have a driver with the variant module path
+  #       support everywhere, we should integrate this into PlatformInfo.cmake
+  check_compiler_flag(Swift "-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/CompilerID/variant.swiftmodule" HAVE_Swift_VARIANT_MODULE_PATH_FLAG)
+  if(HAVE_Swift_VARIANT_MODULE_PATH_FLAG)
+    # Get variant module triple
+    set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info -target ${SwiftCore_COMPILER_VARIANT_TARGET})
+    execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+    message(CONFIGURE_LOG "Swift target variant info: ${target_info_json}")
+
+
+    string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+    set(SwiftCore_VARIANT_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{module,interface} files for the target variant")
+    mark_as_advanced(SwiftCore_VARIANT_MODULE_TRIPLE)
+    message(CONFIGURE_LOG "Swift target variant module triple: ${module_triple}")
+  endif()
 endif()

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -12,6 +12,16 @@ function(emit_swift_interface target)
       $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
       $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
+
+      # Emit catalyst swiftmodules and interfaces
+      if(SwiftCore_VARIANT_MODULE_TRIPLE)
+        set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}")
+        file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
+        target_compile_options(${target} PRIVATE
+          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>"
+          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
+          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
+      endif()
   endif()
 endfunction()
 
@@ -26,5 +36,18 @@ function(install_swift_interface target)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
       RENAME "${SwiftCore_MODULE_TRIPLE}.private.swiftinterface"
       DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+
+    # Install catalyst interface files
+    if(SwiftCore_VARIANT_MODULE_TRIPLE)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
+        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
+        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
+        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface"
+        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
+        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
+        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+    endif()
   endif()
 endfunction()

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -6,6 +6,16 @@
 
 # Generate a swift interface file for the target if library evolution is enabled
 function(emit_swift_interface target)
+  # Generate the target-variant binary swift module when performing zippered
+  # build
+  if(SwiftCore_VARIANT_MODULE_TRIPLE)
+    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}")
+    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+  endif()
+
+  # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
@@ -15,10 +25,7 @@ function(emit_swift_interface target)
 
       # Emit catalyst swiftmodules and interfaces
       if(SwiftCore_VARIANT_MODULE_TRIPLE)
-        set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}")
-        file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
         target_compile_options(${target} PRIVATE
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>"
           "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
           "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
       endif()
@@ -28,6 +35,17 @@ endfunction()
 # Install the generated swift interface file for the target if library evolution
 # is enabled.
 function(install_swift_interface target)
+  # Install binary swift modules
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+    RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+    DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+  if(SwiftCore_VARIANT_MODULE_TRIPLE)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
+      RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
+      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+  endif()
+
+  # Install Swift interfaces if library-evolution is enabled
   if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
       RENAME "${SwiftCore_MODULE_TRIPLE}.swiftinterface"
@@ -39,9 +57,6 @@ function(install_swift_interface target)
 
     # Install catalyst interface files
     if(SwiftCore_VARIANT_MODULE_TRIPLE)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
-        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
-        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
       install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
         RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface"
         DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -327,9 +327,6 @@ install(TARGETS swiftCore
   ARCHIVE DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${SwiftCore_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Swift.swiftmodule"
-  DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/Swift.swiftmodule"
-  RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule")
 emit_swift_interface(swiftCore)
 install_swift_interface(swiftCore)
 


### PR DESCRIPTION
Hooking up building the zippered catalyst slices of libswiftCore.
This patch includes generating the zippered objects, as well as emitting the interfaces and binary modules when the driver supports it. Once all build environments have a driver capable of emitting the target variant module, we can remove the compiler flag check and extract the catalyst module info in the `PlatformInfo` from the same command that generates the target info for the main target module.

Fixes: rdar://144642462