### PR TITLE
[AST] Sink ParamDecl flag collection logic from Parse to AST

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1317,15 +1317,18 @@ BridgedPatternBindingDecl BridgedPatternBindingDecl_createParsed(
     BridgedVarDeclIntroducer cIntorducer, BridgedArrayRef cBindingEntries);
 
 SWIFT_NAME("BridgedParamDecl.createParsed(_:declContext:specifierLoc:argName:"
-           "argNameLoc:paramName:paramNameLoc:type:defaultValue:"
+           "argNameLoc:paramName:paramNameLoc:defaultValue:"
            "defaultValueInitContext:)")
 BridgedParamDecl BridgedParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cSpecifierLoc, BridgedIdentifier cArgName,
     BridgedSourceLoc cArgNameLoc, BridgedIdentifier cParamName,
-    BridgedSourceLoc cParamNameLoc, BridgedNullableTypeRepr type,
-    BridgedNullableExpr defaultValue,
+    BridgedSourceLoc cParamNameLoc, BridgedNullableExpr defaultValue,
     BridgedNullableDefaultArgumentInitializer cDefaultArgumentInitContext);
+
+SWIFT_NAME("BridgedParamDecl.setTypeRepr(self:_:)")
+BRIDGED_INLINE void BridgedParamDecl_setTypeRepr(BridgedParamDecl cDecl,
+                                                 BridgedTypeRepr cType);
 
 /// The various spellings of ownership modifier that can be used in source.
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedParamSpecifier {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -310,6 +310,11 @@ swift::ParamSpecifier unbridge(BridgedParamSpecifier specifier) {
   }
 }
 
+void BridgedParamDecl_setTypeRepr(BridgedParamDecl cDecl,
+                                  BridgedTypeRepr cType) {
+  cDecl.unbridged()->setTypeRepr(cType.unbridged());
+}
+
 void BridgedParamDecl_setSpecifier(BridgedParamDecl cDecl,
                                    BridgedParamSpecifier cSpecifier) {
   cDecl.unbridged()->setSpecifier(unbridge(cSpecifier));

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7031,7 +7031,9 @@ public:
 
   /// Retrieve the TypeRepr corresponding to the parsed type of the parameter, if it exists.
   TypeRepr *getTypeRepr() const { return TyReprAndFlags.getPointer(); }
-  void setTypeRepr(TypeRepr *repr) { TyReprAndFlags.setPointer(repr); }
+
+  /// Set the parsed TypeRepr on the parameter.
+  void setTypeRepr(TypeRepr *repr);
 
   bool isDestructured() const {
     auto flags = ArgumentNameAndFlags.getInt();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8712,6 +8712,47 @@ ParamDecl *ParamDecl::createParsed(
   return decl;
 }
 
+void ParamDecl::setTypeRepr(TypeRepr *repr) {
+  ASSERT(!getTypeRepr() && "TypeRepr already set");
+
+  TyReprAndFlags.setPointer(repr);
+
+  // Dig through the type to find any attributes or modifiers that are
+  // associated with the type but should also be reflected on the
+  // declaration.
+  {
+    auto unwrappedType = repr;
+    while (true) {
+      if (auto *ATR = dyn_cast<AttributedTypeRepr>(unwrappedType)) {
+        // At this point we actually don't know if that's valid to mark
+        // this parameter declaration as `autoclosure` because type has
+        // not been resolved yet - it should either be a function type
+        // or typealias with underlying function type.
+        if (ATR->has(TypeAttrKind::Autoclosure))
+          setAutoClosure(true);
+        if (ATR->has(TypeAttrKind::Addressable))
+          setAddressable(true);
+
+        unwrappedType = ATR->getTypeRepr();
+        continue;
+      }
+
+      if (auto *STR = dyn_cast<SpecifierTypeRepr>(unwrappedType)) {
+        if (isa<IsolatedTypeRepr>(STR))
+          setIsolated(true);
+        else if (isa<CompileTimeConstTypeRepr>(STR))
+          setCompileTimeConst(true);
+        else if (isa<SendingTypeRepr>(STR))
+          setSending(true);
+        unwrappedType = STR->getBase();
+        continue;
+      }
+
+      break;
+    }
+  }
+}
+
 void ParamDecl::setDefaultArgumentKind(DefaultArgumentKind K) {
   assert(getDefaultArgumentKind() == DefaultArgumentKind::None &&
          "Overwrite of default argument kind");

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -365,7 +365,6 @@ extension ASTGenVisitor {
             argNameLoc: nil,
             paramName: ctx.getDollarIdentifier(idx),
             paramNameLoc: loc,
-            type: nil,
             defaultValue: nil,
             defaultValueInitContext: nil
           )

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -176,10 +176,12 @@ extension ASTGenVisitor {
       argNameLoc: argNameLoc,
       paramName: paramName,
       paramNameLoc: paramNameLoc,
-      type: type.asNullable,
       defaultValue: initExpr.asNullable,
       defaultValueInitContext: initContext.asNullable
     )
+    if let type {
+      param.setTypeRepr(type)
+    }
     param.asDecl.attachParsedAttrs(attrs)
     return param
   }
@@ -194,11 +196,9 @@ extension ASTGenVisitor {
       argNameLoc: nil,
       paramName: name.identifier,
       paramNameLoc: name.sourceLoc,
-      type: nil,
       defaultValue: nil,
       defaultValueInitContext: nil
     )
-    param.setSpecifier(.default)
     return param
   }
 }
