### PR TITLE
AST/Sema: Introduce `SemanticAvailabilitySpec`

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -732,9 +732,9 @@ SWIFT_NAME("getter:BridgedAvailabilitySpec.platform(self:)")
 BridgedPlatformKind
 BridgedAvailabilitySpec_getPlatform(BridgedAvailabilitySpec spec);
 
-SWIFT_NAME("getter:BridgedAvailabilitySpec.version(self:)")
+SWIFT_NAME("getter:BridgedAvailabilitySpec.rawVersion(self:)")
 BridgedVersionTuple
-BridgedAvailabilitySpec_getVersion(BridgedAvailabilitySpec spec);
+BridgedAvailabilitySpec_getRawVersion(BridgedAvailabilitySpec spec);
 
 SWIFT_NAME("getter:BridgedAvailabilitySpec.versionRange(self:)")
 BridgedSourceRange

--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -264,10 +264,8 @@ public:
   /// condition that introduced the availability scope for a given platform
   /// version; if zero or multiple such responsible attributes or statements
   /// exist, returns an invalid SourceRange.
-  SourceRange
-  getAvailabilityConditionVersionSourceRange(
-      PlatformKind Platform,
-      const llvm::VersionTuple &Version) const;
+  SourceRange getAvailabilityConditionVersionSourceRange(
+      AvailabilityDomain Domain, const llvm::VersionTuple &Version) const;
 
   /// Returns the availability version range that was explicitly written in
   /// source, if applicable. Otherwise, returns null.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -44,6 +44,7 @@ class FuncDecl;
 class AbstractFunctionDecl;
 class Pattern;
 class PatternBindingDecl;
+class SemanticAvailabilitySpecs;
 class VarDecl;
 class CaseStmt;
 class DoCatchStmt;
@@ -516,7 +517,11 @@ public:
   ArrayRef<AvailabilitySpec *> getQueries() const {
     return llvm::ArrayRef(getTrailingObjects<AvailabilitySpec *>(), NumQueries);
   }
