### PR TITLE
[build] Stop assuming llvm is always the top-level in unified build

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -258,7 +258,7 @@ macro(swift_common_unified_build_config product)
   set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
   set(CLANG_INCLUDE_DIRS
     "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include"
-    "${CMAKE_BINARY_DIR}/tools/clang/include")
+    "${LLVM_BINARY_DIR}/tools/clang/include")
 
   include_directories(${CLANG_INCLUDE_DIRS})
 


### PR DESCRIPTION
Even with unified build, llvm is not always the top-level project but it can be a part of a larger build. (e.g. [^1]) In that case, `CMAKE_BINARY_DIR` is not the binary directory of llvm but the binary directory of the top-level project. This patch fixes the issue by using `LLVM_BINARY_DIR` instead.

[^1]: https://github.com/ChromeDevTools/devtools-frontend/blob/9b4b9070790196d78489756c515c528a0fe7ac00/extensions/cxx_debugging/CMakeLists.txt#L105

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
