### PR TITLE
[ASTGen] Generate MagicIdentifierLiteralExpr

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1765,6 +1765,23 @@ BridgedMacroExpansionExpr BridgedMacroExpansionExpr_createParsed(
     BridgedSourceLoc cLeftAngleLoc, BridgedArrayRef cGenericArgs,
     BridgedSourceLoc cRightAngleLoc, BridgedNullableArgumentList cArgList);
 
+enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMagicIdentifierLiteralKind : uint8_t {
+#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+  BridgedMagicIdentifierLiteralKind##NAME,
+#include "swift/AST/MagicIdentifierKinds.def"
+  BridgedMagicIdentifierLiteralKindNone,
+};
+
+SWIFT_NAME("BridgedMagicIdentifierLiteralKind.init(from:)")
+BridgedMagicIdentifierLiteralKind
+BridgedMagicIdentifierLiteralKind_fromString(BridgedStringRef cStr);
+
+SWIFT_NAME("BridgedMagicIdentifierLiteralExpr.createParsed(_:kind:loc:)")
+BridgedMagicIdentifierLiteralExpr
+BridgedMagicIdentifierLiteralExpr_createParsed(
+    BridgedASTContext cContext, BridgedMagicIdentifierLiteralKind cKind,
+    BridgedSourceLoc cLoc);
+
 SWIFT_NAME("BridgedNilLiteralExpr.createParsed(_:nilKeywordLoc:)")
 BridgedNilLiteralExpr
 BridgedNilLiteralExpr_createParsed(BridgedASTContext cContext,

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1766,7 +1766,7 @@ BridgedMacroExpansionExpr BridgedMacroExpansionExpr_createParsed(
     BridgedSourceLoc cRightAngleLoc, BridgedNullableArgumentList cArgList);
 
 enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMagicIdentifierLiteralKind : uint8_t {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   BridgedMagicIdentifierLiteralKind##NAME,
 #include "swift/AST/MagicIdentifierKinds.def"
   BridgedMagicIdentifierLiteralKindNone,

--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -47,7 +47,7 @@ enum class DefaultArgumentKind : uint8_t {
   /// property's initializer.
   StoredProperty,
   // Magic identifier literals expanded at the call site:
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) NAME,
+#define MAGIC_IDENTIFIER(NAME, STRING) NAME,
 #include "swift/AST/MagicIdentifierKinds.def"
   /// An expression macro.
   ExpressionMacro

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1085,13 +1085,15 @@ public:
 class MagicIdentifierLiteralExpr : public BuiltinLiteralExpr {
 public:
   enum Kind : unsigned {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) NAME,
+#define MAGIC_IDENTIFIER(NAME, STRING) NAME,
 #include "swift/AST/MagicIdentifierKinds.def"
   };
 
   static StringRef getKindString(MagicIdentifierLiteralExpr::Kind value) {
     switch (value) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) case NAME: return STRING;
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
+  case NAME:                                                                   \
+    return STRING;
 #include "swift/AST/MagicIdentifierKinds.def"
     }
 
@@ -1116,11 +1118,11 @@ public:
 
   bool isString() const {
     switch (getKind()) {
-#define MAGIC_STRING_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case NAME: \
+#define MAGIC_STRING_IDENTIFIER(NAME, STRING)                                  \
+    case NAME:                                                                 \
       return true;
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case NAME: \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
+    case NAME:                                                                 \
       return false;
 #include "swift/AST/MagicIdentifierKinds.def"
     }

--- a/include/swift/AST/MagicIdentifierKinds.def
+++ b/include/swift/AST/MagicIdentifierKinds.def
@@ -17,22 +17,22 @@
 
 // Used for any magic identifier.
 #ifndef MAGIC_IDENTIFIER
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)
+#define MAGIC_IDENTIFIER(NAME, STRING)
 #endif
 
 // Used for magic identifiers which produce string literals.
 #ifndef MAGIC_STRING_IDENTIFIER
-#define MAGIC_STRING_IDENTIFIER(NAME, STRING, SYNTAX_KIND) MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)
+#define MAGIC_STRING_IDENTIFIER(NAME, STRING) MAGIC_IDENTIFIER(NAME, STRING)
 #endif
 
 // Used for magic identifiers which produce integer literals.
 #ifndef MAGIC_INT_IDENTIFIER
-#define MAGIC_INT_IDENTIFIER(NAME, STRING, SYNTAX_KIND) MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)
+#define MAGIC_INT_IDENTIFIER(NAME, STRING) MAGIC_IDENTIFIER(NAME, STRING)
 #endif
 
 // Used for magic identifiers which produce raw pointers.
 #ifndef MAGIC_POINTER_IDENTIFIER
-#define MAGIC_POINTER_IDENTIFIER(NAME, STRING, SYNTAX_KIND) MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)
+#define MAGIC_POINTER_IDENTIFIER(NAME, STRING) MAGIC_IDENTIFIER(NAME, STRING)
 #endif
 
 // Used when a given token always maps to a particular magic identifier kind.
@@ -45,27 +45,27 @@
 //
 
 /// The \c #fileID magic identifier literal.
-MAGIC_STRING_IDENTIFIER(FileID, "#fileID", PoundFileIDExpr)
+MAGIC_STRING_IDENTIFIER(FileID, "#fileID")
   MAGIC_IDENTIFIER_TOKEN(FileID, pound_fileID)
 
 /// The \c #file magic identifier literal, written in code where it is
 /// a synonym for \c #fileID (i.e. "Swift 6 mode" code).
-MAGIC_STRING_IDENTIFIER(FileIDSpelledAsFile, "#file", PoundFileExpr)
+MAGIC_STRING_IDENTIFIER(FileIDSpelledAsFile, "#file")
   // tok::pound_file is shared with FilePathSpelledAsFile; please write custom
   // code paths for it.
 
 /// The \c #filePath magic identifier literal.
-MAGIC_STRING_IDENTIFIER(FilePath, "#filePath", PoundFilePathExpr)
+MAGIC_STRING_IDENTIFIER(FilePath, "#filePath")
   MAGIC_IDENTIFIER_TOKEN(FilePath, pound_filePath)
 
 /// The \c #file magic identifier literal, written in code where it is
 /// a synonym for \c #filePath (i.e. Swift 5 mode code).
-MAGIC_STRING_IDENTIFIER(FilePathSpelledAsFile, "#file", PoundFileExpr)
+MAGIC_STRING_IDENTIFIER(FilePathSpelledAsFile, "#file")
   // tok::pound_file is shared with FileIDSpelledAsFile; please write custom
   // code paths for it.
 
 /// The \c #function magic identifier literal.
-MAGIC_STRING_IDENTIFIER(Function, "#function", PoundFunctionExpr)
+MAGIC_STRING_IDENTIFIER(Function, "#function")
   MAGIC_IDENTIFIER_TOKEN(Function, pound_function)
 
 
@@ -75,11 +75,11 @@ MAGIC_STRING_IDENTIFIER(Function, "#function", PoundFunctionExpr)
 //
 
 /// The \c #line magic identifier literal.
-MAGIC_INT_IDENTIFIER(Line, "#line", PoundLineExpr)
+MAGIC_INT_IDENTIFIER(Line, "#line")
   MAGIC_IDENTIFIER_TOKEN(Line, pound_line)
 
 /// The \c #column magic identifier literal.
-MAGIC_INT_IDENTIFIER(Column, "#column", PoundColumnExpr)
+MAGIC_INT_IDENTIFIER(Column, "#column")
   MAGIC_IDENTIFIER_TOKEN(Column, pound_column)
 
 
@@ -89,7 +89,7 @@ MAGIC_INT_IDENTIFIER(Column, "#column", PoundColumnExpr)
 //
 
 /// The \c #dsohandle magic identifier literal.
-MAGIC_POINTER_IDENTIFIER(DSOHandle, "#dsohandle", PoundDsohandleExpr)
+MAGIC_POINTER_IDENTIFIER(DSOHandle, "#dsohandle")
   MAGIC_IDENTIFIER_TOKEN(DSOHandle, pound_dsohandle)
 
 #undef MAGIC_IDENTIFIER

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -381,7 +381,7 @@ static StringRef getDumpString(ForeignErrorConvention::Kind value) {
 static StringRef getDumpString(DefaultArgumentKind value) {
   switch (value) {
     case DefaultArgumentKind::None: return "none";
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
     case DefaultArgumentKind::NAME: return STRING;
 #include "swift/AST/MagicIdentifierKinds.def"
     case DefaultArgumentKind::Inherited: return "inherited";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4008,8 +4008,7 @@ void PrintAST::printOneParameter(const ParamDecl *param,
     Printer << " = ";
 
     switch (param->getDefaultArgumentKind()) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case DefaultArgumentKind::NAME:
+#define MAGIC_IDENTIFIER(NAME, STRING) case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
       Printer.printKeyword(defaultArgStr, Options);
       break;

--- a/lib/AST/Bridging/ExprBridging.cpp
+++ b/lib/AST/Bridging/ExprBridging.cpp
@@ -384,7 +384,9 @@ BridgedMacroExpansionExpr BridgedMacroExpansionExpr_createParsed(
 BridgedMagicIdentifierLiteralKind
 BridgedMagicIdentifierLiteralKind_fromString(BridgedStringRef cStr) {
   StringRef str = cStr.unbridged();
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+
+  // Note: STRING includes '#' e.g. '#fileID'.
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   if (str == StringRef(STRING).drop_front())                                   \
     return BridgedMagicIdentifierLiteralKind##NAME;
 #include "swift/AST/MagicIdentifierKinds.def"
@@ -394,7 +396,7 @@ BridgedMagicIdentifierLiteralKind_fromString(BridgedStringRef cStr) {
 static std::optional<MagicIdentifierLiteralExpr::Kind>
 unbridge(BridgedMagicIdentifierLiteralKind cKind) {
   switch (cKind) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case BridgedMagicIdentifierLiteralKind##NAME:                                \
     return MagicIdentifierLiteralExpr::Kind::NAME;
 #include "swift/AST/MagicIdentifierKinds.def"

--- a/lib/AST/Bridging/ExprBridging.cpp
+++ b/lib/AST/Bridging/ExprBridging.cpp
@@ -381,6 +381,36 @@ BridgedMacroExpansionExpr BridgedMacroExpansionExpr_createParsed(
                           : getFreestandingMacroRoles());
 }
 
+BridgedMagicIdentifierLiteralKind
+BridgedMagicIdentifierLiteralKind_fromString(BridgedStringRef cStr) {
+  StringRef str = cStr.unbridged();
+#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+  if (str == StringRef(STRING).drop_front())                                   \
+    return BridgedMagicIdentifierLiteralKind##NAME;
+#include "swift/AST/MagicIdentifierKinds.def"
+  return BridgedMagicIdentifierLiteralKindNone;
+}
+
+static std::optional<MagicIdentifierLiteralExpr::Kind>
+unbridge(BridgedMagicIdentifierLiteralKind cKind) {
+  switch (cKind) {
+#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+  case BridgedMagicIdentifierLiteralKind##NAME:                                \
+    return MagicIdentifierLiteralExpr::Kind::NAME;
+#include "swift/AST/MagicIdentifierKinds.def"
+  case BridgedMagicIdentifierLiteralKindNone:
+    return std::nullopt;
+  }
+}
+
+BridgedMagicIdentifierLiteralExpr
+BridgedMagicIdentifierLiteralExpr_createParsed(
+    BridgedASTContext cContext, BridgedMagicIdentifierLiteralKind cKind,
+    BridgedSourceLoc cLoc) {
+  return new (cContext.unbridged())
+      MagicIdentifierLiteralExpr(*unbridge(cKind), cLoc.unbridged());
+}
+
 BridgedNilLiteralExpr
 BridgedNilLiteralExpr_createParsed(BridgedASTContext cContext,
                                    BridgedSourceLoc cNilKeywordLoc) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8647,7 +8647,7 @@ static DefaultArgumentKind computeDefaultArgumentKind(DeclContext *dc,
     return DefaultArgumentKind::Normal;
 
   switch (magic->getKind()) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case MagicIdentifierLiteralExpr::NAME:                                       \
     return DefaultArgumentKind::NAME;
 #include "swift/AST/MagicIdentifierKinds.def"
@@ -8867,7 +8867,7 @@ bool ParamDecl::hasDefaultExpr() const {
   case DefaultArgumentKind::StoredProperty:
     return false;
   case DefaultArgumentKind::Normal:
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
   case DefaultArgumentKind::ExpressionMacro:
@@ -8888,7 +8888,7 @@ bool ParamDecl::hasCallerSideDefaultExpr() const {
   case DefaultArgumentKind::StoredProperty:
   case DefaultArgumentKind::Normal:
     return false;
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
   case DefaultArgumentKind::NilLiteral:
@@ -9190,7 +9190,7 @@ ParamDecl::getDefaultValueStringRepresentation(
     return extractInlinableText(getASTContext(), init, scratch);
   }
   case DefaultArgumentKind::Inherited: return "super";
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case DefaultArgumentKind::NAME: return STRING;
 #include "swift/AST/MagicIdentifierKinds.def"
   case DefaultArgumentKind::NilLiteral: return "nil";

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -999,7 +999,7 @@ bool CompletionLookup::hasInterestingDefaultValue(const ParamDecl *param) {
     return true;
 
   case DefaultArgumentKind::None:
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
   case DefaultArgumentKind::ExpressionMacro:

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1719,7 +1719,7 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
     break;
 
   case DefaultArgumentKind::Inherited:
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
   case DefaultArgumentKind::NilLiteral:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4553,8 +4553,8 @@ visitKeyPathApplicationExpr(KeyPathApplicationExpr *E, SGFContext C) {
 RValue RValueEmitter::
 visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, SGFContext C) {
   switch (E->getKind()) {
-#define MAGIC_POINTER_IDENTIFIER(NAME, STRING, SYNTAX_KIND)
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_POINTER_IDENTIFIER(NAME, STRING)
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
   case MagicIdentifierLiteralExpr::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
     return SGF.emitLiteral(E, C);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3061,14 +3061,14 @@ namespace {
 #endif
 
       switch (expr->getKind()) {
-#define MAGIC_STRING_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-      case MagicIdentifierLiteralExpr::NAME: \
+#define MAGIC_STRING_IDENTIFIER(NAME, STRING)                                  \
+      case MagicIdentifierLiteralExpr::NAME:                                   \
         return handleStringLiteralExpr(expr);
-#define MAGIC_INT_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-      case MagicIdentifierLiteralExpr::NAME: \
+#define MAGIC_INT_IDENTIFIER(NAME, STRING)                                     \
+      case MagicIdentifierLiteralExpr::NAME:                                   \
         return handleIntegerLiteralExpr(expr);
-#define MAGIC_POINTER_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-      case MagicIdentifierLiteralExpr::NAME: \
+#define MAGIC_POINTER_IDENTIFIER(NAME, STRING)                                 \
+      case MagicIdentifierLiteralExpr::NAME:                                   \
         return expr;
 #include "swift/AST/MagicIdentifierKinds.def"
       }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -639,7 +639,7 @@ namespace {
 
       switch (expr->getKind()) {
       // Magic pointer identifiers are of type UnsafeMutableRawPointer.
-#define MAGIC_POINTER_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
+#define MAGIC_POINTER_IDENTIFIER(NAME, STRING)                               \
       case MagicIdentifierLiteralExpr::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
       {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -630,8 +630,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     std::optional<MagicIdentifierLiteralExpr::Kind>
     getMagicIdentifierDefaultArgKind(const ParamDecl *param) {
       switch (param->getDefaultArgumentKind()) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-      case DefaultArgumentKind::NAME: \
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
+      case DefaultArgumentKind::NAME:                                          \
         return MagicIdentifierLiteralExpr::Kind::NAME;
 #include "swift/AST/MagicIdentifierKinds.def"
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -707,11 +707,10 @@ static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
   SourceLoc loc = defaultExpr->getLoc();
   auto &ctx = param->getASTContext();
   switch (param->getDefaultArgumentKind()) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-  case DefaultArgumentKind::NAME: \
-    return new (ctx) \
-        MagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr::NAME, loc, \
-                                   /*implicit=*/true);
+#define MAGIC_IDENTIFIER(NAME, STRING)                                         \
+  case DefaultArgumentKind::NAME:                                              \
+    return new (ctx) MagicIdentifierLiteralExpr(                               \
+        MagicIdentifierLiteralExpr::NAME, loc, /*implicit=*/true);
 #include "swift/AST/MagicIdentifierKinds.def"
 
   case DefaultArgumentKind::ExpressionMacro: {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -124,20 +124,20 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(ASTContext &Context, Expr *expr) {
 
   if (auto E = dyn_cast<MagicIdentifierLiteralExpr>(expr)) {
     switch (E->getKind()) {
-#define MAGIC_STRING_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case MagicIdentifierLiteralExpr::NAME: \
-      return TypeChecker::getProtocol( \
-          Context, expr->getLoc(), \
+#define MAGIC_STRING_IDENTIFIER(NAME, STRING)                                  \
+    case MagicIdentifierLiteralExpr::NAME:                                     \
+      return TypeChecker::getProtocol(                                         \
+          Context, expr->getLoc(),                                             \
           KnownProtocolKind::ExpressibleByStringLiteral);
 
-#define MAGIC_INT_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case MagicIdentifierLiteralExpr::NAME: \
-      return TypeChecker::getProtocol( \
-          Context, expr->getLoc(), \
+#define MAGIC_INT_IDENTIFIER(NAME, STRING)                                     \
+    case MagicIdentifierLiteralExpr::NAME:                                     \
+      return TypeChecker::getProtocol(                                         \
+          Context, expr->getLoc(),                                             \
           KnownProtocolKind::ExpressibleByIntegerLiteral);
 
-#define MAGIC_POINTER_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-    case MagicIdentifierLiteralExpr::NAME: \
+#define MAGIC_POINTER_IDENTIFIER(NAME, STRING)                                 \
+    case MagicIdentifierLiteralExpr::NAME:                                     \
       return nullptr;
 
 #include "swift/AST/MagicIdentifierKinds.def"

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -299,3 +299,7 @@ extension ValueStruct where 123 == N {}
 extension ValueStruct where N == -123 {}
 extension ValueStruct where -123 == N {}
 
+func testMagicIdentifier(file: String = #file, line: Int = #line) {
+    let _: String = file
+    let _: Int = line
+}


### PR DESCRIPTION
E.g. `#file`. These are parsed as `MacroExpansionExprSyntax` in SwiftParser.

Also while I'm here, eliminate `SYNTAX_KIND` from MagicIdentifierKinds.def because nothing is using it anymore.