### PR TITLE
[PrintAsClang] Kill declaration sorting bugs super-dead

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6345,6 +6345,17 @@ ERROR(invalid_objc_swift_rooted_class,none,
 NOTE(invalid_objc_swift_root_class_insert_nsobject,none,
      "inherit from 'NSObject' to silence this error", ())
 
+WARNING(objc_header_sorting_arbitrary,none,
+        "arbitrarily printing %0 before %1 in generated header; subsequent "
+        "compilations may print them in a different order",
+        (Decl *, Decl *))
+NOTE(objc_header_sorting_arbitrary_other,none,
+     "%1 will be printed after %0 during this compilation",
+     (Decl *, Decl *))
+NOTE(objc_header_sorting_arbitrary_please_report,none,
+     "please report this as a bug in the Swift compiler and describe both "
+     "declarations", ())
+
 ERROR(invalid_nonobjc_decl,none,
       "only class members and extensions of classes can be declared @nonobjc", ())
 ERROR(invalid_nonobjc_extension,none,

--- a/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
 
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
 
 // RUN: %FileCheck %s --input-file %t/UseCxxTy.h
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -disable-availability-checking
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -disable-availability-checking
 
 // RUN: %FileCheck %s --input-file %t/UseCxxTyExposeOnly.h
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-objcxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %S/bridge-cxx-struct-back-to-cxx.swift %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
 // RUN: echo "#include \"header.h\"" > %t/full-cxx-swift-cxx-bridging.h
 // RUN: cat %t/UseCxxTy.h >> %t/full-cxx-swift-cxx-bridging.h
 

--- a/test/Interop/CxxToSwiftToCxx/consuming-cxx-struct-parameter-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/consuming-cxx-struct-parameter-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxx -typecheck -verify -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o
 // RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -O -Xfrontend -disable-availability-checking

--- a/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
+++ b/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxx -typecheck -verify -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // Use the 'DEBUG' flug to force llvm used
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -DDEBUG

--- a/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -disable-availability-checking -Xcc -DSIMD_NO_CODE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -disable-availability-checking -Xcc -DSIMD_NO_CODE
 
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 

--- a/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-span.swift -typecheck -module-name UseSpan -emit-clang-header-path %t/UseSpan.h -I %t -enable-experimental-cxx-interop -Xcc -Xclang -Xcc -fmodule-format=raw -Xcc -std=c++20 -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend %t/use-span.swift -module-name UseSpan -typecheck -verify -emit-clang-header-path %t/UseSpan.h -I %t -enable-experimental-cxx-interop -Xcc -Xclang -Xcc -fmodule-format=raw -Xcc -std=c++20 -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-span.cpp -I %t -o %t/swift-cxx-execution.o
 // RUN: %target-interop-build-swift %t/use-span.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseSpan -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -O -Xcc --std=c++20

--- a/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -target arm64-apple-macosx13.3
+// RUN: %target-swift-frontend %s -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -target arm64-apple-macosx13.3
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 
 // REQUIRES: OS=macosx

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-objc-types.swift -typecheck -module-name UseObjCTy -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend %t/use-objc-types.swift -module-name UseObjCTy -typecheck -verify -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -fobjc-arc -c %t/use-swift-objc-types.mm -I %t -o %t/swift-objc-execution.o
 // RUN: %target-interop-build-swift %t/use-objc-types.swift -o %t/swift-objc-execution -Xlinker %t/swift-objc-execution.o -module-name UseObjCTy -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-objc-types.swift -typecheck -module-name UseObjCTy -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend %t/use-objc-types.swift -module-name UseObjCTy -typecheck -verify -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %FileCheck %s < %t/UseObjCTy.h
 

--- a/test/Interop/SwiftToC/functions/swift-function-argument-keyword-in-c.swift
+++ b/test/Interop/SwiftToC/functions/swift-function-argument-keyword-in-c.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // CHECK: SWIFT_EXTERN void $s9Functions19testKeywordArgument8registerySi_tF(ptrdiff_t register_) SWIFT_NOEXCEPT SWIFT_CALL;

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging-long-lp64.swift
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging-long-lp64.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-c-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-abi < %t/functions.h
 
 // RUN: %check-interop-c-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-execution-long-lp64.c
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-execution-long-lp64.c
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-primitive-functions-c-bridging-long-lp64.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-primitive-functions-c-bridging-long-lp64.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clang -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/swift-primitive-functions-c-bridging-long-lp64.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-primitive-functions-c-bridging.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-primitive-functions-c-bridging.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clang -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/swift-primitive-functions-c-bridging.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c-execution.c
+++ b/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c-execution.c
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-c.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-c.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clang -c %s -I %t -o %t/swift-structs-execution.o
 // RUN: %target-interop-build-swift %S/large-structs-pass-return-indirect-in-c.swift -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c.swift
+++ b/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-c-header-in-clang(%t/structs.h)

--- a/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-c-header-in-clang(%t/structs.h -Wno-unused-function)

--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c-execution.c
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c-execution.c
@@ -2,7 +2,7 @@
 
 // RUN: cat %S/small-structs-pass-return-direct-in-c.swift %S/small-structs-64-bit-pass-return-direct-in-c.swift > %t/full-small-structs-pass-return-direct-in-c.swift
 
-// RUN: %target-swift-frontend %t/full-small-structs-pass-return-direct-in-c.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %t/full-small-structs-pass-return-direct-in-c.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clang -c %s -I %t -o %t/swift-structs-execution.o -Wno-incompatible-pointer-types
 // RUN: %target-interop-build-swift %t/full-small-structs-pass-return-direct-in-c.swift -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-c-header-in-clang(%t/structs.h -Wno-unused-function)

--- a/test/Interop/SwiftToCxx/class/class-api-prohibited.cpp
+++ b/test/Interop/SwiftToCxx/class/class-api-prohibited.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 
 // RUN: not %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 

--- a/test/Interop/SwiftToCxx/class/swift-actor-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-actor-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -typecheck -module-name Actor -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/actor.h -disable-availability-checking
+// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/actor.h -disable-availability-checking
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-actor-execution.o
 // RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t/swift-actor-execution -Xlinker %t/swift-actor-execution.o -module-name Actor -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -disable-availability-checking
@@ -10,7 +10,7 @@
 
 // RUN: %empty-directory(%t-evo)
 
-// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -typecheck -module-name Actor -clang-header-expose-decls=has-expose-attr -enable-library-evolution -emit-clang-header-path %t-evo/actor.h -disable-availability-checking
+// RUN: %target-swift-frontend %S/swift-actor-in-cxx.swift -module-name Actor -clang-header-expose-decls=has-expose-attr -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo/actor.h -disable-availability-checking
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-actor-execution.o
 // RUN: %target-interop-build-swift %S/swift-actor-in-cxx.swift -o %t-evo/swift-actor-execution-evo -Xlinker %t-evo/swift-actor-execution.o -module-name Actor -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -disable-availability-checking

--- a/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Actor -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/actor.h -disable-availability-checking
+// RUN: %target-swift-frontend %s -module-name Actor -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/actor.h -disable-availability-checking
 // RUN: %FileCheck %s < %t/actor.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/actor.h)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Actor  -emit-clang-header-path %t/actor-public.h -enable-experimental-cxx-interop -disable-availability-checking
+// RUN: %target-swift-frontend %s -module-name Actor  -typecheck -verify -emit-clang-header-path %t/actor-public.h -enable-experimental-cxx-interop -disable-availability-checking
 // RN: %FileCheck %s < %t/actor-public.h
 // RUN: %check-interop-cxx-header-in-clang(%t/actor-public.h)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Actor -enable-library-evolution -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/actor-evo.h -disable-availability-checking
+// RUN: %target-swift-frontend %s -module-name Actor -enable-library-evolution -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/actor-evo.h -disable-availability-checking
 // RUN: %FileCheck %s < %t/actor-evo.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/actor-evo.h)

--- a/test/Interop/SwiftToCxx/class/swift-class-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-availability-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h)

--- a/test/Interop/SwiftToCxx/class/swift-class-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-class-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t-onone)
 
-// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t-onone/class.h -Onone
+// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-onone/class.h -Onone
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-onone -o %t-onone/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-in-cxx.swift -o %t-onone/swift-class-execution -Xlinker %t-onone/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Onone
@@ -14,7 +14,7 @@
 
 // RUN: %empty-directory(%t-ofast)
 
-// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t-ofast/class.h -O
+// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-ofast/class.h -O
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-ofast -o %t-ofast/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-in-cxx.swift -o %t-ofast/swift-class-execution -Xlinker %t-ofast/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain -O
@@ -26,7 +26,7 @@
 
 // RUN: %empty-directory(%t-evo-onone)
 
-// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -enable-library-evolution -emit-clang-header-path %t-evo-onone/class.h -Onone
+// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo-onone/class.h -Onone
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo-onone -o %t-evo-onone/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-in-cxx.swift -o %t-evo-onone/swift-class-execution-evo -Xlinker %t-evo-onone/swift-class-execution.o -module-name Class -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Onone
@@ -38,7 +38,7 @@
 
 // RUN: %empty-directory(%t-evo-ofast)
 
-// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -enable-library-evolution -emit-clang-header-path %t-evo-ofast/class.h -O
+// RUN: %target-swift-frontend %S/swift-class-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo-ofast/class.h -O
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo-ofast -o %t-evo-ofast/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-in-cxx.swift -o %t-evo-ofast/swift-class-execution-evo -Xlinker %t-evo-ofast/swift-class-execution.o -module-name Class -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain -O

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class-evo.h
+// RUN: %target-swift-frontend %s -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class-evo.h
 // RUN: %FileCheck %s < %t/class-evo.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class-evo.h)

--- a/test/Interop/SwiftToCxx/class/swift-class-inheritance-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-class-inheritance-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-class-inheritance-in-cxx.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %S/swift-class-inheritance-in-cxx.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-inheritance-in-cxx.swift -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain
@@ -13,7 +13,7 @@
 
 // RUN: %empty-directory(%t-evo)
 
-// RUN: %target-swift-frontend %S/swift-class-inheritance-in-cxx.swift -typecheck -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t-evo/class.h
+// RUN: %target-swift-frontend %S/swift-class-inheritance-in-cxx.swift -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-evo/class.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-inheritance-in-cxx.swift -o %t-evo/swift-class-execution-evo -Xlinker %t-evo/swift-class-execution.o -module-name Class -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/class/swift-class-inheritance-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-inheritance-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class-evo.h
+// RUN: %target-swift-frontend %s -module-name Class -enable-library-evolution -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class-evo.h
 // RUN: %FileCheck %s < %t/class-evo.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class-evo.h)

--- a/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h)
 

--- a/test/Interop/SwiftToCxx/class/swift-class-static-variables-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-class-static-variables-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-class-static-variables.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %S/swift-class-static-variables.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-static-variables.swift -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
@@ -1,6 +1,6 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-virtual-method-dispatch.swift -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %target-swift-frontend %s -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h -enable-library-evolution
+// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h -enable-library-evolution
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 // RUN: %target-interop-build-swift %S/swift-class-virtual-method-dispatch.swift -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-library-evolution

--- a/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h -enable-library-evolution
+// RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -module-name Class -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/class.h -enable-library-evolution
 // RUN: %FileCheck %s < %t/class.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -D RESILIENT_MODULE -module-name Class -emit-module -emit-module-path %t/Class.swiftmodule -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
 
-// RUN: %target-swift-frontend %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -I %t -typecheck -module-name UseClass -clang-header-expose-decls=all-public -emit-clang-header-path %t/useclass.h
+// RUN: %target-swift-frontend %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -I %t -module-name UseClass -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/useclass.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
 

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -D RESILIENT_MODULE -module-name Class -emit-module -emit-module-path %t/Class.swiftmodule -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
 
-// RUN: %target-swift-frontend %s -I %t -typecheck -module-name UseClass -clang-header-expose-decls=all-public -emit-clang-header-path %t/useclass.h
+// RUN: %target-swift-frontend %s -I %t -module-name UseClass -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/useclass.h
 
 // RUN: %FileCheck %s < %t/useclass.h
 

--- a/test/Interop/SwiftToCxx/core/embedded-swift.swift
+++ b/test/Interop/SwiftToCxx/core/embedded-swift.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Core -target arm64-apple-macos15.0 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %s -module-name Core -target arm64-apple-macos15.0 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // REQUIRES: OS=macosx

--- a/test/Interop/SwiftToCxx/core/gen-header-for-module.swift
+++ b/test/Interop/SwiftToCxx/core/gen-header-for-module.swift
@@ -1,21 +1,21 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -module-name Core -o %t
-// RUN: %target-swift-frontend -parse-as-library %t/Core.swiftmodule -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend -parse-as-library %t/Core.swiftmodule -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // RUN: %empty-directory(%t-evo)
 // RUN: %target-swift-frontend %s -emit-module -enable-library-evolution -module-name Core -o %t-evo
-// RUN: %target-swift-frontend -parse-as-library %t-evo/Core.swiftmodule -enable-library-evolution -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t-evo/core.h
+// RUN: %target-swift-frontend -parse-as-library %t-evo/Core.swiftmodule -enable-library-evolution -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-evo/core.h
 // RUN: %FileCheck %s < %t-evo/core.h
 
 // RUN: %empty-directory(%t-int)
 // RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t-int/Core.swiftinterface -module-name Core
-// RUN: %target-swift-frontend -parse-as-library %t-int/Core.swiftinterface -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t-int/core.h
+// RUN: %target-swift-frontend -parse-as-library %t-int/Core.swiftinterface -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-int/core.h
 // RUN: %FileCheck %s < %t-int/core.h
 
 // RUN: %empty-directory(%t-int-evo)
 // RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -emit-module-interface-path %t-int-evo/Core.swiftinterface -module-name Core
-// RUN: %target-swift-frontend -parse-as-library %t-int-evo/Core.swiftinterface -typecheck -enable-library-evolution -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t-int-evo/core.h
+// RUN: %target-swift-frontend -parse-as-library %t-int-evo/Core.swiftinterface -enable-library-evolution -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t-int-evo/core.h
 // RUN: %FileCheck %s < %t-int-evo/core.h
 
 public func reprintedInImportedModule() -> Int {

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-64-bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-64-bit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/core.h)

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/core.h)

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 // RUN: %FileCheck %s < %t/core.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/core.h)

--- a/test/Interop/SwiftToCxx/core/validate-swift-impl-defs-in-cxx.cpp
+++ b/test/Interop/SwiftToCxx/core/validate-swift-impl-defs-in-cxx.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-impl-defs-in-cxx.swift -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %target-swift-frontend %S/swift-impl-defs-in-cxx.swift -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
 
 // RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o %t/swift-core-validation.o
 // RUN: %target-interop-build-clangxx -std=c++20 -c %s -I %t -o %t/swift-core-validation.o

--- a/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h
+// RUN: %target-swift-frontend %s -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/uses-structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/uses-structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 // RUN: %FileCheck %s < %t/uses-structs.h

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/enums.swift -module-name Enums -emit-module -emit-module-path %t/Enums.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesEnums -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-enums.h -clang-header-expose-module Enums=enums.h
+// RUN: %target-swift-frontend %s -module-name UsesEnums -I %t -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/uses-enums.h -clang-header-expose-module Enums=enums.h
 
 // RUN: %FileCheck %s < %t/uses-enums.h
 

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
+// RUN: %target-swift-frontend %s -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
 
 // RUN: %FileCheck %s < %t/uses-structs.h
 // RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -cxx-interoperability-mode=default -emit-clang-header-path %t/uses-structs-default.h -clang-header-expose-module Structs=structs.h
+// RUN: %target-swift-frontend %s -module-name UsesStructs -I %t -cxx-interoperability-mode=default -typecheck -verify -emit-clang-header-path %t/uses-structs-default.h -clang-header-expose-module Structs=structs.h
 // RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs-default.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 import Structs

--- a/test/Interop/SwiftToCxx/cross-module-refs/not-referenced-cross-module-import.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/not-referenced-cross-module-import.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
+// RUN: %target-swift-frontend %s -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
 
 // RUN: %FileCheck %s < %t/uses-structs.h
 // RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h)

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/enum-associated-value-class-type-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %S/enum-associated-value-class-type-cxx.swift -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
 // RUN: %target-interop-build-swift %S/enum-associated-value-class-type-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
@@ -10,7 +10,7 @@
 
 // RUN: %empty-directory(%t-evo)
 
-// RUN: %target-swift-frontend %S/enum-associated-value-class-type-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=all-public -enable-library-evolution -emit-clang-header-path %t-evo/enums.h
+// RUN: %target-swift-frontend %S/enum-associated-value-class-type-cxx.swift -module-name Enums -clang-header-expose-decls=all-public -enable-library-evolution -typecheck -verify -emit-clang-header-path %t-evo/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-enums-execution.o
 // RUN: %target-interop-build-swift %S/enum-associated-value-class-type-cxx.swift -o %t-evo/swift-enums-execution -Xlinker %t-evo/swift-enums-execution.o -module-name Enums -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 public enum Foo: Hashable, Sendable {

--- a/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/large-enums-pass-return-in-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %S/large-enums-pass-return-in-cxx.swift -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
 // RUN: %target-interop-build-swift %S/large-enums-pass-return-in-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/resilient-enum-in-cxx.swift -enable-library-evolution -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %S/resilient-enum-in-cxx.swift -enable-library-evolution -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
 

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck --check-prefixes=CHECK,OLD_CASE %s < %t/enums.h
 
