### PR TITLE
[ClangImporter][Swiftify] merge importBoundsAttributes with importSpanAttributes and support lifetime bounds for __counted_by

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -566,8 +566,7 @@ void importer::getNormalInvocationArguments(
     }
   }
 
-  if (LangOpts.hasFeature(Feature::SafeInteropWrappers) &&
-      !LangOpts.EnableCXXInterop)
+  if (LangOpts.hasFeature(Feature::SafeInteropWrappers))
     invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
 
   // Set C language options.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -114,8 +114,7 @@ createFuncOrAccessor(ClangImporter::Implementation &impl, SourceLoc funcLoc,
                      std::optional<AccessorInfo> accessorInfo, DeclName name,
                      SourceLoc nameLoc, GenericParamList *genericParams,
                      ParameterList *bodyParams, Type resultTy, bool async,
-                     bool throws, DeclContext *dc, ClangNode clangNode,
-                     bool hasBoundsAnnotation) {
+                     bool throws, DeclContext *dc, ClangNode clangNode) {
   FuncDecl *decl;
   if (accessorInfo) {
     decl = AccessorDecl::create(
@@ -131,9 +130,7 @@ createFuncOrAccessor(ClangImporter::Implementation &impl, SourceLoc funcLoc,
                                     genericParams, dc, clangNode);
   }
   impl.importSwiftAttrAttributes(decl);
-  if (hasBoundsAnnotation)
-    impl.importBoundsAttributes(decl);
-  impl.importSpanAttributes(decl);
+  impl.swiftify(decl);
 
   return decl;
 }
@@ -3381,8 +3378,7 @@ namespace {
       }
       return Impl.importFunctionParameterList(
           dc, decl, nonSelfParams, decl->isVariadic(), allowNSUIntegerAsInt,
-          argNames, genericParams, /*resultType=*/nullptr,
-          /*hasBoundsAnnotatedParam=*/nullptr);
+          argNames, genericParams, /*resultType=*/nullptr);
     }
 
     Decl *
