### PR TITLE
Parse/Sema: Move `#available` query wildcard diagnostics to Sema

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1992,12 +1992,6 @@ NOTE(avail_query_meant_introduced,PointsToFirstBadToken,
 ERROR(avail_query_version_comparison_not_needed,
       none,"version comparison not needed", ())
 
-ERROR(availability_query_wildcard_required, none,
-      "must handle potential future platforms with '*'", ())
-
-ERROR(unavailability_query_wildcard_not_required, none,
-      "platform wildcard '*' is always implicit in #unavailable", ())
-
 ERROR(availability_cannot_be_mixed,none,
       "#available and #unavailable cannot be in the same statement", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6990,6 +6990,12 @@ ERROR(availability_query_package_description_not_allowed, none,
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))
 
+ERROR(availability_query_wildcard_required, none,
+      "must handle potential future platforms with '*'", ())
+
+ERROR(unavailability_query_wildcard_not_required, none,
+      "platform wildcard '*' is always implicit in #unavailable", ())
+
 //------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2144,8 +2144,9 @@ AvailableAttr::AvailableAttr(
       ObsoletedRange(ObsoletedRange) {
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
-  Bits.AvailableAttr.IsFollowedByGroupedAvailableAttr = false;
-  Bits.AvailableAttr.IsFollowedByWildcard = false;
+  Bits.AvailableAttr.IsGroupMember = false;
+  Bits.AvailableAttr.IsGroupTerminator = false;
+  Bits.AvailableAttr.IsAdjacentToWildcard = false;
 }
 
 AvailableAttr *AvailableAttr::createUniversallyUnavailable(ASTContext &C,

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -42,7 +42,7 @@ if #available(OSX 0) { // expected-warning {{expected version number; this is an
 if #available(OSX 0.0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
 }
 
-if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}} expected-error {{must handle potential future platforms with '*'}} {{21-21=, *}}
+if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
 if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -234,7 +234,7 @@ func functionWithShortFormIOSVersionNoPointAvailable() {}
 @available(iOS 8.0, OSX 10.10.3, *)
 func functionWithShortFormIOSOSXAvailable() {}
 
-@available(iOS 8.0 // expected-error {{must handle potential future platforms with '*'}} {{19-19=, *}}
+@available(iOS 8.0
 func shortFormMissingParen() { // expected-error {{expected ')' in 'available' attribute}}
 }
 

--- a/test/attr/attr_availability_swift.swift
+++ b/test/attr/attr_availability_swift.swift
@@ -4,8 +4,20 @@
 func foo() {
 }
 
-@available(swift 3.0, iOS 10, *) // expected-error {{version-availability must be specified alone}}
+@available(swift 3.0, *) // expected-error {{'swift' version-availability must be specified alone}}
+func foo2() {
+}
+
+@available(swift 3.0, iOS 10, *) // expected-error {{'swift' version-availability must be specified alone}}
 func bar() {
+}
+
+@available(iOS 10, swift 3.0, *) // expected-error {{'swift' version-availability must be specified alone}}
+func bar2() {
+}
+
+@available(iOS 10, *, swift 3.0) // expected-error {{'swift' version-availability must be specified alone}}
+func bar3() {
 }
 
 func baz() {


### PR DESCRIPTION
In order to unblock resolution of availability domains during type-checking instead of parsing, diagnostics about missing or superfluous wildcards in availability specification lists need to move to Sema.
