### PR TITLE
Fix BorrowedFromInst operand ownership.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
@@ -91,7 +91,9 @@ private func optimize(value: Value, _ context: FunctionPassContext) {
   var hoistableDestroys = selectHoistableDestroys(of: value, context)
   defer { hoistableDestroys.deinitialize() }
 
-  var minimalLiverange = InstructionRange(withLiverangeOf: value, ignoring: hoistableDestroys, context)
+  guard var minimalLiverange = InstructionRange(withLiverangeOf: value, ignoring: hoistableDestroys, context) else {
+    return
+  }
   defer { minimalLiverange.deinitialize() }
 
   hoistDestroys(of: value, toEndOf: minimalLiverange, restrictingTo: &hoistableDestroys, context)
@@ -177,10 +179,10 @@ private func removeDestroys(
 
 private extension InstructionRange {
 
-  init(withLiverangeOf initialDef: Value, ignoring ignoreDestroys: InstructionSet, _ context: FunctionPassContext)
+  init?(withLiverangeOf initialDef: Value, ignoring ignoreDestroys: InstructionSet, _ context: FunctionPassContext)
   {
     var liverange = InstructionRange(for: initialDef, context)
-    var visitor = InteriorUseWalker(definingValue: initialDef, ignoreEscape: true, visitInnerUses: true, context) {
+    var visitor = InteriorUseWalker(definingValue: initialDef, ignoreEscape: false, visitInnerUses: true, context) {
       if !ignoreDestroys.contains($0.instruction) {
         liverange.insert($0.instruction)
       }
@@ -197,7 +199,10 @@ private extension InstructionRange {
       return .continueWalk
     }
 
-    _ = visitor.visitUses()
+    guard visitor.visitUses() == .continueWalk else {
+      liverange.deinitialize()
+      return nil
+    }
     self = liverange
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DestroyHoisting.swift
@@ -180,7 +180,7 @@ private extension InstructionRange {
   init(withLiverangeOf initialDef: Value, ignoring ignoreDestroys: InstructionSet, _ context: FunctionPassContext)
   {
     var liverange = InstructionRange(for: initialDef, context)
-    var visitor = InteriorUseWalker(definingValue: initialDef, ignoreEscape: true, visitInnerUses: false, context) {
+    var visitor = InteriorUseWalker(definingValue: initialDef, ignoreEscape: true, visitInnerUses: true, context) {
       if !ignoreDestroys.contains($0.instruction) {
         liverange.insert($0.instruction)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -554,8 +554,8 @@ extension AddressOwnershipLiveRange {
   ///
   /// For address values, use AccessBase.computeOwnershipRange.
   ///
-  /// FIXME: This should use computeLinearLiveness rather than computeKnownLiveness as soon as lifetime completion
-  /// runs immediately after SILGen.
+  /// FIXME: This should use computeLinearLiveness rather than computeKnownLiveness as soon as complete OSSA lifetimes
+  /// are verified.
   private static func computeValueLiveRange(of value: Value, _ context: FunctionPassContext)
     -> AddressOwnershipLiveRange? {
     switch value.ownership {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -204,6 +204,13 @@ enum BorrowingInstruction : CustomStringConvertible, Hashable {
     }
   }
 
+  var innerValue: Value? {
+    if let dependent = dependentValue {
+      return dependent
+    }
+    return scopedValue
+  }
+
   var dependentValue: Value? {
     switch self {
     case .borrowedFrom(let bfi):

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -142,9 +142,9 @@ import SIL
 ///
 /// Note: This must handle all instructions with a .borrow operand ownership.
 ///
-/// Note: borrowed_from is a BorrowingInstruction because it creates a borrow scope for its base operand. Its result,
-/// however, is only a BeginBorrowValue (.reborrow) if it forwards a reborrow phi. Otherwise, it simply forwards a
-/// guaranteed value and does not introduce a separate borrow scope.
+/// Note: borrowed_from is a BorrowingInstruction because it creates a borrow scope for its enclosing operands. Its
+/// result, however, is only a BeginBorrowValue (.reborrow) if it forwards a reborrow phi. Otherwise, it simply forwards
+/// a guaranteed value and does not introduce a separate borrow scope.
 ///
 /// Note: mark_dependence [nonescaping] is a BorrowingInstruction because it creates a borrow scope for its base
 /// operand. Its result, however, is not a BeginBorrowValue. Instead it is a ForwardingInstruction relative to its value

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -299,7 +299,7 @@ enum BorrowingInstruction : CustomStringConvertible, Hashable {
 extension BorrowingInstruction {
   private func visitEndBorrows(value: Value, _ context: Context, _ visitor: @escaping (Operand) -> WalkResult)
     -> WalkResult {
-    return value.uses.filterUsers(ofType: EndBorrowInst.self).walk {
+    return value.lookThroughBorrowedFromUser.uses.filterUsers(ofType: EndBorrowInst.self).walk {
       visitor($0)
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -134,14 +134,11 @@ import SIL
 
 /// A scoped instruction that borrows one or more operands.
 ///
-/// If this instruction produces a borrowed value, then
-/// BeginBorrowValue(resultOf: self) != nil.
+/// If this instruction produces a borrowed value, then BeginBorrowValue(resultOf: self) != nil.
 ///
-/// This does not include instructions like `apply` and `try_apply` that
-/// instantaneously borrow a value from the caller.
+/// This does not include instructions like `apply` and `try_apply` that instantaneously borrow a value from the caller.
 ///
-/// This does not include `load_borrow` because it borrows a memory
-/// location, not the value of its operand.
+/// This does not include `load_borrow` because it borrows a memory location, not the value of its operand.
 ///
 /// Note: This must handle all instructions with a .borrow operand ownership.
 ///

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -771,6 +771,8 @@ extension LifetimeDependenceDefUseWalker {
     switch borrowInst {
     case let .beginBorrow(bbi):
       return walkDownUses(of: bbi, using: operand)
+    case let .borrowedFrom(bfi):
+      return walkDownUses(of: bfi, using: operand)
     case let .storeBorrow(sbi):
       return walkDownAddressUses(of: sbi)
     case .beginApply:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -778,7 +778,7 @@ extension LifetimeDependenceDefUseWalker {
     case .beginApply:
       // Skip the borrow scope; the type system enforces non-escapable
       // arguments.
-      return visitInnerBorrowUses(of: borrowInst)
+      return visitInnerBorrowUses(of: borrowInst, operand: operand)
     case .partialApply, .markDependence:
       fatalError("OwnershipUseVisitor should bypass partial_apply [on_stack] "
                  + "and mark_dependence [nonescaping]")

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -608,9 +608,9 @@ extension InteriorUseWalker: OwnershipUseVisitor {
       if handleInner(borrowed: beginBorrow.value) == .abortWalk {
         return .abortWalk
       }
-      if visitInnerUses {
-        return visitAllUses(of: beginBorrow.value)
-      }
+    }
+    if visitInnerUses, let innerValue = borrowInst.innerValue {
+      return visitAllUses(of: innerValue)
     }
     return visitInnerBorrowUses(of: borrowInst, operand: operand)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -552,25 +552,6 @@ struct InteriorUseWalker {
   }
 
   mutating func visitUses() -> WalkResult {
-    // If the outer value is an owned phi or reborrow, consider inner
-    // adjacent phis part of its lifetime.
-    if let phi = Phi(definingValue), phi.endsLifetime {
-      let result = phi.innerAdjacentPhis.walk { innerPhi in
-        if innerPhi.isReborrow {
-          // Inner adjacent reborrows are considered inner borrow scopes.
-          if handleInner(borrowed: innerPhi.value) == .abortWalk {
-            return .abortWalk
-          }
-          return visitInnerScopeUses(of: innerPhi.value)
-        } else {
-          // Inner adjacent guaranteed phis are uses of the outer borrow.
-          return visitAllUses(of: innerPhi.value)
-        }
-      }
-      if result == .abortWalk {
-        return .abortWalk
-      }
-    }
     return visitAllUses(of: definingValue)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -579,10 +579,6 @@ extension InteriorUseWalker: OwnershipUseVisitor {
 
   mutating func interiorPointerUse(of operand: Operand, into address: Value)
     -> WalkResult {
-    // OSSA lifetime ignores trivial types.
-    if operand.value.type.isTrivial(in: function) {
-      return .continueWalk
-    }
     if useVisitor(operand) == .abortWalk {
       return .abortWalk
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -448,6 +448,8 @@ extension OwnershipUseVisitor {
     case let mdi as MarkDependenceInst:
       assert(operand == mdi.baseOperand && mdi.isNonEscaping)
       return dependentUse(of: operand, into: mdi)
+    case let bfi as BorrowedFromInst where !bfi.borrowedPhi.isReborrow:
+      return dependentUse(of: operand, into: bfi)
     default:
       return borrowingUse(of: operand,
                           by: BorrowingInstruction(operand.instruction)!)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -365,6 +365,12 @@ extension OwnershipUseVisitor {
     if let beginBorrow = BeginBorrowValue(resultOf: borrowInst) {
       return visitInnerScopeUses(of: beginBorrow.value)
     }
+    if let dependent = borrowInst.dependentValue {
+      if dependent.ownership == .guaranteed {
+        return visitAllUses(of: dependent)
+      }
+      return pointerEscapingUse(of: operand)
+    }
     // Otherwise, directly visit the scope ending uses as leaf uses.
     //
     // TODO: remove this stack by changing visitScopeEndingOperands to take a non-escaping closure.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -785,6 +785,10 @@ extension InteriorUseWalker {
     }
     switch value.ownership {
     case .owned:
+      // Each owned lifetime is an inner scope.
+      if handleInner(borrowed: value) == .abortWalk {
+        return .abortWalk
+      }
       return visitInnerScopeUses(of: value)
     case .guaranteed:
       return visitAllUses(of: value)
@@ -928,6 +932,11 @@ let interiorLivenessTest = FunctionTest("interior_liveness_swift") {
     return .continueWalk
   }
   defer { visitor.deinitialize() }
+
+  visitor.innerScopeHandler = {
+    print("Inner scope: \($0)")
+    return .continueWalk
+  }
 
   let success = visitor.visitUses()
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1087,6 +1087,10 @@ class MarkDependenceInst : SingleValueInstruction {
   public func settleToEscaping() {
     bridged.MarkDependenceInst_settleToEscaping()
   }
+
+  public var hasScopedLifetime: Bool {
+    return isNonEscaping && type.isObject && ownership == .owned && type.isEscapable(in: parentFunction)
+  }
 }
 
 final public class RefToBridgeObjectInst : SingleValueInstruction {

--- a/include/swift/SIL/OwnershipLiveness.h
+++ b/include/swift/SIL/OwnershipLiveness.h
@@ -242,10 +242,6 @@ public:
   // Summarize address uses
   AddressUseKind addressUseKind = AddressUseKind::Unknown;
 
-  // Record any guaranteed phi uses that are not already enclosed by an outer
-  // adjacent phi.
-  SmallVector<SILValue, 8> unenclosedPhis;
-
 public:
   InteriorLiveness(SILValue def): OSSALiveness(def) {}
 
@@ -258,8 +254,6 @@ public:
   }
 
   AddressUseKind getAddressUseKind() const { return addressUseKind; }
-
-  ArrayRef<SILValue> getUnenclosedPhis() const { return unenclosedPhis; }
 
   void print(llvm::raw_ostream &OS) const;
   void dump() const;

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -326,7 +326,7 @@ bool OwnershipUseVisitor<Impl>::visitInnerBorrowScopeEnd(Operand *borrowEnd) {
     // partial_apply [on_stack] and mark_dependence [nonescaping] can introduce
     // borrowing operand and can have destroy_value, return, or store consumes.
     //
-    // TODO: When we have a C++ ForwardingUseDefWalker, walk the def-use
+    // TODO: When we have a C++ ForwardingUseDefWalker, walk the use-def
     // chain to ensure we have a partial_apply [on_stack] or mark_dependence
     // [nonescaping] def.
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -362,6 +362,10 @@ struct BorrowingOperand {
   /// Returns false and early exits if the \p visitScopeEnd or \p
   /// visitUnknownUse returns false.
   ///
+  /// This only calls 'visitScopeEnd` when getScopeIntroducingUserResult() is
+  /// valid. Otherwise, it immediate calls visitUnknownUse on the current
+  /// operand.
+  ///
   /// For an instantaneous borrow, such as apply, this visits no uses. For
   /// begin_apply it visits the end_apply uses. For borrow introducers, it
   /// visits the end of the introduced borrow scope.
@@ -430,25 +434,7 @@ struct BorrowingOperand {
   /// If true, getBorrowIntroducingUserResult() can be called to acquire the
   /// SILValue that introduces a new borrow scope.
   bool hasBorrowIntroducingUser() const {
-    // TODO: Can we derive this by running a borrow introducer check ourselves?
-    switch (kind) {
-    case BorrowingOperandKind::Invalid:
-      llvm_unreachable("Using invalid case?!");
-    case BorrowingOperandKind::BeginBorrow:
-    case BorrowingOperandKind::BorrowedFrom:
-    case BorrowingOperandKind::Branch:
-      return true;
-    case BorrowingOperandKind::StoreBorrow:
-    case BorrowingOperandKind::BeginApply:
-    case BorrowingOperandKind::Apply:
-    case BorrowingOperandKind::TryApply:
-    case BorrowingOperandKind::Yield:
-    case BorrowingOperandKind::PartialApplyStack:
-    case BorrowingOperandKind::MarkDependenceNonEscaping:
-    case BorrowingOperandKind::BeginAsyncLet:
-      return false;
-    }
-    llvm_unreachable("Covered switch isn't covered?!");
+    return getBorrowIntroducingUserResult() != SILValue();
   }
 
   /// If this operand's user has a single result that introduces the borrow
@@ -457,8 +443,21 @@ struct BorrowingOperand {
   /// guaranteed forwarding phis, are not scoped.
   SILValue getBorrowIntroducingUserResult() const;
 
-  /// Return the borrowing operand's value.
-  SILValue getScopeIntroducingUserResult();
+  /// Return the borrowing operand's value if it is a scoped operation,
+  /// such as partial_apply, mark_dependence, store_borrow, begin_async_let.
+  ///
+  /// This is meant to be equivalent to BeginBorrowValue in
+  /// SwiftCompilerSources.
+  SILValue getScopeIntroducingUserResult() const;
+
+  // Return the dependent value of borrowed-from or mark_dependence.
+  //
+  // This only returns a valid result when getScopeIntroducingUserResult()
+  // returns an invalid result. Ideally, we would convert BorrowingOperand into
+  // an enum to partition the kinds of borrows.
+  //
+  // This may be a guaranteed, trivial, or owned non-escapable value.
+  SILValue getDependentUserResult() const;
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -460,12 +460,6 @@ struct BorrowingOperand {
   /// Return the borrowing operand's value.
   SILValue getScopeIntroducingUserResult();
 
-  /// Compute the implicit uses that this borrowing operand "injects" into the
-  /// set of its operands uses.
-  ///
-  /// E.x.: end_apply uses.
-  void getImplicitUses(SmallVectorImpl<Operand *> &foundUses) const;
-
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -365,6 +365,10 @@ struct BorrowingOperand {
   /// For an instantaneous borrow, such as apply, this visits no uses. For
   /// begin_apply it visits the end_apply uses. For borrow introducers, it
   /// visits the end of the introduced borrow scope.
+  ///
+  /// For borrows that don't introduce a separate borrow scope, this calls
+  /// visitUnknownUse on the current operand. The client may need to check each
+  /// unknown operand to avoid infinite recursion.
   bool visitScopeEndingUses(function_ref<bool(Operand *)> visitScopeEnd,
                             function_ref<bool(Operand *)> visitUnknownUse
                             = [](Operand *){ return false; })

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -428,7 +428,7 @@ struct BorrowingOperand {
   /// cannot be reborrowed.
   ///
   /// If true, getBorrowIntroducingUserResult() can be called to acquire the
-  /// BorrowedValue that introduces a new borrow scope.
+  /// SILValue that introduces a new borrow scope.
   bool hasBorrowIntroducingUser() const {
     // TODO: Can we derive this by running a borrow introducer check ourselves?
     switch (kind) {
@@ -451,9 +451,11 @@ struct BorrowingOperand {
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
-  /// If this operand's user has a borrowed value result return a valid
-  /// BorrowedValue instance.
-  BorrowedValue getBorrowIntroducingUserResult() const;
+  /// If this operand's user has a single result that introduces the borrow
+  /// scope, return the result value. If the result is scoped (begin_borrow)
+  /// then it can be used to initialize a BorrowedValue. Some results, like
+  /// guaranteed forwarding phis, are not scoped.
+  SILValue getBorrowIntroducingUserResult() const;
 
   /// Return the borrowing operand's value.
   SILValue getScopeIntroducingUserResult();

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4782,6 +4782,8 @@ public:
   OperandValueArrayRef getEnclosingValues() const {
     return OperandValueArrayRef(getEnclosingValueOperands());
   }
+
+  bool isReborrow() const;
 };
 
 inline auto BeginBorrowInst::getEndBorrows() const -> EndBorrowRange {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4769,7 +4769,7 @@ class BorrowedFromInst final : public InstructionBaseWithTrailingOperands<
 
 public:
 
-  SILValue getBorrowedValue() {
+  SILValue getBorrowedValue() const {
     return getAllOperands()[0].get();
   }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8815,10 +8815,14 @@ public:
       uint8_t(MarkDependenceKind::Escaping);
   }
 
-  /// Visit the instructions that end the lifetime of an OSSA on-stack closure.
+  /// Visit the instructions that end the lifetime the dependent value.
+  ///
+  /// Preconditions:
+  /// - isNonEscaping()
+  /// - Produces an owned, Escapable, non-address value
   bool visitNonEscapingLifetimeEnds(
     llvm::function_ref<bool (Operand*)> visitScopeEnd,
-    llvm::function_ref<bool (Operand*)> visitUnknownUse) const;
+    llvm::function_ref<bool (Operand*)> visitUnknownUse);
 };
 
 /// Promote an Objective-C block that is on the stack to the heap, or simply

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8815,6 +8815,14 @@ public:
       uint8_t(MarkDependenceKind::Escaping);
   }
 
+  // True if the dependence is limited to the scope of an OSSA lifetime. Only
+  // for nonescaping dependencies with owned escapable values.
+  bool hasScopedLifetime() const {
+    return isNonEscaping() && getType().isObject()
+      && getOwnershipKind() == OwnershipKind::Owned
+      && getType().isEscapable(*getFunction());
+  }
+
   /// Visit the instructions that end the lifetime the dependent value.
   ///
   /// Preconditions:

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -429,7 +429,7 @@ OperandOwnershipClassifier::visitBeginBorrowInst(BeginBorrowInst *borrow) {
 OperandOwnership
 OperandOwnershipClassifier::visitBorrowedFromInst(BorrowedFromInst *bfi) {
   return getOperandIndex() == 0 ? OperandOwnership::GuaranteedForwarding
-                                : OperandOwnership::InstantaneousUse;
+                                : OperandOwnership::Borrow;
 }
 
 // MARK: Instructions whose use ownership depends on the operand in question.

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -301,6 +301,14 @@ Operand *BeginBorrowInst::getSingleNonEndingUse() const {
   return singleUse;
 }
 
+bool BorrowedFromInst::isReborrow() const {
+  // The forwarded operand is either a phi or undef.
+  if (auto *phi = dyn_cast<SILPhiArgument>(getBorrowedValue())) {
+    return phi->isReborrow();
+  }
+  return false;
+}
+
 namespace {
 class InstructionDestroyer
     : public SILInstructionVisitor<InstructionDestroyer> {

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -2022,10 +2022,13 @@ visitRecursivelyLifetimeEndingUses(
 // the dependent value.
 bool MarkDependenceInst::visitNonEscapingLifetimeEnds(
   llvm::function_ref<bool (Operand *)> visitScopeEnd,
-  llvm::function_ref<bool (Operand *)> visitUnknownUse) const {
+  llvm::function_ref<bool (Operand *)> visitUnknownUse) {
   assert(getFunction()->hasOwnership() && isNonEscaping()
          && "only meaningful for nonescaping dependencies");
   assert(getType().isObject() && "lifetime ends only exist for values");
+  assert(getOwnershipKind() == OwnershipKind::Owned
+         && getType().isEscapable(*getFunction())
+         && "only correct for owned escapable values");
   bool noUsers = true;
   if (!visitRecursivelyLifetimeEndingUses(this, noUsers, visitScopeEnd,
                                           visitUnknownUse)) {

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -524,11 +524,6 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(SILValue value,
   }
   InteriorLiveness liveness(value);
   liveness.compute(domInfo, handleInnerScope);
-  // TODO: Rebuild outer adjacent phis on demand (SILGen does not currently
-  // produce guaranteed phis). See FindEnclosingDefs &
-  // findSuccessorDefsFromPredDefs. If no enclosing phi is found, we can create
-  // it here and use updateSSA to recursively populate phis.
-  assert(liveness.getUnenclosedPhis().empty());
   return endLifetimeAtBoundary(value, liveness.getLiveness(), boundary,
                                deadEndBlocks);
 }

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -159,8 +159,7 @@ struct InteriorLivenessVisitor :
   /// Handles begin_borrow, load_borrow, store_borrow, begin_apply.
   bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
     if (handleInnerScopeCallback) {
-      auto value = borrowingOperand.getScopeIntroducingUserResult();
-      if (value) {
+      if (auto value = borrowingOperand.getScopeIntroducingUserResult()) {
         handleInnerScopeCallback(value);
       }
     }

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -150,6 +150,8 @@ struct InteriorLivenessVisitor :
 
   bool handlePointerEscape(Operand *use) {
     interiorLiveness.addressUseKind = AddressUseKind::PointerEscape;
+    if (!handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding))
+      return false;
 
     return true;
   }

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -102,6 +102,14 @@ void LinearLiveness::compute() {
   LinearLivenessVisitor(*this).visitLifetimeEndingUses(ownershipDef);
 }
 
+/// Override OwnershipUseVisitor to callback to handleInnerScopeCallback for
+/// nested borrow scopes. This supports lifetime completion from the inside-out.
+///
+/// By default, handleOwnedPhi and handleOuterReborrow are already treated like
+/// a normal lifetime-ending use.
+///
+/// By default, handleGuaranteedForwardingPhi is already treated like a normal
+/// non-lifetime-ending use.
 struct InteriorLivenessVisitor :
   public OwnershipUseVisitor<InteriorLivenessVisitor> {
 
@@ -142,14 +150,7 @@ struct InteriorLivenessVisitor :
 
   bool handlePointerEscape(Operand *use) {
     interiorLiveness.addressUseKind = AddressUseKind::PointerEscape;
-    return true;
-  }
 
-  // handleOwnedPhi and handleOuterReborrow ends the linear lifetime.
-  // By default, they are treated like a normal lifetime-ending use.
-
-  bool handleGuaranteedForwardingPhi(Operand *use) {
-    recursivelyVisitInnerGuaranteedPhi(PhiOperand(use), /*reborrow*/false);
     return true;
   }
 
@@ -166,18 +167,6 @@ struct InteriorLivenessVisitor :
     return true;
   }
 
-  bool handleInnerAdjacentReborrow(SILArgument *reborrow) {
-    if (handleInnerScopeCallback) {
-      handleInnerScopeCallback(reborrow);
-    }
-    return true;
-  }
-
-  bool handleInnerReborrow(Operand *phiOper) {
-    recursivelyVisitInnerGuaranteedPhi(PhiOperand(phiOper), /*reborrow*/true);
-    return true;
-  }
-
   /// After this returns true, handleUsePoint will be called on the scope
   /// ending operands.
   ///
@@ -188,87 +177,7 @@ struct InteriorLivenessVisitor :
     }
     return true;
   }
-
-  void recursivelyVisitInnerGuaranteedPhi(PhiOperand phiOper, bool isReborrow);
 };
-
-// Dominating ownershipDef example: handleReborrow must continue visiting phi
-// uses:
-//
-// bb0:
-//  d1 = ...
-//  cond_br bb1, bb2
-// bb1:
-//   b1 = borrow d1
-//   br bb3(b1)
-// bb2:
-//   b2 = borrow d1
-//   br bb3(b2)
-// bb3(reborrow):
-//   u1 = d1
-//   u2 = reborrow
-//   // can't move destroy above u2
-//   destroy_value d1
-//
-// Dominating ownershipDef example: handleGuaranteedForwardingPhi must continue
-// visiting phi uses:
-//
-// bb0:
-//  b1 = borrow d1
-//  cond_br bb1, bb2
-// bb1:
-//   p1 = projection b1
-//   br bb3(p1)
-// bb2:
-//   p1 = projection b1
-//   br bb3(p2)
-// bb3(forwardingPhi):
-//   u1 = b1
-//   u2 = forwardingPhi
-//   // can't move end_borrow above u2
-//   end_borrow b1
-//
-// TODO: when phi's have a reborrow flag, remove \p isReborrow.
-void InteriorLivenessVisitor::
-recursivelyVisitInnerGuaranteedPhi(PhiOperand phiOper, bool isReborrow) {
-  SILValue phiValue = phiOper.getValue();
-  if (!visited.insert(phiValue))
-    return;
-
-  if (!visitEnclosingDefs(phiValue, [this](SILValue enclosingDef){
-    // If the enclosing def is \p ownershipDef, return false to check
-    // dominance.
-    if (enclosingDef == interiorLiveness.ownershipDef)
-      return false;
-
-    // Otherwise, phiValue is enclosed by an outer adjacent phi, so its scope
-    // does not contribute to the outer liveness. This phi will be recorded as a
-    // regular use by the visitor, and this enclosing def will be visited as
-    // separate lifetime-ending-use use. Return true to continue checking if any
-    // other enclosing defs do not have an outer adjacent reborrow.
-    return true;
-  })) {
-    // TODO: instead of relying on Dominance, we can reformulate this algorithm
-    // to detect redundant phis, similar to the SSAUpdater.
-    //
-    // At least one enclosing def is ownershipDef. If ownershipDef dominates
-    // phiValue, then this is consistent with a well-formed linear lifetime, and
-    // the phi's uses directly contribute to ownershipDef's liveness.
-    if (domInfo &&
-        domInfo->dominates(interiorLiveness.ownershipDef->getParentBlock(),
-                           phiValue->getParentBlock())) {
-      if (isReborrow) {
-        visitInnerBorrow(phiOper.getOperand());
-      } else {
-        visitInteriorUses(phiValue);
-      }
-      return;
-    }
-    // ownershipDef does not dominate this phi. Record it so the liveness
-    // client can use this information to insert the missing outer adjacent phi.
-    interiorLiveness.unenclosedPhis.push_back(phiValue);
-  }
-}
 
 void InteriorLiveness::compute(const DominanceInfo *domInfo, InnerScopeHandlerRef handleInnerScope) {
   liveness.initializeDef(ownershipDef);
@@ -291,11 +200,6 @@ void InteriorLiveness::print(llvm::raw_ostream &OS) const {
     OS << "Incomplete liveness: Unknown address use\n";
     break;
   }
-  OS << "Unenclosed phis {\n";
-  for (SILValue phi : getUnenclosedPhis()) {
-    OS << "  " << phi;
-  }
-  OS << "}\n";
 }
 
 void InteriorLiveness::dump() const { print(llvm::dbgs()); }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1110,12 +1110,11 @@ bool BorrowedValue::visitInteriorPointerOperandHelper(
       continue;
     }
 
-    // Look through object. SingleValueInstruction is overly restrictive but
-    // rules out any interesting corner cases.
+    // Look through object.
     if (auto *svi = dyn_cast<SingleValueInstruction>(user)) {
-      if (ForwardingInstruction::isa(user)) {
-        for (auto *use : svi->getUses()) {
-          worklist.push_back(use);
+      if (Projection::isObjectProjection(svi)) {
+        for (SILValue result : user->getResults()) {
+          llvm::copy(result->getUses(), std::back_inserter(worklist));
         }
         continue;
       }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1110,11 +1110,12 @@ bool BorrowedValue::visitInteriorPointerOperandHelper(
       continue;
     }
 
-    // Look through object.
+    // Look through object. SingleValueInstruction is overly restrictive but
+    // rules out any interesting corner cases.
     if (auto *svi = dyn_cast<SingleValueInstruction>(user)) {
-      if (Projection::isObjectProjection(svi)) {
-        for (SILValue result : user->getResults()) {
-          llvm::copy(result->getUses(), std::back_inserter(worklist));
+      if (ForwardingInstruction::isa(user)) {
+        for (auto *use : svi->getUses()) {
+          worklist.push_back(use);
         }
         continue;
       }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -828,20 +828,6 @@ SILValue BorrowingOperand::getScopeIntroducingUserResult() {
   llvm_unreachable("covered switch");
 }
 
-void BorrowingOperand::getImplicitUses(
-    SmallVectorImpl<Operand *> &foundUses) const {
-  // FIXME: this visitScopeEndingUses should never return false once dead
-  // borrows are disallowed.
-  auto handleUse = [&](Operand *endOp) {
-    foundUses.push_back(endOp);
-    return true;
-  };
-  if (!visitScopeEndingUses(handleUse, handleUse)) {
-    // Special-case for dead borrows.
-    foundUses.push_back(op);
-  }
-}
-
 //===----------------------------------------------------------------------===//
 //                             Borrow Introducers
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -278,21 +278,18 @@ PrunedLiveRange<LivenessWithDefs>::updateForBorrowingOperand(Operand *operand) {
   // Note: Ownership liveness should follow reborrows that are dominated by the
   // ownership definition.
   auto innerBorrowKind = InnerBorrowKind::Contained;
-  if (!BorrowingOperand(operand).visitScopeEndingUses(
-        [&](Operand *end) {
-          if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
-            innerBorrowKind = InnerBorrowKind::Reborrowed;
-          }
-          updateForUse(end->getUser(), /*lifetimeEnding*/ false);
-          return true;
-        }, [&](Operand *unknownUse) {
-          updateForUse(unknownUse->getUser(), /*lifetimeEnding*/ false);
-          innerBorrowKind = InnerBorrowKind::Escaped;
-          return true;
-        })) {
-    // Handle dead borrows.
-    updateForUse(operand->getUser(), /*lifetimeEnding*/ false);
-  }
+  BorrowingOperand(operand).visitScopeEndingUses(
+    [&](Operand *end) {
+      if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
+        innerBorrowKind = InnerBorrowKind::Reborrowed;
+      }
+      updateForUse(end->getUser(), /*lifetimeEnding*/ false);
+      return true;
+    }, [&](Operand *unknownUse) {
+      updateForUse(unknownUse->getUser(), /*lifetimeEnding*/ false);
+      innerBorrowKind = InnerBorrowKind::Escaped;
+      return true;
+    });
   return innerBorrowKind;
 }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -119,8 +119,10 @@ SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
     if (auto operand = BorrowingOperand(use)) {
       if (operand.isReborrow())
         return nullptr;
-      auto bv = operand.getBorrowIntroducingUserResult();
-      accumulatedBorrowedValues.push_back(bv);
+      auto result = operand.getBorrowIntroducingUserResult();
+      if (auto bv = BorrowedValue(result)) {
+        accumulatedBorrowedValues.push_back(bv);
+      }
       continue;
     }
 

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -618,7 +618,7 @@ void BorrowedLifetimeExtender::analyzeExtendedScope() {
       SWIFT_ASSERT_ONLY(reborrowedOperands.insert(endScope));
 
       // TODO: if non-phi reborrows are added, handle multiple results.
-      discoverReborrow(borrowingOper.getBorrowIntroducingUserResult().value);
+      discoverReborrow(borrowingOper.getBorrowIntroducingUserResult());
     }
     return true;
   };

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPT
-// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -mandatory-copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ONONE
+// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -mandatory-copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK
 
 // REQUIRES: asserts
 
@@ -836,14 +836,16 @@ bb4:
   return %v : $()
 }
 
-// Test a dead begin_borrow (with no scope ending uses). Make sure
-// copy-propagation doesn't end the lifetime before the dead borrow.
+// Test a dead begin_borrow (with no scope ending uses).
+//
+// TODO: with lifetime completion, both copies should be deleted.
 //
 // CHECK-LABEL: sil hidden [ossa] @testDeadBorrow : {{.*}} {
 // CHECK: bb0:
-// CHECK-NOT: copy_value
-// CHECK:   begin_borrow
+// CHECK:   copy_value
 // CHECK:   destroy_value
+// CHECK:   copy_value
+// CHECK:   begin_borrow
 // CHECK:   unreachable
 // CHECK-LABEL: } // end sil function 'testDeadBorrow'
 sil hidden [ossa] @testDeadBorrow : $@convention(thin) () -> () {

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -258,9 +258,9 @@ bb3(%phi : @guaranteed $D):
 // CHECK-NEXT: Incomplete liveness: Reborrowed inner scope
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
-// CHECK-NEXT: regular user:   %7 = borrowed %4 : $C from (%0 : $C)
-// CHECK-NEXT: regular user:   br bb1(%1 : $C, %2 : $PairC)
-// CHECK-NEXT: last user:   %7 = borrowed %4 : $C from (%0 : $C)
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $C, %{{.*}} : $PairC)
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: end running
 sil [ossa] @testSSAInnerReborrowedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -1,10 +1,13 @@
-// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -update-borrowed-from -test-runner \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: %s -o /dev/null 2>&1 | %FileCheck %s
 //
 // TODO: when complete lifetime verification become the default for SIL verification,
 // then consider moving all tests with 'unreachable' into a separate file with the flag
 // -disable-ownership-verification
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
 
 sil_stage canonical
 
@@ -32,6 +35,13 @@ struct PairC {
 }
 
 sil @getC : $@convention(thin) () -> @owned C
+
+struct NE: ~Escapable {
+  var object: C
+
+  @lifetime(borrow object)
+  init(object: borrowing C) { self.object = copy object }
+}
 
 // =============================================================================
 // LinearLiveness
@@ -90,7 +100,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK-NEXT: Live blocks:
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       end_borrow
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: last user:   end_borrow
 // CHECK-NEXT: testLinearBitwiseEscape
@@ -127,7 +137,7 @@ bb3(%phi : @unowned $D):
 // CHECK-NEXT: Live blocks:
 // CHECK-NEXT: begin:      cond_br undef, bb1, bb2
 // CHECK-NEXT: ends:       destroy_value %0 : $C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: last user:   destroy_value %0 : $C
 // CHECK-NEXT: testLinearInnerReborrow
@@ -165,7 +175,7 @@ bb3(%phi : @guaranteed $C):
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       br bb3
 // CHECK-NEXT:             br bb3
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: last user:   br bb3
 // CHECK-NEXT: last user:   br bb3
@@ -217,7 +227,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
 // CHECK:       Live blocks:
 // CHECK:       begin:      cond_br undef, [[HEADER]], [[EXIT]]
 // CHECK:       ends:       destroy_value [[C]]
-// CHECK:       exits:      br [[LOOP]]
+// CHECK:       exits:  br [[LOOP]]
 // CHECK:       interiors:
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK:       boundary edge:
@@ -365,7 +375,7 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: begin:      %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT: Unenclosed phis {
@@ -583,7 +593,7 @@ exit:
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C)
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
@@ -616,6 +626,7 @@ bb1(%reborrow : @guaranteed $C):
 
 // CHECK-LABEL: testInteriorNondominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: exits:
@@ -642,15 +653,16 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorDominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%1 : $C)
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
-// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %1 : $C
@@ -658,11 +670,12 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorDominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
-// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%1 : $C)
 // CHECK-NEXT:             br bb1(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Unenclosed phis {
@@ -685,131 +698,31 @@ bb3(%reborrow2 : @guaranteed $D):
   return %99 : $()
 }
 
-// Test mark_dependence of an address value. Walk down.
-
-// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
-// CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
-// CHECK-NEXT: testInteriorMarkDepAddressValue: interior_liveness with: %0
-
-// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
-// CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
-// CHECK-NEXT:             %{{.*}} = mark_dependence %{{.*}} : $*C on %{{.*}} : $C
-// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
-// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
-sil [ossa] @testInteriorMarkDepAddressValue : $@convention(thin) (@guaranteed D, @guaranteed C) -> () {
-bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
-  specify_test "interior_liveness %0"
-  specify_test "interior_liveness_swift %0"
-  %f = ref_element_addr %0 : $D, #D.object
-  %dependence = mark_dependence %f: $*C on %1: $C
-  %load = load_borrow %dependence : $*C
-  end_borrow %load : $C
-  %99 = tuple()
-  return %99 : $()
-}
-
-// Test mark_dependence on a base address value. Walk down.
-
-// CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence %{{.*}} : $*C on %{{.*}} : $*C
-// CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   %{{.*}} = mark_dependence %{{.*}} : $*C on %{{.*}} : $*C
-// CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness with: %0
-
-// CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
-// CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
-// CHECK-NEXT:             %{{.*}} = mark_dependence %{{.*}} : $*C on %{{.*}} : $*C
-// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
-// CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
-sil [ossa] @testInteriorMarkDepAddressBase : $@convention(thin) (@guaranteed D, @guaranteed D) -> () {
-bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
-  specify_test "interior_liveness %0"
-  specify_test "interior_liveness_swift %0"
-  %f0 = ref_element_addr %0 : $D, #D.object
-  %f1 = ref_element_addr %1 : $D, #D.object
-  %dependence = mark_dependence %f1: $*C on %f0: $*C
-  %load = load_borrow %dependence : $*C
-  end_borrow %load : $C
-  %99 = tuple()
-  return %99 : $()
-}
-
-// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $*C
-// CHECK-NEXT: regular user:   end_access %{{.*}} : $*C
-// CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_access %{{.*}} : $*C
-// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness with: %0
-
-// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
-// CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: ends:       end_access %{{.*}} : $*C
-// CHECK-NEXT: exits:    
-// CHECK-NEXT: interiors:  %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
-// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_access %{{.*}} : $*C
-// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
-sil [ossa] @testInteriorMarkDepAddressDependent : $@convention(thin) (@guaranteed D, @owned C) -> () {
-bb0(%0 : @guaranteed $D, %1 : @owned $C):
-  specify_test "interior_liveness %0"
-  specify_test "interior_liveness_swift %0"
-  %f = ref_element_addr %0 : $D, #D.object
-  %access = begin_access [read] [static] %f : $*C
-  %dependence = mark_dependence [nonescaping] %1: $C on %access: $*C
-  %stack = alloc_stack $C
-  %sb = store_borrow %dependence to %stack : $*C
-  end_borrow %sb : $*C
-  destroy_value %dependence : $C
-  end_access %access : $*C
-  dealloc_stack %stack : $*C
-  %99 = tuple()
-  return %99 : $()
-}
-
 // CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior_liveness with: @argument[0]
-// CHECK: Complete liveness
-// CHECK: last user: %{{.*}} load [copy]
+// CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C)
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb1: LiveOut
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
 
 // CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior_liveness_swift with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
 // CHECK-NEXT: begin:      cond_br undef, bb1, bb2
 // CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C)
 // CHECK-NEXT:             br bb3(%{{.*}} : $D)
@@ -853,7 +766,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       br bb3(%{{.*}} : $C, %{{.*}} : $D)
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
@@ -885,21 +798,28 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 }
 
 // CHECK-LABEL: testInnerDominatedReborrow: interior_liveness with: @argument[0]
-// CHECK: Interior liveness:
-// CHECK: Inner scope:   %{{.*}} = begin_borrow %0 : $C
-// CHECK: Complete liveness
-// CHECK: Unenclosed phis {
+// CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
-// CHECK-NEXT: last user:  %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow: interior_liveness with: @argument[0]
 
 // CHECK-LABEL: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
-// CHECK-NEXT: exits:    
-// CHECK-NEXT: interiors:  %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
-// CHECK-NEXT:             br bb1(%{{.*}} : $C)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  br bb1(%{{.*}} : $C)
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
@@ -918,9 +838,17 @@ bb1(%reborrow : @guaranteed $C):
 }
 
 // CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness with: %copy0a
-// CHECK: Inner scope:   %{{.*}} = begin_borrow %1 : $C
+// CHECK: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C, %{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $C
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
-// CHECK: Complete liveness
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb1: LiveOut
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: lifetime-ending user:   destroy_value %{{.*}} : $C
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value
@@ -928,11 +856,12 @@ bb1(%reborrow : @guaranteed $C):
 
 // CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
 // CHECK: Interior liveness:   %{{.*}} = copy_value %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $C
 // CHECK-NEXT: begin:      %{{.*}} = copy_value %0 : $C
 // CHECK-NEXT: ends:       destroy_value %{{.*}} : $C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $C
-// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%2 : $C, %1 : $C)
 // CHECK-NEXT:             br bb3(%{{.*}} : $C)
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
@@ -972,9 +901,10 @@ bb3(%reborrow : @guaranteed $C):
 
 // CHECK-LABEL: testInnerNonDominatedReborrow: interior_liveness_swift with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $D
 // CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $D)
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
@@ -1007,26 +937,29 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 }
 
 // CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness with: %outer3
-// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
-// CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
-// CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
-// CHECK:      regular user:   br bb4(
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from
-// CHECK-NEXT: Complete liveness
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
+// CHECK-NEXT: bb3: LiveOut
+// CHECK-NEXT: bb4: LiveWithin
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
-// CHECK-NEXT: last user: %{{.*}} = borrowed %{{.*}} : $D from
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness with: %outer3
 
 // CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from
 // CHECK-NEXT: ends:       end_borrow
-// CHECK-NEXT: exits:    
-// CHECK-NEXT: interiors:  %{{.*}} = borrowed %{{.*}} : $D from
-// CHECK-NEXT:             br bb4(
-// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  br bb4(
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow
@@ -1059,26 +992,28 @@ bb4(%inner4 : @guaranteed $D):
 }
 
 // CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness with: %outer3
-// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
-// CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
-// CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
-// CHECK:      regular user:   br bb4(
-// CHECK-NEXT: regular user:   {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: regular user:   {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: Complete liveness
+// CHECK: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
+// CHECK-NEXT: bb3: LiveOut
+// CHECK-NEXT: bb4: LiveWithin
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
-// CHECK-NEXT: last user: {{.*}} borrowed {{.*}} from
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness with: %outer3
 
 // CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $D
-// CHECK-NEXT: exits:    
-// CHECK-NEXT: interiors:  {{.*}} borrowed {{.*}} from
-// CHECK-NEXT:             br bb4(%{{.*}} : $D)
-// CHECK-NEXT:             {{.*}} borrowed {{.*}} from
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
@@ -1159,17 +1094,27 @@ bb4(%inner4 : @guaranteed $D):
 
 // CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
-// CHECK: Complete liveness
-// CHECK: Unenclosed phis {
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
+// CHECK-NEXT: bb3: LiveOut
+// CHECK-NEXT: bb4: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
-// CHECK-NEXT: last user:   %{{.*}} = load [copy]
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi1: interior_liveness with: %inner3
 
 // CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness_swift with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
 // CHECK-NEXT:             br bb4(%{{.*}} : $D)
@@ -1209,17 +1154,27 @@ bb4(%phi4 : @guaranteed $D):
 
 // CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
-// CHECK: Complete liveness
-// CHECK: Unenclosed phis {
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
+// CHECK-NEXT: bb3: LiveOut
+// CHECK-NEXT: bb4: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
-// CHECK-NEXT: last user:   %{{.*}} = load [copy]
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi2: interior_liveness with: %inner3
 
 // CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness_swift with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
 // CHECK-NEXT:             br bb4(%{{.*}} : $D)
@@ -1269,7 +1224,7 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: ends:     
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
@@ -1312,9 +1267,10 @@ bb4(%phi4 : @guaranteed $D):
 
 // CHECK-LABEL: testScopedAddress: interior_liveness_swift with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
 // CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: ends:       end_access %{{.*}} : $*C
-// CHECK-NEXT: exits:    
+// CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: Unenclosed phis {
@@ -1330,6 +1286,827 @@ bb0(%0 : @guaranteed $D):
   %o = load [copy] %access : $*C
   end_access %access : $*C
   destroy_value %o : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// =============================================================================
+// InteriorLiveness and borrowed-from
+// =============================================================================
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFrom: interior_liveness with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
+// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFrom: interior_liveness with: %reborrow2
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness with: %reborrow2
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %reborrow2
+// CHECK: Interior liveness: %5 = argument of bb1 : $D                         // user: %6
+// CHECK-NEXT: Pointer escape:   %8 = address_to_pointer %7 : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %9
+// CHECK-NEXT: ends:       end_borrow %6 : $D                              // id: %9
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %8 = address_to_pointer %7 : $*C to $Builtin.RawPointer
+// CHECK-NEXT:             %7 = ref_element_addr %6 : $D, #D.object        // user: %8
+// CHECK-NEXT:             %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %9
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %6 : $D                              // id: %9
+// CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %reborrow2
+sil [ossa] @testInteriorDominatedReborrowedFrom : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  %borrow2 = begin_borrow %d1 : $D
+  br bb1(%borrow2 : $D)
+ 
+bb1(%reborrow2 : @reborrow $D):
+  specify_test "interior_liveness %reborrow2"
+  specify_test "interior_liveness_swift %reborrow2"
+  %borrowedfrom2 = borrowed %reborrow2 from (%borrow1)
+  %f2 = ref_element_addr %borrowedfrom2 : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  end_borrow %borrowedfrom2 : $D // <=== interior use
+  end_borrow %borrow1 : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %phi
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %phi
+
+// CHECK-LABEL: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %phi
+// CHECK-NEXT: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %phi
+sil [ossa] @testInteriorDominatedPhiBorrowedFrom : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  br bb1(%d1 : $D)
+ 
+bb1(%phi : @guaranteed $D):
+  specify_test "interior_liveness %phi"
+  specify_test "interior_liveness_swift %phi"
+  %borrowedfrom = borrowed %phi from (%borrow1)
+  %f2 = ref_element_addr %borrowedfrom : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  end_borrow %borrow1 : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+
+// CHECK-LABEL: testInteriorNondominatedReborrowedFrom: interior_liveness with: %reborrow1
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: testInteriorNondominatedReborrowedFrom: interior_liveness with: %reborrow1
+
+// CHECK-LABEL: testInteriorNondominatedReborrowedFrom: interior_liveness_swift with: %reborrow1
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: ends:       %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: testInteriorNondominatedReborrowedFrom: interior_liveness_swift with: %reborrow1
+sil [ossa] @testInteriorNondominatedReborrowedFrom : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  %borrow2 = begin_borrow %d1 : $D
+  br bb1(%borrow1 : $C, %borrow2 : $D)
+ 
+bb1(%reborrow1 : @reborrow $C, %reborrow2 : @reborrow $D):
+  specify_test "interior_liveness %reborrow1"
+  specify_test "interior_liveness_swift %reborrow1"
+  %borrowfrom1 = borrowed %reborrow1 from (%0)
+  %borrowfrom2 = borrowed %reborrow2 from (%reborrow1)
+  %f2 = ref_element_addr %borrowfrom2 : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  unreachable
+}
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: lifetime-ending user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %reborrow1
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %reborrow1
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %reborrow1
+// CHECK: Interior liveness: %4 = argument of bb1 : $C                         // users: %6, %7
+// CHECK-NEXT: Pointer escape:   %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %6 = borrowed %5 : $D from (%4 : $C)            // user: %8
+// CHECK-NEXT: ends:       %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %8 = ref_element_addr %6 : $D, #D.object        // user: %9
+// CHECK-NEXT:             %7 = borrowed %4 : $C from (%0 : $C)
+// CHECK-NEXT:             %6 = borrowed %5 : $D from (%4 : $C)            // user: %8
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %reborrow1
+sil [ossa] @testInteriorNondominatedPhiBorrowedFrom : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  br bb1(%borrow1 : $C, %d1 : $D) // <=== %borrow1 end
+ 
+bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
+  specify_test "interior_liveness %reborrow1"
+  specify_test "interior_liveness_swift %reborrow1"
+  %borrowfrom1 = borrowed %reborrow1 from (%0)
+  %borrowfrom2 = borrowed %phi from (%reborrow1)
+  %f2 = ref_element_addr %borrowfrom2 : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer  // %reborrow1 escape
+  unreachable
+}
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %borrow1
+//
+// Recognize borrowed-from as an inner scope. The C++ implementation also detects the reborrow as an inner scope
+// because it still looks for adjacent phis.
+//
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %borrow1
+//
+// The Swift implementation reports the borrowed-from use as an inner scope starting at the reborrow.  Since the
+// reborrow has no scope-ending uses, it is effecively dead, the live range does not even include the borrowed-from
+// instruction.
+//
+// CHECK-NEXT: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb1(%{{.*}} : $D)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %reborrow2
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %reborrow2
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %reborrow2
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %reborrow2
+sil [ossa] @testInteriorDominatedReborrowedFromDeadEnd : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  %borrow2 = begin_borrow %d1 : $D
+  br bb1(%borrow2 : $D)
+ 
+bb1(%reborrow2 : @reborrow $D):
+  specify_test "interior_liveness %reborrow2"
+  specify_test "interior_liveness_swift %reborrow2"
+  %borrowfrom2 = borrowed %reborrow2 from (%borrow1) // %borrow1 inner scope, no escape
+  %f2 = ref_element_addr %borrowfrom2 : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 4 on testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %borrow0
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveWithin
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %borrow0
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %borrow0
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT:             br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %borrow0
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %reborrow
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %reborrow
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %reborrow
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %reborrow
+sil [ossa] @testInteriorDominatedReborrowedFromDeadEndNested : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow0 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow0"
+  specify_test "interior_liveness_swift %borrow0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  %d1 = unchecked_ref_cast %borrow0 : $C to $D
+  %borrow1 = begin_borrow %d1 : $D
+  %c1 = unchecked_ref_cast %borrow1 : $D to $C
+  br bb3(%borrow1, %c1)
+
+bb2:
+  %d2 = unchecked_ref_cast %borrow0 : $C to $D
+  %borrow2 = begin_borrow %d2 : $D
+  %c2 = unchecked_ref_cast %borrow2 : $D to $C
+  br bb3(%borrow2, %c2)
+ 
+bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
+  specify_test "interior_liveness %reborrow"
+  specify_test "interior_liveness_swift %reborrow"
+  %borrowfromarg = borrowed %arg from (%reborrow)
+  %reborrowfrom = borrowed %reborrow from (%borrow0)
+  %f2 = ref_element_addr %reborrowfrom : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  unreachable
+}
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %borrow0
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveWithin
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %borrow0
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %borrow0
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT:             br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %borrow0
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %reborrow
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %reborrow
+
+// CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %reborrow
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %reborrow
+sil [ossa] @testInteriorNondominatedPhiBorrowedFromDeadEnd : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow0 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow0"
+  specify_test "interior_liveness_swift %borrow0"
+  cond_br undef, bb1, bb2
+
+bb1:
+  %d1 = unchecked_ref_cast %borrow0 : $C to $D
+  %borrow1 = begin_borrow %d1 : $D
+  %c1 = unchecked_ref_cast %borrow1 : $D to $C
+  br bb3(%borrow1, %c1)
+
+bb2:
+  %d2 = unchecked_ref_cast %borrow0 : $C to $D
+  %borrow2 = begin_borrow %d2 : $D
+  %c2 = unchecked_ref_cast %borrow2 : $D to $C
+  br bb3(%borrow2, %c2)
+ 
+bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
+  specify_test "interior_liveness %reborrow"
+  specify_test "interior_liveness_swift %reborrow"
+  %borrowfromarg = borrowed %arg from (%reborrow)
+  %reborrowfrom = borrowed %reborrow from (%borrow0)
+  %carg = unchecked_ref_cast %borrowfromarg : $C to $D
+  %f2 = ref_element_addr %carg : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  unreachable
+}
+
+// =============================================================================
+// InteriorLiveness and mark_dependence
+// =============================================================================
+
+// CHECK-LABEL: begin running test 1 of 2 on testInteriorMarkDepOwnedEscapable: interior_liveness with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: regular user:   destroy_value %{{.*}} : $D
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   destroy_value %{{.*}} : $D
+// CHECK-NEXT: testInteriorMarkDepOwnedEscapable: interior_liveness with: %0
+
+// CHECK-LABEL: testInteriorMarkDepOwnedEscapable: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %0 : $D
+// CHECK-NEXT: begin:      %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %0 : $D
+// CHECK-NEXT: ends:       destroy_value %{{.*}} : $D
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %0 : $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   destroy_value %{{.*}} : $D
+// CHECK-NEXT: testInteriorMarkDepOwnedEscapable: interior_liveness_swift with: %0
+sil [ossa] @testInteriorMarkDepOwnedEscapable : $@convention(thin) (@guaranteed D, @owned D) -> () {
+bb0(%0 : @guaranteed $D, %1 : @owned $D):
+  specify_test "interior_liveness %0"
+  specify_test "interior_liveness_swift %0"
+  %dependence = mark_dependence [nonescaping] %1: $D on %0: $D
+  %f0 = ref_element_addr %0 : $D, #D.object
+  %borrow = begin_borrow %dependence : $D
+  %f1 = ref_element_addr %borrow : $D, #D.object
+  end_borrow %borrow : $D
+  destroy_value %dependence : $D
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: testInteriorMarkDepOwnedNonEscapable: interior_liveness with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: testInteriorMarkDepOwnedNonEscapable: interior_liveness with: %0
+
+// CHECK-LABEL: testInteriorMarkDepOwnedNonEscapable: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
+// CHECK-NEXT: begin:      %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
+// CHECK-NEXT: ends:       %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: testInteriorMarkDepOwnedNonEscapable: interior_liveness_swift with: %0
+sil [ossa] @testInteriorMarkDepOwnedNonEscapable : $@convention(thin) (@guaranteed D, @owned NE) -> () {
+bb0(%0 : @guaranteed $D, %1 : @owned $NE):
+  specify_test "interior_liveness %0"
+  specify_test "interior_liveness_swift %0"
+  %dependence = mark_dependence [nonescaping] %1: $NE on %0: $D
+  %f0 = ref_element_addr %0 : $D, #D.object
+  %borrow = begin_borrow %dependence : $NE
+  %f1 = struct_extract %borrow : $NE, #NE.object
+  end_borrow %borrow : $NE
+  destroy_value %dependence : $NE
+  %99 = tuple()
+  return %99 : $()
+}
+
+// Test mark_dependence of an address value. Walk down.
+
+// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorMarkDepAddressValue: interior_liveness with: %0
+
+// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $C
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
+sil [ossa] @testInteriorMarkDepAddressValue : $@convention(thin) (@guaranteed D, @guaranteed C) -> () {
+bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
+  specify_test "interior_liveness %0"
+  specify_test "interior_liveness_swift %0"
+  %f = ref_element_addr %0 : $D, #D.object
+  %dependence = mark_dependence [nonescaping] %f: $*C on %1: $C
+  %load = load_borrow %dependence : $*C
+  end_borrow %load : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// Test mark_dependence on a base address value. Walk down.
+
+// CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
+// CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness with: %0
+
+// CHECK-LABEL: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
+sil [ossa] @testInteriorMarkDepAddressBase : $@convention(thin) (@guaranteed D, @guaranteed D) -> () {
+bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
+  specify_test "interior_liveness %0"
+  specify_test "interior_liveness_swift %0"
+  %f0 = ref_element_addr %0 : $D, #D.object
+  %f1 = ref_element_addr %1 : $D, #D.object
+  %dependence = mark_dependence [nonescaping] %f1: $*C on %f0: $*C
+  %load = load_borrow %dependence : $*C
+  end_borrow %load : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $*C
+// CHECK-NEXT: regular user:   end_access %{{.*}} : $*C
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_access %{{.*}} : $*C
+// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness with: %0
+
+// CHECK-LABEL: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
+// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: ends:       end_access %{{.*}} : $*C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_access %{{.*}} : $*C
+// CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
+sil [ossa] @testInteriorMarkDepAddressDependent : $@convention(thin) (@guaranteed D, @owned C) -> () {
+bb0(%0 : @guaranteed $D, %1 : @owned $C):
+  specify_test "interior_liveness %0"
+  specify_test "interior_liveness_swift %0"
+  %f = ref_element_addr %0 : $D, #D.object
+  %access = begin_access [read] [static] %f : $*C
+  %dependence = mark_dependence [nonescaping] %1: $C on %access: $*C
+  %stack = alloc_stack $C
+  %sb = store_borrow %dependence to %stack : $*C
+  end_borrow %sb : $*C
+  destroy_value %dependence : $C
+  end_access %access : $*C
+  dealloc_stack %stack : $*C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %borrow1
+// The mark_dependence is an escape because we don't follow guaranteed values.
+//
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %borrow1
+// The mark_dependence is an escape because we don't follow guaranteed values.
+//
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
+// CHECK-NEXT:             %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
+// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %borrow1
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %reborrow2
+// CHECK: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: Incomplete liveness: Escaping address
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: end running test 3 of 4 on testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %reborrow2
+
+// CHECK-LABEL: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %reborrow2
+// CHECK: Interior liveness: %5 = argument of bb1 : $D                         // user: %6
+// CHECK-NEXT: Pointer escape:   %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %10
+// CHECK-NEXT: ends:       end_borrow %6 : $D                              // id: %10
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
+// CHECK-NEXT:             %8 = ref_element_addr %7 : $D, #D.object        // user: %9
+// CHECK-NEXT:             %7 = mark_dependence [nonescaping] %6 : $D on %1 : $C // user: %8
+// CHECK-NEXT:             %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %10
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %6 : $D                              // id: %10
+// CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %reborrow2
+sil [ossa] @testInteriorDominatedReborrowedFromMarkDep : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  specify_test "interior_liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  %borrow2 = begin_borrow %d1 : $D
+  br bb1(%borrow2 : $D)
+ 
+bb1(%reborrow2 : @reborrow $D):
+  specify_test "interior_liveness %reborrow2"
+  specify_test "interior_liveness_swift %reborrow2"
+  %borrowedfrom2 = borrowed %reborrow2 from (%borrow1)
+  %markdep2 = mark_dependence [nonescaping] %borrowedfrom2 on %borrow1 // Forces interior liveness
+  %f2 = ref_element_addr %markdep2 : $D, #D.object
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  end_borrow %borrowedfrom2 : $D
+  end_borrow %borrow1 : $C
   %99 = tuple()
   return %99 : $()
 }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -378,8 +378,6 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorRefElementEscape:
 sil [ossa] @testInteriorRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
@@ -401,8 +399,6 @@ bb0(%0 : @guaranteed $C):
 // CHECK-NEXT: regular user:   copy_addr [take] %4 to [init] [[FIELD]] : $*C
 // CHECK-NEXT: regular user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
 // CHECK-NEXT: testInteriorUnconditionalAddrCast: interior_liveness with: %1
 
@@ -414,8 +410,6 @@ bb0(%0 : @guaranteed $C):
 // CHECK-NEXT: interiors:  copy_addr [take] %4 to [init] [[FIELD]] : $*C
 // CHECK-NEXT:             unconditional_checked_cast_addr C in [[FIELD]] : $*C to D in %0 : $*D
 // CHECK-NEXT:             [[FIELD]] = ref_element_addr %1 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
 // CHECK-NEXT: testInteriorUnconditionalAddrCast: interior_liveness_swift with: %1
 sil [ossa] @testInteriorUnconditionalAddrCast : $@convention(thin) (@guaranteed D) -> @out D {
@@ -436,8 +430,6 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: lifetime-ending user:   [[DD:%.*]] = drop_deinit %0 : $NCInt
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   [[DD]] = drop_deinit %0 : $NCInt
 // CHECK-LABEL: end running test 1 of 2 on testInteriorDropDeinit: interior_liveness with: %0
 
@@ -447,8 +439,6 @@ bb0(%0 : $*D, %1 : @guaranteed $D):
 // CHECK-NEXT: ends:       [[DD]] = drop_deinit %0 : $NCInt
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   [[DD]] = drop_deinit %0 : $NCInt
 // CHECK-LABEL: end running test 2 of 2 on testInteriorDropDeinit: interior_liveness_swift with: %0
 sil [ossa] @testInteriorDropDeinit : $@convention(thin) (@owned NCInt) -> () {
@@ -483,8 +473,6 @@ bb0(%0 : @owned $NCInt):
 // CHECK:       lifetime-ending user:   destroy_value [[C]]
 // CHECK:       regular user:   end_borrow [[B]]
 // CHECK:       Complete liveness
-// CHECK:       Unenclosed phis {
-// CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness
 // CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness_swift
@@ -493,8 +481,6 @@ bb0(%0 : @owned $NCInt):
 // CHECK:       ends:       destroy_value [[C]]
 // CHECK:       exits:
 // CHECK:       interiors:  end_borrow [[B]]
-// CHECK:       Unenclosed phis {
-// CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_interior: interior_liveness_swift
 sil [ossa] @testLoopConditional_incomplete_interior : $@convention(thin) (@owned C) -> () {
@@ -541,8 +527,6 @@ exit:
 // CHECK:       regular user:   extend_lifetime [[C]]
 // CHECK:       regular user:   end_borrow [[B]]
 // CHECK:       Complete liveness
-// CHECK:       Unenclosed phis {
-// CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_interior: interior_liveness
 
@@ -553,8 +537,6 @@ exit:
 // CHECK:       exits:
 // CHECK:       interiors:  extend_lifetime [[C]]
 // CHECK:                   end_borrow [[B]]
-// CHECK:       Unenclosed phis {
-// CHECK-NEXT:  }
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_interior: interior_liveness_swift
 sil [ossa] @testLoopConditional_complete_interior : $@convention(thin) (@owned C) -> () {
@@ -584,8 +566,6 @@ exit:
 
 // CHECK-LABEL: testInteriorReborrow: interior_liveness with: %borrow
 // CHECK: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1
 // CHECK-NEXT: testInteriorReborrow: interior_liveness with: %borrow
 
@@ -595,8 +575,6 @@ exit:
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C)
 // CHECK-NEXT: testInteriorReborrow: interior_liveness_swift with: %borrow
 sil [ossa] @testInteriorReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -619,8 +597,6 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: lifetime-ending user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedReborrow: interior_liveness with: %borrow1
 
@@ -631,8 +607,6 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedReborrow: interior_liveness_swift with: %borrow1
 sil [ossa] @testInteriorNondominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -653,18 +627,15 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorDominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   end_borrow %1 : $C
 // CHECK-NEXT: testInteriorDominatedReborrow: interior_liveness with: %borrow1
 
@@ -678,8 +649,6 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
 // CHECK-NEXT:             br bb1(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrow: interior_liveness_swift with: %borrow1
 sil [ossa] @testInteriorDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -700,21 +669,18 @@ bb3(%reborrow2 : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior_liveness with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C)
 // CHECK-NEXT: bb0: LiveOut
-// CHECK-NEXT: bb2: LiveOut
 // CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb2: LiveOut
 // CHECK-NEXT: bb1: LiveOut
-// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
-// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D)
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
 
@@ -729,8 +695,6 @@ bb3(%reborrow2 : @guaranteed $D):
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT:             br bb3(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
 sil [ossa] @testInteriorDominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
@@ -748,7 +712,8 @@ bb2:
   br bb3(%d2 : $D)
 
 bb3(%phi : @guaranteed $D):
-  %f = ref_element_addr %phi : $D, #D.object  
+  %bf = borrowed %phi from (%0)
+  %f = ref_element_addr %bf : $D, #D.object
   %o = load [copy] %f : $*C
   destroy_value %o : $C
   %99 = tuple()
@@ -757,8 +722,6 @@ bb3(%phi : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness with: %borrow1
 // CHECK: Complete liveness
-// CHECK: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(
 // CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness with: %borrow1
 
@@ -768,8 +731,6 @@ bb3(%phi : @guaranteed $D):
 // CHECK-NEXT: ends:       br bb3(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness_swift with: %borrow1
 sil [ossa] @testInteriorNondominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
@@ -799,16 +760,13 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 
 // CHECK-LABEL: testInnerDominatedReborrow: interior_liveness with: @argument[0]
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $C)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow: interior_liveness with: @argument[0]
 
@@ -820,8 +778,6 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  br bb1(%{{.*}} : $C)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -838,9 +794,8 @@ bb1(%reborrow : @guaranteed $C):
 }
 
 // CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness with: %copy0a
-// CHECK: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C, %{{.*}} : $C)
+// CHECK: Inner scope: %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $C
-// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb3: LiveWithin
 // CHECK-NEXT: bb2: LiveOut
@@ -848,9 +803,7 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: lifetime-ending user:   destroy_value %{{.*}} : $C
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $C)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   destroy_value
 // CHECK-NEXT: testInnerDominatedReborrow2: interior_liveness with: %copy0a
 
@@ -863,8 +816,6 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $C
 // CHECK-NEXT:             br bb3(%{{.*}} : $C)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
 sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> () {
@@ -894,8 +845,6 @@ bb3(%reborrow : @guaranteed $C):
 // CHECK-LABEL: testInnerNonDominatedReborrow: interior_liveness with: %borrow1
 // CHECK: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF:%.*]] : $D
 // CHECK: Complete liveness
-// CHECK: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3([[DEF]] : $D, [[BORROW]] : $D)
 // CHECK-NEXT: testInnerNonDominatedReborrow: interior_liveness with: %borrow1
 
@@ -906,8 +855,6 @@ bb3(%reborrow : @guaranteed $C):
 // CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $D)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $D)
 // CHECK-NEXT: testInnerNonDominatedReborrow: interior_liveness_swift with: %borrow1
 sil [ossa] @testInnerNonDominatedReborrow : $@convention(thin) (@guaranteed D) -> () {
@@ -938,17 +885,13 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 
 // CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness with: %outer3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
-// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: bb3: LiveOut
 // CHECK-NEXT: bb4: LiveWithin
-// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness with: %outer3
 
@@ -960,8 +903,6 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 // CHECK-NEXT: ends:       end_borrow
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  br bb4(
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow
 // CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow1 : $@convention(thin) (@guaranteed D) -> () {
@@ -992,17 +933,13 @@ bb4(%inner4 : @guaranteed $D):
 }
 
 // CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness with: %outer3
-// CHECK: Inner scope: %{{.*}} = argument of bb3 : $D
-// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb4 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
+// CHECK: Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: bb3: LiveOut
 // CHECK-NEXT: bb4: LiveWithin
-// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness with: %outer3
 
@@ -1014,8 +951,6 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $D
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow2 : $@convention(thin) (@guaranteed D) -> () {
@@ -1050,8 +985,6 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NOT:  Inner scope
 // CHECK-NOT:  lifetime-ending user
 // CHECK:      Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $D
 // CHECK-NEXT: testInnerNonAdjacentReborrow: interior_liveness with: %outer3
 
@@ -1061,8 +994,6 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: ends:
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: dead def:    %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: testInnerNonAdjacentReborrow: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerNonAdjacentReborrow : $@convention(thin) (@guaranteed D) -> () {
@@ -1094,19 +1025,15 @@ bb4(%inner4 : @guaranteed $D):
 
 // CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
 // CHECK-NEXT: bb3: LiveOut
 // CHECK-NEXT: bb4: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
-// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi1: interior_liveness with: %inner3
 
@@ -1120,8 +1047,6 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT:             br bb4(%{{.*}} : $D)
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi1: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerAdjacentPhi1 : $@convention(thin) (@guaranteed C) -> () {
@@ -1154,19 +1079,15 @@ bb4(%phi4 : @guaranteed $D):
 
 // CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
 // CHECK-NEXT: bb3: LiveOut
 // CHECK-NEXT: bb4: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
-// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%0 : $C, %{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C, %0 : $C)
+// CHECK-NEXT: regular user:   br bb4(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi2: interior_liveness with: %inner3
 
@@ -1180,8 +1101,6 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-NEXT:             br bb4(%{{.*}} : $D)
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
 // CHECK-NEXT:             {{.*}} borrowed {{.*}} from
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
 // CHECK-NEXT: testInnerAdjacentPhi2: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerAdjacentPhi2 : $@convention(thin) (@guaranteed C) -> () {
@@ -1215,8 +1134,6 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-LABEL: testInnerNonAdjacentPhi: interior_liveness with: %inner3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $C
 // CHECK: Complete liveness
-// CHECK: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: testInnerNonAdjacentPhi: interior_liveness with: %inner3
 
@@ -1226,8 +1143,6 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-NEXT: ends:     
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: testInnerNonAdjacentPhi: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerNonAdjacentPhi : $@convention(thin) (@guaranteed C) -> () {
@@ -1260,8 +1175,6 @@ bb4(%phi4 : @guaranteed $D):
 
 // CHECK-LABEL: testScopedAddress: interior_liveness with: @argument[0]
 // CHECK: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access
 // CHECK-NEXT: testScopedAddress: interior_liveness with: @argument[0]
 
@@ -1273,8 +1186,6 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access %{{.*}} : $*C
 // CHECK-NEXT: testScopedAddress: interior_liveness_swift with: @argument[0]
 sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
@@ -1296,18 +1207,15 @@ bb0(%0 : @guaranteed $D):
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFrom: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
-// CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
+// CHECK-NEXT: Complete liveness
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness with: %borrow1
 
@@ -1321,8 +1229,6 @@ bb0(%0 : @guaranteed $D):
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
 // CHECK-NEXT:             br bb1(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %borrow1
 
@@ -1334,8 +1240,6 @@ bb0(%0 : @guaranteed $D):
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness with: %reborrow2
 
@@ -1348,8 +1252,6 @@ bb0(%0 : @guaranteed $D):
 // CHECK-NEXT: interiors:  %8 = address_to_pointer %7 : $*C to $Builtin.RawPointer
 // CHECK-NEXT:             %7 = ref_element_addr %6 : $D, #D.object        // user: %8
 // CHECK-NEXT:             %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %9
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %6 : $D                              // id: %9
 // CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %reborrow2
 sil [ossa] @testInteriorDominatedReborrowedFrom : $@convention(thin) (@guaranteed C) -> () {
@@ -1375,18 +1277,15 @@ bb1(%reborrow2 : @reborrow $D):
 
 // CHECK-LABEL: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
-// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
-// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %borrow1
 
@@ -1401,8 +1300,6 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT:             br bb1(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
 
@@ -1413,8 +1310,6 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness with: %phi
 
@@ -1426,8 +1321,6 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedPhiBorrowedFrom: interior_liveness_swift with: %phi
 sil [ossa] @testInteriorDominatedPhiBorrowedFrom : $@convention(thin) (@guaranteed C) -> () {
@@ -1453,12 +1346,10 @@ bb1(%phi : @guaranteed $D):
 // CHECK-LABEL: testInteriorNondominatedReborrowedFrom: interior_liveness with: %reborrow1
 // CHECK: Interior liveness: %{{.*}} = argument of bb1 : $C
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
 // CHECK-NEXT: testInteriorNondominatedReborrowedFrom: interior_liveness with: %reborrow1
 
@@ -1469,8 +1360,6 @@ bb1(%phi : @guaranteed $D):
 // CHECK-NEXT: ends:       %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
 // CHECK-NEXT: testInteriorNondominatedReborrowedFrom: interior_liveness_swift with: %reborrow1
 sil [ossa] @testInteriorNondominatedReborrowedFrom : $@convention(thin) (@guaranteed C) -> () {
@@ -1496,8 +1385,6 @@ bb1(%reborrow1 : @reborrow $C, %reborrow2 : @reborrow $D):
 // CHECK-NEXT: lifetime-ending user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %borrow1
 
@@ -1507,22 +1394,17 @@ bb1(%reborrow1 : @reborrow $C, %reborrow2 : @reborrow $D):
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %borrow1
 
 // CHECK-LABEL: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %reborrow1
 // CHECK: Interior liveness: %{{.*}} = argument of bb1 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness with: %reborrow1
 
@@ -1535,8 +1417,6 @@ bb1(%reborrow1 : @reborrow $C, %reborrow2 : @reborrow $D):
 // CHECK-NEXT: interiors:  %8 = ref_element_addr %6 : $D, #D.object        // user: %9
 // CHECK-NEXT:             %7 = borrowed %4 : $C from (%0 : $C)
 // CHECK-NEXT:             %6 = borrowed %5 : $D from (%4 : $C)            // user: %8
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFrom: interior_liveness_swift with: %reborrow1
 sil [ossa] @testInteriorNondominatedPhiBorrowedFrom : $@convention(thin) (@guaranteed C) -> () {
@@ -1563,16 +1443,15 @@ bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
 // because it still looks for adjacent phis.
 //
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
-// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %borrow1
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %borrow1
@@ -1588,8 +1467,6 @@ bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $D)
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $D)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %borrow1
 
@@ -1600,8 +1477,6 @@ bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %reborrow2
 
@@ -1613,8 +1488,6 @@ bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %reborrow2
 sil [ossa] @testInteriorDominatedReborrowedFromDeadEnd : $@convention(thin) (@guaranteed C) -> () {
@@ -1637,22 +1510,20 @@ bb1(%reborrow2 : @reborrow $D):
 
 // CHECK-LABEL: begin running test 1 of 4 on testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %borrow0
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveOut
-// CHECK-NEXT: bb2: LiveWithin
-// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb1: LiveOut
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %borrow0
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %borrow0
@@ -1666,23 +1537,18 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %borrow0
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %reborrow
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
 // CHECK-NEXT: bb3: LiveWithin
-// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%11 : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %reborrow
 
@@ -1695,8 +1561,6 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %reborrow
 sil [ossa] @testInteriorDominatedReborrowedFromDeadEndNested : $@convention(thin) (@guaranteed C) -> () {
@@ -1730,22 +1594,20 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 
 // CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %borrow0
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveOut
-// CHECK-NEXT: bb2: LiveWithin
-// CHECK-NEXT: bb1: LiveWithin
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb1: LiveOut
+// CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %borrow0
 
 // CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %borrow0
@@ -1759,15 +1621,12 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %borrow0
 
 // CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %reborrow
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
 // CHECK-NEXT: bb3: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
@@ -1775,8 +1634,6 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: regular user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %reborrow
 
@@ -1790,8 +1647,6 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $D)
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %reborrow
 sil [ossa] @testInteriorNondominatedPhiBorrowedFromDeadEnd : $@convention(thin) (@guaranteed C) -> () {
@@ -1835,8 +1690,6 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: regular user:   destroy_value %{{.*}} : $D
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value %{{.*}} : $D
 // CHECK-NEXT: testInteriorMarkDepOwnedEscapable: interior_liveness with: %0
 
@@ -1848,8 +1701,6 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %0 : $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value %{{.*}} : $D
 // CHECK-NEXT: testInteriorMarkDepOwnedEscapable: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepOwnedEscapable : $@convention(thin) (@guaranteed D, @owned D) -> () {
@@ -1868,12 +1719,10 @@ bb0(%0 : @guaranteed $D, %1 : @owned $D):
 
 // CHECK-LABEL: testInteriorMarkDepOwnedNonEscapable: interior_liveness with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $D
-// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: testInteriorMarkDepOwnedNonEscapable: interior_liveness with: %0
 
@@ -1884,8 +1733,6 @@ bb0(%0 : @guaranteed $D, %1 : @owned $D):
 // CHECK-NEXT: ends:       %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $NE on %0 : $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: testInteriorMarkDepOwnedNonEscapable: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepOwnedNonEscapable : $@convention(thin) (@guaranteed D, @owned NE) -> () {
@@ -1910,8 +1757,6 @@ bb0(%0 : @guaranteed $D, %1 : @owned $NE):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorMarkDepAddressValue: interior_liveness with: %0
 
@@ -1924,8 +1769,6 @@ bb0(%0 : @guaranteed $D, %1 : @owned $NE):
 // CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $C
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-LABEL: testInteriorMarkDepAddressValue: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressValue : $@convention(thin) (@guaranteed D, @guaranteed C) -> () {
@@ -1948,8 +1791,6 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
 // CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness with: %0
 
@@ -1962,8 +1803,6 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 // CHECK-NEXT: interiors:  %{{.*}} = load_borrow %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressBase : $@convention(thin) (@guaranteed D, @guaranteed D) -> () {
@@ -1986,8 +1825,6 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
 // CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $*C
 // CHECK-NEXT: regular user:   end_access %{{.*}} : $*C
 // CHECK-NEXT: Complete liveness
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access %{{.*}} : $*C
 // CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness with: %0
 
@@ -1999,8 +1836,6 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  %{{.*}} = begin_access [read] [static] %{{.*}} : $*C
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access %{{.*}} : $*C
 // CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness_swift with: %0
 sil [ossa] @testInteriorMarkDepAddressDependent : $@convention(thin) (@guaranteed D, @owned C) -> () {
@@ -2024,19 +1859,18 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
 // The mark_dependence is an escape because we don't follow guaranteed values.
 //
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
-// CHECK-NEXT: Inner scope:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
-// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
+// CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: regular user:   br bb1(%{{.*}} : $D)
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %borrow1
 
@@ -2056,8 +1890,6 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
 // CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
 // CHECK-NEXT:             br bb1(%{{.*}} : $D)
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %borrow1
 
@@ -2070,24 +1902,20 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
 // CHECK-NEXT: regular user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: lifetime-ending user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: end running test 3 of 4 on testInteriorDominatedReborrowedFromMarkDep: interior_liveness with: %reborrow2
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %reborrow2
-// CHECK: Interior liveness: %5 = argument of bb1 : $D                         // user: %6
-// CHECK-NEXT: Pointer escape:   %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
-// CHECK-NEXT: begin:      %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %10
-// CHECK-NEXT: ends:       end_borrow %6 : $D                              // id: %10
+// CHECK-NEXT: Interior liveness: %{{.*}} = argument of bb1 : $D
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $D
 // CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %9 = address_to_pointer %8 : $*C to $Builtin.RawPointer
-// CHECK-NEXT:             %8 = ref_element_addr %7 : $D, #D.object        // user: %9
-// CHECK-NEXT:             %7 = mark_dependence [nonescaping] %6 : $D on %1 : $C // user: %8
-// CHECK-NEXT:             %6 = borrowed %5 : $D from (%1 : $C)            // users: %7, %10
-// CHECK-NEXT: Unenclosed phis {
-// CHECK-NEXT: }
-// CHECK-NEXT: last user:   end_borrow %6 : $D                              // id: %10
+// CHECK-NEXT: interiors:  %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %reborrow2
 sil [ossa] @testInteriorDominatedReborrowedFromMarkDep : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -606,7 +606,8 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: interiors:  %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: last user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: testInteriorNondominatedReborrow: interior_liveness_swift with: %borrow1
 sil [ossa] @testInteriorNondominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -647,7 +648,8 @@ bb3(%reborrow1 : @guaranteed $C, %reborrow2 : @guaranteed $D):
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
-// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrow: interior_liveness_swift with: %borrow1
@@ -777,7 +779,8 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  br bb1(%{{.*}} : $C)
+// CHECK-NEXT: interiors:  %{{.*}} = borrowed %{{.*}} : $C from (%0 : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -815,7 +818,8 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: ends:       destroy_value %{{.*}} : $C
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $C
-// CHECK-NEXT:             br bb3(%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $C from (%{{.*}} : $C, %{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $C
 // CHECK-NEXT: last user:   destroy_value %{{.*}} : $C
 // CHECK-NEXT: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
 sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> () {
@@ -902,7 +906,8 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 // CHECK-NEXT: begin:      %{{.*}} = borrowed %{{.*}} : $D from
 // CHECK-NEXT: ends:       end_borrow
 // CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  br bb4(
+// CHECK-NEXT: interiors:  %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
 // CHECK-NEXT: last user:   end_borrow
 // CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow1 : $@convention(thin) (@guaranteed D) -> () {
@@ -950,7 +955,8 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: begin:      {{.*}} borrowed {{.*}} from
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $D
 // CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
+// CHECK-NEXT: interiors:  %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $D, %0 : $D)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%0 : $D, %{{.*}} : $D)
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
 // CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow2 : $@convention(thin) (@guaranteed D) -> () {
@@ -1227,7 +1233,8 @@ bb0(%0 : @guaranteed $D):
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
 // CHECK-NEXT: interiors:  end_borrow %{{.*}} : $D
-// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFrom: interior_liveness_swift with: %borrow1
@@ -1464,10 +1471,11 @@ bb1(%reborrow1 : @reborrow $C, %phi : @guaranteed $D):
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb1 : $D
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: ends:       br bb1(%{{.*}} : $D)
-// CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: last user:   br bb1(%{{.*}} : $D)
+// CHECK-NEXT: ends:       %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness_swift with: %borrow1
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEnd: interior_liveness with: %reborrow2
@@ -1532,13 +1540,13 @@ bb1(%reborrow2 : @reborrow $D):
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT:             br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: ends:       %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness_swift with: %borrow0
 
 // CHECK-LABEL: testInteriorDominatedReborrowedFromDeadEndNested: interior_liveness with: %reborrow
@@ -1616,13 +1624,13 @@ bb3(%reborrow : @reborrow $D, %arg : @guaranteed $C):
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
-// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT:             br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: exits:
-// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: ends:       %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
-// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $D
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: last user:   %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
 // CHECK-NEXT: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness_swift with: %borrow0
 
 // CHECK-LABEL: testInteriorNondominatedPhiBorrowedFromDeadEnd: interior_liveness with: %reborrow
@@ -1888,7 +1896,8 @@ bb0(%0 : @guaranteed $D, %1 : @owned $C):
 // CHECK-NEXT:             %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
 // CHECK-NEXT:             %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $D on %{{.*}} : $C
-// CHECK-NEXT:             br bb1(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = borrowed %{{.*}} : $D from (%{{.*}} : $C)
+// CHECK-NEXT:             %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
 // CHECK-NEXT: testInteriorDominatedReborrowedFromMarkDep: interior_liveness_swift with: %borrow1

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -4932,16 +4932,14 @@ bb0(%0 : @guaranteed $_ContiguousArrayBuffer<Element>):
 }
 
 // CHECK-LABEL: sil [ossa] @cowbuffer_reading_no_lookthrough_reborrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> MyInt {
-// CHECK-NOT: ref_element_addr [immutable]
-// CHECK-NOT: ref_tail_addr [immutable]
+//
+// After updating with borrowed-from instructions, the ref_element_addr's can all be promoted without looking through
+// reborrows because they are reachable from the borrowed-from.
+//
 // CHECK-NOT: builtin "COWBufferForReading"
-// CHECK: ref_element_addr %
-// CHECK-NOT: ref_element_addr [immutable]
-// CHECK-NOT: ref_tail_addr [immutable]
+// CHECK: ref_element_addr [immutable]
 // CHECK-NOT: builtin "COWBufferForReading"
-// CHECK: ref_tail_addr %
-// CHECK-NOT: ref_element_addr [immutable]
-// CHECK-NOT: ref_tail_addr [immutable]
+// CHECK: ref_tail_addr [immutable] %
 // CHECK-NOT: builtin "COWBufferForReading"
 // CHECK: } // end sil function 'cowbuffer_reading_no_lookthrough_reborrow'
 sil [ossa] @cowbuffer_reading_no_lookthrough_reborrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> MyInt {


### PR DESCRIPTION
This is a pile of interrelated liveness fixes. It is actually safer to combine them into one PR so no one is exposed to intermediate partly-broken states. I noticed these issues when reviewing fixes for OSSA lifetime bugs and auditing the code. Begining to fix the problems exposed other problems. 37 commits later I reached a steady state.

1. Fix borrowed-from operand ownership 

The borrowed-from instruction borrows its enclosing value. Liveness extends to the uses of the result. However, it was marked as an InstantaneousUse. Code that switches on OperandOwnership assumes that an InstantaneousUse does not propagate any information that may extend liveness. So we were not getting correct liveness information.

2. Fix liveness utilities: handle inner borrow scopes and dependent values

Fix interior liveness to consistently handle inner borrows. Enforce rules for which borrowing operands create a new scope vs. those that forward guaranteed values. With both borrowed-from and mark_dependence, this depends on the context:
- reborrows create a new scope, guaranteed forwarding phis do not
- owned dependent values create a new scope, guaranteed dependent values do not

Handle borrowed-from and mark_dependence instructions of all flavors.

Follow dependent values to avoid unnecessary pointer escapes.

Conservatively report pointer escapes when they happen.

Consider the pointer escaping instruction also part of liveness.

3. Fix liveness utilities: handle dead borrows

Conservatively report a begin_borrow, or other borrowing instruction without any uses as an unknown use themselves. This hack will go away with complete OSSA.

4. Fix liveness utilities: handle visitInnerUses mode

Interior liveness is designed to be used with complete OSSA lifetimes. But we cannot rely on those yet. Meanwhile, passes like DestroyHoisting have started relying on complete liveness information. To workaround this problem, we need a special mode for interior liveness: visitInnerUses. This mode tries to find all the uses within inner borrow scopes. This mode is horribly complicated. The mode existed but was very incomplete and did not properly bail-out. Handle most of the important cases and add bail-outs where needed. Ensure the bail-outs are respected.

There are still plenty of FIXMEs and issues with this. But I fixed as much as I could.
   
Fix BorrowedValue::visitInteriorPointerOperandHelper to follow forwarding instructions.

Fix InteriorUseWalker.interiorPointerUse to follow address dependencies even when the addressable type is trivial.

5. Synchronize the original C++ utilities with SwiftCompilerSources

These utilities need to behave the same way, or as close as possible, because passes that use the utilities are ported over without considering what's under the hood.

6. Remove adjacent phi handling from liveness utilities

This made the internals of the utility very complicated with redundant logic. It was impossible to test support from borrowed-from.

7. Centralize logic for switching on different kinds of borrows

Distinguish between scoped vs. unscoped borrowed-from instructions. They have different meaninings for ownership and liveness analysis.

--- C++
BorrowedFromInst::isReborrow
MarkDependenceInst::hasScopedLifetime
BorrowingOperand::getDependentUserResult()

--- Swift
MarkDependenceInst.hasScopedLifetime
BorrowingInstruction.scopedValue
BorrowingInstruction.dependentValue
BorrowingInstruction.innerValue

8. Fix DestroyHoisting

- visit all interior uses

- don't ignore pointer escapes.

Known Effects

- fixes DestroyHoisting use-after frees
  
- improves some optimizations that benefit from borrowed-from, like SILCombine's read-only CoW buffer optimization

- CopyPropagation becomes more conservative with dead-borrows. But we should avoid those rather than adding complexity to handle them.
