### PR TITLE
AST: Use `AvailabilityDomainOrIdentifier` to store domains in `AvailabilitySpec`

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -705,24 +705,19 @@ BridgedAvailabilitySpec
 BridgedAvailabilitySpec_createWildcard(BridgedASTContext cContext,
                                        BridgedSourceLoc cLoc);
 
-SWIFT_NAME(
-    "BridgedAvailabilitySpec.createPlatformAgnostic(_:kind:nameLoc:version:"
-    "versionRange:)")
-BridgedAvailabilitySpec BridgedAvailabilitySpec_createPlatformAgnostic(
-    BridgedASTContext cContext, BridgedAvailabilitySpecKind cKind,
+SWIFT_NAME("BridgedAvailabilitySpec.create(_:domain:nameLoc:version:"
+           "versionRange:)")
+BridgedAvailabilitySpec BridgedAvailabilitySpec_createForDomain(
+    BridgedASTContext cContext, BridgedAvailabilityDomain cDomain,
     BridgedSourceLoc cLoc, BridgedVersionTuple cVersion,
     BridgedSourceRange cVersionRange);
-
-SWIFT_NAME("BridgedAvailabilitySpec.createPlatformVersioned(_:platform:"
-           "platformLoc:version:versionRange:)")
-BridgedAvailabilitySpec BridgedAvailabilitySpec_createPlatformVersioned(
-    BridgedASTContext cContext, BridgedPlatformKind cPlatform,
-    BridgedSourceLoc cPlatformLoc, BridgedVersionTuple cVersion,
-    BridgedSourceRange cVersionSrcRange);
 
 SWIFT_NAME("getter:BridgedAvailabilitySpec.sourceRange(self:)")
 BridgedSourceRange
 BridgedAvailabilitySpec_getSourceRange(BridgedAvailabilitySpec spec);
+
+SWIFT_NAME("getter:BridgedAvailabilitySpec.isWildcard(self:)")
+bool BridgedAvailabilitySpec_isWildcard(BridgedAvailabilitySpec spec);
 
 SWIFT_NAME("getter:BridgedAvailabilitySpec.domain(self:)")
 BridgedAvailabilityDomain

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -247,6 +247,11 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddPointer(getOpaqueValue());
   }
+
+private:
+  friend class AvailabilityDomainOrIdentifier;
+
+  AvailabilityDomain copy(ASTContext &ctx) const;
 };
 
 /// Represents an availability domain that has been defined in a module.
@@ -317,6 +322,11 @@ public:
       return storage.get<Identifier>();
     return std::nullopt;
   }
