### PR TITLE
[ASTGen] Adopt '-dump-ast-format default-with-decl-contexts' in tests

### DIFF
--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -1,22 +1,21 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking \
+
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext \
 // RUN:   -enable-experimental-move-only \
-// RUN:   -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
+// RUN:   -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
 
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking \
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext \
-// RUN:   -enable-experimental-move-only > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN:   -enable-experimental-move-only \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/attrs_objc.swift
+++ b/test/ASTGen/attrs_objc.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -dump-parse -import-objc-header %S/Inputs/objc_decls.h -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -dump-parse -import-objc-header %S/Inputs/objc_decls.h > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s %dump-parse -import-objc-header %S/Inputs/objc_decls.h -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s %dump-parse -import-objc-header %S/Inputs/objc_decls.h \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 // RUN: %target-typecheck-verify-swift %clang-importer-sdk -import-objc-header %S/Inputs/objc_decls.h -enable-experimental-feature ParserASTGen 

--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -9,16 +9,12 @@
 // RUN:   -define-availability '_myProject 2.5:macOS 52.5' \
 // RUN: )
 
-// RUN: %target-swift-frontend %s "${COMPILER_ARGS[@]}" -dump-parse \
+// RUN: %target-swift-frontend-dump-parse "${COMPILER_ARGS[@]}" \
 // RUN:   -enable-experimental-feature ParserASTGen \
-// RUN:   > %t/astgen.ast.raw
+// RUN:   | %sanitize-address > %t/astgen.ast
 
-// RUN: %target-swift-frontend %s "${COMPILER_ARGS[@]}" -dump-parse \
-// RUN:   > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+#<ADDR>#g' %t/astgen.ast.raw > %t/astgen.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+#<ADDR>#g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
+// RUN: %target-swift-frontend-dump-parse "${COMPILER_ARGS[@]}" \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -1,11 +1,9 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ParserASTGen -enable-experimental-feature ValueGenerics > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ValueGenerics > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ValueGenerics -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ValueGenerics \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/do_expr.swift
+++ b/test/ASTGen/do_expr.swift
@@ -1,11 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-feature DoExpressions -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-feature DoExpressions > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-feature DoExpressions -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-feature DoExpressions \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/exprs.swift
+++ b/test/ASTGen/exprs.swift
@@ -1,11 +1,8 @@
-
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only -enable-experimental-feature ParserASTGen \
+// RUN:   | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/keypath.swift
+++ b/test/ASTGen/keypath.swift
@@ -8,12 +8,10 @@
 // should end up with the same type-checked AST.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-ast -enable-experimental-feature ParserASTGen -verify > %t/astgen.ast.raw
-// RUN: not %target-swift-frontend %s -dump-ast > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-ast -enable-experimental-feature ParserASTGen -verify \
+// RUN:   | %sanitize-address > %t/astgen.ast
+// RUN: not %target-swift-frontend-dump-ast \
+// RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/lit.local.cfg
+++ b/test/ASTGen/lit.local.cfg
@@ -1,0 +1,6 @@
+
+config.substitutions.insert(0, ('%target-swift-frontend-dump-parse', '%target-swift-frontend %dump-parse %s') )
+config.substitutions.insert(0, ('%target-swift-frontend-dump-ast', '%target-swift-frontend %dump-ast %s') )
+config.substitutions.append( ('%dump-parse', '-dump-parse -dump-ast-format default-with-decl-contexts') )
+config.substitutions.append( ('%dump-ast', '-dump-ast -dump-ast-format default-with-decl-contexts') )
+config.substitutions.append( ('%sanitize-address', '%s %s/sanitize-address.py' % (config.python, config.swift_utils)) )

--- a/test/ASTGen/regex.swift
+++ b/test/ASTGen/regex.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex -disable-availability-checking -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -enable-bare-slash-regex -disable-availability-checking > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -enable-bare-slash-regex -disable-availability-checking -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -enable-bare-slash-regex -disable-availability-checking \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/stmts.swift
+++ b/test/ASTGen/stmts.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ThenStatements -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ThenStatements > %t/cpp-parser.ast.raw
-
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ThenStatements -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ThenStatements \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 

--- a/test/ASTGen/top_level.swift
+++ b/test/ASTGen/top_level.swift
@@ -1,12 +1,18 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ParserASTGen > %t/astgen.ast.raw
-// RUN: %target-swift-frontend %s -dump-parse -disable-availability-checking -enable-experimental-move-only > %t/cpp-parser.ast.raw
 
-// Filter out any addresses in the dump, since they can differ.
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/cpp-parser.ast.raw > %t/cpp-parser.ast
-// RUN: sed -E 's#0x[0-9a-fA-F]+##g' %t/astgen.ast.raw > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// RUN: not %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -parse-as-library -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.library.ast
+// RUN: not %target-swift-frontend-dump-parse -disable-availability-checking -enable-experimental-move-only -parse-as-library \
+// RUN:    | %sanitize-address > %t/cpp-parser.library.ast
+
+// RUN: %diff -u %t/astgen.library.ast %t/cpp-parser.library.ast
 
 // REQUIRES: swift_feature_ParserASTGen
 


### PR DESCRIPTION
Verify ASTGen generating DeclContect hierarchy correctly.
