### PR TITLE
[Observation] Reduce the scope of the observation `shouldNotifyObservers` to only apply to observation and not side effects of accessors like willSet or didSet

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -361,10 +361,13 @@ public struct ObservationTrackedMacro: AccessorMacro {
       }
       """
 
+    // the guard else case must include the assignment else
+    // cases that would notify then drop the side effects of `didSet` etc
     let setAccessor: AccessorDeclSyntax =
       """
       set {
         guard shouldNotifyObservers(_\(identifier), newValue) else {
+          _\(identifier) = newValue
           return
         }
         withMutation(keyPath: \\.\(identifier)) {


### PR DESCRIPTION
There is a degenerate case which a developer may have relied on a side effect of a didSet that has a repetitious value. This restores that case such that properties in the form:

```
var foo: Int { didSet { print("applied") } }
```

When setting `foo = 3` and then setting it again `foo = 3` now restores the behavior of printing "applied" twice. This still leaves observation informing a change once.