### PR TITLE
Parse/Sema: Move some `AvailabilitySpec` diagnostics from Parse to Sema

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1998,18 +1998,6 @@ ERROR(availability_query_wildcard_required, none,
 ERROR(unavailability_query_wildcard_not_required, none,
       "platform wildcard '*' is always implicit in #unavailable", ())
 
-ERROR(availability_must_occur_alone, none,
-      "'%0' version-availability must be specified alone", (StringRef))
-
-ERROR(pound_available_swift_not_allowed, none,
-      "Swift language version checks not allowed in %0(...)", (StringRef))
-
-ERROR(pound_available_package_description_not_allowed, none,
-      "PackageDescription version checks not allowed in %0(...)", (StringRef))
-
-ERROR(availability_query_repeated_platform, none,
-      "version for '%0' already specified", (StringRef))
-
 ERROR(availability_cannot_be_mixed,none,
       "#available and #unavailable cannot be in the same statement", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6963,6 +6963,22 @@ ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
       (Type, Type, StringRef, llvm::VersionTuple))
 
+ERROR(availability_must_occur_alone, none,
+      "'%0' version-availability must be specified alone", (StringRef))
+
+//------------------------------------------------------------------------------
+// MARK: if #available(...)
+//------------------------------------------------------------------------------
+
+ERROR(availability_query_swift_not_allowed, none,
+      "Swift language version checks not allowed in %0(...)", (StringRef))
+
+ERROR(availability_query_package_description_not_allowed, none,
+      "PackageDescription version checks not allowed in %0(...)", (StringRef))
+
+ERROR(availability_query_repeated_platform, none,
+      "version for '%0' already specified", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2141,6 +2141,8 @@ AvailableAttr::AvailableAttr(
       ObsoletedRange(ObsoletedRange) {
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
+  Bits.AvailableAttr.IsFollowedByGroupedAvailableAttr = false;
+  Bits.AvailableAttr.IsFollowedByWildcard = false;
 }
 
 AvailableAttr *AvailableAttr::createUniversallyUnavailable(ASTContext &C,

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -47,6 +47,7 @@ if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to mat
 
 if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
+// expected-error@-2 {{condition required for target platform}}
 }
 
 if #available(iDishwasherOS 51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
@@ -125,4 +126,7 @@ if let _ = Optional(42), #available(iOS 8.0, *) {}
 if #available(macOS 51, *) {
 }
 
+// FIXME: This is weird, but it's already accepted. It should probably be diagnosed.
+if #available(*, macOS 51) {
+}
 

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -70,6 +70,16 @@ if #available(macOS 10.52, *) {
 }
 
 // CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 53
+// CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[QUERY_FUNC:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-NOT: {{.*}}integer_literal $Builtin.Int1, -1
+// CHECK-NOT: builtin "xor_Int1"{{.*}}
+if #available(*, macOS 10.53) {
+}
+
+// CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK: [[QUERY_FUNC:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -82,6 +82,13 @@ if #available(OSX 51, *) {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
+// FIXME: This is weird, but it's already accepted. It should probably be diagnosed.
+if #available(*, OSX 51) {
+  let _: Int = globalFuncAvailableOn51()
+  let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-1 {{add 'if #available' version check}}
+}
+
 if #available(OSX 51, *) {
   let _: Int = globalFuncAvailableOn51()
   let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
@@ -1799,8 +1806,16 @@ func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
+// FIXME: This is weird, but it's already accepted. It should probably be diagnosed.
+@available(iOS 14, *, OSX 51)
+func funcWithWeirdShortFormAvailableOn51() {
+  let _ = ClassWithShortFormAvailableOn51()
+  let _ = ClassWithShortFormAvailableOn54() // expected-error {{'ClassWithShortFormAvailableOn54' is only available in macOS 54 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+}
+
 func useShortFormAvailable() {
-  // expected-note@-1 4{{add @available attribute to enclosing global function}}
+  // expected-note@-1 5{{add @available attribute to enclosing global function}}
 
   funcWithShortFormAvailableOn10_9()
 
@@ -1817,6 +1832,9 @@ func useShortFormAvailable() {
 
   funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available in macOS 53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
+
+  funcWithWeirdShortFormAvailableOn51() // expected-error {{'funcWithWeirdShortFormAvailableOn51()' is only available in macOS 51 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Unavailability takes precedence over availability and is inherited


### PR DESCRIPTION
Eventually, querying the `AvailabilityDomain` associated with an `AvailabilitySpec` will require invoking a request that takes a `DeclContext`. This means that any diagnostics related to the domain identified by an `AvailabilitySpec` need to be emitted during type-checking rather than parsing. This change migrates several `AvailabilitySpec` diagnostics from Parse to Sema to unblock further work.