-  
+
+  /// Returns an iterator for the statement's type-checked availability specs.
+  SemanticAvailabilitySpecs
+  getSemanticAvailabilitySpecs(const DeclContext *declContext) const;
+
   SourceLoc getLParenLoc() const { return LParenLoc; }
   SourceLoc getRParenLoc() const { return RParenLoc; }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1108,9 +1108,9 @@ namespace {
                     ? "*"
                     : Spec->getDomain()->getNameForAttributePrinting();
             printField(domainName, Label::always("domain"));
-            if (!Spec->getVersion().empty())
+            if (!Spec->getRawVersion().empty())
               printFieldRaw(
-                  [&](llvm::raw_ostream &OS) { OS << Spec->getVersion(); },
+                  [&](llvm::raw_ostream &OS) { OS << Spec->getRawVersion(); },
                   Label::always("version"));
             printFoot();
           },

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -269,13 +269,13 @@ static SourceRange getAvailabilityConditionVersionSourceRange(
     const PoundAvailableInfo *PAI, const DeclContext *ReferenceDC,
     AvailabilityDomain Domain, const llvm::VersionTuple &Version) {
   SourceRange Range;
-  for (auto *Spec : PAI->getQueries()) {
-    if (Spec->getDomain() == Domain && Spec->getVersion() == Version) {
+  for (auto Spec : PAI->getSemanticAvailabilitySpecs(ReferenceDC)) {
+    if (Spec.getDomain() == Domain && Spec.getVersion() == Version) {
       // More than one: return invalid range, no unique choice.
       if (Range.isValid())
         return SourceRange();
       else
-        Range = Spec->getVersionSrcRange();
+        Range = Spec.getParsedSpec()->getVersionSrcRange();
     }
   }
   return Range;

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -265,13 +265,12 @@ SourceLoc AvailabilityScope::getIntroductionLoc() const {
   llvm_unreachable("Unhandled Reason in switch.");
 }
 
-static SourceRange
-getAvailabilityConditionVersionSourceRange(const PoundAvailableInfo *PAI,
-                                           PlatformKind Platform,
-                                           const llvm::VersionTuple &Version) {
+static SourceRange getAvailabilityConditionVersionSourceRange(
+    const PoundAvailableInfo *PAI, const DeclContext *ReferenceDC,
+    AvailabilityDomain Domain, const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto *Spec : PAI->getQueries()) {
-    if (Spec->getPlatform() == Platform && Spec->getVersion() == Version) {
+    if (Spec->getDomain() == Domain && Spec->getVersion() == Version) {
       // More than one: return invalid range, no unique choice.
       if (Range.isValid())
         return SourceRange();
@@ -283,13 +282,14 @@ getAvailabilityConditionVersionSourceRange(const PoundAvailableInfo *PAI,
 }
 
 static SourceRange getAvailabilityConditionVersionSourceRange(
-    const MutableArrayRef<StmtConditionElement> &Conds, PlatformKind Platform,
+    const MutableArrayRef<StmtConditionElement> &Conds,
+    const DeclContext *ReferenceDC, AvailabilityDomain Domain,
     const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto const &C : Conds) {
     if (C.getKind() == StmtConditionElement::CK_Availability) {
       SourceRange R = getAvailabilityConditionVersionSourceRange(
-          C.getAvailability(), Platform, Version);
+          C.getAvailability(), ReferenceDC, Domain, Version);
       // More than one: return invalid range.
       if (Range.isValid())
         return SourceRange();
@@ -301,13 +301,13 @@ static SourceRange getAvailabilityConditionVersionSourceRange(
 }
 
 static SourceRange
-getAvailabilityConditionVersionSourceRange(const Decl *D, PlatformKind Platform,
+getAvailabilityConditionVersionSourceRange(const Decl *D,
+                                           AvailabilityDomain Domain,
                                            const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto Attr : D->getSemanticAvailableAttrs()) {
     if (Attr.getIntroduced().has_value() &&
-        Attr.getIntroduced().value() == Version &&
-        Attr.getPlatform() == Platform) {
+        Attr.getIntroduced().value() == Version && Attr.getDomain() == Domain) {
 
       // More than one: return invalid range.
       if (Range.isValid())
@@ -320,29 +320,31 @@ getAvailabilityConditionVersionSourceRange(const Decl *D, PlatformKind Platform,
 }
 
 SourceRange AvailabilityScope::getAvailabilityConditionVersionSourceRange(
-    PlatformKind Platform, const llvm::VersionTuple &Version) const {
+    AvailabilityDomain Domain, const llvm::VersionTuple &Version) const {
   switch (getReason()) {
   case Reason::Decl:
     return ::getAvailabilityConditionVersionSourceRange(Node.getAsDecl(),
-                                                        Platform, Version);
+                                                        Domain, Version);
 
   case Reason::IfStmtThenBranch:
   case Reason::IfStmtElseBranch:
     return ::getAvailabilityConditionVersionSourceRange(
-        Node.getAsIfStmt()->getCond(), Platform, Version);
+        Node.getAsIfStmt()->getCond(), Node.getDeclContext(), Domain, Version);
 
   case Reason::ConditionFollowingAvailabilityQuery:
     return ::getAvailabilityConditionVersionSourceRange(
-        Node.getAsPoundAvailableInfo(), Platform, Version);
+        Node.getAsPoundAvailableInfo(), Node.getDeclContext(), Domain, Version);
 
   case Reason::GuardStmtFallthrough:
   case Reason::GuardStmtElseBranch:
     return ::getAvailabilityConditionVersionSourceRange(
-        Node.getAsGuardStmt()->getCond(), Platform, Version);
+        Node.getAsGuardStmt()->getCond(), Node.getDeclContext(), Domain,
+        Version);
 
   case Reason::WhileStmtBody:
     return ::getAvailabilityConditionVersionSourceRange(
-        Node.getAsWhileStmt()->getCond(), Platform, Version);
+        Node.getAsWhileStmt()->getCond(), Node.getDeclContext(), Domain,
+        Version);
 
   case Reason::Root:
   case Reason::DeclImplicit:

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -144,8 +144,8 @@ BridgedAvailabilitySpec_getPlatform(BridgedAvailabilitySpec spec) {
 }
 
 BridgedVersionTuple
-BridgedAvailabilitySpec_getVersion(BridgedAvailabilitySpec spec) {
-  return spec.unbridged()->getVersion();
+BridgedAvailabilitySpec_getRawVersion(BridgedAvailabilitySpec spec) {
+  return spec.unbridged()->getRawVersion();
 }
 
 BridgedSourceRange

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -619,6 +619,11 @@ PoundAvailableInfo::create(ASTContext &ctx, SourceLoc PoundLoc,
                                            RParenLoc, isUnavailability);
 }
 
+SemanticAvailabilitySpecs PoundAvailableInfo::getSemanticAvailabilitySpecs(
+    const DeclContext *declContext) const {
+  return SemanticAvailabilitySpecs(getQueries(), declContext);
+}
+
 SourceLoc PoundAvailableInfo::getEndLoc() const {
   if (RParenLoc.isInvalid()) {
     if (NumQueries == 0) {

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -85,7 +85,7 @@ extension ASTGenVisitor {
         kind: .default,
         message: BridgedStringRef(),
         renamed: BridgedStringRef(),
-        introduced: spec.version,
+        introduced: spec.rawVersion,
         introducedRange: spec.versionRange,
         deprecated: BridgedVersionTuple(),
         deprecatedRange: BridgedSourceRange(),
@@ -392,7 +392,7 @@ extension ASTGenVisitor {
             guard platform != .none else {
               continue
             }
-            result.append((platform: platform, version: spec.version))
+            result.append((platform: platform, version: spec.rawVersion))
           }
         }
         continue

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -254,7 +254,7 @@ extension ASTGenVisitor {
     return map.has(name: name.bridged)
   }
 
-  func generate(availabilityMacroDefinition node: AvailabilityMacroDefinitionSyntax) -> BridgedAvailabilityMacroDefinition {
+  func generate(availabilityMacroDefinition node: AvailabilityMacroDefinitionFileSyntax) -> BridgedAvailabilityMacroDefinition {
 
     let name = allocateBridgedString(node.platformVersion.platform.text)
     let version = self.generate(versionTuple: node.platformVersion.version)
@@ -446,7 +446,7 @@ func parseAvailabilityMacroDefinition(
 
   // Parse.
   var parser = Parser(buffer)
-  let parsed = AvailabilityMacroDefinitionSyntax.parse(from: &parser)
+  let parsed = AvailabilityMacroDefinitionFileSyntax.parse(from: &parser)
 
   // Emit diagnostics.
   let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: parsed)

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1052,11 +1052,12 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
   }
   for (auto elt : ifStmt->getCond()) {
     if (elt.getKind() == StmtConditionElement::CK_Availability) {
-      for (auto *Q : elt.getAvailability()->getQueries()) {
-        if (Q->getPlatform() != PlatformKind::none) {
-          auto spec = BuilderValue::ConditionalMember::AvailabilitySpec(
-              *Q->getDomain(), Q->getVersion());
-          AvailabilitySpecs.push_back(spec);
+      for (auto spec :
+           elt.getAvailability()->getSemanticAvailabilitySpecs(declContext)) {
+        if (spec.getDomain().isPlatform()) {
+          AvailabilitySpecs.push_back(
+              BuilderValue::ConditionalMember::AvailabilitySpec(
+                  spec.getDomain(), spec.getVersion()));
         }
       }
       memberKind = BuilderValue::LimitedAvailability;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -804,7 +804,7 @@ bool Parser::parseAvailability(
                         AvailableAttr::Kind::Default,
                         /*Message=*/StringRef(),
                         /*Rename=*/StringRef(),
-                        /*Introduced=*/Spec->getVersion(),
+                        /*Introduced=*/Spec->getRawVersion(),
                         /*IntroducedRange=*/Spec->getVersionSrcRange(),
                         /*Deprecated=*/llvm::VersionTuple(),
                         /*DeprecatedRange=*/SourceRange(),
@@ -1888,7 +1888,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
       // macros, we only expect platform specific constraints here.
       DEBUG_ASSERT(Platform != PlatformKind::none);
 
-      auto Version = Spec->getVersion();
+      auto Version = Spec->getRawVersion();
       if (Version.getSubminor().has_value() || Version.getBuild().has_value()) {
         diagnose(Spec->getVersionSrcRange().Start,
                  diag::attr_availability_platform_version_major_minor_only,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1231,7 +1231,7 @@ private:
       if (!Query->isUnavailability() && Query->getQueries().empty())
         continue;
 
-      AvailabilitySpec *Spec = bestActiveSpecForQuery(Query);
+      auto Spec = bestActiveSpecForQuery(Query);
       if (!Spec) {
         // We couldn't find an appropriate spec for the current platform,
         // so rather than refining, emit a diagnostic and just use the current
@@ -1243,8 +1243,9 @@ private:
         continue;
       }
 
-      AvailabilityRange NewConstraint = contextForSpec(Spec, false);
-      Query->setAvailableRange(contextForSpec(Spec, true).getRawVersionRange());
+      AvailabilityRange NewConstraint = contextForSpec(*Spec, false);
+      Query->setAvailableRange(
+          contextForSpec(*Spec, true).getRawVersionRange());
 
       // When compiling zippered for macCatalyst, we need to collect both
       // a macOS version (the target version) and an iOS/macCatalyst version
@@ -1252,11 +1253,13 @@ private:
       // entrypoint that will check either the macOS version or the iOS
       // version depending on the kind of process this code is loaded into.
       if (Context.LangOpts.TargetVariant) {
-        AvailabilitySpec *VariantSpec =
+        auto VariantSpec =
             bestActiveSpecForQuery(Query, /*ForTargetVariant*/ true);
-        VersionRange VariantRange =
-            contextForSpec(VariantSpec, true).getRawVersionRange();
-        Query->setVariantAvailableRange(VariantRange);
+        if (VariantSpec) {
+          VersionRange VariantRange =
+              contextForSpec(*VariantSpec, true).getRawVersionRange();
+          Query->setVariantAvailableRange(VariantRange);
+        }
       }
 
       if (Spec->isWildcard()) {
@@ -1284,12 +1287,13 @@ private:
         if (CurrentScope->getReason() != AvailabilityScope::Reason::Root) {
           PlatformKind BestPlatform = targetPlatform(Context.LangOpts);
 
+          auto Domain = Spec->getDomain();
           // If possible, try to report the diagnostic in terms for the
           // platform the user uttered in the '#available()'. For a platform
           // that inherits availability from another platform it may be
           // different from the platform specified in the target triple.
-          if (Spec->getPlatform() != PlatformKind::none)
-            BestPlatform = Spec->getPlatform();
+          if (Domain.getPlatformKind() != PlatformKind::none)
+            BestPlatform = Domain.getPlatformKind();
           Diags.diagnose(Query->getLoc(),
                          diag::availability_query_useless_enclosing_scope,
                          platformString(BestPlatform));
@@ -1362,29 +1366,34 @@ private:
 
   /// Return the best active spec for the target platform or nullptr if no
   /// such spec exists.
-  AvailabilitySpec *bestActiveSpecForQuery(PoundAvailableInfo *available,
-                                           bool forTargetVariant = false) {
-    AvailabilitySpec *FoundWildcardSpec = nullptr;
-    AvailabilitySpec *BestSpec = nullptr;
+  std::optional<SemanticAvailabilitySpec>
+  bestActiveSpecForQuery(PoundAvailableInfo *available,
+                         bool forTargetVariant = false) {
+    std::optional<SemanticAvailabilitySpec> FoundWildcardSpec;
+    std::optional<SemanticAvailabilitySpec> BestSpec;
 
-    for (auto *Spec : available->getQueries()) {
-      if (Spec->isWildcard()) {
+    for (auto Spec :
+         available->getSemanticAvailabilitySpecs(getCurrentDeclContext())) {
+      if (Spec.isWildcard()) {
         FoundWildcardSpec = Spec;
         continue;
       }
 
-      auto Domain = Spec->getDomain();
-      if (!Domain || !Domain->isPlatform())
+      auto Domain = Spec.getDomain();
+      if (!Domain.isPlatform())
         continue;
 
       // FIXME: This is not quite right: we want to handle AppExtensions
       // properly. For example, on the OSXApplicationExtension platform
       // we want to chose the OS X spec unless there is an explicit
       // OSXApplicationExtension spec.
-      if (isPlatformActive(Spec->getPlatform(), Context.LangOpts,
-                           forTargetVariant, /* ForRuntimeQuery */ true)) {
-        if (!BestSpec || inheritsAvailabilityFromPlatform(
-                             Spec->getPlatform(), BestSpec->getPlatform())) {
+      auto Platform = Domain.getPlatformKind();
+      if (isPlatformActive(Platform, Context.LangOpts, forTargetVariant,
+                           /* ForRuntimeQuery */ true)) {
+
+        if (!BestSpec ||
+            inheritsAvailabilityFromPlatform(
+                Platform, BestSpec->getDomain().getPlatformKind())) {
           BestSpec = Spec;
         }
       }
@@ -1402,19 +1411,19 @@ private:
       SourceLoc Loc = available->getRParenLoc();
       return AvailabilitySpec::createWildcard(Context, Loc);
     } else {
-      return nullptr;
+      return std::nullopt;
     }
   }
 
   /// Return the availability context for the given spec.
-  AvailabilityRange contextForSpec(AvailabilitySpec *Spec,
+  AvailabilityRange contextForSpec(SemanticAvailabilitySpec Spec,
                                    bool GetRuntimeContext) {
-    if (Spec->isWildcard()) {
+    if (Spec.isWildcard()) {
       return AvailabilityRange::alwaysAvailable();
     }
 
     llvm::VersionTuple Version =
-        (GetRuntimeContext ? Spec->getRuntimeVersion() : Spec->getVersion());
+        (GetRuntimeContext ? Spec.getRuntimeVersion() : Spec.getVersion());
 
     return AvailabilityRange(VersionRange::allGTE(Version));
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2026,7 +2026,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
       return false;
 
     auto FixRange = scope->getAvailabilityConditionVersionSourceRange(
-        Platform, RunningVers);
+        AvailabilityDomain::forPlatform(Platform), RunningVers);
     if (!FixRange.isValid())
       return false;
     // Have found a nontrivial availability scope-introducer to narrow.


### PR DESCRIPTION
It wraps a type-checked `AvailabilitySpec`, which guarantees that the spec has a valid `AvailabilityDomain` associated with it. This will unblock moving AvailabilitySpec domain resolution from parsing to sema.