-// RUN: %target-swift-frontend %s -enable-library-evolution -D NEW_CASE -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums_new_case.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -D NEW_CASE -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums_new_case.h
 // RUN: %FileCheck --check-prefixes=CHECK,NEW_CASE %s < %t/enums_new_case.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/small-enums-pass-return-in-cxx.swift -typecheck -module-name Enums -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %S/small-enums-pass-return-in-cxx.swift -module-name Enums -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
 // RUN: %target-interop-build-swift %S/small-enums-pass-return-in-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-enum-implementation.swift -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %S/swift-enum-implementation.swift -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
 // RUN: %target-interop-build-swift %S/swift-enum-implementation.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -enable-experimental-cxx-interop -emit-clang-header-path %t/enums-default.h
+// RUN: %target-swift-frontend %s -module-name Enums -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/enums-default.h
 // RUN: %FileCheck %s < %t/enums-default.h
 
 public enum E {

--- a/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %target-swift-frontend %s -module-name Enums -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
 public enum EmptyEnum {}

--- a/test/Interop/SwiftToCxx/expose-attr/expose-rename-to-unavailable-decl.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-rename-to-unavailable-decl.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Expose -enable-experimental-cxx-interop -emit-clang-header-path %t/expose.h
+// RUN: %target-swift-frontend %s -module-name Expose -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/expose.h
 // RUN: %FileCheck %s < %t/expose.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/expose.h -Wno-error=unused-function)

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -1,22 +1,22 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/expose.h
+// RUN: %target-swift-frontend %s -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/expose.h
 // RUN: %FileCheck %s < %t/expose.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/expose.h -Wno-error=unused-function)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -module-name Expose -o %t
-// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftmodule -typecheck -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/expose.h
+// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftmodule -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/expose.h
 // RUN: %FileCheck %s < %t/expose.h
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -emit-module-interface-path %t/Expose.swiftinterface -module-name Expose
-// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/expose.h
+// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-name Expose -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/expose.h
 // RUN: %FileCheck %s < %t/expose.h
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -emit-module-interface-path %t/Expose.swiftinterface -module-name Expose
-// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Expose -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/expose.h
+// RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-name Expose -clang-header-expose-decls=has-expose-attr-or-stdlib -typecheck -verify -emit-clang-header-path %t/expose.h
 // RUN: %FileCheck %s < %t/expose.h
 
 @_expose(Cxx)

--- a/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/PrintAsCxx/function_with_array.swift
+++ b/test/Interop/SwiftToCxx/functions/PrintAsCxx/function_with_array.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -clang-header-expose-decls=all-public -emit-clang-header-path %t/function_with_array.h
+// RUN: %target-swift-frontend %s -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/function_with_array.h
 // RUN: %FileCheck %s < %t/function_with_array.h
 
 // CHECK: namespace function_with_array

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/cdecl.swift -module-name CdeclFunctions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/cdecl-execution.o
 // RUN: %target-interop-build-swift %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name CdeclFunctions -clang-header-expose-decls=all-public -emit-clang-header-path %t/cdecl.h
+// RUN: %target-swift-frontend %s -module-name CdeclFunctions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/cdecl.h
 // RUN: %FileCheck %s < %t/cdecl.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/cdecl.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -Xcc -fno-exceptions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-functions-errors.swift -module-name Functions -Xcc -fno-exceptions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -fno-exceptions -o %t/swift-expected-execution.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
 // RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-expected-execution -Xlinker %t/swift-expected-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX

--- a/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-functions-errors.swift -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-errors-execution.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
 // RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-functions-errors-execution -Xlinker %t/swift-functions-errors-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h  -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-swift-frontend %S/swift-functions.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h  -cxx-interoperability-mode=upcoming-swift
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o -g
 // RUN: %target-interop-build-swift %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -g

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h  -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h  -cxx-interoperability-mode=upcoming-swift
 // RUN: %FileCheck %s < %t/functions.h
 
 import CxxStdlib

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -target %target-swift-5.1-abi-triple -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -target %target-swift-5.1-abi-triple -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Operators -clang-header-expose-decls=all-public -emit-clang-header-path %t/operators.h
+// RUN: %target-swift-frontend %s -module-name Operators -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/operators.h
 // RUN: %FileCheck %s < %t/operators.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/operators.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-abi < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-primitive-functions-cxx-bridging.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-primitive-functions-cxx-bridging.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/swift-primitive-functions-cxx-bridging.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-primitive-inout-functions-cxx-bridging.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-primitive-inout-functions-cxx-bridging.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/swift-primitive-inout-functions-cxx-bridging.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/swift-transparent-functions-cxx-bridging.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/swift-transparent-functions-cxx-bridging.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/swift-transparent-functions-cxx-bridging.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-enum-in-cxx.swift -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-enum-in-cxx.swift -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-enum-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Generics -enable-experimental-cxx-interop -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -module-name Generics -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
@@ -33,6 +33,7 @@ public struct StructForEnum {
 }
 
 @frozen public enum GenericOpt<T> {
+    // expected-note@-1 {{'T' previously declared here}}
     case none
     case some(T)
 
@@ -46,6 +47,7 @@ public struct StructForEnum {
     }
 
     public func genericMethod<T>(_ x: T) -> T {
+        // expected-warning@-1 {{generic parameter 'T' shadows generic parameter from outer scope with the same name}}
         print("GenericOpt<T>::genericMethod<T>::\(self),\(x);")
         return x
     }

--- a/test/Interop/SwiftToCxx/generics/generic-function-cxx-type-invalid.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-function-cxx-type-invalid.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o /dev/null -DUSE_TYPE=int
 // RUN: %target-interop-build-clangxx -std=gnu++17 -c %s -I %t -o /dev/null -DUSE_TYPE=int

--- a/test/Interop/SwiftToCxx/generics/generic-function-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-function-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/generic-function-in-cxx.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions-evo.h
+// RUN: %target-swift-frontend %s -module-name Functions -enable-library-evolution -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions-evo.h
 // RUN: %FileCheck %s < %t/functions-evo.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions-evo.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/generics/generic-struct-as-generic-func-arg-in-cpp.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-as-generic-func-arg-in-cpp.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/generics.swift -typecheck -module-name Generics -enable-experimental-cxx-interop -emit-clang-header-path %t/Generics-Swift.h
+// RUN: %target-swift-frontend %t/generics.swift -module-name Generics -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Generics-Swift.h
 
 // RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/generics.cpp -I %t -o %t/generics.o
 // RUN: %target-build-swift %t/generics.swift -o %t/generics -Xlinker %t/generics.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-direct.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-direct.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-indirect.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-indirect.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
@@ -8,7 +8,7 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
@@ -39,6 +39,7 @@ class ClassWithT<T>: CustomStringConvertible {
 
 @frozen
 public struct GenericPair<T, T2> {
+    // expected-note@-1 {{'T' previously declared here}}
     #if KNOWN_LAYOUT
     var x_: ClassWithT<T>
     var y_: ClassWithT<T2>
@@ -108,6 +109,7 @@ public struct GenericPair<T, T2> {
     }
 
     public func genericMethod<T>(_ x: T, _ y: T2) -> T {
+        // expected-warning@-1 {{generic parameter 'T' shadows generic parameter from outer scope with the same name}}
         print("GenericPair<T, T2>::genericMethod<T>::\(x),\(y);")
         return x
     }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift  -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift  -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 

--- a/test/Interop/SwiftToCxx/generics/generic-type-cxx-type-invalid.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-type-cxx-type-invalid.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o /dev/null -DUSE_TYPE=int
 // RUN: %target-interop-build-clangxx -std=gnu++17 -c %s -I %t -o /dev/null -DUSE_TYPE=int

--- a/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Generics -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -module-name Generics -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h)
 

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-function-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-function-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -typecheck -module-name Functions -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %S/generic-function-in-cxx.swift -module-name Functions -enable-library-evolution -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-interop-build-swift %S/generic-function-in-cxx.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -enable-library-evolution -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-direct.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-direct.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-indirect.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-indirect.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -enable-library-evolution -module-name Generics -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/generics.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
 // RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/init-in-cxx.swift -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits.h
+// RUN: %target-swift-frontend %S/init-in-cxx.swift -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/inits.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-init-execution.o
 // RUN: %target-interop-build-swift %S/init-in-cxx.swift -o %t/swift-init-execution -Xlinker %t/swift-init-execution.o -module-name Init -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits.h
+// RUN: %target-swift-frontend %s -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/inits.h
 // RUN: %FileCheck %s < %t/inits.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/inits.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -swift-version 5 -emit-clang-header-path %t/inits2.h
+// RUN: %target-swift-frontend %s -module-name Init -clang-header-expose-decls=all-public -swift-version 5 -typecheck -verify -emit-clang-header-path %t/inits2.h
 // RUN: %FileCheck %s < %t/inits2.h
 
 

--- a/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %s -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
+++ b/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name MacroNameCollision -clang-header-expose-decls=all-public -emit-clang-header-path %t/macros.h
+// RUN: %target-swift-frontend %s -module-name MacroNameCollision -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/macros.h
 // RUN: %FileCheck %s < %t/macros.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/macros.h)
@@ -8,9 +8,11 @@
 
 @freestanding(expression)
 public macro myLogMacro(error: String) = #externalMacro(module: "CompilerPlugin", type: "LogMacro")
+// expected-warning@-1 {{plugin for module 'CompilerPlugin' not found}}
 
 @freestanding(expression)
 public macro myLogMacro(fault: String) = #externalMacro(module: "CompilerPlugin", type: "LogMacro")
+// expected-warning@-1 {{plugin for module 'CompilerPlugin' not found}}
 
 // CHECK: // Unavailable in C++: Swift macro 'myLogMacro(error:)'
 // CHECK: // Unavailable in C++: Swift macro 'myLogMacro(fault:)'

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/method-in-cxx.swift -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %S/method-in-cxx.swift -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-methods-execution.o
 // RUN: %target-interop-build-swift %S/method-in-cxx.swift -o %t/swift-methods-execution -Xlinker %t/swift-methods-execution.o -module-name Methods -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %s -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/mutating-method-in-cxx.swift -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %S/mutating-method-in-cxx.swift -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-methods-execution.o
 // RUN: %target-interop-build-swift %S/mutating-method-in-cxx.swift -o %t/swift-methods-execution -Xlinker %t/swift-methods-execution.o -module-name Methods -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %s -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %s -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/module/module-to-namespace.swift
+++ b/test/Interop/SwiftToCxx/module/module-to-namespace.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Test -clang-header-expose-decls=all-public -emit-clang-header-path %t/empty.h
+// RUN: %target-swift-frontend %s -module-name Test -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/empty.h
 // RUN: %FileCheck %s < %t/empty.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/empty.h)

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/consuming-parameter-in-cxx.swift -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/consuming.h
+// RUN: %target-swift-frontend %S/consuming-parameter-in-cxx.swift -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/consuming.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-consume-execution.o
 // RUN: %target-interop-build-swift %S/consuming-parameter-in-cxx.swift -o %t/swift-consume-execution -Xlinker %t/swift-consume-execution.o -module-name Init -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits.h
+// RUN: %target-swift-frontend %s -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/inits.h
 // RUN: %FileCheck --check-prefixes=CHECK,CHECK-NON_EVO %s < %t/inits.h
 // RUN: %check-interop-cxx-header-in-clang(%t/inits.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits-evo.h -enable-library-evolution
+// RUN: %target-swift-frontend %s -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/inits-evo.h -enable-library-evolution
 // RUN: %FileCheck %s < %t/inits-evo.h
 // RUN: %check-interop-cxx-header-in-clang(%t/inits-evo.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 

--- a/test/Interop/SwiftToCxx/ownership/resilient-consuming-parameter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/ownership/resilient-consuming-parameter-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/consuming-parameter-in-cxx.swift -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/consuming.h -enable-library-evolution
+// RUN: %target-swift-frontend %S/consuming-parameter-in-cxx.swift -module-name Init -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/consuming.h -enable-library-evolution
 
 // RUN: %target-interop-build-clangxx -c %S/consuming-parameter-in-cxx-execution.cpp -I %t -o %t/swift-consume-execution.o
 // RUN: %target-interop-build-swift %S/consuming-parameter-in-cxx.swift -o %t/swift-consume-execution-evo -Xlinker %t/swift-consume-execution.o -module-name Init -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-library-evolution

--- a/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %s -module-name Properties -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/getter-in-cxx.swift -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %S/getter-in-cxx.swift -module-name Properties -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/properties.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-props-execution.o
 // RUN: %target-interop-build-swift %S/getter-in-cxx.swift -o %t/swift-props-execution -Xlinker %t/swift-props-execution.o -module-name Properties -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %s -module-name Properties -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/properties/name-collision.swift
+++ b/test/Interop/SwiftToCxx/properties/name-collision.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -clang-header-expose-decls=all-public -emit-clang-header-path %t/name-collision.h
+// RUN: %target-swift-frontend %s -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/name-collision.h
 // RUN: %FileCheck %s < %t/name-collision.h
 
 public class C0 {

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/setter-in-cxx.swift -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %S/setter-in-cxx.swift -module-name Properties -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/properties.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-props-execution.o
 // RUN: %target-interop-build-swift %S/setter-in-cxx.swift -o %t/swift-props-execution -Xlinker %t/swift-props-execution.o -module-name Properties -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %s -module-name Properties -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
+// RUN: %target-swift-frontend %s -module-name Methods -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/stdlib/array/array-execution-cxx17.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/array/array-execution-cxx17.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %S/array-execution.cpp %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-array.swift -typecheck -module-name UseArray -enable-experimental-cxx-interop -emit-clang-header-path %t/UseArray.h
+// RUN: %target-swift-frontend %t/use-array.swift -module-name UseArray -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseArray.h
 
 // RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++17 -c %t/array-execution.cpp -I %t -o %t/swift-stdlib-execution.o
 // RUN: %target-build-swift %t/use-array.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseArray -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/stdlib/array/array-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/array/array-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-array.swift -typecheck -module-name UseArray -enable-experimental-cxx-interop -emit-clang-header-path %t/UseArray.h
+// RUN: %target-swift-frontend %t/use-array.swift -module-name UseArray -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseArray.h
 
 // RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/array-execution.cpp -I %t -o %t/swift-stdlib-execution.o
 // RUN: %target-build-swift %t/use-array.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseArray -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/stdlib/combination-of-stdlib-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/combination-of-stdlib-generics-in-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -emit-clang-header-path %t/stdlib.h
+// RUN: %target-swift-frontend %s -module-name UseOptional -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/stdlib.h
 // RUN: %FileCheck %s < %t/stdlib.h
 
 // RUN: %check-interop-cxx-header-in-clang(-DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY %t/stdlib.h -Wno-unused-private-field -Wno-unused-function)

--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/UseCoreFoundation.h
+// RUN: %target-swift-frontend %s -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseCoreFoundation.h
 // RUN: %FileCheck %s < %t/UseCoreFoundation.h
 
 // REQUIRES: objc_interop

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseFoundation -enable-experimental-cxx-interop -emit-clang-header-path %t/UseFoundation.h
+// RUN: %target-swift-frontend %s -module-name UseFoundation -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseFoundation.h
 // RUN: %FileCheck %s < %t/UseFoundation.h
 
 // REQUIRES: objc_interop

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-optional.swift -typecheck -module-name UseOptional -enable-experimental-cxx-interop -emit-clang-header-path %t/UseOptional.h
+// RUN: %target-swift-frontend %t/use-optional.swift -module-name UseOptional -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/UseOptional.h
 
 // RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/optional-execution.cpp -I %t -o %t/swift-stdlib-execution.o
 // RUN: %target-build-swift %t/use-optional.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name UseOptional -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/useopt.h
+// RUN: %target-swift-frontend %s -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/useopt.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/useopt.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -emit-clang-header-path %t/stdlib.h
+// RUN: %target-swift-frontend %s -module-name UseOptional -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/stdlib.h
 // RUN: %FileCheck %s < %t/stdlib.h
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/stdlib_expose_flag.h
+// RUN: %target-swift-frontend %s -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -typecheck -verify -emit-clang-header-path %t/stdlib_expose_flag.h
 // RUN: %FileCheck %s < %t/stdlib_expose_flag.h
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional2 -enable-experimental-cxx-interop -emit-clang-header-path %t/stdlib2.h
+// RUN: %target-swift-frontend %s -module-name UseOptional2 -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/stdlib2.h
 
 // RUN: cat %t/stdlib.h %t/stdlib2.h > %t/two_includes.h
 

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
+// RUN: %target-swift-frontend %t/print-string.swift -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
 
 // Ensure: we don't hit any spurious warnings instantiating
 // C++ standard library templates because of the generated header.

--- a/test/Interop/SwiftToCxx/stdlib/string/string-conversions.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-conversions.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
+// RUN: %target-swift-frontend %t/print-string.swift -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o
 // RUN: %target-build-swift %t/print-string.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name Stringer -Xfrontend -entry-point-function-name -Xfrontend swiftMain %target-cxx-lib

--- a/test/Interop/SwiftToCxx/stdlib/string/string-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-in-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
+// RUN: %target-swift-frontend %t/print-string.swift -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o -DDEBUG=1
 // RUN: %target-build-swift %t/print-string.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name Stringer -Xfrontend -entry-point-function-name -Xfrontend swiftMain %target-cxx-lib

--- a/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/create_string.swift -typecheck -module-name StringCreator -enable-experimental-cxx-interop -emit-clang-header-path %t/StringCreator.h
+// RUN: %target-swift-frontend %t/create_string.swift -module-name StringCreator -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/StringCreator.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c %t/string-to-nsstring.mm -I %t -o %t/swift-stdlib-execution.o
 // RUN: %target-build-swift %t/use_foundation.swift %t/create_string.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name StringCreator -Xfrontend -entry-point-function-name -Xfrontend swiftMain -lc++

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-imported-into-framework-module.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-imported-into-framework-module.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/TestFmSwift.swift -typecheck -module-name TestFm -enable-experimental-cxx-interop -emit-clang-header-path %t/TestFm.framework/Headers/TestFm-Swift.h
+// RUN: %target-swift-frontend %t/TestFmSwift.swift -module-name TestFm -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/TestFm.framework/Headers/TestFm-Swift.h
 
-// RUN: %target-swift-frontend -typecheck %t/SecondSwift.swift -typecheck -module-name Second -enable-experimental-cxx-interop -emit-clang-header-path %t/Second.framework/Headers/Second-Swift.h
+// RUN: %target-swift-frontend %t/SecondSwift.swift -module-name Second -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Second.framework/Headers/Second-Swift.h
 
 // RUN: %target-interop-build-clangxx -std=gnu++17 -fmodules -fcxx-modules -c %t/consumer.cpp -F %t -fsyntax-only -Werror=non-modular-include-in-framework-module
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-synchronization-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-synchronization-in-cxx.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseSynchronization -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/UseSynchronization.h
+// RUN: %target-swift-frontend %s -module-name UseSynchronization -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseSynchronization.h
 // RUN: %FileCheck %s < %t/UseSynchronization.h
 
 // REQUIRES: synchronization

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-cxx.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-cxx.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o
 // RUN: %target-interop-build-swift %S/large-structs-pass-return-indirect-in-cxx.swift -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/nested-structs-in-cxx.swift -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/nested-structs-in-cxx.swift -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o %t/swift-structs-execution.o
 

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o
 

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/small-structs-pass-return-direct-in-cxx.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/small-structs-pass-return-direct-in-cxx.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o -Wno-incompatible-pointer-types
 // RUN: %target-interop-build-swift %S/small-structs-pass-return-direct-in-cxx.swift -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: sed -e 's/^public struct/@frozen public struct/' %s > %t/small-structs-frozen.swift
-// RUN: %target-swift-frontend %t/small-structs-frozen.swift -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/small-structs-frozen.h -D RESILIENT
+// RUN: %target-swift-frontend %t/small-structs-frozen.swift -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/small-structs-frozen.h -D RESILIENT
 // RUN: %FileCheck --check-prefixes=CHECK,RESILIENT %s < %t/small-structs-frozen.h
 
 public struct StructOneI64 {

--- a/test/Interop/SwiftToCxx/structs/struct-move-semantics-in-cxx.cpp
+++ b/test/Interop/SwiftToCxx/structs/struct-move-semantics-in-cxx.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-cxx.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/large-structs-pass-return-indirect-in-cxx.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // Link should fail by default when a move is
 // performed in C++.

--- a/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
 
-// RUN: %target-swift-frontend %S/struct-with-opaque-layout-resilient-member-in-cxx.swift -typecheck -module-name UseStructs -clang-header-expose-decls=all-public -emit-clang-header-path %t/useStructs.h -I %t
+// RUN: %target-swift-frontend %S/struct-with-opaque-layout-resilient-member-in-cxx.swift -module-name UseStructs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/useStructs.h -I %t
 
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o

--- a/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UseStructs -clang-header-expose-decls=all-public -emit-clang-header-path %t/useStructs.h -I %t
+// RUN: %target-swift-frontend %s -module-name UseStructs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/useStructs.h -I %t
 // RUN: %FileCheck %s < %t/useStructs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/useStructs.h)

--- a/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member-execution.cpp
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/struct-with-refcounted-member.swift -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %S/struct-with-refcounted-member.swift -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 
 // RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o
 // RUN: %target-interop-build-swift %S/struct-with-refcounted-member.swift -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain

--- a/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
+++ b/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/structs/swift-struct-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-availability-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Struct -clang-header-expose-decls=all-public -emit-clang-header-path %t/struct.h
+// RUN: %target-swift-frontend %s -module-name Struct -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/struct.h
 // RUN: %FileCheck %s < %t/struct.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/struct.h)

--- a/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h)

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function)

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // CHECK: namespace Structs SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Structs") {

--- a/test/Interop/SwiftToCxx/unsupported/unexposed-non-public-api-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unexposed-non-public-api-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/apis.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/apis.h
 // RUN: %FileCheck %s < %t/apis.h
 
 internal func takeFloat(_ x: Float) {}

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
 // REQUIRES: concurrency

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/header.h)

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/header.h)

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Decls -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/decls.h
+// RUN: %target-swift-frontend %s -module-name Decls -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/decls.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/decls.h
 // RUN: %FileCheck %s < %t/decls.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/decls.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-objc-decls-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-objc-decls-in-cxx.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/functions.h
 
 // RUN: cat %s | grep -v _expose > %t/clean.swift
-// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
 // REQUIRES: objc_interop

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)

