### PR TITLE
Sema: Allow unavailable stored properties in swiftinterfaces

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5386,6 +5386,10 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D) {
     if (parentIsUnavailable(D))
       return std::nullopt;
 
+    // Be lenient in interfaces to accomodate @_spi_available.
+    if (D->getDeclContext()->isInSwiftinterface())
+      return std::nullopt;
+
     // Do not permit unavailable script-mode global variables; their initializer
     // expression is not lazily evaluated, so this would not be safe.
     if (VD->isTopLevelGlobal())

--- a/test/ModuleInterface/availability-storage-macos.swift
+++ b/test/ModuleInterface/availability-storage-macos.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s -module-name Test -target %target-cpu-apple-macos51
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
+// RUN: %FileCheck %s < %t/Test.swiftinterface
+
+// RUN: %target-swift-emit-module-interface(%t/TestMinInlining.swiftinterface) %s -module-name Test -target %target-cpu-apple-macos51 -target-min-inlining-version min
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestMinInlining.swiftinterface) -module-name Test
+// RUN: %FileCheck %s < %t/TestMinInlining.swiftinterface
+
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: public struct StructWithProperties
+public struct StructWithProperties {
+  // CHECK:      @available(macOS, unavailable)
+  // CHECK-NEXT: public var unavailableComputed: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  @available(macOS, unavailable)
+  public var unavailableComputed: Int { 1 }
+
+  // CHECK:      @available(macOS 51, *)
+  // CHECK-NEXT: public let introducedAtDeploymentStored: Swift.Int
+  @available(macOS 51, *)
+  public let introducedAtDeploymentStored: Int = 1
+
+  // CHECK:      @available(macOS 99, *)
+  // CHECK-NEXT: public var introducedAfterDeploymentComputed: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  @available(macOS 99, *)
+  public var introducedAfterDeploymentComputed: Int { 1 }
+
+  // CHECK:      @available(macOS, unavailable)
+  // CHECK-NEXT: public let introducedAtDeploymentSPIStored: Swift.Int
+  @_spi_available(macOS 51, *)
+  public let introducedAtDeploymentSPIStored: Int = 1
+}
+
+// CHECK-LABEL: public enum EnumWithAssociatedValues
+public enum EnumWithAssociatedValues {
+  // CHECK:      @available(macOS, unavailable)
+  // CHECK-NEXT: case unavailable
+  @available(macOS, unavailable)
+  case unavailable
+
+  // CHECK:      @available(macOS 51, *)
+  // CHECK-NEXT: case introducedAtDeployment
+  @available(macOS 51, *)
+  case introducedAtDeployment
+
+  // CHECK:      @available(macOS 99, *)
+  // CHECK-NEXT: case introducedAfterDeployment
+  @available(macOS 99, *)
+  case introducedAfterDeployment
+
+  // CHECK:      @available(macOS, unavailable)
+  // CHECK-NEXT: case unavailableWithAssoc(Swift.Int)
+  @available(macOS, unavailable)
+  case unavailableWithAssoc(Int)
+
+  // CHECK:      @available(macOS 51, *)
+  // CHECK-NEXT: case introducedAtDeploymentWithAssoc(Swift.Int)
+  @available(macOS 51, *)
+  case introducedAtDeploymentWithAssoc(Int)
+}


### PR DESCRIPTION
In a swiftinterface a declaration could be unavailable because it was written in source with an `@_spi_available` attribute so it isn't possible to safely reject unavailable stored properties in that context.

Resolves rdar://144958440.
