### PR TITLE
[TypeChecker/NameLookup] SE-0463: A few fixes for `SendableCompletionHandlers` feature

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1898,6 +1898,11 @@ ERROR(objc_implementation_type_mismatch,none,
       "%kind0 of type %1 does not match type %2 declared by the header",
       (ValueDecl *, Type, Type))
 
+ERROR(objc_implementation_sendability_mismatch,none,
+      "sendability of function types in %kind0 of type %1 does not match "
+      "type %2 declared by the header",
+      (ValueDecl *, Type, Type))
+
 ERROR(objc_implementation_required_attr_mismatch,none,
       "%kind0 %select{should not|should}2 be 'required' to match %1 declared "
       "by the header",

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -375,7 +375,8 @@ private:
         if (firstFunc->isNoEscape() != secondFunc->isNoEscape())
           return mismatch(firstFunc.getPointer(), secondFunc, sugaredFirstType);
 
-        if (firstFunc->isSendable() != secondFunc->isSendable())
+        if (!Matcher.asDerived().allowSendableFunctionMismatch() &&
+            firstFunc->isSendable() != secondFunc->isSendable())
           return mismatch(firstFunc.getPointer(), secondFunc, sugaredFirstType);
 
         auto sugaredFirstFunc = sugaredFirstType->castTo<AnyFunctionType>();
@@ -553,6 +554,8 @@ private:
   };
 
   bool alwaysMismatchTypeParameters() const { return false; }
