### PR TITLE
ConstExpr: fix handling of store_borrow

### DIFF
--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1825,6 +1825,10 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
     return computeCallResult(apply);
 
   if (isa<StoreInst>(inst) || isa<StoreBorrowInst>(inst)) {
+    if (auto *sb = dyn_cast<StoreBorrowInst>(inst)) {
+      auto addr = getConstantValue(inst->getOperand(1));
+      setValue(sb, addr);
+    }
     auto stored = getConstantValue(inst->getOperand(0));
     if (!stored.isConstant())
       return stored;

--- a/validation-test/SILOptimizer/oslog.swift
+++ b/validation-test/SILOptimizer/oslog.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -swift-version 6 -verify %s -emit-sil -o /dev/null
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+import os.log
+
+let logger = Logger(subsystem: "x.y.z", category: "c")
+
+// Check that this compiles without errors
+
+func testit(buffer: UnsafeRawBufferPointer) {
+  logger.fault("buffer \(buffer, privacy: .sensitive)")
+}  


### PR DESCRIPTION
The `store_borrow` instruction has a result and that must be set.

Fixes a false error of the OSLogOptimization.
rdar://144896232
