### PR TITLE
PassManager: invalidate analysis if a pass forgot to do so.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -1056,6 +1056,10 @@ public:
   /// See scheduledForDeletion for details.
   void flushDeletedInsts();
 
+  bool hasInstructionsScheduledForDeletion() const {
+    return !scheduledForDeletion.empty();
+  }
+
   /// Looks up the llvm intrinsic ID and type for the builtin function.
   ///
   /// \returns Returns llvm::Intrinsic::not_intrinsic if the function is not an


### PR DESCRIPTION
If a pass forgot to call invalidateAnalysis but deleted some instructions, the pass-manager can fix this.

Currently following passes do not invalidate analysis when they change the SIL:
* LowerTupleAddrConstructor
* DestroyAddrHoisting
* MoveOnlyChecker
* PredictableDeadAllocationElimination

Ideally we should fix those passes. But with this addition in the pass-manager it's not strictly necessary.

Fixes a compiler crash.
