### PR TITLE
Tests: Stop referring to the Span feature since it has been removed

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -21,7 +21,6 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -cxx-interoperability-mode=default
-    -enable-experimental-feature Span
     -enable-experimental-feature BuiltinModule
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).

--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature SafeInteropWrappers)
+// RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers)
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -7,7 +7,6 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_Span
 // REQUIRES: swift_feature_LifetimeDependence
 
 // REQUIRES: executable_test


### PR DESCRIPTION
Fixes CI fallout from https://github.com/swiftlang/swift/pull/79399.

Resolves rdar://144919269.