### PR TITLE
[Sema] Either variant of `@execution` is incompatible with other isol…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8289,32 +8289,27 @@ ERROR(attr_execution_type_attr_only_on_async,none,
       "cannot use '@execution' on non-async function type",
       ())
 
-ERROR(attr_execution_concurrent_incompatible_isolated_parameter,none,
-      "cannot use '@execution(concurrent)' on %kind0 because it has "
+ERROR(attr_execution_incompatible_isolated_parameter,none,
+      "cannot use '@execution' on %kind0 because it has "
       "an isolated parameter: %1",
       (ValueDecl *, ValueDecl *))
 
-ERROR(attr_execution_concurrent_incompatible_dynamically_isolated_parameter,none,
-      "cannot use '@execution(concurrent)' on %kind0 because it has "
+ERROR(attr_execution_incompatible_dynamically_isolated_parameter,none,
+      "cannot use '@execution' on %kind0 because it has "
       "a dynamically isolated parameter: %1",
       (ValueDecl *, ValueDecl *))
 
-ERROR(attr_execution_concurrent_incompatible_with_nonisolated,none,
-      "cannot use '@execution(concurrent)' and 'nonisolated' on the same %0 "
-      "because they serve the same purpose",
-      (ValueDecl *))
-
-ERROR(attr_execution_concurrent_type_attr_incompatible_with_global_isolation,none,
-      "cannot use '@execution(concurrent)' because function type is "
-      "isolated to global actor %0",
+ERROR(attr_execution_type_attr_incompatible_with_global_isolation,none,
+      "cannot use '@execution' because function type is "
+      "isolated to a global actor %0",
       (Type))
 
-ERROR(attr_execution_concurrent_type_attr_incompatible_with_isolated_param,none,
-      "cannot use '@execution(concurrent)' together with isolated parameter",
+ERROR(attr_execution_type_attr_incompatible_with_isolated_param,none,
+      "cannot use '@execution' together with an isolated parameter",
       ())
 
-ERROR(attr_execution_concurrent_type_attr_incompatible_with_isolated_any,none,
-      "cannot use '@execution(concurrent)' together with @isolated(any)",
+ERROR(attr_execution_type_attr_incompatible_with_isolated_any,none,
+      "cannot use '@execution' together with @isolated(any)",
       ())
 
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4179,37 +4179,32 @@ NeverNullType TypeResolver::resolveASTFunctionType(
                       diag::attr_execution_type_attr_only_on_async);
     }
 
-    if (executionAttr->getBehavior() == ExecutionKind::Concurrent) {
-      switch (isolation.getKind()) {
-      case FunctionTypeIsolation::Kind::NonIsolated:
-        break;
+    switch (isolation.getKind()) {
+    case FunctionTypeIsolation::Kind::NonIsolated:
+      break;
 
-      case FunctionTypeIsolation::Kind::GlobalActor:
-        diagnoseInvalid(
-            repr, executionAttr->getAtLoc(),
-            diag::
-                attr_execution_concurrent_type_attr_incompatible_with_global_isolation,
-            isolation.getGlobalActorType());
-        break;
+    case FunctionTypeIsolation::Kind::GlobalActor:
+      diagnoseInvalid(
+          repr, executionAttr->getAtLoc(),
+          diag::attr_execution_type_attr_incompatible_with_global_isolation,
+          isolation.getGlobalActorType());
+      break;
 
-      case FunctionTypeIsolation::Kind::Parameter:
-        diagnoseInvalid(
-            repr, executionAttr->getAtLoc(),
-            diag::
-                attr_execution_concurrent_type_attr_incompatible_with_isolated_param);
-        break;
+    case FunctionTypeIsolation::Kind::Parameter:
+      diagnoseInvalid(
+          repr, executionAttr->getAtLoc(),
+          diag::attr_execution_type_attr_incompatible_with_isolated_param);
+      break;
 
-      case FunctionTypeIsolation::Kind::Erased:
-        diagnoseInvalid(
-            repr, executionAttr->getAtLoc(),
-            diag::
-                attr_execution_concurrent_type_attr_incompatible_with_isolated_any);
-        break;
+    case FunctionTypeIsolation::Kind::Erased:
+      diagnoseInvalid(
+          repr, executionAttr->getAtLoc(),
+          diag::attr_execution_type_attr_incompatible_with_isolated_any);
+      break;
 
-      case FunctionTypeIsolation::Kind::NonIsolatedCaller:
-        llvm_unreachable("cannot happen because multiple @execution attributes "
-                         "aren't allowed.");
-      }
+    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      llvm_unreachable("cannot happen because multiple @execution attributes "
+                       "aren't allowed.");
     }
 
     if (!repr->isInvalid()) {

--- a/test/Parse/execution.swift
+++ b/test/Parse/execution.swift
@@ -8,14 +8,23 @@ typealias E = @execution(concurrent) () -> Void
 func test1(_: @execution(caller) (Int...) async -> Void) {}
 func test2(_: @execution(concurrent) (Int...) async -> Void) {}
 
-func test_err1(_: @execution(concurrent) @MainActor () async -> Void) {}
-// expected-error@-1 {{cannot use '@execution(concurrent)' because function type is isolated to global actor 'MainActor'}}
+func test_err1_concurrent(_: @execution(concurrent) @MainActor () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' because function type is isolated to a global actor 'MainActor'}}
 
-func test_err2(_: @execution(concurrent) @isolated(any) () async -> Void) {}
-// expected-error@-1 {{cannot use '@execution(concurrent)' together with @isolated(any)}}
+func test_err1_caller(_: @execution(caller) @MainActor () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' because function type is isolated to a global actor 'MainActor'}}
 
-func test_err3(_: @execution(concurrent) (isolated (any Actor)?) async -> Void) {}
-// expected-error@-1 {{cannot use '@execution(concurrent)' together with isolated parameter}}
+func test_err2_concurrent(_: @execution(concurrent) @isolated(any) () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' together with @isolated(any)}}
+
+func test_err2_caller(_: @execution(caller) @isolated(any) () async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' together with @isolated(any)}}
+
+func test_err3_concurrent(_: @execution(concurrent) (isolated (any Actor)?) async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' together with an isolated parameter}}
+
+func test_err3_caller(_: @execution(caller) (isolated (any Actor)?) async -> Void) {}
+// expected-error@-1 {{cannot use '@execution' together with an isolated parameter}}
 
 func test_err4(_: @execution (Int) -> Void) {}
 // expected-error@-1 {{expected 'concurrent' or 'caller' as the execution behavior}}

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -44,10 +44,10 @@ struct TestAttributeCollisions {
   @execution(concurrent) nonisolated func testNonIsolated() async {}
 
   @execution(concurrent) func test(arg: isolated MainActor) async {}
-  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}
+  // expected-error@-1 {{cannot use '@execution' on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}
 
   @execution(concurrent) func testIsolationAny(arg: @isolated(any) () -> Void) async {}
-  // expected-error@-1 {{cannot use '@execution(concurrent)' on instance method 'testIsolationAny(arg:)' because it has a dynamically isolated parameter: 'arg'}}
+  // expected-error@-1 {{cannot use '@execution' on instance method 'testIsolationAny(arg:)' because it has a dynamically isolated parameter: 'arg'}}
 
   @MainActor @execution(concurrent) func testGlobalActor() async {}
   // expected-warning @-1 {{instance method 'testGlobalActor()' has multiple actor-isolation attributes ('MainActor' and 'execution(concurrent)')}}
@@ -55,8 +55,9 @@ struct TestAttributeCollisions {
   @execution(caller) nonisolated func testNonIsolatedCaller() async {} // Ok
   @MainActor @execution(caller) func testGlobalActorCaller() async {}
   // expected-warning@-1 {{instance method 'testGlobalActorCaller()' has multiple actor-isolation attributes ('MainActor' and 'execution(caller)')}}
-  @execution(caller) func testCaller(arg: isolated MainActor) async {} // Ok
-
+  @execution(caller) func testCaller(arg: isolated MainActor) async {}
+  // expected-error@-1 {{cannot use '@execution' on instance method 'testCaller(arg:)' because it has an isolated parameter: 'arg'}}
+  
   @execution(concurrent) @Sendable func test(_: @Sendable () -> Void, _: sending Int) async {} // Ok
   @execution(caller) @Sendable func testWithSendableCaller(_: @Sendable () -> Void, _: sending Int) async {} // Ok
 }


### PR DESCRIPTION
…ation

According to the proposal both variants cannot be used together with other forms of isolation i.e. isolated parameters, global actors, `@isolated(any)` attributes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