@@ -3812,7 +3808,6 @@ namespace {
 
       bool importFuncWithoutSignature =
           isa<clang::CXXMethodDecl>(decl) && Impl.importSymbolicCXXDecls;
-      bool hasBoundsAnnotation = false;
       if (!dc->isModuleScopeContext() && !isa<clang::CXXMethodDecl>(decl)) {
         // Handle initializers.
         if (name.getBaseName().isConstructor()) {
@@ -3909,7 +3904,7 @@ namespace {
           importedType = Impl.importFunctionParamsAndReturnType(
               dc, decl, {decl->param_begin(), decl->param_size()},
               decl->isVariadic(), isInSystemModule(dc), name, bodyParams,
-              templateParams, &hasBoundsAnnotation);
+              templateParams);
         }
 
         if (auto *mdecl = dyn_cast<clang::CXXMethodDecl>(decl)) {
@@ -3975,11 +3970,10 @@ namespace {
       } else {
         auto resultTy = importedType.getType();
 
-        FuncDecl *func =
-            createFuncOrAccessor(Impl, loc, accessorInfo, name, nameLoc,
-                                 genericParams, bodyParams, resultTy,
-                                 /*async=*/false, /*throws=*/false, dc,
-                                 clangNode, hasBoundsAnnotation);
+        FuncDecl *func = createFuncOrAccessor(
+            Impl, loc, accessorInfo, name, nameLoc, genericParams, bodyParams,
+            resultTy,
+            /*async=*/false, /*throws=*/false, dc, clangNode);
         result = func;
 
         if (!dc->isModuleScopeContext()) {
@@ -5068,14 +5062,12 @@ namespace {
         }
       }
 
-      bool hasBoundsAnnotation =
-          false; // currently only implemented for functions
-      auto result = createFuncOrAccessor(
-          Impl,
-          /*funcLoc*/ SourceLoc(), accessorInfo, importedName.getDeclName(),
-          /*nameLoc*/ SourceLoc(),
-          /*genericParams=*/nullptr, bodyParams, resultTy, async, throws, dc,
-          decl, hasBoundsAnnotation);
+      auto result = createFuncOrAccessor(Impl,
+                                         /*funcLoc*/ SourceLoc(), accessorInfo,
+                                         importedName.getDeclName(),
+                                         /*nameLoc*/ SourceLoc(),
+                                         /*genericParams=*/nullptr, bodyParams,
+                                         resultTy, async, throws, dc, decl);
 
       result->setAccess(decl->isDirectMethod() ? AccessLevel::Public
                                                : getOverridableAccessLevel(dc));
@@ -6737,7 +6729,7 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
     parameterList = Impl.importFunctionParameterList(
         dc, decl, {decl->param_begin(), decl->param_end()}, decl->isVariadic(),
         allowNSUIntegerAsInt, argNames, /*genericParams=*/{},
-        /*resultType=*/nullptr, /*hasBoundsAnnotatedParam=*/nullptr);
+        /*resultType=*/nullptr);
 
     if (name && parameterList && argNames.size() != parameterList->size()) {
       // Remember that the name has changed.
@@ -8909,7 +8901,7 @@ private:
 };
 } // namespace
 
-void ClangImporter::Implementation::importSpanAttributes(FuncDecl *MappedDecl) {
+void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
   auto ClangDecl =
@@ -8918,94 +8910,78 @@ void ClangImporter::Implementation::importSpanAttributes(FuncDecl *MappedDecl) {
     return;
 
   llvm::SmallString<128> MacroString;
+  // We only attach the macro if it will produce an overload. Any __counted_by
+  // will produce an overload, since UnsafeBufferPointer is still an improvement
+  // over UnsafePointer, but std::span will only produce an overload if it also
+  // has lifetime information, since std::span already contains bounds info.
   bool attachMacro = false;
   {
     llvm::raw_svector_ostream out(MacroString);
     llvm::StringMap<std::string> typeMapping;
 
-    auto registerSwiftifyMacro =
-        [&typeMapping, &attachMacro](ParamDecl *swiftParam,
-                                     const clang::ParmVarDecl *param) {
-          typeMapping.insert(std::make_pair(
-              swiftParam->getInterfaceType()->getString(),
-              swiftParam->getInterfaceType()->getDesugaredType()->getString()));
-          attachMacro = true;
+    auto registerStdSpanTypeMapping =
+        [&typeMapping](Type swiftType, const clang::QualType clangType) {
+          const auto *decl = clangType->getAsTagDecl();
+          if (decl && decl->isInStdNamespace() && decl->getName() == "span") {
+            typeMapping.insert(
+                std::make_pair(swiftType->getString(),
+                               swiftType->getDesugaredType()->getString()));
+            return true;
+          }
+          return false;
         };
     SwiftifyInfoPrinter printer(getClangASTContext(), out);
-    auto retDecl = ClangDecl->getReturnType()->getAsTagDecl();
-    bool returnIsSpan =
-        retDecl && retDecl->isInStdNamespace() && retDecl->getName() == "span";
-    if (returnIsSpan) {
-      typeMapping.insert(
-          std::make_pair(MappedDecl->getResultInterfaceType()->getString(),
-                         MappedDecl->getResultInterfaceType()
-                             ->getDesugaredType()
-                             ->getString()));
+    bool returnIsStdSpan = registerStdSpanTypeMapping(
+        MappedDecl->getResultInterfaceType(), ClangDecl->getReturnType());
+    if (auto CAT =
+            ClangDecl->getReturnType()->getAs<clang::CountAttributedType>()) {
+      printer.printCountedBy(CAT, -1);
+      attachMacro = true;
     }
+    bool returnHasLifetimeInfo = false;
     bool lifetimeDependenceOn = MappedDecl->getASTContext().LangOpts.hasFeature(
         Feature::LifetimeDependence);
     if (SwiftDeclConverter::getImplicitObjectParamAnnotation<
             clang::LifetimeBoundAttr>(ClangDecl) &&
-        lifetimeDependenceOn && returnIsSpan) {
+        lifetimeDependenceOn) {
       printer.printLifetimeboundReturn(-2, true);
-      attachMacro = true;
+      returnHasLifetimeInfo = true;
     }
-    for (auto [index, param] : llvm::enumerate(ClangDecl->parameters())) {
-      auto paramTy = param->getType();
-      const auto *decl = paramTy->getAsTagDecl();
+    for (auto [index, clangParam] : llvm::enumerate(ClangDecl->parameters())) {
+      auto clangParamTy = clangParam->getType();
       auto swiftParam = MappedDecl->getParameters()->get(index);
-      bool isSpan =
-          decl && decl->isInStdNamespace() && decl->getName() == "span";
-      if (param->hasAttr<clang::LifetimeBoundAttr>() && lifetimeDependenceOn &&
-          (isSpan || returnIsSpan)) {
-        printer.printLifetimeboundReturn(
-            index, !isSpan && swiftParam->getInterfaceType()->isEscapable());
-        registerSwiftifyMacro(swiftParam, param);
+      bool paramHasBoundsInfo = false;
+      if (auto CAT = clangParamTy->getAs<clang::CountAttributedType>()) {
+        printer.printCountedBy(CAT, index);
+        attachMacro = paramHasBoundsInfo = true;
       }
-      if (!isSpan)
-        continue;
-      if (param->hasAttr<clang::NoEscapeAttr>()) {
+      bool paramIsStdSpan = registerStdSpanTypeMapping(
+          swiftParam->getInterfaceType(), clangParamTy);
+      paramHasBoundsInfo |= paramIsStdSpan;
+
+      bool paramHasLifetimeInfo = false;
+      if (clangParam->hasAttr<clang::NoEscapeAttr>()) {
         printer.printNonEscaping(index);
-        registerSwiftifyMacro(swiftParam, param);
+        paramHasLifetimeInfo = true;
       }
+      if (clangParam->hasAttr<clang::LifetimeBoundAttr>() &&
+          lifetimeDependenceOn) {
+        printer.printLifetimeboundReturn(
+            index, !paramHasBoundsInfo &&
+                       swiftParam->getInterfaceType()->isEscapable());
+        paramHasLifetimeInfo = true;
+        returnHasLifetimeInfo = true;
+      }
+      if (paramIsStdSpan && paramHasLifetimeInfo)
+        attachMacro = true;
     }
+    if (returnIsStdSpan && returnHasLifetimeInfo)
+      attachMacro = true;
     printer.printTypeMapping(typeMapping);
   }
 
   if (attachMacro)
     importNontrivialAttribute(MappedDecl, MacroString);
-}
-
-void ClangImporter::Implementation::importBoundsAttributes(
-    FuncDecl *MappedDecl) {
-  assert(SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers));
-  auto ClangDecl =
-      dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
-  // any function with safe pointer imports should have a clang decl
-  assert(ClangDecl);
-  if (!ClangDecl)
-    return;
-
-  llvm::SmallString<128> MacroString;
-  {
-    llvm::raw_svector_ostream out(MacroString);
-
-    SwiftifyInfoPrinter printer(getClangASTContext(), out);
-    for (auto [index, param] : llvm::enumerate(ClangDecl->parameters())) {
-      if (auto CAT = param->getType()->getAs<clang::CountAttributedType>()) {
-        printer.printCountedBy(CAT, index);
-        if (param->hasAttr<clang::NoEscapeAttr>()) {
-          printer.printNonEscaping(index);
-        }
-      }
-    }
-    if (auto CAT =
-            ClangDecl->getReturnType()->getAs<clang::CountAttributedType>()) {
-      printer.printCountedBy(CAT, -1);
-    }
-  }
-
-  importNontrivialAttribute(MappedDecl, MacroString);
 }
 
 static bool isUsingMacroName(clang::SourceManager &SM,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1366,8 +1366,7 @@ public:
       ImportTypeAttrs attrs,
       OptionalTypeKind optional = OTK_ImplicitlyUnwrappedOptional,
       bool resugarNSErrorPointer = true,
-      std::optional<unsigned> completionHandlerErrorParamIndex = std::nullopt,
-      bool *isBoundsAnnotated = nullptr);
+      std::optional<unsigned> completionHandlerErrorParamIndex = std::nullopt);
 
   /// Import the given Clang type into Swift.
   ///
@@ -1384,7 +1383,7 @@ public:
       bool allowNSUIntegerAsInt, Bridgeability topLevelBridgeability,
       ImportTypeAttrs attrs,
       OptionalTypeKind optional = OTK_ImplicitlyUnwrappedOptional,
-      bool resugarNSErrorPointer = true, bool *isBoundsAnnotated = nullptr);
+      bool resugarNSErrorPointer = true);
 
   /// Import the given Clang type into Swift, returning the
   /// Swift parameters and result type and whether we should treat it
@@ -1417,8 +1416,7 @@ public:
       DeclContext *dc, const clang::FunctionDecl *clangDecl,
       ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
       bool isFromSystemModule, DeclName name, ParameterList *&parameterList,
-      ArrayRef<GenericTypeParamDecl *> genericParams,
-      bool *hasBoundsAnnotatedParam);
+      ArrayRef<GenericTypeParamDecl *> genericParams);
 
   /// Import the given function return type.
   ///
@@ -1432,8 +1430,7 @@ public:
   /// imported.
   ImportedType importFunctionReturnType(DeclContext *dc,
                                         const clang::FunctionDecl *clangDecl,
-                                        bool allowNSUIntegerAsInt,
-                                        bool *isBoundsAnnotated = nullptr);
+                                        bool allowNSUIntegerAsInt);
 
   /// Import the parameter list for a function
   ///
@@ -1450,8 +1447,7 @@ public:
       DeclContext *dc, const clang::FunctionDecl *clangDecl,
       ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
       bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
-      ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType,
-      bool *hasBoundsAnnotatedParam);
+      ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType);
 
   struct ImportParameterTypeResult {
     /// The imported parameter Swift type.
@@ -1462,8 +1458,6 @@ public:
     bool isConsuming;
     /// If the parameter is implicitly unwrapped or not.
     bool isParamTypeImplicitlyUnwrapped;
-    /// If the parameter has (potentially nested) safe pointer types
-    bool isBoundsAnnotated;
   };
 
   /// Import a parameter type
