### PR TITLE
SIL: Lower lifetime dependencies when lowering function types.

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -51,11 +51,12 @@ struct LifetimeDescriptor {
     } Named;
     struct {
       unsigned index;
+      bool isAddress;
     } Ordered;
     struct {
     } Self;
     Value(StringRef name) : Named({name}) {}
-    Value(unsigned index) : Ordered({index}) {}
+    Value(unsigned index, bool isAddress) : Ordered({index, isAddress}) {}
     Value() : Self() {}
   } value;
 
@@ -71,10 +72,10 @@ private:
                      SourceLoc loc)
       : value{name}, kind(DescriptorKind::Named),
         parsedLifetimeDependenceKind(parsedLifetimeDependenceKind), loc(loc) {}
-  LifetimeDescriptor(unsigned index,
+  LifetimeDescriptor(unsigned index, bool isAddress,
                      ParsedLifetimeDependenceKind parsedLifetimeDependenceKind,
                      SourceLoc loc)
-      : value{index}, kind(DescriptorKind::Ordered),
+      : value{index, isAddress}, kind(DescriptorKind::Ordered),
         parsedLifetimeDependenceKind(parsedLifetimeDependenceKind), loc(loc) {}
   LifetimeDescriptor(ParsedLifetimeDependenceKind parsedLifetimeDependenceKind,
                      SourceLoc loc)
@@ -91,8 +92,9 @@ public:
   static LifetimeDescriptor
   forOrdered(unsigned index,
              ParsedLifetimeDependenceKind parsedLifetimeDependenceKind,
-             SourceLoc loc) {
-    return {index, parsedLifetimeDependenceKind, loc};
+             SourceLoc loc,
+             bool isAddress = false) {
+    return {index, isAddress, parsedLifetimeDependenceKind, loc};
   }
   static LifetimeDescriptor
   forSelf(ParsedLifetimeDependenceKind parsedLifetimeDependenceKind,
@@ -112,6 +114,12 @@ public:
   unsigned getIndex() const {
     assert(kind == DescriptorKind::Ordered);
     return value.Ordered.index;
+  }
+  
+  bool isAddressable() const {
+    return kind == DescriptorKind::Ordered
+      ? value.Ordered.isAddress
+      : false;
   }
 
   DescriptorKind getDescriptorKind() const { return kind; }
@@ -206,8 +214,9 @@ public:
 class LifetimeDependenceInfo {
   IndexSubset *inheritLifetimeParamIndices;
   IndexSubset *scopeLifetimeParamIndices;
+  llvm::PointerIntPair<IndexSubset *, 1, bool>
+    addressableParamIndicesAndImmortal;
   unsigned targetIndex;
-  bool immortal;
 
   static LifetimeDependenceInfo getForIndex(AbstractFunctionDecl *afd,
                                             unsigned targetIndex,
@@ -238,11 +247,14 @@ class LifetimeDependenceInfo {
 public:
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
                          IndexSubset *scopeLifetimeParamIndices,
-                         unsigned targetIndex, bool isImmortal)
+                         unsigned targetIndex, bool isImmortal,
+                         // set during SIL type lowering
+                         IndexSubset *addressableParamIndices = nullptr)
       : inheritLifetimeParamIndices(inheritLifetimeParamIndices),
         scopeLifetimeParamIndices(scopeLifetimeParamIndices),
-        targetIndex(targetIndex), immortal(isImmortal) {
-    assert(isImmortal || inheritLifetimeParamIndices ||
+        addressableParamIndicesAndImmortal(addressableParamIndices, isImmortal),
+        targetIndex(targetIndex) {
+    assert(this->isImmortal() || inheritLifetimeParamIndices ||
            scopeLifetimeParamIndices);
     assert(!inheritLifetimeParamIndices ||
            !inheritLifetimeParamIndices->isEmpty());
@@ -252,11 +264,11 @@ public:
   operator bool() const { return !empty(); }
 
   bool empty() const {
-    return !immortal && inheritLifetimeParamIndices == nullptr &&
+    return !isImmortal() && inheritLifetimeParamIndices == nullptr &&
            scopeLifetimeParamIndices == nullptr;
   }
 
-  bool isImmortal() const { return immortal; }
+  bool isImmortal() const { return addressableParamIndicesAndImmortal.getInt(); }
 
   unsigned getTargetIndex() const { return targetIndex; }
 
@@ -266,10 +278,17 @@ public:
   bool hasScopeLifetimeParamIndices() const {
     return scopeLifetimeParamIndices != nullptr;
   }
+  bool hasAddressableParamIndices() const {
+    return addressableParamIndicesAndImmortal.getPointer() != nullptr;
+  }
 
   IndexSubset *getInheritIndices() const { return inheritLifetimeParamIndices; }
 
   IndexSubset *getScopeIndices() const { return scopeLifetimeParamIndices; }
+
+  IndexSubset *getAddressableIndices() const {
+    return addressableParamIndicesAndImmortal.getPointer();
+  }
 
   bool checkInherit(int index) const {
     return inheritLifetimeParamIndices
@@ -300,15 +319,15 @@ public:
     return this->isImmortal() == other.isImmortal() &&
            this->getTargetIndex() == other.getTargetIndex() &&
            this->getInheritIndices() == other.getInheritIndices() &&
+           this->getAddressableIndices() == other.getAddressableIndices() &&
            this->getScopeIndices() == other.getScopeIndices();
   }
 
   bool operator!=(const LifetimeDependenceInfo &other) const {
-    return this->isImmortal() != other.isImmortal() &&
-           this->getTargetIndex() != other.getTargetIndex() &&
-           this->getInheritIndices() != other.getInheritIndices() &&
-           this->getScopeIndices() != other.getScopeIndices();
+    return !(*this == other);
   }
+  
+  SWIFT_DEBUG_DUMPER(dump());
 };
 
 std::optional<LifetimeDependenceInfo>

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -48,7 +48,9 @@ getLifetimeDependenceFor(ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
 
 std::string LifetimeDependenceInfo::getString() const {
   std::string lifetimeDependenceString = "@lifetime(";
-  auto getSourceString = [](IndexSubset *bitvector, StringRef kind) {
+  auto addressable = getAddressableIndices();
+  
+  auto getSourceString = [&](IndexSubset *bitvector, StringRef kind) {
     std::string result;
     bool isFirstSetBit = true;
     for (unsigned i = 0; i < bitvector->getCapacity(); i++) {
@@ -57,6 +59,9 @@ std::string LifetimeDependenceInfo::getString() const {
           result += ", ";
         }
         result += kind;
+        if (addressable && addressable->contains(i)) {
+          result += "address ";
+        }
         result += std::to_string(i);
         isFirstSetBit = false;
       }
@@ -84,6 +89,8 @@ std::string LifetimeDependenceInfo::getString() const {
 }
 
 void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
+  ID.AddBoolean(addressableParamIndicesAndImmortal.getInt());
+  ID.AddInteger(targetIndex);
   if (inheritLifetimeParamIndices) {
     ID.AddInteger((uint8_t)LifetimeDependenceKind::Inherit);
     inheritLifetimeParamIndices->Profile(ID);
@@ -91,6 +98,12 @@ void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
   if (scopeLifetimeParamIndices) {
     ID.AddInteger((uint8_t)LifetimeDependenceKind::Scope);
     scopeLifetimeParamIndices->Profile(ID);
+  }
+  if (addressableParamIndicesAndImmortal.getPointer()) {
+    ID.AddBoolean(true);
+    addressableParamIndicesAndImmortal.getPointer()->Profile(ID);
+  } else {
+    ID.AddBoolean(false);  
   }
 }
 
@@ -195,6 +208,9 @@ void LifetimeDependenceInfo::getConcatenatedData(
   }
   if (hasScopeLifetimeParamIndices()) {
     pushData(scopeLifetimeParamIndices);
+  }
+  if (hasAddressableParamIndices()) {
+    pushData(addressableParamIndicesAndImmortal.getPointer());  
   }
 }
 
@@ -434,6 +450,7 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromDependsOn(
 
   SmallBitVector inheritLifetimeParamIndices(capacity);
   SmallBitVector scopeLifetimeParamIndices(capacity);
+  SmallBitVector addressableLifetimeParamIndices(capacity);
 
   auto updateLifetimeDependenceInfo = [&](LifetimeDescriptor descriptor,
                                           unsigned paramIndexToSet,
@@ -476,6 +493,9 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromDependsOn(
       if (updateLifetimeDependenceInfo(source, index, paramConvention)) {
         return std::nullopt;
       }
+      if (source.isAddressable()) {
+        addressableLifetimeParamIndices.set(index);
+      }
       break;
     }
     case LifetimeDescriptor::DescriptorKind::Named: {
@@ -499,7 +519,10 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromDependsOn(
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr,
       targetIndex,
-      /*isImmortal*/ false);
+      /*isImmortal*/ false,
+      addressableLifetimeParamIndices.any()
+          ? IndexSubset::get(ctx, addressableLifetimeParamIndices)
+          : nullptr);
 }
 
 std::optional<LifetimeDependenceInfo>
@@ -743,6 +766,25 @@ LifetimeDependenceInfo::get(FunctionTypeRepr *funcRepr,
   }
 
   return dc->getASTContext().AllocateCopy(lifetimeDependencies);
+}
+
+void LifetimeDependenceInfo::dump() const {
+  llvm::errs() << "target: " << getTargetIndex() << '\n';
+  if (isImmortal()) {
+    llvm::errs() << "  immortal\n";
+  }
+  if (auto scoped = getScopeIndices()) {
+    llvm::errs() << "  scoped: ";
+    scoped->dump();
+  }
+  if (auto inherited = getInheritIndices()) {
+    llvm::errs() << "  inherited: ";
+    inherited->dump();
+  }
+  if (auto addressable = getAddressableIndices()) {
+    llvm::errs() << "  addressable: ";
+    addressable->dump();
+  }
 }
 
 } // namespace swift

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4009,10 +4009,10 @@ namespace {
                                               /*isImmortal*/ true);
       if (const auto *funDecl = dyn_cast<FuncDecl>(result))
         if (hasUnsafeAPIAttr(decl) && !funDecl->getResultInterfaceType()->isEscapable()) {
+          lifetimeDependencies.push_back(immortalLifetime);
           Impl.SwiftContext.evaluator.cacheOutput(
               LifetimeDependenceInfoRequest{result},
               Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
-          lifetimeDependencies.push_back(immortalLifetime);
           return;
         }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2484,6 +2484,23 @@ parseLifetimeDescriptor(Parser &P,
   case tok::identifier: {
     Identifier name;
     auto loc = P.consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
+    
+    // In SIL, lifetimes explicitly state whether they are dependent on a
+    // memory location in addition to the value stored at that location.
+    if (P.isInSILMode()
+        && name.str() == "address"
+        && P.Tok.is(tok::integer_literal)) {
+      SourceLoc orderedLoc;
+      unsigned index;
+      
+      if (P.parseUnsignedInteger(
+              index, loc, diag::expected_param_index_lifetime_dependence)) {
+        return std::nullopt;
+      }
+      return LifetimeDescriptor::forOrdered(index, lifetimeDependenceKind, loc,
+                                            /*addressable*/ true);
+    }
+    
     return LifetimeDescriptor::forNamed(name.str(), lifetimeDependenceKind,
                                         loc);
   }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1573,18 +1573,29 @@ class DestructureInputs {
   std::optional<ForeignSelfInfo> ForeignSelf;
   AbstractionPattern TopLevelOrigType = AbstractionPattern::getInvalid();
   SmallVectorImpl<SILParameterInfo> &Inputs;
-  ArrayRef<LifetimeDependenceInfo> Dependencies;
+  SmallVectorImpl<int> &ParameterMap;
+  SmallBitVector &AddressableLoweredParameters;
   unsigned NextOrigParamIndex = 0;
+
+  void addLoweredParameter(SILParameterInfo parameter,
+                           unsigned formalParameterIndex) {
+    assert(Inputs.size() == ParameterMap.size());
+    Inputs.push_back(parameter);
+    ParameterMap.push_back(formalParameterIndex);
+  }
 
 public:
   DestructureInputs(TypeExpansionContext expansion, TypeConverter &TC,
                     const Conventions &conventions, const ForeignInfo &foreign,
                     std::optional<ActorIsolation> isolationInfo,
                     SmallVectorImpl<SILParameterInfo> &inputs,
-                    ArrayRef<LifetimeDependenceInfo> dependencies)
+                    SmallVectorImpl<int> &parameterMap,
+                    SmallBitVector &addressableParams)
       : expansion(expansion), TC(TC), Convs(conventions), Foreign(foreign),
         IsolationInfo(isolationInfo), Inputs(inputs),
-        Dependencies(dependencies) {}
+        ParameterMap(parameterMap),
+        AddressableLoweredParameters(addressableParams)
+  {}
 
   void destructure(AbstractionPattern origType,
                    CanAnyFunctionType::CanParamArrayRef params,
@@ -1656,7 +1667,8 @@ private:
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);
       auto actorType =
           ExistentialType::get(actorProtocol->getDeclaredInterfaceType());
-      addParameter(CanType(actorType).wrapInOptionalType(),
+      addParameter(-1,
+                   CanType(actorType).wrapInOptionalType(),
                    ParameterConvention::Direct_Guaranteed,
                    ParameterTypeFlags().withIsolated(true),
                    true /*implicit leading parameter*/);
@@ -1667,10 +1679,9 @@ private:
     // positioned after any parameters it adds.
     maybeAddForeignParameters();
     
-    // Parameters may lower differently when the function returns values that
-    // depends on them.
+    // Parameters may lower differently when they have scoped dependencies.
     SmallBitVector paramsWithScopedDependencies(params.size(), false);
-    for (auto &depInfo : Dependencies) {
+    for (auto &depInfo : extInfoBuilder.getLifetimeDependencies()) {
       if (auto scopeIndices = depInfo.getScopeIndices()) {
         paramsWithScopedDependencies |= scopeIndices->getBitVector();
       }
@@ -1700,7 +1711,8 @@ private:
         auto packTy = SILPackType::get(TC.Context, extInfo, {loweredParamTy});
 
         auto origFlags = param.getOrigFlags();
-        addPackParameter(packTy, origFlags.getValueOwnership(), origFlags);
+        addPackParameter(param.getSubstIndex(),
+                         packTy, origFlags.getValueOwnership(), origFlags);
         return;
       }
       
@@ -1709,6 +1721,7 @@ private:
       // pattern for the type.
       if (!param.isOrigPackExpansion()) {
         visit(param.getOrigType(), param.getSubstParams()[0],
+              param.getSubstIndex(),
               /*forSelf*/false,
               paramsWithScopedDependencies[param.getSubstIndex()]);
         return;
@@ -1731,7 +1744,8 @@ private:
       auto packTy = SILPackType::get(TC.Context, extInfo, packElts);
 
       auto origFlags = param.getOrigFlags();
-      addPackParameter(packTy, origFlags.getValueOwnership(), origFlags);
+      addPackParameter(param.getSubstIndex(),
+                       packTy, origFlags.getValueOwnership(), origFlags);
     });
 
     // Process the self parameter.  But if we have a formal foreign self
@@ -1740,15 +1754,24 @@ private:
     if (hasSelf && !hasForeignSelf) {
       auto origParamType = origType.getFunctionParamType(numOrigParams - 1);
       auto substParam = params.back();
-      visit(origParamType, substParam, /*forSelf*/true,
+      visit(origParamType, substParam,
+            params.size() - 1,
+            /*forSelf*/true,
             paramsWithScopedDependencies[params.size() - 1]);
     }
 
     TopLevelOrigType = AbstractionPattern::getInvalid();
     ForeignSelf = std::nullopt;
+
+    assert(ParameterMap.size() == Inputs.size());
+    
+    // Any parameters not yet marked addressable shouldn't be.
+    assert(AddressableLoweredParameters.size() <= ParameterMap.size());
+    AddressableLoweredParameters.resize(ParameterMap.size(), false);
   }
 
   void visit(AbstractionPattern origType, AnyFunctionType::Param substParam,
+             unsigned formalParamIndex,
              bool forSelf, bool hasScopedDependency) {
     // FIXME: we should really be using the flags from the original
     // parameter here, right?
@@ -1765,14 +1788,17 @@ private:
       bool indirect = true;
       SILPackType::ExtInfo extInfo(/*address*/ indirect);
       auto packTy = SILPackType::get(TC.Context, extInfo, {substType});
-      return addPackParameter(packTy, flags.getValueOwnership(), flags);
+      return addPackParameter(formalParamIndex,
+                              packTy, flags.getValueOwnership(), flags);
     }
 
-    visit(flags.getValueOwnership(), forSelf, hasScopedDependency,
+    visit(flags.getValueOwnership(), formalParamIndex,
+          forSelf, hasScopedDependency,
           origType, substType, flags);
   }
 
-  void visit(ValueOwnership ownership, bool forSelf, bool hasScopedDependency,
+  void visit(ValueOwnership ownership, int formalParamIndex,
+             bool forSelf, bool hasScopedDependency,
              AbstractionPattern origType, CanType substType,
              ParameterTypeFlags origFlags) {
     assert(!isa<InOutType>(substType));
@@ -1781,6 +1807,11 @@ private:
     // abstraction.
     if (origFlags.isAddressable()) {
       origType = AbstractionPattern::getOpaque();
+      
+      // Remember that this lowered parameter is addressable in the
+      // addressable parameters vector.
+      AddressableLoweredParameters.resize(ParameterMap.size() + 1, false);
+      AddressableLoweredParameters[ParameterMap.size()] = true;
     } else if (hasScopedDependency) {
       // If there is a scoped dependency on this parameter, and the parameter
       // is addressable-for-dependencies, then lower it with maximal abstraction
@@ -1788,12 +1819,18 @@ private:
       auto &initialSubstTL = TC.getTypeLowering(origType, substType, expansion);
       if (initialSubstTL.getRecursiveProperties().isAddressableForDependencies()) {
         origType = AbstractionPattern::getOpaque();
+
+        // Remember that this lowered parameter is addressable in the
+        // addressable parameters vector.
+        AddressableLoweredParameters.resize(ParameterMap.size() + 1, false);
+        AddressableLoweredParameters[ParameterMap.size()] = true;
       }
     }
 
     // Tuples get expanded unless they're inout.
     if (origType.isTuple() && ownership != ValueOwnership::InOut) {
-      expandTuple(ownership, forSelf, origType, substType, origFlags);
+      expandTuple(ownership, formalParamIndex,
+                  forSelf, origType, substType, origFlags);
       return;
     }
 
@@ -1824,11 +1861,12 @@ private:
       assert(!isIndirectFormalParameter(convention));
     }
 
-    addParameter(loweredType, convention, origFlags);
+    addParameter(formalParamIndex, loweredType, convention, origFlags);
   }
 
   /// Recursively expand a tuple type into separate parameters.
-  void expandTuple(ValueOwnership ownership, bool forSelf,
+  void expandTuple(ValueOwnership ownership, int formalParamIndex,
+                   bool forSelf,
                    AbstractionPattern origType, CanType substType,
                    ParameterTypeFlags oldFlags) {
     assert(ownership != ValueOwnership::InOut);
@@ -1836,7 +1874,7 @@ private:
 
     origType.forEachTupleElement(substType, [&](TupleElementGenerator &elt) {
       if (!elt.isOrigPackExpansion()) {
-        visit(ownership, forSelf, /*scoped dependency*/ false,
+        visit(ownership, formalParamIndex, forSelf, /*scoped dependency*/ false,
               elt.getOrigType(), elt.getSubstTypes()[0],
               oldFlags);
         return;
@@ -1857,13 +1895,14 @@ private:
       SILPackType::ExtInfo extInfo(/*address*/ indirect);
       auto packTy = SILPackType::get(TC.Context, extInfo, packElts);
 
-      addPackParameter(packTy, ownership, oldFlags);
+      addPackParameter(formalParamIndex, packTy, ownership, oldFlags);
     });
   }
 
   /// Add a parameter that we derived from deconstructing the
   /// formal type.
-  void addParameter(CanType loweredType, ParameterConvention convention,
+  void addParameter(int formalParameterIndex,
+                    CanType loweredType, ParameterConvention convention,
                     ParameterTypeFlags origFlags, bool isImplicit = false) {
     SILParameterInfo param(loweredType, convention);
 
@@ -1877,14 +1916,16 @@ private:
       param = param.addingOption(SILParameterInfo::ImplicitLeading);
 
     Inputs.push_back(param);
+    ParameterMap.push_back(formalParameterIndex);
     maybeAddForeignParameters();
   }
 
-  void addPackParameter(CanSILPackType packTy, ValueOwnership ownership,
+  void addPackParameter(int formalParameterIndex,
+                        CanSILPackType packTy, ValueOwnership ownership,
                         ParameterTypeFlags origFlags) {
     unsigned origParamIndex = NextOrigParamIndex++;
     auto convention = Convs.getPack(ownership, origParamIndex);
-    addParameter(packTy, convention, origFlags);
+    addParameter(formalParameterIndex, packTy, convention, origFlags);
   }
 
   /// Given that we've just reached an argument index for the
@@ -1911,6 +1952,8 @@ private:
       .getASTType();
     Inputs.push_back(SILParameterInfo(completionHandlerTy,
                                       ParameterConvention::Direct_Unowned));
+    // No corresponding formal parameter.
+    ParameterMap.push_back(-1);
     ++NextOrigParamIndex;
     return true;
   }
@@ -1926,6 +1969,8 @@ private:
     // Assume the error parameter doesn't have interesting lowering.
     Inputs.push_back(SILParameterInfo(foreignErrorTy,
                                       ParameterConvention::Direct_Unowned));
+    // No corresponding formal parameter.
+    ParameterMap.push_back(-1);
     ++NextOrigParamIndex;
     return true;
   }
@@ -1938,6 +1983,7 @@ private:
     if (ForeignSelf) {
       // This is a "self", but it's not a Swift self, we handle it differently.
       visit(ForeignSelf->SubstSelfParam.getValueOwnership(),
+            Foreign.self.getSelfIndex(),
             /*forSelf=*/false, /*scoped dependency=*/false,
             ForeignSelf->OrigSelfParam,
             ForeignSelf->SubstSelfParam.getParameterType(), {});
@@ -2512,19 +2558,10 @@ static CanSILFunctionType getSILFunctionType(
   updateResultTypeForForeignInfo(foreignInfo, genericSig, origResultType,
                                  substFormalResultType);
 
-  // Lifetime dependencies can influence parameter lowering if there are
-  // address dependencies.
-  ArrayRef<LifetimeDependenceInfo> dependencies = {};
-  if (constant) {
-    if (auto afd = dyn_cast_or_null<AbstractFunctionDecl>(constant->getDecl())){
-      if (auto declDependencies = afd->getLifetimeDependencies()) {
-        dependencies = *declDependencies;
-      }
-    }
-  }
-
   // Destructure the input tuple type.
   SmallVector<SILParameterInfo, 8> inputs;
+  SmallVector<int, 8> parameterMap;
+  SmallBitVector addressableParams;
   {
     std::optional<ActorIsolation> actorIsolation;
     if (constant) {
@@ -2547,7 +2584,7 @@ static CanSILFunctionType getSILFunctionType(
     }
     DestructureInputs destructurer(expansionContext, TC, conventions,
                                    foreignInfo, actorIsolation, inputs,
-                                   dependencies);
+                                   parameterMap, addressableParams);
     destructurer.destructure(origType, substFnInterfaceType.getParams(),
                              extInfoBuilder, unimplementable);
   }
@@ -2574,6 +2611,87 @@ static CanSILFunctionType getSILFunctionType(
     lowerCaptureContextParameters(TC, *constant, genericSig,
                                   TC.getCaptureTypeExpansionContext(*constant),
                                   inputs);
+  }
+  
+  // Form the lowered lifetime dependency records using the parameter mapping
+  // we formed above.
+  SmallVector<LifetimeDependenceInfo, 8> loweredLifetimes;
+  auto lowerLifetimeDependence
+    = [&](const LifetimeDependenceInfo &formalDeps,
+          unsigned target) -> LifetimeDependenceInfo {
+      if (formalDeps.isImmortal()) {
+        return LifetimeDependenceInfo(nullptr, nullptr,
+                                      target, /*immortal*/ true);
+      }
+      
+      auto lowerIndexSet = [&](IndexSubset *formal) -> IndexSubset * {
+        if (!formal) {
+          return nullptr;
+        }
+        
+        SmallBitVector loweredIndices;
+        loweredIndices.resize(parameterMap.size());      
+        for (unsigned j = 0; j < parameterMap.size(); ++j) {
+          int formalIndex = parameterMap[j];
+          if (formalIndex < 0) {
+            continue;
+          }
+          loweredIndices[j] = formal->contains(formalIndex);
+        }
+        
+        if (!loweredIndices.any()) {
+          return nullptr;
+        }
+        
+        return IndexSubset::get(TC.Context, loweredIndices);
+      };
+      
+      IndexSubset *inheritIndicesSet
+        = lowerIndexSet(formalDeps.getInheritIndices());
+      IndexSubset *scopeIndicesSet
+        = lowerIndexSet(formalDeps.getScopeIndices());
+      
+      // If the original formal parameter dependencies were lowered away
+      // entirely (such as if they were of `()` type), then there is effectively
+      // no dependency, leaving behind an immortal value.
+      if (!inheritIndicesSet && !scopeIndicesSet) {
+        return LifetimeDependenceInfo(nullptr, nullptr, target,
+                                      /*immortal*/ true);
+      }
+      
+      SmallBitVector addressableDeps = scopeIndicesSet
+        ? scopeIndicesSet->getBitVector() & addressableParams
+        : SmallBitVector(1, false);
+      IndexSubset *addressableSet = addressableDeps.any()
+        ? IndexSubset::get(TC.Context, addressableDeps)
+        : nullptr;
+      
+      return LifetimeDependenceInfo(inheritIndicesSet,
+                                    scopeIndicesSet,
+                                    target, /*immortal*/ false,
+                                    addressableSet);
+    };
+  // Lower parameter dependencies.
+  for (unsigned i = 0; i < parameterMap.size(); ++i) {
+    if (parameterMap[i] < 0) {
+      continue;
+    }
+    
+    auto formalParamDeps = getLifetimeDependenceFor(
+                                       extInfoBuilder.getLifetimeDependencies(),
+                                       parameterMap[i]);
+    if (!formalParamDeps) {
+      continue;
+    }
+    
+    loweredLifetimes.emplace_back(lowerLifetimeDependence(*formalParamDeps, i));
+  }
+  // Lower the return value dependencies.
+  if (auto formalReturnDeps = getLifetimeDependenceFor(
+                                      extInfoBuilder.getLifetimeDependencies(),
+                                      substFnInterfaceType.getParams().size())){
+    loweredLifetimes.emplace_back(lowerLifetimeDependence(*formalReturnDeps,
+                                                          parameterMap.size()));
   }
   
   auto calleeConvention = ParameterConvention::Direct_Unowned;
@@ -2606,7 +2724,7 @@ static CanSILFunctionType getSILFunctionType(
           .withSendable(isSendable)
           .withAsync(isAsync)
           .withUnimplementable(unimplementable)
-          .withLifetimeDependencies(extInfoBuilder.getLifetimeDependencies())
+          .withLifetimeDependencies(loweredLifetimes)
           .build();
 
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,
@@ -2636,8 +2754,12 @@ static CanSILFunctionType getSILFunctionTypeForInitAccessor(
     bool unimplementable = false;
     ForeignInfo foreignInfo;
     std::optional<ActorIsolation> actorIsolation; // For now always null.
+    SmallVector<int, 8> unusedParameterMap;
+    SmallBitVector unusedAddressableParams;
     DestructureInputs destructurer(context, TC, conventions, foreignInfo,
-                                   actorIsolation, inputs, {});
+                                   actorIsolation, inputs,
+                                   unusedParameterMap,
+                                   unusedAddressableParams);
     destructurer.destructure(
         origType, substAccessorType.getParams(),
         extInfoBuilder.withRepresentation(SILFunctionTypeRepresentation::Thin),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9106,13 +9106,16 @@ ModuleFile::maybeReadLifetimeDependence(unsigned numParams) {
   bool isImmortal;
   bool hasInheritLifetimeParamIndices;
   bool hasScopeLifetimeParamIndices;
+  bool hasAddressableParamIndices;
   ArrayRef<uint64_t> lifetimeDependenceData;
   LifetimeDependenceLayout::readRecord(
       scratch, targetIndex, isImmortal, hasInheritLifetimeParamIndices,
-      hasScopeLifetimeParamIndices, lifetimeDependenceData);
+      hasScopeLifetimeParamIndices, hasAddressableParamIndices,
+      lifetimeDependenceData);
 
   SmallBitVector inheritLifetimeParamIndices(numParams, false);
   SmallBitVector scopeLifetimeParamIndices(numParams, false);
+  SmallBitVector addressableParamIndices(numParams, false);
 
   unsigned startIndex = 0;
   auto pushData = [&](SmallBitVector &bits) {
@@ -9130,6 +9133,9 @@ ModuleFile::maybeReadLifetimeDependence(unsigned numParams) {
   if (hasScopeLifetimeParamIndices) {
     pushData(scopeLifetimeParamIndices);
   }
+  if (hasAddressableParamIndices) {
+    pushData(addressableParamIndices);
+  }
 
   ASTContext &ctx = getContext();
   return LifetimeDependenceInfo(
@@ -9139,5 +9145,8 @@ ModuleFile::maybeReadLifetimeDependence(unsigned numParams) {
       hasScopeLifetimeParamIndices
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr,
-      targetIndex, isImmortal);
+      targetIndex, isImmortal,
+      hasAddressableParamIndices
+          ? IndexSubset::get(ctx, addressableParamIndices)
+          : nullptr);
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2284,6 +2284,7 @@ namespace decls_block {
                      BCFixed<1>,         // isImmortal
                      BCFixed<1>,         // hasInheritLifetimeParamIndices
                      BCFixed<1>,         // hasScopeLifetimeParamIndices
+                     BCFixed<1>,         // hasAddressableParamIndices
                      BCArray<BCFixed<1>> // concatenated param indices
                      >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2696,7 +2696,9 @@ void Serializer::writeLifetimeDependencies(
     LifetimeDependenceLayout::emitRecord(
         Out, ScratchRecord, abbrCode, info.getTargetIndex(), info.isImmortal(),
         info.hasInheritLifetimeParamIndices(),
-        info.hasScopeLifetimeParamIndices(), paramIndices);
+        info.hasScopeLifetimeParamIndices(),
+        info.hasAddressableParamIndices(),
+        paramIndices);
     paramIndices.clear();
   }
 }

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -34,7 +34,7 @@ public func test(pview: borrowing PView) -> View {
   return pview.getDefault()
 }
 
-// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @lifetime(borrow 0)  @out Self.E {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @lifetime(borrow address 0)  @out Self.E {
 
 // CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyF : $@convention(method) (PView) -> @lifetime(immortal) @owned View {
 

--- a/test/SILGen/lifetime_dependence_lowering.swift
+++ b/test/SILGen/lifetime_dependence_lowering.swift
@@ -1,0 +1,112 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes %s | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableParameters
+// REQUIRES: swift_feature_AddressableTypes
+
+struct Foo: ~Escapable { }
+
+struct Butt {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test1{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
+    @lifetime(borrow self)
+    func test1(other: Butt) -> Foo {
+    }
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test2{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
+    @lifetime(borrow other)
+    func test2(other: Butt) -> Foo {
+    }
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test3{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 4) @owned Foo
+    @lifetime(borrow self)
+    func test3(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test4{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
+    @lifetime(borrow other)
+    func test4(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test5{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 1, borrow 2) @owned Foo
+    @lifetime(borrow tuple)
+    func test5(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test6{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 3) @owned Foo
+    @lifetime(borrow another)
+    func test6(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test7{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 2) @owned Foo
+    @lifetime(borrow self)
+    func test7(other: Butt, nothing: (), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test8{{.*}} : $
+    // CHECK-SAME: -> @lifetime(immortal) @owned Foo
+    @lifetime(borrow nothing)
+    func test8(other: Butt, nothing: (), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test9{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
+    @lifetime(borrow other)
+    func test9(other: Butt, nothing: (), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test10{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
+    @lifetime(borrow another)
+    func test10(other: Butt, nothing: (), another: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test11{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 1) @owned Foo
+    @_addressableSelf
+    @lifetime(borrow self)
+    func test11(other: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test12{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
+    @_addressableSelf
+    @lifetime(borrow other)
+    func test12(other: Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test13{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
+    @lifetime(borrow self)
+    func test13(other: @_addressable Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test14{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
+    @lifetime(borrow other)
+    func test14(other: @_addressable Butt) -> Foo {}
+
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test15{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
+    @lifetime(borrow tuple)
+    func test15(tuple: @_addressable (Butt, Butt)) -> Foo {}
+}
+
+@_addressableForDependencies
+struct AddressableForDeps {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test16{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 3) @owned Foo
+    @lifetime(borrow self)
+    func test16(tuple: (AddressableForDeps, AddressableForDeps),
+                other: AddressableForDeps) -> Foo {}
+
+    // The dependency makes the tuple pass as a single indirect argument.
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test17{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
+    @lifetime(borrow tuple)
+    func test17(tuple: (AddressableForDeps, AddressableForDeps),
+                other: AddressableForDeps) -> Foo {}
+
+    // The tuple destructures as usual, but `other` is passed indirectly.
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test18{{.*}} : $
+    // CHECK-SAME: -> @lifetime(borrow address 2) @owned Foo
+    @lifetime(borrow other)
+    func test18(tuple: (AddressableForDeps, AddressableForDeps),
+                other: AddressableForDeps) -> Foo {}
+}
+


### PR DESCRIPTION
Map the lifetime dependencies described in terms of the formal AST-level parameters to the correct parameter(s) in the lowered SIL function type. There can be 0, 1, or many SIL parameters per formal parameter because of tuple exploding. Also, record which dependencies are on addressable parameters (meaning that the dependency includes not only the value of the parameter, but its specific memory location).
