### PR TITLE
[AST] Directly store GTPD in TypeValueExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1434,39 +1434,39 @@ public:
 };
 
 class TypeValueExpr : public Expr {
-  TypeLoc paramTypeLoc;
+  GenericTypeParamDecl *paramDecl;
+  DeclNameLoc loc;
+  Type paramType;
+
+  /// Create a \c TypeValueExpr from a given generic value param decl.
+  TypeValueExpr(DeclNameLoc loc, GenericTypeParamDecl *paramDecl) :
+      Expr(ExprKind::TypeValue, /*implicit*/ false), paramDecl(paramDecl),
+      loc(loc), paramType(nullptr) {}
 
 public:
-  /// Create a \c TypeValueExpr from an underlying parameter \c TypeRepr.
-  TypeValueExpr(TypeRepr *paramRepr) :
-      Expr(ExprKind::TypeValue, /*implicit*/ false), paramTypeLoc(paramRepr) {}
-
-  /// Create a \c TypeValueExpr for a given \c TypeDecl at the specified
-  /// location.
+  /// Create a \c TypeValueExpr for a given \c GenericTypeParamDecl.
   ///
-  /// The given location must be valid. If it is not, you must use
-  /// \c TypeExpr::createImplicitForDecl instead.
-  static TypeValueExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D,
-                                      DeclContext *DC);
+  /// The given location must be valid.
+  static TypeValueExpr *createForDecl(DeclNameLoc Loc, GenericTypeParamDecl *D);
 
-  TypeRepr *getParamTypeRepr() const {
-    return paramTypeLoc.getTypeRepr();
+  GenericTypeParamDecl *getParamDecl() const {
+    return paramDecl;
   }
 
   /// Retrieves the corresponding parameter type of the value referenced by this
   /// expression.
-  ArchetypeType *getParamType() const {
-    return paramTypeLoc.getType()->castTo<ArchetypeType>();
+  Type getParamType() const {
+    return paramType;
   }
 
   /// Sets the corresponding parameter type of the value referenced by this
   /// expression.
   void setParamType(Type paramType) {
-    paramTypeLoc.setType(paramType);
+    this->paramType = paramType;
   }
 
   SourceRange getSourceRange() const {
-    return paramTypeLoc.getSourceRange();
+    return loc.getSourceRange();
   }
 
   static bool classof(const Expr *E) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2399,13 +2399,11 @@ bool Expr::isSelfExprOf(const AbstractFunctionDecl *AFD, bool sameBase) const {
   return false;
 }
 
-TypeValueExpr *TypeValueExpr::createForDecl(DeclNameLoc Loc, TypeDecl *Decl,
-                                            DeclContext *DC) {
-  ASTContext &C = Decl->getASTContext();
-  assert(Loc.isValid());
-  auto *Repr = UnqualifiedIdentTypeRepr::create(C, Loc, Decl->createNameRef());
-  Repr->setValue(Decl, DC);
-  return new (C) TypeValueExpr(Repr);
+TypeValueExpr *TypeValueExpr::createForDecl(DeclNameLoc loc, 
+                                            GenericTypeParamDecl *paramDecl) {
+  auto &ctx = paramDecl->getASTContext();
+  ASSERT(loc.isValid());
+  return new (ctx) TypeValueExpr(loc, paramDecl);
 }
 
 OpenedArchetypeType *OpenExistentialExpr::getOpenedArchetype() const {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3219,7 +3219,7 @@ namespace {
 
     Expr *visitTypeValueExpr(TypeValueExpr *expr) {
       auto toType = simplifyType(cs.getType(expr));
-      assert(toType->isEqual(expr->getParamType()->getValueType()));
+      assert(toType->isEqual(expr->getParamDecl()->getValueType()));
       cs.setType(expr, toType);
       return expr;
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1682,18 +1682,10 @@ namespace {
     }
 
     Type visitTypeValueExpr(TypeValueExpr *E) {
-      auto locator = CS.getConstraintLocator(E);
-      auto type = resolveTypeReferenceInExpression(E->getParamTypeRepr(),
-                                              TypeResolverContext::InExpression,
-                                                  locator);
-
-      if (!type || type->hasError()) {
-        return Type();
-      }
-
-      auto archetype = type->castTo<ArchetypeType>();
-      E->setParamType(archetype);
-      return archetype->getValueType();
+      auto ty = E->getParamDecl()->getDeclaredInterfaceType();
+      auto paramType = CS.DC->mapTypeIntoContext(ty);
+      E->setParamType(paramType);
+      return E->getParamDecl()->getValueType();
     }
 
     Type visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *expr) {

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -792,7 +792,8 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
                    : D->getInterfaceType());
     } else {
       if (makeTypeValue) {
-        return TypeValueExpr::createForDecl(UDRE->getNameLoc(), D, LookupDC);
+        return TypeValueExpr::createForDecl(UDRE->getNameLoc(),
+                                            cast<GenericTypeParamDecl>(D));
       } else {
         return TypeExpr::createForDecl(UDRE->getNameLoc(), D, LookupDC);
       }

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -42,6 +42,12 @@ extension A where N: P {} // expected-error {{value generic type 'N' cannot conf
 
 extension A where N == Int {} // expected-error {{cannot constrain value parameter 'N' to be type 'Int'}}
 
+extension A where N == 123 {
+  func thing() -> Int {
+    N // OK (this used to crash the compiler in a concrete case 'where N == 123')
+  }
+}
+
 func b(with a: A<123>) {} // OK
 func c<let M: Int>(with a: A<M>) {} // OK
 func d<T>(with a: A<T>) {} // expected-error {{cannot pass type 'T' as a value for generic value 'N'}}


### PR DESCRIPTION
Previously, `TypeValueExpr` stored a just built `TypeRepr` that we resolved in context in CSGen, but when we were in an extension context that concretized the generic parameter to something like `123`, we would resolve it to this integer type instead of the archetype of that generic parameter. We relied on getting the archetype to return the underlying value type to treat the expression as, but with an integer type we are unable to retrieve that information back out. Instead, we always have the GTPD when making type value expressions (at least right now), so just store that directly and be a little less strict about requiring an `ArchetypeType` as our parameter type. An `IntegerType` is fine, SIL will properly optimize the instruction away if that's the case anyway.

Resolves: rdar://144818205