### PR TITLE
[Compile Time Constant Extraction] Handle cases where variables with attached result builders are initialized without builder syntax

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1366,6 +1366,7 @@ void writeProperties(llvm::json::OStream &JSON,
     for (const auto &PropertyInfo : TypeInfo.Properties) {
       JSON.object([&] {
         const auto *decl = PropertyInfo.VarDecl;
+        std::shared_ptr<CompileTimeValue> value = PropertyInfo.Value;
         JSON.attribute("label", decl->getName().str().str());
         JSON.attribute("type", toFullyQualifiedTypeNameString(
             decl->getInterfaceType()));
@@ -1374,12 +1375,17 @@ void writeProperties(llvm::json::OStream &JSON,
         JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
         writeLocationInformation(JSON, decl->getLoc(),
                                  decl->getDeclContext()->getASTContext());
-        if (auto builderValue =
-                extractBuilderValueIfExists(&NomTypeDecl, decl)) {
-          writeValue(JSON, builderValue.value());
-        } else {
-          writeValue(JSON, PropertyInfo.Value);
+
+        if (value.get()->getKind() == CompileTimeValue::ValueKind::Runtime) {
+          // Extract result builder information only if the variable has not
+          // used a different kind of initializer
+          if (auto builderValue =
+                  extractBuilderValueIfExists(&NomTypeDecl, decl)) {
+            value = builderValue.value();
+          }
         }
+
+        writeValue(JSON, value);
         writePropertyWrapperAttributes(JSON, PropertyInfo.PropertyWrappers,
                                        decl->getASTContext());
         writeAvailabilityAttributes(JSON, *decl);

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -104,7 +104,7 @@ public struct MyFooProviderInferred: FooProvider {
             Foo(name: "MyFooProviderInferred.foos.Array.\(i)")
         }
 
-        if (Bool.random()) {
+        if Bool.random() {
             Foo(name: "MyFooProviderInferred.foos.Optional")
         }
 
@@ -114,6 +114,25 @@ public struct MyFooProviderInferred: FooProvider {
         } else {
             Foo(name: "MyFooProviderInferred.foos.limitedAvailability.else")
         }
+    }
+}
+
+public struct MyFooProviderInferredWithArrayInitialization: FooProvider {
+    public static var foos: [Foo] = [
+        Foo(name: "MyFooProviderInferredWithArrayInitialization.foos.1", baz: {
+            "Nested.Builder.1"
+            "Nested.Builder.2"
+        }),
+        Foo(name: "MyFooProviderInferredWithArrayInitialization.foos.2"),
+    ]
+}
+
+public struct MyFooProviderInferredWithArrayReturn: FooProvider {
+    public static var foos: [Foo] {
+        return [
+            Foo(name: "MyFooProviderInferredWithArrayReturn.foos.1"),
+            Foo(name: "MyFooProviderInferredWithArrayInitialization.foos.2"),
+        ]
     }
 }
 
@@ -522,6 +541,148 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:             }
 // CHECK-NEXT:           ]
 // CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "ExtractResultBuilders.MyFooProviderInferredWithArrayInitialization",
+// CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders44MyFooProviderInferredWithArrayInitializationV",
+// CHECK-NEXT:     "kind": "struct",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:     "line": 120,
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractResultBuilders.FooProvider",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractResultBuilders"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:     "properties": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "foos",
+// CHECK-NEXT:         "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "true",
+// CHECK-NEXT:         "isComputed": "false",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:         "line": 121,
+// CHECK-NEXT:         "valueKind": "Array",
+// CHECK-NEXT:         "value": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "valueKind": "InitCall",
+// CHECK-NEXT:             "value": {
+// CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:               "arguments": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "label": "name",
+// CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "valueKind": "RawLiteral",
+// CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.1"
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "label": "baz",
+// CHECK-NEXT:                   "type": "() -> Swift.String",
+// CHECK-NEXT:                   "valueKind": "Builder",
+// CHECK-NEXT:                   "value": {
+// CHECK-NEXT:                     "type": "",
+// CHECK-NEXT:                     "members": [
+// CHECK-NEXT:                       {
+// CHECK-NEXT:                         "kind": "buildExpression",
+// CHECK-NEXT:                         "element": {
+// CHECK-NEXT:                           "valueKind": "RawLiteral",
+// CHECK-NEXT:                           "value": "Nested.Builder.1"
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                       },
+// CHECK-NEXT:                       {
+// CHECK-NEXT:                         "kind": "buildExpression",
+// CHECK-NEXT:                         "element": {
+// CHECK-NEXT:                           "valueKind": "RawLiteral",
+// CHECK-NEXT:                           "value": "Nested.Builder.2"
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                       }
+// CHECK-NEXT:                     ]
+// CHECK-NEXT:                   }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           },
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "valueKind": "InitCall",
+// CHECK-NEXT:             "value": {
+// CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:               "arguments": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "label": "name",
+// CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "valueKind": "RawLiteral",
+// CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.2"
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "ExtractResultBuilders.MyFooProviderInferredWithArrayReturn",
+// CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders36MyFooProviderInferredWithArrayReturnV",
+// CHECK-NEXT:     "kind": "struct",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:     "line": 130,
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "allConformances": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "protocolName": "ExtractResultBuilders.FooProvider",
+// CHECK-NEXT:         "conformanceDefiningModule": "ExtractResultBuilders"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "associatedTypeAliases": [],
+// CHECK-NEXT:     "properties": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "foos",
+// CHECK-NEXT:         "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "true",
+// CHECK-NEXT:         "isComputed": "true",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:         "line": 131,
+// CHECK-NEXT:         "valueKind": "Array",
+// CHECK-NEXT:         "value": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "valueKind": "InitCall",
+// CHECK-NEXT:             "value": {
+// CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:               "arguments": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "label": "name",
+// CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "valueKind": "RawLiteral",
+// CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayReturn.foos.1"
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           },
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "valueKind": "InitCall",
+// CHECK-NEXT:             "value": {
+// CHECK-NEXT:               "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:               "arguments": [
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "label": "name",
+// CHECK-NEXT:                   "type": "Swift.String",
+// CHECK-NEXT:                   "valueKind": "RawLiteral",
+// CHECK-NEXT:                   "value": "MyFooProviderInferredWithArrayInitialization.foos.2"
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               ]
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ]
 // CHECK-NEXT:   }


