### PR TITLE
[Backtracing] Fix bug in Compact Image Map decoder.

### DIFF
--- a/docs/CompactImageMapFormat.md
+++ b/docs/CompactImageMapFormat.md
@@ -106,7 +106,7 @@ need to be stored in CIF data:
 |   8  | `/System/Applications`              |
 |   9  | `/Applications`                     |
 |  10  | `C:\Windows\System32`               |
-|  11  | `C:\Program Files\`                 |
+|  11  | `C:\Program Files`                  |
 
 Codes below 32 are reserved for future expansion of the fixed list.
 

--- a/stdlib/public/RuntimeModule/CompactImageMap.swift
+++ b/stdlib/public/RuntimeModule/CompactImageMap.swift
@@ -244,7 +244,7 @@ public enum CompactImageMapFormat {
           if (byte & 0x40) == 0 {
             code = Int(byte & 0x3f)
           } else {
-            let byteCount = Int(byte & 0x3f)
+            let byteCount = Int(byte & 0x3f) + 1
             code = 0
             for _ in 0..<byteCount {
               guard let byte = iterator.next() else {
@@ -252,6 +252,7 @@ public enum CompactImageMapFormat {
               }
               code = (code << 8) | Int(byte)
             }
+            code += 64
           }
 
           #if DEBUG_COMPACT_IMAGE_MAP


### PR DESCRIPTION
The `expand` opcode was being decoded incorrectly in the case where we were trying to expand prefixes with codes of 64 or above.

rdar://144497804
