### PR TITLE
[AST] Define feature for Builtin.emplace typed throws

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -202,6 +202,7 @@ CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedAny, 431, "@isolated(any) fu
 LANGUAGE_FEATURE(IsolatedAny2, 431, "@isolated(any) function types")
 LANGUAGE_FEATURE(ObjCImplementation, 436, "@objc @implementation extensions")
 LANGUAGE_FEATURE(NonescapableTypes, 446, "Nonescapable types")
+LANGUAGE_FEATURE(BuiltinEmplaceTypedThrows, 0, "Builtin.emplace typed throws")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -411,6 +411,11 @@ static bool usesFeatureCustomAvailability(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinEmplaceTypedThrows(Decl *decl) {
+  // Callers of 'Builtin.emplace' should explicitly guard the usage with #if.
+  return false;
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -105,7 +105,7 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(_ body: (Int) throws(E) -> Element) throws(E) {
-#if hasFeature(BuiltinEmplaceTypedThrows)
+#if $BuiltinEmplaceTypedThrows
     self = try Builtin.emplace { (rawPtr) throws(E) -> () in
       let buffer = InlineArray<count, Element>._initializationBuffer(
         start: rawPtr
@@ -153,7 +153,7 @@ extension InlineArray where Element: ~Copyable {
     first: consuming Element,
     next: (borrowing Element) throws(E) -> Element
   ) throws(E) {
-#if hasFeature(BuiltinEmplaceTypedThrows)
+#if $BuiltinEmplaceTypedThrows
     // FIXME: We should be able to mark 'Builtin.emplace' as '@once' or something
     //        to give the compiler enough information to know we will only run
     //        it once so it can consume the capture. For now, we use an optional

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -105,6 +105,7 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(_ body: (Int) throws(E) -> Element) throws(E) {
+#if hasFeature(BuiltinEmplaceTypedThrows)
     self = try Builtin.emplace { (rawPtr) throws(E) -> () in
       let buffer = InlineArray<count, Element>._initializationBuffer(
         start: rawPtr
@@ -125,6 +126,9 @@ extension InlineArray where Element: ~Copyable {
         }
       }
     }
+#else
+    fatalError()
+#endif
   }
 
   /// Initializes every element in this vector by running the closure with the
@@ -149,6 +153,7 @@ extension InlineArray where Element: ~Copyable {
     first: consuming Element,
     next: (borrowing Element) throws(E) -> Element
   ) throws(E) {
+#if hasFeature(BuiltinEmplaceTypedThrows)
     // FIXME: We should be able to mark 'Builtin.emplace' as '@once' or something
     //        to give the compiler enough information to know we will only run
     //        it once so it can consume the capture. For now, we use an optional
@@ -176,6 +181,9 @@ extension InlineArray where Element: ~Copyable {
         }
       }
     }
+#else
+    fatalError()
+#endif
   }
 }
 


### PR DESCRIPTION
Older compilers who don't understand that this function is now typed throws capable will fail to compile the usage in the stdlib.

Resolves: rdar://144990080