--- a/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -typecheck -verify -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
 
 // RUN: %FileCheck %s < %t/swiftMod.h
 
-// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -emit-clang-header-path %t/swiftMod2.h -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -typecheck -verify -emit-clang-header-path %t/swiftMod2.h -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
 
 // RUN: %check-interop-cxx-header-in-clang(%t/swiftMod2.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY  -Wno-error)
 
@@ -27,8 +27,8 @@ import SwiftToCxxTest
 
 @_expose(Cxx)
 public func testFunction() -> String {
-    let arr = Swift.Array<Int>()
-    let rng = Swift.SystemRandomNumberGenerator()
+    let arr = Swift.Array<Int>() // expected-warning {{initialization of immutable value 'arr' was never used}}
+    let rng = Swift.SystemRandomNumberGenerator() // expected-warning {{initialization of immutable value 'rng' was never used}}
     return ""
 }
 

--- a/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift-execution.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift-execution.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -typecheck -verify -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
 
 // RUN: %target-interop-build-swift %t/swiftMod.swift -o %t/swift-execution -module-name SwiftMod -I %t -g -DSECOND_PASS -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
 

--- a/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
+// RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -typecheck -verify -emit-clang-header-path %t/swiftMod.h -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
 
 // RUN: %target-swift-frontend %t/swiftMod.swift -module-name SwiftMod -emit-module -o %t/SwiftMod.swiftmodule -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=SwiftToCxxTest -I %t -source-filename=x -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR | %FileCheck --check-prefix=INTERFACE %s
 
-// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -DSECOND_PASS -emit-sil -o - | %FileCheck --check-prefix=SIL %s
+// RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -module-name SwiftMod -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -DSECOND_PASS -emit-sil -o - | %FileCheck --check-prefix=SIL %s
 
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/PrintAsObjC/accessibility.swift
+++ b/test/PrintAsObjC/accessibility.swift
@@ -1,25 +1,25 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %s -typecheck -emit-objc-header-path %t/accessibility.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -parse-as-library %s -typecheck -verify -emit-objc-header-path %t/accessibility.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/accessibility.h
 // RUN: %check-in-clang %t/accessibility.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/accessibility-internal.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/accessibility-internal.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-INTERNAL %s < %t/accessibility-internal.h
 // RUN: %check-in-clang %t/accessibility-internal.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -import-objc-header %S/../Inputs/empty.h -emit-objc-header-path %t/accessibility-imported-header.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -import-objc-header %S/../Inputs/empty.h -typecheck -verify -emit-objc-header-path %t/accessibility-imported-header.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-INTERNAL %s < %t/accessibility-imported-header.h
 // RUN: %check-in-clang %t/accessibility-imported-header.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -DMAIN -emit-objc-header-path %t/accessibility-main.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -DMAIN -typecheck -verify -emit-objc-header-path %t/accessibility-main.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-INTERNAL %s < %t/accessibility-main.h
 // RUN: %check-in-clang %t/accessibility-main.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -application-extension -emit-objc-header-path %t/accessibility-appext.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -application-extension -typecheck -verify -emit-objc-header-path %t/accessibility-appext.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-INTERNAL %s < %t/accessibility-appext.h
 // RUN: %check-in-clang %t/accessibility-appext.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -application-extension-library -emit-objc-header-path %t/accessibility-appextlib.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -application-extension-library -typecheck -verify -emit-objc-header-path %t/accessibility-appextlib.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/accessibility-appextlib.h
 // RUN: %check-in-clang %t/accessibility-appextlib.h
 

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/any_as_id.swiftmodule -typecheck -emit-objc-header-path %t/any_as_id.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/any_as_id.swiftmodule -typecheck -verify -emit-objc-header-path %t/any_as_id.h
 
 // RUN: %FileCheck %s < %t/any_as_id.h
 

