### PR TITLE
[ASTGen] Assorted fixes

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1568,14 +1568,15 @@ BridgedImportDecl BridgedImportDecl_createParsed(
 
 SWIFT_NAME("BridgedSubscriptDecl.createParsed(_:declContext:staticLoc:"
            "staticSpelling:subscriptKeywordLoc:genericParamList:parameterList:"
-           "arrowLoc:returnType:)")
+           "arrowLoc:returnType:genericWhereClause:)")
 BridgedSubscriptDecl BridgedSubscriptDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStaticLoc, BridgedStaticSpelling cStaticSpelling,
     BridgedSourceLoc cSubscriptKeywordLoc,
     BridgedNullableGenericParamList cGenericParamList,
     BridgedParameterList cParamList, BridgedSourceLoc cArrowLoc,
-    BridgedTypeRepr returnType);
+    BridgedTypeRepr returnType,
+    BridgedNullableTrailingWhereClause genericWhereClause);
 
 SWIFT_NAME("BridgedTopLevelCodeDecl.create(_:declContext:)")
 BridgedTopLevelCodeDecl

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2510,6 +2510,10 @@ BridgedDictionaryTypeRepr BridgedDictionaryTypeRepr_createParsed(
     BridgedTypeRepr keyType, BridgedSourceLoc cColonloc,
     BridgedTypeRepr valueType, BridgedSourceLoc cRSquareLoc);
 
