### PR TITLE
Basic: Limit `version::getCompilerversion()` to major + minor only

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -343,11 +343,10 @@ std::string getCompilerVersion() {
   std::string buf;
   llvm::raw_string_ostream OS(buf);
 
-#if defined(SWIFT_COMPILER_VERSION)
-  OS << SWIFT_COMPILER_VERSION;
-#else
-  OS << SWIFT_VERSION_STRING;
-#endif
+ // TODO: This should print SWIFT_COMPILER_VERSION when
+ // available, but to do that we need to switch from
+ // llvm::VersionTuple to swift::Version.
+ OS << SWIFT_VERSION_STRING;
 
   return OS.str();
 }


### PR DESCRIPTION
Revert to printing just the major and minor version for `-interface-compiler-version` in order to temporarily preserve backward compatibility with release/6.1 compilers.

Resolves rdar://144964099.