### PR TITLE
Parsing and type checking for the definition of isolated conformances 

### DIFF
--- a/include/swift/AST/ConformanceAttributes.h
+++ b/include/swift/AST/ConformanceAttributes.h
@@ -27,6 +27,9 @@ struct ConformanceAttributes {
 
   /// The location of the "unsafe" attribute if present.
   SourceLoc unsafeLoc;
+
+  /// The location of the "@isolated" attribute if present.
+  SourceLoc isolatedLoc;
   
   /// Merge other conformance attributes into this set.
   ConformanceAttributes &
@@ -37,6 +40,8 @@ struct ConformanceAttributes {
       preconcurrencyLoc = other.preconcurrencyLoc;
     if (other.unsafeLoc.isValid())
       unsafeLoc = other.unsafeLoc;
+    if (other.isolatedLoc.isValid())
+      isolatedLoc = other.isolatedLoc;
     return *this;
   }
 };

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1836,12 +1836,13 @@ public:
   bool isPreconcurrency() const {
     return getOptions().contains(ProtocolConformanceFlags::Preconcurrency);
   }
+  bool isIsolated() const {
+    return getOptions().contains(ProtocolConformanceFlags::Isolated);
+  }
 
   ExplicitSafety getExplicitSafety() const {
     if (getOptions().contains(ProtocolConformanceFlags::Unsafe))
       return ExplicitSafety::Unsafe;
-    if (getOptions().contains(ProtocolConformanceFlags::Safe))
-      return ExplicitSafety::Safe;
     return ExplicitSafety::Unspecified;
   }
 
