### PR TITLE
[6.1] Sema: don't use `llvm::StringSwitch` for runtime function names

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2294,14 +2294,14 @@ static bool canDeclareSymbolName(StringRef symbol, ModuleDecl *fromModule) {
   // to predict ways. Warn when code attempts to do so; hopefully we can
   // promote this to an error after a while.
   
-  return llvm::StringSwitch<bool>(symbol)
 #define FUNCTION(_, Name, ...) \
-    .Case(#Name, false) \
-    .Case("_" #Name, false) \
-    .Case(#Name "_", false) \
-    .Case("_" #Name "_", false)
+  if (symbol == #Name) { return false; } \
+  if (symbol == "_" #Name) { return false; } \
+  if (symbol == #Name "_") { return false; } \
+  if (symbol == "_" #Name "_") { return false; }
 #include "swift/Runtime/RuntimeFunctions.def"
-    .Default(true);
+
+  return true;
 }
 
 void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {


### PR DESCRIPTION
Using `llvm::StringSwitch` with this many cases causes clang to crash due to a stack overflow. Works around rdar://143944155

(cherry picked from commit ed4863f76cb5b0799e16bf0b2feef0b89423d73c)

--- CCC ---

Explanation: clang 16.0 is often used to build release branches but crashes with infinite recursion when compiling TypeCheckAttr.cpp with asserts enabled. We need an asserts compiler to debug Swift 6.1 issues.

Scope: No functional change. This is a syntax workaround to avoid crashing clang.

Radar/SR Issue: rdar://143944155 (clang crashes compiling TypeCheckAttr.cpp when building the swift compiler: infinite recursion in EmitCXXConstructorCall)

Original PR: https://github.com/swiftlang/swift/pull/79109

Risk: Minimal

Testing: clang 16.0 successfully builds

Reviewer: Pavel Yaskevich
