### PR TITLE
Remove redundant word "error" from type name

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -81,7 +81,7 @@ import SwiftShims
 /// including the line and column numbers where the error occurred:
 ///
 ///     struct XMLParsingError: Error {
-///         enum ErrorKind {
+///         enum Kind {
 ///             case invalidCharacter
 ///             case mismatchedTag
 ///             case internalError
@@ -89,7 +89,7 @@ import SwiftShims
 ///
 ///         let line: Int
 ///         let column: Int
-///         let kind: ErrorKind
+///         let kind: Kind
 ///     }
 ///
 ///     func parse(_ source: String) throws -> XMLDoc {


### PR DESCRIPTION
The other examples in the documentation, here in the standard library and in The Swift Programming Language, use enums for their error type — this seems to be the only example in the docs of an error represented by a struct with a nested error kind.  So there isn't a strong precedent from that to tell us which way to do things here, or other places that we should also change to be consistent.

Fixes: rdar://41136833