@@ -1852,13 +1853,10 @@ public:
   }
 
   void setOption(ExplicitSafety safety) {
-    RawOptions = (getOptions() - ProtocolConformanceFlags::Unsafe
-                    - ProtocolConformanceFlags::Safe).toRaw();
+    RawOptions = (getOptions() - ProtocolConformanceFlags::Unsafe).toRaw();
     switch (safety) {
     case ExplicitSafety::Unspecified:
-      break;
     case ExplicitSafety::Safe:
-      RawOptions = (getOptions() | ProtocolConformanceFlags::Safe).toRaw();
       break;
     case ExplicitSafety::Unsafe:
       RawOptions = (getOptions() | ProtocolConformanceFlags::Unsafe).toRaw();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2722,8 +2722,17 @@ WARNING(add_predates_concurrency_import,none,
 GROUPED_WARNING(remove_predates_concurrency_import,PreconcurrencyImport,
                 DefaultIgnore,
                 "'@preconcurrency' attribute on module %0 has no effect", (Identifier))
+NOTE(add_isolated_to_conformance,none,
+     "add 'isolated' to the %0 conformance to restrict it to %1 code",
+    (DeclName, ActorIsolation))
 NOTE(add_preconcurrency_to_conformance,none,
      "add '@preconcurrency' to the %0 conformance to defer isolation checking to run time", (DeclName))
+ERROR(isolated_conformance_not_global_actor_isolated,none,
+      "isolated conformance is only permitted on global-actor-isolated types",
+      ())
+ERROR(isolated_conformance_experimental_feature,none,
+      "isolated conformances require experimental feature "
+      " 'IsolatedConformances'", ())
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,6 +2733,12 @@ ERROR(isolated_conformance_not_global_actor_isolated,none,
 ERROR(isolated_conformance_experimental_feature,none,
       "isolated conformances require experimental feature "
       " 'IsolatedConformances'", ())
+ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
+      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as 'isolated'",
+      (Type, DeclName, ActorIsolation, Type, DeclName))
+ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
+      "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
+      (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (Identifier))

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -669,6 +669,11 @@ public:
     return getOptions().contains(ProtocolConformanceFlags::Preconcurrency);
   }
 
+  /// Whether this is an isolated conformance.
+  bool isIsolated() const {
+    return getOptions().contains(ProtocolConformanceFlags::Isolated);
+  }
+
   /// Retrieve the location of `@preconcurrency`, if there is one and it is
   /// known.
   SourceLoc getPreconcurrencyLoc() const { return PreconcurrencyLoc; }
@@ -678,8 +683,6 @@ public:
   ExplicitSafety getExplicitSafety() const {
     if (getOptions().contains(ProtocolConformanceFlags::Unsafe))
       return ExplicitSafety::Unsafe;
-    if (getOptions().contains(ProtocolConformanceFlags::Safe))
-      return ExplicitSafety::Safe;
     return ExplicitSafety::Unspecified;
   }
 

--- a/include/swift/AST/ProtocolConformanceOptions.h
+++ b/include/swift/AST/ProtocolConformanceOptions.h
@@ -34,8 +34,8 @@ enum class ProtocolConformanceFlags {
   /// @retroactive conformance
   Retroactive = 0x08,
 
-  /// @safe conformance
-  Safe = 0x10,
+  /// @isolated conformance
+  Isolated = 0x10,
 
   // Note: whenever you add a bit here, update
   // NumProtocolConformanceOptions below.

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -450,10 +450,14 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 /// Be strict about the Sendable conformance of metatypes.
 EXPERIMENTAL_FEATURE(StrictSendableMetatypes, true)
 
+
 /// Allow public enumerations to be extensible by default
 /// regardless of whether the module they are declared in
 /// is resilient or not.
 EXPERIMENTAL_FEATURE(ExtensibleEnums, true)
+
+/// Allow isolated conformances.
+EXPERIMENTAL_FEATURE(IsolatedConformances, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -154,6 +154,8 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
         options |= ProtocolConformanceFlags::Preconcurrency;
       if (getUnsafeLoc().isValid())
         options |= ProtocolConformanceFlags::Unsafe;
+      if (getIsolatedLoc().isValid())
+        options |= ProtocolConformanceFlags::Isolated;
       return options;
     }
 
@@ -207,6 +209,11 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
     /// The location of the @unsafe attribute, if any.
     SourceLoc getUnsafeLoc() const {
       return attributes.unsafeLoc;
+    }
+
+    /// The location of the @isolated attribute, if any.
+    SourceLoc getIsolatedLoc() const {
+      return attributes.isolatedLoc;
     }
 
     /// For an inherited conformance, retrieve the class declaration

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1780,6 +1780,8 @@ InheritedEntry::InheritedEntry(const TypeLoc &typeLoc)
       setOption(ProtocolConformanceFlags::Unsafe);
     if (typeRepr->findAttrLoc(TypeAttrKind::Preconcurrency).isValid())
       setOption(ProtocolConformanceFlags::Preconcurrency);
+    if (typeRepr->findAttrLoc(TypeAttrKind::Isolated).isValid())
+      setOption(ProtocolConformanceFlags::Isolated);
   }
 }
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -348,6 +348,11 @@ static bool usesFeatureABIAttribute(Decl *decl) {
   return getABIAttr(decl) != nullptr;
 }
 
+static bool usesFeatureIsolatedConformances(Decl *decl) { 
+  // FIXME: Check conformances associated with this decl?
+  return false;
+}
+
 UNINTERESTING_FEATURE(WarnUnsafe)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -163,7 +163,9 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     Diag<> MessageID, ParseTypeReason reason) {
   ParserResult<TypeRepr> ty;
 
-  if (isParameterSpecifier()) {
+  if (isParameterSpecifier() &&
+      !(!Context.LangOpts.hasFeature(Feature::IsolatedConformances) &&
+        Tok.isContextualKeyword("isolated"))) {
     // Type specifier should already be parsed before here. This only happens
     // for construct like 'P1 & inout P2'.
     diagnose(Tok.getLoc(), diag::attr_only_on_parameters, Tok.getRawText());

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -699,6 +699,19 @@ void introduceUnsafeInheritExecutorReplacements(
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
+/// Enumerate all of the isolated conformances in the given conformance.
+/// 
+/// The given `body` will be called on each isolated conformance. If it ever
+/// returns `true`, this function will abort the search and return `true`.
+bool forEachIsolatedConformance(
+    ProtocolConformanceRef conformance, 
+    llvm::function_ref<bool(ProtocolConformance*)> body
+);
+
+/// Determine the isolation of the given conformance. This only applies to
+/// the immediate conformance, not any conformances on which it depends.
+ActorIsolation getConformanceIsolation(ProtocolConformance *conformance);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -112,8 +112,8 @@ enum class ResolveWitnessResult {
 /// This helper class handles most of the details of checking whether a
 /// given type (\c Adoptee) conforms to a protocol (\c Proto).
 class ConformanceChecker : public WitnessChecker {
-  /// Whether we already suggested adding `@preconcurrency`.
-  bool suggestedPreconcurrency = false;
+  /// Whether we already suggested adding `@preconcurrency` or 'isolated'.
+  bool suggestedPreconcurrencyOrIsolated = false;
 
 public:
   NormalProtocolConformance *Conformance;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5175,8 +5175,9 @@ NeverNullType
 TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                       TypeResolutionOptions options) {
   // isolated is only value for non-EnumCaseDecl parameters.
-  if (!options.is(TypeResolverContext::FunctionInput) ||
-      options.hasBase(TypeResolverContext::EnumElementDecl)) {
+  if ((!options.is(TypeResolverContext::FunctionInput) ||
+       options.hasBase(TypeResolverContext::EnumElementDecl)) &&
+      !options.is(TypeResolverContext::Inherited)) {
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::attr_only_on_parameters,
         "isolated");
@@ -5197,7 +5198,8 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
     unwrappedType = dynamicSelfType->getSelfType();
   }
 
-  if (inStage(TypeResolutionStage::Interface)) {
+  if (inStage(TypeResolutionStage::Interface) &&
+      !options.is(TypeResolverContext::Inherited)) {
     if (auto *env = resolution.getGenericSignature().getGenericEnvironment())
       unwrappedType = env->mapTypeIntoContext(unwrappedType);
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+
+protocol P {
+  func f() // expected-note 2{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+}
+
+// expected-note@+3{{add '@preconcurrency' to the 'P' conformance to defer isolation checking to run time}}{{25-25=@preconcurrency }}
+// expected-note@+2{{add 'isolated' to the 'P' conformance to restrict it to main actor-isolated code}}{{25-25=isolated }}
+@MainActor
+class CWithNonIsolated: P {
+  func f() { } // expected-error{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  // expected-note@-1{{add 'nonisolated' to 'f()' to make this instance method not isolated to the actor}}
+}
+
+actor SomeActor { }
+
+// Isolated conformances need a global-actor-constrained type.
+class CNonIsolated: isolated P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
+  func f() { }
+}
+
+extension SomeActor: isolated P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
+  nonisolated func f() { }
+}
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+// Isolation of the function needs to match that of the enclosing type.
+@MainActor
+class CMismatchedIsolation: isolated P {
+  @SomeGlobalActor func f() { } // expected-error{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+}
+
+@MainActor
+class C: isolated P {
+  func f() { } // okay
+}

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -40,3 +40,41 @@ class CMismatchedIsolation: isolated P {
 class C: isolated P {
   func f() { } // okay
 }
+
+// Associated conformances with isolation
+
+protocol Q {
+  associatedtype A: P
+}
+
+// expected-error@+2{{conformance of 'SMissingIsolation' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as 'isolated'}}{{27-27=isolated }}
+@MainActor
+struct SMissingIsolation: Q {
+  typealias A = C
+}
+
+struct PWrapper<T: P>: P {
+  func f() { }
+}
+
+// expected-error@+2{{conformance of 'SMissingIsolationViaWrapper' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as 'isolated'}}
+@MainActor
+struct SMissingIsolationViaWrapper: Q {
+  typealias A = PWrapper<C>
+}
+
+@SomeGlobalActor
+class C2: isolated P {
+  func f() { }
+}
+
+@MainActor
+struct S: isolated Q {
+  typealias A = C
+}
+
+// expected-error@+2{{main actor-isolated conformance of 'SMismatchedActors' to 'Q' cannot depend on global actor 'SomeGlobalActor'-isolated conformance of 'C2' to 'P'}}
+@MainActor
+struct SMismatchedActors: isolated Q {
+  typealias A = C2
+}


### PR DESCRIPTION
Allow a conformance to be "isolated", meaning that it stays in the same isolation domain as the conforming type. Only allow this for global-actor-isolated types.

When a conformance is isolated, a nonisolated requirement can be witnessed by a declaration with the same global actor isolation as the enclosing type.

Additionally, insure that isolated conformances are viral to other conformances: if a conformance depends on an isolated conformance, it might itself be isolated, and to the same global actor.