### PR TITLE
[ASTGen] Generate PatternBindingDecl at top level

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -568,6 +568,13 @@ SWIFT_NAME("getter:BridgedDeclContext.astContext(self:)")
 BRIDGED_INLINE BridgedASTContext
 BridgedDeclContext_getASTContext(BridgedDeclContext dc);
 
+SWIFT_NAME("getter:BridgedDeclContext.parentSourceFile(self:)")
+BRIDGED_INLINE BridgedSourceFile
+BridgedDeclContext_getParentSourceFile(BridgedDeclContext dc);
+
+SWIFT_NAME("getter:BridgedSourceFile.isScriptMode(self:)")
+BRIDGED_INLINE bool BridgedSourceFile_isScriptMode(BridgedSourceFile sf);
+
 SWIFT_NAME("BridgedPatternBindingInitializer.create(declContext:)")
 BridgedPatternBindingInitializer
 BridgedPatternBindingInitializer_create(BridgedDeclContext cDeclContext);
@@ -1143,6 +1150,10 @@ struct BridgedFingerprint;
 SWIFT_NAME("BridgedDecl.attachParsedAttrs(self:_:)")
 void BridgedDecl_attachParsedAttrs(BridgedDecl decl, BridgedDeclAttributes attrs);
 
+SWIFT_NAME("BridgedDecl.forEachDeclToHoist(self:_:)")
+void BridgedDecl_forEachDeclToHoist(BridgedDecl decl,
+                                    BridgedSwiftClosure closure);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedStaticSpelling {
   BridgedStaticSpellingNone,
   BridgedStaticSpellingStatic,
@@ -1434,19 +1445,14 @@ BridgedSubscriptDecl BridgedSubscriptDecl_createParsed(
     BridgedParameterList cParamList, BridgedSourceLoc cArrowLoc,
     BridgedTypeRepr returnType);
 
-SWIFT_NAME(
-    "BridgedTopLevelCodeDecl.createParsed(_:declContext:startLoc:stmt:endLoc:)")
-BridgedTopLevelCodeDecl BridgedTopLevelCodeDecl_createStmt(
-    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-    BridgedSourceLoc cStartLoc, BridgedStmt statement,
-    BridgedSourceLoc cEndLoc);
+SWIFT_NAME("BridgedTopLevelCodeDecl.create(_:declContext:)")
+BridgedTopLevelCodeDecl
+BridgedTopLevelCodeDecl_create(BridgedASTContext cContext,
+                               BridgedDeclContext cDeclContext);
 
-SWIFT_NAME(
-    "BridgedTopLevelCodeDecl.createParsed(_:declContext:startLoc:expr:endLoc:)")
-BridgedTopLevelCodeDecl BridgedTopLevelCodeDecl_createExpr(
-    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-    BridgedSourceLoc cStartLoc, BridgedExpr expression,
-    BridgedSourceLoc cEndLoc);
+SWIFT_NAME("BridgedTopLevelCodeDecl.setBody(self:body:)")
+void BridgedTopLevelCodeDecl_setBody(BridgedTopLevelCodeDecl cDecl,
+                                     BridgedBraceStmt cBody);
 
 SWIFT_NAME("BridgedTopLevelCodeDecl.dump(self:)")
 void BridgedTopLevelCodeDecl_dump(BridgedTopLevelCodeDecl decl);
@@ -2018,6 +2024,12 @@ BridgedBraceStmt BridgedBraceStmt_createParsed(BridgedASTContext cContext,
                                                BridgedSourceLoc cLBLoc,
                                                BridgedArrayRef elements,
                                                BridgedSourceLoc cRBLoc);
+
+SWIFT_NAME("BridgedBraceStmt.createImplicit(_:lBraceLoc:element:rBraceLoc:)")
+BridgedBraceStmt BridgedBraceStmt_createImplicit(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cLBLoc,
+                                                 BridgedASTNode element,
+                                                 BridgedSourceLoc cRBLoc);
 
 SWIFT_NAME("BridgedBreakStmt.createParsed(_:loc:targetName:targetLoc:)")
 BridgedBreakStmt BridgedBreakStmt_createParsed(BridgedDeclContext cDeclContext,

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -148,6 +148,19 @@ BridgedASTContext BridgedDeclContext_getASTContext(BridgedDeclContext dc) {
   return dc.unbridged()->getASTContext();
 }
 
+BridgedSourceFile
+BridgedDeclContext_getParentSourceFile(BridgedDeclContext dc) {
+  return dc.unbridged()->getParentSourceFile();
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedSoureFile
+//===----------------------------------------------------------------------===//
+
+BRIDGED_INLINE bool BridgedSourceFile_isScriptMode(BridgedSourceFile sf) {
+  return sf.unbridged()->isScriptMode();
+}
+
 //===----------------------------------------------------------------------===//
 // MARK: BridgedDeclObj
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1516,6 +1516,10 @@ public:
   /// Returns true if this declaration has any `@backDeployed` attributes.
   bool hasBackDeployedAttr() const;
 
+  /// Apply the specified function to decls that should be placed _next_ to
+  /// this decl when constructing AST.
+  void forEachDeclToHoist(llvm::function_ref<void(Decl *)> callback) const;
+
   /// Emit a diagnostic tied to this declaration.
   template<typename ...ArgTypes>
   InFlightDiagnostic diagnose(

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -512,6 +512,18 @@ struct BridgedVersionTuple {
   llvm::VersionTuple unbridged() const;
 };
 
+//===----------------------------------------------------------------------===//
+// MARK: BridgedSwiftClosure
+//===----------------------------------------------------------------------===//
+
+/// Wrapping a pointer to a Swift closure `(UnsafeRawPointer?) -> Void`
+/// See 'withBridgedSwiftClosure(closure:call:)' in ASTGen.
+struct BridgedSwiftClosure {
+  const void *_Nonnull closure;
+
+  BRIDGED_INLINE void operator()(const void *_Nullable);
+};
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #ifndef PURE_BRIDGING_MODE

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -141,6 +141,14 @@ BridgedSwiftVersion::BridgedSwiftVersion(SwiftInt major, SwiftInt minor)
   ASSERT(major == Major && minor == Minor);
 }
 
+extern "C" void
+swift_ASTGen_bridgedSwiftClosureCall_1(const void *_Nonnull closure,
+                                       const void *_Nullable arg1);
+
+void BridgedSwiftClosure::operator()(const void *_Nullable arg1) {
+  swift_ASTGen_bridgedSwiftClosureCall_1(closure, arg1);
+}
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif // SWIFT_BASIC_BASICBRIDGINGIMPL_H

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2378,6 +2378,15 @@ namespace {
       printFlag(VD->getAttrs().hasAttribute<LazyAttr>(), "lazy",
                 DeclModifierColor);
       printStorageImpl(VD);
+      printFlag(VD->isSelfParamCapture(), "self_param_capture",
+                DeclModifierColor);
+      printFlag(VD->isDebuggerVar(), "debugger_var", DeclModifierColor);
+      printFlag(VD->isLazyStorageProperty(), "lazy_storage_property",
+                DeclModifierColor);
+      printFlag(VD->isTopLevelGlobal(), "top_level_global", DeclModifierColor);
+      printFlag(VD->isLazyStorageProperty(), "lazy_storage_property",
+                DeclModifierColor);
+
       printFlag(VD->getAttrs().hasAttribute<KnownToBeLocalAttr>(),
                 "known_to_be_local", DeclModifierColor);
       if (auto *nonisolatedAttr =

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -387,7 +387,7 @@ extension ASTGenVisitor {
     case .typeAlias(let typealiasDecl):
       abiDecl = self.generate(typeAliasDecl: typealiasDecl)?.asDecl
     case .variable(let varDecl):
-      abiDecl = self.generate(variableDecl: varDecl).asDecl
+      abiDecl = self.generate(variableDecl: varDecl)
     case .missing(_):
       // This error condition will have been diagnosed in SwiftSyntax.
       abiDecl = nil

--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -131,6 +131,23 @@ extension ASTGenDiagnostic {
   }
 }
 
+/// Decl diagnostics
+extension ASTGenDiagnostic {
+  static func illegalTopLevelStmt(_ stmt: some SyntaxProtocol) -> Self {
+    Self(
+      node: stmt,
+      message: "statements are not allowed at the top level"
+    )
+  }
+
+  static func illegalTopLevelExpr(_ expr: some SyntaxProtocol) -> Self {
+    Self(
+      node: expr,
+      message: "expressions are not allowed at the top level"
+    )
+  }
+}
+
 /// DeclAttributes diagnostics
 extension ASTGenDiagnostic {
   static func expectedArgumentsInAttribute(_ attribute: AttributeSyntax) -> Self {

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -90,6 +90,16 @@ extension ASTGenVisitor {
         return
       }
       allItems.append(item.bridged)
+
+      // Hoist 'VarDecl' to the block.
+      if case .decl(let decl) = item {
+        withBridgedSwiftClosure { ptr in
+          let d = ptr!.load(as: BridgedDecl.self)
+          allItems.append(ASTNode.decl(d).bridged)
+        } call: { handle in
+          decl.forEachDeclToHoist(handle)
+        }
+      }
     }
 
     return allItems.lazy.bridgedArray(in: self)

--- a/test/ASTGen/top_level.swift
+++ b/test/ASTGen/top_level.swift
@@ -22,5 +22,10 @@ if let first = [1,2,3].first {
 
 func foo(x: Int) {}
 
-// FIXME: Top-level pattern binding decl must be enclosed with TopLevelCodeDecl
-// let a = 42
+let a = 42
+
+var b = {
+  12 + a
+}() {
+  didSet { print("didSet") }
+}


### PR DESCRIPTION
* Hoist `VarDecl` in `ASTGen`,  instead of do it in the bridging functions.
* Introduce `Decl::forEachDeclToHoist` to handle VarDecls in PatternBindingDecl, and EnumElementDecl in EnumCaseDecl.
* Introduce `withBridgedSwiftClosure(closure:call:)` as a callback mechanism between Swift and C++
* In `generate(sourceFile:)`, instead of using `generate(codeBlockItem:)`, handle `CodeBlockItemSyntax.Item` manually to perform `TLCD` wrapping and `VarDecl` hoisting.
* Make `generate(variableDecl:)` handle TLCD correctly.
