### PR TITLE
[swift-mode] require flymake-proc

### DIFF
--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -503,6 +503,7 @@ directory."
              (funcall swift-find-executable-fn "swiftc")
              temp-file)))
 
+(require 'flymake-proc)
 (add-to-list 'flymake-allowed-file-name-masks '(".+\\.swift$" flymake-swift-init))
 
 (setq flymake-err-line-patterns


### PR DESCRIPTION
This appears to be necessary in newer versions.

See this discussion about haskell-mode: https://github.com/haskell/haskell-mode/issues/1825