### PR TITLE
[6.1 🍒 ] [Frontend] Support `-index-store-path` for explicit module interface compilation.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -976,6 +976,21 @@ static void dumpAPIIfNeeded(const CompilerInstance &Instance) {
   }
 }
 
+static bool shouldEmitIndexData(const CompilerInvocation &Invocation) {
+  const auto &opts = Invocation.getFrontendOptions();
+  auto action = opts.RequestedAction;
+
+  if (action == FrontendOptions::ActionType::CompileModuleFromInterface &&
+      opts.ExplicitInterfaceBuild) {
+    return true;
+  }
+
+  // FIXME: This predicate matches the status quo, but there's no reason
+  // indexing cannot run for actions that do not require stdlib e.g. to better
+  // facilitate tests.
+  return FrontendOptions::doesActionRequireSwiftStandardLibrary(action);
+}
+
 /// Perform any actions that must have access to the ASTContext, and need to be
 /// delayed until the Swift compile pipeline has finished. This may be called
 /// before or after LLVM depending on when the ASTContext gets freed.
@@ -1070,10 +1085,7 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
     }
   }
 
-  // FIXME: This predicate matches the status quo, but there's no reason
-  // indexing cannot run for actions that do not require stdlib e.g. to better
-  // facilitate tests.
-  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(action)) {
+  if (shouldEmitIndexData(Invocation)) {
     emitIndexData(Instance);
   }
 

--- a/test/ModuleInterface/IndexWhileBuilding.swiftinterface
+++ b/test/ModuleInterface/IndexWhileBuilding.swiftinterface
@@ -1,0 +1,38 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name IndexWhileBuilding
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/idx)
+// RUN: %target-swift-frontend -compile-module-from-interface -explicit-interface-module-build -module-name IndexWhileBuilding -index-store-path %/t/idx -index-include-locals -o %/t/IndexWhileBuilding.swiftmodule %s
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s
+
+import Swift
+// CHECK:        [[@LINE-1]]:8 | module/Swift | c:@M@Swift | Ref | rel: 0
+
+public struct MyStruct {
+  // CHECK:      [[@LINE-1]]:15 | struct/Swift | s:18IndexWhileBuilding8MyStructV | Def
+  public init()
+  // CHECK:      [[@LINE-1]]:10 | constructor/Swift | s:18IndexWhileBuilding8MyStructVACycfc | Def,RelChild
+  // CHECK-NEXT:    RelChild | s:18IndexWhileBuilding8MyStructV
+}
+
+@inlinable public func myFunc() {
+  // CHECK:      [[@LINE-1]]:24 | function/Swift | s:18IndexWhileBuilding6myFuncyyF | Def
+  let s = MyStruct()
+  // CHECK:      [[@LINE-1]]:7 | function/acc-get(local)/Swift | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvg | Def,Impl,RelChild,RelAcc
+  // CHECK-NEXT:    RelChild,RelAcc | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp
+  // CHECK:      [[@LINE-3]]:7 | function/acc-set(local)/Swift | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvs | Def,Impl,RelChild,RelAcc
+  // CHECK-NEXT:    RelChild,RelAcc | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp
+  // CHECK:      [[@LINE-5]]:7 | variable(local)/Swift | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp | Def,RelChild
+  // CHECK-NEXT:    RelChild | s:18IndexWhileBuilding6myFuncyyF
+  // CHECK:      [[@LINE-7]]:11 | struct/Swift | s:18IndexWhileBuilding8MyStructV | Ref,RelCont
+  // CHECK-NEXT:    RelCont | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp
+  // CHECK:      [[@LINE-9]]:11 | constructor/Swift | s:18IndexWhileBuilding8MyStructVACycfc | Ref,Call,RelCall,RelCont
+  // CHECK-NEXT:    RelCont | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp
+  // CHECK-NEXT:    RelCall | s:18IndexWhileBuilding6myFuncyyF
+  _ = s
+  // CHECK:      [[@LINE-1]]:7 | function/acc-get(local)/Swift | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvg | Ref,Call,Impl,RelCall,RelCont | rel: 1
+  // CHECK-NEXT:    RelCall,RelCont | s:18IndexWhileBuilding6myFuncyyF
+  // CHECK:      [[@LINE-3]]:7 | variable(local)/Swift | s:18IndexWhileBuilding6myFuncyyF1sL_AA8MyStructVvp | Ref,Read,RelCont | rel: 1
+  // CHECK-NEXT:    RelCont | s:18IndexWhileBuilding6myFuncyyF
+}


### PR DESCRIPTION
  - **Explanation**: Support index-while-building when performing explicit module interface compilation.
  - **Scope**: This would not break any existing code. This fixes a bug where the `-index-store-path` flag has been silently ignored when compiling an interface with `-explicit-module-interface-build`.
  - **Issues**: N/A
  - **Original PRs**: https://github.com/swiftlang/swift/pull/79485
  - **Risk**: Very low.
  - **Testing**: Added a lit test to verify that the index store output is correct.
  - **Reviewers**: @bnbarham 
