### PR TITLE
Gardening: Fix unused variable and missing field warnings

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1773,7 +1773,6 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code(handler, 62877);
   auto *record = ::new (allocation)
       EscalationNotificationStatusRecord(handler, context);
 


### PR DESCRIPTION
NFC.