### PR TITLE
[ASTGen] Assorted fixes pt.2

### DIFF
--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -282,12 +282,33 @@ swift::DeclAttributes BridgedDeclAttributes::unbridged() const {
   return attrs;
 }
 
+//===----------------------------------------------------------------------===//
+// MARK: AvailabilityDomain
+//===----------------------------------------------------------------------===//
+
 BridgedAvailabilityDomain::BridgedAvailabilityDomain(
     swift::AvailabilityDomain domain)
     : opaque(domain.getOpaqueValue()) {}
 
 swift::AvailabilityDomain BridgedAvailabilityDomain::unbridged() const {
   return swift::AvailabilityDomain::fromOpaque(opaque);
+}
+
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forUniversal() {
+  return swift::AvailabilityDomain::forUniversal();
+}
+BridgedAvailabilityDomain
+BridgedAvailabilityDomain::forPlatform(BridgedPlatformKind platformKind) {
+  return swift::AvailabilityDomain::forPlatform(unbridge(platformKind));
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forSwiftLanguage() {
+  return swift::AvailabilityDomain::forSwiftLanguage();
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forPackageDescription() {
+  return swift::AvailabilityDomain::forPackageDescription();
+}
+BridgedAvailabilityDomain BridgedAvailabilityDomain::forEmbedded() {
+  return swift::AvailabilityDomain::forEmbedded();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -152,24 +152,3 @@ BridgedSourceRange
 BridgedAvailabilitySpec_getVersionRange(BridgedAvailabilitySpec spec) {
   return spec.unbridged()->getVersionSrcRange();
 }
-
-//===----------------------------------------------------------------------===//
-// MARK: AvailabilityDomain
-//===----------------------------------------------------------------------===//
-
-BridgedAvailabilityDomain BridgedAvailabilityDomain::forUniversal() {
-  return swift::AvailabilityDomain::forUniversal();
-}
-BridgedAvailabilityDomain
-BridgedAvailabilityDomain::forPlatform(BridgedPlatformKind platformKind) {
-  return swift::AvailabilityDomain::forPlatform(unbridge(platformKind));
-}
-BridgedAvailabilityDomain BridgedAvailabilityDomain::forSwiftLanguage() {
-  return swift::AvailabilityDomain::forSwiftLanguage();
-}
-BridgedAvailabilityDomain BridgedAvailabilityDomain::forPackageDescription() {
-  return swift::AvailabilityDomain::forPackageDescription();
-}
-BridgedAvailabilityDomain BridgedAvailabilityDomain::forEmbedded() {
-  return swift::AvailabilityDomain::forEmbedded();
-}

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -187,6 +187,8 @@ extension ASTGenVisitor {
         fatalError("unimplemented")
       case .unavailableFromAsync:
         return handle(self.generateUnavailableFromAsyncAttr(attribute: node)?.asDeclAttribute)
+      case .none where attrName == "_unavailableInEmbedded":
+        return handle(self.generateUnavailableInEmbeddedAttr(attribute: node)?.asDeclAttribute)
 
       // Simple attributes.
       case .addressableSelf,
@@ -1776,6 +1778,30 @@ extension ASTGenVisitor {
       range: self.generateAttrSourceRange(node),
       message: self.ctx.allocateCopy(string: message ?? "")
     )
+  }
+
+  func generateUnavailableInEmbeddedAttr(attribute node: AttributeSyntax) -> BridgedAvailableAttr? {
+    if ctx.langOptsHasFeature(.Embedded) {
+      return BridgedAvailableAttr.createParsed(
+        self.ctx,
+        atLoc: self.generateSourceLoc(node.atSign),
+        range: self.generateAttrSourceRange(node),
+        domain: .forEmbedded(),
+        domainLoc: nil,
+        kind: .unavailable,
+        message: "unavailable in embedded Swift",
+        renamed: "",
+        introduced: BridgedVersionTuple(),
+        introducedRange: BridgedSourceRange(),
+        deprecated: BridgedVersionTuple(),
+        deprecatedRange:  BridgedSourceRange(),
+        obsoleted: BridgedVersionTuple(),
+        obsoletedRange: BridgedSourceRange()
+      )
+    } else {
+      // For non-Embedded mode, ignore it.
+      return nil
+    }
   }
 
   func generateSimpleDeclAttr(attribute node: AttributeSyntax, kind: BridgedDeclAttrKind) -> BridgedDeclAttribute? {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -2066,17 +2066,18 @@ extension ASTGenVisitor {
       kind = .weak
       guard node.detail == nil else {
         // TODO: Diagnose.
-        return nil
+        fatalError("invalid argument for 'weak' modifier")
       }
     case .unowned:
-      switch node.detail?.detail.keywordKind {
-      case .safe, nil:
+      switch node.detail?.detail.rawText {
+      case "safe", nil:
         kind = .unowned
-      case .unsafe:
+      case "unsafe":
         kind = .unmanaged
-      case _?:
+      case let text?:
         // TODO: Diagnose
-        kind = .unowned
+        _ = text
+        fatalError("invalid argument for 'unowned' modifier")
       }
     default:
       preconditionFailure("ReferenceOwnership modifier must be 'weak' or 'unowned'")

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -227,3 +227,10 @@ func testNonIsolated(actor: MyActor) {
   _ = actor.constFlag
   _ = actor.mutableFlag
 }
+
+struct ReferenceOwnershipModifierTest<X: AnyObject> {
+    weak var weakValue: X?
+    unowned var unownedValue: X
+    unowned(safe) var unownedSafeValue: X
+    unowned(unsafe) var unmanagedValue: X
+}

--- a/test/ASTGen/embedded_availability.swift
+++ b/test/ASTGen/embedded_availability.swift
@@ -1,0 +1,91 @@
+// **Copied from test/embedded/availability.swift**
+// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature ParserASTGen
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_ParserASTGen
+
+@_unavailableInEmbedded
+public struct UnavailableInEmbedded {}
+// expected-note@-1 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, message: "always unavailable")
+public struct UniverallyUnavailable {}
+// expected-note@-1 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
+
+@_unavailableInEmbedded
+public func unavailable_in_embedded() { }
+// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, message: "always unavailable")
+public func universally_unavailable() { }
+// expected-note@-1 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
+
+@_unavailableInEmbedded
+public func unused() { } // no error
+
+public struct S1 {} // expected-note 2 {{found this candidate}}
+public struct S2 {} // expected-note 2 {{found this candidate}}
+
+@_unavailableInEmbedded
+public func has_unavailable_in_embedded_overload(_ s1: S1) { }
+
+public func has_unavailable_in_embedded_overload(_ s2: S2) { }
+
+@available(*, unavailable)
+public func has_universally_unavailable_overload(_ s1: S1) { }
+
+public func has_universally_unavailable_overload(_ s2: S2) { }
+
+public struct Available {}
+
+@_unavailableInEmbedded
+extension Available {
+  public func unavailable_in_embedded_method( // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
+    _ uie: UnavailableInEmbedded,
+    _ uu: UniverallyUnavailable,
+    _ a: Available,
+  ) {
+    unavailable_in_embedded()
+    universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+    a.unavailable_in_embedded_method(uie, uu, a)
+  }
+}
+
+public func available(
+  _ uie: UnavailableInEmbedded, // expected-error {{'UnavailableInEmbedded' is unavailable: unavailable in embedded Swift}}
+  _ uu: UniverallyUnavailable, // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
+  _ a: Available,
+) {
+  unavailable_in_embedded() // expected-error {{'unavailable_in_embedded()' is unavailable: unavailable in embedded Swift}}
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a) // expected-error {{'unavailable_in_embedded_method' is unavailable: unavailable in embedded Swift}}
+  has_unavailable_in_embedded_overload(.init())
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
+}
+
+@_unavailableInEmbedded
+public func also_unavailable_in_embedded(
+  _ uie: UnavailableInEmbedded, // OK
+  _ uu: UniverallyUnavailable, // OK
+  _ a: Available,
+) {
+  unavailable_in_embedded() // OK
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a)
+  has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
+}
+
+@available(*, unavailable)
+public func also_universally_unavailable(
+  _ uie: UnavailableInEmbedded, // OK
+  _ uu: UniverallyUnavailable, // OK
+  _ a: Available,
+) {
+  unavailable_in_embedded()
+  universally_unavailable() // expected-error {{'universally_unavailable()' is unavailable: always unavailable}}
+  a.unavailable_in_embedded_method(uie, uu, a)
+  has_unavailable_in_embedded_overload(.init()) // expected-error {{ambiguous use of 'init()'}}
+  has_universally_unavailable_overload(.init()) // not ambiguous, selects available overload
+}


### PR DESCRIPTION
* Generate `@_unavailableInEmbedded` attribute. This is a sugar of `@available(*, unavailable)` when `Embedded` feature is enabled.
* Fix `ReferenceOwnershipAttr` modifier. Similar to 7dd89445123a0160c6069d6fc7f66dd8d0b94641, Modifier argument is not parsed as a keyword.