### PR TITLE
Tests: Use a local cache for error-sil-function.swift

### DIFF
--- a/test/Serialization/Recovery/error-sil-function.swift
+++ b/test/Serialization/Recovery/error-sil-function.swift
@@ -1,4 +1,5 @@
-// RUN: not --crash %target-swift-frontend -c %s 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t/cache)
+// RUN: not --crash %target-swift-frontend -c %s -module-cache-path %t/cache 2>&1 | %FileCheck %s
 // CHECK: *** DESERIALIZATION FAILURE ***
 // CHECK: SILFunction type mismatch for 'asinf': '$@convention(thin) (Float) -> Float' != '$@convention(c) (Float) -> Float'
 


### PR DESCRIPTION
This test appears flaky and from the timing with other failures it looks to be related to errors on modules in the SDK. The flakiness is likely from non-determinism in the module cache caused by the other tests. Update the test to use a local cache, which is a good practice when importing from the SDK.

rdar://144272339