### PR TITLE
[IRGen] Pack: Scope recursive pack allocations.

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -413,18 +413,17 @@ static void emitPackExpansionPack(
   IGF.Builder.emitBlock(loop);
   ConditionalDominanceScope condition(IGF);
 
-  auto *element = elementForIndex(phi);
+  IGF.withLocalStackPackAllocs([&]() {
+    auto *element = elementForIndex(phi);
 
-  // Store the element metadata into to the current destination index.
-  auto *eltIndex = IGF.Builder.CreateAdd(dynamicIndex, phi);
-  Address eltPtr(
-      IGF.Builder.CreateInBoundsGEP(pack.getElementType(),
-                                    pack.getAddress(),
-                                    eltIndex),
-      pack.getElementType(),
-      pack.getAlignment());
+    // Store the element metadata into to the current destination index.
+    auto *eltIndex = IGF.Builder.CreateAdd(dynamicIndex, phi);
+    Address eltPtr(IGF.Builder.CreateInBoundsGEP(pack.getElementType(),
+                                                 pack.getAddress(), eltIndex),
+                   pack.getElementType(), pack.getAlignment());
 
-  IGF.Builder.CreateStore(element, eltPtr);
+    IGF.Builder.CreateStore(element, eltPtr);
+  });
 
   // Increment our counter.
   auto *next = IGF.Builder.CreateAdd(phi,
@@ -717,6 +716,20 @@ void IRGenFunction::eraseStackPackWitnessTableAlloc(StackAddress addr,
   (void)removed;
 }
 
+void IRGenFunction::withLocalStackPackAllocs(llvm::function_ref<void()> fn) {
+  auto oldSize = OutstandingStackPackAllocs.size();
+  fn();
+  SmallVector<StackPackAlloc, 2> allocs;
+  for (auto index = oldSize, size = OutstandingStackPackAllocs.size();
+       index < size; ++index) {
+    allocs.push_back(OutstandingStackPackAllocs[index]);
+  }
+  while (OutstandingStackPackAllocs.size() > oldSize) {
+    OutstandingStackPackAllocs.pop_back();
+  }
+  cleanupStackAllocPacks(*this, allocs);
+}
+
 llvm::Value *irgen::emitWitnessTablePackRef(IRGenFunction &IGF,
                                             CanPackType packType,
                                             PackConformance *conformance) {
@@ -970,42 +983,46 @@ llvm::Value *irgen::emitTypeMetadataPackElementRef(
     auto *materialize = IGF.createBasicBlock("pack-index-element-metadata");
     IGF.Builder.emitBlock(materialize);
 
-    llvm::Value *metadata = nullptr;
-    llvm::SmallVector<llvm::Value *, 2> wtables;
-    wtables.reserve(conformances.size());
-    if (auto expansionTy = dyn_cast<PackExpansionType>(elementTy)) {
-      // Actually materialize %inner.  Then use it to get the metadata from the
-      // pack expansion at that index.
-      auto *relativeIndex = IGF.Builder.CreateSub(index, lowerBound);
-      auto context =
-          OpenedElementContext::createForContextualExpansion(IGF.IGM.Context, expansionTy);
-      auto patternTy = expansionTy.getPatternType();
-      metadata = emitPackExpansionElementMetadata(IGF, context, patternTy,
-                                                  relativeIndex, request);
-      for (auto conformance : conformances) {
-        auto patternConformance = conformance.getPack()->getPatternConformances()[i];
-        auto *wtable = emitPackExpansionElementWitnessTable(
-            IGF, context, patternTy, patternConformance,
-            &metadata, relativeIndex);
-        wtables.push_back(wtable);
+    IGF.withLocalStackPackAllocs([&]() {
+      llvm::Value *metadata = nullptr;
+      llvm::SmallVector<llvm::Value *, 2> wtables;
+      wtables.reserve(conformances.size());
+      if (auto expansionTy = dyn_cast<PackExpansionType>(elementTy)) {
+        // Actually materialize %inner.  Then use it to get the metadata from
+        // the pack expansion at that index.
+        auto *relativeIndex = IGF.Builder.CreateSub(index, lowerBound);
+        auto context = OpenedElementContext::createForContextualExpansion(
+            IGF.IGM.Context, expansionTy);
+        auto patternTy = expansionTy.getPatternType();
+        metadata = emitPackExpansionElementMetadata(IGF, context, patternTy,
+                                                    relativeIndex, request);
+        for (auto conformance : conformances) {
+          auto patternConformance =
+              conformance.getPack()->getPatternConformances()[i];
+          auto *wtable = emitPackExpansionElementWitnessTable(
+              IGF, context, patternTy, patternConformance, &metadata,
+              relativeIndex);
+          wtables.push_back(wtable);
+        }
+      } else {
+        metadata = IGF.emitTypeMetadataRef(elementTy, request).getMetadata();
+        for (auto conformance : conformances) {
+          auto patternConformance =
+              conformance.getPack()->getPatternConformances()[i];
+          llvm::Value *_metadata = nullptr;
+          auto *wtable = emitWitnessTableRef(IGF, elementTy,
+                                             /*srcMetadataCache=*/&_metadata,
+                                             patternConformance);
+          wtables.push_back(wtable);
+        }
       }
-    } else {
-      metadata = IGF.emitTypeMetadataRef(elementTy, request).getMetadata();
-      for (auto conformance : conformances) {
-        auto patternConformance = conformance.getPack()->getPatternConformances()[i];
-        llvm::Value *_metadata = nullptr;
-        auto *wtable =
-            emitWitnessTableRef(IGF, elementTy, /*srcMetadataCache=*/&_metadata,
-                                patternConformance);
-        wtables.push_back(wtable);
+      metadataPhi->addIncoming(metadata, IGF.Builder.GetInsertBlock());
+      for (auto i : indices(wtables)) {
+        auto *wtable = wtables[i];
+        auto *wtablePhi = wtablePhis[i];
+        wtablePhi->addIncoming(wtable, IGF.Builder.GetInsertBlock());
       }
-    }
-    metadataPhi->addIncoming(metadata, IGF.Builder.GetInsertBlock());
-    for (auto i : indices(wtables)) {
-      auto *wtable = wtables[i];
-      auto *wtablePhi = wtablePhis[i];
-      wtablePhi->addIncoming(wtable, IGF.Builder.GetInsertBlock());
-    }
+    });
     IGF.Builder.CreateBr(exit);
     // }} Finished emitting emit_i.
 

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -430,7 +430,7 @@ static void emitPackExpansionPack(
   auto *next = IGF.Builder.CreateAdd(phi,
                                      llvm::ConstantInt::get(IGF.IGM.SizeTy, 1));
 
-  phi->addIncoming(next, loop);
+  phi->addIncoming(next, IGF.Builder.GetInsertBlock());
 
   // Repeat the loop.
   IGF.Builder.CreateBr(check);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -437,6 +437,8 @@ public:
   void recordStackPackWitnessTableAlloc(StackAddress addr, llvm::Value *shape);
   void eraseStackPackWitnessTableAlloc(StackAddress addr, llvm::Value *shape);
 
+  void withLocalStackPackAllocs(llvm::function_ref<void()> fn);
+
   /// Emit a load of a reference to the given Objective-C selector.
   llvm::Value *emitObjCSelectorRefLoad(StringRef selector);
 

--- a/validation-test/IRGen/rdar141718098.swift
+++ b/validation-test/IRGen/rdar141718098.swift
@@ -1,0 +1,31 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+struct S<T> {
+  let t: T
+  func f<each A, each B>(
+    _ b: S<(repeat each B)>
+  ) -> S<(repeat each A, repeat each B)>
+  where T == (repeat each A) {
+    S<(repeat each A, repeat each B)>(
+      t: (repeat each t, repeat each b.t)
+    )
+  }
+}
+
+func doit() {
+  let s1 = S(t: ("", ""))
+// CHECK: S<(String, String)>(t: ("", ""))
+  print(s1)
+  let s2 = s1.f(S(t: (5, 5)))
+// CHECK: S<(String, String, Int, Int)>(t: ("", "", 5, 5))
+  print(s2)
+  let s3 = s2.f(S(t: (13.1, 26.2)))
+// CHECK: S<(String, String, Int, Int, Double, Double)>(t: ("", "", 5, 5, 13.1, 26.2))
+  print(s3)
+  let s4 = s3.f(S(t: (S(t: ""), S(t: ""))))
+// CHECK: S<(String, String, Int, Int, Double, Double, S<String>, S<String>)>(t: ("", "", 5, 5, 13.1, 26.2, main.S<Swift.String>(t: ""), main.S<Swift.String>(t: "")))
+  print(s4)
+}
+
+doit()


### PR DESCRIPTION
While materializing one metadata pack, another pack may need to be materialized. When that happens, the inner pack's dynamically sized allocation must be deallocated within the same dominance scope.

The CFG within which the inner dynamically sized pack is allocated isn't visible from SIL; that explains why the existing infrastructure around `de`/`alloc_pack_metadata` instructions fails to produce a deallocation at the appropriate point.

In the fullness of time, this emitted code should be optimized such that the inner loop is hoisted out of its current outer loop.

rdar://141718098

