### PR TITLE
[SourceKit] Do not hardcode the XPC service name

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -445,6 +445,9 @@ macro(add_sourcekit_framework name)
       "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
 
+    file(GENERATE OUTPUT "xpc_service_name.txt" CONTENT "com.apple.SourceKitService.${SOURCEKIT_VERSION_STRING}_${SOURCEKIT_TOOLCHAIN_NAME}")
+    target_sources(${name} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/xpc_service_name.txt")
+
     set_target_properties(${name} PROPERTIES
                           BUILD_WITH_INSTALL_RPATH TRUE
                           FOLDER "SourceKit frameworks"
@@ -455,7 +458,8 @@ macro(add_sourcekit_framework name)
                           MACOSX_FRAMEWORK_IDENTIFIER "com.apple.${name}"
                           MACOSX_FRAMEWORK_SHORT_VERSION_STRING "1.0"
                           MACOSX_FRAMEWORK_BUNDLE_VERSION "${SOURCEKIT_VERSION_STRING}"
-                          PUBLIC_HEADER "${headers}")
+                          PUBLIC_HEADER "${headers}"
+                          RESOURCE "${CMAKE_CURRENT_BINARY_DIR}/xpc_service_name.txt")
     add_dependencies(${SOURCEKITFW_INSTALL_IN_COMPONENT} ${name})
     swift_install_in_component(TARGETS ${name}
                                FRAMEWORK

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
@@ -16,8 +16,6 @@ add_sourcekit_framework(sourcekitd
 )
 target_link_libraries(sourcekitd PRIVATE sourcekitdAPI)
 
-add_definitions(-DSOURCEKIT_XPCSERVICE_IDENTIFIER="com.apple.SourceKitService.${SOURCEKIT_VERSION_STRING}_${SOURCEKIT_TOOLCHAIN_NAME}")
-
 if (SOURCEKIT_BUILT_STANDALONE)
   # Create the symlink necessary to find the swift stdlib.
   swift_create_post_build_symlink(sourcekitd


### PR DESCRIPTION
Write the service name into a resource file rather than have it hardcoded, allowing it to be updated post-build if necessary.