### PR TITLE
Add sending to subscript sending result

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4450,6 +4450,13 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
     Printer.printDeclResultTypePre(decl, elementTy);
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
 
+    if (!Options.SuppressSendingArgsAndResults) {
+      if (auto typeRepr = decl->getElementTypeRepr()) {
+        if (isa<SendingTypeRepr>(decl->getResultTypeRepr()))
+          Printer << "sending ";
+      }
+    }
+
     PrintWithOpaqueResultTypeKeywordRAII x(Options);
     printTypeLocForImplicitlyUnwrappedOptional(
       elementTy, decl->isImplicitlyUnwrappedOptional());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10754,6 +10754,9 @@ AccessorDecl *AccessorDecl::createParsed(
 
       newParams.push_back(param);
     }
+
+    if (isa<SendingTypeRepr>(SD->getElementTypeRepr()))
+      accessor->setSendingResult();
   }
   accessor->setParameters(
       ParameterList::create(ctx, paramsStart, newParams, paramsEnd));

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2638,6 +2638,10 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     AnyFunctionType::ExtInfoBuilder infoBuilder;
     maybeAddParameterIsolation(infoBuilder, argTy);
 
+    if (auto typeRepr = SD->getElementTypeRepr())
+      if (isa<SendingTypeRepr>(typeRepr))
+        infoBuilder = infoBuilder.withSendingResult();
+
     Type funcTy;
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     auto info = infoBuilder.build();

--- a/test/Concurrency/sending_subscript.swift
+++ b/test/Concurrency/sending_subscript.swift
@@ -4,10 +4,19 @@
 
 class NonSendableKlass {}
 
-// CHECK: subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { get }
+// CHECK-DAG: subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { get }
 
-// CHECK: sil hidden [ossa] @$s17sending_subscript1SVyAA16NonSendableKlassCAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S) -> @sil_sending @owned NonSendableKlass {
+// CHECK-DAG: sil hidden [ossa] @$s17sending_subscript1SVyAA16NonSendableKlassCAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S) -> @sil_sending @owned NonSendableKlass {
 struct S {
   subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { NonSendableKlass() }
+}
+
+// CHECK-DAG: subscript(_: sending NonSendableKlass) -> sending (NonSendableKlass, NonSendableKlass) { get }
+
+// CHECK-DAG: sil hidden [ossa] @$s17sending_subscript2S2VyAA16NonSendableKlassC_AEtAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S2) -> (@sil_sending @owned NonSendableKlass, @sil_sending @owned NonSendableKlass) {
+struct S2 {
+  subscript(_: sending NonSendableKlass) -> sending (NonSendableKlass, NonSendableKlass) { 
+    (NonSendableKlass(), NonSendableKlass()) 
+  }
 }
 

--- a/test/Concurrency/sending_subscript.swift
+++ b/test/Concurrency/sending_subscript.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-silgen | %FileCheck %s
+
+// REQUIRES: concurrency
+
+class NonSendableKlass {}
+
+// CHECK: subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { get }
+
+// CHECK: sil hidden [ossa] @$s17sending_subscript1SVyAA16NonSendableKlassCAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S) -> @sil_sending @owned NonSendableKlass {
+struct S {
+  subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { NonSendableKlass() }
+}
+


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #79559

When the `sending` is applied to the return type in a subscript and SIL is emitted, the `sending` disappears from the output.

Here's an example to demonstrate this behavior:

```swift
class NonSendableKlass {}

struct S {
    subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { NonSendableKlass() }
}
```

The SIL output(the result of `emit-silgen`) shows :

```
sil_stage raw
...
struct S {
  subscript(_: sending NonSendableKlass) -> NonSendableKlass { get } // no sending for the return value
  init()
}

...

sil hidden [ossa] @$s4main1SVyAA16NonSendableKlassCAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S) -> @owned NonSendableKlass { // no @sil_sending for the return value
```

Note that while the parameter retains its `sending` in the SIL output, the return type's `sending` is missing.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
