### PR TITLE
mailmap: add some entries for myself

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -134,6 +134,9 @@ Ross Bayer <ross.m.bayer@gmail.com>
 Ross Bayer <ross.m.bayer@gmail.com> <Rostepher@users.noreply.github.com>
 Russ Bishop <rbishopjr@apple.com> <russ@plangrid.com>
 Ryan Lovelett <ryan@lovelett.me> <RLovelett@users.noreply.github.com>
+Saleem Abdulrasool <compnerd@compnerd.org> <abdulras@fb.com>
+Saleem Abdulrasool <compnerd@compnerd.org> <abdulras@google.com>
+Saleem Abdulrasool <compnerd@compnerd.org> <abdulras@thebrowser.company>
 Shawn Erickson <shawn.erickson@citrix.com> <shawnce@gmail.com>
 Slava Pestov <spestov@apple.com> <sviatoslav.pestov@gmail.com>
 Stephen Canon <scanon@apple.com>


### PR DESCRIPTION
Add aliases for the various email addresses that have been used over time and normalise to my personal email address.