### PR TITLE
Add StrictSendableMetatypes to require Sendable requirements on metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5607,6 +5607,10 @@ ERROR(non_sendable_isolated_capture,none,
       "capture of %1 with non-sendable type %0 in an isolated "
       "%select{local function|closure}2",
       (Type, DeclName, bool))
+ERROR(non_sendable_metatype_capture,none,
+      "capture of non-sendable type %0 in an isolated "
+      "%select{local function|closure}1",
+      (Type, bool))
 ERROR(self_capture_deinit_task,none,
       "capture of 'self' in a closure that outlives deinit",
       ())

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -107,6 +107,7 @@ PROTOCOL(Encodable)
 PROTOCOL(Decodable)
 
 PROTOCOL(Sendable)
+PROTOCOL(SendableMetatype)
 PROTOCOL(UnsafeSendable)
 
 PROTOCOL_(ObjectiveCBridgeable)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -446,6 +446,9 @@ EXPERIMENTAL_FEATURE(NonIsolatedAsyncInheritsIsolationFromContext, false)
 /// Allow custom availability domains to be defined and referenced.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 
+/// Be strict about the Sendable conformance of metatypes.
+EXPERIMENTAL_FEATURE(StrictSendableMetatypes, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -269,6 +269,7 @@ UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)
 UNINTERESTING_FEATURE(Extern)
 UNINTERESTING_FEATURE(ConsumeSelfInDeinit)
+UNINTERESTING_FEATURE(StrictSendableMetatypes)
 
 static bool usesFeatureBitwiseCopyable2(Decl *decl) {
   if (!decl->getModuleContext()->isStdlibModule()) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6985,6 +6985,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Copyable:
   case KnownProtocolKind::Escapable:
   case KnownProtocolKind::BitwiseCopyable:
+  case KnownProtocolKind::SendableMetatype:
     return SpecialProtocol::None;
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2952,9 +2952,10 @@ CONSTANT_TRANSLATION(WitnessMethodInst, AssignFresh)
 CONSTANT_TRANSLATION(IntegerLiteralInst, AssignFresh)
 CONSTANT_TRANSLATION(FloatLiteralInst, AssignFresh)
 CONSTANT_TRANSLATION(StringLiteralInst, AssignFresh)
-// Metatypes are Sendable, but AnyObject isn't
-CONSTANT_TRANSLATION(ObjCMetatypeToObjectInst, AssignFresh)
-CONSTANT_TRANSLATION(ObjCExistentialMetatypeToObjectInst, AssignFresh)
+// Metatypes are often, but not always, Sendable, but AnyObject isn't
+CONSTANT_TRANSLATION(ObjCMetatypeToObjectInst, Assign)
+CONSTANT_TRANSLATION(ObjCExistentialMetatypeToObjectInst, Assign)
+CONSTANT_TRANSLATION(MetatypeInst, AssignFresh)
 
 //===---
 // Assign
@@ -2997,6 +2998,10 @@ CONSTANT_TRANSLATION(UncheckedAddrCastInst, Assign)
 CONSTANT_TRANSLATION(UncheckedEnumDataInst, Assign)
 CONSTANT_TRANSLATION(UncheckedOwnershipConversionInst, Assign)
 CONSTANT_TRANSLATION(IndexRawPointerInst, Assign)
+
+CONSTANT_TRANSLATION(InitExistentialMetatypeInst, Assign)
+CONSTANT_TRANSLATION(OpenExistentialMetatypeInst, Assign)
+CONSTANT_TRANSLATION(ObjCToThickMetatypeInst, Assign)
 
 // These are used by SIL to aggregate values together in a gep like way. We
 // want to look at uses of structs, not the struct uses itself. So just
@@ -3095,7 +3100,6 @@ CONSTANT_TRANSLATION(EndUnpairedAccessInst, Ignored)
 CONSTANT_TRANSLATION(HopToExecutorInst, Ignored)
 CONSTANT_TRANSLATION(InjectEnumAddrInst, Ignored)
 CONSTANT_TRANSLATION(DestroyNotEscapedClosureInst, Ignored)
-CONSTANT_TRANSLATION(MetatypeInst, Ignored)
 CONSTANT_TRANSLATION(EndApplyInst, Ignored)
 CONSTANT_TRANSLATION(AbortApplyInst, Ignored)
 CONSTANT_TRANSLATION(DebugStepInst, Ignored)
@@ -3126,15 +3130,6 @@ CONSTANT_TRANSLATION(ValueMetatypeInst, Require)
 CONSTANT_TRANSLATION(ExistentialMetatypeInst, Require)
 // These can take a parameter. If it is non-Sendable, use a require.
 CONSTANT_TRANSLATION(GetAsyncContinuationAddrInst, Require)
-
-//===---
-// Asserting If Non Sendable Parameter
-//
-
-// Takes metatypes as parameters and metatypes today are always sendable.
-CONSTANT_TRANSLATION(InitExistentialMetatypeInst, AssertingIfNonSendable)
-CONSTANT_TRANSLATION(OpenExistentialMetatypeInst, AssertingIfNonSendable)
-CONSTANT_TRANSLATION(ObjCToThickMetatypeInst, AssertingIfNonSendable)
 
 //===---
 // Terminators

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -805,6 +805,12 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     }
   }
 
