### PR TITLE
Sema: Clean up odd bit of dead code in binding inference

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -175,11 +175,6 @@ private:
   /// Notify all of the type variables referenced by this one about a change.
   void notifyReferencedVars(
       llvm::function_ref<void(ConstraintGraphNode &)> notification) const;
-
-  void updateFixedType(
-      Type fixedType,
-      llvm::function_ref<void (ConstraintGraphNode &,
-                               Constraint *)> notification) const;
   /// }
 
   /// The constraint graph this node belongs to.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -148,7 +148,7 @@ private:
 
   /// Perform graph updates that must be undone after we bind a fixed type
   /// to a type variable.
-  void retractFromInference(Type fixedType);
+  void retractFromInference();
 
   /// Perform graph updates that must be undone before we bind a fixed type
   /// to a type variable.
@@ -294,7 +294,7 @@ public:
 
   /// Perform graph updates that must be undone after we bind a fixed type
   /// to a type variable.
-  void retractFromInference(TypeVariableType *typeVar, Type fixedType);
+  void retractFromInference(TypeVariableType *typeVar);
 
   /// Perform graph updates that must be undone before we bind a fixed type
   /// to a type variable.

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -322,10 +322,16 @@ void ConstraintGraphNode::updateFixedType(
   }
 }
 
-void ConstraintGraphNode::retractFromInference(Type fixedType) {
+void ConstraintGraphNode::retractFromInference() {
   auto &cs = CG.getConstraintSystem();
-  return updateFixedType(
-      fixedType,
+
+  // Notify all of the type variables that reference this one.
+  //
+  // Since this type variable is going to be replaced with a fixed type
+  // all of the concrete types that reference it are going to change,
+  // which means that all of the not-yet-attempted bindings should
+  // change as well.
+  return notifyReferencingVars(
       [&cs](ConstraintGraphNode &node, Constraint *constraint) {
         node.getPotentialBindings().retract(cs, node.getTypeVariable(), constraint);
       });
@@ -523,8 +529,8 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
   }
 }
 
-void ConstraintGraph::retractFromInference(TypeVariableType *typeVar, Type fixed) {
-  (*this)[typeVar].retractFromInference(fixed);
+void ConstraintGraph::retractFromInference(TypeVariableType *typeVar) {
+  (*this)[typeVar].retractFromInference();
 }
 
 void ConstraintGraph::introduceToInference(TypeVariableType *typeVar, Type fixed) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -287,17 +287,33 @@ void ConstraintGraphNode::removeReferencedBy(TypeVariableType *typeVar) {
   }
 }
 
-void ConstraintGraphNode::updateFixedType(
-    Type fixedType,
-    llvm::function_ref<void (ConstraintGraphNode &,
-                             Constraint *)> notification) const {
+void ConstraintGraphNode::retractFromInference() {
+  auto &cs = CG.getConstraintSystem();
+
+  // Notify all of the type variables that reference this one.
+  //
+  // Since this type variable is going to be replaced with a fixed type
+  // all of the concrete types that reference it are going to change,
+  // which means that all of the not-yet-attempted bindings should
+  // change as well.
+  return notifyReferencingVars(
+      [&cs](ConstraintGraphNode &node, Constraint *constraint) {
+        node.getPotentialBindings().retract(cs, node.getTypeVariable(), constraint);
+      });
+}
+
+void ConstraintGraphNode::introduceToInference(Type fixedType) {
+  auto &cs = CG.getConstraintSystem();
+  
   // Notify all of the type variables that reference this one.
   //
   // Since this type variable has been replaced with a fixed type
   // all of the concrete types that reference it are going to change,
   // which means that all of the not-yet-attempted bindings should
   // change as well.
-  notifyReferencingVars(notification);
+  notifyReferencingVars([&cs](ConstraintGraphNode &node, Constraint *constraint) {
+    node.getPotentialBindings().infer(cs, node.getTypeVariable(), constraint);
+  });
 
   if (!fixedType->hasTypeVariable())
     return;
@@ -317,33 +333,9 @@ void ConstraintGraphNode::updateFixedType(
     // all of the constraints that reference bound type variable.
     for (auto *constraint : getConstraints()) {
       if (isUsefulForReferencedVars(constraint))
-        notification(node, constraint);
+        node.getPotentialBindings().infer(cs, node.getTypeVariable(), constraint);
     }
   }
-}
-
-void ConstraintGraphNode::retractFromInference() {
-  auto &cs = CG.getConstraintSystem();
-
-  // Notify all of the type variables that reference this one.
-  //
-  // Since this type variable is going to be replaced with a fixed type
-  // all of the concrete types that reference it are going to change,
-  // which means that all of the not-yet-attempted bindings should
-  // change as well.
-  return notifyReferencingVars(
-      [&cs](ConstraintGraphNode &node, Constraint *constraint) {
-        node.getPotentialBindings().retract(cs, node.getTypeVariable(), constraint);
-      });
-}
-
-void ConstraintGraphNode::introduceToInference(Type fixedType) {
-  auto &cs = CG.getConstraintSystem();
-  return updateFixedType(
-      fixedType,
-      [&cs](ConstraintGraphNode &node, Constraint *constraint) {
-        node.getPotentialBindings().infer(cs, node.getTypeVariable(), constraint);
-      });
 }
 
 #pragma mark Graph mutation

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -217,7 +217,7 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
   assert(!type->hasError() &&
          "Should not be assigning a type involving ErrorType!");
 
-  CG.retractFromInference(typeVar, type);
+  CG.retractFromInference(typeVar);
   typeVar->getImpl().assignFixedType(type, getTrail());
 
   if (!updateState)


### PR DESCRIPTION
Recently the question came up as to why `assignFixedType()` was calling `retractFromInference()` on the _new_ fixed type before this new type was even assigned; what could there be to "retract"? Turns out the answer is "nothing". We don't need to pass a fixed type down to `retractFromInference()`.