### PR TITLE
[rbi] Respect nonisolated(unsafe) when assigning or merging into a sending out parameter.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1323,12 +1323,16 @@ public:
           if (auto value = instance.maybeGetValue()) {
             if (auto *fArg = dyn_cast<SILFunctionArgument>(value)) {
               if (fArg->getArgumentConvention().isIndirectOutParameter()) {
+                auto staticRegionIsolation =
+                    getIsolationRegionInfo(op.getOpArgs()[1]);
                 Region srcRegion = p.getRegion(op.getOpArgs()[1]);
                 auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
+
                 // We can unconditionally getValue here since we can never
                 // assign an actor introducing inst.
                 auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
-                if (!dynamicRegionIsolation.isDisconnected()) {
+                if (!dynamicRegionIsolation.isDisconnected() &&
+                    !staticRegionIsolation.isUnsafeNonIsolated()) {
                   handleError(AssignNeverSendableIntoSendingResultError(
                       op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
                       dynamicRegionIsolation));
@@ -1451,12 +1455,15 @@ public:
           if (auto value = instance.maybeGetValue()) {
             if (auto *fArg = dyn_cast<SILFunctionArgument>(value)) {
               if (fArg->getArgumentConvention().isIndirectOutParameter()) {
+                auto staticRegionIsolation =
+                    getIsolationRegionInfo(op.getOpArgs()[1]);
                 Region srcRegion = p.getRegion(op.getOpArgs()[1]);
                 auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
                 // We can unconditionally getValue here since we can never
                 // assign an actor introducing inst.
                 auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
-                if (!dynamicRegionIsolation.isDisconnected()) {
+                if (!dynamicRegionIsolation.isDisconnected() &&
+                    !staticRegionIsolation.isUnsafeNonIsolated()) {
                   handleError(AssignNeverSendableIntoSendingResultError(
                       op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
                       dynamicRegionIsolation));

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -320,6 +320,8 @@ static bool isLookThroughIfOperandAndResultNonSendable(SILInstruction *inst) {
   case SILInstructionKind::StructElementAddrInst:
   case SILInstructionKind::TupleElementAddrInst:
   case SILInstructionKind::UncheckedTakeEnumDataAddrInst:
+  case SILInstructionKind::ConvertEscapeToNoEscapeInst:
+  case SILInstructionKind::ConvertFunctionInst:
     return true;
   }
 }
@@ -2985,8 +2987,6 @@ CONSTANT_TRANSLATION(LoadUnownedInst, Assign)
 // getUnderlyingTrackedObject.
 CONSTANT_TRANSLATION(AddressToPointerInst, Assign)
 CONSTANT_TRANSLATION(BaseAddrForOffsetInst, Assign)
-CONSTANT_TRANSLATION(ConvertEscapeToNoEscapeInst, Assign)
-CONSTANT_TRANSLATION(ConvertFunctionInst, Assign)
 CONSTANT_TRANSLATION(ThunkInst, Assign)
 CONSTANT_TRANSLATION(CopyBlockInst, Assign)
 CONSTANT_TRANSLATION(CopyBlockWithoutEscapingInst, Assign)
@@ -3314,6 +3314,8 @@ LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(UncheckedValueCastInst)
 LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(TupleElementAddrInst)
 LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(StructElementAddrInst)
 LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(UncheckedTakeEnumDataAddrInst)
+LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(ConvertEscapeToNoEscapeInst)
+LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND(ConvertFunctionInst)
 
 #undef LOOKTHROUGH_IF_NONSENDABLE_RESULT_AND_OPERAND
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1944,3 +1944,14 @@ func testFunctionIsNotEmpty(input: SendableKlass) async throws {
     }
   }
 }
+
+func unsafeNonIsolatedAppliesToAssignToOutParam(ns: NonSendableKlass) -> sending NonSendableKlass {
+  func withUnsafeValue<T>(_ block: (NonSendableKlass) throws -> sending T) rethrows -> sending T {
+    fatalError()
+  }
+
+  return withUnsafeValue {
+    nonisolated(unsafe) let obj = $0
+    return obj
+  }
+}


### PR DESCRIPTION
I also included an additional change that makes convert_function/convert_escape_to_no_escape look through if they have both non-Sendable result/operands to make this apply more broadly and propagate better.

rdar://143714959