### PR TITLE
[BuilderTransform] Type-check `buildBlock` of each condition body separately from "join" operation

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -511,7 +511,8 @@ protected:
 
       auto *ifBraceStmt = cast<BraceStmt>(ifStmt->getThenStmt());
 
-      std::tie(thenVarRef, unsupported) = transform(ifBraceStmt, thenBody);
+      std::tie(thenVarRef, unsupported) =
+          transform(ifBraceStmt, thenBody, /*isolateBuildBlock=*/true);
       if (unsupported) {
         recordUnsupported(*unsupported);
         return nullptr;
@@ -546,7 +547,8 @@ protected:
         auto *elseBraceStmt = cast<BraceStmt>(elseStmt);
         SmallVector<ASTNode> elseBody;
 
-        std::tie(elseVarRef, unsupported) = transform(elseBraceStmt, elseBody);
+        std::tie(elseVarRef, unsupported) = transform(
+            elseBraceStmt, elseBody, /*isolateBuildBlock=*/true);
         if (unsupported) {
           recordUnsupported(*unsupported);
           return nullptr;

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -57,7 +57,7 @@ public enum FooBuilder {
     public static func buildBlock(_ components: Component...) -> Component {
         return components.flatMap { $0 }
     }
-    
+
     public static func buildLimitedAvailability(_ component: Component) -> Component {
         return component
     }
@@ -340,6 +340,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": [
@@ -360,6 +363,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                           ]
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                       }
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       "element": {}
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   ],
 // CHECK-NEXT:                   "elseElements": [
@@ -378,6 +384,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                           ]
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                       }
+// CHECK-NEXT:                     },
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       "element": {}
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   ]
 // CHECK-NEXT:                 }
@@ -436,6 +445,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": []
@@ -499,6 +511,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                 },
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   "element": {}
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": [
@@ -517,6 +532,9 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
+// CHECK-NEXT:                 },
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ]
 // CHECK-NEXT:             }

--- a/test/Constraints/result_builder_switch_with_vars.swift
+++ b/test/Constraints/result_builder_switch_with_vars.swift
@@ -90,3 +90,33 @@ tuplify {
     value.a
   }
 }
+
+tuplify { _ in
+  switch true {
+  // CHECK: (case_stmt {{.*}}
+  // CHECK:   (pattern_named implicit type="Int" "$__builder2")
+  // CHECK:   (declref_expr implicit type="(TupleBuilder.Type) -> (Int) -> Int" location={{.*}} range={{.*}} decl="{{.*}}buildBlock@{{.*}}" function_ref=single apply)
+
+  // CHECK: (call_expr implicit type="Either<Int, Int>" {{.*}}
+  // CHECK-NEXT: (dot_syntax_call_expr implicit type="(Int) -> Either<Int, Int>" {{.*}}
+  // CHECK-NEXT: (declref_expr implicit type="(TupleBuilder.Type) -> (Int) -> Either<Int, Int>" location={{.*}} range={{.*}} decl="{{.*}}buildEither(first:)@{{.*}}" function_ref=single apply)
+  // CHECK:   (argument_list implicit labels="first:"
+  // CHECK-NEXT: (argument label="first"
+  // CHECK-NEXT:   (load_expr implicit type="Int" {{.*}}
+  // CHECK-NEXT:     (declref_expr implicit type="@lvalue Int" location={{.*}} range={{.*}} decl="{{.*}}.$__builder2@{{.*}}" function_ref=unapplied))))))))
+  case true: 0
+
+  // CHECK: (case_stmt {{.*}}
+  // CHECK:   (pattern_named implicit type="Int" "$__builder4")
+  // CHECK:   (declref_expr implicit type="(TupleBuilder.Type) -> (Int) -> Int" location={{.*}} range={{.*}} decl="{{.*}}buildBlock@{{.*}}" function_ref=single apply)
+
+  // CHECK: (call_expr implicit type="Either<Int, Int>" {{.*}}
+  // CHECK-NEXT: (dot_syntax_call_expr implicit type="(Int) -> Either<Int, Int>" {{.*}}
+  // CHECK-NEXT: (declref_expr implicit type="(TupleBuilder.Type) -> (Int) -> Either<Int, Int>" location={{.*}} range={{.*}} decl="{{.*}}buildEither(second:)@{{.*}}" function_ref=single apply)
+  // CHECK:   (argument_list implicit labels="second:"
+  // CHECK-NEXT: (argument label="second"
+  // CHECK-NEXT:   (load_expr implicit type="Int" {{.*}}
+  // CHECK-NEXT:     (declref_expr implicit type="@lvalue Int" location={{.*}} range={{.*}} decl="{{.*}}.$__builder4@{{.*}}" function_ref=unapplied))))))))
+  case false: 1
+  }
+}

--- a/validation-test/Sema/result_builder_buildBlock_resolution.swift
+++ b/validation-test/Sema/result_builder_buildBlock_resolution.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 // RUN: %target-typecheck-verify-swift -I %t
 
-// This test verifies that `buildBlock` is type-checked together with enclosing context,
-// which means that it's not captured into separate variable but rather used directly and
-// contextual information can impact overload resolution.
+// ! - Based on the result builders proposal `buildBlock` shouldn't be type-checked together with `buildOptional`.
 
 protocol ActionIdentifier: Hashable {
 }
@@ -14,11 +12,11 @@ struct ActionLookup<Identifier: ActionIdentifier> {
 
 @resultBuilder
 enum ActionLookupBuilder<Identifier: ActionIdentifier> { // expected-note 3{{'Identifier' previously declared here}}
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found this candidate}}
     fatalError()
   }
 
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}} expected-note {{found this candidate}}
     []
   }
 
@@ -43,7 +41,8 @@ enum ActionType: String, ActionIdentifier, CaseIterable {
         ActionTypeLookup(
             .download
         )
-        if true { // If condition is needed to make sure that `buildOptional` affects `buildBlock` resolution.
+        if true { // If condition without else is needed to make sure that `buildOptional` affects `buildBlock` resolution.
+          // expected-error@-1 {{ambiguous use of 'buildBlock'}}
             ActionTypeLookup(
                 .upload
             )


### PR DESCRIPTION
The result builder transform proposal  (SE-0289) states that `buildBlock` is always 
type-checked separately and `buildEither` and `buildOptional` no effect on its inference. 

There was a problem with previous implementation that allowed `buildBlock` to be
type-checked together with `buildOptional` in some circumstances. We'd like to 
rectify this now and finally align the implement with the semantics stated by the proposal.

Resolves: rdar://141473488

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
