### PR TITLE
Fix a comment reference to TaskGroupBase

### DIFF
--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -109,7 +109,7 @@ public:
 
 /// A status record which states that a task has a task group.
 ///
-/// A record always is a specific `TaskGroupImpl`.
+/// A record always is an instance of a `TaskGroupBase` subclass.
 ///
 /// This record holds references to all the non-completed children of
 /// the task group.  It may also hold references to completed children


### PR DESCRIPTION
Update a reference to `TaskGroupImpl` to `TaskGroupBase`.