### PR TITLE
Windows; improve SDK overlay for WinSDK

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -222,13 +222,16 @@ public struct WindowsBool: ExpressibleByBooleanLiteral {
   }
 }
 
+#if SWIFT_ENABLE_REFLECTION
 extension WindowsBool: CustomReflectable {
   /// Returns a mirror that reflects `self`.
   public var customMirror: Mirror {
     return Mirror(reflecting: boolValue)
   }
 }
+#endif
 
+@_unavailableInEmbedded
 extension WindowsBool: CustomStringConvertible {
   /// A textual representation of `self`.
   public var description: String {

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -14,91 +14,122 @@
 @_exported import WinSDK // Clang module
 
 // WinBase.h
+@inlinable
 public var HANDLE_FLAG_INHERIT: DWORD {
   0x00000001
 }
 
 // WinBase.h
+@inlinable
 public var STARTF_USESTDHANDLES: DWORD {
   0x00000100
 }
 
 // WinBase.h
+@inlinable
 public var INFINITE: DWORD {
   DWORD(bitPattern: -1)
 }
 
 // WinBase.h
+@inlinable
 public var WAIT_OBJECT_0: DWORD {
   0
 }
 
 // WinBase.h
+@inlinable
 public var STD_INPUT_HANDLE: DWORD {
   DWORD(bitPattern: -10)
 }
+
+@inlinable
 public var STD_OUTPUT_HANDLE: DWORD {
   DWORD(bitPattern: -11)
 }
+
+@inlinable
 public var STD_ERROR_HANDLE: DWORD {
   DWORD(bitPattern: -12)
 }
 
 // handleapi.h
+@inlinable
 public var INVALID_HANDLE_VALUE: HANDLE {
   HANDLE(bitPattern: -1)!
 }
 
 // shellapi.h
+@inlinable
 public var FOF_NO_UI: FILEOP_FLAGS {
   FILEOP_FLAGS(FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR)
 }
 
 // winioctl.h
+@inlinable
 public var FSCTL_SET_REPARSE_POINT: DWORD {
   0x900a4
 }
+
+@inlinable
 public var FSCTL_GET_REPARSE_POINT: DWORD {
   0x900a8
 }
+
+@inlinable
 public var FSCTL_DELETE_REPARSE_POINT: DWORD {
   0x900ac
 }
 
 // WinSock2.h
+@inlinable
 public var INVALID_SOCKET: SOCKET {
   SOCKET(bitPattern: -1)
 }
+
+@inlinable
 public var FIONBIO: Int32 {
   Int32(bitPattern: 0x8004667e)
 }
 
 // WinUser.h
+@inlinable
 public var CW_USEDEFAULT: Int32 {
   Int32(bitPattern: 2147483648)
 }
 
+@inlinable
 public var QS_MOUSE: UINT {
   UINT(QS_MOUSEMOVE | QS_MOUSEBUTTON)
 }
+
+@inlinable
 public var QS_INPUT: UINT {
   QS_MOUSE | UINT(QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
 }
+
+@inlinable
 public var QS_ALLEVENTS: UINT {
   QS_INPUT | UINT(QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY)
 }
+
+@inlinable
 public var QS_ALLINPUT: UINT {
   QS_INPUT | UINT(QS_POSTMESSAGE | QS_TIMER | QS_PAINT | QS_HOTKEY | QS_SENDMESSAGE)
 }
 
+@inlinable
 public var WS_OVERLAPPEDWINDOW: UINT {
   UINT(WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
 }
+
+@inlinable
 public var WS_POPUPWINDOW: UINT {
   UINT(numericCast(WS_POPUP) | WS_BORDER | WS_SYSMENU)
 }
 
 // fileapi.h
+@inlinable
 public var INVALID_FILE_ATTRIBUTES: DWORD {
   DWORD(bitPattern: -1)
 }
@@ -124,55 +155,84 @@ public let TRACKBAR_CLASSW: [WCHAR] = Array<WCHAR>("msctls_trackbar32".utf16)
 public let UPDOWN_CLASSW: [WCHAR] = Array<WCHAR>("msctls_updown32".utf16)
 
 // consoleapi.h
+@inlinable
 public var PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: DWORD_PTR {
   0x00020016
 }
 
 // windef.h
+@inlinable
 public var DPI_AWARENESS_CONTEXT_UNAWARE: DPI_AWARENESS_CONTEXT {
   DPI_AWARENESS_CONTEXT(bitPattern: -1)!
 }
+
+@inlinable
 public var DPI_AWARENESS_CONTEXT_SYSTEM_AWARE: DPI_AWARENESS_CONTEXT {
   DPI_AWARENESS_CONTEXT(bitPattern: -2)!
 }
+
+@inlinable
 public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE: DPI_AWARENESS_CONTEXT {
   DPI_AWARENESS_CONTEXT(bitPattern: -3)!
 }
+
+@inlinable
 public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT {
   DPI_AWARENESS_CONTEXT(bitPattern: -4)!
 }
+
+@inlinable
 public var DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT {
   DPI_AWARENESS_CONTEXT(bitPattern: -5)!
 }
 
 // winreg.h
+@inlinable
 public var HKEY_CLASSES_ROOT: HKEY {
   HKEY(bitPattern: UInt(0x80000000))!
 }
+
+@inlinable
 public var HKEY_CURRENT_USER: HKEY {
   HKEY(bitPattern: UInt(0x80000001))!
 }
+
+@inlinable
 public var HKEY_LOCAL_MACHINE: HKEY {
   HKEY(bitPattern: UInt(0x80000002))!
 }
+
+@inlinable
 public var HKEY_USERS: HKEY {
   HKEY(bitPattern: UInt(0x80000003))!
 }
+
+@inlinable
 public var HKEY_PERFORMANCE_DATA: HKEY {
   HKEY(bitPattern: UInt(0x80000004))!
 }
+
+@inlinable
 public var HKEY_PERFORMANCE_TEXT: HKEY {
   HKEY(bitPattern: UInt(0x80000050))!
 }
+
+@inlinable
 public var HKEY_PERFORMANCE_NLSTEXT: HKEY {
   HKEY(bitPattern: UInt(0x80000060))!
 }
+
+@inlinable
 public var HKEY_CURRENT_CONFIG: HKEY {
   HKEY(bitPattern: UInt(0x80000005))!
 }
+
+@inlinable
 public var HKEY_DYN_DATA: HKEY {
   HKEY(bitPattern: UInt(0x80000006))!
 }
+
+@inlinable
 public var HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY {
   HKEY(bitPattern: UInt(0x80000007))!
 }

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -200,7 +200,7 @@ public extension FILETIME {
 ///
 /// The C type is a typedef for `int`.
 @frozen
-public struct WindowsBool : ExpressibleByBooleanLiteral {
+public struct WindowsBool: ExpressibleByBooleanLiteral {
   @usableFromInline
   var _value: Int32
 
@@ -222,21 +222,21 @@ public struct WindowsBool : ExpressibleByBooleanLiteral {
   }
 }
 
-extension WindowsBool : CustomReflectable {
+extension WindowsBool: CustomReflectable {
   /// Returns a mirror that reflects `self`.
   public var customMirror: Mirror {
     return Mirror(reflecting: boolValue)
   }
 }
 
-extension WindowsBool : CustomStringConvertible {
+extension WindowsBool: CustomStringConvertible {
   /// A textual representation of `self`.
   public var description: String {
     return self.boolValue.description
   }
 }
 
-extension WindowsBool : Equatable {
+extension WindowsBool: Equatable {
   @_transparent
   public static func ==(lhs: WindowsBool, rhs: WindowsBool) -> Bool {
     return lhs.boolValue == rhs.boolValue


### PR DESCRIPTION
Clean up the WinSDK module some for allowing building without reflection or in embedded (just for matching the Darwin platform overlay rather than for actual purpose).

Thanks to @grynspan for the discussion around this cleanup.