### PR TITLE
Ensure stdlib parses again after #79186.

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -441,6 +441,7 @@ extension MutableCollection where Self: BidirectionalCollection {
       swapAt(lo, hi)
       formIndex(after: &lo)
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -85,6 +85,7 @@ extension FlattenSequence.Iterator: IteratorProtocol {
       _inner = s!.makeIterator()
     }
     while true
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -386,6 +386,7 @@ extension _HashTable {
         return Bucket(word: word, bit: bit)
       }
     }
+    fatalError()
   }
 
   @inlinable
@@ -413,6 +414,7 @@ extension _HashTable {
         return Bucket(word: word, bit: bit)
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -125,6 +125,7 @@ extension JoinedSequence.Iterator: IteratorProtocol {
         return nil
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -192,6 +192,7 @@ public class AnyKeyPath: _AppendKeyPath {
 
         if optNextType == nil { return .some(offset) }
       }
+      fatalError()
     }
     #else
     // compiler optimizes _storedInlineOffset into a direct offset computation,
@@ -270,6 +271,7 @@ extension AnyKeyPath: Hashable {
             return true
           }
         }
+        fatalError()
       }
     }
   }
@@ -431,6 +433,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
             }
           }
         }
+        fatalError()
       }
     }
   }

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -332,6 +332,7 @@ extension Sequence {
       case (nil, nil):           return true
       }
     }
+    fatalError()
   }
 }
 
@@ -425,6 +426,7 @@ extension Sequence {
         return false
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -265,6 +265,7 @@ private func _findBoundary(
 
     idx &-= _utf8ScalarLength(utf8, endingAt: idx)
   }
+  fatalError()
 }
 
 @frozen

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -945,6 +945,7 @@ extension String.UTF16View {
 
         readIdx &+= len
       }
+      fatalError()
     }
   }
 

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -256,6 +256,7 @@ extension Unicode.UTF16 {
         return (utf16Count, utf16BitUnion < 0x80)
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -585,6 +585,7 @@ public func transcode<
     }
     OutputEncoding.encodedReplacementCharacter.forEach(processCodeUnit)
   }
+  fatalError()
 }
 
 /// Instances of conforming types are used in internal `String`


### PR DESCRIPTION
That pr converted PredictableMemoryAccessOptimizations function pass to Swift. Both versions of this pass remove unreachable terminators at the end of apparent infinite loops that are guaranteed to eventually return. The stdlib has a number of instances where apparent infinite loops are used.

When Swift host tools are available, so are the Swift function passes, and these unreachable terminators are removed as before. However, when the host tools are not available (e.g., using a configuration like the stdlib and we get a dataflow error manifesting as a "missing return".

To extricate ourselves out of this situation, we have a few options.

One option is determining that #79186 marks the end of the road for the compiler to be bootstrapped from C++. However, that is somewhat unsatisfying, since there is a great reticence to accepting maintenance patches on previous compiler branches and leaves questions about how an older version of the "bootstrap" compiler should be kept up-to-date, since presumably as new platforms come online to bootstrap Swift, code changes to C++ would still be warranted.

Alternatively, there is already a stated goal that the C++ compiler should not necessarily emit the most optimized code, and that the compiler built with Swift host tools would emit better optimized code. In this case, we would want to add an additional pass for the bootstrap compiler to just detect the apparent infinite loop case and make sure no errors occur. This is probably the correct thing to do, however, it is probably a slightly nontrivial undertaking.

In the meantime, we need to ensure we can continue to bootstrap with the spot where the "missing return" error happens. This is not exactly the cleanest solution, but it does ensure the build is fixed again in this configuration.

(Because this is not perhaps the best solution to address this problem, I've made this a draft pr instead, so at least this unblocks builds.)
