### PR TITLE
[DependencyScan] Use `llvm::DefaultThreadPool` instead of `llvm::StdThreadPool`

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -180,7 +180,7 @@ private:
   /// The available pool of workers for filesystem module search
   unsigned NumThreads;
   std::list<std::unique_ptr<ModuleDependencyScanningWorker>> Workers;
-  llvm::StdThreadPool ScanningThreadPool;
+  llvm::DefaultThreadPool ScanningThreadPool;
   /// Protect worker access.
   std::mutex WorkersLock;
   /// Count of filesystem queries performed


### PR DESCRIPTION
`llvm::StdThreadPool` is only available when LLVM_ENABLE_THREADS is enabled. LLVM defines `DefaultThreadPool` type alias, which is always available regardless of the threads enabled. This change allows building the library without threads enabled, especially for Emscripten toolchain.

  ```c++
  #if LLVM_ENABLE_THREADS
  using DefaultThreadPool = StdThreadPool;
  #else
  using DefaultThreadPool = SingleThreadExecutor;
  #endif
  ```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
