### PR TITLE
[Sema] Permit dot reference with isolation change without call

### DIFF
--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -95,3 +95,42 @@ nonisolated func accessAcrossActors() {
   // expected-error@+1 {{main actor-isolated static property 'shared' can not be referenced from a nonisolated context}}
   let _ = MainActorIsolated.shared
 }
+
+struct ReferenceSelfDotMethods {
+  @MainActor
+  func mainActorAffinedFunction() {}
+
+  nonisolated
+  private func testCurry() -> (Self) -> (@MainActor () -> Void) {
+    let functionRef = Self.mainActorAffinedFunction
+    return functionRef
+  }
+
+  @MainActor
+  private func callOnMainActorOk() {
+    let mainActorAffinedClosure = testCurry()(self)
+    mainActorAffinedClosure()
+  }
+
+  nonisolated
+  private func nonisolatedCallErrors() {
+    let mainActorAffinedClosure = testCurry()(self)
+    // expected-note@-1 {{calls to let 'mainActorAffinedClosure' from outside of its actor context are implicitly asynchronous}}
+    mainActorAffinedClosure()
+    // expected-error@-1 {{call to main actor-isolated let 'mainActorAffinedClosure' in a synchronous nonisolated context}}
+  }
+}
+
+actor UserDefinedActorSelfDotMethod {
+  func actorAffinedFunc() {} // expected-note {{calls to instance method 'actorAffinedFunc()' from outside of its actor context are implicitly asynchronous}}
+
+  // Unfortunately we can't express the desired isolation of this returned closure statically to
+  // be able to call it on the desired actor. This may be possible with the acceptance of
+  // https://forums.swift.org/t/closure-isolation-control/70378 but I think we need more expressivity
+  // in the type system to express this sort of curry.
+  nonisolated
+  private func testCurry() -> (UserDefinedActorSelfDotMethod) -> (@isolated(any) () -> Void) {
+    let functionRef = Self.actorAffinedFunc // expected-error {{call to actor-isolated instance method 'actorAffinedFunc()' in a synchronous nonisolated context}}
+    return functionRef // expected-error {{cannot convert return expression of type '@Sendable (isolated Self) -> @Sendable () -> ()' to return type '(UserDefinedActorSelfDotMethod) -> @isolated(any) () -> Void'}}
+  }
+}


### PR DESCRIPTION
A dot-reference of a method defined on `Self` (as well as through `self`) should be permitted to be made in a different actor isolation than the referenced function's actor isolation if a call is not yet made, as the DeclRefExpr can store the isolation of the referenced decl. That said, we currently can only express that known isolation with global actor annotations until the language adopts closure isolation control.

Resolves (for global actors) #76453