--- a/test/PrintAsObjC/async.swift
+++ b/test/PrintAsObjC/async.swift
@@ -11,7 +11,7 @@
 
 // REQUIRES: concurrency
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/async.h -import-objc-header %S/../Inputs/empty.h   -typecheck -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -verify -emit-objc-header-path %t/async.h -I %S/Inputs/custom-modules -import-objc-header %S/../Inputs/empty.h -target %target-swift-5.1-abi-triple
 // RUN: %FileCheck %s < %t/async.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/async.h
 

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %s
-// RUN: %target-swift-frontend -parse-as-library %t/availability-real-sdk.swiftmodule -typecheck -emit-objc-header-path %t/availability-real-sdk.h -import-objc-header %S/../Inputs/empty.h
+// RUN: %target-swift-frontend -parse-as-library %t/availability-real-sdk.swiftmodule -typecheck -verify -emit-objc-header-path %t/availability-real-sdk.h -import-objc-header %S/../Inputs/empty.h
 // RUN: %FileCheck %s < %t/availability-real-sdk.h
 // RUN: %check-in-clang %t/availability-real-sdk.h
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability.swiftmodule -typecheck -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability.swiftmodule -typecheck -verify -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/availability.h
 // RUN: %check-in-clang %t/availability.h
 

--- a/test/PrintAsObjC/availability_macosx_canonical_versions.swift
+++ b/test/PrintAsObjC/availability_macosx_canonical_versions.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability_macosx_canonical_versions.swiftmodule -typecheck -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability_macosx_canonical_versions.swiftmodule -typecheck -verify -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/availability.h
 // RUN: %check-in-clang %t/availability.h
 

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/blocks.swiftmodule -typecheck -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/blocks.swiftmodule -typecheck -verify -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/blocks.h
 // RUN: %check-in-clang %t/blocks.h
 

--- a/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
+++ b/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
@@ -7,7 +7,7 @@
 // relying solely on whether or not the decl has a Clang node is not sufficient.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %target-swift-frontend %s -parse-as-library -typecheck -verify -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift

--- a/test/PrintAsObjC/bridged-known-types.swift
+++ b/test/PrintAsObjC/bridged-known-types.swift
@@ -7,7 +7,7 @@
 // relying solely on whether or not the decl has a Clang node is not sufficient.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %target-swift-frontend %s -parse-as-library -typecheck -verify -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift

--- a/test/PrintAsObjC/cdecl-imports.swift
+++ b/test/PrintAsObjC/cdecl-imports.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -parse-as-library -typecheck -verify -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %check-in-clang %t/swift.h
 // RUN: %check-in-clang-cxx %t/swift.h

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -typecheck -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -typecheck -verify -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/cdecl.h
 // RUN: %check-in-clang %t/cdecl.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/cdecl.h -include ctypes.h -include CoreFoundation.h

--- a/test/PrintAsObjC/circularity-errors.swift
+++ b/test/PrintAsObjC/circularity-errors.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity-errors.swiftmodule -typecheck -emit-objc-header-path %t/circularity-errors.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity-errors.swiftmodule -typecheck -verify -emit-objc-header-path %t/circularity-errors.h
 
 // RUN: %FileCheck %s < %t/circularity-errors.h
 // RUN: not %check-in-clang %t/circularity-errors.h

--- a/test/PrintAsObjC/circularity.swift
+++ b/test/PrintAsObjC/circularity.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity.swiftmodule -typecheck -emit-objc-header-path %t/circularity.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity.swiftmodule -typecheck -verify -emit-objc-header-path %t/circularity.h
 
 // RUN: %FileCheck %s < %t/circularity.h
 

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -13,7 +13,7 @@
 
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/classes.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/classes.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/classes.swiftmodule -typecheck -verify -emit-objc-header-path %t/classes.h -I %S/Inputs/custom-modules -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s --input-file %t/classes.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/classes.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/classes.h

--- a/test/PrintAsObjC/comments.swift
+++ b/test/PrintAsObjC/comments.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -module-name comments %S/../Inputs/comment_to_something_conversion.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/comments.swiftmodule -typecheck -emit-objc-header-path %t/comments.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/comments.swiftmodule -typecheck -verify -emit-objc-header-path %t/comments.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: awk '/A000/,0' %t/comments.h > %t/comments.h-cleaned
 // RUN: diff -u %t/comments.h-cleaned %S/Inputs/comments-expected-output.h
 // RUN: %check-in-clang -Wno-documentation %t/comments.h

--- a/test/PrintAsObjC/compatibility-symbols.swift
+++ b/test/PrintAsObjC/compatibility-symbols.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -emit-objc-header-path %t/empty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -verify -emit-objc-header-path %t/empty.h
 // RUN: %clang -extract-api -o %t/empty.symbols.json --target=%target-triple -isysroot %clang-importer-sdk-path -F %clang-importer-sdk-path/frameworks --extract-api-ignores=%swift-share-dir/swift/compatibility-symbols -fmodules -x objective-c-header %t/empty.h
 // RUN: %FileCheck %s --input-file %t/empty.symbols.json
 

--- a/test/PrintAsObjC/cross-compiler.swift
+++ b/test/PrintAsObjC/cross-compiler.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/CrossCompiler.framework %t/
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -emit-objc-header-path %t/CrossCompiler.framework/Headers/empty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -verify -emit-objc-header-path %t/CrossCompiler.framework/Headers/empty.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/CrossCompiler.framework/Modules/CrossCompiler.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -F %clang-importer-sdk-path/frameworks -module-name CrossCompiler -disable-objc-attr-requires-foundation-module -parse-as-library %s -Xcc -Werror
 
 // Ensure that building with multiple compatibility headers from different compilers doesn't

--- a/test/PrintAsObjC/depends-on-swift-framework.swift
+++ b/test/PrintAsObjC/depends-on-swift-framework.swift
@@ -9,7 +9,7 @@
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/depends-on-swift-framework-helper.swift -module-name OtherModule
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -emit-module -o %t %s -module-name main
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/main.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -parse-as-library %t/main.swiftmodule -typecheck -verify -emit-objc-header-path %t/main.h
 
 // RUN: %FileCheck %s < %t/main.h
 

--- a/test/PrintAsObjC/dispatch.swift
+++ b/test/PrintAsObjC/dispatch.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %target-swift-frontend %s -parse-as-library -typecheck -verify -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/dynamicself.swift
+++ b/test/PrintAsObjC/dynamicself.swift
@@ -11,7 +11,7 @@
 
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/dynamicself.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/dynamicself.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/dynamicself.swiftmodule -typecheck -verify -emit-objc-header-path %t/dynamicself.h -I %S/Inputs/custom-modules -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/dynamicself.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/dynamicself.h
 

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-mock-sdk.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-mock-sdk.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -typecheck -emit-objc-header-path %t/textual-imports.h -emit-clang-header-nonmodular-includes %s 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -typecheck -verify -emit-objc-header-path %t/textual-imports.h -emit-clang-header-nonmodular-includes %s 
 // RUN: %FileCheck %s < %t/textual-imports.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/textual-imports.h -F %S/Inputs
 

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-modulemap-not-in-include-dir.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-modulemap-not-in-include-dir.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-objc-header-path %t/textual-imports.h -emit-clang-header-nonmodular-includes %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-clang-header-nonmodular-includes %s
 // RUN: %FileCheck %s < %t/textual-imports.h
 
 // The module map does not lie in a provided include dir, but we should still include <header-regular.h> and NOT <header_subdirectory/header-regular.h> because

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-path-normalization.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-path-normalization.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/./header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-objc-header-path %t/textual-imports.h -emit-clang-header-nonmodular-includes %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/./header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-clang-header-nonmodular-includes %s
 // RUN: %FileCheck %s < %t/textual-imports.h
 
 // The period in the provided include directory above should not break the system.

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-symlinked-header.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-symlinked-header.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-objc-header-path %t/textual-imports.h -emit-clang-header-nonmodular-includes %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-clang-header-nonmodular-includes %s
 // RUN: %FileCheck %s < %t/textual-imports.h
 
 // Make sure the include we get is not based on the resolved symlink, but rather the path to the symlink itself.

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/empty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/empty.h
 // RUN: %FileCheck %s < %t/empty.h
 
 // RUN: %check-in-clang -std=c99 %t/empty.h

