### PR TITLE
[embedded] Allow string-interpolating fatalError in Embedded Swift

### DIFF
--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -63,6 +63,17 @@ public func print(_ object: some CustomStringConvertible, terminator: StaticStri
   }
 }
 
+func print(_ buf: UnsafeBufferPointer<UInt8>, terminator: StaticString = "\n") {
+  for c in buf {
+    putchar(CInt(c))
+  }
+  var p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(CInt(p.pointee))
+    p += 1
+  }
+}
+
 func printCharacters(_ buf: UnsafeRawBufferPointer) {
   for unsafe c in unsafe buf {
     putchar(CInt(c))

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -527,6 +527,7 @@ public func swift_clearSensitive(buf: UnsafeMutableRawPointer, nbytes: Int) {
 }
 
 @usableFromInline
+@inline(never)
 func _embeddedReportFatalError(prefix: StaticString, message: StaticString) {
   print(prefix, terminator: "")
   if message.utf8CodeUnitCount > 0 { print(": ", terminator: "") }
@@ -534,10 +535,21 @@ func _embeddedReportFatalError(prefix: StaticString, message: StaticString) {
 }
 
 @usableFromInline
+@inline(never)
 func _embeddedReportFatalErrorInFile(prefix: StaticString, message: StaticString, file: StaticString, line: UInt) {
   print(file, terminator: ":")
   print(line, terminator: ": ")
   print(prefix, terminator: "")
   if message.utf8CodeUnitCount > 0 { print(": ", terminator: "") }
+  print(message)
+}
+
+@usableFromInline
+@inline(never)
+func _embeddedReportFatalErrorInFile(prefix: StaticString, message: UnsafeBufferPointer<UInt8>, file: StaticString, line: UInt) {
+  print(file, terminator: ":")
+  print(line, terminator: ": ")
+  print(prefix, terminator: "")
+  if message.count > 0 { print(": ", terminator: "") }
   print(message)
 }

--- a/test/embedded/traps-fatalerror-exec2.swift
+++ b/test/embedded/traps-fatalerror-exec2.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -x c -c %S/Inputs/unbuffered-putchar.c -o %t/unbuffered-putchar.o
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s --check-prefix=CHECK-MESSAGE
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out -O
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out -Osize
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out -O     -assert-config Debug
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s --check-prefix=CHECK-MESSAGE
+
+// RUN: %target-build-swift -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out -Osize -assert-config Debug
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s --check-prefix=CHECK-MESSAGE
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: swift_feature_Embedded
+
+func testWithInterpolation(i: Int) {
+     fatalError("task failed successfully \(i)")
+     // CHECK-MESSAGE: {{.*}}/traps-fatalerror-exec2.swift:[[@LINE-1]]: Fatal error: task failed successfully 42
+     // CHECK-NOMESSAGE-NOT: Fatal error
+     // CHECK-NOMESSAGE-NOT: task failed successfully 42
+}
+
+testWithInterpolation(i: 42)

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -27,3 +27,23 @@ public func test() {
 // CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap()
 // CHECK-NOMESSAGE-NEXT:   unreachable
 // CHECK-NOMESSAGE-NEXT: }
+
+public func testWithInterpolation(i: Int) {
+     fatalError("task failed successfully \(i)")
+}
+
+// CHECK-MESSAGE: define {{.*}}void @"$e4main21testWithInterpolation1iySi_tF"(i64 %0){{.*}} {
+// CHECK-MESSAGE: entry:
+// CHECK-MESSAGE: task failed successfully
+// CHECK-MESSAGE:   {{.*}}call {{.*}}void @"${{(es17_assertionFailure__|es31_embeddedReportFatalErrorInFile6prefix7message4file4lineys12StaticStringV_SRys5UInt8VGAGSutF)}}
+// CHECK-MESSAGE-SAME: Fatal error
+// CHECK-MESSAGE-SAME: traps-fatalerror-ir.swift
+// CHECK-MESSAGE:   unreachable
+// CHECK-MESSAGE: }
+
+// CHECK-NOMESSAGE:      define {{.*}}void @"$e4main21testWithInterpolation1iySi_tF"(i64 %0){{.*}} {
+// CHECK-NOMESSAGE-NEXT: entry:
+// CHECK-NOMESSAGE-NEXT:   tail call void asm sideeffect "", "n"(i32 0)
+// CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE-NEXT:   unreachable
+// CHECK-NOMESSAGE-NEXT: }


### PR DESCRIPTION
This makes `fatalError` accept String and string interpolations in Embedded Swift (previously we only accepted StaticString). Given that the String type is nowadays available in Embedded Swift, there's no reason to keep this divergence in the fatalError API between regular Swift and Embedded Swift.

Left TODOs:
- [ ] also apply the same to assert
- [ ] also apply the same to precondition
- [ ] also apply the same to assertionFailure
- [ ] also apply the same to preconditionFailure

TODOs are addressed in https://github.com/swiftlang/swift/pull/79698.

rdar://138205827