@@ -1749,8 +1743,7 @@ public:
   }
 
   void importSwiftAttrAttributes(Decl *decl);
-  void importBoundsAttributes(FuncDecl *MappedDecl);
-  void importSpanAttributes(FuncDecl *MappedDecl);
+  void swiftify(FuncDecl *MappedDecl);
 
   /// Find the lookup table that corresponds to the given Clang module.
   ///

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -894,14 +894,18 @@ public struct SwiftifyImportMacro: PeerMacro {
     }
     var result : [ParamInfo] = []
     let process = { type, expr, orig in
-      let typeName = try getTypeName(type).text;
-      if let desugaredType = typeMappings[typeName] {
-        if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
-          if unqualifiedDesugaredType.starts(with: "span<") {
-            result.append(CxxSpan(pointerIndex: expr, nonescaping: false,
-              dependencies: [], typeMappings: typeMappings, original: orig))
+      do {
+        let typeName = try getTypeName(type).text
+        if let desugaredType = typeMappings[typeName] {
+          if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
+            if unqualifiedDesugaredType.starts(with: "span<") {
+              result.append(CxxSpan(pointerIndex: expr, nonescaping: false,
+                dependencies: [], typeMappings: typeMappings, original: orig))
+            }
           }
         }
+      } catch is DiagnosticError {
+        // type doesn't match expected pattern
       }
     }
     for (idx, param) in signature.parameterClause.parameters.enumerated() {

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -88,6 +88,9 @@ struct CxxSpan: ParamInfo {
       return CxxSpanThunkBuilder(base: base, index: i - 1, signature: funcDecl.signature,
         typeMappings: typeMappings, node: original, nonescaping: nonescaping)
     case .return:
+      if dependencies.isEmpty {
+        return base
+      }
       return CxxSpanReturnThunkBuilder(base: base, signature: funcDecl.signature,
         typeMappings: typeMappings, node: original)
     case .self:
@@ -125,7 +128,7 @@ struct CountedBy: ParamInfo {
       return CountedOrSizedReturnPointerThunkBuilder(
         base: base, countExpr: count,
         signature: funcDecl.signature,
-        nonescaping: nonescaping, isSizedBy: sizedBy)
+        nonescaping: nonescaping, isSizedBy: sizedBy, dependencies: dependencies)
     case .self:
       return base
     }
@@ -184,11 +187,13 @@ func getTypeName(_ type: TypeSyntax) throws -> TokenSyntax {
   }
 }
 
-func replaceTypeName(_ type: TypeSyntax, _ name: TokenSyntax) -> TypeSyntax {
+func replaceTypeName(_ type: TypeSyntax, _ name: TokenSyntax) throws -> TypeSyntax {
   if let memberType = type.as(MemberTypeSyntax.self) {
     return TypeSyntax(memberType.with(\.name, name))
   }
-  let idType = type.as(IdentifierTypeSyntax.self)!
+  guard let idType = type.as(IdentifierTypeSyntax.self) else {
+    throw DiagnosticError("unexpected type \(type) with kind \(type.kind)", node: type)
+  }
   return TypeSyntax(idType.with(\.name, name))
 }
 
@@ -264,6 +269,10 @@ func transformType(_ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool) 
   if let impOptType = prev.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
     return try transformType(impOptType.wrappedType, generateSpan, isSizedBy)
   }
+  if let attrType = prev.as(AttributedTypeSyntax.self) {
+    return TypeSyntax(
+      attrType.with(\.baseType, try transformType(attrType.baseType, generateSpan, isSizedBy)))
+  }
   let name = try getTypeName(prev)
   let text = name.text
   let isRaw = isRawPointerType(text: text)
@@ -283,7 +292,7 @@ func transformType(_ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool) 
   if isSizedBy {
     return TypeSyntax(IdentifierTypeSyntax(name: token))
   }
-  return replaceTypeName(prev, token)
+  return try replaceTypeName(prev, token)
 }
 
 protocol BoundsCheckedThunkBuilder {
@@ -485,8 +494,9 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
   public let signature: FunctionSignatureSyntax
   public let nonescaping: Bool
   public let isSizedBy: Bool
+  public let dependencies: [LifetimeDependence]
 
-  var generateSpan: Bool = false // needs more lifetime information
+  var generateSpan: Bool { !dependencies.isEmpty }
 
   var oldType: TypeSyntax {
     return signature.returnClause!.type
@@ -504,9 +514,14 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
 
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     let call = try base.buildFunctionCall(pointerArgs)
+    let startLabel = if generateSpan {
+      "_unsafeStart"
+    } else {
+      "start"
+    }
     return
       """
-      \(raw: try newType)(start: \(call), count: Int(\(countExpr)))
+      \(raw: try newType)(\(raw: startLabel): \(call), count: Int(\(countExpr)))
       """
   }
 }
