### PR TITLE
[CS] Fix DeclContext for multi-statement closure captures

### DIFF
--- a/test/Constraints/issue-79444.swift
+++ b/test/Constraints/issue-79444.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/79444
+class C {
+  func foo() {
+    _ = { [x = "\(self)"] in } // expected-warning {{capture 'x' was never used}}
+    _ = { [x = "\(self)"] in x }
+    _ = { [x = "\(self)"] in 
+      let y = x
+      return y 
+    }
+    _ = { [x = "\(self)"] in
+      let fn = { [y = "\(x)"] in
+        let z = y
+        return z 
+      }
+      return fn() 
+    }
+  }
+}


### PR DESCRIPTION
Make sure we set the correct DeclContext for CSGen of multi-statement closure captures, since otherwise the DeclContext is set to the closure itself, which is wrong.

Resolves #79444