### PR TITLE
[cxx-interop] Remove a feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -401,9 +401,6 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AllowUnsafeAttribute, true)
 /// Warn on use of unsafe constructs.
 EXPERIMENTAL_FEATURE(WarnUnsafe, true)
 
-/// Import unsafe C and C++ constructs as @unsafe.
-EXPERIMENTAL_FEATURE(SafeInterop, true)
-
 // Import bounds safety and lifetime attributes from interop headers to
 // generate Swift wrappers with safe pointer types.
 EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -348,7 +348,6 @@ static bool usesFeatureABIAttribute(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(WarnUnsafe)
-UNINTERESTING_FEATURE(SafeInterop)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2040,8 +2040,7 @@ namespace {
       if (Impl.SwiftContext.LangOpts.hasFeature(Feature::LifetimeDependence)) {
         fd->getAttrs().add(new (Impl.SwiftContext)
                                UnsafeNonEscapableResultAttr(/*Implicit=*/true));
-        if (Impl.SwiftContext.LangOpts.hasFeature(Feature::SafeInterop) &&
-            Impl.SwiftContext.LangOpts.hasFeature(
+        if (Impl.SwiftContext.LangOpts.hasFeature(
                 Feature::AllowUnsafeAttribute))
           fd->getAttrs().add(new (Impl.SwiftContext)
                                  UnsafeAttr(/*Implicit=*/true));
@@ -2203,8 +2202,7 @@ namespace {
 
       // We have to do this after populating ImportedDecls to avoid importing
       // the same multiple times.
-      if (Impl.SwiftContext.LangOpts.hasFeature(Feature::SafeInterop) &&
-          Impl.SwiftContext.LangOpts.hasFeature(
+      if (Impl.SwiftContext.LangOpts.hasFeature(
               Feature::AllowUnsafeAttribute)) {
         if (const auto *ctsd =
                 dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
@@ -4135,8 +4133,7 @@ namespace {
             LifetimeDependenceInfoRequest{result},
             Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
       }
-      if (ASTContext.LangOpts.hasFeature(Feature::AllowUnsafeAttribute) &&
-          ASTContext.LangOpts.hasFeature(Feature::SafeInterop)) {
+      if (ASTContext.LangOpts.hasFeature(Feature::AllowUnsafeAttribute)) {
         for (auto [idx, param] : llvm::enumerate(decl->parameters())) {
           if (swiftParams->get(idx)->getInterfaceType()->isEscapable())
             continue;
@@ -8500,8 +8497,7 @@ static bool importAsUnsafe(ClangImporter::Implementation &impl,
                            const clang::NamedDecl *decl,
                            const Decl *MappedDecl) {
   auto &context = impl.SwiftContext;
-  if (!context.LangOpts.hasFeature(Feature::SafeInterop) ||
-      !context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
+  if (!context.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
     return false;
 
   if (isa<clang::CXXMethodDecl>(decl) &&

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -1,11 +1,10 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe  -enable-experimental-feature SafeInterop -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
+// RUN: %target-swift-frontend -typecheck -verify -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -I %t/Inputs  %t/test.swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_AllowUnsafeAttribute
-// REQUIRES: swift_feature_SafeInterop
 // REQUIRES: swift_feature_WarnUnsafe
 // REQUIRES: swift_feature_LifetimeDependence
 


### PR DESCRIPTION
SafeInterop was guarding whether we import certain foreign types as unsafe. Since these attrbutes are only considered when an opt-in strict language mode is on, this PR removes this feature flag. We still rely on the presence of the AllowUnsafeAttribute flag to add the unsafe attributes to the imported types and functions.