@@ -1102,6 +1117,11 @@ public struct SwiftifyImportMacro: PeerMacro {
         }
       }
       try checkArgs(parsedArgs, funcDecl)
+      parsedArgs.sort { a, b in
+        // make sure return value cast to Span happens last so that withUnsafeBufferPointer
+        // doesn't return a ~Escapable type
+        (a.pointerIndex != .return && b.pointerIndex == .return) || paramOrReturnIndex(a.pointerIndex) < paramOrReturnIndex(b.pointerIndex)
+      }
       let baseBuilder = FunctionCallBuilder(funcDecl)
 
       let skipTrivialCount = hasTrivialCountVariants(parsedArgs)

--- a/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
@@ -2,6 +2,7 @@
 
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 #define __noescape __attribute__((noescape))
+#define __lifetimebound __attribute__((lifetimebound))
 
 void simple(int len, int * __counted_by(len) __noescape p);
 
@@ -20,3 +21,4 @@ void nonnull(int len, int * __counted_by(len) _Nonnull __noescape p);
 
 int * __counted_by(len) __noescape returnPointer(int len);
 
+int * __counted_by(len1) returnLifetimeBound(int len1, int len2, int * __counted_by(len2) p __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -1,6 +1,7 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
@@ -13,6 +14,8 @@ import CountedByNoEscapeClang
 // CHECK:      @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: MutableSpan<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: MutableSpan<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: MutableSpan<Int{{.*}}>)
+// CHECK-NEXT: @lifetime(p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func returnLifetimeBound(_ len1: Int32, _ p: MutableSpan<Int32>) -> MutableSpan<Int32>
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_  len: Int{{.*}}) -> UnsafeMutableBufferPointer<Int{{.*}}>
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: MutableSpan<Int{{.*}}>, _ p2: MutableSpan<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: MutableSpan<Int{{.*}}>)

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -109,4 +109,8 @@ inline void mixedFuncWithSafeWrapper5(ConstSpanOfInt s,
 inline void mixedFuncWithSafeWrapper6(ConstSpanOfInt s,
                                       int * __counted_by(len) p, int len) {}
 
+inline ConstSpanOfInt mixedFuncWithSafeWrapper7(const int * __counted_by(len) p, int len) {
+  return ConstSpanOfInt(p, len);
+}
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -85,4 +85,28 @@ struct X {
   inline void methodWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}
 };
 
