### PR TITLE
utils: clean up some of the build and test rules for XCTest and Testing

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -442,6 +442,10 @@ function Get-TargetProjectBinaryCache($Arch, [TargetComponent]$Project) {
   return "$BinaryCache\$($Arch.LLVMTarget)\$Project"
 }
 
+function Get-TargetProjectCMakeModules($Arch, [TargetComponent]$Project) {
+  return "$Binarycache\$($Arch.LLVMTarget)\$Project\cmake\modules"
+}
+
 enum HostComponent {
   Compilers
   FoundationMacros
@@ -2333,42 +2337,43 @@ function Build-FoundationMacros() {
     }
 }
 
-function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
-  $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
-  $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch DynamicFoundation
-  $XCTestBinaryCache = Get-TargetProjectBinaryCache $Arch XCTest
-
-  Isolate-EnvVars {
-    if ($Test) {
-      $TestingDefines = @{
-        ENABLE_TESTING = "YES";
-        LLVM_DIR = "$(Get-TargetProjectBinaryCache $Arch LLVM)/lib/cmake/llvm";
-        XCTEST_PATH_TO_LIBDISPATCH_BUILD = $DispatchBinaryCache;
-        XCTEST_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
-        XCTEST_PATH_TO_FOUNDATION_BUILD = $FoundationBinaryCache;
-      }
-      $Targets = @("default", "check-xctest")
-      $InstallPath = ""
-      $env:Path = "$XCTestBinaryCache;$FoundationBinaryCache\bin;$DispatchBinaryCache;$(Get-TargetProjectBinaryCache $Arch Runtime)\bin;$env:Path;$UnixToolsBinDir"
-    } else {
-      $TestingDefines = @{ ENABLE_TESTING = "NO" }
-      $Targets = @("install")
-      $InstallPath = "$($Arch.XCTestInstallRoot)\usr"
+function Build-XCTest([Platform]$Platform, $Arch) {
+  Build-CMakeProject `
+    -Src $SourceCache\swift-corelibs-xctest `
+    -Bin $(Get-TargetProjectBinaryCache $Arch XCTest) `
+    -InstallTo "$($Arch.XCTestInstallRoot)\usr" `
+    -Arch $Arch `
+    -Platform $Platform `
+    -UseBuiltCompilers Swift `
+    -Defines @{
+      CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
+      ENABLE_TESTING = "NO";
+      dispatch_DIR = $(Get-TargetProjectCMakeModules $Arch Dispatch);
+      Foundation_DIR = $(Get-TargetProjectCMakeModules $Arch DynamicFoundation);
     }
+}
+
+function Test-XCTest {
+  Isolate-EnvVars {
+    $env:Path = "$(Get-TargetProjectBinaryCache $BuildArch XCTest);$(Get-TargetProjectBinaryCache $BuildArch DynamicFoundation)\bin;$(Get-TargetProjectBinaryCache $BuildArch Dispatch);$(Get-TargetProjectBinaryCache $BuildArch Runtime)\bin;${env:Path};$UnixToolsBinDir"
 
     Build-CMakeProject `
       -Src $SourceCache\swift-corelibs-xctest `
-      -Bin $XCTestBinaryCache `
-      -InstallTo $InstallPath `
-      -Arch $Arch `
-      -Platform $Platform `
+      -Bin (Get-TargetProjectBinaryCache $BuildArch XCTest) `
+      -Arch $BuildArch `
+      -Platform Windows `
       -UseBuiltCompilers Swift `
-      -BuildTargets $Targets `
-      -Defines (@{
+      -BuildTargets default,check-xctest `
+      -Defines @{
         CMAKE_BUILD_WITH_INSTALL_RPATH = "YES";
-        dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
-        Foundation_DIR = "$FoundationBinaryCache\cmake\modules";
-      } + $TestingDefines)
+        ENABLE_TESTING = "YES";
+        dispatch_DIR = $(Get-TargetProjectCMakeModules $BuildArch Dispatch);
+        Foundation_DIR = $(Get-TargetProjectCMakeModules $BuildArch DynamicFoundation);
+        LLVM_DIR = "$(Get-TargetProjectBinaryCache $BuildArch LLVM)\lib\cmake\llvm";
+        XCTEST_PATH_TO_FOUNDATION_BUILD = $(Get-TargetProjectBinaryCache $BuildArch DynamicFoundation);
+        XCTEST_PATH_TO_LIBDISPATCH_BUILD = $(Get-TargetProjectBinaryCache $BuildArch Dispatch);
+        XCTEST_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
+      }
   }
 }
 
@@ -3300,7 +3305,7 @@ if (-not $IsCrossCompiling) {
     Build-Foundation Windows $HostArch -Test
   }
   if ($Test -contains "xctest") {
-    Build-XCTest Windows $HostArch -Test
+    Test-XCTest
   }
   if ($Test -contains "testing") {
     Build-Testing Windows $HostArch -Test


### PR DESCRIPTION
Split up `Build-XCTest` and `Test-XCTest` and remove `-Test` support for `Build-Testing`.