### PR TITLE
Flesh out Windows ToolchainInfo.plist

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1709,7 +1709,7 @@ function Build-Compilers() {
       })
   }
 
-  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'Identifier': '${ToolchainIdentifier}' }), encoding='utf-8'))" `
+  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'Identifier': '${ToolchainIdentifier}', 'FallbackLibrarySearchPaths': ['usr/bin'], 'Version': '${ProductVersion}' }), encoding='utf-8'))" `
       -OutFile "$($Arch.ToolchainInstallRoot)\ToolchainInfo.plist"
 }
 


### PR DESCRIPTION
- Add FallbackLibraryPaths to usr/bin - swift-build uses this to lookup dlls like libclang
- Define TOOLCHAIN_VERSION as a default build setting - swift-build uses this when looking up runtimes