### PR TITLE
[ASTGen] Generate OpaqueReturnTypeOfTypeAttr

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2262,26 +2262,37 @@ BridgedConventionTypeAttr BridgedConventionTypeAttr_createParsed(
     BridgedSourceLoc cNameLoc, BridgedDeclNameRef cWitnessMethodProtocol,
     BridgedStringRef cClangType, BridgedSourceLoc cClangTypeLoc);
 
-SWIFT_NAME("BridgedIsolatedTypeAttr.createParsed(_:atLoc:nameLoc:lpLoc:"
-           "isolationKindLoc:isolationKind:rpLoc:)")
-BridgedIsolatedTypeAttr BridgedIsolatedTypeAttr_createParsed(
-    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceLoc cNameLoc, BridgedSourceLoc cLPLoc,
-    BridgedSourceLoc cIsolationLoc,
-    BridgedIsolatedTypeAttrIsolationKind cIsolation, BridgedSourceLoc cRPLoc);
-
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedExecutionTypeAttrExecutionKind {
   BridgedExecutionTypeAttrExecutionKind_Concurrent,
   BridgedExecutionTypeAttrExecutionKind_Caller
 };
 
-SWIFT_NAME("BridgedExecutionTypeAttr.createParsed(_:atLoc:nameLoc:lpLoc:"
-           "behaviorLoc:behavior:rpLoc:)")
+SWIFT_NAME("BridgedExecutionTypeAttr.createParsed(_:atLoc:nameLoc:parensRange:"
+           "behavior:behaviorLoc:)")
 BridgedExecutionTypeAttr BridgedExecutionTypeAttr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceLoc cNameLoc, BridgedSourceLoc cLPLoc,
-    BridgedSourceLoc cBehaviorLoc,
-    BridgedExecutionTypeAttrExecutionKind behavior, BridgedSourceLoc cRPLoc);
+    BridgedSourceLoc cNameLoc, BridgedSourceRange cParensRange,
+    BridgedExecutionTypeAttrExecutionKind behavior,
+    BridgedSourceLoc cBehaviorLoc);
+
+SWIFT_NAME("BridgedIsolatedTypeAttr.createParsed(_:atLoc:nameLoc:parensRange:"
+           "isolationKind:isolationKindLoc:)")
+BridgedIsolatedTypeAttr BridgedIsolatedTypeAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceLoc cNameLoc, BridgedSourceRange cParensRange,
+
+    BridgedIsolatedTypeAttrIsolationKind cIsolation,
+    BridgedSourceLoc cIsolationLoc);
+
+SWIFT_NAME("BridgedOpaqueReturnTypeOfTypeAttr.createParsed(_:atLoc:nameLoc:"
+           "parensRange:"
+           "mangled:mangledLoc:index:indexLoc:)")
+BridgedOpaqueReturnTypeOfTypeAttr
+BridgedOpaqueReturnTypeOfTypeAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceLoc cKwLoc, BridgedSourceRange cParens,
+    BridgedStringRef cMangled, BridgedSourceLoc cMangledDoc, size_t index,
+    BridgedSourceLoc cIndexLoc);
 
 //===----------------------------------------------------------------------===//
 // MARK: TypeReprs

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -107,7 +107,6 @@ BridgedASTContext BridgedASTContext_fromRaw(void * _Nonnull ptr) {
   return *static_cast<swift::ASTContext *>(ptr);
 }
 
