### PR TITLE
[🍒] [6.1] Discard non-indexed relations instead of entire references.

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -549,7 +549,9 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
     assert(D);
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (!shouldIndex(VD, /*IsRef*/ true))
-        return true;
+        // Let the caller continue while discarding the relation to a symbol
+        // that won't appear in the index.
+        return false;
     }
     auto Match = std::find_if(Info.Relations.begin(), Info.Relations.end(),
                               [D](IndexRelation R) { return R.decl == D; });

--- a/test/Index/index_private_type_receiver.swift
+++ b/test/Index/index_private_type_receiver.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SDK)
+// RUN: split-file %s %t
+//
+// RUN: mkdir -p %t/SDK/Frameworks/FakeSystem.framework/Modules/FakeSystem.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name FakeSystem \
+// RUN:     -o %t/SDK/Frameworks/FakeSystem.framework/Modules/FakeSystem.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/FakeSystem.swift
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %t/view.swift
+//
+// --- Check the index.
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s
+//
+
+//--- FakeSystem.swift
+public protocol View {
+}
+
+public protocol ViewModifier {
+  associatedtype Body: View
+  typealias Content = _HiddenView<Self>
+  func body(content: Self.Content) -> Self.Body
+}
+
+public struct _HiddenView<M>: View where M: ViewModifier {
+  init(m: M) {}
+}
+
+public struct _HiddenModifier: ViewModifier {
+  public func body(content: Content) -> some View {
+    return _HiddenView(m: self)
+  }
+}
+
+extension View {
+  public func background() -> some View {
+    return _HiddenView(m: _HiddenModifier())
+  }
+}
+
+//--- view.swift
+import FakeSystem
+
+private struct Mod: FakeSystem.ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      .background()
+    // CHECK: 6:8 | instance-method/Swift | s:10FakeSystem4ViewPAAE10backgroundQryF | Ref,Call,Dyn{{.*}}
+  }
+}


### PR DESCRIPTION
  - **Explanation**:
    - Fixes a regression in index data, where entire references are discarded instead of just the relation. This occurs when the reference has a relation where the related entity is not indexed. Instead of discarding the entire reference, e.g. a function call, this fix discards the relation to a non-indexed symbol, e.g. the received-by relation to a private type.
  - **Scope**:
    - This adds references to the index output, and should not impact code compilation or other compiler outputs. These references were emitted in the past, removed starting in Swift 6.0, so reintroducing them is likely safe.
  - **Issues**:
    - N/A
  - **Original PRs**:
    -  https://github.com/swiftlang/swift/pull/79577
  - **Risk**:
    - Low. This only adds some new references to index data.
  - **Testing**:
    - New test case, and existing test suite for index data and its users.
  - **Reviewers**:
    - @bnbarham 
    - @ahoppen 