### PR TITLE
[SE-0458] Don't warn about unsafe conformances outside of strict safety mode

### DIFF
--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -296,6 +296,13 @@ bool swift::enumerateUnsafeUses(ArrayRef<ProtocolConformanceRef> conformances,
                                 SourceLoc loc,
                                 llvm::function_ref<bool(UnsafeUse)> fn) {
   for (auto conformance : conformances) {
+    if (conformance.isInvalid())
+      continue;
+
+    ASTContext &ctx = conformance.getRequirement()->getASTContext();
+    if (!ctx.LangOpts.hasFeature(Feature::WarnUnsafe))
+      return false;
+
     if (!conformance.hasEffect(EffectKind::Unsafe))
       continue;
 

--- a/test/Unsafe/unsafe_in_unsafe.swift
+++ b/test/Unsafe/unsafe_in_unsafe.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -print-diagnostic-groups
+
+// REQUIRES: swift_feature_AllowUnsafeAttribute
+
+
+protocol P { }
+
+struct X: @unsafe P { }
+
+func returnMe(x: X) -> any P {
+  x
+}


### PR DESCRIPTION
I forgot the appropriate feature flag check