### PR TITLE
Set Swift language version to 5

### DIFF
--- a/Runtimes/Core/cmake/modules/CompilerSettings.cmake
+++ b/Runtimes/Core/cmake/modules/CompilerSettings.cmake
@@ -1,7 +1,10 @@
 include(CheckSourceCompiles)
 include(CheckCompilerFlag)
 
-# Use C+17
+# Use Swift 5 mode
+set(CMAKE_Swift_LANGUAGE_VERSION 5)
+
+# Use C++17
 set(SwiftCore_MIN_CXX_STANDARD 17)
 # Unset CMAKE_CXX_STANDARD if it's too low and in the CMakeCache.txt
 if($CACHE{CMAKE_CXX_STANDARD} AND $CACHE{CMAKE_CXX_STANDARD} LESS ${SwiftCore_MIN_CXX_STANDARD})


### PR DESCRIPTION
The swift version impacts how swift interfaces work so it's important that we set this explicitly on Apple platforms. Setting it explicitly now.

rdar://145118843
