### PR TITLE
update_checkout: bump swift-system to 1.4.1

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -148,7 +148,7 @@
                 "swift-log": "1.5.4",
                 "swift-numerics": "1.0.2",
                 "swift-syntax": "main",
-                "swift-system": "1.3.0",
+                "swift-system": "1.4.1",
                 "swift-stress-tester": "main",
                 "swift-testing": "main",
                 "swift-corelibs-xctest": "main",


### PR DESCRIPTION
This updates the swift-system dependency to v1.4.1. The update is motivated by the dependency in swift-build.