+inline ConstSpanOfInt mixedFuncWithSafeWrapper1(const int * __counted_by(len) p
+                                           [[clang::lifetimebound]], int len) {
+  return ConstSpanOfInt(p, len);
+}
+
+inline const int * __counted_by(len) mixedFuncWithSafeWrapper2(const VecOfInt &v
+                                           [[clang::lifetimebound]], int len) {
+  if (v.size() <= len)
+    return v.data();
+  return nullptr;
+}
+
+inline void mixedFuncWithSafeWrapper3(ConstSpanOfInt s [[clang::noescape]],
+                                      int * __counted_by(len) p, int len) {}
+
+inline void mixedFuncWithSafeWrapper4(ConstSpanOfInt s [[clang::noescape]],
+                                      const int * __counted_by(len) p [[clang::noescape]], int len) {}
+
+inline void mixedFuncWithSafeWrapper5(ConstSpanOfInt s,
+                                      const int * __counted_by(len) p [[clang::noescape]], int len) {}
+
+inline void mixedFuncWithSafeWrapper6(ConstSpanOfInt s,
+                                      int * __counted_by(len) p, int len) {}
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -6,6 +6,14 @@
 #include <string>
 #include <vector>
 
+#ifndef __counted_by // cstddef already imports ptrcheck.h on apple platforms
+#if defined(__has_feature) && __has_feature(bounds_safety_attributes)
+  #define __counted_by(x) __attribute__((__counted_by__(x)))
+#else
+  #define __counted_by(x)
+#endif
+#endif
+
 using ConstSpanOfInt = std::span<const int>;
 using SpanOfInt = std::span<int>;
 using ConstSpanOfString = std::span<const std::string>;

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -33,6 +33,10 @@ import CxxStdlib
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>
 // CHECK-NEXT: @lifetime(p)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper1(_ p: UnsafePointer<Int32>!, _ len: Int32) -> Span<CInt>
-// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper3(_ s: Span<CInt>, _ p: UnsafeMutablePointer<Int32>!, _ len: Int32)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper4(_ s: Span<CInt>, _ p: UnsafePointer<Int32>!, _ len: Int32)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper1(_ p: Span<Int32>) -> Span<CInt>
+// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper2(_ v: borrowing VecOfInt, _ len: Int32) -> UnsafeBufferPointer<Int32>
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper3(_ s: Span<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper4(_ s: Span<CInt>, _ p: Span<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper5(_ s: ConstSpanOfInt, _ p: Span<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper6(_ s: ConstSpanOfInt, _ p: UnsafeMutableBufferPointer<Int32>)

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -35,8 +35,9 @@ import CxxStdlib
 // CHECK-NEXT: @lifetime(p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper1(_ p: Span<Int32>) -> Span<CInt>
 // CHECK-NEXT: @lifetime(borrow v)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper2(_ v: borrowing VecOfInt, _ len: Int32) -> UnsafeBufferPointer<Int32>
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper2(_ v: borrowing VecOfInt, _ len: Int32) -> Span<Int32>
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper3(_ s: Span<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper4(_ s: Span<CInt>, _ p: Span<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper5(_ s: ConstSpanOfInt, _ p: Span<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper6(_ s: ConstSpanOfInt, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<Int32>) -> ConstSpanOfInt

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -27,8 +27,12 @@ import CxxStdlib
 // CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func methodWithSafeWrapper(_ s: ConstSpanOfInt)
 // CHECK-NEXT: }
-// CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
+// CHECK: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT: @lifetime(s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>
+// CHECK-NEXT: @lifetime(p)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper1(_ p: UnsafePointer<Int32>!, _ len: Int32) -> Span<CInt>
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper3(_ s: Span<CInt>, _ p: UnsafeMutablePointer<Int32>!, _ len: Int32)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper4(_ s: Span<CInt>, _ p: UnsafePointer<Int32>!, _ len: Int32)

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature LifetimeDependence -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
 func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
@@ -8,6 +8,14 @@ func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .nonescaping(pointer: .return))
 func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len2"), .countedBy(pointer: .param(1), count: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func lifetimeDependentCopy(_ p: UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len2"), .countedBy(pointer: .param(1), count: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow))
+func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
 }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
@@ -18,5 +26,16 @@ func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
 // CHECK-NEXT:     return UnsafeBufferPointer<CInt> (start: nonEscaping(len), count: Int(len))
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(p)
+// CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
+// CHECK-NEXT:     return Span<CInt> (_unsafeStart:   p.withUnsafeBufferPointer { _pPtr in
+// CHECK-NEXT:         return lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: p.count)!, len2)
+// CHECK-NEXT:       }, count: Int(len2))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p)
+// CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
+// CHECK-NEXT:     return Span<CInt> (_unsafeStart: lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,4 +1,5 @@
 // REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_LifetimeDependence
 
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature LifetimeDependence -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 


### PR DESCRIPTION
    [ClangImporter] Merge paths for std::span and __counted_by
    
    importBoundsAttributes and importSpanAttributes are merged into a single
    function named swiftify. This allows us to not have to duplicate the
    effort of attaching _SwiftifyImport macros, but is also necessary to
    allow importing a function with both __counted_by and std::span types.

    [ClangImporter] Enable parsing bounds safety attributes in C++
    
    This allows combining __counted_by and std::span for safe interop.
    Previously we disabled this in C++ mode due to issues when bounds
    attributes occurred directly or indirectly in templated contexts, but
    this has now been resolved on the clang side.

    [Swiftify] Emit Span for counted_by return values with lifetime info
    
    __counted_by return values with .lifetimeDependence are now mapped to
    Span instead of UnsafeBufferPointer. Also fixes bug where std::span
    return values would map to Span even if lifetime dependence info was
    missing.