### PR TITLE
CMake: Find Dispatch module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1632,7 +1632,8 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
           -DCMAKE_COLOR_DIAGNOSTICS:BOOLEAN=${CMAKE_COLOR_DIAGNOSTICS}
           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
           -DSwiftCore_PLATFORM_SUBDIR=${SWIFT_SDK_${sdk}_LIB_SUBDIR}
-          -DSwiftCore_ARCH_SUBDIR=${arch})
+          -DSwiftCore_ARCH_SUBDIR=${arch}
+          -DSwiftCore_ENABLE_CONCURRENCY=YES)
       if(NOT ${CMAKE_CROSSCOMPILING})
         add_dependencies("${stdlib_target}" swift-frontend)
       endif()

--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -112,6 +112,7 @@ defaulted_option(SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS "Resolve ab
 defaulted_option(SwiftCore_ENABLE_BACKDEPLOYMENT_SUPPORT "Add symbols for runtime backdeployment")
 defaulted_option(SwiftCore_ENABLE_STDLIB_TRACING "Enable tracing in the runtime. Assumes the presence of os_log(3) and the os_signpost(3) API.")
 defaulted_option(SwiftCore_ENABLE_CONCURRENCY "Enable Concurrency runtime support")
+defaulted_set(SwiftCore_CONCURRENCY_GLOBAL_EXECUTOR STRING "Default Concurrency global executor implementation")
 option(SwiftCore_ENABLE_UNICODE_DATA "Include unicode data in Swift runtimes" ON)
 option(SwiftCore_ENABLE_SHORT_MANGLING_LOOKUPS "Build with fast-path context descriptor lookups based on well-known short manglings." ON)
 option(SwiftCore_ENABLE_FILESYSTEM_SUPPORT "Build for systems that have a filesystem" ON)

--- a/Runtimes/Core/Concurrency/dispatch.cmake
+++ b/Runtimes/Core/Concurrency/dispatch.cmake
@@ -1,5 +1,5 @@
 
-find_package(dispatch QUIET)
+find_package(dispatch QUIET REQUIRED)
 
 target_sources(swift_Concurrency PRIVATE
   DispatchGlobalExecutor.cpp)

--- a/Runtimes/Core/cmake/modules/Finddispatch.cmake
+++ b/Runtimes/Core/cmake/modules/Finddispatch.cmake
@@ -1,0 +1,123 @@
+#[=======================================================================[.rst:
+Finddispatch
+------------
+
+Find libdispatch, deferring to dispatchConfig.cmake when requested.
+This is meant to find the C implementation of libdispatch for use as the
+executor for Swift concurrency. This library is not intended for use by
+third-party program on Linux or Windows.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+The following :prop_tgt:`IMPORTED` TARGETS may be defined:
+
+ ``dispatch``
+
+Hint Variables
+^^^^^^^^^^^^^^
+
+ ``swift_SDKROOT``
+   Set the path to the Swift SDK installation.
+   This only affects Linux and Windows builds.
+   Apple builds always use the library provided by the SDK.
+
+ ``dispatch_STATIC``
+   Look for the libdispatch static archive instead of the dynamic library.
+   This only affects Linux. Apple builds always use the
+   dynamic library provided by the SDK. Windows does not currently have a static
+   libdispatch implementation.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+The module may set the following variables if `dispatch_DIR` is not set.
+
+ ``dispatch_FOUND``
+   true if dispatch headers and libraries were found
+
+ ``dispatch_INCLUDE_DIR``
+   the directory containing the libdispatch headers
+
+ ``dispatch_LIBRARIES`` OR ``dispatch_IMPLIB``
+   the libraries to be linked
+
+#]=======================================================================]
+
+# If the dispatch_DIR is specified, look there instead. The cmake-generated
+# config file is more accurate, but requires that the SDK has one available.
+if(dispatch_DIR)
+  if(dispatch_FIND_REQUIRED)
+    list(APPEND args REQUIRED)
+  endif()
+  if(dispatch_FIND_QUIETLY)
+    list(APPEND args QUIET)
+  endif()
+  find_package(dispatch NO_MODULE ${args})
+  return()
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+if(APPLE)
+  # When building for Apple platforms, libdispatch always comes from within the
+  # SDK as a tbd for a shared library in the shared cache.
+  find_path(dispatch_INCLUDE_DIR "dispatch/dispatch.h")
+  find_library(dispatch_IMPLIB
+    NAMES "libdispatch.tbd"
+    PATH "usr/lib"
+    PATH_SUFFIXES system)
+  add_library(dispatch SHARED IMPORTED GLOBAL)
+  set_target_properties(dispatch PROPERTIES
+    IMPORTED_IMPLIB "${dispatch_IMPLIB}"
+    INTERFACE_INCLUDE_DIRECTORIES "${dispatch_INCLUDE_DIR}")
+  find_package_handle_standard_args(dispatch DEFAULT_MSG
+    dispatch_IMPLIB dispatch_INCLUDE_DIR)
+elseif(LINUX)
+  if(dispatch_STATIC)
+    find_path(dispatch_INCLUDE_DIR
+      "dispatch/dispatch.h"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift_static")
+    find_library(dispatch_LIBRARY
+      NAMES "libdispatch.a"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift_static/linux")
+    add_library(dispatch STATIC IMPORTED GLOBAL)
+  else()
+    find_path(dispatch_INCLUDE_DIR
+      "dispatch/dispatch.h"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift")
+    find_library(dispatch_LIBRARY
+      NAMES "libdispatch.so"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift/linux")
+    add_library(dispatch SHARED IMPORTED GLOBAL)
+  endif()
+  set_target_properties(dispatch
+    IMPORTED_LOCATION "${dispatch_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${dispatch_INCLUDE_DIR}")
+  find_package_handle_standard_args(dispatch DEFAULT_MSG
+    dispatch_LIBRARY dispatch_INCLUDE_DIR)
+elseif(WIN32)
+  find_path(dispatch_INCLUDE_DIR
+    "dispatch/dispatch.h"
+    HINTS
+      "${Swift_SDKROOT}/usr/include"
+      "$ENV{SDKROOT}/usr/include")
+  find_library(dispatch_LIBRARY
+    NAMES "dispatch.lib"
+    HINTS
+      "${Swift_SDKROOT}/usr/lib/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+      "${Swift_SDKROOT}/usr/lib/swift"
+      "$ENV{SDKROOT}/usr/lib/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+      "$ENV{SDKROOT}/usr/lib/swift")
+
+  add_library(dispatch SHARED IMPORTED GLOBAL)
+  set_target_properties(dispatch
+    IMPORTED_IMPLIB "${dispatch_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${dispatch_INCLUDE_DIR}")
+  find_package_handle_standard_args(dispatch DEFAULT_MSG
+    dispatch_IMPLIB dispatch_INCLUDE_DIR)
+else()
+  message(FATAL_ERROR "Finddispatch.cmake module search not implemented for targeted platform\n"
+  " Build corelibs libdispatch for your platform and set `dispatch_DIR` to"
+  " the directory containing dispatchConfig.cmake\n")
+endif()


### PR DESCRIPTION
Adding a `Finddispatch.cmake` module to find libdispatch, both on Apple platforms and from corelibs-libdispatch.
This gets concurrency building on Apple platforms, picking up Dispatch from the SDK.
When building for Windows and Linux, this module imports the library from the pre-existing SDK, making it possible to build Swift Concurrency without having to build dispatch if an existing copy is available.
If desired, one can set `dispatch_DIR` to point at the directory containing `dispatchConfig.cmake` in order to pull in a new build, or set CMAKE_FIND_PACKAGE_PREFER_CONFIG to ignore the module entirely and search for an installed config file.

When building for Apple-platforms, the module will only look for the libdispatch from the SDK.
When building for Linux, the module considers two variables:
 - `swift_SDKROOT`:`FILEPATH`: Path to the installed Swift SDK. The SDK and toolchain are currently shipped as one package, so this is likely just pointing at the root of the downloaded tarball.
 - `dispatch_STATIC`:`BOOLEAN`: Hint the module to find the static archive for libdispatch instead of the dynamic library.