### PR TITLE
[6.1][Concurrency/Diagnostics] A few fixes to diagnostic downgrades and tracking

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -432,7 +432,8 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
     limitBehavior(limit);
   }
 
-  if (majorVersion == 6) {
+  // Record all of the diagnostics that are going to be emitted.
+  if (majorVersion == 6 && limit != DiagnosticBehavior::Ignore) {
     if (auto stats = Engine->statsReporter) {
       ++stats->getFrontendCounters().NumSwift6Errors;
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2307,8 +2307,11 @@ diagnosePotentialUnavailability(const RootProtocolConformance *rootConf,
         ctx.getTargetPlatformStringForDiagnostics(),
         availability.getRawMinimumVersion());
 
-    err.warnUntilSwiftVersion(6);
-    err.limitBehavior(behaviorLimitForExplicitUnavailability(rootConf, dc));
+    auto behaviorLimit = behaviorLimitForExplicitUnavailability(rootConf, dc);
+    if (behaviorLimit >= DiagnosticBehavior::Warning)
+      err.limitBehavior(behaviorLimit);
+    else
+      err.warnUntilSwiftVersion(6);
 
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(loc, dc, availability, ctx,


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/79599

---

- Explanation:

  Fixes incorrect statistics reporting for Swift 6 errors when presence of `@preconcurrency` downgrades them into ignored state.

  - Avoid downgrading diagnostics multiple times

     Unify `warn` + `limitBehavior` into a single call to make sure
     that diagnostic doesn't get downgraded multiple times because
     that could affect how diagnostics are tracked.

  -  Don't account ignored diagnostics in `Sema.NumSwift6Errors` statistic

     Since the diagnostic is not going to be emitted counting it in
    `Swift6Errors` statistics is going to be confusing to the users.

 
- Main Branch PR: https://github.com/swiftlang/swift/pull/79599

- Risk: Very low (only non-NFC part here is related to statistics which are not enabled by default).

- Resolves: rdar://145341605

- Reviewed By: @hborla 

- Testing: Non-NFC only for statistics


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