+  /// Consider non-Sendable metatypes to be task-isolated, so they cannot cross
+  /// into another isolation domain.
+  if (auto *mi = dyn_cast<MetatypeInst>(inst)) {
+    return SILIsolationInfo::getTaskIsolated(mi);
+  }
+
   // Check if we have an ApplyInst with nonisolated.
   //
   // NOTE: We purposely avoid using other isolation info from an ApplyExpr since

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -54,6 +54,10 @@ class FindCapturedVars : public ASTWalker {
   /// can go here too.
   llvm::SetVector<GenericEnvironment *> CapturedEnvironments;
 
+  /// The captured types.
+  SmallVector<CapturedType, 4> CapturedTypes;
+  llvm::SmallDenseMap<CanType, unsigned, 4> CapturedTypeEntryNumber;
+
   SourceLoc GenericParamCaptureLoc;
   SourceLoc DynamicSelfCaptureLoc;
   DynamicSelfType *DynamicSelf = nullptr;
@@ -83,7 +87,8 @@ public:
 
     return CaptureInfo(Context, Captures, dynamicSelfToRecord,
                        OpaqueValue, HasGenericParamCaptures,
-                       CapturedEnvironments.getArrayRef());
+                       CapturedEnvironments.getArrayRef(),
+                       CapturedTypes);
   }
 
   bool hasGenericParamCaptures() const {
@@ -156,6 +161,22 @@ public:
       }));
     }
 
+    // Note that we're using a generic type.
+    auto recordUseOfGenericType = [&](Type type) {
+      if (!HasGenericParamCaptures) {
+        GenericParamCaptureLoc = loc;
+        HasGenericParamCaptures = true;
+      }
+
+      auto [insertionPos, inserted] = CapturedTypeEntryNumber.insert(
+          {type->getCanonicalType(), CapturedTypes.size()});
+      if (inserted) {
+        CapturedTypes.push_back(CapturedType(type, loc));
+      } else if (CapturedTypes[insertionPos->second].getLoc().isInvalid()) {
+        CapturedTypes[insertionPos->second] = CapturedType(type, loc);
+      }
+    };
+
     // Similar to dynamic 'Self', IRGen doesn't really need type metadata
     // for class-bound archetypes in nearly as many cases as with opaque
     // archetypes.
@@ -174,23 +195,18 @@ public:
             CapturedEnvironments.insert(env);
         }
 
