### PR TITLE
Discard non-indexed relations instead of entire references.

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -549,7 +549,9 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
     assert(D);
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (!shouldIndex(VD, /*IsRef*/ true))
-        return true;
+        // Let the caller continue while discarding the relation to a symbol
+        // that won't appear in the index.
+        return false;
     }
     auto Match = std::find_if(Info.Relations.begin(), Info.Relations.end(),
                               [D](IndexRelation R) { return R.decl == D; });

--- a/test/Index/index_private_type_receiver.swift
+++ b/test/Index/index_private_type_receiver.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SDK)
+// RUN: split-file %s %t
+//
+// RUN: mkdir -p %t/SDK/Frameworks/FakeSystem.framework/Modules/FakeSystem.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name FakeSystem \
+// RUN:     -o %t/SDK/Frameworks/FakeSystem.framework/Modules/FakeSystem.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/FakeSystem.swift
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %t/view.swift
+//
+// --- Check the index.
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s
+//
+
+//--- FakeSystem.swift
+public protocol View {
+}
+
+public protocol ViewModifier {
+  associatedtype Body: View
+  typealias Content = _HiddenView<Self>
+  func body(content: Self.Content) -> Self.Body
+}
+
+public struct _HiddenView<M>: View where M: ViewModifier {
+  init(m: M) {}
+}
+
+public struct _HiddenModifier: ViewModifier {
+  public func body(content: Content) -> some View {
+    return _HiddenView(m: self)
+  }
+}
+
+extension View {
+  public func background() -> some View {
+    return _HiddenView(m: _HiddenModifier())
+  }
+}
+
+//--- view.swift
+import FakeSystem
+
+private struct Mod: FakeSystem.ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      .background()
+    // CHECK: 6:8 | instance-method/Swift | s:10FakeSystem4ViewPAAE10backgroundQryF | Ref,Call,Dyn{{.*}}
+  }
+}


### PR DESCRIPTION
References for function calls where there would normally be a received-by relationship were being discarded. This happened when the receiver type is a non-indexed type, e.g. a private type in a system framework. The function call could be public or defined in any module though, so discarding it entirely because of the receiver type is not desirable.

Follow up to refine the behavior of [previous commit](https://github.com/swiftlang/swift/commit/b65d8c212e8f83006090d91dc5f833f6a5c94eed).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
