### PR TITLE
Update benchmark readme with info on how to ensure benchmarks test locally built stdlib

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -152,8 +152,8 @@ swift-source/swift/benchmark$ .build/release/SwiftBench
 
 ### Troubleshooting
 
-- To check what libraries benchmark is linked against set `DYLD_PRINT_SEARCHING` environment variable. E.g. `export DYLD_PRINT_SEARCHING=1`.
-- To force linking with built stdlib use `DYLD_LIBRARY_PATH` environment variable. E.g. `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
+- To check what libraries benchmark is linked against, set the `DYLD_PRINT_SEARCHING` environment variable. E.g. `export DYLD_PRINT_SEARCHING=1`.
+- To force linking with a locally built stdlib, use the `DYLD_LIBRARY_PATH` environment variable. E.g. `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
 
 ## Editing in Xcode
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,9 +119,8 @@ installed libraries instead, enable
 This will reflect the performance of the Swift standard library
 installed on the device, not the one included in the Swift root.
 
-If build fails due with the error like `cannot find X in scope` it my be because default toolchains don't give access to stdlib SPI.
-Try using dev toolchain built locally or dev snapshot from [swift.org](https://www.swift.org/install/).
-
+If a build fails with an error like `cannot find X in scope`, it may be because default toolchains don't give access to stdlib SPI.
+Try using a dev toolchain built locally or a dev snapshot from [Swift.org](https://www.swift.org/install/).
 ### build-script using SwiftPM+LLBuild
 
 To build the benchmarks using build-script/swiftpm, one must build both

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,8 +119,8 @@ installed libraries instead, enable
 This will reflect the performance of the Swift standard library
 installed on the device, not the one included in the Swift root.
 
-If build fails due with the error like `cannot find X in scope` it is because default toolchains don't give access to stdlib SPI.
-Use dev toolchain built locally or dev snapshot from [swift.org](https://www.swift.org/install/).
+If build fails due with the error like `cannot find X in scope` it my be because default toolchains don't give access to stdlib SPI.
+Try using dev toolchain built locally or dev snapshot from [swift.org](https://www.swift.org/install/).
 
 ### build-script using SwiftPM+LLBuild
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,6 +119,9 @@ installed libraries instead, enable
 This will reflect the performance of the Swift standard library
 installed on the device, not the one included in the Swift root.
 
+If build fails due with the error like `cannot find X in scope` it is because default toolchains don't give access to stdlib SPI.
+Use dev toolchain built locally or dev snapshot from [swift.org](https://www.swift.org/install/).
+
 ### build-script using SwiftPM+LLBuild
 
 To build the benchmarks using build-script/swiftpm, one must build both
@@ -147,6 +150,11 @@ swift-source/swift/benchmark$ .build/release/SwiftBench
 2,AngryPhonebook,1,2044,2044,2044,0,2044
 ...
 ```
+
+### Troubleshooting
+
+- To check what libraries benchmark is linked against set `DYLD_PRINT_SEARCHING` environment variable. E.g. `export DYLD_PRINT_SEARCHING=1`.
+- To force linking with built stdlib use `DYLD_LIBRARY_PATH` environment variable. E.g. `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
 
 ## Editing in Xcode
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,8 +119,9 @@ installed libraries instead, enable
 This will reflect the performance of the Swift standard library
 installed on the device, not the one included in the Swift root.
 
-If a build fails with an error like `cannot find X in scope`, it may be because default toolchains don't give access to stdlib SPI.
-Try using a dev toolchain built locally or a dev snapshot from [Swift.org](https://www.swift.org/install/).
+If a build fails with an error like `cannot find X in scope`, it may be because
+default toolchains don't give access to stdlib SPI. Try using a dev toolchain
+built locally or a dev snapshot from [Swift.org](https://www.swift.org/install/).
 ### build-script using SwiftPM+LLBuild
 
 To build the benchmarks using build-script/swiftpm, one must build both
@@ -152,8 +153,12 @@ swift-source/swift/benchmark$ .build/release/SwiftBench
 
 ### Troubleshooting
 
-- To check what libraries benchmark is linked against, set the `DYLD_PRINT_SEARCHING` environment variable. E.g. `export DYLD_PRINT_SEARCHING=1`.
-- To force linking with a locally built stdlib, use the `DYLD_LIBRARY_PATH` environment variable. E.g. `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
+* To check what libraries benchmark is linked against, set the
+  `DYLD_PRINT_SEARCHING` environment variable. E.g.
+  `export DYLD_PRINT_SEARCHING=1`.
+* To force linking with a locally built stdlib, use the `DYLD_LIBRARY_PATH`
+  environment variable. E.g.
+  `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
 
 ## Editing in Xcode
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -121,7 +121,9 @@ installed on the device, not the one included in the Swift root.
 
 If a build fails with an error like `cannot find X in scope`, it may be because
 default toolchains don't give access to stdlib SPI. Try using a dev toolchain
-built locally or a dev snapshot from [Swift.org](https://www.swift.org/install/).
+built locally or a dev snapshot from
+[Swift.org](https://www.swift.org/install/).
+
 ### build-script using SwiftPM+LLBuild
 
 To build the benchmarks using build-script/swiftpm, one must build both
@@ -157,8 +159,8 @@ swift-source/swift/benchmark$ .build/release/SwiftBench
   `DYLD_PRINT_SEARCHING` environment variable. E.g.
   `export DYLD_PRINT_SEARCHING=1`.
 * To force linking with a locally built stdlib, use the `DYLD_LIBRARY_PATH`
-  environment variable. E.g.
-  `export DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
+  environment variable. E.g. `export
+  DYLD_LIBRARY_PATH=<path_to_build_folder>/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/x86_64`.
 
 ## Editing in Xcode
 


### PR DESCRIPTION
I recently tried to run modify stdlib and run benchmarks, but I had issues with it, and readme was not helpful enough.
This PR adds a bit of info to readme to help future readers.

Problems addressed:
1. Building standalone benchmarks fails when using standard xcode toolchains. In my case error looked like `- error: cannot find '_wordIndex' in scope`.
2. I could not make benchmarks use locally built stdlib. Even though this readme says they should use `../lib/swift`. So the two env variables helped me solve the problem.

Special thanks to @Catfish-Man for helping with these.