### PR TITLE
[Runtime] Add ccAttrs to slow path in compatibility overrides

### DIFF
--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
@@ -195,9 +195,10 @@ namespace swift {
   /* We are creating this separate function for the override case, */          \
   /* to prevent a stack frame from being created for the default case. */      \
   SWIFT_NOINLINE                                                               \
-  static ret swift_##name##Slow(COMPATIBILITY_UNPAREN_WITH_COMMA(typedArgs)    \
-                                    std::atomic<uintptr_t> &Override,          \
-                                uintptr_t fn, Original_##name defaultImpl) {   \
+  ccAttrs static ret swift_##name##Slow(                                       \
+      COMPATIBILITY_UNPAREN_WITH_COMMA(typedArgs)                              \
+          std::atomic<uintptr_t> &Override,                                    \
+      uintptr_t fn, Original_##name defaultImpl) {                             \
     constexpr uintptr_t DEFAULT_IMPL_SENTINEL = 0x1;                           \
     if (SWIFT_UNLIKELY(fn == 0x0)) {                                           \
       fn = (uintptr_t)getOverride_##name();                                    \


### PR DESCRIPTION
rdar://145523626

This was accidentally dropped when introducing the slow path, which causes CC mismatches for functions using custom CC.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