-        if ((t->is<PrimaryArchetypeType>() ||
-             t->is<PackArchetypeType>() ||
-             t->is<GenericTypeParamType>()) &&
-            !HasGenericParamCaptures) {
-          GenericParamCaptureLoc = loc;
-          HasGenericParamCaptures = true;
+        if (t->is<PrimaryArchetypeType>() ||
+            t->is<PackArchetypeType>() ||
+            t->is<GenericTypeParamType>()) {
+          recordUseOfGenericType(t);
         }
       }));
     }
 
     if (auto *gft = type->getAs<GenericFunctionType>()) {
       TypeCaptureWalker walker(ObjC, [&](Type t) {
-        if (t->is<GenericTypeParamType>() &&
-            !HasGenericParamCaptures) {
-          GenericParamCaptureLoc = loc;
-          HasGenericParamCaptures = true;
-        }
+        if (t->is<GenericTypeParamType>())
+          recordUseOfGenericType(t);
       });
 
       for (const auto &param : gft->getParams())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2339,7 +2339,8 @@ static void diagnoseConformanceImpliedByConditionalConformance(
 /// to the given protocol. This should return true when @unchecked can be
 /// used to disable those semantic checks.
 static bool hasAdditionalSemanticChecks(ProtocolDecl *proto) {
-  return proto->isSpecificProtocol(KnownProtocolKind::Sendable);
+  return proto->isSpecificProtocol(KnownProtocolKind::Sendable) ||
+      proto->isSpecificProtocol(KnownProtocolKind::SendableMetatype);
 }
 
 /// Determine whether a conformance to this protocol can be determined at

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A type `T` whose metatype `T.Type` is `Sendable`.
+@_marker public protocol SendableMetatype: ~Copyable, ~Escapable { }
+
 /// A thread-safe type whose values can be shared across arbitrary concurrent
 /// contexts without introducing a risk of data races. Values of the type may
 /// have no shared mutable state, or they may protect that state with a lock or
@@ -132,7 +135,7 @@
 /// ### Sendable Metatypes
 ///
 /// Metatypes such as `Int.Type` implicitly conform to the `Sendable` protocol.
-@_marker public protocol Sendable: ~Copyable, ~Escapable { }
+@_marker public protocol Sendable: SendableMetatype, ~Copyable, ~Escapable { }
 
 ///
 /// A type whose values can safely be passed across concurrency domains by copying,

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -16,20 +16,6 @@ func acceptMetaOnMainActor<T>(_: T.Type) { }
 // -------------------------------------------------------------------------
 // Non-Sendable metatype instances that cross into other isolation domains.
 // -------------------------------------------------------------------------
-nonisolated func staticCallThroughMeta<T: Q>(_: T.Type) {
-  let x = T.self
-  Task.detached { // expected-error{{risks causing data races}}
-    x.g() // expected-note{{closure captures 'x' which is accessible to code in the current task}}
-  }
-}
-
-nonisolated func passMeta<T: Q>(_: T.Type) {
-  let x = T.self
-  Task.detached { // expected-error{{risks causing data races}}
-    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
-  }
-}
-
 nonisolated func staticCallThroughMetaSmuggled<T: Q>(_: T.Type) {
   let x: Q.Type = T.self
   Task.detached { // expected-error{{risks causing data races}}
@@ -60,14 +46,6 @@ nonisolated func passToMainActorSmuggledAny<T: Q>(_: T.Type) async {
 // -------------------------------------------------------------------------
 // Sendable metatype instances that cross into other isolation domains.
 // -------------------------------------------------------------------------
-nonisolated func passMetaWithSendable<T: Sendable & Q>(_: T.Type) {
-  let x = T.self
-  Task.detached {
-    acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable
-    x.g() // okay, because T is Sendable implies T.Type: Sendable
-  }
-}
-
 nonisolated func passMetaWithSendableSmuggled<T: Sendable & Q>(_: T.Type) {
   let x: any (Q & Sendable).Type = T.self
   Task.detached {
@@ -80,21 +58,3 @@ nonisolated func passSendableToMainActorSmuggledAny<T: Sendable>(_: T.Type) asyn
   let x: Sendable.Type = T.self
   await acceptMetaOnMainActor(x)
 }
-
-// -------------------------------------------------------------------------
-// Sendable requirements on metatypes
-// -------------------------------------------------------------------------
-
-nonisolated func passMetaWithMetaSendable<T: Q>(_: T.Type) where T.Type: Sendable {
-  // FIXME: Bogus errors below because we don't currently handle constraints on
-  // metatypes.
-  let x = T.self
-  Task.detached { // expected-error{{risks causing data races}}
-    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
-                  // should be okay, because T is Sendable implies T.Type: Sendable
-    x.g() // okay, because T is Sendable implies T.Type: Sendable
-  }
-}
-
-// TODO: Cannot currently express an existential or opaque type where the
-// metatype is Sendable.

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -54,6 +54,14 @@ nonisolated func passMetaWithSendableSmuggled<T: Sendable & Q>(_: T.Type) {
   }
 }
 
+nonisolated func passMetaWithSendableSmuggled<T: SendableMetatype & Q>(_: T.Type) {
+  let x: any Q.Type = T.self
+  Task.detached {
+    acceptMeta(x) // okay, because T: SendableMetatype implies T.Type: Sendable
+    x.g() // okay, because T: SendableMetatype implies T.Type: Sendable
+  }
+}
+
 nonisolated func passSendableToMainActorSmuggledAny<T: Sendable>(_: T.Type) async {
   let x: Sendable.Type = T.self
   await acceptMetaOnMainActor(x)

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -1,0 +1,86 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature StrictSendableMetatypes -emit-sil -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_StrictSendableMetatypes
+
+
+protocol Q {
+  static func g()
+}
+
+nonisolated func acceptMeta<T>(_: T.Type) { }
+
+// -------------------------------------------------------------------------
+// Non-Sendable metatype instances that cross into other isolation domains.
+// -------------------------------------------------------------------------
+nonisolated func staticCallThroughMeta<T: Q>(_: T.Type) {
+  let x = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    x.g() // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  }
+}
+
+nonisolated func passMeta<T: Q>(_: T.Type) {
+  let x = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  }
+}
+
+nonisolated func staticCallThroughMetaSmuggled<T: Q>(_: T.Type) {
+  let x: Q.Type = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    x.g() // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  }
+}
+
+nonisolated func passMetaSmuggled<T: Q>(_: T.Type) {
+  let x: Q.Type = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  }
+}
+
+nonisolated func passMetaSmuggledAny<T: Q>(_: T.Type) {
+  let x: Any.Type = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  }
+}
+
+// -------------------------------------------------------------------------
+// Sendable metatype instances that cross into other isolation domains.
+// -------------------------------------------------------------------------
+nonisolated func passMetaWithSendable<T: Sendable & Q>(_: T.Type) {
+  let x = T.self
+  Task.detached {
+    acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable
+    x.g() // okay, because T is Sendable implies T.Type: Sendable
+  }
+}
+
+nonisolated func passMetaWithSendableSmuggled<T: Sendable & Q>(_: T.Type) {
+  let x: any (Q & Sendable).Type = T.self
+  Task.detached {
+    acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable
+    x.g() // okay, because T is Sendable implies T.Type: Sendable
+  }
+}
+
+// -------------------------------------------------------------------------
+// Sendable requirements on metatypes
+// -------------------------------------------------------------------------
+
+nonisolated func passMetaWithMetaSendable<T: Q>(_: T.Type) where T.Type: Sendable {
+  // FIXME: Bogus errors below because we don't currently handle constraints on
+  // metatypes.
+  let x = T.self
+  Task.detached { // expected-error{{risks causing data races}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+                  // should be okay, because T is Sendable implies T.Type: Sendable
+    x.g() // okay, because T is Sendable implies T.Type: Sendable
+  }
+}
+
+// TODO: Cannot currently express an existential or opaque type where the
+// metatype is Sendable.

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature StrictSendableMetatypes
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_StrictSendableMetatypes
+
+// This test checks for typecheck-only diagnostics involving non-sendable
+// metatypes.
+
+protocol Q {
+  static func g()
+}
+
+nonisolated func acceptMeta<T>(_: T.Type) { }
+
+nonisolated func staticCallThroughMeta<T: Q>(_: T.Type) {
+  Task.detached {
+    T.g()
+  }
+}
+
+nonisolated func passMeta<T: Q>(_: T.Type) {
+  Task.detached {
+    acceptMeta(T.self)
+  }
+}

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -51,7 +51,21 @@ nonisolated func passMetaSendable<T: Sendable & Q>(_: T.Type) {
   }
 }
 
+nonisolated func passMetaSendableMeta<T: SendableMetatype & Q>(_: T.Type) {
+  Task.detached {
+    acceptMeta(T.self)
+  }
+}
+
 nonisolated func passMetaWithSendableVal<T: Sendable & Q>(_: T.Type) {
+  let x = T.self
+  Task.detached {
+    acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable
+    x.g() // okay, because T is Sendable implies T.Type: Sendable
+  }
+}
+
+nonisolated func passMetaWithMetaSendableVal<T: SendableMetatype & Q>(_: T.Type) {
   let x = T.self
   Task.detached {
     acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -12,14 +12,49 @@ protocol Q {
 
 nonisolated func acceptMeta<T>(_: T.Type) { }
 
+nonisolated func staticCallThroughMetaVal<T: Q>(_: T.Type) {
+  let x = T.self // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  Task.detached {
+    x.g() // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  }
+}
+
+nonisolated func passMetaVal<T: Q>(_: T.Type) {
+  let x = T.self // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  Task.detached {
+    acceptMeta(x) // expected-error{{capture of non-sendable type}}
+  }
+}
+
 nonisolated func staticCallThroughMeta<T: Q>(_: T.Type) {
   Task.detached {
-    T.g()
+    T.g() // expected-error{{capture of non-sendable type}}
   }
 }
 
 nonisolated func passMeta<T: Q>(_: T.Type) {
   Task.detached {
+    acceptMeta(T.self) // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  }
+}
+
+
+nonisolated func staticCallThroughMetaSendable<T: Sendable & Q>(_: T.Type) {
+  Task.detached {
+    T.g()
+  }
+}
+
+nonisolated func passMetaSendable<T: Sendable & Q>(_: T.Type) {
+  Task.detached {
     acceptMeta(T.self)
+  }
+}
+
+nonisolated func passMetaWithSendableVal<T: Sendable & Q>(_: T.Type) {
+  let x = T.self
+  Task.detached {
+    acceptMeta(x) // okay, because T is Sendable implies T.Type: Sendable
+    x.g() // okay, because T is Sendable implies T.Type: Sendable
   }
 }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -55,7 +55,7 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrusive.
-// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface_type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface_type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> {{.*}})
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
 // CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T -> Int)]" function_ref=unapplied))

--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -38,7 +38,7 @@
 // - ExtraStruct.Inner
 // (ExtraStruct.Inner will have two sourceOrigins because it has two relationships: a memberOf and a
 // conformsTo)
-// COUNT-COUNT-3: sourceOrigin
+// COUNT-COUNT-4: sourceOrigin
 // COUNT-NOT: sourceOrigin
 
 public protocol SomeProtocol {

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -111,6 +111,7 @@ cake: Class C7 has added a conformance to an existing protocol P1
 cake: Class SuperClassChange has added a conformance to an existing protocol P1
 cake: Enum IceKind has removed conformance to BitwiseCopyable
 cake: Enum IceKind has removed conformance to Sendable
+cake: Enum IceKind has removed conformance to SendableMetatype
 cake: Protocol P3 has added inherited protocol P4
 cake: Protocol P3 has removed inherited protocol P2
 cake: Struct fixedLayoutStruct has added a conformance to an existing protocol P2

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -51,6 +51,7 @@ cake: EnumElement FrozenKind.AddedCase has been added as a new enum case
 /* Conformance changes */
 cake: Enum IceKind has removed conformance to BitwiseCopyable
 cake: Enum IceKind has removed conformance to Sendable
+cake: Enum IceKind has removed conformance to SendableMetatype
 cake: Func ObjCProtocol.removeOptional() is no longer an optional requirement
 cake: Protocol P3 has added inherited protocol P4
 cake: Protocol P3 has removed inherited protocol P2

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -269,6 +269,13 @@
           },
           {
             "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
             "name": "P2",
             "printedName": "P2",
             "usr": "s:4cake2P2P",
@@ -1067,6 +1074,13 @@
             "printedName": "Escapable",
             "usr": "s:s9EscapableP",
             "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           }
         ]
       },
@@ -2223,6 +2237,13 @@
             "printedName": "Sendable",
             "usr": "s:s8SendableP",
             "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           },
           {
             "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -274,6 +274,13 @@
           },
           {
             "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
             "name": "P2",
             "printedName": "P2",
             "usr": "s:4cake2P2P",
@@ -1010,6 +1017,13 @@
             "printedName": "Escapable",
             "usr": "s:s9EscapableP",
             "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           }
         ]
       },
@@ -2103,6 +2117,13 @@
             "printedName": "Sendable",
             "usr": "s:s8SendableP",
             "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           },
           {
             "kind": "Conformance",

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -360,3 +360,6 @@ Func ContiguousArray.withUnsafeBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
+
+Protocol CodingKey has added inherited protocol SendableMetatype
+Protocol Error has added inherited protocol SendableMetatype

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -75,6 +75,9 @@ Protocol GlobalActor has added inherited protocol Escapable
 Protocol SerialExecutor has added inherited protocol Copyable
 Protocol SerialExecutor has added inherited protocol Escapable
 Protocol AsyncSequence is now without @rethrows
+Protocol Actor has added inherited protocol SendableMetatype
+Protocol Executor has added inherited protocol SendableMetatype
+Protocol SerialExecutor has added inherited protocol SendableMetatype
 
 // #isolated adoption in with...Continuation
 // api-digester is not aware of silgen_name trickery we do to keep this ABI compatible

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -825,4 +825,8 @@ Struct String.Index has added a conformance to an existing protocol CustomDebugS
 Enum _SwiftifyInfo is a new API without @available attribute
 Enum _SwiftifyExpr is a new API without @available attribute
 Enum _DependenceType is a new API without @available attribute
+
+Protocol CodingKey has added inherited protocol SendableMetatype
+Protocol Error has added inherited protocol SendableMetatype
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -6,7 +6,7 @@ func doSomething<T>(_ t: T) {}
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=0 nonisolated captures=(<generic> t<direct>) escaping single_expression
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=0 nonisolated captures=(<generic> t<direct> type=T, type=τ_0_0) escaping single_expression
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
@@ -15,20 +15,20 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Special case -- closure captures outer generic parameter, but it does not
   // appear as the type of any expression
-  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=2 nonisolated captures=(<generic> x<direct>)
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=2 nonisolated captures=(<generic> x<direct> type=T)
   _ = { if x is T {} }
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl{{.*}}"innerGeneric(u:)" "<U>" interface_type="<T, U> (u: U) -> ()" {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" "<U>" interface_type="<T, U> (u: U) -> ()" {{.*}} captures=(<generic> type=τ_1_0)
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
-  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface_type="<T> (tt: TT) -> ()" {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface_type="<T> (tt: TT) -> ()" {{.*}} captures=(<generic>  type=τ_0_0)
   func localFunction(tt: TT) {}
 
-  // CHECK: closure_expr type="(TT) -> ()" {{.*}} captures=(<generic> )
+  // CHECK: closure_expr type="(TT) -> ()" {{.*}} captures=(<generic> type=T)
   let _: (TT) -> () = { _ in }
 }


### PR DESCRIPTION
Introduce a new experimental feature StrictSendableMetatypes that stops treating all metatypes as `Sendable`. Instead, metatypes of generic parameters and existentials are only considered Sendable if their corresponding instance types are guaranteed to be Sendable.

Enforce this property within region isolation. Track metatype creation instructions and put them in the task's isolation domain, so that transferring them into another isolation domain produces a diagnostic. As an example:

    func f<T: P>(_: T.Type) {
      let x: P.Type = T.self
      Task.detached {
        x.someStaticMethod() // oops, T.Type is not Sendable
      }
    }

At the type checker level, handle direct attempts to capture metatypes by tracking generic type captures within closures, so that we can diagnose, e.g.,

    func g<T: P>(_: T.Type) {
      Task.detached {
        T.someStaticMethod() // oops, T.Type is not Sendable
      }
    }

Model the sendability of a type's metatype with the new marker protocol `SendableMetatype`, which `Sendable` now inherits from and which is used to determine when a metatype is Sendable. Specifically, `T: SendableMetatype` implies `T.Type: Sendable`, on which this analysis is based. Thank you to @slavapestov for the insight into this approach!