### PR TITLE
Factor conformance attributes into their own separate structure.

### DIFF
--- a/include/swift/AST/ConformanceAttributes.h
+++ b/include/swift/AST/ConformanceAttributes.h
@@ -1,0 +1,46 @@
+//===--- ConformanceLookup.h - Global conformance lookup --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_CONFORMANCEATTRIBUTES_H
+#define SWIFT_AST_CONFORMANCEATTRIBUTES_H
+
+#include "swift/Basic/SourceLoc.h"
+
+namespace swift {
+
+/// Describes all of the attributes that can occur on a conformance.
+struct ConformanceAttributes {
+  /// The location of the "unchecked" attribute, if present.
+  SourceLoc uncheckedLoc;
+
+  /// The location of the "preconcurrency" attribute if present.
+  SourceLoc preconcurrencyLoc;
+
+  /// The location of the "unsafe" attribute if present.
+  SourceLoc unsafeLoc;
+  
+  /// Merge other conformance attributes into this set.
+  ConformanceAttributes &
+  operator |=(const ConformanceAttributes &other) {
+    if (other.uncheckedLoc.isValid())
+      uncheckedLoc = other.uncheckedLoc;
+    if (other.preconcurrencyLoc.isValid())
+      preconcurrencyLoc = other.preconcurrencyLoc;
+    if (other.unsafeLoc.isValid())
+      unsafeLoc = other.unsafeLoc;
+    return *this;
+  }
+};
+
+}
+
+#endif

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/CatchNode.h"
+#include "swift/AST/ConformanceAttributes.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
@@ -603,14 +604,7 @@ void forEachPotentialAttachedMacro(
 
 /// Describes an inherited nominal entry.
 struct InheritedNominalEntry : Located<NominalTypeDecl *> {
-  /// The location of the "unchecked" attribute, if present.
-  SourceLoc uncheckedLoc;
-
-  /// The location of the "preconcurrency" attribute if present.
-  SourceLoc preconcurrencyLoc;
-
-  /// The location of the "unsafe" attribute if present.
-  SourceLoc unsafeLoc;
+  ConformanceAttributes attributes;
 
   /// Whether this inherited entry was suppressed via "~".
   bool isSuppressed;
@@ -618,10 +612,9 @@ struct InheritedNominalEntry : Located<NominalTypeDecl *> {
   InheritedNominalEntry() { }
 
   InheritedNominalEntry(NominalTypeDecl *item, SourceLoc loc,
-                        SourceLoc uncheckedLoc, SourceLoc preconcurrencyLoc,
-                        SourceLoc unsafeLoc, bool isSuppressed)
-      : Located(item, loc), uncheckedLoc(uncheckedLoc),
-        preconcurrencyLoc(preconcurrencyLoc), unsafeLoc(unsafeLoc),
+                        ConformanceAttributes attributes,
+                        bool isSuppressed)
+      : Located(item, loc), attributes(attributes),
         isSuppressed(isSuppressed) {}
 };
 

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -21,6 +21,7 @@
 #define SWIFT_AST_CONFORMANCE_LOOKUP_TABLE_H
 
 #include "swift/AST/DeclContext.h"
+#include "swift/AST/ConformanceAttributes.h"
 #include "swift/AST/ProtocolConformanceOptions.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
@@ -89,14 +90,7 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
 
     ConformanceEntryKind Kind;
 
-    /// The location of the "unchecked" attribute, if there is one.
-    SourceLoc uncheckedLoc;
-
-    /// The location of the "preconcurrency" attribute, if there is one.
-    SourceLoc preconcurrencyLoc;
-
-    /// The location of the "unsafe" attribute, if there is one.
-    SourceLoc unsafeLoc;
+    ConformanceAttributes attributes;
 
     ConformanceSource(void *ptr, ConformanceEntryKind kind)
       : Storage(ptr), Kind(kind) { }
@@ -140,29 +134,16 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
       return ConformanceSource(dc, ConformanceEntryKind::PreMacroExpansion);
     }
 
-    /// Return a new conformance source with the given location of "@unchecked".
-    ConformanceSource withUncheckedLoc(SourceLoc uncheckedLoc) {
+    /// Return a new conformance source with the given conformance
+    /// attributes.
+    ConformanceSource withAttributes(ConformanceAttributes attributes) {
       ConformanceSource result(*this);
-      if (uncheckedLoc.isValid())
-        result.uncheckedLoc = uncheckedLoc;
+      result.attributes |= attributes;
       return result;
     }
 
-    /// Return a new conformance source with the given location of
-    /// "@preconcurrency".
-    ConformanceSource withPreconcurrencyLoc(SourceLoc preconcurrencyLoc) {
-      ConformanceSource result(*this);
-      if (preconcurrencyLoc.isValid())
-        result.preconcurrencyLoc = preconcurrencyLoc;
-      return result;
-    }
-
-    /// Return a new conformance source with the given location of "@unsafe".
-    ConformanceSource withUnsafeLoc(SourceLoc unsafeLoc) {
-      ConformanceSource result(*this);
-      if (unsafeLoc.isValid())
-        result.unsafeLoc = unsafeLoc;
-      return result;
+    ConformanceAttributes getAttributes() const {
+      return attributes;
     }
 
     ProtocolConformanceOptions getOptions() const {
@@ -216,16 +197,16 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
 
     /// The location of the @unchecked attribute, if any.
     SourceLoc getUncheckedLoc() const {
-      return uncheckedLoc;
+      return attributes.uncheckedLoc;
     }
 
     SourceLoc getPreconcurrencyLoc() const {
-      return preconcurrencyLoc;
+      return attributes.preconcurrencyLoc;
     }
 
     /// The location of the @unsafe attribute, if any.
     SourceLoc getUnsafeLoc() const {
-      return unsafeLoc;
+      return attributes.unsafeLoc;
     }
 
     /// For an inherited conformance, retrieve the class declaration


### PR DESCRIPTION
We had an exploded form of conformance attributes (@unchecked, @preconcurrency, @unsafe) at several different places in the compiler. Pull these into a single structure so it's easier to manage and extend.

Should have done this a long time ago.
