### PR TITLE
[Frontend] Rename `NonIsolatedAsyncInheritsIsolationFromContext` feature and add a feature for `@execution`

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -545,6 +545,7 @@ DECL_ATTR_FEATURE_REQUIREMENT(ABI, ABIAttribute)
 DECL_ATTR(execution, Execution,
   OnFunc | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   166)
+DECL_ATTR_FEATURE_REQUIREMENT(Execution, ExecutionAttribute)
 
 LAST_DECL_ATTR(Execution)
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -397,6 +397,9 @@ struct PrintOptions {
   /// Suppress modify/read accessors.
   bool SuppressCoroutineAccessors = false;
 
+  /// Suppress the @execution attribute
+  bool SuppressExecutionAttribute = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -438,7 +438,7 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)
 
 /// Functions with nonisolated isolation inherit their isolation from the
 /// calling context.
-EXPERIMENTAL_FEATURE(NonIsolatedAsyncInheritsIsolationFromContext, false)
+EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)
 
 /// Allow custom availability domains to be defined and referenced.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -436,6 +436,10 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
 /// Allow the @abi attribute.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)
 
+/// Allow the @execution attribute. This is also connected to
+/// AsyncCallerExecution feature.
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ExecutionAttribute, false)
+
 /// Functions with nonisolated isolation inherit their isolation from the
 /// calling context.
 EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3251,6 +3251,14 @@ suppressingFeatureCustomAvailability(PrintOptions &options,
   action();
 }
 
