### PR TITLE
[AST/Sema] Add new function type isolation - `caller` to cover `@execution(caller)` attribute

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -63,6 +63,21 @@ public:
 
     /// The function's isolation is statically erased with @isolated(any).
     Erased,
+
+    /// Inherits isolation from the caller. This is only applicable
+    /// to asynchronous function types.
+    ///
+    /// NOTE: The difference in between NonIsolatedCaller and
+    /// NonIsolated is that NonIsolatedCaller is a strictly
+    /// weaker form of nonisolation. While both in their bodies cannot
+    /// access isolated state directly, NonIsolatedCaller functions
+    /// /are/ allowed to access state isolated to their caller via
+    /// function arguments since we know that the callee will stay
+    /// in the caller's isolation domain. In contrast, NonIsolated
+    /// is strongly nonisolated and is not allowed to access /any/
+    /// isolated state (even via function parameters) since it is
+    /// considered safe to run on /any/ actor.
+    NonIsolatedCaller,
   };
 
   static constexpr size_t NumBits = 3; // future-proof this slightly
@@ -86,6 +101,9 @@ public:
   }
   static FunctionTypeIsolation forErased() {
     return { Kind::Erased };
+  }
+  static FunctionTypeIsolation forNonIsolatedCaller() {
+    return { Kind::NonIsolatedCaller };
   }
 
   Kind getKind() const { return value.getInt(); }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3285,6 +3285,11 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
     if (AllowIsolatedAny)
       appendOperator("YA");
     break;
+
+  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+    // TODO: We need a special mangling for this to
+    // make it distinct from the `@execution(concurrent)`.
+    break;
   }
 
   if (isRecursedInto && fn->hasSendingResult()) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6421,6 +6421,10 @@ public:
       if (!Options.SuppressIsolatedAny)
         Printer << "@isolated(any) ";
       break;