--- a/test/PrintAsObjC/enums-frozen.swift
+++ b/test/PrintAsObjC/enums-frozen.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution -module-name enums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -verify -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution
 // RUN: %FileCheck %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.h -include ctypes.h -include CoreFoundation.h

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -verify -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/enums.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h
@@ -17,7 +17,7 @@
 // file map also works.
 
 // RUN: echo "{\"%s\": {\"objc-header\": \"%t/enums-supplemental.h\"}}" > %t-output-file-map.json
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -enable-source-import -typecheck -supplementary-output-file-map %t-output-file-map.json -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -enable-source-import -typecheck -verify -supplementary-output-file-map %t-output-file-map.json -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix CHECK-SUPPLEMENTAL %s < %t/enums-supplemental.h
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -parse-as-library %t/error-delegate.swiftmodule -typecheck -emit-objc-header-path %t/error-delegate.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -parse-as-library %t/error-delegate.swiftmodule -typecheck -verify -emit-objc-header-path %t/error-delegate.h
 
 // RUN: %FileCheck %s < %t/error-delegate.h
 // RUN: %check-in-clang %t/error-delegate.h

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -typecheck -verify -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
 // RUN: %FileCheck %s --input-file %t/extensions.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/extensions.h
 // RUN: %check-in-clang %t/extensions.h

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -97,21 +97,21 @@ extension A5 {
 @objc class A6 {}
 
 extension A6 {
-  @objc(skippedInt:) func skipped(_: Int) {}
-  @objc func abc() {}
-}
-extension A6 {
   @objc(skippedBool:) func skipped(_: Bool) {}
   @objc func def() {}
 }
+extension A6 {
+  @objc(skippedInt:) func skipped(_: Int) {}
+  @objc func abc() {}
+}
 // CHECK: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)skippedBool:
-// CHECK-NEXT: - (void)def
+// CHECK-NEXT: - (void)skippedInt:
+// CHECK-NEXT: - (void)abc
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 // CHECK-NEXT: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)skippedInt:
-// CHECK-NEXT: - (void)abc
+// CHECK-NEXT: - (void)skippedBool:
+// CHECK-NEXT: - (void)def
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -44,11 +44,11 @@ extension A2 {
 @objc @objcMembers class A3 {}
 
 // CHECK-NEXT: @interface A3 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger some;
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger more;
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 // CHECK-NEXT: @interface A3 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger more;
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger some;
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 extension A3 {
@@ -97,21 +97,21 @@ extension A5 {
 @objc class A6 {}
 
 extension A6 {
-  @objc(skippedBool:) func skipped(_: Bool) {}
-  @objc func def() {}
-}
-extension A6 {
   @objc(skippedInt:) func skipped(_: Int) {}
   @objc func abc() {}
 }
+extension A6 {
+  @objc(skippedBool:) func skipped(_: Bool) {}
+  @objc func def() {}
+}
 // CHECK: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)skippedInt:
-// CHECK-NEXT: - (void)abc
+// CHECK-NEXT: - (void)skippedBool:
+// CHECK-NEXT: - (void)def
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 // CHECK-NEXT: @interface A6 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)skippedBool:
-// CHECK-NEXT: - (void)def
+// CHECK-NEXT: - (void)skippedInt:
+// CHECK-NEXT: - (void)abc
 // CHECK-NEXT: @end
 // CHECK-EMPTY:
 

--- a/test/PrintAsObjC/generic-ancestry.swift
+++ b/test/PrintAsObjC/generic-ancestry.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name generic -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/generic.swiftmodule -typecheck -emit-objc-header-path %t/generic.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/generic.swiftmodule -typecheck -verify -emit-objc-header-path %t/generic.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/generic.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/generic.h
 // RUN: %check-in-clang %t/generic.h

--- a/test/PrintAsObjC/imported-block-typedefs.swift
+++ b/test/PrintAsObjC/imported-block-typedefs.swift
@@ -1,10 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -import-objc-header %S/Inputs/imported-block-typedefs.h -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/imported-block-typedefs.swiftmodule -typecheck -emit-objc-header-path %t/imported-block-typedefs-output.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
-// RUN: %FileCheck %s < %t/imported-block-typedefs-output.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/imported-block-typedefs.swiftmodule -typecheck -emit-objc-header-path %t/imported-block-typedefs-output.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module 2>%t/stderr.txt
+// RUN: %FileCheck %s --input-file %t/imported-block-typedefs-output.h
+// RUN: %FileCheck --check-prefix ERROR %s --input-file %t/stderr.txt
 // RUN: %check-in-clang %t/imported-block-typedefs-output.h -include %S/Inputs/imported-block-typedefs.h
 
 // REQUIRES: objc_interop
+
+// ERROR-DAG: <unknown>:0: warning: implicit import of bridging header 'imported-block-typedefs.h' via module 'main' is deprecated and will be removed in a later version of Swift
+// ERROR-NOT: warning: arbitrarily printing
 
 import ObjectiveC
 

--- a/test/PrintAsObjC/imported-generic-typealias.swift
+++ b/test/PrintAsObjC/imported-generic-typealias.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -emit-objc-header-path %t/imported-generic-typealias.h -import-objc-header %S/Inputs/imported-generic-typealias.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -verify -emit-objc-header-path %t/imported-generic-typealias.h -import-objc-header %S/Inputs/imported-generic-typealias.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imported-generic-typealias.h
 
 @objc public class MyRedBarn : Barn {

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -parse-as-library %t/imports.swiftmodule -typecheck -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -parse-as-library %t/imports.swiftmodule -typecheck -verify -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imports.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/imports.h
 // RUN: %check-in-clang %t/imports.h -I %S/Inputs/custom-modules/ -F %S/Inputs/ -Watimport-in-framework-header

--- a/test/PrintAsObjC/include-underlying.swift
+++ b/test/PrintAsObjC/include-underlying.swift
@@ -1,10 +1,10 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print ""
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -verify -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print ""
 // RUN: %FileCheck -check-prefix=CHECK-DEFAULT %s < %t/emit.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print "Headers/PrivateHeaders/"
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -verify -emit-objc-header-path %t/emit.h -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/CoreGraphics-Bridging-Header.h -import-underlying-module -module-name CoreGraphics -bridging-header-directory-for-print "Headers/PrivateHeaders/"
 // RUN: %FileCheck -check-prefix=CHECK-DIR %s < %t/emit.h
 
 @objc public class X: UIColor {

--- a/test/PrintAsObjC/interfering-macros.swift
+++ b/test/PrintAsObjC/interfering-macros.swift
@@ -6,7 +6,7 @@
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -typecheck -emit-objc-header-path %t/interfering-macros.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -typecheck -verify -emit-objc-header-path %t/interfering-macros.h
 // RUN: %check-in-clang -fsyntax-only -Werror %t/interfering-macros.h -D'any=UNWANTED_MACRO_SUBSTITUTION'
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/local-types.swift
+++ b/test/PrintAsObjC/local-types.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name local -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/local.swiftmodule -typecheck -emit-objc-header-path %t/local.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/local.swiftmodule -typecheck -verify -emit-objc-header-path %t/local.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/local.h
 // RUN: %check-in-clang %t/local.h
 

--- a/test/PrintAsObjC/mixed-framework-fwd.swift
+++ b/test/PrintAsObjC/mixed-framework-fwd.swift
@@ -1,17 +1,17 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module %s -typecheck -emit-objc-header-path %t/mixed.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module %s -typecheck -verify -emit-objc-header-path %t/mixed.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=NO-IMPORT %s < %t/mixed.h
 // RUN: %check-in-clang -F %S/Inputs/ %t/mixed.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t/mixed-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -verify -emit-objc-header-path %t/mixed-header.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=NO-IMPORT %s < %t/mixed-header.h
 // RUN: %check-in-clang -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t/mixed-header.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module %s -typecheck -emit-objc-header-path %t/mixed-proto.h -DREQUIRE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module %s -typecheck -verify -emit-objc-header-path %t/mixed-proto.h -DREQUIRE
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t/mixed-proto.h
 // RUN: %check-in-clang -F %S/Inputs/ %t/mixed-proto.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t/mixed-header-proto.h -DREQUIRE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -verify -emit-objc-header-path %t/mixed-header-proto.h -DREQUIRE
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t/mixed-header-proto.h
 // RUN: %check-in-clang -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t/mixed-header-proto.h
 

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t.framework)
 // RUN: %empty-directory(%t.framework/Headers)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module -parse-as-library %s -typecheck -emit-objc-header-path %t.framework/Headers/mixed.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module -parse-as-library %s -typecheck -verify -emit-objc-header-path %t.framework/Headers/mixed.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t.framework/Headers/mixed.h
 // RUN: %check-in-clang -Watimport-in-framework-header -F %S/Inputs/ %t.framework/Headers/mixed.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t.framework/Headers/mixed-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -verify -emit-objc-header-path %t.framework/Headers/mixed-header.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t.framework/Headers/mixed-header.h
 // RUN: %check-in-clang -Watimport-in-framework-header -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t.framework/Headers/mixed-header.h
 

--- a/test/PrintAsObjC/never.swift
+++ b/test/PrintAsObjC/never.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name never -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/never.swiftmodule -typecheck -emit-objc-header-path %t/never.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/never.swiftmodule -typecheck -verify -emit-objc-header-path %t/never.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/never.h
 // RUN: %check-in-clang %t/never.h
 

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -parse-as-library %t/newtype.swiftmodule -typecheck -emit-objc-header-path %t/newtype.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -parse-as-library %t/newtype.swiftmodule -typecheck -verify -emit-objc-header-path %t/newtype.h
 
 // RUN: %FileCheck %s < %t/newtype.h
 

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -16,7 +16,7 @@
 
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -import-underlying-module -o %t %s -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/objc_implementation.swiftmodule -typecheck -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -emit-objc-header-path %t/objc_implementation-Swift.h -import-underlying-module -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/objc_implementation.swiftmodule -typecheck -verify -emit-objc-header-path %t/objc_implementation-Swift.h -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -import-underlying-module -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
 // RUN: %FileCheck %s --input-file %t/objc_implementation-Swift.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/objc_implementation-Swift.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/objc_implementation-Swift.h

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -8,7 +8,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/override.swiftmodule -typecheck -emit-objc-header-path %t/override.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/override.swiftmodule -typecheck -verify -emit-objc-header-path %t/override.h
 // RUN: %FileCheck %s < %t/override.h
 // RUN: %check-in-clang %t/override.h -I %S/Inputs/custom-modules -Wno-super-class-method-mismatch -Wno-overriding-method-mismatch
 // RUN: not %check-in-clang %t/override.h -Wno-super-class-method-mismatch -I %S/Inputs/custom-modules 2>&1 | %FileCheck -check-prefix=CLANG %s

--- a/test/PrintAsObjC/pragma-clang.swift
+++ b/test/PrintAsObjC/pragma-clang.swift
@@ -6,7 +6,7 @@
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -import-objc-header %S/Inputs/bridging-header.h -typecheck -emit-objc-header-path %t/pragma-clang.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -import-objc-header %S/Inputs/bridging-header.h -typecheck -verify -emit-objc-header-path %t/pragma-clang.h
 // RUN: %check-in-clang -fsyntax-only -Werror %t/pragma-clang.h
 // RUN: %FileCheck %s < %t/pragma-clang.h
 

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -9,7 +9,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -verify -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/protocols.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/protocols.h
 // RUN: %check-in-clang %t/protocols.h

--- a/test/PrintAsObjC/reintroduced-new.m
+++ b/test/PrintAsObjC/reintroduced-new.m
@@ -7,11 +7,11 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/reintroduced-new.swift -swift-version 4 -disable-objc-attr-requires-foundation-module -module-name main
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -verify -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 4
 // RUN: not %clang -fsyntax-only -x objective-c %s -include %t/generated.h -fobjc-arc -fmodules -Werror -F %clang-importer-sdk-path/frameworks -isysroot %S/../../test/Inputs/clang-importer-sdk 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/reintroduced-new.swift -disable-objc-attr-requires-foundation-module -module-name main -swift-version 5
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 5
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -verify -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 5
 // RUN: not %clang -fsyntax-only -x objective-c %s -include %t/generated.h -fobjc-arc -fmodules -Werror -F %clang-importer-sdk-path/frameworks -isysroot %S/../../test/Inputs/clang-importer-sdk 2>&1 | %FileCheck  -check-prefix=CHECK -check-prefix=CHECK-5 %s
 
 // CHECK-NOT: error:

--- a/test/PrintAsObjC/resilient-ancestry-stable-abi.swift
+++ b/test/PrintAsObjC/resilient-ancestry-stable-abi.swift
@@ -4,7 +4,7 @@
 
 // RUN: cp %S/Inputs/custom-modules/module.modulemap %t/module.modulemap
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %S/resilient-ancestry.swift -module-name resilient -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution -target %target-next-stable-abi-triple
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/resilient-ancestry.swift -module-name resilient -typecheck -verify -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution -target %target-next-stable-abi-triple
 // RUN: %FileCheck %S/resilient-ancestry.swift < %t/resilient.h
 // RUN: %check-in-clang %t/resilient.h -I %t
 

--- a/test/PrintAsObjC/resilient-ancestry.swift
+++ b/test/PrintAsObjC/resilient-ancestry.swift
@@ -6,7 +6,7 @@
 
 // RUN: cp %S/Inputs/custom-modules/module.modulemap %t/module.modulemap
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-pre-stable-abi-triple -typecheck %s -module-name resilient -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-pre-stable-abi-triple %s -module-name resilient -typecheck -verify -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution
 // RUN: %FileCheck %s --check-prefix=NO-STUBS < %t/resilient.h
 // RUN: %check-in-clang %t/resilient.h -I %t
 

--- a/test/PrintAsObjC/simd.swift
+++ b/test/PrintAsObjC/simd.swift
@@ -8,7 +8,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -emit-module-doc -o %t -module-name simd_test %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/simd_test.swiftmodule -typecheck -emit-objc-header-path %t/simd.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/simd_test.swiftmodule -typecheck -verify -emit-objc-header-path %t/simd.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/simd.h
 // RUN: %check-in-clang %t/simd.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/simd.h

--- a/test/PrintAsObjC/spi.swift
+++ b/test/PrintAsObjC/spi.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/out.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/out.h
 // RUN: %FileCheck %s < %t/out.h
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/swift_name.m
+++ b/test/PrintAsObjC/swift_name.m
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -emit-objc-header-path %t/empty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -verify -emit-objc-header-path %t/empty.h
 // RUN: %clang -F %clang-importer-sdk-path/frameworks -E -fobjc-arc -fmodules -isysroot %clang-importer-sdk-path -I %t %s | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -11,7 +11,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -parse-as-library %t/swift_name.swiftmodule -typecheck -emit-objc-header-path %t/swift_name.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -parse-as-library %t/swift_name.swiftmodule -typecheck -verify -emit-objc-header-path %t/swift_name.h
 
 // RUN: %FileCheck %s < %t/swift_name.h
 // RUN: %check-in-clang %t/swift_name.h

--- a/test/PrintAsObjC/typealias.swift
+++ b/test/PrintAsObjC/typealias.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -o %t/typealias.swiftmodule %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -parse-as-library %t/typealias.swiftmodule -typecheck -emit-objc-header-path %t/typealias.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -parse-as-library %t/typealias.swiftmodule -typecheck -verify -emit-objc-header-path %t/typealias.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/typealias.h
 // RUN: %check-in-clang %t/typealias.h
 
-// RUN: %target-swift-frontend -typecheck %s -emit-objc-header-path %t/typealias_wmo.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend %s -typecheck -verify -emit-objc-header-path %t/typealias_wmo.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/typealias_wmo.h
 // RUN: %check-in-clang %t/typealias_wmo.h
 

--- a/test/PrintAsObjC/unmodified.swift
+++ b/test/PrintAsObjC/unmodified.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/out.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/out.h
 // RUN: touch -t 201401240005 %t/out.h
 // RUN: %S/../Inputs/getmtime.py %t/out.h > %t/orig-mtime.txt
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/out.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/out.h
 // RUN: diff %t/orig-mtime.txt <(%S/../Inputs/getmtime.py %t/out.h)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/out.h -DPRIVATE_EXTRA
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/out.h -DPRIVATE_EXTRA
 // RUN: diff %t/orig-mtime.txt <(%S/../Inputs/getmtime.py %t/out.h)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/out.h -DPUBLIC_EXTRA
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -emit-objc-header-path %t/out.h -DPUBLIC_EXTRA
 // RUN: not diff %t/orig-mtime.txt <(%S/../Inputs/getmtime.py %t/out.h)
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -10,7 +10,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/versioned.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/versioned.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/versioned.swiftmodule -typecheck -verify -emit-objc-header-path %t/versioned.h -I %S/Inputs/custom-modules -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4
 // RUN: %FileCheck %s < %t/versioned.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/versioned.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/versioned.h -include VersionedFMWK.h


### PR DESCRIPTION
PrintAsClang is supposed to emit declarations in the same order regardless of the compiler’s internal state, but we have repeatedly found that our current criteria are inadequate, resulting in non-functionality-affecting changes to generated header content. This PR is an attempt to address this problem more comprehensively:

* Corrects a bug that stopped several extension sorting rules from taking effect.
* Adds several new rules, like interface type and generic signature, to sort extensions by members.
* Adds a new rule that sorts an extension as a whole by its generic signature.
* Most importantly, emits diagnostics if PrintAsClang is unable to stably sort two declarations.
* Tests those diagnostics by enabling `-verify` on a large number of existing tests, demonstrating that those diagnostics are not emitted.

The new diagnostics—which users *should* never see, though I wouldn't be surprised to learn that there are still edge cases to fix—look like this:

```
Swift._RuntimeFunctionCountersStats:1:11: warning: arbitrarily printing extension of '_RuntimeFunctionCountersStats' before extension of '_RuntimeFunctionCountersStats' in generated header; subsequent compilations may print them in a different order
1 | extension _RuntimeFunctionCountersStats {
  |           |- warning: arbitrarily printing extension of '_RuntimeFunctionCountersStats' before extension of '_RuntimeFunctionCountersStats' in generated header; subsequent compilations may print them in a different order
  |           `- note: please report this as a bug in the Swift compiler and describe both declarations
2 |     public func dump(skipUnchanged: Bool)
3 |     public func dumpDiff(_ after: Self, skipUnchanged: Bool)

Swift._RuntimeFunctionCountersStats:1:11: note: extension of '_RuntimeFunctionCountersStats' will be printed after extension of '_RuntimeFunctionCountersStats' during this compilation
1 | extension _RuntimeFunctionCountersStats {
  |           `- note: extension of '_RuntimeFunctionCountersStats' will be printed after extension of '_RuntimeFunctionCountersStats' during this compilation
2 |     public var debugDescription: String { get }
3 | }
```

Fixes rdar://143533893 (harder).