### PR TITLE
Import llvm_config in lit.site.cfg script

### DIFF
--- a/test/IRGen/static-library.swift
+++ b/test/IRGen/static-library.swift
@@ -1,5 +1,7 @@
+// UNSUPPORTED: linker_overridden
+
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver_plain -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -o %t/library.lib -emit-module-path %t
+// RUN: %target-swiftc_driver_plain -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -use-ld=%target-ld -o %t/library.lib -emit-module-path %t
 // RUN: %target-swiftc_driver_plain -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -S -emit-ir -o - | %FileCheck -check-prefix CHECK-LIBRARY %s
 // RUN: %target-swiftc_driver_plain -I %t -emit-library -S -emit-ir -o - %s | %FileCheck -check-prefix CHECK-EMBEDDING %s
 

--- a/test/Interop/Cxx/foreign-reference/layout-in-opaque-layout-struct.swift
+++ b/test/Interop/Cxx/foreign-reference/layout-in-opaque-layout-struct.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 
 
-// RUN: %target-build-swift %t/struct.swift -emit-module -emit-library -static -module-name OpaqueStruct -emit-module-path %t/Inputs/OpaqueStruct.swiftmodule -enable-library-evolution
+// RUN: %target-build-swift %t/struct.swift -emit-module -emit-library -static -use-ld=%target-ld -module-name OpaqueStruct -emit-module-path %t/Inputs/OpaqueStruct.swiftmodule -enable-library-evolution
 
 // RUN: %target-swift-emit-irgen %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
  

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -372,8 +372,6 @@ config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax
 config.refactor_check_compiles = make_path(config.swift_utils, 'refactor-check-compiles.py')
 config.abi_symbol_checker = make_path(config.swift_utils, 'swift-abi-symbol-checker.py')
 
-config.link = lit.util.which('lld-link', config.environment.get('PATH', ''))
-
 config.color_output = lit_config.params.get('color_output', None) is not None
 
 # Tell the (new) driver to invoke the Clang we've inferred. The
@@ -1696,6 +1694,13 @@ elif run_os in ['windows-msvc']:
     config.target_clang =                                                        \
             ('clang++ -target %s %s %s -fobjc-runtime=ios-5.0' %                 \
              (config.variant_triple, clang_mcp_opt, config.target_cc_options))
+
+    # Make sure we pick link.exe from MSVC host toolchain and not from coreutils
+    PATH = config.environment['PATH']
+    PATH_MSVC = ';'.join([p for p in PATH.split(';') if 'MSVC' in p])
+    config.link = lit.util.which('link', PATH_MSVC) or                           \
+                  lit.util.which('lld-link', PATH)
+
     config.target_ld =                                                           \
             ('%r -libpath:%s' % (config.link, os.path.join(test_resource_dir,    \
                                                            config.target_sdk_name)))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -372,8 +372,7 @@ config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax
 config.refactor_check_compiles = make_path(config.swift_utils, 'refactor-check-compiles.py')
 config.abi_symbol_checker = make_path(config.swift_utils, 'swift-abi-symbol-checker.py')
 
-config.link = lit.util.which('link', config.environment.get('PATH', '')) or      \
-              lit.util.which('lld-link', config.environment.get('PATH', ''))
+config.link = lit.util.which('lld-link', config.environment.get('PATH', ''))
 
 config.color_output = lit_config.params.get('color_output', None) is not None
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -173,6 +173,9 @@ config.freestanding_sdk_name = "@SWIFT_SDK_FREESTANDING_LIB_SUBDIR@"
 if '@SWIFT_BUILD_SWIFT_SYNTAX@' == 'TRUE':
   config.available_features.add('swift_swift_parser')
 
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
 # Let the main config do the real work.
 if config.test_exec_root is None:
     config.test_exec_root = os.path.dirname(lit.util.abs_path_preserve_drive(__file__))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -173,8 +173,14 @@ config.freestanding_sdk_name = "@SWIFT_SDK_FREESTANDING_LIB_SUBDIR@"
 if '@SWIFT_BUILD_SWIFT_SYNTAX@' == 'TRUE':
   config.available_features.add('swift_swift_parser')
 
+print("*********** config.environment before llvm_config ***********")
+print(config.environment)
+
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
+
+print("*********** config.environment after llvm_config ***********")
+print(config.environment)
 
 # Let the main config do the real work.
 if config.test_exec_root is None:

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1584,7 +1584,7 @@ function Build-Compilers() {
     $BuildTools = Join-Path -Path (Get-BuildProjectBinaryCache BuildTools) -ChildPath bin
 
     if ($TestClang -or $TestLLD -or $TestLLDB -or $TestLLVM -or $TestSwift) {
-      $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$CompilersBinaryCache\tools\swift\libdispatch-windows-$($Arch.LLVMName)-prefix\bin;$CompilersBinaryCache\bin;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostArch.VSName);$UnixToolsBinDir"
+      $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$CompilersBinaryCache\tools\swift\libdispatch-windows-$($Arch.LLVMName)-prefix\bin;$CompilersBinaryCache\bin;$env:Path;$VSInstallRoot\DIA SDK\bin\$($HostArch.VSName)"
       $Targets = @()
       $TestingDefines = @{
         SWIFT_BUILD_DYNAMIC_SDK_OVERLAY = "YES";


### PR DESCRIPTION
LIT provides a mechanism to locate unix tools on Windows (and deal with quirks of other platforms). We should start using and stop duplicating them: https://github.com/swiftlang/llvm-project/blob/stable/20240723/llvm/utils/lit/lit/llvm/config.py#L187