@@ -259,7 +259,6 @@ extension ASTGenVisitor {
       argNameLoc: nil,
       paramName: name,
       paramNameLoc: nameLoc,
-      type: nil,
       defaultValue: nil,
       defaultValueInitContext: nil
     )
@@ -276,7 +275,6 @@ extension ASTGenVisitor {
     params.reserveCapacity(node.parameters.count)
     for (index, node) in node.parameters.enumerated() {
       let param = self.generate(closureParameter: node, at: index)
-      param.setSpecifier(.default)
       params.append(param)
     }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -607,40 +607,6 @@ mapParsedParameters(Parser &parser,
 
       param->setTypeRepr(type);
 
-      // Dig through the type to find any attributes or modifiers that are
-      // associated with the type but should also be reflected on the
-      // declaration.
-      {
-        auto unwrappedType = type;
-        while (true) {
-          if (auto *ATR = dyn_cast<AttributedTypeRepr>(unwrappedType)) {
-            // At this point we actually don't know if that's valid to mark
-            // this parameter declaration as `autoclosure` because type has
-            // not been resolved yet - it should either be a function type
-            // or typealias with underlying function type.
-            if (ATR->has(TypeAttrKind::Autoclosure))
-              param->setAutoClosure(true);
-            if (ATR->has(TypeAttrKind::Addressable))
-              param->setAddressable(true);
-
-            unwrappedType = ATR->getTypeRepr();
-            continue;
-          }
-
-          if (auto *STR = dyn_cast<SpecifierTypeRepr>(unwrappedType)) {
-            if (isa<IsolatedTypeRepr>(STR))
-              param->setIsolated(true);
-            else if (isa<CompileTimeConstTypeRepr>(STR))
-              param->setCompileTimeConst(true);
-            else if (isa<SendingTypeRepr>(STR))
-              param->setSending(true);
-            unwrappedType = STR->getBase();
-            continue;
-          }
-
-          break;
-        }
-      }
     } else if (paramInfo.SpecifierLoc.isValid()) {
       llvm::SmallString<16> specifier;
       {
@@ -653,10 +619,6 @@ mapParsedParameters(Parser &parser,
                       specifier);
       paramInfo.SpecifierLoc = SourceLoc();
       paramInfo.SpecifierKind = ParamDecl::Specifier::Default;
-
-      param->setSpecifier(ParamSpecifier::Default);
-    } else {
-      param->setSpecifier(ParamSpecifier::Default);
     }
 
     return param;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2234,6 +2234,12 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
   }
 
   auto typeRepr = param->getTypeRepr();
+
+  if (!typeRepr && !param->isImplicit()) {
+    // Untyped closure parameter.
+    return ParamSpecifier::Default;
+  }
+
   assert(typeRepr != nullptr && "Should call setSpecifier() on "
          "synthesized parameter declarations");
 

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -49,7 +49,13 @@ func test2(y: Int = 0, oi: Int? = nil) -> Int {
 }
 
 func test3(_ b: inout Bool) {
-  // b = true
+  b = true
+}
+
+func testInOutClosureParam() -> (inout (Int, String)) -> Void {
+  return { (arg: inout (Int, String)) in
+    arg.1 = "rewritten"
+  }
 }
 
 func test4(_ i: _const Int) {


### PR DESCRIPTION
* Collect flags in `ParamDecl::setTypeRepr()`.

* Update `ParamSpecifierRequest::evaluate` to handle non-implicit `ParamDecl` without `TypeRepr` (i.e. untyped closure parameter), instead of `setSpecifier(::Default)` manually in Parse.

*  (ASTGen) Separate `BridgedParamDecl.setTypeRepr(_:)` from `BridgedParamDecl.createParsed(_:)` aligning with C++ API. The majority of the creations don't set the typerepr.

