### PR TITLE
[.editorconfig] Remove `trim_trailing_whitespace`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,5 +5,4 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = false
 insert_final_newline = true


### PR DESCRIPTION
Forcing this to be `false` is unhelpful for editors that allow incremental removal of trailing whitespace as you edit, such as Xcode. For now, avoid enforcing the setting, leaving it up to individual editor configurations. This restores the behavior prior to the addition of the `.editorconfig`.