### PR TITLE
[Macros] Recognize the $e Embedded Swift prefix in MacroDecl::isUniqueMacroName

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12071,8 +12071,8 @@ bool MacroDecl::isUniqueNamePlaceholder(DeclName name) {
 }
 
 bool MacroDecl::isUniqueMacroName(StringRef name) {
-  // Unique macro names are mangled names, which always start with "$s".
-  if (!name.starts_with("$s"))
+  // Unique macro names are mangled names, which always start with "$s" or "$e".
+  if (!name.starts_with("$s") && !name.starts_with("$e"))
     return false;
 
   // Unique macro names end with fMu<digits>_. Match that.

--- a/test/Macros/macro_unique_name_embedded.swift
+++ b/test/Macros/macro_unique_name_embedded.swift
@@ -1,0 +1,34 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// Create the plugin
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroPlugin) -module-name TestModule %t/TestModule.swift \
+// RUN:   -enable-experimental-feature Embedded -wmo -target arm64-apple-macos14
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddMemberMacro: PeerMacro {
+  public static func expansion(of node: AttributeSyntax, providingPeersOf declaration: some DeclSyntaxProtocol, in context: some MacroExpansionContext) throws -> [DeclSyntax] {
+    return [
+      """
+      func \(context.makeUniqueName("foo"))() { }
+      """
+    ]
+  }
+}
+
+//--- TestModule.swift
+@attached(peer)
+public macro AddMember() = #externalMacro(module: "MacroPlugin", type: "AddMemberMacro")
+
+@AddMember
+struct TestStruct { }


### PR DESCRIPTION
See the attached test case. With the new Embedded Swift's mangling that uses $e as the prefix, we were failing to recognize macro-generated unique names, and rejecting them with "... is not covered by macro" if we were expanding macros while compiling in Embedded Swift mode. This fixes that.