### PR TITLE
utils: pass static library prefix for Swift to Swift

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2109,6 +2109,7 @@ function Build-ExperimentalRuntime {
      -Defines @{
        BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
        CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
+       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
        dispatch_DIR = "$(Get-TargetProjectBinaryCache $Arch Dispatch)\cmake\modules";
      }
   }


### PR DESCRIPTION
Update the build invocation for the experimental swift runtime to ensure that we generate the libraries with the expected names.