### PR TITLE
build.ps1: various clean up towards unified staging of multiple SDKs

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3177,7 +3177,6 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-XCTest Windows $BuildArch
   Invoke-BuildStep Build-Testing Windows $BuildArch
   Invoke-BuildStep Write-SDKSettingsPlist Windows $BuildArch
-  Invoke-BuildStep Write-PlatformInfoPlist $BuildArch
 
   Invoke-BuildStep Build-ExperimentalRuntime -Static Windows $BuildArch
   Invoke-BuildStep Build-ExperimentalRuntime Windows $BuildArch
@@ -3197,7 +3196,6 @@ if (-not $SkipBuild) {
     Invoke-BuildStep Build-XCTest Windows $Arch
     Invoke-BuildStep Build-Testing Windows $Arch
     Invoke-BuildStep Write-SDKSettingsPlist Windows $Arch
-    Invoke-BuildStep Write-PlatformInfoPlist $Arch
 
     Invoke-BuildStep Build-ExperimentalRuntime -Static Windows $Arch
     Invoke-BuildStep Build-Foundation -Static Windows $Arch
@@ -3226,7 +3224,6 @@ if (-not $SkipBuild) {
       Invoke-BuildStep Build-Inspect -Platform Android -Arch $Arch
     }
     Invoke-BuildStep Write-SDKSettingsPlist Android $Arch
-    Invoke-BuildStep Write-PlatformInfoPlist $Arch
 
     Invoke-BuildStep Build-ExperimentalRuntime -Static Android $Arch
     Invoke-BuildStep Build-Foundation -Static Android $Arch
@@ -3249,9 +3246,13 @@ if (-not $ToBatch) {
   foreach ($Arch in $WindowsSDKArchs) {
     Install-Platform Windows $Arch
   }
+  Invoke-BuildStep Write-PlatformInfoPlist Windows
 
   foreach ($Arch in $AndroidSDKArchs) {
     Install-Platform Android $Arch
+  }
+  if ($Android) {
+    Invoke-BuildStep Write-PlatformInfoPlist Android
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3066,6 +3066,12 @@ function Build-Installer($Arch) {
     $Properties["SDK_ROOT_$($SDK.VSName.ToUpperInvariant())"] = "$($SDK.SDKInstallRoot)\"
   }
 
+  foreach ($SDK in $AndroidSDKArchs) {
+    $Properties["INCLUDE_ANDROID_$($SDK.ShortName.ToUpperInvariant())_SDK"] = "true"
+    $Properties["PLATFORM_ROOT_$($SDK.ShortName.ToUpperInvariant())"] = "$($SDK.PlatformInstallRoot)\"
+    $Properties["SDK_ROOT_$($SDK.ShortName.ToUpperInvariant())"] = "$($SDK.SDKInstallRoot)\"
+  }
+
   Build-WiXProject bundle\installer.wixproj -Arch $Arch -Bundle -Properties $Properties
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1697,7 +1697,13 @@ function Build-Compilers() {
       })
   }
 
-  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'Identifier': '${ToolchainIdentifier}', 'FallbackLibrarySearchPaths': ['usr/bin'], 'Version': '${ProductVersion}' }), encoding='utf-8'))" `
+  $Settings = @{
+    FallbackLibrarySearchPaths = @("usr/bin")
+    Identifier = "${ToolchainIdentifier}"
+    Version = "${ProductVersion}"
+  }
+
+  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps($(($Settings | ConvertTo-JSON -Compress) -replace '"', "'")), encoding='utf-8'))" `
       -OutFile "$($Arch.ToolchainInstallRoot)\ToolchainInfo.plist"
 }
 
@@ -2119,13 +2125,16 @@ function Build-ExperimentalRuntime {
 }
 
 function Write-SDKSettingsPlist([Platform]$Platform, $Arch) {
-  if ($Platform -eq [Platform]::Windows) {
-    Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }), encoding='utf-8'))" `
-      -OutFile "$($Arch.SDKInstallRoot)\SDKSettings.plist"
-  } else {
-    Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { } }), encoding='utf-8'))" `
-      -OutFile "$($Arch.SDKInstallRoot)\SDKSettings.plist"
+  $SDKSettings = @{
+    DefaultProperties = @{
+    }
   }
