### PR TITLE
[Completion] Remove uses of unbounded generic types

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -185,6 +185,11 @@ private:
   /// \p selfTy must be a \c Self type of the context.
   static bool canBeUsedAsRequirementFirstType(Type selfTy, TypeAliasDecl *TAD);
 
+  /// Retrieve the type to use as the base for a member completion.
+  Type getMemberBaseType() const {
+    return BaseType ? BaseType : ExprType;
+  }
+
 public:
   struct RequestedResultsTy {
     const ModuleDecl *TheModule;

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -395,8 +395,7 @@ static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
 
   // Equality/Conversion of GenericTypeParameterType won't account for
   // requirements – ignore them
-  if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter() &&
-      !Ty->hasUnboundGenericType() && !ExpectedTy->hasUnboundGenericType()) {
+  if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
     if (Ty->isEqual(ExpectedTy))
       return TypeRelation::Convertible;
     bool isAny = false;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3006,11 +3006,14 @@ void CompletionLookup::getGenericRequirementCompletions(
                            /*includeDerivedRequirements*/ false,
                            /*includeProtocolExtensionMembers*/ true);
   // We not only allow referencing nested types/typealiases directly, but also
-  // qualified by the current type. Thus also suggest current self type so the
+  // qualified by the current type, as long as it's a top-level type (nested
+  // types need to be qualified). Thus also suggest current self type so the
   // user can do a memberwise lookup on it.
-  if (auto SelfType = typeContext->getSelfNominalTypeDecl()) {
-    addNominalTypeRef(SelfType, DeclVisibilityKind::LocalDecl,
-                      DynamicLookupInfo());
+  if (auto *NTD = typeContext->getSelfNominalTypeDecl()) {
+    if (!NTD->getDeclContext()->isTypeContext()) {
+      addNominalTypeRef(NTD, DeclVisibilityKind::LocalDecl,
+                        DynamicLookupInfo());
+    }
   }
 
   // Self is also valid in all cases in which it can be used in function

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -763,9 +763,7 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
 }
 
 Type CompletionLookup::getAssociatedTypeType(const AssociatedTypeDecl *ATD) {
-  Type BaseTy = BaseType;
-  if (!BaseTy)
-    BaseTy = ExprType;
+  Type BaseTy = getMemberBaseType();
   if (!BaseTy && CurrDeclContext)
     BaseTy =
         CurrDeclContext->getInnermostTypeContext()->getDeclaredTypeInContext();

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -89,11 +89,11 @@ static Type defaultTypeLiteralKind(CodeCompletionLiteralKind kind,
   case CodeCompletionLiteralKind::ArrayLiteral:
     if (!Ctx.getArrayDecl())
       return Type();
-    return Ctx.getArrayDecl()->getDeclaredType();
+    return Ctx.getArrayDecl()->getDeclaredInterfaceType();
   case CodeCompletionLiteralKind::DictionaryLiteral:
     if (!Ctx.getDictionaryDecl())
       return Type();
-    return Ctx.getDictionaryDecl()->getDeclaredType();
+    return Ctx.getDictionaryDecl()->getDeclaredInterfaceType();
   case CodeCompletionLiteralKind::NilLiteral:
   case CodeCompletionLiteralKind::ColorLiteral:
   case CodeCompletionLiteralKind::ImageLiteral:
@@ -1715,7 +1715,7 @@ void CompletionLookup::addNominalTypeRef(const NominalTypeDecl *NTD,
   if (!customAttributeAnnotation.empty()) {
     Builder.addTypeAnnotation(customAttributeAnnotation);
   } else {
-    addTypeAnnotation(Builder, NTD->getDeclaredType());
+    addTypeAnnotation(Builder, NTD->getDeclaredInterfaceType());
   }
 
   // Override the type relation for NominalTypes. Use the better relation
@@ -1741,11 +1741,7 @@ void CompletionLookup::addTypeAliasRef(const TypeAliasDecl *TAD,
   Builder.addBaseName(TAD->getName().str());
   if (auto underlyingType = TAD->getUnderlyingType()) {
     if (underlyingType->hasError()) {
-      addTypeAnnotation(Builder,
-                        TAD->isGeneric()
-                        ? TAD->getUnboundGenericType()
-                        : TAD->getDeclaredInterfaceType());
-
+      addTypeAnnotation(Builder, TAD->getDeclaredInterfaceType());
     } else {
       addTypeAnnotation(Builder, underlyingType);
     }

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -51,8 +51,10 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
   // Use the contextual type, unless it is still unresolved, in which case fall
   // back to getting the type from the expression.
   if (auto ContextualType = S.getContextualType(Node)) {
-    if (!ContextualType->hasUnresolvedType())
+    if (!ContextualType->hasUnresolvedType() &&
+        !ContextualType->hasUnboundGenericType()) {
       return ContextualType;
+    }
   }
 
   if (!S.hasType(Node)) {

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -35,8 +35,8 @@ func testGlobal() {
 // GLOBAL_EXPR-DAG: Literal[Boolean]/None:              <name>false</name>; typename=<typeid.sys>Bool</typeid.sys>;
 // GLOBAL_EXPR-DAG: Literal[Nil]/None:                  <name>nil</name>; typename=;
 // GLOBAL_EXPR-DAG: Literal[String]/None:               &quot;<callarg><callarg.param>abc</callarg.param></callarg>&quot;; typename=<typeid.sys>String</typeid.sys>;
-// GLOBAL_EXPR-DAG: Literal[Array]/None:                [<callarg><callarg.param>values</callarg.param></callarg>]; typename=<typeid.sys>Array</typeid.sys>;
-// GLOBAL_EXPR-DAG: Literal[Dictionary]/None:           [<callarg><callarg.param>key</callarg.param></callarg>: <callarg><callarg.param>value</callarg.param></callarg>]; typename=<typeid.sys>Dictionary</typeid.sys>;
+// GLOBAL_EXPR-DAG: Literal[Array]/None:                [<callarg><callarg.param>values</callarg.param></callarg>]; typename=<typeid.sys>Array</typeid.sys>&lt;<typeid.sys>Element</typeid.sys>&gt;;
+// GLOBAL_EXPR-DAG: Literal[Dictionary]/None:           [<callarg><callarg.param>key</callarg.param></callarg>: <callarg><callarg.param>value</callarg.param></callarg>]; typename=<typeid.sys>Dictionary</typeid.sys>&lt;<typeid.sys>Key</typeid.sys>, <typeid.sys>Value</typeid.sys>&gt;;
 // GLOBAL_EXPR-DAG: Literal[_Color]/None:               <name>#colorLiteral</name>(<callarg><callarg.label>red</callarg.label>: <callarg.type><typeid.sys>Float</typeid.sys></callarg.type></callarg>, <callarg><callarg.label>green</callarg.label>: <callarg.type><typeid.sys>Float</typeid.sys></callarg.type></callarg>, <callarg><callarg.label>blue</callarg.label>: <callarg.type><typeid.sys>Float</typeid.sys></callarg.type></callarg>, <callarg><callarg.label>alpha</callarg.label>: <callarg.type><typeid.sys>Float</typeid.sys></callarg.type></callarg>); typename=;
 // GLOBAL_EXPR-DAG: Literal[_Image]/None:               <name>#imageLiteral</name>(<callarg><callarg.label>resourceName</callarg.label>: <callarg.type><typeid.sys>String</typeid.sys></callarg.type></callarg>); typename=;
 // GLOBAL_EXPR-DAG: Literal[Tuple]/None:                (<callarg><callarg.param>values</callarg.param></callarg>); typename=;

--- a/test/IDE/complete_at_top_level_library.swift
+++ b/test/IDE/complete_at_top_level_library.swift
@@ -70,8 +70,8 @@ protocol MyProtocol {}
 // LIBRARY-DAG: Literal[Boolean]/None/Flair[ExprAtFileScope]: false[#Bool#]; name=false
 // LIBRARY-DAG: Literal[Nil]/None/Flair[ExprAtFileScope]: nil; name=nil
 // LIBRARY-DAG: Literal[String]/None/Flair[ExprAtFileScope]: "{#(abc)#}"[#String#]; name=""
-// LIBRARY-DAG: Literal[Array]/None/Flair[ExprAtFileScope]: [{#(values)#}][#Array#]; name=[]
-// LIBRARY-DAG: Literal[Dictionary]/None/Flair[ExprAtFileScope]: [{#(key)#}: {#(value)#}][#Dictionary#]; name=[: ]
+// LIBRARY-DAG: Literal[Array]/None/Flair[ExprAtFileScope]: [{#(values)#}][#Array<Element>#]; name=[]
+// LIBRARY-DAG: Literal[Dictionary]/None/Flair[ExprAtFileScope]: [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#]; name=[: ]
 // LIBRARY-DAG: Literal[Tuple]/None/Flair[ExprAtFileScope]: ({#(values)#}); name=()
 // LIBRARY-DAG: Decl[Struct]/CurrModule/Flair[ExprAtFileScope]: MyStruct[#MyStruct#]; name=MyStruct
 // LIBRARY-DAG: Decl[Protocol]/CurrModule/Flair[RareType,ExprAtFileScope]: MyProtocol[#MyProtocol#]; name=MyProtocol
@@ -136,8 +136,8 @@ protocol MyProtocol {}
 // SCRIPT-DAG: Literal[Boolean]/None: false[#Bool#]; name=false
 // SCRIPT-DAG: Literal[Nil]/None: nil; name=nil
 // SCRIPT-DAG: Literal[String]/None: "{#(abc)#}"[#String#]; name=""
-// SCRIPT-DAG: Literal[Array]/None: [{#(values)#}][#Array#]; name=[]
-// SCRIPT-DAG: Literal[Dictionary]/None: [{#(key)#}: {#(value)#}][#Dictionary#]; name=[: ]
+// SCRIPT-DAG: Literal[Array]/None: [{#(values)#}][#Array<Element>#]; name=[]
+// SCRIPT-DAG: Literal[Dictionary]/None: [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#]; name=[: ]
 // SCRIPT-DAG: Literal[Tuple]/None: ({#(values)#}); name=()
 // SCRIPT-DAG: Decl[Struct]/CurrModule: MyStruct[#MyStruct#]; name=MyStruct
 // SCRIPT-DAG: Decl[Protocol]/CurrModule/Flair[RareType]: MyProtocol[#MyProtocol#]; name=MyProtocol

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -75,7 +75,7 @@ func foo(s: MyStruct<Int>) {
 // META_MYSTRUCT_INT_DOT: Begin completions, 11 items
 // META_MYSTRUCT_INT_DOT-DAG: Keyword[self]/CurrNominal:          self[#MyStruct<Int>.Type#]; name=self
 // META_MYSTRUCT_INT_DOT-DAG: Keyword/CurrNominal:                Type[#MyStruct<Int>.Type#]; name=Type
-// META_MYSTRUCT_INT_DOT-DAG: Decl[TypeAlias]/CurrNominal:        Assoc[#T#]; name=Assoc
+// META_MYSTRUCT_INT_DOT-DAG: Decl[TypeAlias]/CurrNominal:        Assoc[#Int#]; name=Assoc
 // META_MYSTRUCT_INT_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#int: U#})[#MyStruct<Int>#]; name=init(int:)
 // META_MYSTRUCT_INT_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#withConstrainedGenericParam: SomeProto#})[#MyStruct<Int>#]; name=init(withConstrainedGenericParam:)
 // META_MYSTRUCT_INT_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   methodWithConstrainedGenericParam({#(self): MyStruct<Int>#})[#(x: SomeProto) -> Int#]; name=methodWithConstrainedGenericParam(:)

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -311,8 +311,8 @@ class DependentTypeInClosure<Data: DataType> {
 func testDependentTypeInClosure() {
   let _: DependentTypeInClosure = .#^DEPENDENT_IN_CLOSURE_3^#
 // DEPENDENT_IN_CLOSURE_3: Begin completions, 2 items
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal: init({#(arg): DataType#}, {#fn: (DataType.Content) -> Void##(DataType.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal: init({#arg: DataType#}, {#fn: () -> DataType.Content##() -> DataType.Content#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#(arg): DataType#}, {#fn: (Data.Content) -> Void##(Data.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#arg: DataType#}, {#fn: () -> Data.Content##() -> Data.Content#})[#DependentTypeInClosure<DataType>#];
 
   let _ = DependentTypeInClosure(#^DEPENDENT_IN_CLOSURE_1^#)
 // DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#(arg): DataType#}, {#fn: (_) -> Void##(_) -> Void#}[')'][#DependentTypeInClosure<DataType>#];
@@ -348,6 +348,6 @@ func testIgnoreGenericArgsAfterCompletionToken() {
   func deserializeRecord() throws -> HostRecord<IPv4> {
     var position = 42
     return try #^IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN^#HostRecord<IPv4>(position: &position)
-// IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN-DAG: Decl[Struct]/Local: HostRecord[#HostRecord#];
+// IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN-DAG: Decl[Struct]/Local: HostRecord[#HostRecord<IPType>#];
   }
 }

--- a/test/IDE/complete_embedded_linux.swift
+++ b/test/IDE/complete_embedded_linux.swift
@@ -11,6 +11,6 @@ func test() {
 // GLOBAL: Literal[Boolean]/None:              false[#Bool#];
 // GLOBAL: Literal[Nil]/None:                  nil;
 // GLOBAL: Literal[String]/None:               "{#(abc)#}"[#String#];
-// GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array#];
-// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary#];
+// GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array<Element>#];
+// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#];
 }

--- a/test/IDE/complete_embedded_macos.swift
+++ b/test/IDE/complete_embedded_macos.swift
@@ -11,6 +11,6 @@ func test() {
 // GLOBAL: Literal[Boolean]/None:              false[#Bool#];
 // GLOBAL: Literal[Nil]/None:                  nil;
 // GLOBAL: Literal[String]/None:               "{#(abc)#}"[#String#];
-// GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array#];
-// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary#];
+// GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array<Element>#];
+// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#];
 }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -5,7 +5,7 @@
 
 #^PLAIN_TOP_LEVEL_1?check=PLAIN_TOP_LEVEL;check=NO_STDLIB_PRIVATE^#
 
-// PLAIN_TOP_LEVEL-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Array[#Array#]{{; name=.+$}}
+// PLAIN_TOP_LEVEL-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Array[#Array<Element>#]{{; name=.+$}}
 
 func privateNominalMembers(_ a: String) {
   a.#^PRIVATE_NOMINAL_MEMBERS_1?check=PRIVATE_NOMINAL_MEMBERS_1;check=NO_STDLIB_PRIVATE^#

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -134,15 +134,15 @@ struct Foo: Swift.Array.#^STDLIB_TYPE_QUALIFIED_NESTED^# {}
 
 struct Bar: Swift.#^STDLIB_TYPE_QUALIFIED^# {}
 // STDLIB_TYPE_QUALIFIED-NOT: Decl[Module]
-// STDLIB_TYPE_QUALIFIED: Decl[Struct]/OtherModule[Swift]/IsSystem: AnyCollection[#AnyCollection#]; name=AnyCollection
+// STDLIB_TYPE_QUALIFIED: Decl[Struct]/OtherModule[Swift]/IsSystem: AnyCollection[#AnyCollection<Element>#]; name=AnyCollection
 // STDLIB_TYPE_QUALIFIED-NOT: Decl[Module]
 
 func foo() -> foo_swift_module.#^MODULE_TYPE_QUALIFIED^# {}
 // MODULE_TYPE_QUALIFIED: Decl[Protocol]/OtherModule[foo_swift_module]: BarProtocol[#BarProtocol#]; name=BarProtocol
 // MODULE_TYPE_QUALIFIED: Decl[Enum]/OtherModule[foo_swift_module]: MyQuickLookObject[#MyQuickLookObject#]; name=MyQuickLookObject
-// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct1[#BarGenericSwiftStruct1#]; name=BarGenericSwiftStruct1
+// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct1[#BarGenericSwiftStruct1<T>#]; name=BarGenericSwiftStruct1
 // MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: FooSwiftStruct[#FooSwiftStruct#]; name=FooSwiftStruct
-// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct2[#BarGenericSwiftStruct2#]; name=BarGenericSwiftStruct2
+// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct2[#BarGenericSwiftStruct2<T, U>#]; name=BarGenericSwiftStruct2
 
 // rdar://92048610
 func testAmbiguousResultBuilder() {

--- a/test/IDE/complete_member_type.swift
+++ b/test/IDE/complete_member_type.swift
@@ -115,10 +115,10 @@ do {
   // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#DefaultIndices<Dictionary<Key, Value>>#]; name=Indices
   // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Key[#Key#]; name=Key
   // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Value[#Value#]; name=Value
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Keys[#Dictionary.Keys#]; name=Keys
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Values[#Dictionary.Values#]; name=Values
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Index[#Dictionary.Index#]; name=Index
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Iterator[#Dictionary.Iterator#]; name=Iterator
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Keys[#Dictionary<Key, Value>.Keys#]; name=Keys
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Values[#Dictionary<Key, Value>.Values#]; name=Values
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Index[#Dictionary<Key, Value>.Index#]; name=Index
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Iterator[#Dictionary<Key, Value>.Iterator#]; name=Iterator
   // DICTIONARY-NEXT: Decl[TypeAlias]/Super/NotRecommended/IsSystem: IndexDistance[#Int#]; name=IndexDistance; diagnostics=warning
   // DICTIONARY-NEXT: Keyword/None: Type[#{{Dictionary<Int, Int>|\[Int : Int\]}}.Type#]; name=Type
 }

--- a/test/IDE/complete_member_type.swift
+++ b/test/IDE/complete_member_type.swift
@@ -90,7 +90,7 @@ do {
   let _: Int!.#^SUGARED_IUOPTIONAL_MEMBER_DOT?check=OPTIONAL^#
 
   // OPTIONAL-LABEL: Begin completions, 2 items
-  // OPTIONAL-LABEL: Decl[TypeAlias]/CurrNominal: Wrappt[#Wrapped#]; name=Wrappt
+  // OPTIONAL-LABEL: Decl[TypeAlias]/CurrNominal: Wrappt[#Int#]; name=Wrappt
   // OPTIONAL-LABEL: Keyword/None: Type[#{{Optional<Int>|Int\?}}.Type#]; name=Type
 
   let _: Array<Int>.#^ARRAY_MEMBER_DOT?check=ARRAY^#
@@ -99,10 +99,10 @@ do {
   // ARRAY-LABEL: Begin completions, 8 items
   // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Index[#Int#]; name=Index
   // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#Range<Int>#]; name=Indices
-  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Iterator[#IndexingIterator<Array<Element>>#]; name=Iterator
-  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#Element#]; name=Element
-  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: ArrayLiteralElement[#Element#]; name=ArrayLiteralElement
-  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#ArraySlice<Element>#]; name=SubSequence
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Iterator[#IndexingIterator<Array<Int>>#]; name=Iterator
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#Int#]; name=Element
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: ArrayLiteralElement[#Int#]; name=ArrayLiteralElement
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#ArraySlice<Int>#]; name=SubSequence
   // ARRAY-DAG: Decl[TypeAlias]/Super/NotRecommended/IsSystem: IndexDistance[#Int#]; name=IndexDistance; diagnostics=warning:'IndexDistance' is deprecated: all index distances are now of type Int
   // ARRAY-DAG: Keyword/None: Type[#{{Array<Int>|\[Int\]}}.Type#]; name=Type
 
@@ -110,15 +110,15 @@ do {
   let _: [Int : Int].#^SUGARED_DICTIONARY_MEMBER_DOT?check=DICTIONARY^#
 
   // DICTIONARY-LABEL: Begin completions, 11 items
-  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#(key: Key, value: Value)#]; name=Element
-  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#Slice<Dictionary<Key, Value>>#]; name=SubSequence
-  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#DefaultIndices<Dictionary<Key, Value>>#]; name=Indices
-  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Key[#Key#]; name=Key
-  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Value[#Value#]; name=Value
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Keys[#Dictionary<Key, Value>.Keys#]; name=Keys
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Values[#Dictionary<Key, Value>.Values#]; name=Values
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Index[#Dictionary<Key, Value>.Index#]; name=Index
-  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Iterator[#Dictionary<Key, Value>.Iterator#]; name=Iterator
+  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#(key: Int, value: Int)#]; name=Element
+  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#Slice<Dictionary<Int, Int>>#]; name=SubSequence
+  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#DefaultIndices<Dictionary<Int, Int>>#]; name=Indices
+  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Key[#Int#]; name=Key
+  // DICTIONARY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Value[#Int#]; name=Value
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Keys[#Dictionary<Int, Int>.Keys#]; name=Keys
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Values[#Dictionary<Int, Int>.Values#]; name=Values
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Index[#Dictionary<Int, Int>.Index#]; name=Index
+  // DICTIONARY-NEXT: Decl[Struct]/CurrNominal/IsSystem: Iterator[#Dictionary<Int, Int>.Iterator#]; name=Iterator
   // DICTIONARY-NEXT: Decl[TypeAlias]/Super/NotRecommended/IsSystem: IndexDistance[#Int#]; name=IndexDistance; diagnostics=warning
   // DICTIONARY-NEXT: Keyword/None: Type[#{{Dictionary<Int, Int>|\[Int : Int\]}}.Type#]; name=Type
 }
@@ -160,3 +160,10 @@ do {
   // MEMBER_EXISTENTIAL_NO_DOT-NEXT: Keyword/None: .Protocol[#(any Sequence).Type#]; name=Protocol
   // MEMBER_EXISTENTIAL_NO_DOT-NEXT: Keyword/None: .Type[#any Sequence.Type#]; name=Type
 }
+
+struct TestGenericTypealias<T, U> {
+  typealias K<V> = TestGenericTypealias<(T, U), V>
+}
+
+let _ = TestGenericTypealias<Int, String>.K<Float>.#^GENERIC_TYPEALIAS^#
+// GENERIC_TYPEALIAS-DAG: Decl[TypeAlias]/CurrNominal: K[#TestGenericTypealias<((Int, String), Float), V>#]; name=K

--- a/test/IDE/complete_name_lookup.swift
+++ b/test/IDE/complete_name_lookup.swift
@@ -49,4 +49,4 @@ extension ObservableConvertibleType {
 // CATCHSEQUENCE_DOT-DAG: Keyword/CurrNominal:                Type[#CatchSequence<_>.Type#]; name=Type
 // CATCHSEQUENCE_DOT-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#CatchSequence<_>#]; name=init()
 // CATCHSEQUENCE_DOT-DAG: Decl[StaticMethod]/Super/TypeRelation[Convertible]: catchError()[#Observable<CatchSequence<_>.T>#]; name=catchError()
-// CATCHSEQUENCE_DOT-DAG: Decl[TypeAlias]/Super:              T[#T#]; name=T
+// CATCHSEQUENCE_DOT-DAG: Decl[TypeAlias]/Super: T[#Observable<_.Element.T>.T#]; name=T

--- a/test/IDE/complete_value_literals.swift
+++ b/test/IDE/complete_value_literals.swift
@@ -8,8 +8,8 @@ func testAll0() {
 // NO_CONTEXT_0-DAG: Literal[Boolean]/None:              false[#Bool#];
 // NO_CONTEXT_0-DAG: Literal[Nil]/None:                  nil;
 // NO_CONTEXT_0-DAG: Literal[String]/None:               "{#(abc)#}"[#String#];
-// NO_CONTEXT_0-DAG: Literal[Array]/None:                [{#(values)#}][#Array#];
-// NO_CONTEXT_0-DAG: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary#];
+// NO_CONTEXT_0-DAG: Literal[Array]/None:                [{#(values)#}][#Array<Element>#];
+// NO_CONTEXT_0-DAG: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#];
 // NO_CONTEXT_0-DAG: Literal[_Color]/None:               #colorLiteral({#red: Float#}, {#green: Float#}, {#blue: Float#}, {#alpha: Float#});
 // NO_CONTEXT_0-DAG: Literal[_Image]/None:               #imageLiteral({#resourceName: String#});
 }
@@ -146,7 +146,7 @@ func testString5() {
 func testArray0() {
   let x: Int = #^ARRAY_0^#
 }
-// ARRAY_0: Literal[Array]/None: [{#(values)#}][#Array#];
+// ARRAY_0: Literal[Array]/None: [{#(values)#}][#Array<Element>#];
 
 func testArray1() {
   let x: MyArray1<MyInt1> = #^ARRAY_1^#
@@ -161,7 +161,7 @@ func testArray2() {
 func testDict0() {
   let x: Int = #^DICT_0^#
 }
-// DICT_0: Literal[Dictionary]/None: [{#(key)#}: {#(value)#}][#Dictionary#];
+// DICT_0: Literal[Dictionary]/None: [{#(key)#}: {#(value)#}][#Dictionary<Key, Value>#];
 
 func testDict1() {
   let x: MyDict1<MyInt1, MyString1> = #^DICT_1^#

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -209,21 +209,17 @@ struct TA2<T: Assoc> {
 // NOMINAL_TYPEALIAS_NESTED2-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 }
 extension TA2.Inner1 where #^NOMINAL_TYPEALIAS_NESTED1_EXT^# {}
-// NOMINAL_TYPEALIAS_NESTED1_EXT: Begin completions, 6 items
+// NOMINAL_TYPEALIAS_NESTED1_EXT: Begin completions, 5 items
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[GenericTypeParam]/Local:       U[#U#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
-// FIXME : We shouldn't be suggesting Inner1 because it's not fully-qualified
-// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[Struct]/Local:                 Inner1[#TA2<T>.Inner1<U>#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner1<U>#];
 extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
-// NOMINAL_TYPEALIAS_NESTED2_EXT: Begin completions, 5 items
+// NOMINAL_TYPEALIAS_NESTED2_EXT: Begin completions, 4 items
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
-// FIXME : We shouldn't be suggesting Inner2 because it's not fully-qualified
-// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[Struct]/Local:                 Inner2[#TA2<T>.Inner2#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner2#];
 
 protocol WithAssoc {

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -64,14 +64,14 @@ extension A1 where T1.#^GP6^# {}
 // A1-DAG: Decl[GenericTypeParam]/Local:       T1[#T1#]; name=T1
 // A1-DAG: Decl[GenericTypeParam]/Local:       T2[#T2#]; name=T2
 // A1-DAG: Decl[GenericTypeParam]/Local:       T3[#T3#]; name=T3
-// A1-DAG: Decl[Class]/Local:                  A1[#A1#]; name=A1
+// A1-DAG: Decl[Class]/Local:                  A1[#A1<T1, T2, T3>#]; name=A1
 // A1-NOT: T4
 // A1-NOT: T5
 // A1-NOT: Self
 
 // TYPE1-DAG: Decl[Protocol]/CurrModule:          P1[#P1#]; name=P1
-// TYPE1-DAG: Decl[Class]/CurrModule:             A1[#A1#]; name=A1
-// TYPE1-DAG: Decl[Class]/CurrModule:             A2[#A2#]; name=A2
+// TYPE1-DAG: Decl[Class]/CurrModule:             A1[#A1<T1, T2, T3>#]; name=A1
+// TYPE1-DAG: Decl[Class]/CurrModule:             A2[#A2<T4, T5>#]; name=A2
 // TYPE1-NOT: T1
 // TYPE1-NOT: T2
 // TYPE1-NOT: T3
@@ -138,7 +138,7 @@ enum E2<T> where T.#^ENUM_2^# {}
 // GEN_T_NOMINAL: Decl[GenericTypeParam]/Local: T[#T#]; name=T
 
 // ANYTYPE-DAG: Decl[GenericTypeParam]/Local: T[#T#];
-// ANYTYPE-DAG: Decl[Class]/CurrModule: A1[#A1#];
+// ANYTYPE-DAG: Decl[Class]/CurrModule: A1[#A1<T1, T2, T3>#];
 // ANYTYPE-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Int[#Int#];
 
 protocol P2 {
@@ -190,7 +190,7 @@ extension TA1 where #^NOMINAL_TYPEALIAS_EXT^# { }
 // NOMINAL_TYPEALIAS_EXT: Begin completions, 4 items
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[GenericTypeParam]/Local:       T[#T#];
 // NOMINAL_TYPEALIAS_EXT-DAG: Decl[TypeAlias]/CurrNominal:        U[#T.Q#];
-// NOMINAL_TYPEALIAS_EXT-DAG: Decl[Struct]/Local:                 TA1[#TA1#];
+// NOMINAL_TYPEALIAS_EXT-DAG: Decl[Struct]/Local:                 TA1[#TA1<T>#];
 // NOMINAL_TYPEALIAS_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA1<T>#];
 
 struct TA2<T: Assoc> {
@@ -215,7 +215,7 @@ extension TA2.Inner1 where #^NOMINAL_TYPEALIAS_NESTED1_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
 // FIXME : We shouldn't be suggesting Inner1 because it's not fully-qualified
-// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[Struct]/Local:                 Inner1[#TA2.Inner1#];
+// NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Decl[Struct]/Local:                 Inner1[#TA2<T>.Inner1<U>#];
 // NOMINAL_TYPEALIAS_NESTED1_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner1<U>#];
 extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED2_EXT: Begin completions, 5 items
@@ -223,7 +223,7 @@ extension TA2.Inner2 where #^NOMINAL_TYPEALIAS_NESTED2_EXT^# {}
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X1[#T#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[TypeAlias]/CurrNominal:        X2[#T.Q#];
 // FIXME : We shouldn't be suggesting Inner2 because it's not fully-qualified
-// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[Struct]/Local:                 Inner2[#TA2.Inner2#];
+// NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Decl[Struct]/Local:                 Inner2[#TA2<T>.Inner2#];
 // NOMINAL_TYPEALIAS_NESTED2_EXT-DAG: Keyword[Self]/CurrNominal:          Self[#TA2<T>.Inner2#];
 
 protocol WithAssoc {

--- a/test/SourceKit/Misc/load-module-with-errors.swift
+++ b/test/SourceKit/Misc/load-module-with-errors.swift
@@ -30,7 +30,7 @@ func testInvalidTypeCompletion() {
   let foo: #^INVALID-TYPE^#;
   // INVALID-TYPE-DAG: Decl[Enum]/OtherModule[errors]:     InvalidEnum[#InvalidEnum#];
   // INVALID-TYPE-DAG: Decl[Class]/OtherModule[errors]:    InvalidClass[#InvalidClass#];
-  // INVALID-TYPE-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct#];
+  // INVALID-TYPE-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct<T, U>#];
   // INVALID-TYPE-DAG: Decl[Struct]/OtherModule[errors]:   InvalidStruct[#InvalidStruct#];
   // INVALID-TYPE-DAG: Decl[TypeAlias]/OtherModule[errors]: InvalidAlias[#InvalidAlias#];
   // INVALID-TYPE-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub1[#InvalidClassSub1#];
@@ -48,7 +48,7 @@ func testInvalidTopLevelCompletion() {
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureBody[#<<error type>>#];
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncSignature()[#Void#];
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalMissingInit[#String#];
-  // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct#];
+  // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct<T, U>#];
   // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidStruct[#InvalidStruct#];
   // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: typeUsesFunc({#pe: InvalidEnum#}, {#pa: <<error type>>#}, {#pp: any InvalidProtocol#}, {#ps: InvalidStruct#}, {#pg: <<error type>>#}, {#pc: InvalidClass#})[#Int#];
   // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalKeypath[#InvalidStruct.Type#];


### PR DESCRIPTION
Ensure we always produce bounded generic type annotations and contextual types. While here, also make sure we substitute the base type for nested type completions.