### PR TITLE
[Test] Remove -enable-experimental-feature Span

### DIFF
--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature SafeInteropWrappers)
+// RUN: %target-run-simple-swift(-plugin-path %swift-plugin-dir -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -swift-version 6 -Xfrontend -disable-availability-checking -Xcc -std=c++20 -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers)
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -7,7 +7,6 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_Span
 // REQUIRES: swift_feature_LifetimeDependence
 
 // REQUIRES: executable_test


### PR DESCRIPTION
Fix a test failure caused by a merge race between https://github.com/swiftlang/swift/pull/79399 and https://github.com/swiftlang/swift/pull/79396

https://ci.swift.org/job/swift-PR-Linux-smoke-test/17809/consoleText
```
FAIL: Swift(linux-x86_64) :: Misc/verify-swift-feature-testing.test-sh (8297 of 18908)
******************** TEST 'Swift(linux-x86_64) :: Misc/verify-swift-feature-testing.test-sh' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
error: /home/build-user/swift/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift: Unknown feature: Span
```