+
+  bool allowSendableFunctionMismatch() const { return false; }
 
   void pushPosition(Position pos) {}
   void popPosition(Position pos) {}

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -826,6 +826,20 @@ static void recordShadowedDeclsAfterSignatureMatch(
     else
       type = removeThrownError(decl->getInterfaceType()->getCanonicalType());
 
+    // Strip `@Sendable` annotations for declarations that come from
+    // or are exposed to Objective-C to make it possible to introduce
+    // new annotations without breaking shadowing rules.
+    //
+    // This is a narrow fix for specific backwards-incompatible cases
+    // we know about, it could be extended to use `isObjC()` in the
+    // future if we find problematic cases were a more general change
+    // is required.
+    if (decl->hasClangNode() || decl->getAttrs().hasAttribute<ObjCAttr>()) {
+      type =
+          type->stripConcurrency(/*recursive=*/true, /*dropGlobalActor=*/false)
+              ->getCanonicalType();
+    }
+
     // Record this declaration based on its signature.
     auto &known = collisions[type];
     if (known.size() == 1) {

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2269,6 +2269,25 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
       return true;
     }
 
+    bool allowSendableFunctionMismatch() const {
+      // Allow mismatches on `@Sendable` only if the witness comes
+      // from ObjC as a very narrow fix to avoid introducing new
+      // ambiguities like this:
+      //
+      // protocol P {
+      //   associatedtype T
+      //   func test(_: (T) -> Void)
+      // }
+      //
+      // struct S : P {
+      //   func test(_: @Sendable (Int) -> Void) {}
+      //   func test(_: (Int) -> Void) {}
+      // }
+      //
+      // Currently, there is only one binding for `T` - `Int`.
+      return Inferred.Witness && Inferred.Witness->hasClangNode();
+    }
+
     bool mismatch(GenericTypeParamType *selfParamType,
                   TypeBase *secondType, Type sugaredFirstType) {
       if (selfParamType->isEqual(Conformance->getProtocol()->getSelfInterfaceType())) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3435,6 +3435,7 @@ private:
     WrongWritability,
     WrongRequiredAttr,
     WrongForeignErrorConvention,
+    WrongSendability,
 
     Match,
     MatchWithExplicitObjCName,
@@ -3621,70 +3622,93 @@ private:
     return lhs == rhs;
   }
 
-  static bool matchParamTypes(Type reqTy, Type implTy, ValueDecl *implDecl) {
+  static MatchOutcome matchParamTypes(Type reqTy, Type implTy,
+                                      ValueDecl *implDecl) {
     TypeMatchOptions matchOpts = {};
-
     // Try a plain type match.
     if (implTy->matchesParameter(reqTy, matchOpts))
-      return true;
+      return MatchOutcome::Match;
 
-    // If the implementation type is IUO, try unwrapping it.
-    if (auto unwrappedImplTy = implTy->getOptionalObjectType())
-      return implDecl->isImplicitlyUnwrappedOptional()
-                && unwrappedImplTy->matchesParameter(reqTy, matchOpts);
+    // Try to drop `@Sendable`.
+    {
+      auto ignoreSendable =
+          matchOpts | TypeMatchFlags::IgnoreFunctionSendability;
 
-    return false;
+      if (implTy->matchesParameter(reqTy, ignoreSendable))
+        return MatchOutcome::WrongSendability;
+    }
+
+    if (implDecl) {
+      // If the implementation type is IUO, try unwrapping it.
+      if (auto unwrappedImplTy = implTy->getOptionalObjectType())
+        return implDecl->isImplicitlyUnwrappedOptional() &&
+                       unwrappedImplTy->matchesParameter(reqTy, matchOpts)
+                   ? MatchOutcome::Match
+                   : MatchOutcome::WrongType;
+    }
+
+    return MatchOutcome::WrongType;
   }
 
-  static bool matchTypes(Type reqTy, Type implTy, ValueDecl *implDecl) {
+  static MatchOutcome matchTypes(Type reqTy, Type implTy, ValueDecl *implDecl) {
     TypeMatchOptions matchOpts = {};
 
     // Try a plain type match.
     if (reqTy->matches(implTy, matchOpts))
-      return true;
+      return MatchOutcome::Match;
 
     // If the implementation type is optional, try unwrapping it.
     if (auto unwrappedImplTy = implTy->getOptionalObjectType())
-      return implDecl->isImplicitlyUnwrappedOptional()
-                  && reqTy->matches(unwrappedImplTy, matchOpts);
+      return implDecl->isImplicitlyUnwrappedOptional() &&
+                     reqTy->matches(unwrappedImplTy, matchOpts)
+                 ? MatchOutcome::Match
+                 : MatchOutcome::WrongType;
 
     // Apply these rules to the result type and parameters if it's a function
     // type.
-    if (auto funcReqTy = reqTy->getAs<AnyFunctionType>())
-      if (auto funcImplTy = implTy->getAs<AnyFunctionType>())
-        return funcReqTy->matchesFunctionType(funcImplTy, matchOpts,
-                                              [=]() -> bool {
-          auto reqParams = funcReqTy->getParams();
-          auto implParams = funcImplTy->getParams();
-          if (reqParams.size() != implParams.size())
-            return false;
-
-          ParameterList *implParamList = nullptr;
-          if (auto afd = dyn_cast<AbstractFunctionDecl>(implDecl))
-            implParamList = afd->getParameters();
-
-          for (auto i : indices(reqParams)) {
-            const auto &reqParam = reqParams[i];
-            const auto &implParam = implParams[i];
-            if (implParamList) {
-              // Some of the parameters may be IUOs; apply special logic.
-              if (!matchParamTypes(reqParam.getOldType(),
-                                   implParam.getOldType(),
-                                   implParamList->get(i)))
+    if (auto funcReqTy = reqTy->getAs<AnyFunctionType>()) {
+      if (auto funcImplTy = implTy->getAs<AnyFunctionType>()) {
+        bool hasSendabilityMismatches = false;
+        bool isMatch = funcReqTy->matchesFunctionType(
+            funcImplTy, matchOpts, [=, &hasSendabilityMismatches]() -> bool {
+              auto reqParams = funcReqTy->getParams();
+              auto implParams = funcImplTy->getParams();
+              if (reqParams.size() != implParams.size())
                 return false;
-            } else {
-              // IUOs not allowed here; apply ordinary logic.
-              if (!reqParam.getOldType()->matchesParameter(
-                      implParam.getOldType(), matchOpts))
-                return false;
-            }
-          }
 
-          return matchTypes(funcReqTy->getResult(), funcImplTy->getResult(),
-                            implDecl);
-        });
+              ParameterList *implParamList = nullptr;
+              if (auto afd = dyn_cast<AbstractFunctionDecl>(implDecl))
+                implParamList = afd->getParameters();
 
-    return false;
+              for (auto i : indices(reqParams)) {
+                const auto &reqParam = reqParams[i];
+                const auto &implParam = implParams[i];
+
+                auto outcome = matchParamTypes(
+                    reqParam.getOldType(), implParam.getOldType(),
+                    implParamList ? implParamList->get(i) : nullptr);
+
+                if (outcome == MatchOutcome::WrongSendability)
+                  hasSendabilityMismatches = true;
+
+                if (outcome < MatchOutcome::WrongSendability)
+                  return false;
+              }
+
+              return matchTypes(funcReqTy->getResult(), funcImplTy->getResult(),
+                                implDecl) == MatchOutcome::Match;
+            });
+
+        if (isMatch) {
+          return hasSendabilityMismatches ? MatchOutcome::WrongSendability
+                                          : MatchOutcome::Match;
+        }
+
+        return MatchOutcome::WrongType;
+      }
+    }
+
+    return MatchOutcome::WrongType;
   }
 
   static Type getMemberType(ValueDecl *decl) {
@@ -3729,7 +3753,9 @@ private:
     if (cand->getKind() != req->getKind())
       return MatchOutcome::WrongDeclKind;
 
-    if (!matchTypes(getMemberType(req), getMemberType(cand), cand))
+    auto matchTypesOutcome =
+        matchTypes(getMemberType(req), getMemberType(cand), cand);
+    if (matchTypesOutcome == MatchOutcome::WrongType)
       return MatchOutcome::WrongType;
 
     if (auto reqVar = dyn_cast<AbstractStorageDecl>(req))
@@ -3749,6 +3775,15 @@ private:
     // If we got here, everything matched. But at what quality?
     if (explicitObjCName)
       return MatchOutcome::MatchWithExplicitObjCName;
+
+    // Sendable mismatches are downgraded to warnings because ObjC
+    // declarations are `@preconcurrency`, we need to make sure
+    // that there are no other problems before returning `WrongSendability`.
+    if (matchTypesOutcome == MatchOutcome::WrongSendability)
+      return MatchOutcome::WrongSendability;
+
+    ASSERT(matchTypesOutcome == MatchOutcome::Match &&
+           "unexpected matchTypes() return");
 
     return MatchOutcome::Match;
   }
@@ -3785,6 +3820,13 @@ private:
       // Successful outcomes!
       // If this member will require a vtable entry, diagnose that now.
       diagnoseVTableUse(cand);
+      return;
+
+    case MatchOutcome::WrongSendability:
+      diagnose(cand, diag::objc_implementation_sendability_mismatch, cand,
+               getMemberType(cand), getMemberType(req))
+          .limitBehaviorWithPreconcurrency(DiagnosticBehavior::Warning,
+                                           /*preconcurrency*/ true);
       return;
 
     case MatchOutcome::WrongImplicitObjCName:

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -78,6 +78,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void)willSendDataWithCompletion: (void (^)(void)) completion;
 @end
 
+@interface DataHandler : NSObject
++(void)sendDataWithCompletion: (void (^)(MyValue *)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -188,4 +192,14 @@ class ImplicitShadowing : NSObject, TestWitnesses {
   func test() {
     (self as AnyObject).willSendData { } // Ok
   }
+}
+
+protocol CompletionWithoutSendable {
+  associatedtype T
+  static func sendData(completion: @escaping (T) -> Void) // expected-note {{expected sendability to match requirement here}}
+}
+
+extension DataHandler : CompletionWithoutSendable {
+  // expected-warning@-1 {{sendability of function types in class method 'sendData(completion:)' does not match requirement in protocol 'CompletionWithoutSendable'}}
+  // It should be possible to infer `T` from method that mismatches on @Sendable in Swift 5 mode
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -64,6 +64,11 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void) testWithCallback:(NSString *)name handler:(MAIN_ACTOR void (^)(NSDictionary<NSString *, SWIFT_SENDABLE id> *, NSError * _Nullable))handler;
 @end
 
+@interface SwiftImpl : NSObject
+-(id)initWithCallback:  (void (^ SWIFT_SENDABLE)(void)) callback;
+-(void)computeWithCompletionHandler: (void (^)(void)) handler;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -144,4 +149,12 @@ class TestConformanceWithoutStripping : InnerSendableTypes {
 
   func test(withCallback name: String, handler: @escaping @MainActor ([String : any Sendable], (any Error)?) -> Void) { // Ok
   }
+}
+
+@objc @implementation extension SwiftImpl {
+  @objc public required init(callback: @escaping () -> Void) {}
+  // expected-error@-1 {{initializer 'init(callback:)' should not be 'required' to match initializer declared by the header}}
+  
+  @objc func compute(completionHandler: @escaping () -> Void) {}
+  // expected-warning@-1 {{sendability of function types in instance method 'compute(completionHandler:)' of type '(@escaping () -> Void) -> ()' does not match type '(@escaping @Sendable () -> Void) -> Void' declared by the header}}
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -74,6 +74,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void)updateWithCompletionHandler: (void (^_Nullable)(void)) handler;
 @end
 
+@protocol TestWitnesses
+-(void)willSendDataWithCompletion: (void (^)(void)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -174,5 +178,14 @@ class TestConformanceWithoutStripping : InnerSendableTypes {
   func testCompute() {
     self.compute { } // Ok - no ambiguity
     self.update { }  // Ok - no ambiguity
+  }
+}
+
+@objc
+class ImplicitShadowing : NSObject, TestWitnesses {
+  func willSendData(completion: @escaping () -> Void) {}
+
+  func test() {
+    (self as AnyObject).willSendData { } // Ok
   }
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -69,6 +69,11 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void)computeWithCompletionHandler: (void (^)(void)) handler;
 @end
 
+@interface Shadowing : NSObject
+-(void)computeWithCompletion: (void (^)(void)) completion;
+-(void)updateWithCompletionHandler: (void (^_Nullable)(void)) handler;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -157,4 +162,17 @@ class TestConformanceWithoutStripping : InnerSendableTypes {
   
   @objc func compute(completionHandler: @escaping () -> Void) {}
   // expected-warning@-1 {{sendability of function types in instance method 'compute(completionHandler:)' of type '(@escaping () -> Void) -> ()' does not match type '(@escaping @Sendable () -> Void) -> Void' declared by the header}}
+}
+
+// Methods deliberately has no `@Sendable` to make sure that
+// shadowing rules are preserved when SendableCompletionHandlers feature is enabled.
+@objc extension Shadowing {
+  @objc func compute(completion: @escaping () -> Void) {}
+
+  @objc func update(completionHandler: (() -> Void)? = nil) {}
+
+  func testCompute() {
+    self.compute { } // Ok - no ambiguity
+    self.update { }  // Ok - no ambiguity
+  }
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -82,6 +82,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 +(void)sendDataWithCompletion: (void (^)(MyValue *)) completion;
 @end
 
+@interface TestDR : NSObject
+-(void) testWithCompletion: (void (^)(void)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -202,4 +206,9 @@ protocol CompletionWithoutSendable {
 extension DataHandler : CompletionWithoutSendable {
   // expected-warning@-1 {{sendability of function types in class method 'sendData(completion:)' does not match requirement in protocol 'CompletionWithoutSendable'}}
   // It should be possible to infer `T` from method that mismatches on @Sendable in Swift 5 mode
+}
+
+extension TestDR {
+  @_dynamicReplacement(for: test(completion:))
+  func __replaceObjCFunc(_: @escaping () -> Void) {} // Ok
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -82,6 +82,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 +(void)sendDataWithCompletion: (void (^)(MyValue *)) completion;
 @end
 
+@interface TestDR : NSObject
+-(void) testWithCompletion: (void (^)(void)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -209,4 +213,9 @@ protocol CompletionWithoutSendable {
 extension DataHandler : CompletionWithoutSendable {
   // expected-error@-1 {{sendability of function types in class method 'sendData(completion:)' does not match requirement in protocol 'CompletionWithoutSendable'}}
   // It should be possible to infer `T` from method that mismatches on @Sendable in Swift 5 mode
+}
+
+extension TestDR {
+  @_dynamicReplacement(for: test(completion:))
+  func __replaceObjCFunc(_: @escaping () -> Void) {} // Ok
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -74,6 +74,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void)updateWithCompletionHandler: (void (^_Nullable)(void)) handler;
 @end
 
+@protocol TestWitnesses
+-(void)willSendDataWithCompletion: (void (^)(void)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -178,8 +182,17 @@ class TestConformanceWithoutStripping : InnerSendableTypes {
 
   @objc func update(completionHandler: (() -> Void)? = nil) {}
 
-  func testCompute() {
+  func test() {
     self.compute { } // Ok - no ambiguity
     self.update { }  // Ok - no ambiguity
+  }
+}
+
+@objc
+class ImplicitShadowing : NSObject, TestWitnesses {
+  func willSendData(completion: @escaping () -> Void) {}
+
+  func test() {
+    (self as AnyObject).willSendData { } // Ok
   }
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -64,6 +64,11 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void) testWithCallback:(NSString *)name handler:(MAIN_ACTOR void (^)(NSDictionary<NSString *, SWIFT_SENDABLE id> *, NSError * _Nullable))handler;
 @end
 
+@interface SwiftImpl : NSObject
+-(id)initWithCallback:  (void (^ SWIFT_SENDABLE)(void)) callback;
+-(void)computeWithCompletionHandler: (void (^)(void)) handler;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -151,4 +156,12 @@ class TestConformanceWithoutStripping : InnerSendableTypes {
 
   func test(withCallback name: String, handler: @escaping @MainActor ([String : any Sendable], (any Error)?) -> Void) { // Ok
   }
+}
+
+@objc @implementation extension SwiftImpl {
+  @objc public required init(callback: @escaping () -> Void) {}
+  // expected-error@-1 {{initializer 'init(callback:)' should not be 'required' to match initializer declared by the header}}
+
+  @objc func compute(completionHandler: @escaping () -> Void) {}
+  // expected-warning@-1 {{sendability of function types in instance method 'compute(completionHandler:)' of type '(@escaping () -> Void) -> ()' does not match type '(@escaping @Sendable () -> Void) -> Void' declared by the header}}
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -78,6 +78,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void)willSendDataWithCompletion: (void (^)(void)) completion;
 @end
 
+@interface DataHandler : NSObject
++(void)sendDataWithCompletion: (void (^)(MyValue *)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -195,4 +199,14 @@ class ImplicitShadowing : NSObject, TestWitnesses {
   func test() {
     (self as AnyObject).willSendData { } // Ok
   }
+}
+
+protocol CompletionWithoutSendable {
+  associatedtype T
+  static func sendData(completion: @escaping (T) -> Void) // expected-note {{expected sendability to match requirement here}}
+}
+
+extension DataHandler : CompletionWithoutSendable {
+  // expected-error@-1 {{sendability of function types in class method 'sendData(completion:)' does not match requirement in protocol 'CompletionWithoutSendable'}}
+  // It should be possible to infer `T` from method that mismatches on @Sendable in Swift 5 mode
 }


### PR DESCRIPTION
-  Allow `@objc @implementation` to mismatch on `@Sendable` in parameter positions

   Warn about missing `@Sendable` annotations (even in Swift 6 language mode) to give users and developers time to adopt Swift concurrency.

- Shadowing: strip `@Sendable` annotations for declarations ObjC/@objc declarations to avoid ambiguities until shadowing declarations adopt `@Sendable`.

- Strip Sendable while processing AnyObject lookup results

-  Allow associated type inference to skip `@Sendable` on ObjC witnesses

- Fix `@_dynamicReplacement` to skip sendable annotations on ObjC declarations

Resolves: rdar://85569247

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
