### PR TITLE
[ASTGen] Fix SetterAccessAttr e.g. private(set)

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1983,7 +1983,10 @@ extension ASTGenVisitor {
     -> BridgedDeclAttribute?
   {
     if let detail = node.detail {
-      precondition(detail.detail.keywordKind == .set, "only accepted modifier argument is '(set)'")
+      guard detail.detail.rawText == "set" else {
+        // TODO: Diagnose
+        fatalError("only accepted modifier argument is '(set)'")
+      }
       return BridgedSetterAccessAttr.createParsed(
         self.ctx,
         range: self.generateSourceRange(node),

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -141,6 +141,8 @@ struct TestVars {
   var s: Int {
     get async throws { return 0 }
   }
+
+  private(set) var testPrivateSet = 1
 }
 
 extension TestVars {


### PR DESCRIPTION
`set` part was not parsed as a keyword. Let's just compare the text.
