### PR TITLE
[gardening] Fix capitalization in define guard.

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -16,8 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SIL_SILDeclRef_H
-#define SWIFT_SIL_SILDeclRef_H
+#ifndef SWIFT_SIL_SILDECLREF_H
+#define SWIFT_SIL_SILDECLREF_H
 
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/ClangNode.h"


### PR DESCRIPTION
Just a little thing that I noticed while doing some other work.