### PR TITLE
IRGen: adjust addressability of the generic metadata

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -836,6 +836,12 @@ bool irgen::isSpecializedNominalTypeMetadataStaticallyAddressable(
     if (IGM.getSwiftModule() == nominal->getModuleContext()) {
       return false;
     }
+    // We cannot reference the type context across the module boundary on
+    // PE/COFF without a load. This prevents us from statically initializing the
+    // pattern.
+    if (IGM.Triple.isOSWindows() &&
+        !nominal->getModuleContext()->isStaticLibrary())
+      return false;
     if (nominal->isResilient(IGM.getSwiftModule(),
                              ResilienceExpansion::Maximal)) {
       return false;


### PR DESCRIPTION
When building on Windows, if the nominal base type is in a non-static library, we cannot reference the type descriptor directly. As a load is required, we cannot statically initialise the pattern metadata. Account for this in the addressability computation.

Fixes: #79417