### PR TITLE
[swift-inspect] On Darwin, don't try to inspect processes that don't have Swift.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -163,6 +163,11 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     self.swiftCore =
         CSSymbolicatorGetSymbolOwnerWithNameAtTime(self.symbolicator,
                                                    "libswiftCore.dylib", kCSNow)
+    if CSIsNull(self.swiftCore) {
+      print("pid \(processId) does not have libswiftCore.dylib loaded")
+      return nil
+    }
+
     self.swiftConcurrency = CSSymbolicatorGetSymbolOwnerWithNameAtTime(
       symbolicator, "libswift_Concurrency.dylib", kCSNow)
     _ = task_start_peeking(self.task)


### PR DESCRIPTION
When we locate libswiftCore.dylib in the remote process, check for failure and give up immediately if we don't find one. If the process doesn't have Swift, there's no point in trying to inspect anything in it.

rdar://143978694