### PR TITLE
runtime: adjust the program name reference

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -110,6 +110,7 @@ target_include_directories(swiftRuntime PRIVATE
 
 target_link_libraries(swiftRuntime PRIVATE
   $<$<PLATFORM_ID:Windows>:User32>
+  $<$<PLATFORM_ID:Windows>:ShLwApi>
   swiftShims
   swiftDemangling)
 


### PR DESCRIPTION
`__progname` is not available on Windows, and is provided by libbsd on Linux. This provides a replacement for the functional aspect of the symbol on Windows.