### PR TITLE
Do not use `os._exit` when build-script fatal errors

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -184,28 +184,6 @@ def tar(source, destination):
     shell.call(args + [source], stderr=shell.DEVNULL)
 
 
-def process_system_exit(e: SystemExit) -> int:
-    # According to Python's documents, `SystemExit.code` is the exit status
-    # or error message that is passed to the constructor. (Defaults to None.)
-    #
-    # This means that `SystemExit.code` is either `None`, an `int` object or
-    # a `string` object of error message.
-    if e.code is None:
-        # Fallback to 1 if there is no error code but a `SystemExit`.
-        return 1
-    try:
-        numeric_code = int(e.code)
-        return numeric_code
-    except ValueError:
-        # Fallback to 1 if it is an error message and print that message.
-        print(e)
-        return 1
-    finally:
-        # Fallback to 1 and do nothing, since there is only ValueError as
-        # expected exception.
-        return 1
-
-
 # -----------------------------------------------------------------------------
 # Argument Validation
 
@@ -825,11 +803,12 @@ def main():
 if __name__ == "__main__":
     try:
         exit_code = main()
-    except SystemExit as e:
-        error_code = process_system_exit(e)
-        os._exit(error_code)
+        log_analyzer()
+    except SystemExit:
+        raise
     except KeyboardInterrupt:
         sys.exit(1)
-    finally:
+    except Exception:
         log_analyzer()
+        raise
     sys.exit(exit_code)


### PR DESCRIPTION
`os._exit` does not run any cleanup handlers or flush any buffers, which means that we may end up missing helpful log output. It was being used to avoid printing the log analysis when `--help` was passed, but we can have the same behavior by just not using `finally`.