### PR TITLE
[cxx-interop] Prevent usage in Swift of C++ move constructor with default args

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -174,6 +174,10 @@ NOTE(record_not_automatically_importable, none, "record '%0' is not "
                                                 "does this type have reference "
                                                 "semantics?",
      (StringRef, StringRef))
+NOTE(record_unsupported_default_args, none,
+     "copy constructors and move constructors with more than one parameter are "
+     "unavailable in Swift",
+     ())
 
 NOTE(projection_value_not_imported, none, "C++ method '%0' that returns a value "
                                           "of type '%1' is unavailable",

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -347,8 +347,10 @@ enum class CxxRecordSemanticsKind {
   MoveOnly,
   Reference,
   Iterator,
-  // A record that is either not copyable or not destructible.
+  // A record that is either not copyable/movable or not destructible.
   MissingLifetimeOperation,
+  // A record that has no copy and no move operations
+  UnavailableConstructors,
   // A C++ record that represents a Swift class type exposed to C++ from Swift.
   SwiftClassType
 };

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8010,14 +8010,6 @@ static bool isSufficientlyTrivial(const clang::CXXRecordDecl *decl) {
   return true;
 }
 
-static bool hasNonFirstDefaultArg(const clang::CXXConstructorDecl *ctor) {
-  if (ctor->getNumParams() < 2)
-    return false;
-
-  auto lastParam = ctor->parameters().back();
-  return lastParam->hasDefaultArg();
-}
-
 /// Checks if a record provides the required value type lifetime operations
 /// (copy and destroy).
 static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
@@ -8034,7 +8026,8 @@ static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
   // struct.
   return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
     return ctor->isCopyConstructor() && !ctor->isDeleted() &&
-           !hasNonFirstDefaultArg(ctor) &&
+           // FIXME: Support default arguments (rdar://142414553)
+           ctor->getNumParams() == 1 &&
            ctor->getAccess() == clang::AccessSpecifier::AS_public;
   });
 }
@@ -8050,7 +8043,9 @@ static bool hasMoveTypeOperations(const clang::CXXRecordDecl *decl) {
     return false;
 
   return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
-    return ctor->isMoveConstructor();
+    return ctor->isMoveConstructor() &&
+           // FIXME: Support default arguments (rdar://142414553)
+           ctor->getNumParams() == 1;
   });
 }
 
@@ -8067,6 +8062,15 @@ static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl) {
 static bool hasCustomCopyOrMoveConstructor(const clang::CXXRecordDecl *decl) {
   return decl->hasUserDeclaredCopyConstructor() ||
          decl->hasUserDeclaredMoveConstructor();
+}
+
+static bool
+hasConstructorWithUnsupportedDefaultArgs(const clang::CXXRecordDecl *decl) {
+  return llvm::any_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
+    return (ctor->isCopyConstructor() || ctor->isMoveConstructor()) &&
+           // FIXME: Support default arguments (rdar://142414553)
+           ctor->getNumParams() != 1;
+  });
 }
 
 static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
@@ -8123,6 +8127,9 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
         importerImpl->diagnose(loc, diag::api_pattern_attr_ignored,
                                "import_iterator", decl->getNameAsString());
     }
