### PR TITLE
[cxx-interop] Remove duplicated logic to import types as unsafe

### DIFF
--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -34,6 +34,7 @@ struct SWIFT_ESCAPABLE Owner {};
 
 struct Unannotated {
     Unannotated();
+    int *pointer;
 };
 
 struct SWIFT_UNSAFE_REFERENCE UnsafeReference {};


### PR DESCRIPTION
After PR #79424 was merged the compiler proper is doing inference on what C++ types should be considered unsafe. Remove the duplicated (and slightly divergent) logic from the importer as we no longer need it and we should have a consistent view of what is considered unsafe. The only divergence left is the old logic that renames some methods to have "Unsafe" in their names. In the future, we want to get rid of this behavior (potentially under a new interop version).
