### PR TITLE
[build] Add initial support for Emscripten SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ else()
     set(SWIFT_HOST_VARIANT_SDK_default "OSX")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "WASI")
     set(SWIFT_HOST_VARIANT_SDK_default "WASI")
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+    set(SWIFT_HOST_VARIANT_SDK_default "EMSCRIPTEN")
   else()
     message(FATAL_ERROR "Unable to detect SDK for host system: ${CMAKE_SYSTEM_NAME}")
   endif()
@@ -1238,6 +1240,15 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WASI")
       "Deployment OS for Swift host tools (the compiler) [wasi]")
 
   configure_sdk_unix("WASI" "wasm32")
+  set(SWIFT_PRIMARY_VARIANT_SDK_default  "${SWIFT_HOST_VARIANT_SDK}")
+  set(SWIFT_PRIMARY_VARIANT_ARCH_default "${SWIFT_HOST_VARIANT_ARCH}")
+
+elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "EMSCRIPTEN")
+
+  set(SWIFT_HOST_VARIANT "emscripten" CACHE STRING
+      "Deployment OS for Swift host tools (the compiler) [emscripten]")
+
+  configure_sdk_unix("Emscripten" "wasm32")
   set(SWIFT_PRIMARY_VARIANT_SDK_default  "${SWIFT_HOST_VARIANT_SDK}")
   set(SWIFT_PRIMARY_VARIANT_ARCH_default "${SWIFT_HOST_VARIANT_ARCH}")
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -106,6 +106,12 @@ function(_add_host_variant_c_compile_link_flags name)
     if("${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC") # clang-cl options
       target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:--target=${SWIFT_HOST_TRIPLE}>)
       target_link_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:--target=${SWIFT_HOST_TRIPLE}>)
+    elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "EMSCRIPTEN") # emcc options
+      # some older emcc don't understand -target=<triple>
+      # FIXME: remove this when we no longer support Emscripten < 3.1.44
+      # https://github.com/emscripten-core/emscripten/pull/19840
+      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:--target=${SWIFT_HOST_TRIPLE}>)
+      target_link_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-target=${SWIFT_HOST_TRIPLE}>)
     else()
       target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-target;${SWIFT_HOST_TRIPLE}>)
       target_link_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-target;${SWIFT_HOST_TRIPLE}>)

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -322,6 +322,7 @@ macro(configure_sdk_unix name architectures)
   # Static linking is supported on Linux and WASI
   if("${prefix}" STREQUAL "LINUX"
       OR "${prefix}" STREQUAL "LINUX_STATIC"
+      OR "${prefix}" STREQUAL "EMSCRIPTEN"
       OR "${prefix}" STREQUAL "WASI")
     set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED TRUE)
   else()
@@ -461,6 +462,8 @@ macro(configure_sdk_unix name architectures)
         else()
           set(SWIFT_SDK_WASI_ARCH_wasm32_TRIPLE "wasm32-unknown-wasi")
         endif()
+      elseif("${prefix}" STREQUAL "EMSCRIPTEN")
+        set(SWIFT_SDK_EMSCRIPTEN_ARCH_${arch}_TRIPLE "${arch}-unknown-emscripten")
       elseif("${prefix}" STREQUAL "LINUX_STATIC")
         set(SWIFT_SDK_LINUX_STATIC_ARCH_${arch}_TRIPLE "${arch}-swift-linux-musl")
         set(SWIFT_SDK_LINUX_STATIC_ARCH_${arch}_PATH "${SWIFT_MUSL_PATH}/${arch}")


### PR DESCRIPTION
This patch adds initial support for Emscripten SDK alongside the existing support for WASI SDK. This is a first step towards building a part of Swift compiler for Emscripten target (which will be used to build LLDB with Swift to WebAssembly target).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
