### PR TITLE
utils: add a toggle for the toolchain variant

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3067,6 +3067,7 @@ function Build-Installer($Arch) {
     # When cross-compiling, bundle the second mimalloc redirect dll as a workaround for
     # https://github.com/microsoft/mimalloc/issues/997
     WORKAROUND_MIMALLOC_ISSUE_997 = if ($IsCrossCompiling) { "true" } else { "false" };
+    INCLUDE_ASSERTS_TOOLCHAIN = "true";
     INCLUDE_SWIFT_DOCC = $INCLUDE_SWIFT_DOCC;
     SWIFT_DOCC_BUILD = "$($Arch.BinaryCache)\swift-docc\release";
     SWIFT_DOCC_RENDER_ARTIFACT_ROOT = "${SourceCache}\swift-docc-render-artifact";


### PR DESCRIPTION
Prepare to package multiple variants of the toolchain. This wires up the variant information to the packaging rules.