### PR TITLE
[rbi] Make a confusing comment clearer.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -428,6 +428,10 @@ enum class PartitionOpKind : uint8_t {
   Assign,
 
   /// Assign one value to a fresh region, takes one arg.
+  ///
+  /// NOTE: This just produces a new value that is tracked by the dataflow. The
+  /// isolation characteristics of the value are actually decided by
+  /// tryToTrackValue and SILIsolationInfo::get().
   AssignFresh,
 
   /// Merge the regions of two values, takes two args, both must be from

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1553,8 +1553,13 @@ enum class TranslationSemantics {
   Ignored,
 
   /// An instruction whose result produces a completely new region. E.x.:
-  /// alloc_box, alloc_pack, key_path. This results in the translator
-  /// producing a partition op that introduces the new region.
+  /// alloc_box, alloc_pack, key_path, a function without any parameters. This
+  /// results in the translator producing a partition op that introduces the new
+  /// region.
+  ///
+  /// NOTE: This just introduces a new value and must always occur before a
+  /// value is actually used. The isolation of the value is actually determined
+  /// by invoking tryToTrackValue and SILIsolationInfo::get().
   AssignFresh,
 
   /// An instruction that merges together all of its operands regions and


### PR DESCRIPTION
From talking with @dgregor, it became clear that this comment was easily interpreted as saying that AssignFresh always introduced a disconnected value... which is not the case. Instead, AssignFresh just introduces a new value that could have any form of isolation. The actual isolation of the value is assigned via tryToTrackValue and eventually SILIsolationInfo::get().
