### PR TITLE
[6.1] [AutoDiff] Peel off @sendable implicit conversion when checking for unsupported differentiable function conversion

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6570,7 +6570,19 @@ maybeDiagnoseUnsupportedDifferentiableConversion(ConstraintSystem &cs,
           maybeDiagnoseFunctionRef(unwrappedFnExpr);
           return;
         }
+      } else if (auto conv = dyn_cast<FunctionConversionExpr>(semanticExpr)) {
+        // Look through a function conversion that only adds or removes
+        // `@Sendable`.
+        auto ty1 = conv->getType()->castTo<AnyFunctionType>();
+        auto ty2 = conv->getSubExpr()->getType()->castTo<AnyFunctionType>();
+
+        if (ty1->withExtInfo(ty1->getExtInfo().withSendable(false))
+            ->isEqual(ty2->withExtInfo(ty2->getExtInfo().withSendable(false)))) {
+          maybeDiagnoseFunctionRef(conv->getSubExpr()->getSemanticsProvidingExpr());
+          return;
+        }
       }
+
       ctx.Diags.diagnose(expr->getLoc(),
                          diag::invalid_differentiable_function_conversion_expr);
     };


### PR DESCRIPTION
  - **Explanation**:
Peel off @sendable implicit conversion when checking for unsupported differentiable function conversion
  - **Scope**:
Only affects autodiff code. 
  - **Issues**:
N/A
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/77869
  - **Risk**:
Low.
  - **Testing**:
Confirmed that a test package with the following snippet fails against the latest snapshot from `release/6.1`, but succeeds against the latest `main` snapshot. The sendable conformance is implicitly added by the test framework.

```
import Testing
import _Differentiation

@inlinable
@derivative(of: min)
public func _vjpMin<T: Comparable & Differentiable>(
    _ lhs: T,
    _ rhs: T
) -> (value: T, pullback: (T.TangentVector) -> (T.TangentVector, T.TangentVector)) {
    func pullback(_ tangentVector: T.TangentVector) -> (T.TangentVector, T.TangentVector) {
        if lhs <= rhs {
            return (tangentVector, .zero)
        }
        else {
            return (.zero, tangentVector)
        }
    }
    return (value: min(lhs, rhs), pullback: pullback)
}

@Test
func testMin() {
    @differentiable(reverse)
    func minContainer(_ lhs: Float, _ rhs: Float) -> Float {
        return min(lhs, rhs)
    }
    let vwgLessThan = valueWithGradient(at: 2.0, 3.0, of: min(_:_:))
    print(vwgLessThan.value == 2.0)
    print(vwgLessThan.gradient == (1.0, 0.0))
}
```
  - **Reviewers**:
@asl @xedin 