### PR TITLE
[cxx-interop] Fix calling convention for rvalue reference params

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1256,6 +1256,9 @@ public:
     case ValueOwnership::Shared:
       return ParameterConvention::Indirect_In_Guaranteed;
     case ValueOwnership::Owned:
+      if (kind == ConventionsKind::CFunction ||
+          kind == ConventionsKind::CFunctionType)
+        return getIndirectParameter(index, type, substTL);
       return ParameterConvention::Indirect_In;
     }
     llvm_unreachable("unhandled ownership");
@@ -3392,6 +3395,8 @@ static ParameterConvention getIndirectCParameterConvention(clang::QualType type)
   // A trivial const * parameter in C should be considered @in.
   if (importer::isCxxConstReferenceType(type.getTypePtr()))
     return ParameterConvention::Indirect_In_Guaranteed;
+  if (type->isRValueReferenceType())
+    return ParameterConvention::Indirect_In_CXX;
   if (auto *decl = type->getAsRecordDecl()) {
     if (!decl->isParamDestroyedInCallee())
       return ParameterConvention::Indirect_In_CXX;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4655,7 +4655,8 @@ static void emitConsumedLValueRecursive(SILGenFunction &SGF, SILLocation loc,
 
   // Load if necessary.
   if (value.getType().isAddress()) {
-    if (!param.isIndirectIn() || !SGF.silConv.useLoweredAddresses()) {
+    if ((!param.isIndirectIn() && !param.isIndirectInCXX()) ||
+        !SGF.silConv.useLoweredAddresses()) {
       value = SGF.B.createFormalAccessLoadTake(loc, value);
 
       // If our value is a moveonlywrapped type, unwrap it using owned so that

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -341,6 +341,7 @@ public:
     case SILArgumentConvention::Indirect_In:
       return true;
     case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_Inout:
     case SILArgumentConvention::Indirect_InoutAliasable:
       return false;
@@ -445,6 +446,7 @@ public:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Indirect_In_Guaranteed:
       return false;
+    case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_In:
       llvm_unreachable("copy_addr src destroyed without reinitialization");
     default:

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -3,6 +3,11 @@ module Reference {
   requires cplusplus
 }
 
+module SpecialMembers {
+  header "print-special-members.h"
+  requires cplusplus
+}
+
 module Closures {
   header "closures.h"
   requires cplusplus

--- a/test/Interop/Cxx/reference/Inputs/print-special-members.h
+++ b/test/Interop/Cxx/reference/Inputs/print-special-members.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdio>
+
+struct MoveOnly {
+    int id;
+    MoveOnly() : id(0) { printf("MoveOnly %d created\n", id); }
+    MoveOnly(const MoveOnly&) = delete;
+    MoveOnly(MoveOnly&& other) : id(other.id + 1) { printf("MoveOnly %d move-created\n", id); }
+    ~MoveOnly() { printf("MoveOnly %d destroyed\n", id); }
+};
+
+struct Copyable {
+    int id;
+    Copyable() : id(0) { printf("Copyable %d created\n", id); }
+    Copyable(const Copyable& other) : id(other.id + 1) { printf("Copyable %d copy-created\n", id); }
+    Copyable(Copyable&& other) : id(other.id + 1) { printf("Copyable %d move-created\n", id); }
+    ~Copyable() { printf("Copyable %d destroyed\n", id); }
+};
+
+inline void byRValueRef(MoveOnly&& x) {}
+inline void byRValueRef(Copyable&& x) {}

--- a/test/Interop/Cxx/reference/rvalue-reference.swift
+++ b/test/Interop/Cxx/reference/rvalue-reference.swift
@@ -1,0 +1,70 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Onone) | %FileCheck -check-prefix=CHECK-DASH-ONONE %s
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O) | %FileCheck -check-prefix=CHECK-DASH-O %s
+//
+// REQUIRES: executable_test
+
+import SpecialMembers
+
+func consume(_ x: consuming MoveOnly) {}
+func consume(_ x: consuming Copyable) {}
+
+func moveOnly1() {
+    let x = MoveOnly()
+// CHECK-DASH-ONONE: MoveOnly 0 created
+// CHECK-DASH-O: MoveOnly 0 created
+    byRValueRef(consuming: x)
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 move-created
+// CHECK-DASH-O-NEXT: MoveOnly 1 move-created
+// CHECK-DASH-ONONE-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-O-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 destroyed
+// CHECK-DASH-O-NEXT: MoveOnly 1 destroyed
+}
+
+func moveOnly2() {
+    let x = MoveOnly()
+// CHECK-DASH-ONONE-NEXT: MoveOnly 0 created
+// CHECK-DASH-O-NEXT: MoveOnly 0 created
+    consume(x)
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 move-created
+// CHECK-DASH-ONONE-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-O-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-ONONE-NEXT: MoveOnly 2 move-created
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 destroyed
+// CHECK-DASH-ONONE-NEXT: MoveOnly 2 destroyed
+}
+
+func copyable1() {
+    let x = Copyable()
+// CHECK-DASH-ONONE-NEXT: Copyable 0 created
+// CHECK-DASH-O-NEXT: Copyable 0 created
+    byRValueRef(consuming: x)
+// CHECK-DASH-ONONE-NEXT: Copyable 1 copy-created
+// CHECK-DASH-O-NEXT: Copyable 1 copy-created
+// CHECK-DASH-ONONE-NEXT: Copyable 1 destroyed
+// CHECK-DASH-O-NEXT: Copyable 1 destroyed
+// CHECK-DASH-ONONE-NEXT: Copyable 0 destroyed
+// CHECK-DASH-O-NEXT: Copyable 0 destroyed
+}
+
+func copyable2() {
+    let x4 = Copyable()
+// CHECK-DASH-ONONE-NEXT: Copyable 0 created
+// CHECK-DASH-O-NEXT: Copyable 0 created
+    consume(x4)
+// CHECK-DASH-ONONE-NEXT: Copyable 1 copy-created
+// CHECK-DASH-ONONE-NEXT: Copyable 2 move-created
+// CHECK-DASH-ONONE-NEXT: Copyable 1 destroyed
+// CHECK-DASH-ONONE-NEXT: Copyable 2 destroyed
+// CHECK-DASH-ONONE-NEXT: Copyable 0 destroyed
+// CHECK-DASH-O-NEXT: Copyable 0 destroyed
+}
+
+func main() {
+    moveOnly1()
+    moveOnly2()
+    copyable1()
+    copyable2()
+}
+
+main()


### PR DESCRIPTION
In C++, we always expected to invoke the dtor for moved-from objects. This is not the case for swift. Fortunately, @inCxx calling convention is already expressing that the caller supposed to destroy the object. This fixes the missing dtor calls when calling C++ functions taking rvalue references. Fixes #77894.

rdar://140786022