+SWIFT_NAME("BridgedErrorTypeRepr.create(_:range:)")
+BridgedErrorTypeRepr BridgedErrorTypeRepr_create(BridgedASTContext cContext,
+                                                 BridgedSourceRange cRange);
+
 SWIFT_NAME("BridgedFunctionTypeRepr.createParsed(_:argsType:asyncLoc:throwsLoc:"
            "thrownType:arrowLoc:resultType:)")
 BridgedFunctionTypeRepr BridgedFunctionTypeRepr_createParsed(

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7459,6 +7459,8 @@ public:
   /// operation.
   Type getElementInterfaceType() const;
 
+  std::optional<Type> getCachedElementInterfaceType() const;
+
   TypeRepr *getElementTypeRepr() const { return ElementTy.getTypeRepr(); }
   SourceRange getElementTypeSourceRange() const {
     return ElementTy.getSourceRange();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2192,6 +2192,7 @@ namespace {
                                 Label::optional("generic_signature"));
         } else {
           printParsedGenericParams(GC->getParsedGenericParams());
+          printWhereRequirements(GC);
         }
       }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2563,6 +2563,8 @@ namespace {
       printCommon(SD, "subscript_decl", label);
       printStorageImpl(SD);
       printAttributes(SD);
+      printTypeOrTypeRepr(SD->getCachedElementInterfaceType(),
+                          SD->getElementTypeRepr(), Label::always("element"));
       printAccessors(SD);
       printFoot();
     }

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -615,12 +615,15 @@ BridgedSubscriptDecl BridgedSubscriptDecl_createParsed(
     BridgedSourceLoc cSubscriptKeywordLoc,
     BridgedNullableGenericParamList cGenericParamList,
     BridgedParameterList cParamList, BridgedSourceLoc cArrowLoc,
-    BridgedTypeRepr returnType) {
-  return SubscriptDecl::createParsed(
+    BridgedTypeRepr returnType,
+    BridgedNullableTrailingWhereClause genericWhereClause) {
+  auto *decl = SubscriptDecl::createParsed(
       cContext.unbridged(), cStaticLoc.unbridged(), unbridged(cStaticSpelling),
       cSubscriptKeywordLoc.unbridged(), cParamList.unbridged(),
       cArrowLoc.unbridged(), returnType.unbridged(), cDeclContext.unbridged(),
       cGenericParamList.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
+  return decl;
 }
 
 BridgedTopLevelCodeDecl

--- a/lib/AST/Bridging/TypeReprBridging.cpp
+++ b/lib/AST/Bridging/TypeReprBridging.cpp
@@ -95,6 +95,11 @@ BridgedDictionaryTypeRepr BridgedDictionaryTypeRepr_createParsed(
                          SourceRange{lSquareLoc, rSquareLoc});
 }
 
+BridgedErrorTypeRepr BridgedErrorTypeRepr_create(BridgedASTContext cContext,
+                                                 BridgedSourceRange cRange) {
+  return ErrorTypeRepr::create(cContext.unbridged(), cRange.unbridged());
+}
+
 BridgedInverseTypeRepr
 BridgedInverseTypeRepr_createParsed(BridgedASTContext cContext,
                                     BridgedSourceLoc cTildeLoc,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9343,6 +9343,11 @@ Type SubscriptDecl::getElementInterfaceType() const {
   return ErrorType::get(ctx);
 }
 
+std::optional<Type> SubscriptDecl::getCachedElementInterfaceType() const {
+  auto mutableThis = const_cast<SubscriptDecl *>(this);
+  return ResultTypeRequest{mutableThis}.getCachedResult();
+}
+
 ObjCSubscriptKind SubscriptDecl::getObjCSubscriptKind() const {
   // If the index type is an integral type, we have an indexed
   // subscript.

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -630,7 +630,8 @@ extension ASTGenVisitor {
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       parameterList: self.generate(functionParameterClause: node.parameterClause, for: .subscript),
       arrowLoc: self.generateSourceLoc(node.returnClause.arrow),
-      returnType: self.generate(type: node.returnClause.type)
+      returnType: self.generate(type: node.returnClause.type),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
     subscriptDecl.asDecl.attachParsedAttrs(attrs.attributes)
 

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -148,17 +148,16 @@ extension ASTGenVisitor {
       var pat = self.generate(pattern: node.pattern)
       let keywordLoc = self.generateSourceLoc(node.bindingSpecifier)
       let isLet = node.bindingSpecifier.keywordKind == .let
-      pat =
-        BridgedBindingPattern.createParsed(
-          self.ctx,
-          keywordLoc: keywordLoc,
-          isLet: isLet,
-          subPattern: pat
-        ).asPattern
+      pat = BridgedBindingPattern.createParsed(
+        self.ctx,
+        keywordLoc: keywordLoc,
+        isLet: isLet,
+        subPattern: pat
+      ).asPattern
 
       // NOTE: (From the comment in libParse) The let/var pattern is part of the
-      // statement. But since the statement doesn't have the information. But,
-      // I'm not sure this should really be implicit.
+      // statement. But since the statement doesn't have the information, I'm not
+      // sure this should really be implicit.
       pat.setImplicit()
 
       if let typeAnnotation = node.typeAnnotation {

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -161,6 +161,14 @@ extension ASTGenVisitor {
       // I'm not sure this should really be implicit.
       pat.setImplicit()
 
+      if let typeAnnotation = node.typeAnnotation {
+        pat = BridgedTypedPattern.createParsed(
+          self.ctx,
+          pattern: pat,
+          type: self.generate(type: typeAnnotation.type)
+        ).asPattern
+      }
+
       let initializer: BridgedExpr
       if let initNode = node.initializer {
         initializer = self.generate(expr: initNode.value)

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -44,8 +44,8 @@ extension ASTGenVisitor {
       return self.generate(memberType: node).asTypeRepr
     case .metatypeType(let node):
       return self.generate(metatypeType: node)
-    case .missingType:
-      fatalError("unimplemented")
+    case .missingType(let node):
+      return self.generate(missingType: node)
     case .namedOpaqueReturnType(let node):
       return self.generate(namedOpaqueReturnType: node).asTypeRepr
     case .optionalType(let node):
@@ -162,6 +162,13 @@ extension ASTGenVisitor {
         protocolKeywordLoc: tyLoc
       ).asTypeRepr
     }
+  }
+
+  func generate(missingType node: MissingTypeSyntax) -> BridgedTypeRepr {
+    return BridgedErrorTypeRepr.create(
+      self.ctx,
+      range: self.generateSourceRange(node)
+    ).asTypeRepr
   }
 
   func generate(

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -174,6 +174,10 @@ struct TestSubscripts {
     }
     set(x) {}
   }
+
+  subscript<I: Proto3, J: Proto3>(i: I, j: J) -> Int where I.A == J.B {
+    1
+  }
 }
 
 protocol Proto1 {}

--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -28,3 +28,8 @@ func dummy() {}
 
 @_silgen_name("whatever", extra)  // expected-error@:27 {{unexpected arguments in '_silgen_name' attribute}}
 func _whatever()
+
+struct S {
+    subscript(x: Int) { _ = 1 } // expected-error@:23 {{expected '->' and return type in subscript}}
+                                // expected-note@-1:23 {{insert '->' and return type}}
+}

--- a/test/ASTGen/stmts.swift
+++ b/test/ASTGen/stmts.swift
@@ -116,6 +116,17 @@ func testThen() {
   }
 }
 
+func intOrString() -> Int? { 1 }
+func intOrString() -> String? { "" }
+func testIf() {
+  if
+    let i: Int = intOrString(),
+    case let str? = intOrString() as String?
+  {
+    _ = (i, str)
+  }
+}
+
 struct GenericTypeWithYields<T> {
   var storedProperty: T?
 


### PR DESCRIPTION
* Wrap optional binding pattern with type annotation if exist. e.g. `if let x: Int = optionalInt`. Previously the type annotation was ignored.
* Trailing `where` clause for `SubscriptDecl`. Peviously it was just missing
* Generate `ErrorTypeRepr` from `MissingTypeSyntax`.