### PR TITLE
[SwiftShims] Include Target.h in the modulemap for SwiftShims

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -18,6 +18,7 @@ module SwiftShims {
   header "SwiftStddef.h"
   header "SwiftStdint.h"
   header "System.h"
+  header "Target.h"
   header "ThreadLocalStorage.h"
   header "UnicodeData.h"
   header "Visibility.h"


### PR DESCRIPTION
Seems to be just a simple omission, and we can get a "include of a non-modular header" warning.

rdar://145018703
