### PR TITLE
Fix declaration context for unsafe storage checking

### DIFF
--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -443,7 +443,7 @@ void swift::checkUnsafeStorage(NominalTypeDecl *nominal) {
 
   // Look for any unsafe storage in this nominal type.
   SmallVector<UnsafeUse, 4> unsafeUses;
-  UnsafeStorageVisitor(ctx, unsafeUses).visit(nominal, nominal->getDeclContext());
+  UnsafeStorageVisitor(ctx, unsafeUses).visit(nominal, nominal);
 
   // If we didn't find any unsafe storage, there's nothing to do.
   if (unsafeUses.empty())

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -191,3 +191,11 @@ class ClassWithUnsafeStorage {
   var int: Int = 0
   var array: [UnsafeSuper]? = nil // expected-note{{property 'array' involves unsafe type 'UnsafeSuper'}}
 }
+
+// expected-warning@+3{{generic struct 'GenericStructWithUnsafeThings' has storage involving unsafe types}}
+// expected-note@+2{{add '@unsafe' if this type is also unsafe to use}}
+// expected-note@+1{{add '@safe' if this type encapsulates the unsafe storage in a safe interface}}
+struct GenericStructWithUnsafeThings<T> {
+  var property: T
+  var pointer: PointerType // expected-note{{property 'pointer' involves unsafe type 'PointerType'}}
+}


### PR DESCRIPTION
Fix a compiler crash involving checking of generic types for unsafe storage.
