### PR TITLE
[SE-0458] Unify escapability inference for AST and Interop

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -417,10 +417,8 @@ private:
 
 struct SafeUseOfCxxDeclDescriptor final {
   const clang::Decl *decl;
-  ASTContext &ctx;
 
-  SafeUseOfCxxDeclDescriptor(const clang::Decl *decl, ASTContext &ctx)
-      : decl(decl), ctx(ctx) {}
+  SafeUseOfCxxDeclDescriptor(const clang::Decl *decl) : decl(decl) {}
 
   friend llvm::hash_code hash_value(const SafeUseOfCxxDeclDescriptor &desc) {
     return llvm::hash_combine(desc.decl);
@@ -528,7 +526,7 @@ enum class CxxEscapability { Escapable, NonEscapable, Unknown };
 
 struct EscapabilityLookupDescriptor final {
   const clang::Type *type;
-  ClangImporter::Implementation &impl;
+  ClangImporter::Implementation *impl;
   bool annotationOnly = true;
 
   friend llvm::hash_code hash_value(const EscapabilityLookupDescriptor &desc) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1153,9 +1153,9 @@ ExplicitSafety Decl::getExplicitSafety() const {
   // If this declaration is from C, ask the Clang importer.
   if (auto clangDecl = getClangDecl()) {
     ASTContext &ctx = getASTContext();
-    return evaluateOrDefault(
-        ctx.evaluator, ClangDeclExplicitSafety({clangDecl, ctx}),
-        ExplicitSafety::Unspecified);
+    return evaluateOrDefault(ctx.evaluator,
+                             ClangDeclExplicitSafety({clangDecl}),
+                             ExplicitSafety::Unspecified);
   }
   
   // Inference: Check the enclosing context.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2246,7 +2246,7 @@ namespace {
       bool isNonEscapable = false;
       if (evaluateOrDefault(
               Impl.SwiftContext.evaluator,
-              ClangTypeEscapability({decl->getTypeForDecl(), Impl}),
+              ClangTypeEscapability({decl->getTypeForDecl(), &Impl}),
               CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
         result->getAttrs().add(new (Impl.SwiftContext)
                                    NonEscapableAttr(/*Implicit=*/true));
@@ -4118,7 +4118,7 @@ namespace {
             evaluateOrDefault(
                 Impl.SwiftContext.evaluator,
                 ClangTypeEscapability(
-                    {ctordecl->getParent()->getTypeForDecl(), Impl}),
+                    {ctordecl->getParent()->getTypeForDecl(), &Impl}),
                 CxxEscapability::Unknown) == CxxEscapability::NonEscapable)
           lifetimeDependencies.push_back(immortalLifetime);
       }
@@ -8505,8 +8505,7 @@ static bool importAsUnsafe(ClangImporter::Implementation &impl,
     return false;
 
   if (isa<clang::CXXMethodDecl>(decl) &&
-      !evaluateOrDefault(context.evaluator, IsSafeUseOfCxxDecl({decl, context}),
-                         {}))
+      !evaluateOrDefault(context.evaluator, IsSafeUseOfCxxDecl({decl}), {}))
     return true;
 
   if (isa<ClassDecl>(MappedDecl))
@@ -8522,7 +8521,7 @@ static bool importAsUnsafe(ClangImporter::Implementation &impl,
   if (const auto *record = dyn_cast<clang::RecordDecl>(decl))
     return evaluateOrDefault(
                context.evaluator,
-               ClangTypeEscapability({record->getTypeForDecl(), impl, false}),
+               ClangTypeEscapability({record->getTypeForDecl(), &impl, false}),
                CxxEscapability::Unknown) == CxxEscapability::Unknown;
 
   return false;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1494,7 +1494,7 @@ static StringRef renameUnsafeMethod(ASTContext &ctx,
                                     const clang::NamedDecl *decl,
                                     StringRef name) {
   if (isa<clang::CXXMethodDecl>(decl) &&
-      !evaluateOrDefault(ctx.evaluator, IsSafeUseOfCxxDecl({decl, ctx}), {})) {
+      !evaluateOrDefault(ctx.evaluator, IsSafeUseOfCxxDecl({decl}), {})) {
     return ctx.getIdentifier(("__" + name + "Unsafe").str()).str();
   }
 


### PR DESCRIPTION
Interop is injecting escapability annotations for the STL and doing a limited inference for aggregates. Let's reuse the same facilities in the AST when we calculate the safety of the foreign types.

