### PR TITLE
[Caching] Fix a bug when emitting diagnostics from nested macros

### DIFF
--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -348,7 +348,7 @@ unsigned DiagnosticSerializer::getFileIDFromBufferID(SourceManager &SM,
 
   Files.emplace_back(std::move(File));
   Allocated.insert({Idx, ++CurrentFileID});
-
+  unsigned NewFileID = CurrentFileID;
 
   auto Info = SM.getGeneratedSourceInfo(Idx);
   auto convertGeneratedFileInfo =
@@ -364,7 +364,7 @@ unsigned DiagnosticSerializer::getFileIDFromBufferID(SourceManager &SM,
     GeneratedFileInfo.emplace_back(std::move(GI));
   }
 
-  return CurrentFileID;
+  return NewFileID;
 }
 
 SerializedSourceLoc

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -49,12 +49,23 @@ public struct CallDeprecatedMacro: ExpressionMacro {
   }
 }
 
+public struct ToMyWarningMacro: ExpressionMacro {
+   public static func expansion(
+     of macro: some FreestandingMacroExpansionSyntax,
+     in context: some MacroExpansionContext
+   ) throws -> ExprSyntax {
+     return "#myWarning(\"\")"
+  }
+}
+
 //--- main.swift
 @freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "CallDeprecatedMacro")
+@freestanding(expression) macro toMyWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "ToMyWarningMacro")
 
 @available(*, deprecated)
 func testDeprecated() {}
 
 func testDiscardableStringify(x: Int) {
+  #toMyWarning("this is a warning")
   #myWarning("this is a warning")
 }


### PR DESCRIPTION
Fix a bug when emitting cached diagnostics from nested macros. When building a new source manager for cached diagnostics, there is a bug when creating mapping between FileIDs between two different source managers. If the newly created file in source manager requires another file to be mapped, e.g. when emitting a diagnostic from nested macros, the returning FileID can be updated by the second request before returning. Fix the bug by making sure two different FileIDs are returned in this case.

rdar://144810862

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
