### PR TITLE
[ConstraintSystem] Always choose an available type eraser type.

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -267,7 +267,7 @@ SIMPLE_DECL_ATTR(_inheritsConvenienceInitializers, InheritsConvenienceInitialize
   OnClass | UserInaccessible | NotSerialized | APIStableToAdd | ABIStableToAdd | APIBreakingToRemove | ABIBreakingToRemove,
   93)
 DECL_ATTR(_typeEraser, TypeEraser,
-  OnProtocol | UserInaccessible | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
+  OnProtocol | UserInaccessible | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove | AllowMultipleAttributes,
   94)
 SIMPLE_DECL_ATTR(IBSegueAction, IBSegueAction,
   OnFunc | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,


### PR DESCRIPTION
If no available type eraser type exists, do not perform type erasure. If multiple available type erasers exist, choose the least available type eraser type. The type eraser type's availability is compared against the availability within the lexical context of the erased expression to determine whether the type eraser type is available.

There may be better approaches, such as leveraging [SE-0360: Opaque result types with limited availability](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0360-opaque-result-types-with-availability.md) to choose the type eraser type at runtime, but this minimal change at least lets a type eraser type be replaced without causing runtime crashes when that new type is not available at runtime.

Resolves: rdar://144572195