### PR TITLE
[6.1] Emit reabstraction thunks for implicit conversions between T.TangentType and Optional<T>.TangentType

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1122,6 +1122,16 @@ public:
       AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
       llvm::SetVector<AutoDiffConfig> &results);
 
+  /// Given `Optional<T>.TangentVector` type, retrieve the
+  /// `Optional<T>.TangentVector.init` declaration.
+  ConstructorDecl *getOptionalTanInitDecl(CanType optionalTanType);
+
+  /// Optional<T>.TangentVector is a struct with a single
+  /// Optional<T.TangentVector> `value` property. This is an implementation
+  /// detail of OptionalDifferentiation.swift. Retrieve `VarDecl` corresponding
+  /// to this property.
+  VarDecl *getOptionalTanValueDecl(CanType optionalTanType);
+
   /// Retrieve the next macro expansion discriminator within the given
   /// name and context.
   unsigned getNextMacroDiscriminator(MacroDiscriminatorContext context,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -343,6 +343,12 @@ struct ASTContext::Implementation {
   /// The declaration of Swift.Optional<T>.None.
   EnumElementDecl *OptionalNoneDecl = nullptr;
 
+  /// The declaration of Optional<T>.TangentVector.init
+  ConstructorDecl *OptionalTanInitDecl = nullptr;
+
+  /// The declaration of Optional<T>.TangentVector.value
+  VarDecl *OptionalTanValueDecl = nullptr;
+  
   /// The declaration of Swift.Void.
   TypeAliasDecl *VoidDecl = nullptr;
 
@@ -2240,6 +2246,52 @@ void ASTContext::loadObjCMethods(
     loader->loadObjCMethods(tyDecl, selector, isInstanceMethod,
                             previousGeneration, methods);
   }
+}
+
+ConstructorDecl *ASTContext::getOptionalTanInitDecl(CanType optionalTanType) {
+  if (!getImpl().OptionalTanInitDecl) {
+    auto *optionalTanDecl = optionalTanType.getNominalOrBoundGenericNominal();
+    // Look up the `Optional<T>.TangentVector.init` declaration.
+    auto initLookup =
+      optionalTanDecl->lookupDirect(DeclBaseName::createConstructor());
+    ConstructorDecl *constructorDecl = nullptr;
+    for (auto *candidate : initLookup) {
+      auto candidateModule = candidate->getModuleContext();
+      if (candidateModule->getName() == Id_Differentiation ||
+          candidateModule->isStdlibModule()) {
+        assert(!constructorDecl && "Multiple `Optional.TangentVector.init`s");
+        constructorDecl = cast<ConstructorDecl>(candidate);
+#ifdef NDEBUG
+        break;
+#endif
+      }
+    }
+    assert(constructorDecl && "No `Optional.TangentVector.init`");
+
+    getImpl().OptionalTanInitDecl = constructorDecl;
+  }
+
+  return getImpl().OptionalTanInitDecl;
+}
+
+VarDecl *ASTContext::getOptionalTanValueDecl(CanType optionalTanType) {
+  if (!getImpl().OptionalTanValueDecl) {
+    // TODO: Maybe it would be better to have getters / setters here that we
+    // can call and hide this implementation detail?
+    StructDecl *optStructDecl = optionalTanType.getStructOrBoundGenericStruct();
+    assert(optStructDecl && "Unexpected type of Optional.TangentVector");
+
+    ArrayRef<VarDecl *> properties = optStructDecl->getStoredProperties();
+    assert(properties.size() == 1 && "Unexpected type of Optional.TangentVector");
+    VarDecl *wrappedValueVar = properties[0];
+
+    assert(wrappedValueVar->getTypeInContext()->getEnumOrBoundGenericEnum() ==
+           getOptionalDecl() && "Unexpected type of Optional.TangentVector");
+
+    getImpl().OptionalTanValueDecl = wrappedValueVar;
+  }
+
+  return getImpl().OptionalTanValueDecl;
 }
 
 void ASTContext::loadDerivativeFunctionConfigurations(

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AutoDiff.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -6072,7 +6073,7 @@ namespace {
     }
 
     void printAnyFunctionTypeCommonRec(AnyFunctionType *T, Label label,
-                                    StringRef name) {
+                                       StringRef name) {
       printCommon(name, label);
 
       if (T->hasExtInfo()) {
@@ -6087,6 +6088,24 @@ namespace {
         printFlag(T->isAsync(), "async");
         printFlag(T->isThrowing(), "throws");
         printFlag(T->hasSendingResult(), "sending_result");
+        if (T->isDifferentiable()) {
+          switch (T->getDifferentiabilityKind()) {
+          default:
+            llvm_unreachable("unexpected differentiability kind");
+          case DifferentiabilityKind::Reverse:
+            printFlag("@differentiable(reverse)");
+            break;
+          case DifferentiabilityKind::Forward:
+            printFlag("@differentiable(_forward)");
+            break;
+          case DifferentiabilityKind::Linear:
+            printFlag("@differentiable(_linear)");
+            break;
+          case DifferentiabilityKind::Normal:
+            printFlag("@differentiable");
+            break;
+          }
+        }
       }
       if (Type globalActor = T->getGlobalActor()) {
         printFieldQuoted(globalActor.getString(), Label::always("global_actor"));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2505,6 +2505,25 @@ public:
                                            CanSILFunctionType toType,
                                            bool reorderSelf);
 
+  /// Emit conversion from T.TangentVector to Optional<T>.TangentVector.
+  ManagedValue
+  emitTangentVectorToOptionalTangentVector(SILLocation loc,
+                                           ManagedValue input,
+                                           CanType wrappedType, // `T`
+                                           CanType inputType,   // `T.TangentVector`
+                                           CanType outputType,  // `Optional<T>.TangentVector`
+                                           SGFContext ctxt);
+
+  /// Emit conversion from Optional<T>.TangentVector to T.TangentVector.
+  ManagedValue
+  emitOptionalTangentVectorToTangentVector(SILLocation loc,
+                                           ManagedValue input,
+                                           CanType wrappedType, // `T`
+                                           CanType inputType,   // `Optional<T>.TangentVector`
+                                           CanType outputType,  // `T.TangentVector`
+                                           SGFContext ctxt);
+
+  
   //===--------------------------------------------------------------------===//
   // Back Deployment thunks
   //===--------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -83,6 +83,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "silgen-poly"
+#include "ArgumentSource.h"
 #include "ExecutorBreadcrumb.h"
 #include "FunctionInputGenerator.h"
 #include "Initialization.h"
@@ -292,6 +293,67 @@ SILGenFunction::emitTransformExistential(SILLocation loc,
                    [&](SGFContext C) -> ManagedValue {
                      return manageOpaqueValue(input, loc, C);
                    });
+}
+
+// Convert T.TangentVector to Optional<T>.TangentVector.
+// Optional<T>.TangentVector is a struct wrapping Optional<T.TangentVector>
+// So we just need to call appropriate .init on it.
+ManagedValue SILGenFunction::emitTangentVectorToOptionalTangentVector(
+    SILLocation loc, ManagedValue input, CanType wrappedType, CanType inputType,
+    CanType outputType, SGFContext ctxt) {
+  // Look up the `Optional<T>.TangentVector.init` declaration.
+  auto *constructorDecl = getASTContext().getOptionalTanInitDecl(outputType);
+
+  // `Optional<T.TangentVector>`
+  CanType optionalOfWrappedTanType = inputType.wrapInOptionalType();
+
+  const TypeLowering &optTL = getTypeLowering(optionalOfWrappedTanType);
+  auto optVal = emitInjectOptional(
+      loc, optTL, SGFContext(), [&](SGFContext objectCtxt) { return input; });
+
+  auto *diffProto = getASTContext().getProtocol(KnownProtocolKind::Differentiable);
+  auto diffConf = lookupConformance(wrappedType, diffProto);
+  assert(!diffConf.isInvalid() && "Missing conformance to `Differentiable`");
+  ConcreteDeclRef initDecl(
+      constructorDecl,
+      SubstitutionMap::get(constructorDecl->getGenericSignature(),
+                           {wrappedType}, {diffConf}));
+  PreparedArguments args({AnyFunctionType::Param(optionalOfWrappedTanType)});
+  args.add(loc, RValue(*this, {optVal}, optionalOfWrappedTanType));
+
+  auto result = emitApplyAllocatingInitializer(loc, initDecl, std::move(args),
+                                               Type(), ctxt);
+  return std::move(result).getScalarValue();
+}
+
+ManagedValue SILGenFunction::emitOptionalTangentVectorToTangentVector(
+    SILLocation loc, ManagedValue input, CanType wrappedType, CanType inputType,
+    CanType outputType, SGFContext ctxt) {
+  // Optional<T>.TangentVector should be a struct with a single
+  // Optional<T.TangentVector> `value` property. This is an implementation
+  // detail of OptionalDifferentiation.swift
+  // TODO: Maybe it would be better to have explicit getters / setters here that we can
+  // call and hide this implementation detail?
+  VarDecl *wrappedValueVar = getASTContext().getOptionalTanValueDecl(inputType);
+  // `Optional<T.TangentVector>`
+  CanType optionalOfWrappedTanType = outputType.wrapInOptionalType();
+
+  FormalEvaluationScope scope(*this);
+
+  auto sig = wrappedValueVar->getDeclContext()->getGenericSignatureOfContext();
+  auto *diffProto =
+      getASTContext().getProtocol(KnownProtocolKind::Differentiable);
+  auto diffConf = lookupConformance(wrappedType, diffProto);
+  assert(!diffConf.isInvalid() && "Missing conformance to `Differentiable`");
+
+  auto wrappedVal = emitRValueForStorageLoad(
+      loc, input, inputType, /*super*/ false, wrappedValueVar,
+      PreparedArguments(), SubstitutionMap::get(sig, {wrappedType}, {diffConf}),
+      AccessSemantics::Ordinary, optionalOfWrappedTanType, SGFContext());
+
+  return emitCheckedGetOptionalValueFrom(
+      loc, std::move(wrappedVal).getScalarValue(),
+      /*isImplicitUnwrap*/ true, getTypeLowering(optionalOfWrappedTanType), ctxt);
 }
 
 /// Apply this transformation to an arbitrary value.
@@ -673,6 +735,54 @@ ManagedValue Transform::transform(ManagedValue v,
     if (result.isInContext())
       return ManagedValue::forInContext();
     return std::move(result).getAsSingleValue(SGF, Loc);
+  }
+
+  // - T.TangentVector to Optional<T>.TangentVector
+  // Optional<T>.TangentVector is a struct wrapping Optional<T.TangentVector>
+  // So we just need to call appropriate .init on it.
+  // However, we might have T.TangentVector == T, so we need to calculate all
+  // required types first.
+  {
+    CanType optionalTy = isa<NominalType>(outputSubstType)
+                             ? outputSubstType.getNominalParent()
+                             : CanType(); // `Optional<T>`
+    if (optionalTy && (bool)optionalTy.getOptionalObjectType()) {
+      CanType wrappedType = optionalTy.getOptionalObjectType(); // `T`
+      // Check that T.TangentVector is indeed inputSubstType (this also handles
+      // case when T == T.TangentVector).
+      // Also check that outputSubstType is an Optional<T>.TangentVector.
+      auto inputTanSpace =
+          wrappedType->getAutoDiffTangentSpace(LookUpConformanceInModule());
+      auto outputTanSpace =
+          optionalTy->getAutoDiffTangentSpace(LookUpConformanceInModule());
+      if (inputTanSpace && outputTanSpace &&
+          inputTanSpace->getCanonicalType() == inputSubstType &&
+          outputTanSpace->getCanonicalType() == outputSubstType)
+        return SGF.emitTangentVectorToOptionalTangentVector(
+            Loc, v, wrappedType, inputSubstType, outputSubstType, ctxt);
+    }
+  }
+
+  // - Optional<T>.TangentVector to T.TangentVector.
+  {
+    CanType optionalTy = isa<NominalType>(inputSubstType)
+                             ? inputSubstType.getNominalParent()
+                             : CanType(); // `Optional<T>`
+    if (optionalTy && (bool)optionalTy.getOptionalObjectType()) {
+      CanType wrappedType = optionalTy.getOptionalObjectType(); // `T`
+      // Check that T.TangentVector is indeed outputSubstType (this also handles
+      // case when T == T.TangentVector)
+      // Also check that inputSubstType is an Optional<T>.TangentVector
+      auto inputTanSpace =
+          optionalTy->getAutoDiffTangentSpace(LookUpConformanceInModule());
+      auto outputTanSpace =
+          wrappedType->getAutoDiffTangentSpace(LookUpConformanceInModule());
+      if (inputTanSpace && outputTanSpace &&
+          inputTanSpace->getCanonicalType() == inputSubstType &&
+          outputTanSpace->getCanonicalType() == outputSubstType)
+        return SGF.emitOptionalTangentVectorToTangentVector(
+            Loc, v, wrappedType, inputSubstType, outputSubstType, ctxt);
+    }
   }
 
   // Should have handled the conversion in one of the cases above.

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1831,27 +1831,9 @@ public:
 
     auto adjOpt = getAdjointValue(bb, ei);
     auto adjStruct = materializeAdjointDirect(adjOpt, loc);
-    StructDecl *adjStructDecl =
-        adjStruct->getType().getStructOrBoundGenericStruct();
 
-    VarDecl *adjOptVar = nullptr;
-    if (adjStructDecl) {
-      ArrayRef<VarDecl *> properties = adjStructDecl->getStoredProperties();
-      adjOptVar = properties.size() == 1 ? properties[0] : nullptr;
-    }
-
-    EnumDecl *adjOptDecl =
-        adjOptVar ? adjOptVar->getTypeInContext()->getEnumOrBoundGenericEnum()
-                  : nullptr;
-
-    // Optional<T>.TangentVector should be a struct with a single
-    // Optional<T.TangentVector> property. This is an implementation detail of
-    // OptionalDifferentiation.swift
-    // TODO: Maybe it would be better to have getters / setters here that we
-    // can call and hide this implementation detail?
-    if (!adjOptDecl || adjOptDecl != optionalEnumDecl)
-      llvm_unreachable("Unexpected type of Optional.TangentVector");
-
+    VarDecl *adjOptVar =
+      getASTContext().getOptionalTanValueDecl(adjStruct->getType().getASTType());
     auto *adjVal = builder.createStructExtract(loc, adjStruct, adjOptVar);
 
     EnumElementDecl *someElemDecl = getASTContext().getOptionalSomeDecl();
@@ -1910,24 +1892,8 @@ public:
     }
 
     SILValue adjDest = getAdjointBuffer(bb, origEnum);
-    StructDecl *adjStructDecl =
-        adjDest->getType().getStructOrBoundGenericStruct();
-
-    VarDecl *adjOptVar = nullptr;
-    if (adjStructDecl) {
-      ArrayRef<VarDecl *> properties = adjStructDecl->getStoredProperties();
-      adjOptVar = properties.size() == 1 ? properties[0] : nullptr;
-    }
-
-    EnumDecl *adjOptDecl =
-        adjOptVar ? adjOptVar->getTypeInContext()->getEnumOrBoundGenericEnum()
-                  : nullptr;
-
-    // Optional<T>.TangentVector should be a struct with a single
-    // Optional<T.TangentVector> property. This is an implementation detail of
-    // OptionalDifferentiation.swift
-    if (!adjOptDecl || adjOptDecl != optionalEnumDecl)
-      llvm_unreachable("Unexpected type of Optional.TangentVector");
+    VarDecl *adjOptVar =
+      getASTContext().getOptionalTanValueDecl(adjDest->getType().getASTType());
 
     SILLocation loc = origData->getLoc();
     StructElementAddrInst *adjOpt =
@@ -2657,24 +2623,9 @@ AllocStackInst *PullbackCloner::Implementation::createOptionalAdjoint(
   auto optionalOfWrappedTanType = SILType::getOptionalType(wrappedTanType);
   // `Optional<T>.TangentVector`
   auto optionalTanTy = getRemappedTangentType(optionalTy);
-  auto *optionalTanDecl = optionalTanTy.getNominalOrBoundGenericNominal();
   // Look up the `Optional<T>.TangentVector.init` declaration.
-  auto initLookup =
-      optionalTanDecl->lookupDirect(DeclBaseName::createConstructor());
-  ConstructorDecl *constructorDecl = nullptr;
-  for (auto *candidate : initLookup) {
-    auto candidateModule = candidate->getModuleContext();
-    if (candidateModule->getName() ==
-            builder.getASTContext().Id_Differentiation ||
-        candidateModule->isStdlibModule()) {
-      assert(!constructorDecl && "Multiple `Optional.TangentVector.init`s");
-      constructorDecl = cast<ConstructorDecl>(candidate);
-#ifdef NDEBUG
-      break;
-#endif
-    }
-  }
-  assert(constructorDecl && "No `Optional.TangentVector.init`");
+  ConstructorDecl *constructorDecl =
+    getASTContext().getOptionalTanInitDecl(optionalTanTy.getASTType());
 
   // Allocate a local buffer for the `Optional` adjoint value.
   auto *optTanAdjBuf = builder.createAllocStack(pbLoc, optionalTanTy);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -52,6 +52,7 @@
 #include "clang/Sema/TemplateDeduction.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -7606,8 +7607,20 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
             fromEI.intoBuilder()
                 .withDifferentiabilityKind(toEI.getDifferentiabilityKind())
                 .build();
-        fromFunc = FunctionType::get(toFunc->getParams(), fromFunc->getResult(),
-                                     newEI);
+        SmallVector<AnyFunctionType::Param, 4> params(fromFunc->getParams());
+        assert(params.size() == toFunc->getParams().size() &&
+               "unexpected @differentiable conversion");
+        // Propagate @noDerivate from target function type
+        for (auto paramAndIndex : llvm::enumerate(toFunc->getParams())) {
+          if (!paramAndIndex.value().isNoDerivative())
+            continue;
+
+          auto &param = params[paramAndIndex.index()];
+          param =
+            param.withFlags(param.getParameterFlags().withNoDerivative(true));
+        }
+
+        fromFunc = FunctionType::get(params, fromFunc->getResult(), newEI);
         switch (toEI.getDifferentiabilityKind()) {
         // TODO: Ban `Normal` and `Forward` cases.
         case DifferentiabilityKind::Normal:

--- a/test/AutoDiff/compiler_crashers_fixed/issue-77871-implicit-diff-optional-conversion.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-77871-implicit-diff-optional-conversion.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// https://github.com/swiftlang/swift/issues/77871
+// Ensure we are correctl generating reabstraction thunks for Double <-> Optional<Double>
+// conversion for derivatives: for differential and pullback we need
+// to emit thunks to convert T.TangentVector <-> Optional<T>.TangentVector.
+
+import _Differentiation
+
+@differentiable(reverse)
+func testFunc(_ x: Double?) -> Double? {
+    x! * x! * x!
+}
+print(pullback(at: 1.0, of: testFunc)(.init(1.0)) == 3.0)
+
+func foo<T>(_ fn: @escaping @differentiable(reverse) (T?) -> Double) {
+  let _: @differentiable(reverse) (T) -> Double = fn
+}


### PR DESCRIPTION
  - **Explanation**:
Emit reabstraction thunks for implicit conversions between T.TangentType and Optional<T>.TangentType. Resolves a crash from silgen, producing a diagnostic instead.
  - **Scope**:
Affects primarily autodiff code.
  - **Issues**:
https://github.com/swiftlang/swift/issues/77871
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/78076
  - **Risk**:
Low.
  - **Testing**:
Verified the silgen crash still occurs on the latest `release/6.1` snapshot, and the correct diagnostic is emitted using the latest `main` snapshot.
  - **Reviewers**:
@asl @hamishknight @slavapestov 