### PR TITLE
[SIL] Explicitly use `uint64_t` for `maxBitfieldID`

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -154,7 +154,7 @@ public:
 
   enum { numCustomBits = std::numeric_limits<CustomBitsType>::digits };
 
-  constexpr static const size_t maxBitfieldID =
+  constexpr static const uint64_t maxBitfieldID =
       std::numeric_limits<uint64_t>::max();
 
   /// Gets the ID (= index in the function's block list) of the block.

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -128,7 +128,7 @@ public:
 
   enum { numCustomBits = 20 };
 
-  constexpr static const size_t maxBitfieldID =
+  constexpr static const uint64_t maxBitfieldID =
       std::numeric_limits<uint64_t>::max() >> numCustomBits;
 
 protected:

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1033,7 +1033,7 @@ class Operand {
 public:
   enum { numCustomBits = 8 };
 
-  constexpr static const size_t maxBitfieldID =
+  constexpr static const uint64_t maxBitfieldID =
       std::numeric_limits<uint64_t>::max() >> numCustomBits;
 
 private:


### PR DESCRIPTION
The `maxBitfieldID` was defined as `size_t` and used to assert bitfield ID values. The `currentBitfieldID` of `SILFunction` is defined as `uint64_t`, so we should consistently use `uint64_t` for `maxBitfieldID` as well to take 32-bit platforms into account.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
