### PR TITLE
[6.1][IRGen] Apply correct type to conversion for direct values and erorrs…

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4541,8 +4541,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
 
   Explosion errorExplosion;
   if (!errorSchema.empty()) {
-    if (auto *structTy =
-            dyn_cast<llvm::StructType>(errorSchema.getExpandedType(IGF.IGM))) {
+    auto *expandedType = errorSchema.getExpandedType(IGF.IGM);
+    if (auto *structTy = dyn_cast<llvm::StructType>(expandedType)) {
       for (unsigned i = 0, e = structTy->getNumElements(); i < e; ++i) {
         llvm::Value *elt = values[combined.errorValueMapping[i]];
         auto *nativeTy = structTy->getElementType(i);
@@ -4552,7 +4552,7 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
     } else {
       auto *converted =
           convertForDirectError(IGF, values[combined.errorValueMapping[0]],
-                                combined.combinedTy, /*forExtraction*/ true);
+                                expandedType, /*forExtraction*/ true);
       errorExplosion.add(converted);
     }
 
@@ -4565,8 +4565,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
   // If the regular result type is void, there is nothing to explode
   if (!nativeSchema.empty()) {
     Explosion resultExplosion;
-    if (auto *structTy =
-            dyn_cast<llvm::StructType>(nativeSchema.getExpandedType(IGF.IGM))) {
+    auto *expandedType = nativeSchema.getExpandedType(IGF.IGM);
+    if (auto *structTy = dyn_cast<llvm::StructType>(expandedType)) {
       for (unsigned i = 0, e = structTy->getNumElements(); i < e; ++i) {
         auto *nativeTy = structTy->getElementType(i);
         auto *converted = convertForDirectError(IGF, values[i], nativeTy,
@@ -4574,8 +4574,8 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
         resultExplosion.add(converted);
       }
     } else {
-      auto *converted = convertForDirectError(
-          IGF, values[0], combined.combinedTy, /*forExtraction*/ true);
+      auto *converted = convertForDirectError(IGF, values[0], expandedType,
+                                              /*forExtraction*/ true);
       resultExplosion.add(converted);
     }
     out = nativeSchema.mapFromNative(IGF.IGM, IGF, resultExplosion, resultType);

--- a/test/Interpreter/typed_throws_abi.swift
+++ b/test/Interpreter/typed_throws_abi.swift
@@ -284,6 +284,40 @@ func checkAsync() async {
     await invoke { try await impl.nonMatching_f1(false) }
 }
 
+enum SmallError: Error {
+    case a(Int)
+}
+
+@inline(never)
+func smallResultLargerError() throws(SmallError) -> Int8? {
+  return 10
+}
+
+func callSmallResultLargerError() {
+  let res = try! smallResultLargerError()
+  print("Result is: \(String(describing: res))")
+}
+
+enum UInt8OptSingletonError: Error {
+  case a(Int8?)
+}
+
+@inline(never)
+func smallErrorLargerResult() throws(UInt8OptSingletonError) -> Int {
+  throw .a(10)
+}
+
+func callSmallErrorLargerResult() {
+  do {
+    _ = try smallErrorLargerResult()
+  } catch {
+    switch error {
+      case .a(let x):
+        print("Error value is: \(String(describing: x))")
+    }
+  }
+}
+
 enum MyError: Error {
     case x
     case y
@@ -314,5 +348,10 @@ public struct Main {
         await checkAsync()
         // CHECK: Arg is 10
         print(try! await callAsyncIndirectResult(p: AsyncGenProtoImpl(), x: 10))
+
+        // CHECK: Result is: Optional(10)
+        callSmallResultLargerError()
+        // CHECK: Error value is: Optional(10)
+        callSmallErrorLargerResult()
     }
 }


### PR DESCRIPTION
… with typed throws

  - **Explanation**: When converting the combined result back to the actual types when directly returning typed errors, in case the error or result value was a single value smaller then pointer size and the combined value was larger, the value was converted to the combined type instead of the actual type, making it a no-op, which caused undefined behavior when writing the value to the coerced alloca.
  - **Scope**: Typed throws ABI
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://144719032
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/79369
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. The change is simple, well understood and tested.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Added regression tests for the problematic patterns and existing tests still pass.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @aschwaighofer 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->