+
+    if (hasConstructorWithUnsupportedDefaultArgs(cxxDecl))
+      return CxxRecordSemanticsKind::UnavailableConstructors;
 
     return CxxRecordSemanticsKind::MissingLifetimeOperation;
   }

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -541,20 +541,14 @@ namespace {
                                   FixedTypeInfo, ClangFieldInfo> {
     const clang::RecordDecl *ClangDecl;
 
-    bool hasNonFirstDefaultArg(const clang::CXXConstructorDecl *ctor) const {
-      if (ctor->getNumParams() < 2)
-        return false;
-
-      auto lastParam = ctor->parameters().back();
-      return lastParam->hasDefaultArg();
-    }
-
     const clang::CXXConstructorDecl *findCopyConstructor() const {
       const auto *cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(ClangDecl);
       if (!cxxRecordDecl)
         return nullptr;
       for (auto ctor : cxxRecordDecl->ctors()) {
-        if (ctor->isCopyConstructor() && !hasNonFirstDefaultArg(ctor) &&
+        if (ctor->isCopyConstructor() &&
+            // FIXME: Support default arguments (rdar://142414553)
+            ctor->getNumParams() == 1 &&
             ctor->getAccess() == clang::AS_public && !ctor->isDeleted())
           return ctor;
       }
@@ -567,6 +561,8 @@ namespace {
         return nullptr;
       for (auto ctor : cxxRecordDecl->ctors()) {
         if (ctor->isMoveConstructor() &&
+            // FIXME: Support default arguments (rdar://142414553)
+            ctor->getNumParams() == 1 &&
             ctor->getAccess() == clang::AS_public && !ctor->isDeleted())
           return ctor;
       }

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -108,4 +108,18 @@ struct HasPtrAuthMember {
 };
 #endif
 
+struct MoveConstructorWithOneParameterWithDefaultArg {
+  int value;
+
+  MoveConstructorWithOneParameterWithDefaultArg(int value) : value(value) {}
+
+  MoveConstructorWithOneParameterWithDefaultArg(
+      const MoveConstructorWithOneParameterWithDefaultArg &) = delete;
+
+  MoveConstructorWithOneParameterWithDefaultArg(
+      MoveConstructorWithOneParameterWithDefaultArg &&other =
+          MoveConstructorWithOneParameterWithDefaultArg{0})
+      : value(other.value + 1) {}
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -274,4 +274,26 @@ struct HasCopyConstructorWithDefaultArgs {
       default;
 };
 
+struct HasMoveConstructorWithDefaultArgs {
+  int value;
+  HasMoveConstructorWithDefaultArgs(int value) : value(value) {}
+
+  HasMoveConstructorWithDefaultArgs(HasMoveConstructorWithDefaultArgs &&other,
+                                    int value = 1)
+      : value(other.value + value) {}
+};
+
+struct HasCopyAndMoveConstructorWithDefaultArgs {
+  int value;
+  HasCopyAndMoveConstructorWithDefaultArgs(int value) : value(value) {}
+
+  HasCopyAndMoveConstructorWithDefaultArgs(
+      const HasCopyAndMoveConstructorWithDefaultArgs &other, int value = 1)
+      : value(other.value + value) {}
+
+  HasCopyAndMoveConstructorWithDefaultArgs(
+      HasCopyAndMoveConstructorWithDefaultArgs &&other, int value = 1)
+      : value(other.value + value) {}
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H

--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -63,4 +63,11 @@ CxxConstructorTestSuite.test("implicit default ctor") {
   expectNil(instance3.ptr)
 }
 
+CxxConstructorTestSuite.test("MoveConstructorWithOneParamWithDefaultArg") {
+  let instance1 = MoveConstructorWithOneParameterWithDefaultArg(5)
+  let instance2 = instance1
+  let instance3 = MoveConstructorWithOneParameterWithDefaultArg(5)
+  expectTrue(instance2.value + instance3.value >= 10)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/copy-move-assignment-executable.swift
+++ b/test/Interop/Cxx/class/copy-move-assignment-executable.swift
@@ -25,7 +25,7 @@ CxxCopyMoveAssignTestSuite.test("NonTrivialCopyAssign") {
         expectEqual(0, instance.copyAssignCounter)
         takeValue(instance2)
     }
-    // The number of construcors and destructors called for `NonTrivialCopyAssign` must be balanced.
+    // The number of constructors and destructors called for `NonTrivialCopyAssign` must be balanced.
     expectEqual(0, InstanceBalanceCounter.getCounterValue())
 }
 
@@ -37,7 +37,7 @@ CxxCopyMoveAssignTestSuite.test("NonTrivialMoveAssign") {
         // `operator=` isn't called.
         expectEqual(0, instance.moveAssignCounter)
     }
-    // The number of construcors and destructors called for `NonTrivialCopyAssign` must be balanced.
+    // The number of constructors and destructors called for `NonTrivialCopyAssign` must be balanced.
     expectEqual(0, InstanceBalanceCounter.getCounterValue())
 }
 
@@ -51,7 +51,7 @@ CxxCopyMoveAssignTestSuite.test("NonTrivialCopyAndCopyMoveAssign") {
         expectEqual(0, instance.assignCounter)
         takeValue(instance2)
     }
-    // The number of construcors and destructors called for `NonTrivialCopyAndCopyMoveAssign` must be balanced.
+    // The number of constructors and destructors called for `NonTrivialCopyAndCopyMoveAssign` must be balanced.
     expectEqual(0, InstanceBalanceCounter.getCounterValue())
 }
 

--- a/test/Interop/Cxx/class/invalid-class-errors.swift
+++ b/test/Interop/Cxx/class/invalid-class-errors.swift
@@ -27,17 +27,17 @@ struct Nested {
 
 import Test
 
-// CHECK: note: record 'A' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
+// CHECK: note: record 'A' is not automatically available: it must have a copy/move constructor and a destructor; does this type have reference semantics?
 // CHECK: struct A {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)
 public func test(x: A) { }
-// CHECK: note: record 'B' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
+// CHECK: note: record 'B' is not automatically available: it must have a copy/move constructor and a destructor; does this type have reference semantics?
 // CHECK: struct {{.*}}B {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)
 public func test(x: B) { }
-// CHECK: note: record 'Nested' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
+// CHECK: note: record 'Nested' is not automatically available: it must have a copy/move constructor and a destructor; does this type have reference semantics?
 // CHECK: struct Nested {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)

--- a/test/Interop/Cxx/class/type-classification-typechecker.swift
+++ b/test/Interop/Cxx/class/type-classification-typechecker.swift
@@ -22,13 +22,35 @@ func testAnnotated() {
   _ = v
 }
 
-func testNonCopyable() {
+func testHasCopyTypeOperations() {
   let x = HasCopyConstructorWithDefaultArgs(5)
   let v = copy x // expected-error {{'copy' cannot be applied to noncopyable types}}
   _ = v
 }
 
+func testFuncCallNoncopyable() {
+  func aux(input: HasCopyConstructorWithDefaultArgs) {}
+  let x = HasCopyConstructorWithDefaultArgs(5)
+  aux(input: x) 
+  // expected-error@-3 {{parameter of noncopyable type 'HasCopyConstructorWithDefaultArgs' must specify ownership}}
+  // expected-note@-4 {{add 'borrowing' for an immutable reference}}
+  // expected-note@-5 {{add 'consuming' to take the value from the caller}}
+  // expected-note@-6 {{add 'inout' for a mutable reference}}
+}
+
+func testHasMoveTypeOperations() {
+  let x = HasMoveConstructorWithDefaultArgs(5) // expected-error {{cannot find 'HasMoveConstructorWithDefaultArgs' in scope}}
+}
+
+func testHasCopyOrMoveTypeOperations() {
+  let x = HasCopyAndMoveConstructorWithDefaultArgs(5) 
+  // expected-error@-1 {{cannot find 'HasCopyAndMoveConstructorWithDefaultArgs' in scope}}
+}
+
 test()
 testField()
 testAnnotated()
-testNonCopyable()
+testHasCopyTypeOperations()
+testFuncCallNoncopyable()
+testHasMoveTypeOperations()
+testHasCopyOrMoveTypeOperations()


### PR DESCRIPTION
While support for C++ move constructors with default args in Swift isn't added, we don't import these move constructors to Swift.