### PR TITLE
Sema: Don't record constraints containing UnboundGenericType from shrink()

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -858,9 +858,10 @@ bool ConstraintSystem::Candidate::solve(
     auto constraintKind = ConstraintKind::Conversion;
     if (CTP == CTP_CallArgument)
       constraintKind = ConstraintKind::ArgumentConversion;
-
-    cs.addConstraint(constraintKind, cs.getType(E), CT,
-                     cs.getConstraintLocator(E), /*isFavored=*/true);
+    if (!CT->hasUnboundGenericType()) {
+      cs.addConstraint(constraintKind, cs.getType(E), CT,
+                       cs.getConstraintLocator(E), /*isFavored=*/true);
+    }
   }
 
   // Try to solve the system and record all available solutions.

--- a/test/Constraints/rdar145092838.swift
+++ b/test/Constraints/rdar145092838.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+func f(a: Array<Int>, n: Int) {
+  let _: Array = a.prefix(n) + a.suffix(a.count - n - 1)
+}


### PR DESCRIPTION
Something changed here between the removal of shrink() and it's re-introduction, and we now record constraints that contain UnboundGenericType, which crashes in matchTypes().

As a narrow workaround until shrink() is removed again (hopefully for the last time :) ), let's just ignore the contextual type if contains an UnboundGenericType.

Fixes rdar://145092838.