+static void
+suppressingFeatureExecutionAttribute(PrintOptions &options,
+                                    llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<bool> scope1(options.SuppressExecutionAttribute, true);
+  ExcludeAttrRAII scope2(options.ExcludeAttrList, DeclAttrKind::Execution);
+  action();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {
@@ -6423,7 +6431,8 @@ public:
       break;
 
     case FunctionTypeIsolation::Kind::NonIsolatedCaller:
-      Printer << "@execution(caller) ";
+      if (!Options.SuppressExecutionAttribute)
+        Printer << "@execution(caller) ";
       break;
     }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -305,6 +305,9 @@ void IsolatedTypeAttr::printImpl(ASTPrinter &printer,
 
 void ExecutionTypeAttr::printImpl(ASTPrinter &printer,
                                   const PrintOptions &options) const {
+  if (options.SuppressExecutionAttribute)
+    return;
+
   printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
   printer.printAttrName("@execution");
   printer << "(";

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -121,7 +121,7 @@ UNINTERESTING_FEATURE(Volatile)
 UNINTERESTING_FEATURE(SuppressedAssociatedTypes)
 UNINTERESTING_FEATURE(StructLetDestructuring)
 UNINTERESTING_FEATURE(MacrosOnImports)
-UNINTERESTING_FEATURE(NonIsolatedAsyncInheritsIsolationFromContext)
+UNINTERESTING_FEATURE(AsyncCallerExecution)
 
 static bool usesFeatureNonescapableTypes(Decl *decl) {
   auto containsNonEscapable =

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4725,6 +4725,12 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
   }
 
   case TypeAttrKind::Execution: {
+    if (!Context.LangOpts.hasFeature(Feature::ExecutionAttribute)) {
+      diagnose(Tok, diag::requires_experimental_feature, "@execution", false,
+               getFeatureName(Feature::ExecutionAttribute));
+      return makeParserError();
+    }
+
     SourceLoc lpLoc = Tok.getLoc(), behaviorLoc, rpLoc;
     if (!consumeIfNotAtStartOfLine(tok::l_paren)) {
       if (!justChecking) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1658,8 +1658,7 @@ private:
     }
 
     // If we are an async function that is unspecified or nonisolated, insert an
-    // isolated parameter if NonIsolatedAsyncInheritsIsolationFromContext is
-    // enabled.
+    // isolated parameter if AsyncCallerExecution is enabled.
     if (IsolationInfo &&
         IsolationInfo->getKind() == ActorIsolation::CallerIsolationInheriting &&
         extInfoBuilder.isAsync()) {

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-swift-frontend-dump-parse \
 // RUN:   -enable-experimental-feature ABIAttribute \
+// RUN:   -enable-experimental-feature ExecutionAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
@@ -11,6 +12,7 @@
 
 // RUN: %target-swift-frontend-dump-parse \
 // RUN:   -enable-experimental-feature ABIAttribute \
+// RUN:   -enable-experimental-feature ExecutionAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
@@ -23,6 +25,7 @@
 // RUN:   -module-abi-name ASTGen \
 // RUN:   -enable-experimental-feature ParserASTGen \
 // RUN:   -enable-experimental-feature ABIAttribute \
+// RUN:   -enable-experimental-feature ExecutionAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
@@ -32,6 +35,7 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_ParserASTGen
 // REQUIRES: swift_feature_ABIAttribute
+// REQUIRES: swift_feature_ExecutionAttribute
 // REQUIRES: swift_feature_Extern
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_SymbolLinkageMarkers

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -4,7 +4,6 @@
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-move-only \
 // RUN:   -enable-experimental-feature ParserASTGen \
@@ -14,7 +13,6 @@
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-move-only \
 // RUN:   | %sanitize-address > %t/cpp-parser.ast
@@ -27,7 +25,6 @@
 // RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-move-only
 
@@ -37,7 +34,6 @@
 // REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: swift_feature_Extern
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
 // REQUIRES: swift_feature_SymbolLinkageMarkers
 
 // rdar://116686158

--- a/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-experimental-feature AsyncCallerExecution )
+// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-experimental-feature ExecutionAttribute -enable-experimental-feature AsyncCallerExecution )
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -6,6 +6,7 @@
 // REQUIRES: libdispatch
 // REQUIRES: asserts
 
+// REQUIRES: swift_feature_ExecutionAttribute
 // REQUIRES: swift_feature_AsyncCallerExecution
 
 // UNSUPPORTED: freestanding

--- a/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext )
+// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-experimental-feature AsyncCallerExecution )
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -6,7 +6,7 @@
 // REQUIRES: libdispatch
 // REQUIRES: asserts
 
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 // UNSUPPORTED: freestanding
 

--- a/test/Concurrency/attr_execution.swift
+++ b/test/Concurrency/attr_execution.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature ExecutionAttribute -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
 
 // REQUIRES: asserts
+// REQUIRES: swift_feature_ExecutionAttribute
 // REQUIRES: swift_feature_AsyncCallerExecution
 
 

--- a/test/Concurrency/attr_execution.swift
+++ b/test/Concurrency/attr_execution.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
 
 // REQUIRES: asserts
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 
 // CHECK-LABEL: // concurrentTest()

--- a/test/Concurrency/attr_execution_conversions.swift
+++ b/test/Concurrency/attr_execution_conversions.swift
@@ -1,6 +1,8 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature ExecutionAttribute
 
+// REQUIRES: asserts
 // REQUIRES: concurrency
+// REQUIRES: swift_feature_ExecutionAttribute
 
 @execution(concurrent)
 func concurrentTest() async {

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -1,12 +1,11 @@
 // RUN: %target-swift-frontend %s -swift-version 6 -verify -verify-additional-prefix disabled- -c
-// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
+// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-experimental-feature AsyncCallerExecution -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
-// This test checks and validates that when
-// NonIsolatedAsyncInheritsIsolationFromContext is enabled, we emit the
+// This test checks and validates that when AsyncCallerExecution is enabled, we emit the
 // appropriate diagnostics. It also runs with the mode off so we can validate
 // and compare locally against the normal errors.
 

--- a/test/Concurrency/nonisolated_inherits_isolation_sema.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation_sema.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -parse-as-library
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature AsyncCallerExecution -parse-as-library
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 class NonSendable {} // expected-note {{}}
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -251,7 +251,6 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-DAG: Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
 // ON_METHOD-DAG: Keyword/None:                       lifetime[#Func Attribute#]; name=lifetime
-// ON_METHOD-DAG: Keyword/None:                       execution[#Func Attribute#]; name=execution
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -326,7 +325,6 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
 // ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // ON_MEMBER_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
-// ON_MEMBER_LAST-DAG: Keyword/None:                       execution[#Declaration Attribute#]; name=execution
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -399,7 +397,6 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // KEYWORD_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
-// KEYWORD_LAST-DAG: Keyword/None:                       execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyGenericPropertyWrapper[#Property Wrapper#]; name=MyGenericPropertyWrapper

--- a/test/IDE/complete_decl_attribute_feature_requirement.swift
+++ b/test/IDE/complete_decl_attribute_feature_requirement.swift
@@ -7,7 +7,8 @@
 
 // RUN: %batch-code-completion -filecheck-additional-suffix _DISABLED
 // RUN: %batch-code-completion -filecheck-additional-suffix _ENABLED \
-// RUN:        -enable-experimental-feature ABIAttribute
+// RUN:        -enable-experimental-feature ABIAttribute \
+// RUN:        -enable-experimental-feature ExecutionAttribute
 
 // NOTE: Please do not include the ", N items" after "Begin completions". The
 // item count creates needless merge conflicts given that an "End completions"
@@ -17,14 +18,18 @@
 
 // KEYWORD2:              Begin completions
 // KEYWORD2_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
+// KEYWORD2_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // KEYWORD2_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD2_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD2:              End completions
 
 @#^KEYWORD3^# class C {}
 
 // KEYWORD3:              Begin completions
 // KEYWORD3_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD3_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD3_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD3:              End completions
 
 @#^KEYWORD3_2?check=KEYWORD3^#IB class C2 {}
@@ -33,46 +38,60 @@
 @#^KEYWORD4^# enum E {}
 // KEYWORD4:              Begin completions
 // KEYWORD4_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD4_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD4_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD4:              End completions
 
 @#^KEYWORD5^# struct S{}
 // KEYWORD5:              Begin completions
 // KEYWORD5_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD5_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD5_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // KEYWORD5:              End completions
 
 @#^ON_GLOBALVAR^# var globalVar
 // ON_GLOBALVAR:              Begin completions
 // ON_GLOBALVAR_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
+// ON_GLOBALVAR_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_GLOBALVAR_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_GLOBALVAR:              End completions
 
 struct _S {
   @#^ON_INIT^# init()
 // ON_INIT:              Begin completions
 // ON_INIT_ENABLED-DAG:  Keyword/None:              abi[#Constructor Attribute#]; name=abi
+// ON_INIT_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_INIT_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_INIT:              End completions
 
   @#^ON_PROPERTY^# var foo
 // ON_PROPERTY:              Begin completions
 // ON_PROPERTY_ENABLED-DAG:  Keyword/None:              abi[#Var Attribute#]; name=abi
+// ON_PROPERTY_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PROPERTY_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PROPERTY:              End completions
 
   @#^ON_METHOD^# private
   func foo()
 // ON_METHOD:              Begin completions
 // ON_METHOD_ENABLED-DAG:  Keyword/None:              abi[#Func Attribute#]; name=abi
+// ON_METHOD_ENABLED-DAG:  Keyword/None:              execution[#Func Attribute#]; name=execution
 // ON_METHOD_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_METHOD_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_METHOD:              End completions
 
 
   func bar(@#^ON_PARAM_1?check=ON_PARAM^#)
 // ON_PARAM:              Begin completions
 // ON_PARAM_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PARAM_ENABLED-NOT:  Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_PARAM_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_PARAM:              End completions
 
   func bar(
@@ -95,7 +114,9 @@ struct _S {
   @#^ON_MEMBER_LAST^#
 // ON_MEMBER_LAST:              Begin completions
 // ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// ON_MEMBER_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// ON_MEMBER_LAST_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // ON_MEMBER_LAST:              End completions
 }
 
@@ -107,7 +128,9 @@ func takeClosure(_: () -> Void) {
 // IN_CLOSURE:              Begin completions
 // FIXME: Not valid in this position (but CompletionLookup can't tell that)
 // IN_CLOSURE_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// IN_CLOSURE_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // IN_CLOSURE_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// IN_CLOSURE_DISABLED-NOT: Keyword/None:              execution[#{{.*}} Attribute#]; name=execution
 // IN_CLOSURE:              End completions
 
 @#^KEYWORD_INDEPENDENT_1?check=KEYWORD_LAST^#
@@ -123,5 +146,7 @@ func dummy2() {}
 
 // KEYWORD_LAST:              Begin completions
 // KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// KEYWORD_LAST_ENABLED-DAG:  Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST_DISABLED-NOT: Keyword/None:              abi[#Declaration Attribute#]; name=abi
+// KEYWORD_LAST_DISABLED-NOT: Keyword/None:              execution[#Declaration Attribute#]; name=execution
 // KEYWORD_LAST:              End completions

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs \
 // RUN:  -enable-experimental-feature ABIAttribute \
-// RUN:  -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+// RUN:  -enable-experimental-feature AsyncCallerExecution
 
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
 
 // RUN: %FileCheck %s --input-file %t.swiftinterface
 
 // REQUIRES: swift_feature_ABIAttribute
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 // CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs \
 // RUN:  -enable-experimental-feature ABIAttribute \
-// RUN:  -enable-experimental-feature AsyncCallerExecution
+// RUN:  -enable-experimental-feature ExecutionAttribute
 
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
 
 // RUN: %FileCheck %s --input-file %t.swiftinterface
 
 // REQUIRES: swift_feature_ABIAttribute
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_ExecutionAttribute
 
 // CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }

--- a/test/ModuleInterface/execution_attr.swift
+++ b/test/ModuleInterface/execution_attr.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name execution_attr -enable-experimental-feature ExecutionAttribute
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name execution_attr
+
+// RUN: %FileCheck %s --input-file %t.swiftinterface
+
+// REQUIRES: swift_feature_ExecutionAttribute
+
+public struct Test {
+  // CHECK:  #if compiler(>=5.3) && $ExecutionAttribute
+  // CHECK-NEXT:  @execution(concurrent) public func test() async
+  // CHECK-NEXT:  #else
+  // CHECK-NEXT:  public func test() async
+  // CHECK-NEXT:  #endif
+  @execution(concurrent)
+  public func test() async {
+  }
+
+  // CHECK:  #if compiler(>=5.3) && $ExecutionAttribute
+  // CHECK-NEXT:  public func other(_: @execution(caller) () async -> Swift.Void)
+  // CHECK-NEXT:  #else
+  // CHECK-NEXT:  public func other(_: () async -> Swift.Void)
+  // CHECK-NEXT:  #endif
+  public func other(_: @execution(caller) () async -> Void) {}
+}
+

--- a/test/Parse/execution.swift
+++ b/test/Parse/execution.swift
@@ -1,4 +1,8 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature ExecutionAttribute
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_ExecutionAttribute
 
 typealias F = @execution(concurrent) () async -> Void
 

--- a/test/SILGen/execution_attr.swift
+++ b/test/SILGen/execution_attr.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature AsyncCallerExecution | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 // Validate that both with and without the experimental flag we properly codegen
 // execution(caller) and execution(concurrent).

--- a/test/SILGen/execution_attr.swift
+++ b/test/SILGen/execution_attr.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -enable-experimental-feature AsyncCallerExecution | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature ExecutionAttribute | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature ExecutionAttribute -enable-experimental-feature AsyncCallerExecution | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_ExecutionAttribute
 // REQUIRES: swift_feature_AsyncCallerExecution
 
 // Validate that both with and without the experimental flag we properly codegen

--- a/test/SILGen/nonisolated_inherits_isolation.swift
+++ b/test/SILGen/nonisolated_inherits_isolation.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-silgen -swift-version 6 -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 6 -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 //===----------------------------------------------------------------------===//
 //                             MARK: Declarations

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -1,12 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
-// RUN: %target-swift-frontend -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -enable-experimental-feature ExecutionAttribute -enable-experimental-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -enable-experimental-feature ExecutionAttribute -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 
 // RUN: %target-swift-frontend -module-name main -I %t %s -emit-sil -o - | %FileCheck %s
 
-// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
+// RUN: %target-swift-frontend -enable-experimental-feature ExecutionAttribute -enable-experimental-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
 
 // REQUIRES: asserts
+// REQUIRES: swift_feature_ExecutionAttribute
 // REQUIRES: swift_feature_AsyncCallerExecution
 
 import WithFeature

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 // RUN: %target-swift-frontend -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 
 // RUN: %target-swift-frontend -module-name main -I %t %s -emit-sil -o - | %FileCheck %s
 
-// RUN: %target-swift-frontend -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext -module-name main -I %t %s -emit-sil -verify -swift-version 6
+// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
 
 // REQUIRES: asserts
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 import WithFeature
 import WithoutFeature

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature NonIsolatedAsyncInheritsIsolationFromContext
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature AsyncCallerExecution
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_NonIsolatedAsyncInheritsIsolationFromContext
+// REQUIRES: swift_feature_AsyncCallerExecution
 
 @execution(something) func invalidAttr() async {} // expected-error {{unknown option 'something' for attribute 'execution'}}
 

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature AsyncCallerExecution
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -enable-experimental-feature ExecutionAttribute
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_ExecutionAttribute
 
 @execution(something) func invalidAttr() async {} // expected-error {{unknown option 'something' for attribute 'execution'}}
 


### PR DESCRIPTION
- `NonIsolatedAsyncInheritsIsolationFromContext` -> `AsyncCallerExecution`
- Hide `@execution` attribute behind an experimental feature `ExecutionAttribute`

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
