### PR TITLE
Runtimes: attempt to wire in the build number into the version

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -41,8 +41,18 @@ list(APPEND CMAKE_MODULE_PATH ${SwiftCore_CMAKE_MODULES_DIR})
 include(CMakeWorkarounds)
 # NOTE: always use the 3-component style as the expansion as
 # `${PROJECT_VERSION}` will not extend this to the complete form and this can
-# change the behaviour for comparison with non-SemVer compliant parsing.
-project(SwiftCore LANGUAGES C CXX Swift VERSION 6.1.0)
+# change the behaviour for comparison with non-SemVer compliant parsing. If
+# possible, use the 4-version component as that is used to differentiate the
+# builds of the runtime for Windows.
+if($ENV{BUILD_NUMBER})
+  # NOTE: SxS modules have a limit on each component being [0-65535].
+  # https://learn.microsoft.com/en-us/windows/win32/sbscs/assembly-versions
+  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
+  set(BUILD_NUMBER ".${BUILD_NUMBER}")
+endif()
+project(SwiftCore
+  LANGUAGES C CXX Swift
+  VERSION 6.1.0${BUILD_NUMBER})
 
 # The Swift standard library is not intended for use as a sub-library as part of
 # another project. It is tightly coupled with the compiler version.


### PR DESCRIPTION
This is in preparation for using Win32 SxS assembly manifests to permit co-installation of the runtimes on Windows without an ABI consideration and allow users to select between the revision.