+
+    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      Printer << "@execution(caller) ";
+      break;
     }
 
     if (!Options.excludeAttrKind(TypeAttrKind::Sendable) && info.isSendable()) {

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -563,6 +563,7 @@ SILGenFunction::emitFunctionTypeIsolation(SILLocation loc,
 
   // Emit nonisolated by simply emitting Optional.none in the result type.
   case FunctionTypeIsolation::Kind::NonIsolated:
+  case FunctionTypeIsolation::Kind::NonIsolatedCaller:
     return emitNonIsolatedIsolation(loc);
 
   // Emit global actor isolation by loading .shared from the global actor,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5439,6 +5439,10 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
     case FunctionTypeIsolation::Kind::NonIsolated:
       break;
 
+    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      hopToIsolatedParameter = true;
+      break;
+
     // For a function with parameter isolation, we'll have to dig the
     // argument out after translation but before making the call.
     case FunctionTypeIsolation::Kind::Parameter:

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7036,15 +7036,19 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
 
   fnType = applyUnsafeConcurrencyToFunctionType(
       fnType, decl, strictChecking, numApplies, isMainDispatchQueue);
-  Type globalActorType;
+  std::optional<FunctionTypeIsolation> funcIsolation;
   if (decl) {
     switch (auto isolation = getActorIsolation(decl)) {
     case ActorIsolation::ActorInstance:
       // The function type may or may not have parameter isolation.
       return fnType;
 
-    case ActorIsolation::Nonisolated:
     case ActorIsolation::CallerIsolationInheriting:
+      assert(fnType->getIsolation().isNonIsolated());
+      funcIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      break;
+
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::Unspecified:
       assert(fnType->getIsolation().isNonIsolated());
@@ -7059,12 +7063,13 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
       if (!strictChecking && isolation.preconcurrency())
         return fnType;
 
-      globalActorType = openType(isolation.getGlobalActor());
+      Type globalActorType = openType(isolation.getGlobalActor());
+      funcIsolation = FunctionTypeIsolation::forGlobalActor(globalActorType);
       break;
     }
   }
 
-  auto isolation = FunctionTypeIsolation::forGlobalActor(globalActorType);
+  ASSERT(funcIsolation.has_value());
 
   // If there's no implicit "self" declaration, apply the isolation to
   // the outermost function type.
@@ -7072,7 +7077,8 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
       (isa<AbstractFunctionDecl>(decl) &&
        cast<AbstractFunctionDecl>(decl)->hasImplicitSelfDecl()));
   if (!hasImplicitSelfDecl) {
-    return fnType->withExtInfo(fnType->getExtInfo().withIsolation(isolation));
+    return fnType->withExtInfo(
+        fnType->getExtInfo().withIsolation(*funcIsolation));
   }
 
   // Dig out the inner function type.
@@ -7082,7 +7088,7 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
 
   // Update the inner function type with the isolation.
   innerFnType = innerFnType->withExtInfo(
-      innerFnType->getExtInfo().withIsolation(isolation));
+      innerFnType->getExtInfo().withIsolation(*funcIsolation));
 
   // Rebuild the outer function type around it.
   if (auto genericFnType = dyn_cast<GenericFunctionType>(fnType)) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4206,7 +4206,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     switch (isolation.getKind()) {
     case FunctionTypeIsolation::Kind::NonIsolated:
       break;
-
+         
     case FunctionTypeIsolation::Kind::GlobalActor:
       diagnoseInvalid(
           repr, executionAttr->getAtLoc(),
@@ -4228,15 +4228,19 @@ NeverNullType TypeResolver::resolveASTFunctionType(
           diag::
               attr_execution_concurrent_type_attr_incompatible_with_isolated_any);
       break;
+
+    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      llvm_unreachable("cannot happen because multiple @execution attributes "
+                       "aren't allowed.");
     }
 
     if (!repr->isInvalid()) {
       switch (executionAttr->getBehavior()) {
       case ExecutionKind::Concurrent:
-        // TODO: We need to introduce a new isolation kind to support this.
+        isolation = FunctionTypeIsolation::forNonIsolated();
         break;
       case ExecutionKind::Caller:
-        isolation = FunctionTypeIsolation::forNonIsolated();
+        isolation = FunctionTypeIsolation::forNonIsolatedCaller();
         break;
       }
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4203,35 +4203,37 @@ NeverNullType TypeResolver::resolveASTFunctionType(
                       diag::attr_execution_type_attr_only_on_async);
     }
 
-    switch (isolation.getKind()) {
-    case FunctionTypeIsolation::Kind::NonIsolated:
-      break;
-         
-    case FunctionTypeIsolation::Kind::GlobalActor:
-      diagnoseInvalid(
-          repr, executionAttr->getAtLoc(),
-          diag::
-              attr_execution_concurrent_type_attr_incompatible_with_global_isolation,
-          isolation.getGlobalActorType());
-      break;
+    if (executionAttr->getBehavior() == ExecutionKind::Concurrent) {
+      switch (isolation.getKind()) {
+      case FunctionTypeIsolation::Kind::NonIsolated:
+        break;
 
-    case FunctionTypeIsolation::Kind::Parameter:
-      diagnoseInvalid(
-          repr, executionAttr->getAtLoc(),
-          diag::
-              attr_execution_concurrent_type_attr_incompatible_with_isolated_param);
-      break;
+      case FunctionTypeIsolation::Kind::GlobalActor:
+        diagnoseInvalid(
+            repr, executionAttr->getAtLoc(),
+            diag::
+                attr_execution_concurrent_type_attr_incompatible_with_global_isolation,
+            isolation.getGlobalActorType());
+        break;
 
-    case FunctionTypeIsolation::Kind::Erased:
-      diagnoseInvalid(
-          repr, executionAttr->getAtLoc(),
-          diag::
-              attr_execution_concurrent_type_attr_incompatible_with_isolated_any);
-      break;
+      case FunctionTypeIsolation::Kind::Parameter:
+        diagnoseInvalid(
+            repr, executionAttr->getAtLoc(),
+            diag::
+                attr_execution_concurrent_type_attr_incompatible_with_isolated_param);
+        break;
 
-    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
-      llvm_unreachable("cannot happen because multiple @execution attributes "
-                       "aren't allowed.");
+      case FunctionTypeIsolation::Kind::Erased:
+        diagnoseInvalid(
+            repr, executionAttr->getAtLoc(),
+            diag::
+                attr_execution_concurrent_type_attr_incompatible_with_isolated_any);
+        break;
+
+      case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+        llvm_unreachable("cannot happen because multiple @execution attributes "
+                         "aren't allowed.");
+      }
     }
 
     if (!repr->isInvalid()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7133,6 +7133,8 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
   auto isolation = swift::FunctionTypeIsolation::forNonIsolated();
   if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolated)) {
     // do nothing
+  } else if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolatedCaller)) {
+    isolation = swift::FunctionTypeIsolation::forNonIsolatedCaller();
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::Parameter)) {
     isolation = swift::FunctionTypeIsolation::forParameter();
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::Erased)) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 921; // remove alloc_vector
+const uint16_t SWIFTMODULE_VERSION_MINOR = 922; // function type isolation - caller
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -707,6 +707,7 @@ enum class FunctionTypeIsolation : uint8_t {
   Parameter,
   Erased,
   GlobalActorOffset, // Add this to the global actor type ID
+  NonIsolatedCaller,
 };
 using FunctionTypeIsolationField = TypeIDField;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5781,6 +5781,8 @@ public:
     switch (isolation.getKind()) {
     case swift::FunctionTypeIsolation::Kind::NonIsolated:
       return unsigned(FunctionTypeIsolation::NonIsolated);
+    case swift::FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      return unsigned(FunctionTypeIsolation::NonIsolatedCaller);
     case swift::FunctionTypeIsolation::Kind::Parameter:
       return unsigned(FunctionTypeIsolation::Parameter);
     case swift::FunctionTypeIsolation::Kind::Erased:

--- a/test/Concurrency/attr_execution_conversions.swift
+++ b/test/Concurrency/attr_execution_conversions.swift
@@ -1,0 +1,77 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
+
+// REQUIRES: concurrency
+
+@execution(concurrent)
+func concurrentTest() async {
+}
+
+@execution(caller)
+func callerTest() async {
+}
+
+@MainActor
+func actorIsolated() async {}
+
+let _: @execution(caller) () async -> Void = concurrentTest // Ok
+let _: @execution(concurrent) () async -> Void = callerTest // Ok
+
+let _: @MainActor () async -> Void = concurrentTest // Ok
+let _: @MainActor () async -> Void = callerTest // Ok
+
+let _: @isolated(any) () async -> Void = concurrentTest // Ok
+let _: @isolated(any) () async -> Void = callerTest
+// expected-error@-1 {{cannot convert value of type '@execution(caller) () async -> ()' to specified type '@isolated(any) () async -> Void'}}
+
+let _: @execution(caller) () async -> Void = actorIsolated // Ok
+let _: @execution(concurrent) () async -> Void = actorIsolated // Ok
+
+func testIsolationErasure(fn: @escaping @isolated(any) () async -> Void) {
+  let _: @execution(concurrent) () async -> Void = fn // Ok
+  let _: @execution(caller) () async -> Void = fn // Ok
+}
+
+func testUpcast(arr: [@execution(caller) () async -> Void]) {
+  let _: [() async -> Void] = arr // Ok - collection upcast
+  let _: [String: () async -> Void] = ["": arr]
+  // expected-error@-1 {{cannot convert value of type '[@execution(caller) () async -> Void]' to expected dictionary value type '() async -> Void'}}
+}
+
+// Isolated parameter
+func testParameterIsolation(fn: @escaping (isolated (any Actor)?) async -> Void) {
+  let _: @execution(caller) () async -> Void = fn
+  // expected-error@-1 {{cannot convert value of type '(isolated (any Actor)?) async -> Void' to specified type '@execution(caller) () async -> Void'}}
+  let _: @execution(concurrent) () async -> Void = fn
+  // expected-error@-1 {{cannot convert value of type '(isolated (any Actor)?) async -> Void' to specified type '() async -> Void'}}
+}
+
+// Non-conversion situations
+do {
+  struct S<T> {
+  }
+  func test<T>(_: S<T>, _: T.Type) {}
+  
+  test(S<() async -> Void>(), type(of: callerTest))
+  // expected-error@-1 {{cannot convert value of type '(@execution(caller) () async -> ()).Type' to expected argument type '(() async -> Void).Type'}}
+
+  test(S<@execution(caller) () async -> Void>(), type(of: concurrentTest))
+  // expected-error@-1 {{cannot convert value of type '(() async -> ()).Type' to expected argument type '(@execution(caller) () async -> Void).Type'}}
+
+  test(S<@MainActor () async -> Void>(), type(of: callerTest))
+  // expected-error@-1 {{cannot convert value of type '(@execution(caller) () async -> ()).Type' to expected argument type '(@MainActor () async -> Void).Type'}}
+
+  test(S<@MainActor () async -> Void>(), type(of: concurrentTest))
+  // expected-error@-1 {{cannot convert value of type '(() async -> ()).Type' to expected argument type '(@MainActor () async -> Void).Type'}}
+
+  test(S<(isolated (any Actor)?) async -> Void>(), type(of: callerTest))
+  // expected-error@-1 {{cannot convert value of type '(@execution(caller) () async -> ()).Type' to expected argument type '((isolated (any Actor)?) async -> Void).Type'}}
+
+  test(S<(isolated (any Actor)?) async -> Void>(), type(of: concurrentTest))
+  // expected-error@-1 {{cannot convert value of type '(() async -> ()).Type' to expected argument type '((isolated (any Actor)?) async -> Void).Type'}}
+
+  test(S<@isolated(any) () async -> Void>(), type(of: concurrentTest))
+  // expected-error@-1 {{cannot convert value of type '(() async -> ()).Type' to expected argument type '(@isolated(any) () async -> Void).Type'}}
+  test(S<@isolated(any) () async -> Void>(), type(of: callerTest))
+  // expected-error@-1 {{cannot convert value of type '(@execution(caller) () async -> ()).Type' to expected argument type '(@isolated(any) () async -> Void).Type'}}
+}
+

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -53,7 +53,13 @@ struct TestAttributeCollisions {
   @MainActor @execution(concurrent) func testGlobalActor() async {}
   // expected-warning @-1 {{instance method 'testGlobalActor()' has multiple actor-isolation attributes ('MainActor' and 'execution(concurrent)')}}
 
+  @execution(caller) nonisolated func testNonIsolatedCaller() async {} // Ok
+  @MainActor @execution(caller) func testGlobalActorCaller() async {}
+  // expected-warning@-1 {{instance method 'testGlobalActorCaller()' has multiple actor-isolation attributes ('MainActor' and 'execution(caller)')}}
+  @execution(caller) func testCaller(arg: isolated MainActor) async {} // Ok
+
   @execution(concurrent) @Sendable func test(_: @Sendable () -> Void, _: sending Int) async {} // Ok
+  @execution(caller) @Sendable func testWithSendableCaller(_: @Sendable () -> Void, _: sending Int) async {} // Ok
 }
 
 @MainActor


### PR DESCRIPTION
- The kind is called `NonIsolatedCaller` (we'd rename corresponding `ActorIsolation::Kind` separately)
- `adjustFunctionTypeForConcurrency` is changed to use it when declaration isolation is "caller"
- Fixed some diagnostics for `@execution` to apply on to `@execution(concurrent)` and not `@execution(caller)`.
- Updated `matchFunctionIsolation` in the solver to correctly handle conversions to/from caller isolated function types.

Resolves: rdar://142920095
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
