### PR TITLE
[cxx-interop] Work around lifetime errors in SwiftifyImport generated code

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -437,7 +437,7 @@ struct CxxSpanReturnThunkBuilder: BoundsCheckedThunkBuilder {
 
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     let call = try base.buildFunctionCall(pointerArgs)
-    return "Span(_unsafeCxxSpan: \(call))"
+    return "_unsafeRemoveLifetime(Span(_unsafeCxxSpan: \(call)))"
   }
 }
 

--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -18,6 +18,15 @@ internal func unsafeBitCast<T: ~Escapable, U>(
   Builtin.reinterpretCast(x)
 }
 
+/// Used by SwiftifyImport to work around a compiler diagnostic. It should be removed once the
+/// workaround is no longer needed.
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+public func _unsafeRemoveLifetime<T: ~Copyable & ~Escapable>(_ dependent: consuming T) -> T {
+  dependent
+}
+
 /// Unsafely discard any lifetime dependency on the `dependent` argument. Return
 /// a value identical to `dependent` with a lifetime dependency on the caller's
 /// borrow scope of the `source` argument.
@@ -81,7 +90,7 @@ extension CxxSpan {
 extension Span {
   @_alwaysEmitIntoClient
   @unsafe
-  @lifetime(borrow span)
+  @_unsafeNonescapableResult
   public init<T: CxxSpan<Element>>(
     _unsafeCxxSpan span: borrowing T,
   ) {

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -57,7 +57,7 @@ inline SpanOfInt initSpan(int arr[], size_t size) {
 struct DependsOnSelf {
   std::vector<int> v;
   __attribute__((swift_name("get()")))
-  ConstSpanOfInt get() [[clang::lifetimebound]] { return ConstSpanOfInt(v.data(), v.size()); }
+  ConstSpanOfInt get() const [[clang::lifetimebound]] { return ConstSpanOfInt(v.data(), v.size()); }
 };
 
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -16,8 +16,8 @@ import CxxStdlib
 
 // CHECK:     struct DependsOnSelf {
 // CHECK:       @lifetime(borrow self)
-// CHECK-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public mutating func get() -> Span<CInt>
-// CHECK-NEXT:  mutating func get() -> ConstSpanOfInt
+// CHECK-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
+// CHECK-NEXT:  borrowing func get() -> ConstSpanOfInt
 
 // CHECK:      mutating func set(_ x: borrowing std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>)
 // CHECK:      func funcWithSafeWrapper(_ s: ConstSpanOfInt)

--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature SafeInteropWrappers)
+
+// FIXME swift-ci linux tests do not support std::span
+// UNSUPPORTED: OS=linux-gnu
+
+// TODO: test failed in Windows PR testing: rdar://144384453
+// UNSUPPORTED: OS=windows-msvc
+
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_Span
+// REQUIRES: swift_feature_LifetimeDependence
+
+// REQUIRES: executable_test
+
+#if !BRIDGING_HEADER
+import StdSpan
+#endif
+import CxxStdlib
+
+func canCallSafeSpanAPIs(_ x: Span<CInt>) {
+    funcWithSafeWrapper(x)
+    funcWithSafeWrapper2(x)
+}

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -36,25 +36,25 @@ struct X {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(span)
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc(SpanOfInt(span)))
+// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc(SpanOfInt(span))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
-// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc2(vec))
+// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc2(vec)))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(span1, span2)
 // CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2)))
+// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, span)
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span)))
+// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self) @_disfavoredOverload
 // CHECK-NEXT: func myFunc5() -> Span<CInt> {
-// CHECK-NEXT:     return Span(_unsafeCxxSpan: myFunc5())
+// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc5()))
 // CHECK-NEXT: }


### PR DESCRIPTION
Unfortunately, this was not discovered earlier as swift-ide-test is not invoking the SIL passes that produce this diagnostic. When creating Swift spans from C++ spans we have no lifetime dependency information to propagate as C++ spans are modeled as escapable types. Hence, this PR introduces a helper function to bypass the lifetime checks triggered by this discepancy. Hopefully, the new utility will go away as the lifetime analysis matures on the Swift side and we get standardized way to deal with unsafe lifetimes.
