### PR TITLE
[Frontend] NFC: Remove `getCompilerVersion`

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -187,10 +187,6 @@ StringRef getCurrentCompilerChannel();
 /// users.
 unsigned getUpcomingCxxInteropCompatVersion();
 
-/// Retrieves the version of the running compiler. It could be a tag or
-/// a "development" version that only has major/minor.
-std::string getCompilerVersion();
-
 } // end namespace version
 } // end namespace swift
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -339,17 +339,5 @@ unsigned getUpcomingCxxInteropCompatVersion() {
   return SWIFT_VERSION_MAJOR + 1;
 }
 
-std::string getCompilerVersion() {
-  std::string buf;
-  llvm::raw_string_ostream OS(buf);
-
- // TODO: This should print SWIFT_COMPILER_VERSION when
- // available, but to do that we need to switch from
- // llvm::VersionTuple to swift::Version.
- OS << SWIFT_VERSION_STRING;
-
-  return OS.str();
-}
-
 } // end namespace version
 } // end namespace swift

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeRepr.h"
+#include "swift/Basic/Version.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Frontend/Frontend.h"
@@ -130,7 +131,11 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
         ignorableFlags, [&out](StringRef str) { out << str; },
         [&out] { out << " "; });
 
-    out << " -interface-compiler-version " << version::getCompilerVersion();
+    auto currentVersion = version::Version::getCurrentLanguageVersion();
+    // Prints only major + minor to maintain compatibility with older
+    // compilers.
+    out << " -interface-compiler-version " << currentVersion[0] << '.'
+        << currentVersion[1];
     out << "\n";
   }
 }


### PR DESCRIPTION
Since we only going to be printing major + minor components, `printToolVersionAndFlagsComment` can use `Version::getCurrentLanguageVersion()` API directly.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
