### PR TITLE
[ASTGen] Eliminate ASTGen.ASTNode

### DIFF
--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -224,14 +224,32 @@ bool BridgedDeclObj::Destructor_isIsolated() const {
 // MARK: BridgedASTNode
 //===----------------------------------------------------------------------===//
 
+BridgedASTNode::BridgedASTNode(void *_Nonnull pointer, BridgedASTNodeKind kind)
+    : opaque(intptr_t(pointer) | kind) {
+  assert(getPointer() == pointer && getKind() == kind);
+}
+
+BridgedExpr BridgedASTNode::castToExpr() const {
+  assert(getKind() == BridgedASTNodeKindExpr);
+  return static_cast<swift::Expr *>(getPointer());
+}
+BridgedStmt BridgedASTNode::castToStmt() const {
+  assert(getKind() == BridgedASTNodeKindStmt);
+  return static_cast<swift::Stmt *>(getPointer());
+}
+BridgedDecl BridgedASTNode::castToDecl() const {
+  assert(getKind() == BridgedASTNodeKindDecl);
+  return static_cast<swift::Decl *>(getPointer());
+}
+
 swift::ASTNode BridgedASTNode::unbridged() const {
-  switch (Kind) {
-  case ASTNodeKindExpr:
-    return swift::ASTNode(static_cast<swift::Expr *>(Raw));
-  case ASTNodeKindStmt:
-    return swift::ASTNode(static_cast<swift::Stmt *>(Raw));
-  case ASTNodeKindDecl:
-    return swift::ASTNode(static_cast<swift::Decl *>(Raw));
+  switch (getKind()) {
+  case BridgedASTNodeKindExpr:
+    return castToExpr().unbridged();
+  case BridgedASTNodeKindStmt:
+    return castToStmt().unbridged();
+  case BridgedASTNodeKindDecl:
+    return castToDecl().unbridged();
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -596,7 +596,7 @@ extension ASTGenVisitor {
       let body = BridgedBraceStmt.createImplicit(
         self.ctx,
         lBraceLoc: range.start,
-        element: ASTNode.decl(decl.asDecl).bridged,
+        element: .decl(decl.asDecl),
         rBraceLoc: range.end
       )
       topLevelDecl.setBody(body: body);

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -67,7 +67,7 @@ extension ASTGenVisitor {
     }()
 
     // 'stmts' is a list of body elements of 'TapExpr' aka "appendingExpr" for the 'InterpolatedStringLiteralExpr'.
-    var stmts: [ASTNode] = []
+    var stmts: [BridgedASTNode] = []
 
     // The first element is a 'VarDecl'.
     let interpolationVar = BridgedVarDecl.createImplicitStringInterpolationVar(self.declContext)
@@ -199,7 +199,7 @@ extension ASTGenVisitor {
     let body = BridgedBraceStmt.createParsed(
       self.ctx,
       lBraceLoc: nil,
-      elements: stmts.lazy.map({ $0.bridged }).bridgedArray(in: self),
+      elements: stmts.lazy.bridgedArray(in: self),
       rBraceLoc: nil
     )
     let appendingExpr = BridgedTapExpr.create(


### PR DESCRIPTION
We can simply use `BridgedASTNode`, no need to have its own ASTNode

Rework `BridgedASTNode` to make it a tagged pointer.