### PR TITLE
Sema: Allow optional-to-optional CGFloat <-> Double conversion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7392,28 +7392,18 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Look through all value-to-optional promotions to allow
         // conversions like Double -> CGFloat?? and vice versa.
         // T -> Optional<T>
-        if (location.endsWith<LocatorPathElt::OptionalPayload>()) {
+        if (location.endsWith<LocatorPathElt::OptionalPayload>() ||
+            location.endsWith<LocatorPathElt::GenericArgument>()) {
           SmallVector<LocatorPathElt, 4> path;
           auto anchor = location.getLocatorParts(path);
 
-          // An attempt at Double/CGFloat conversion through
-          // optional chaining. This is not supported at the
-          // moment because solution application doesn't know
-          // how to map Double to/from CGFloat through optionals.
-          if (isExpr<OptionalEvaluationExpr>(anchor)) {
-            if (!shouldAttemptFixes())
-              return getTypeMatchFailure(locator);
-
-            conversionsOrFixes.push_back(ContextualMismatch::create(
-                *this, nominal1, nominal2, getConstraintLocator(locator)));
-            break;
-          }
-
-          // Drop all of the applied `value-to-optional` promotions.
+          // Drop all of the applied `value-to-optional` and
+          // `optional-to-optional` conversions.
           path.erase(llvm::remove_if(
                          path,
                          [](const LocatorPathElt &elt) {
-                           return elt.is<LocatorPathElt::OptionalPayload>();
+                           return elt.is<LocatorPathElt::OptionalPayload>() ||
+                                  elt.is<LocatorPathElt::GenericArgument>();
                          }),
                      path.end());
 

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -342,3 +342,8 @@ func test_init_validation() {
     }
   }
 }
+
+// Optional-to-optional conversion
+func optional_to_optional(x: CGFloat?) -> Double? {
+  return x
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
@@ -12,5 +12,5 @@ func compute(_: Double?) -> Double? {
 }
 
 func test(s: S?) {
-  _ = compute(s?.test) // expected-error {{cannot implicitly convert value of type 'CGFloat?' to expected type 'Double?'}}
+  _ = compute(s?.test)
 }


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/78957, there is no technical reason to not allow this conversion. This is needed for an upcoming optimization.