### PR TITLE
[stdlib] Update `WordPair: Comparable` conformance

### DIFF
--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Atomics open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -183,9 +183,9 @@ extension WordPair: Hashable {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftStdlib 6.1, *)
 extension WordPair: Comparable {
-  @available(SwiftStdlib 6.2, *)
+  @available(SwiftStdlib 6.1, *)
   @_alwaysEmitIntoClient
   @_transparent
   public static func <(lhs: WordPair, rhs: WordPair) -> Bool {

--- a/test/stdlib/Synchronization/Atomics/WordPair.swift
+++ b/test/stdlib/Synchronization/Atomics/WordPair.swift
@@ -49,7 +49,7 @@ suite.test("basics") {
 
 } // if #available(SwiftStdlib 6.0, *)
 
-if #available(SwiftStdlib 6.2, *) {
+if #available(SwiftStdlib 6.1, *) {
 suite.test("comparable") {
   let c0 = WordPair(first: 0, second: 0)
   let c1 = WordPair(first: 1, second: 0)
@@ -65,6 +65,6 @@ suite.test("comparable") {
   expectTrue(c4 < c5)
   expectFalse(c5 < c4)
 }
-} // if #available(SwiftStdlib 6.2, *)
+} // if #available(SwiftStdlib 6.1, *)
 
 runAllTests()


### PR DESCRIPTION
Update availability to match `release/6.1` branch.

Follow-up to: swiftlang/swift#79189
