### PR TITLE
LICM: fix handling of stores of Optional.none in OSSA

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -909,7 +909,17 @@ void LoopTreeOptimization::analyzeCurrentLoop(
         LoadsAndStores.push_back(&Inst);
         break;
       case SILInstructionKind::StoreInst: {
-        Stores.push_back(cast<StoreInst>(&Inst));
+        auto *store = cast<StoreInst>(&Inst);
+        switch (store->getOwnershipQualifier()) {
+          case StoreOwnershipQualifier::Assign:
+          case StoreOwnershipQualifier::Init:
+            // Currently not supported.
+            continue;
+          case StoreOwnershipQualifier::Unqualified:
+          case StoreOwnershipQualifier::Trivial:
+            break;
+        }
+        Stores.push_back(store);
         LoadsAndStores.push_back(&Inst);
         checkSideEffects(Inst, sideEffects, sideEffectsInBlock);
         break;

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1639,3 +1639,31 @@ bb3:
   %15 = tuple ()
   return %15
 }
+
+// Hoisting non-trivial loads/stores is currently not supported in OSSA.
+// CHECK-LABEL: sil [ossa] @store_of_optional_none :
+// CHECK:       bb2:
+// CHECK:         store %0 to [assign] %1
+// CHECK:       bb3:
+// CHECK-LABEL: } // end sil function 'store_of_optional_none'
+sil [ossa] @store_of_optional_none : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $Optional<String>, #Optional.none!enumelt 
+  %1 = alloc_stack $Optional<String>
+  store %0 to [init] %1
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  store %0 to [assign] %1
+  br bb1
+
+bb3:
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple()
+  return %r : $()
+}
+


### PR DESCRIPTION
Currently we don't support hoisting ownership instructions. But the check was missing a store of Optional.none because such a value has no ownership even if the optional is not trivial.

Fixes a SIL verifier crash.
https://github.com/swiftlang/swift/issues/79491
