### PR TITLE
[IRGen] Apply correct type to conversion for direct values and erorrs…

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4534,8 +4534,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
 
   Explosion errorExplosion;
   if (!errorSchema.empty()) {
-    if (auto *structTy =
-            dyn_cast<llvm::StructType>(errorSchema.getExpandedType(IGF.IGM))) {
+    auto *expandedType = errorSchema.getExpandedType(IGF.IGM);
+    if (auto *structTy = dyn_cast<llvm::StructType>(expandedType)) {
       for (unsigned i = 0, e = structTy->getNumElements(); i < e; ++i) {
         llvm::Value *elt = values[combined.errorValueMapping[i]];
         auto *nativeTy = structTy->getElementType(i);
@@ -4545,7 +4545,7 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
     } else {
       auto *converted =
           convertForDirectError(IGF, values[combined.errorValueMapping[0]],
-                                combined.combinedTy, /*forExtraction*/ true);
+                                expandedType, /*forExtraction*/ true);
       errorExplosion.add(converted);
     }
 
@@ -4558,8 +4558,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
   // If the regular result type is void, there is nothing to explode
   if (!nativeSchema.empty()) {
     Explosion resultExplosion;
-    if (auto *structTy =
-            dyn_cast<llvm::StructType>(nativeSchema.getExpandedType(IGF.IGM))) {
+    auto *expandedType = nativeSchema.getExpandedType(IGF.IGM);
+    if (auto *structTy = dyn_cast<llvm::StructType>(expandedType)) {
       for (unsigned i = 0, e = structTy->getNumElements(); i < e; ++i) {
         auto *nativeTy = structTy->getElementType(i);
         auto *converted = convertForDirectError(IGF, values[i], nativeTy,
@@ -4567,8 +4567,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
         resultExplosion.add(converted);
       }
     } else {
-      auto *converted = convertForDirectError(
-          IGF, values[0], combined.combinedTy, /*forExtraction*/ true);
+      auto *converted = convertForDirectError(IGF, values[0], expandedType,
+                                              /*forExtraction*/ true);
       resultExplosion.add(converted);
     }
     out = nativeSchema.mapFromNative(IGF.IGM, IGF, resultExplosion, resultType);

--- a/test/Interpreter/typed_throws_abi.swift
+++ b/test/Interpreter/typed_throws_abi.swift
@@ -285,6 +285,40 @@ func checkAsync() async {
     await invoke { try await impl.nonMatching_f1(false) }
 }
 
+enum SmallError: Error {
+    case a(Int)
+}
+
+@inline(never)
+func smallResultLargerError() throws(SmallError) -> Int8? {
+  return 10
+}
+
+func callSmallResultLargerError() {
+  let res = try! smallResultLargerError()
+  print("Result is: \(String(describing: res))")
+}
+
+enum UInt8OptSingletonError: Error {
+  case a(Int8?)
+}
+
+@inline(never)
+func smallErrorLargerResult() throws(UInt8OptSingletonError) -> Int {
+  throw .a(10)
+}
+
+func callSmallErrorLargerResult() {
+  do {
+    _ = try smallErrorLargerResult()
+  } catch {
+    switch error {
+      case .a(let x):
+        print("Error value is: \(String(describing: x))")
+    }
+  }
+}
+
 enum MyError: Error {
     case x
     case y
@@ -315,5 +349,10 @@ public struct Main {
         await checkAsync()
         // CHECK: Arg is 10
         print(try! await callAsyncIndirectResult(p: AsyncGenProtoImpl(), x: 10))
+
+        // CHECK: Result is: Optional(10)
+        callSmallResultLargerError()
+        // CHECK: Error value is: Optional(10)
+        callSmallErrorLargerResult()
     }
 }


### PR DESCRIPTION
… with typed throws

rdar://144719032

When converting the combined result back to the actual types when directly returning typed errors, in case the error or result value was a single value smaller then pointer size and the combined value was larger, the value was converted to the combined type instead of the actual type, making it a no-op, which caused undefined behavior when writing the value to the coerced alloca.