### PR TITLE
Fix loop rotate when header has instructions producing ownership results

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -44,6 +44,9 @@ static llvm::cl::opt<int> LoopRotateSizeLimit("looprotate-size-limit",
                                               llvm::cl::init(20));
 static llvm::cl::opt<bool> RotateSingleBlockLoop("looprotate-single-block-loop",
                                                  llvm::cl::init(false));
+static llvm::cl::opt<bool>
+    LoopRotateInfiniteBudget("looprotate-infinite-budget",
+                             llvm::cl::init(false));
 
 static bool rotateLoop(SILLoop *loop, DominanceInfo *domInfo,
                        SILLoopInfo *loopInfo, bool rotateSingleBlockLoops,
@@ -118,9 +121,7 @@ canDuplicateOrMoveToPreheader(SILLoop *loop, SILBasicBlock *preheader,
     if (!inst->mayHaveSideEffects() && !inst->mayReadFromMemory() &&
         !isa<TermInst>(inst) &&
         !isa<AllocationInst>(inst) && /* not marked mayhavesideeffects */
-        !isa<CopyValueInst>(inst) &&
-        !isa<MoveValueInst>(inst) &&
-        !isa<BeginBorrowInst>(inst) &&
+        !hasOwnershipOperandsOrResults(inst) &&
         hasLoopInvariantOperands(inst, loop, invariants)) {
       moves.push_back(inst);
       invariants.insert(inst);
@@ -133,7 +134,7 @@ canDuplicateOrMoveToPreheader(SILLoop *loop, SILBasicBlock *preheader,
     cost += (int)instructionInlineCost(instRef);
   }
 
-  return cost < LoopRotateSizeLimit;
+  return cost < LoopRotateSizeLimit || LoopRotateInfiniteBudget;
 }
 
 static void mapOperands(SILInstruction *inst,

--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -1,11 +1,10 @@
-// RUN: %target-sil-opt -loop-rotate -update-borrowed-from -looprotate-single-block-loop=true %s | %FileCheck %s
+// RUN: %target-sil-opt -loop-rotate -update-borrowed-from -looprotate-single-block-loop=true -looprotate-infinite-budget %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin
 import Swift
 
 class Klass {
-
 }
 
 struct BoxStruct {
@@ -244,3 +243,41 @@ bb8:
 bb9:
   unreachable
 }
+
+// Ensure no verifier error
+
+sil @foo : $@convention(thin) (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+
+sil [ossa] @looprotate_ownership_results : $@convention(thin) (Int32, @guaranteed Klass) -> Int32 {
+bb0(%0 : $Int32, %1 : @guaranteed $Klass):
+  %2 = struct_extract %0, #Int32._value
+  %3 = integer_literal $Builtin.Int32, 0
+  br bb1(%2, %3)
+
+bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32):
+  %7 = function_ref @foo : $@convention(thin) (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+  %8 = thin_to_thick_function %7 to $@noescape @callee_guaranteed (@in_guaranteed UInt64, @in_guaranteed UInt64) -> (Bool, @error any Error) 
+  %9 = convert_function %8 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error any Error) for <UInt64, UInt64>, forwarding: @owned 
+  destroy_value %9
+  %11 = struct $Int32 (%6)
+  %12 = builtin "cmp_eq_Word"(%6, %2) : $Builtin.Int1
+  cond_br %12, bb3, bb2
+
+bb2:
+  %14 = integer_literal $Builtin.Int32, 1
+  %15 = integer_literal $Builtin.Int1, -1
+  %16 = builtin "sadd_with_overflow_Word"(%6, %14, %15) : $(Builtin.Int32, Builtin.Int1)
+  %17 = tuple_extract %16, 0
+  %18 = enum $Optional<Int32>, #Optional.some!enumelt, %11
+  %19 = unchecked_enum_data %18, #Optional.some!enumelt
+  %20 = struct_extract %19, #Int32._value
+  %21 = integer_literal $Builtin.Int1, -1
+  %22 = builtin "sadd_with_overflow_Word"(%5, %20, %21) : $(Builtin.Int32, Builtin.Int1)
+  %23 = tuple_extract %22, 0
+  br bb1(%23, %17)
+
+bb3:
+  %25 = struct $Int32 (%5)
+  return %25
+}
+


### PR DESCRIPTION
LoopRotate currently should avoid moving instructions that produce ownership results to the loop header. Such instructions may have uses with the loop that cannot be moved to the loop header causing over consume ownership verifier errors.

rdar://145086395