-BRIDGED_INLINE
 void *_Nullable BridgedASTContext_allocate(BridgedASTContext bridged,
                                            size_t size, size_t alignment) {
   return bridged.unbridged().Allocate(size, alignment);
@@ -157,7 +156,7 @@ BridgedDeclContext_getParentSourceFile(BridgedDeclContext dc) {
 // MARK: BridgedSoureFile
 //===----------------------------------------------------------------------===//
 
-BRIDGED_INLINE bool BridgedSourceFile_isScriptMode(BridgedSourceFile sf) {
+bool BridgedSourceFile_isScriptMode(BridgedSourceFile sf) {
   return sf.unbridged()->isScriptMode();
 }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2037,13 +2037,14 @@ namespace {
     void visitTypeAliasDecl(TypeAliasDecl *TAD, Label label) {
       printCommon(TAD, "typealias", label);
 
+      printWhereRequirements(TAD);
+      printAttributes(TAD);
+      
       if (auto underlying = TAD->getCachedUnderlyingType()) {
         printTypeField(underlying, Label::always("type"));
       } else {
-        printFlag("unresolved_type", TypeColor);
+        printRec(TAD->getUnderlyingTypeRepr(), Label::always("type_repr"));
       }
-      printWhereRequirements(TAD);
-      printAttributes(TAD);
 
       printFoot();
     }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2037,14 +2037,14 @@ namespace {
     void visitTypeAliasDecl(TypeAliasDecl *TAD, Label label) {
       printCommon(TAD, "typealias", label);
 
-      printWhereRequirements(TAD);
-      printAttributes(TAD);
-      
       if (auto underlying = TAD->getCachedUnderlyingType()) {
         printTypeField(underlying, Label::always("type"));
       } else {
         printRec(TAD->getUnderlyingTypeRepr(), Label::always("type_repr"));
       }
+
+      printWhereRequirements(TAD);
+      printAttributes(TAD);
 
       printFoot();
     }

--- a/lib/AST/Bridging/TypeAttributeBridging.cpp
+++ b/lib/AST/Bridging/TypeAttributeBridging.cpp
@@ -96,29 +96,11 @@ BridgedConventionTypeAttr BridgedConventionTypeAttr_createParsed(
       {cClangType.unbridged(), cClangTypeLoc.unbridged()});
 }
 
-BridgedIsolatedTypeAttr BridgedIsolatedTypeAttr_createParsed(
-    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceLoc cNameLoc, BridgedSourceLoc cLPLoc,
-    BridgedSourceLoc cIsolationLoc,
-    BridgedIsolatedTypeAttrIsolationKind cIsolation, BridgedSourceLoc cRPLoc) {
-  auto isolationKind = [=] {
-    switch (cIsolation) {
-    case BridgedIsolatedTypeAttrIsolationKind_DynamicIsolation:
-      return IsolatedTypeAttr::IsolationKind::Dynamic;
-    }
-    llvm_unreachable("bad kind");
-  }();
-  return new (cContext.unbridged())
-      IsolatedTypeAttr(cAtLoc.unbridged(), cNameLoc.unbridged(),
-                       {cLPLoc.unbridged(), cRPLoc.unbridged()},
-                       {isolationKind, cIsolationLoc.unbridged()});
-}
-
 BridgedExecutionTypeAttr BridgedExecutionTypeAttr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceLoc cNameLoc, BridgedSourceLoc cLPLoc,
-    BridgedSourceLoc cBehaviorLoc,
-    BridgedExecutionTypeAttrExecutionKind behavior, BridgedSourceLoc cRPLoc) {
+    BridgedSourceLoc cNameLoc, BridgedSourceRange cParensRange,
+    BridgedExecutionTypeAttrExecutionKind behavior,
+    BridgedSourceLoc cBehaviorLoc) {
   auto behaviorKind = [=] {
     switch (behavior) {
     case BridgedExecutionTypeAttrExecutionKind_Concurrent:
@@ -128,8 +110,37 @@ BridgedExecutionTypeAttr BridgedExecutionTypeAttr_createParsed(
     }
     llvm_unreachable("bad kind");
   }();
-  return new (cContext.unbridged())
-      ExecutionTypeAttr(cAtLoc.unbridged(), cNameLoc.unbridged(),
-                        {cLPLoc.unbridged(), cRPLoc.unbridged()},
-                        {behaviorKind, cBehaviorLoc.unbridged()});
+  return new (cContext.unbridged()) ExecutionTypeAttr(
+      cAtLoc.unbridged(), cNameLoc.unbridged(), cParensRange.unbridged(),
+      {behaviorKind, cBehaviorLoc.unbridged()});
+}
+
+BridgedIsolatedTypeAttr BridgedIsolatedTypeAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceLoc cNameLoc, BridgedSourceRange cParensRange,
+
+    BridgedIsolatedTypeAttrIsolationKind cIsolation,
+    BridgedSourceLoc cIsolationLoc) {
+  auto isolationKind = [=] {
+    switch (cIsolation) {
+    case BridgedIsolatedTypeAttrIsolationKind_DynamicIsolation:
+      return IsolatedTypeAttr::IsolationKind::Dynamic;
+    }
+    llvm_unreachable("bad kind");
+  }();
+  return new (cContext.unbridged()) IsolatedTypeAttr(
+      cAtLoc.unbridged(), cNameLoc.unbridged(), cParensRange.unbridged(),
+      {isolationKind, cIsolationLoc.unbridged()});
+}
+
+BridgedOpaqueReturnTypeOfTypeAttr
+BridgedOpaqueReturnTypeOfTypeAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceLoc cKwLoc, BridgedSourceRange cParens,
+    BridgedStringRef cMangled, BridgedSourceLoc cMangledLoc, size_t index,
+    BridgedSourceLoc cIndexLoc) {
+  return new (cContext.unbridged()) OpaqueReturnTypeOfTypeAttr(
+      cAtLoc.unbridged(), cKwLoc.unbridged(), cParens.unbridged(),
+      {cMangled.unbridged(), cMangledLoc.unbridged()},
+      {static_cast<unsigned int>(index), cIndexLoc.unbridged()});
 }

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -20,11 +20,12 @@
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 
 // RUN: %target-typecheck-verify-swift \
+// RUN:   -module-abi-name ASTGen \
+// RUN:   -enable-experimental-feature ParserASTGen \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-move-only \
-// RUN:   -enable-experimental-feature ParserASTGen \
 // RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
 
 // REQUIRES: executable_test
@@ -190,4 +191,14 @@ do {
   }
 }
 
-func testConvention(fn: @convention(c) (Int) -> Int) {}
+typealias testConvention = @convention(c) (Int) -> Int
+typealias testExecution = @execution(concurrent) () async -> Void
+typealias testIsolated = @isolated(any) () -> Void
+
+protocol OpProto {}
+struct OpStruct: OpProto {}
+struct OpTest {
+  func opResult() -> some OpProto { OpStruct() }
+  // FIXME: Implement SF->addUnvalidatedDeclWithOpaqueResultType() in ASTGen
+  // typealias Result = @_opaqueReturnTypeOf("$s6ASTGen6OpTestV8opResultQryF", 0) __
+}

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -199,6 +199,5 @@ protocol OpProto {}
 struct OpStruct: OpProto {}
 struct OpTest {
   func opResult() -> some OpProto { OpStruct() }
-  // FIXME: Implement SF->addUnvalidatedDeclWithOpaqueResultType() in ASTGen
-  // typealias Result = @_opaqueReturnTypeOf("$s6ASTGen6OpTestV8opResultQryF", 0) __
+  typealias Result = @_opaqueReturnTypeOf("$s6ASTGen6OpTestV8opResultQryF", 0) __
 }


### PR DESCRIPTION
Also rework existing type attribute functions to use the standard attribute arguments facilities.

Move the `SF->addUnvalidatedDeclWithOpaqueResultType(VD)` logic out of `Parser`, so `Parse` and `ASTGen` can share the logic.