### PR TITLE
[CSFix] Fix a null pointer dereference in `getStructuralTypeContext`

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -805,3 +805,18 @@ func testMatchingNonErrorConformingTypeInClosure(_ x: any Error) {
     }
   }
 }
+
+// rdar://131819800 - crash in `transformWithPosition` while trying to emit diagnostics for `AllowFunctionTypeMismatch` fix
+do {
+  enum E {
+  case test(kind: Int, defaultsToEmpty: Bool = false)
+  }
+
+  func test(e: E) {
+    if case .test(kind: _, // expected-error {{tuple pattern has the wrong length for tuple type '(Int, Bool)'}}
+                  name: let name?,
+                  defaultsToEmpty: _,
+                  deprecateName: let deprecatedName?) = e {
+    }
+  }
+}


### PR DESCRIPTION
First problem - the logic used constraint system, which shouldn't be required,
second - it expects the type to be always present in `ContextualTypeInfo` but
that's not the case for some patterns.

Resolves: rdar://131819800

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
