### PR TITLE
[CS] Ensure DeclContext is switched for if/switch expressions

### DIFF
--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -706,3 +706,25 @@ func testInvalidOptionalChainingInIfContext() {
   let v63796 = 1
   if v63796? {} // expected-error{{cannot use optional chaining on non-optional value of type 'Int'}}
 }
+
+// https://github.com/swiftlang/swift/issues/79395
+_ = {
+  if .random() {
+    struct S: Error {}
+    throw S()
+  } else {
+    1
+  }
+}
+_ = {
+  if .random() {
+    if .random() {
+      struct S: Error {}
+      throw S()
+    } else {
+      0
+    }
+  } else {
+    1
+  }
+}

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -819,3 +819,28 @@ func builderInClosure() {
     }
   }
 }
+
+// https://github.com/swiftlang/swift/issues/79395
+_ = {
+  switch Bool.random() {
+  case true:
+    struct S: Error {}
+    throw S()
+  case false:
+    1
+  }
+}
+_ = {
+  switch Bool.random() {
+  case true:
+    switch Bool.random() {
+    case true:
+      struct S: Error {}
+      throw S()
+    case false:
+      0
+    }
+  case false:
+    1
+  }
+}


### PR DESCRIPTION
Similar to multi-statement closures, we need to make sure we change the DeclContext of the ConstraintSystem when solving a conjunction for an if/switch expression. This is unfortunately needed for cases within single-expression closures since they can't switch the system's DeclContext (as they're solved together with the rest of the system).

Resolves #79395