### PR TITLE
[6.1] Look for keywords in inactive #if regions when checking for variable uses

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -359,11 +359,15 @@ private enum InactiveCodeChecker {
       // match.
       switch self {
       case .name(let name):
-        guard let identifier = token.identifier, identifier.name == name else {
-          continue
+        if let identifier = token.identifier, identifier.name == name {
+          break
         }
 
-        break
+        if case .keyword = token.tokenKind, token.text == name {
+          break
+        }
+
+        continue
 
       case .tryOrThrow:
         guard let keywordKind = token.keywordKind,

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -563,3 +563,16 @@ func testUselessCastWithInvalidParam(foo: Any?) -> Int {
   if let bar = foo as? Foo { return 42 } // expected-warning {{value 'bar' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{20-23=is}}
   else { return 54 }
 }
+
+// https://github.com/swiftlang/swift/issues/79555
+final class A {
+  var x: () -> Void {
+    { [weak self] in // Used to warn: variable 'self' was written to, but never read
+      #if NOT_PROCESSED
+      self?.f()
+      #endif
+    }
+  }
+
+ func f() {}
+}


### PR DESCRIPTION
  - **Explanation**: Removal of the `IfConfigDecl` AST node and the move to the new `SwiftIfConfig` library caused a diagnostics regression when a captured `self` is only referenced within an inactive `#if` region.
  - **Scope**: Only impacts diagnostics by suppressing `variable 'self' was written to, but never read` diagnostic when `self` is used within code in an inactive `#if` region.
  - **Issues**: https://github.com/swiftlang/swift/issues/79555
  - **Original PRs**: https://github.com/swiftlang/swift/pull/79597
  - **Risk**: Low; this change restores the behavior before the removal of `IfConfigDecl` from the AST.
  - **Testing**: N/A