### PR DESCRIPTION
There was a bug where in cases such as the following:
```
public protocol FooProvider {
    @FooBuilder
    static var foos: [Foo] { get }
}
```

If a `struct` that implements `FooProvider` just initialized the array directly, as opposed to using the result builder syntax, then the result was unexpectedly a result builder with empty members.
```
public struct MyFooProviderInferredWithArrayInitialization: FooProvider {
    public static var foos: [Foo] = [
        Foo(...),
        Foo(...),
    ]
}
```

This PR now ensures that the `.swiftconstvalues` will contain the correct Array representation.

```
{
        "label": "foos",
         .
         .
        .
        "valueKind": "Array",
        "value": [
          {
            "valueKind": "InitCall",
            "value": {
              "type": "ExtractResultBuilders.Foo",
              "arguments": [
                {
                  "label": "name",
                  "type": "Swift.String",
                  "valueKind": "RawLiteral",
                  "value": "MyFooProviderInferredWithArrayReturn.foos.1"
                }
              ]
            }
          },
          {
            "valueKind": "InitCall",
            "value": {
              "type": "ExtractResultBuilders.Foo",
              "arguments": [
                {
                  "label": "name",
                  "type": "Swift.String",
                  "valueKind": "RawLiteral",
                  "value": "MyFooProviderInferredWithArrayInitialization.foos.2"
                }
              ]
            }
          }
        ]
      }
```

Resolves rdar://144796012