### PR TITLE
Re-work the mixins for swiftpm and downstream packages

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1827,8 +1827,11 @@ skip-test-foundation
 #===------------------------------------------------------------------------===#
 # Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
+# Base of SwiftPM and packages
 [preset: mixin_swiftpm_base]
-mixin-preset=buildbot_incremental_base
+mixin-preset=
+    buildbot_incremental_base
+    mixin_buildbot_install_components_with_clang
 build-subdir=buildbot_incremental
 
 libcxx
@@ -1846,18 +1849,17 @@ swift-testing-macros
 install-swift-testing
 install-swift-testing-macros
 
-infer-cross-compile-hosts-on-darwin
 skip-test-swift
 
+# SwiftPM base
 [preset: mixin_swiftpm_macos_platform]
-mixin-preset=
-    mixin_swiftpm_base
-    mixin_buildbot_install_components_with_clang
+mixin-preset=mixin_swiftpm_base
 
+infer-cross-compile-hosts-on-darwin
+
+# SwiftPM base
 [preset: mixin_swiftpm_linux_platform]
-mixin-preset=
-    mixin_swiftpm_base
-    mixin_linux_install_components_with_clang
+mixin-preset=mixin_swiftpm_base
 
 libdispatch
 foundation
@@ -1875,9 +1877,9 @@ skip-test-xctest
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
 
-# Builds enough of the toolchain to build a swift package on macOS.
+# SwiftPM package base
 [preset: mixin_swiftpm_package_macos_platform]
-mixin-preset=mixin_swiftpm_macos_platform
+mixin-preset=mixin_swiftpm_base
 
 # We don't need to build the benchmark if we just want SwiftPM
 skip-build-benchmarks
@@ -1890,10 +1892,22 @@ skip-watchos
 skip-test-llbuild
 skip-test-swiftpm
 
-# Builds enough of the toolchain to build a swift package on Linux.
+# SwiftPM package base
 [preset: mixin_swiftpm_package_linux_platform]
-mixin-preset=mixin_swiftpm_linux_platform
+mixin-preset=mixin_swiftpm_base
 
+libdispatch
+foundation
+xctest
+libcxx=false
+
+install-foundation
+install-libdispatch
+install-xctest
+
+skip-test-foundation
+skip-test-libdispatch
+skip-test-xctest
 skip-test-llbuild
 skip-test-swiftpm
 


### PR DESCRIPTION
Keep mixin_swiftpm_base as the base of SwiftPM and all dependents, but then separate the SwiftPM + package bases and their respective platforms.

This allows SwiftPM to add its own changes without impacting downstream packages (eg. the recently added cross compile setting).