+
+  /// Creates a new `AvailabilityDomainOrIdentifier`, defensively copying
+  /// members of the original into the given `ASTContext` in case it is
+  /// different than the context that the original was created for.
+  AvailabilityDomainOrIdentifier copy(ASTContext &ctx) const;
 };
 
 } // end namespace swift

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -86,20 +86,6 @@ static BridgedPlatformKind bridge(PlatformKind platform) {
 // MARK: AvailabilitySpec
 //===----------------------------------------------------------------------===//
 
-static AvailabilitySpecKind unbridge(BridgedAvailabilitySpecKind kind) {
-  switch (kind) {
-  case BridgedAvailabilitySpecKindPlatformVersionConstraint:
-    return AvailabilitySpecKind::PlatformVersionConstraint;
-  case BridgedAvailabilitySpecKindWildcard:
-    return AvailabilitySpecKind::Wildcard;
-  case BridgedAvailabilitySpecKindLanguageVersionConstraint:
-    return AvailabilitySpecKind::LanguageVersionConstraint;
-  case BridgedAvailabilitySpecKindPackageDescriptionVersionConstraint:
-    return AvailabilitySpecKind::PackageDescriptionVersionConstraint;
-  }
-  llvm_unreachable("unhandled enum value");
-}
-
 BridgedAvailabilitySpec
 BridgedAvailabilitySpec_createWildcard(BridgedASTContext cContext,
                                        BridgedSourceLoc cLoc) {
@@ -107,27 +93,22 @@ BridgedAvailabilitySpec_createWildcard(BridgedASTContext cContext,
                                           cLoc.unbridged());
 }
 
-BridgedAvailabilitySpec BridgedAvailabilitySpec_createPlatformAgnostic(
-    BridgedASTContext cContext, BridgedAvailabilitySpecKind cKind,
+BridgedAvailabilitySpec BridgedAvailabilitySpec_createForDomain(
+    BridgedASTContext cContext, BridgedAvailabilityDomain cDomain,
     BridgedSourceLoc cLoc, BridgedVersionTuple cVersion,
     BridgedSourceRange cVersionRange) {
-  return AvailabilitySpec::createPlatformAgnostic(
-      cContext.unbridged(), unbridge(cKind), cLoc.unbridged(),
+  return AvailabilitySpec::createForDomain(
+      cContext.unbridged(), cDomain.unbridged(), cLoc.unbridged(),
       cVersion.unbridged(), cVersionRange.unbridged());
-}
-
-BridgedAvailabilitySpec BridgedAvailabilitySpec_createPlatformVersioned(
-    BridgedASTContext cContext, BridgedPlatformKind cPlatform,
-    BridgedSourceLoc cPlatformLoc, BridgedVersionTuple cVersion,
-    BridgedSourceRange cVersionSrcRange) {
-  return AvailabilitySpec::createPlatformVersioned(
-      cContext.unbridged(), unbridge(cPlatform), cPlatformLoc.unbridged(),
-      cVersion.unbridged(), cVersionSrcRange.unbridged());
 }
 
 BridgedSourceRange
 BridgedAvailabilitySpec_getSourceRange(BridgedAvailabilitySpec spec) {
   return spec.unbridged()->getSourceRange();
+}
+
+bool BridgedAvailabilitySpec_isWildcard(BridgedAvailabilitySpec spec) {
+  return spec.unbridged()->isWildcard();
 }
 
 BridgedAvailabilityDomain

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -72,6 +72,9 @@ extension ASTGenVisitor {
 
     var result: [BridgedAvailableAttr] = []
     for spec in specs {
+      guard !spec.isWildcard else {
+        continue
+      }
       let domain = spec.domain
       guard !domain.isNull() else {
         continue
@@ -287,13 +290,13 @@ extension ASTGenVisitor {
 
       switch domainNode.rawText {
       case "swift", "_PackageVersion":
-        let kind: BridgedAvailabilitySpecKind = domainNode.rawText == "swift"
-          ? .languageVersionConstraint
-          : .packageDescriptionVersionConstraint
+        let domain: BridgedAvailabilityDomain = domainNode.rawText == "swift"
+          ? .forSwiftLanguage()
+          : .forPackageDescription()
 
-        let spec = BridgedAvailabilitySpec.createPlatformAgnostic(
+        let spec = BridgedAvailabilitySpec.create(
           self.ctx,
-          kind: kind,
+          domain: domain,
           nameLoc: nameLoc,
           version: version?.bridged ?? BridgedVersionTuple(),
           versionRange: versionRange
@@ -329,10 +332,10 @@ extension ASTGenVisitor {
             // TODO: Diagnostics.
             fatalError("expected version")
           }
-          let spec = BridgedAvailabilitySpec.createPlatformVersioned(
+          let spec = BridgedAvailabilitySpec.create(
             self.ctx,
-            platform: platform,
-            platformLoc: nameLoc,
+            domain: BridgedAvailabilityDomain.forPlatform(platform),
+            nameLoc: nameLoc,
             version: version.bridged,
             versionRange: versionRange
           )

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -201,8 +201,9 @@ struct RuntimeVersionCheck {
   /// fails, e.g. "guard #available(iOS 10, *) else { return nil }".
   Stmt *createEarlyReturnStmt(ASTContext &C) const {
     // platformSpec = "\(attr.platform) \(attr.introduced)"
-    auto platformSpec = AvailabilitySpec::createPlatformVersioned(
-        C, Platform, SourceLoc(), Version, SourceLoc());
+    auto platformSpec = AvailabilitySpec::createForDomain(
+        C, AvailabilityDomain::forPlatform(Platform), SourceLoc(), Version,
+        SourceLoc());
 
     // wildcardSpec = "*"
     auto wildcardSpec = AvailabilitySpec::createWildcard(C, SourceLoc());

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -464,7 +464,7 @@ class AvailabilityScopeBuilder : private ASTWalker {
   }
 
   const char *stackTraceAction() const {
-    return "building availabiilty scope for";
+    return "building availabilty scope for";
   }
 
   friend class swift::ExpandChildAvailabilityScopesRequest;


### PR DESCRIPTION
This is another step towards deferring resolution of the `AvailabilityDomain` associated with an `AvailabilitySpec` from parsing to type-checking. NFC.