+  if ($Platform -eq [Platform]::Windows) {
+    $SDKSettings.DefaultProperties.DEFAULT_USE_RUNTIME = "MD"
+  }
+
+  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps($(($SDKSettings | ConvertTo-JSON -Compress) -replace '"', "'")), encoding='utf-8'))" `
+    -OutFile "$($Arch.SDKInstallRoot)\SDKSettings.plist"
 
   $SDKSettings = @{
     CanonicalName = "$($Arch.LLVMTarget)"
@@ -2377,8 +2386,18 @@ function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
 }
 
 function Write-PlatformInfoPlist([Platform] $Platform) {
-    Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development', 'SWIFT_TESTING_VERSION': 'development', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }), encoding='utf-8'))" `
-      -OutFile ([IO.Path]::Combine((Get-PlatformRoot $Platform), "Info.plist"))
+  $Settings = @{
+    DefaultProperties = @{
+      SWIFT_TESTING_VERSION = "development"
+      XCTEST_VERSION = "development"
+    }
+  }
+  if ($Platform -eq [Platform]::Windows) {
+    $Settings.DefaultProperties.SWIFTC_FLAGS = @( "-use-ld=lld" )
+  }
+
+  Invoke-Program "$(Get-PythonExecutable)" -c "import plistlib; print(str(plistlib.dumps($(($Settings | ConvertTo-JSON -Compress) -replace '"', "'")), encoding='utf-8'))" `
+    -OutFile ([IO.Path]::Combine((Get-PlatformRoot $Platform), "Info.plist"))
 }
 
 # Copies files installed by CMake from the arch-specific platform root,

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2150,7 +2150,7 @@ function Write-SDKSettingsPlist([Platform]$Platform, $Arch) {
   if ($Platform -eq [Platform]::Windows) {
     $SDKSettings.DefaultProperties.DEFAULT_USE_RUNTIME = "MD"
   }
-  $SDKSettings | ConvertTo-JSON | Out-FIle -FilePath "$($Arch.SDKInstallRoot)\SDKSettings.json"
+  $SDKSettings | ConvertTo-JSON | Out-File -FilePath "$($Arch.SDKInstallRoot)\SDKSettings.json"
 }
 
 function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3134,7 +3134,29 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-XML2 Windows $HostArch
   Invoke-BuildStep Build-Compilers $HostArch
 
-  foreach ($Arch in $WindowsSDKArchs) {
+  # Build BuildArch SDK
+  Invoke-BuildStep Build-ZLib Windows $BuildArch
+  Invoke-BuildStep Build-XML2 Windows $BuildArch
+  Invoke-BuildStep Build-CURL Windows $BuildArch
+  Invoke-BuildStep Build-LLVM Windows $BuildArch
+
+  # Build platform: SDK, Redist and XCTest
+  Invoke-BuildStep Build-Runtime Windows $BuildArch
+  Invoke-BuildStep Build-Dispatch Windows $BuildArch
+  Invoke-BuildStep Build-FoundationMacros -Build Windows $BuildArch
+  Invoke-BuildStep Build-TestingMacros -Build Windows $BuildArch
+  Invoke-BuildStep Build-Foundation Windows $BuildArch
+  Invoke-BuildStep Build-Sanitizers Windows $BuildArch
+  Invoke-BuildStep Build-XCTest Windows $BuildArch
+  Invoke-BuildStep Build-Testing Windows $BuildArch
+  Invoke-BuildStep Write-SDKSettingsPlist Windows $BuildArch
+  Invoke-BuildStep Write-PlatformInfoPlist $BuildArch
+
+  Invoke-BuildStep Build-ExperimentalRuntime -Static Windows $BuildArch
+  Invoke-BuildStep Build-ExperimentalRuntime Windows $BuildArch
+  Invoke-BuildStep Build-Foundation -Static Windows $BuildArch
+
+  foreach ($Arch in $WindowsSDKArchs | Where-Object { $_ -ne $BuildArch }) {
     Invoke-BuildStep Build-ZLib Windows $Arch
     Invoke-BuildStep Build-XML2 Windows $Arch
     Invoke-BuildStep Build-CURL Windows $Arch
@@ -3143,9 +3165,6 @@ if (-not $SkipBuild) {
     # Build platform: SDK, Redist and XCTest
     Invoke-BuildStep Build-Runtime Windows $Arch
     Invoke-BuildStep Build-Dispatch Windows $Arch
-    # FIXME(compnerd) ensure that the _build_ is the first arch and don't rebuild on each arch
-    Invoke-BuildStep Build-FoundationMacros -Build Windows $BuildArch
-    Invoke-BuildStep Build-TestingMacros -Build Windows $BuildArch
     Invoke-BuildStep Build-Foundation Windows $Arch
     Invoke-BuildStep Build-Sanitizers Windows $Arch
     Invoke-BuildStep Build-XCTest Windows $Arch


### PR DESCRIPTION
This cleans up various issues with the build.ps1 script to allow some minor optimizations and a path towards a shared stage location for multiple SDKs to enable artifact sharing across builds.