### PR TITLE
[ASTGen] Add an assertion for attribute as an modifier

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -768,6 +768,9 @@ struct BridgedDeclAttributes {
   BRIDGED_INLINE swift::DeclAttributes unbridged() const;
 };
 
+SWIFT_NAME("BridgedDeclAttribute.isDeclModifier(_:)")
+bool BridgedDeclAttribute_isDeclModifier(BridgedDeclAttrKind cKind);
+
 SWIFT_NAME("BridgedDeclAttributes.add(self:_:)")
 void BridgedDeclAttributes_add(BridgedDeclAttributes *_Nonnull attrs,
                                BridgedDeclAttribute add);

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -66,6 +66,13 @@ BridgedDeclAttribute BridgedDeclAttribute_createSimple(
                                      cAtLoc.unbridged(), cAttrLoc.unbridged());
 }
 
+bool BridgedDeclAttribute_isDeclModifier(BridgedDeclAttrKind cKind) {
+  auto optKind = unbridged(cKind);
+  if (!optKind)
+    return false;
+  return DeclAttribute::isDeclModifier(*optKind);
+}
+
 void BridgedDeclAttributes_add(BridgedDeclAttributes *cAttrs,
                                BridgedDeclAttribute cAdd) {
   auto attrs = cAttrs->unbridged();

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1971,9 +1971,12 @@ extension ASTGenVisitor {
       // Other modifiers are all "simple" attributes.
       let kind = BridgedDeclAttrKind(from: node.name.rawText.bridged)
       guard kind != .none else {
-        // TODO: Diagnose?
-        assertionFailure("unknown decl modifier")
-        return nil
+        // TODO: Diagnose.
+        fatalError("(compiler bug) unknown decl modifier")
+      }
+      if !BridgedDeclAttribute.isDeclModifier(kind) {
+        // TODO: Diagnose.
+        fatalError("(compiler bug) decl attribute was parsed as a modifier")
       }
       return self.generateSimpleDeclAttr(declModifier: node, kind: kind)
     }


### PR DESCRIPTION
Just to be safe, `fatalError` when ASTGen see an non-modifier attribute name as a decl modifier.
