### PR TITLE
[6.1] Disable the crash in non-asserts builds when closures don't have a discriminator

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1949,6 +1949,12 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
   evaluateOrDefault(
       ctx.evaluator, LocalDiscriminatorsRequest{getParent()}, 0);
 
+#if NDEBUG
+  static constexpr bool useFallbackDiscriminator = true;
+#else
+  static constexpr bool useFallbackDiscriminator = false;
+#endif
+
   // If we don't have a discriminator, and either
   //   1. We have ill-formed code and we're able to assign a discriminator, or
   //   2. We are in a macro expansion buffer
@@ -1958,7 +1964,8 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
   if (getRawDiscriminator() == InvalidDiscriminator &&
       (ctx.Diags.hadAnyError() ||
        getParentSourceFile()->getFulfilledMacroRole() != std::nullopt ||
-       getParent()->isModuleScopeContext())) {
+       getParent()->isModuleScopeContext() ||
+       useFallbackDiscriminator)) {
     auto discriminator = ctx.getNextDiscriminator(getParent());
     ctx.setMaxAssignedDiscriminator(getParent(), discriminator + 1);
     const_cast<AbstractClosureExpr *>(this)->


### PR DESCRIPTION
* Explanation: Disable a compiler abort in non-asserts builds when a certain internal invariant does not hold, instead providing a safe fallback. This goes back to behavior we had in o
* Scope: Affects certain code using autoclosures with macros.
* Original PR: https://github.com/swiftlang/swift/pull/79401
* Reviewer: @hborla 
* Issue: rdar://143590572
* Risk: Very low. Avoids a compiler abort in rare circumstances.