### PR TITLE
[CoroutineAccessors] Use retcon.once variant.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -235,6 +235,7 @@ types where the metadata itself has unknown layout.)
   global ::= global 'TF'                 // distributed method accessor
   global ::= global 'TI'                 // implementation of a dynamic_replaceable function
   global ::= global 'Tu'                 // async function pointer of a function
+  global ::= global 'Tv'                 // coro function pointer of a function
   global ::= global 'TX'                 // function pointer of a dynamic_replaceable function
   global ::= global 'Twb'                // back deployment thunk
   global ::= global 'TwB'                // back deployment fallback function

--- a/include/swift/ABI/Coro.h
+++ b/include/swift/ABI/Coro.h
@@ -1,0 +1,80 @@
+//===---------- Coro.h - ABI structures for coroutines ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift ABI describing the coroutine ABI.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_CORO_H
+#define SWIFT_ABI_CORO_H
+
+#include "swift/Basic/FlagSet.h"
+#include <cstddef>
+#include <cstdint>
+
+namespace swift {
+
+enum class CoroAllocatorKind : uint8_t {
+  // stacksave/stackrestore
+  Sync = 0,
+  // swift_task_alloc/swift_task_dealloc_through
+  Async = 1,
+  // malloc/free
+  Malloc = 2,
+};
+
+class CoroAllocatorFlags : public FlagSet<uint32_t> {
+public:
+  // clang-format off
+  enum {
+    Kind           = 0,
+    Kind_width     = 8,
+
+    // 24 reserved bits
+  };
+  // clang-format on
+
+  constexpr explicit CoroAllocatorFlags(uint32_t bits) : FlagSet(bits) {}
+  CoroAllocatorFlags(CoroAllocatorKind kind) { setKind(kind); }
+  constexpr CoroAllocatorFlags() {}
+
+  FLAGSET_DEFINE_FIELD_ACCESSORS(Kind, Kind_width, CoroAllocatorKind, getKind,
+                                 setKind)
+};
+
+using CoroAllocation = void *;
+using CoroAllocateFn = CoroAllocation (*)(size_t);
+using CoroDealllocateFn = void (*)(CoroAllocation);
+
+struct CoroAllocator {
+  CoroAllocatorFlags flags;
+  CoroAllocateFn allocate;
+  CoroDealllocateFn deallocate;
+
+  /// Whether the allocator should deallocate memory on calls to
+  /// swift_coro_dealloc.
+  constexpr bool shouldDeallocateImmediately() {
+    // Only the "mallocator" should immediately deallocate in
+    // swift_coro_dealloc.  It must because the ABI does not provide a means for
+    // the callee to return its allocations to the caller.
+    //
+    // Async allocations can be deferred until the first non-coroutine caller
+    // from where swift_task_dealloc_through can be called and passed the
+    // caller-allocated fixed-per-callee-sized-frame.
+    // Stack allocations just pop the stack.
+    return flags.getKind() == CoroAllocatorKind::Malloc;
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -386,6 +386,7 @@ public:
   unsigned LazyInitializeClassMetadata : 1;
   unsigned LazyInitializeProtocolConformances : 1;
   unsigned IndirectAsyncFunctionPointer : 1;
+  unsigned IndirectCoroFunctionPointer : 1;
 
   /// Use absolute function references instead of relative ones.
   /// Mainly used on WebAssembly, that doesn't support relative references
@@ -580,10 +581,10 @@ public:
         HasValueNamesSetting(false), ValueNames(false),
         ReflectionMetadata(ReflectionMetadataMode::Runtime),
         EnableReflectionNames(true), DisableLLVMMergeFunctions(false),
-        EnableAnonymousContextMangledNames(false),
-        ForcePublicLinkage(false), LazyInitializeClassMetadata(false),
+        EnableAnonymousContextMangledNames(false), ForcePublicLinkage(false),
+        LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false),
-        IndirectAsyncFunctionPointer(false),
+        IndirectAsyncFunctionPointer(false), IndirectCoroFunctionPointer(false),
         CompactAbsoluteFunctionPointer(false), DisableLegacyTypeInfo(false),
         PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),
         UseTypeLayoutValueHandling(true), ForceStructTypeLayouts(false),
@@ -598,16 +599,15 @@ public:
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
-        MergeableSymbols(false),
-        EmitGenericRODatas(true), NoPreallocatedInstantiationCaches(false),
+        MergeableSymbols(false), EmitGenericRODatas(true),
+        NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false), EnableHotColdSplit(false),
         EmitAsyncFramePushPopMetadata(true), EmitTypeMallocForCoroFrame(false),
         EmitYieldOnce2AsYieldOnce(true), AsyncFramePointerAll(false),
-        UseProfilingMarkerThunks(false),
-        DebugInfoForProfiling(false), CmdArgs(),
-        SanitizeCoverage(llvm::SanitizerCoverageOptions()),
+        UseProfilingMarkerThunks(false), DebugInfoForProfiling(false),
+        CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),
         CASObjMode(llvm::CASBackendMode::Native) {

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -551,6 +551,44 @@ class LinkEntity {
     /// Pointer is the (generalized) existential type.
     /// SecondaryPointer is the GenericSignatureImpl*.
     ExtendedExistentialTypeShape,
+
+    /// A global struct containing a relative pointer to the single-yield
+    /// coroutine ramp function and the fixed-size to be allocated in the
+    /// caller.
+    /// The pointer is a SILFunction*.
+    CoroFunctionPointer,
+
+    /// The same as CoroFunctionPointer but with a different stored value, for
+    /// use by TBDGen.
+    /// The pointer is an AbstractFunctionDecl*.
+    CoroFunctionPointerAST,
+
+    /// An coro function pointer for a method dispatch thunk.  The pointer is
+    /// a FuncDecl* inside a protocol or a class.
+    DispatchThunkCoroFunctionPointer,
+
+    /// An coro function pointer for a method dispatch thunk for an
+    /// initializing constructor.  The pointer is a ConstructorDecl* inside a
+    /// class.
+    DispatchThunkInitializerCoroFunctionPointer,
+
+    /// An coro function pointer for a method dispatch thunk for an allocating
+    /// constructor.  The pointer is a ConstructorDecl* inside a protocol or
+    /// a class.
+    DispatchThunkAllocatorCoroFunctionPointer,
+
+    /// An coro function pointer for a distributed thunk.
+    /// The pointer is a FuncDecl* inside an actor (class).
+    DistributedThunkCoroFunctionPointer,
+
+    /// An coro function pointer to a partial apply forwarder.
+    /// The pointer is the llvm::Function* for a partial apply forwarder.
+    PartialApplyForwarderCoroFunctionPointer,
+
+    /// An coro function pointer for a distributed accessor (method or
+    /// property).
+    /// The pointer is a SILFunction*.
+    DistributedAccessorCoroFunctionPointer,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -1454,6 +1492,98 @@ public:
         LINKENTITY_SET_FIELD(Kind, unsigned(Kind::ExtendedExistentialTypeShape))
       | LINKENTITY_SET_FIELD(ExtendedExistentialIsUnique, unsigned(isUnique))
       | LINKENTITY_SET_FIELD(ExtendedExistentialIsShared, unsigned(isShared));
+    return entity;
+  }
+
+  static LinkEntity forCoroFunctionPointer(LinkEntity other) {
+    LinkEntity entity;
+    entity.Pointer = other.Pointer;
+    entity.SecondaryPointer = nullptr;
+
+    switch (other.getKind()) {
+    case LinkEntity::Kind::SILFunction:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::CoroFunctionPointer));
+      break;
+
+    case LinkEntity::Kind::DispatchThunk:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::DispatchThunkCoroFunctionPointer));
+      break;
+
+    case LinkEntity::Kind::DispatchThunkInitializer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind,
+          unsigned(
+              LinkEntity::Kind::DispatchThunkInitializerCoroFunctionPointer));
+      break;
+
+    case LinkEntity::Kind::DispatchThunkAllocator:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind,
+          unsigned(
+              LinkEntity::Kind::DispatchThunkAllocatorCoroFunctionPointer));
+      break;
+    case LinkEntity::Kind::PartialApplyForwarder:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind,
+          unsigned(LinkEntity::Kind::PartialApplyForwarderCoroFunctionPointer));
+      break;
+
+    case LinkEntity::Kind::DistributedAccessor: {
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind,
+          unsigned(LinkEntity::Kind::DistributedAccessorCoroFunctionPointer));
+      break;
+    }
+
+    default:
+      llvm_unreachable("Link entity kind cannot have an coro function pointer");
+    }
+
+    return entity;
+  }
+
+  LinkEntity getUnderlyingEntityForCoroFunctionPointer() const {
+    LinkEntity entity;
+    entity.Pointer = Pointer;
+    entity.SecondaryPointer = nullptr;
+
+    switch (getKind()) {
+    case LinkEntity::Kind::CoroFunctionPointer:
+      entity.Data =
+          LINKENTITY_SET_FIELD(Kind, unsigned(LinkEntity::Kind::SILFunction));
+      break;
+
+    case LinkEntity::Kind::DispatchThunkCoroFunctionPointer:
+      entity.Data =
+          LINKENTITY_SET_FIELD(Kind, unsigned(LinkEntity::Kind::DispatchThunk));
+      break;
+
+    case LinkEntity::Kind::DispatchThunkInitializerCoroFunctionPointer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::DispatchThunkInitializer));
+      break;
+
+    case LinkEntity::Kind::DispatchThunkAllocatorCoroFunctionPointer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::DispatchThunkAllocator));
+      break;
+
+    case LinkEntity::Kind::PartialApplyForwarderCoroFunctionPointer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::PartialApplyForwarder));
+      break;
+
+    case LinkEntity::Kind::DistributedAccessorCoroFunctionPointer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::DistributedAccessor));
+      break;
+
+    default:
+      llvm_unreachable("Link entity is not an coro function pointer");
+    }
+
     return entity;
   }
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -389,6 +389,11 @@ class LinkEntity {
     /// The pointer is an AbstractFunctionDecl*.
     AsyncFunctionPointerAST,
 
+    /// The same as CoroFunctionPointer but with a different stored value, for
+    /// use by TBDGen.
+    /// The pointer is an AbstractFunctionDecl*.
+    CoroFunctionPointerAST,
+
     /// The pointer is a SILFunction*.
     DynamicallyReplaceableFunctionKey,
 
@@ -558,11 +563,6 @@ class LinkEntity {
     /// The pointer is a SILFunction*.
     CoroFunctionPointer,
 
-    /// The same as CoroFunctionPointer but with a different stored value, for
-    /// use by TBDGen.
-    /// The pointer is an AbstractFunctionDecl*.
-    CoroFunctionPointerAST,
-
     /// An coro function pointer for a method dispatch thunk.  The pointer is
     /// a FuncDecl* inside a protocol or a class.
     DispatchThunkCoroFunctionPointer,
@@ -610,9 +610,7 @@ class LinkEntity {
     return !(LHS == RHS);
   }
 
-  static bool isDeclKind(Kind k) {
-    return k <= Kind::AsyncFunctionPointerAST;
-  }
+  static bool isDeclKind(Kind k) { return k <= Kind::CoroFunctionPointerAST; }
   static bool isTypeKind(Kind k) {
     return k >= Kind::ProtocolWitnessTableLazyAccessFunction;
   }
@@ -1541,6 +1539,17 @@ public:
       llvm_unreachable("Link entity kind cannot have an coro function pointer");
     }
 
+    return entity;
+  }
+
+  static LinkEntity forCoroFunctionPointer(SILDeclRef declRef) {
+    LinkEntity entity;
+    entity.setForDecl(declRef.isDistributedThunk()
+                          ? Kind::DistributedThunkCoroFunctionPointer
+                          : Kind::CoroFunctionPointerAST,
+                      declRef.getAbstractFunctionDecl());
+    entity.SecondaryPointer =
+        reinterpret_cast<void *>(static_cast<uintptr_t>(declRef.kind));
     return entity;
   }
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -18,6 +18,7 @@
 #define SWIFT_RUNTIME_CONCURRENCY_H
 
 #include "swift/ABI/AsyncLet.h"
+#include "swift/ABI/Coro.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskGroup.h"
 
@@ -118,6 +119,35 @@ void *swift_task_alloc(size_t size);
 /// must be allocated and deallocated in a strict stack discipline.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_dealloc(void *ptr);
+
+/// Deallocate multiple memory allocations in a task.
+///
+/// The pointer provided must be a pointer previously allocated on
+/// this task that has not yet been deallocated.  All allocations up to and
+/// including that allocation will be deallocated.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void swift_task_dealloc_through(void *ptr);
+
+// TODO: CoroutineAccessors: Eliminate this entry point and replace its uses
+//                           with direct references the globals.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift)
+CoroAllocator *swift_coro_getGlobalAllocator(CoroAllocatorFlags flags);
+
+// TODO: CoroutineAccessors: Mark the underlying struct const.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+CoroAllocator *const _swift_coro_task_allocator;
+
+// TODO: CoroutineAccessors: Move these declarations back to swiftCore {{
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void *swift_coro_alloc(CoroAllocator *allocator, size_t size);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void swift_coro_dealloc(CoroAllocator *allocator, void *ptr);
+
+// TODO: CoroutineAccessors: Mark the underlying struct const.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+CoroAllocator *const _swift_coro_malloc_allocator;
+// }} TODO: CoroutineAccessors
 
 /// Cancel a task and all of its child tasks.
 ///

--- a/include/swift/Runtime/Coro.h
+++ b/include/swift/Runtime/Coro.h
@@ -1,0 +1,26 @@
+//===-------- Coro.h - Runtime interface for coroutines ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The runtime interface for coroutines.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_CORO_H
+#define SWIFT_RUNTIME_CORO_H
+
+#include "swift/ABI/Coro.h"
+#include "swift/Runtime/Config.h"
+#include <cstddef>
+
+namespace swift {} // end namespace swift
+
+#endif

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2325,6 +2325,16 @@ FUNCTION(TaskDealloc,
          EFFECT(Concurrency),
          MEMEFFECTS(ArgMemOnly))
 
+// void swift_task_dealloc_through(void *ptr);
+FUNCTION(TaskDeallocThrough,
+         _Concurrency, swift_task_dealloc_through, SwiftCC,
+         CoroutineAccessorsAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
+
 // void swift_task_cancel(AsyncTask *task);
 FUNCTION(TaskCancel,
          _Concurrency, swift_task_cancel, SwiftCC,
@@ -2987,6 +2997,36 @@ FUNCTION(MemsetS, c, memset_s, C_CC, AlwaysAvailable,
          ARGS(PtrTy, SizeTy, Int32Ty, SizeTy),
          ATTRS(NoUnwind),
          EFFECT(NoEffect),
+         UNKNOWN_MEMEFFECTS)
+
+// void *swift_coro_alloc(CoroAllocator *, size_t size);
+FUNCTION(CoroAlloc,
+         _Concurrency, swift_coro_alloc, SwiftCC,
+         CoroutineAccessorsAvailability,
+         RETURNS(Int8PtrTy),
+         ARGS(CoroAllocatorPtrTy, SizeTy),
+         NO_ATTRS,
+         EFFECT(Allocating, Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_coro_dealloc(CoroAllocator *, void *ptr);
+FUNCTION(CoroDealloc,
+         _Concurrency, swift_coro_dealloc, SwiftCC,
+         CoroutineAccessorsAvailability,
+         RETURNS(VoidTy),
+         ARGS(CoroAllocatorPtrTy, Int8PtrTy),
+         NO_ATTRS,
+         EFFECT(Deallocating, Concurrency),
+         UNKNOWN_MEMEFFECTS)
+
+// const CoroAllocator *swift_coro_getGlobalAllocator(CoroAllocatorFlags flags);
+FUNCTION(CoroGetGlobalAllocator, 
+         _Concurrency, swift_coro_getGlobalAllocator, SwiftCC, 
+         CoroutineAccessorsAvailability, 
+         RETURNS(CoroAllocatorPtrTy), 
+         ARGS(CoroAllocatorFlagsTy), 
+         ATTRS(NoUnwind, WillReturn), 
+         EFFECT(Allocating),
          UNKNOWN_MEMEFFECTS)
 
 #undef RETURNS

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -768,6 +768,10 @@ public:
 
   bool isAsync() const { return LoweredType->isAsync(); }
 
+  bool isCalleeAllocatedCoroutine() const {
+    return LoweredType->isCalleeAllocatedCoroutine();
+  }
+
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {
     return getLoweredFunctionType()->getRepresentation();

--- a/include/swift/SIL/SILSymbolVisitor.h
+++ b/include/swift/SIL/SILSymbolVisitor.h
@@ -100,6 +100,7 @@ public:
   virtual void addAsyncFunctionPointer(SILDeclRef declRef) {}
   virtual void addBaseConformanceDescriptor(BaseConformance BC) {}
   virtual void addClassMetadataBaseOffset(ClassDecl *CD) {}
+  virtual void addCoroFunctionPointer(SILDeclRef declRef) {}
   virtual void addDispatchThunk(SILDeclRef declRef) {}
   virtual void addDynamicFunction(AbstractFunctionDecl *AFD,
                                   DynamicKind dynKind) {}

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3431,6 +3431,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // AsyncFunctionPointer access.
   Opts.IndirectAsyncFunctionPointer = Triple.isOSBinFormatCOFF();
 
+  // PE/COFF cannot deal with the cross-module reference to the
+  // CoroFunctionPointer data block.  Force the use of indirect
+  // CoroFunctionPointer access.
+  Opts.IndirectCoroFunctionPointer = Triple.isOSBinFormatCOFF();
+
   // On some Harvard architectures that allow sliding code and data address space
   // offsets independently, it's impossible to make direct relative reference to
   // code from data because the relative offset between them is not representable.

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -72,6 +72,10 @@ protected:
   /// Whether this is a coroutine invocation.
   bool IsCoroutine;
 
+  /// Whether this is a invocation for a coroutine that dynamically allocates
+  /// in the callee.
+  bool IsCalleeAllocatedCoroutine;
+
   /// Whether we've emitted the call for the current callee yet.  This
   /// is just for debugging purposes --- e.g. the destructor asserts
   /// that it's true --- but is otherwise derivable from
@@ -177,6 +181,9 @@ public:
 
   virtual llvm::Value *getResumeFunctionPointer() = 0;
   virtual llvm::Value *getAsyncContext() = 0;
+
+  virtual StackAddress getCoroStaticFrame() = 0;
+  virtual llvm::Value *getCoroAllocator() = 0;
 
   void setIndirectTypedErrorResultSlot(llvm::Value *addr) {
     Args[IndirectTypedErrorArgIdx] = addr;

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -172,7 +172,8 @@ namespace irgen {
   public:
     enum class BasicKind {
       Function,
-      AsyncFunctionPointer
+      AsyncFunctionPointer,
+      CoroFunctionPointer,
     };
 
     enum class SpecialKind {
@@ -190,13 +191,15 @@ namespace irgen {
     };
 
   private:
-    static constexpr unsigned SpecialOffset = 2;
+    static constexpr unsigned SpecialOffset = 3;
     unsigned value;
   public:
     static constexpr BasicKind Function =
       BasicKind::Function;
     static constexpr BasicKind AsyncFunctionPointer =
       BasicKind::AsyncFunctionPointer;
+    static constexpr BasicKind CoroFunctionPointer =
+        BasicKind::CoroFunctionPointer;
 
     FunctionPointerKind(BasicKind kind)
       : value(unsigned(kind)) {}
@@ -219,6 +222,9 @@ namespace irgen {
     }
     bool isAsyncFunctionPointer() const {
       return value == unsigned(BasicKind::AsyncFunctionPointer);
+    }
+    bool isCoroFunctionPointer() const {
+      return value == unsigned(BasicKind::CoroFunctionPointer);
     }
 
     bool isSpecial() const {
@@ -325,7 +331,10 @@ namespace irgen {
     /// An additional value whose meaning varies by the FunctionPointer's Kind:
     /// - Kind::AsyncFunctionPointer -> pointer to the corresponding function
     ///                                 if the FunctionPointer was created via
-    ///                                 forDirect; nullptr otherwise. 
+    ///                                 forDirect; nullptr otherwise.
+    /// - Kind::CoroFunctionPointer - pointer to the corresponding function
+    ///                               if the FunctionPointer was created via
+    ///                               forDirect; nullptr otherwise.
     llvm::Value *SecondaryValue;
 
     PointerAuthInfo AuthInfo;
@@ -461,6 +470,13 @@ namespace irgen {
     /// pointer to the corresponding function if available.
     llvm::Value *getRawAsyncFunction() const {
       assert(kind.isAsyncFunctionPointer());
+      return SecondaryValue;
+    }
+
+    /// Assuming that the receiver is of kind CoroFunctionPointer, returns the
+    /// pointer to the corresponding function if available.
+    llvm::Value *getRawCoroFunction() const {
+      assert(kind.isCoroFunctionPointer());
       return SecondaryValue;
     }
 

--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -51,12 +51,12 @@ public:
   virtual llvm::Value *getSelfWitnessTable() = 0;
   virtual llvm::Value *getSelfMetadata() = 0;
   virtual llvm::Value *getCoroutineBuffer() = 0;
-  virtual Explosion
+  Explosion
   explosionForObject(IRGenFunction &IGF, unsigned index, SILArgument *param,
                      SILType paramTy, const LoadableTypeInfo &loadableParamTI,
                      const LoadableTypeInfo &loadableArgTI,
                      std::function<Explosion(unsigned index, unsigned size)>
-                         explosionForArgument) = 0;
+                         explosionForArgument);
 };
 
 } // end namespace irgen

--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -51,6 +51,7 @@ public:
   virtual llvm::Value *getSelfWitnessTable() = 0;
   virtual llvm::Value *getSelfMetadata() = 0;
   virtual llvm::Value *getCoroutineBuffer() = 0;
+  virtual llvm::Value *getCoroutineAllocator() = 0;
   Explosion
   explosionForObject(IRGenFunction &IGF, unsigned index, SILArgument *param,
                      SILType paramTy, const LoadableTypeInfo &loadableParamTI,

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2513,9 +2513,10 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
 }
 }
 
-std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
-    IRGenFunction &IGF, FunctionPointer functionPointer,
-    llvm::Value *thickContext, std::pair<bool, bool> values) {
+std::pair<llvm::Value *, llvm::Value *>
+irgen::getAsyncFunctionAndSize(IRGenFunction &IGF,
+                               FunctionPointer functionPointer,
+                               std::pair<bool, bool> values) {
   assert(values.first || values.second);
   assert(functionPointer.getKind() != FunctionPointer::Kind::Function);
 
@@ -2958,8 +2959,8 @@ public:
     // Allocate space for the async context.
 
     llvm::Value *dynamicContextSize32;
-    std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        IGF, CurCallee.getFunctionPointer(), thickContext);
+    std::tie(calleeFunction, dynamicContextSize32) =
+        getAsyncFunctionAndSize(IGF, CurCallee.getFunctionPointer());
     auto *dynamicContextSize =
         IGF.Builder.CreateZExt(dynamicContextSize32, IGF.IGM.SizeTy);
     if (auto staticSize = dyn_cast<llvm::ConstantInt>(dynamicContextSize)) {
@@ -2983,7 +2984,6 @@ public:
     super::end();
   }
   void setFromCallee() override {
-    thickContext = nullptr; // TODO: this should go
 
     super::setFromCallee();
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/ABI/Coro.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -77,15 +78,14 @@ static Alignment getYieldManyCoroutineBufferAlignment(IRGenModule &IGM) {
   return IGM.getPointerAlignment();
 }
 
-static Size getCoroutineContextSize(IRGenModule &IGM,
-                                    CanSILFunctionType fnType) {
+static std::optional<Size> getCoroutineContextSize(IRGenModule &IGM,
+                                                   CanSILFunctionType fnType) {
   switch (fnType->getCoroutineKind()) {
   case SILCoroutineKind::None:
     llvm_unreachable("expand a coroutine");
   case SILCoroutineKind::YieldOnce2:
     if (!IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce)
-      llvm::report_fatal_error(
-          "callee allocated coroutines do not have fixed-size buffers");
+      return std::nullopt;
     LLVM_FALLTHROUGH;
   case SILCoroutineKind::YieldOnce:
     return getYieldOnceCoroutineBufferSize(IGM);
@@ -161,6 +161,10 @@ Alignment IRGenModule::getAsyncContextAlignment() const {
   return Alignment(MaximumAlignment);
 }
 
+Alignment IRGenModule::getCoroStaticFrameAlignment() const {
+  return Alignment(MaximumAlignment);
+}
+
 std::optional<Size>
 FunctionPointerKind::getStaticAsyncContextSize(IRGenModule &IGM) const {
   if (!isSpecial())
@@ -202,6 +206,21 @@ void IRGenFunction::setupAsync(unsigned asyncContextIndex) {
   builder.SetInsertPoint(getEarliestInsertionPoint()->getParent(),
                          getEarliestInsertionPoint()->getIterator());
   builder.CreateStore(c, asyncContextLocation);
+}
+
+std::optional<CoroAllocatorKind>
+IRGenFunction::getDefaultCoroutineAllocatorKind() {
+  if (isCalleeAllocatedCoroutine()) {
+    // This is a yield_once_2 coroutine.  It has no default kind.
+    return std::nullopt;
+  }
+  if (isAsync()) {
+    return CoroAllocatorKind::Async;
+  }
+  if (isCoroutine()) {
+    return CoroAllocatorKind::Malloc;
+  }
+  return CoroAllocatorKind::Sync;
 }
 
 llvm::Value *IRGenFunction::getAsyncTask() {
@@ -549,7 +568,7 @@ namespace {
 
     /// Expand the components of the continuation entrypoint of the
     /// function type.
-    void expandCoroutineContinuationType();
+    void expandCoroutineContinuationType(bool emitYieldOnce2AsYieldOnce);
 
     // Expand the components for the async continuation entrypoint of the
     // function type (the function to be called on returning).
@@ -602,6 +621,7 @@ namespace {
     }
 
     void addCoroutineContextParameter();
+    void addCoroutineAllocatorParameter();
     void addAsyncParameters();
 
     void expandResult(SignatureExpansionABIDetails *recordedABIDetails);
@@ -616,7 +636,7 @@ namespace {
     void expandExternalSignatureTypes();
 
     void expandCoroutineResult(bool forContinuation);
-    void expandCoroutineContinuationParameters();
+    void expandCoroutineContinuationParameters(bool emitYieldOnce2AsYieldOnce);
 
     void addIndirectThrowingResult();
     llvm::Type *getErrorRegisterType();
@@ -856,12 +876,18 @@ void SignatureExpansion::expandCoroutineResult(bool forContinuation) {
                    : llvm::StructType::get(IGM.getLLVMContext(), components);
 }
 
-void SignatureExpansion::expandCoroutineContinuationParameters() {
+void SignatureExpansion::expandCoroutineContinuationParameters(
+    bool emitYieldOnce2AsYieldOnce) {
   // The coroutine context.
   addCoroutineContextParameter();
 
-  // Whether this is an unwind resumption.
-  ParamIRTypes.push_back(IGM.Int1Ty);
+  if (FnType->isCalleeAllocatedCoroutine() && !emitYieldOnce2AsYieldOnce) {
+    // Whether this is an unwind resumption.
+    ParamIRTypes.push_back(IGM.CoroAllocatorPtrTy);
+  } else {
+    // Whether this is an unwind resumption.
+    ParamIRTypes.push_back(IGM.Int1Ty);
+  }
 }
 
 void SignatureExpansion::addAsyncParameters() {
@@ -877,14 +903,18 @@ void SignatureExpansion::addAsyncParameters() {
 void SignatureExpansion::addCoroutineContextParameter() {
   // Flag that the context is dereferenceable and unaliased.
   auto contextSize = getCoroutineContextSize(IGM, FnType);
-  Attrs = Attrs.addDereferenceableParamAttr(IGM.getLLVMContext(),
-                                            getCurParamIndex(),
-                                            contextSize.getValue());
+  Attrs = Attrs.addDereferenceableParamAttr(
+      IGM.getLLVMContext(), getCurParamIndex(),
+      contextSize ? contextSize->getValue() : 0);
   Attrs = Attrs.addParamAttribute(IGM.getLLVMContext(),
                                   getCurParamIndex(),
                                   llvm::Attribute::NoAlias);
 
   ParamIRTypes.push_back(IGM.Int8PtrTy);
+}
+
+void SignatureExpansion::addCoroutineAllocatorParameter() {
+  ParamIRTypes.push_back(IGM.CoroAllocatorPtrTy);
 }
 
 NativeConventionSchema::NativeConventionSchema(IRGenModule &IGM,
@@ -1910,10 +1940,12 @@ void SignatureExpansion::expandParameters(
   case SILCoroutineKind::None:
     break;
   case SILCoroutineKind::YieldOnce2:
-    if (!IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce)
+    if (!IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+      addCoroutineContextParameter();
+      addCoroutineAllocatorParameter();
       break;
+    }
     LLVM_FALLTHROUGH;
-
   case SILCoroutineKind::YieldOnce:
   case SILCoroutineKind::YieldMany:
     addCoroutineContextParameter();
@@ -2079,9 +2111,10 @@ void SignatureExpansion::expandFunctionType(
   llvm_unreachable("bad abstract calling convention");
 }
 
-void SignatureExpansion::expandCoroutineContinuationType() {
+void SignatureExpansion::expandCoroutineContinuationType(
+    bool emitYieldOnce2AsYieldOnce) {
   expandCoroutineResult(/*for continuation*/ true);
-  expandCoroutineContinuationParameters();
+  expandCoroutineContinuationParameters(emitYieldOnce2AsYieldOnce);
 }
 
 llvm::Type *SignatureExpansion::getErrorRegisterType() {
@@ -2413,7 +2446,8 @@ Signature Signature::forCoroutineContinuation(IRGenModule &IGM,
                                               CanSILFunctionType fnType) {
   assert(fnType->isCoroutine());
   SignatureExpansion expansion(IGM, fnType, FunctionPointerKind(fnType));
-  expansion.expandCoroutineContinuationType();
+  expansion.expandCoroutineContinuationType(
+      IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce);
   return expansion.getSignature();
 }
 
@@ -2511,6 +2545,36 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
   //         (inttoptr (and (ptrtoint %AsyncFunctionPointer), -2)))
   return IGF.Builder.CreateSelect(ICmp, BitCast, Load);
 }
+llvm::Value *emitIndirectCoroFunctionPointer(IRGenFunction &IGF,
+                                             llvm::Value *pointer) {
+  llvm::IntegerType *IntPtrTy = IGF.IGM.IntPtrTy;
+  llvm::Type *CoroFunctionPointerPtrTy = IGF.IGM.CoroFunctionPointerPtrTy;
+  llvm::Constant *Zero = llvm::Constant::getIntegerValue(
+      IntPtrTy, APInt(IntPtrTy->getBitWidth(), 0));
+  llvm::Constant *One = llvm::Constant::getIntegerValue(
+      IntPtrTy, APInt(IntPtrTy->getBitWidth(), 1));
+  llvm::Constant *NegativeOne = llvm::Constant::getIntegerValue(
+      IntPtrTy, APInt(IntPtrTy->getBitWidth(), -2));
+  swift::irgen::Alignment PointerAlignment = IGF.IGM.getPointerAlignment();
+
+  llvm::Value *PtrToInt = IGF.Builder.CreatePtrToInt(pointer, IntPtrTy);
+  llvm::Value *And = IGF.Builder.CreateAnd(PtrToInt, One);
+  llvm::Value *ICmp = IGF.Builder.CreateICmpEQ(And, Zero);
+
+  llvm::Value *BitCast =
+      IGF.Builder.CreateBitCast(pointer, CoroFunctionPointerPtrTy);
+
+  llvm::Value *UntaggedPointer = IGF.Builder.CreateAnd(PtrToInt, NegativeOne);
+  llvm::Value *IntToPtr = IGF.Builder.CreateIntToPtr(
+      UntaggedPointer, CoroFunctionPointerPtrTy->getPointerTo());
+  llvm::Value *Load = IGF.Builder.CreateLoad(IntToPtr, CoroFunctionPointerPtrTy,
+                                             PointerAlignment);
+
+  // (select (icmp eq, (and (ptrtoint %CoroFunctionPointer), 1), 0),
+  //         (%CoroFunctionPointer),
+  //         (inttoptr (and (ptrtoint %CoroFunctionPointer), -2)))
+  return IGF.Builder.CreateSelect(ICmp, BitCast, Load);
+}
 }
 
 std::pair<llvm::Value *, llvm::Value *>
@@ -2591,10 +2655,80 @@ irgen::getAsyncFunctionAndSize(IRGenFunction &IGF,
   return {fn, size};
 }
 
+std::pair<llvm::Value *, llvm::Value *>
+irgen::getCoroFunctionAndSize(IRGenFunction &IGF,
+                              FunctionPointer functionPointer,
+                              std::pair<bool, bool> values) {
+  assert(values.first || values.second);
+  assert(functionPointer.getKind() != FunctionPointer::Kind::Function);
+
+  bool emitFunction = values.first;
+  bool emitSize = values.second;
+  assert(emitFunction || emitSize);
+
+  // Ensure that the CoroFunctionPointer is not auth'd if it is not used and
+  // that it is not auth'd more than once if it is needed.
+  //
+  // The CoroFunctionPointer is not needed in the case where only the function
+  // is being loaded and the FunctionPointer was created from a function_ref
+  // instruction.
+  std::optional<llvm::Value *> _coroPtr = std::nullopt;
+  auto getCoroPtr = [&]() {
+    if (!_coroPtr) {
+      auto *ptr = functionPointer.getRawPointer();
+      if (auto authInfo = functionPointer.getAuthInfo()) {
+        ptr = emitPointerAuthAuth(IGF, ptr, authInfo);
+      }
+      _coroPtr = (IGF.IGM.getOptions().IndirectCoroFunctionPointer)
+                     ? emitIndirectCoroFunctionPointer(IGF, ptr)
+                     : IGF.Builder.CreateBitCast(
+                           ptr, IGF.IGM.CoroFunctionPointerPtrTy);
+    }
+    return *_coroPtr;
+  };
+
+  llvm::Value *fn = nullptr;
+  if (emitFunction) {
+    if (auto *function = functionPointer.getRawCoroFunction()) {
+      // If we've opportunistically also emitted the direct address of the
+      // function, always prefer that.
+      fn = function;
+
+    } else {
+      // Otherwise, extract the function pointer from the coro FP structure.
+      llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(
+          IGF.IGM.CoroFunctionPointerTy, getCoroPtr(), 0);
+      fn = IGF.emitLoadOfCompactFunctionPointer(
+          Address(addrPtr, IGF.IGM.RelativeAddressTy,
+                  IGF.IGM.getPointerAlignment()),
+          /*isFar*/ false,
+          /*expectedType*/ functionPointer.getFunctionType());
+    }
+
+    if (auto authInfo =
+            functionPointer.getAuthInfo().getCorrespondingCodeAuthInfo()) {
+      fn = emitPointerAuthSign(IGF, fn, authInfo);
+    }
+  }
+
+  llvm::Value *size = nullptr;
+  if (emitSize) {
+    auto *sizePtr = IGF.Builder.CreateStructGEP(IGF.IGM.CoroFunctionPointerTy,
+                                                getCoroPtr(), 1);
+    size = IGF.Builder.CreateLoad(sizePtr, IGF.IGM.Int32Ty,
+                                  IGF.IGM.getPointerAlignment());
+  }
+  return {fn, size};
+}
+
 namespace {
 
 class SyncCallEmission final : public CallEmission {
   using super = CallEmission;
+
+  StackAddress coroStaticFrame;
+  llvm::Value *coroAllocator = nullptr;
+  llvm::Value *calleeFunction = nullptr;
 
 public:
   SyncCallEmission(IRGenFunction &IGF, llvm::Value *selfValue, Callee &&callee)
@@ -2618,7 +2752,24 @@ public:
                                           invokeUnwindDest);
   }
 
-  void begin() override { super::begin(); }
+  void begin() override {
+    super::begin();
+    assert(!coroStaticFrame.isValid());
+    assert(!coroAllocator);
+
+    if (IsCalleeAllocatedCoroutine &&
+        !IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+      llvm::Value *bufferSize32;
+      std::tie(calleeFunction, bufferSize32) =
+          getCoroFunctionAndSize(IGF, CurCallee.getFunctionPointer());
+      auto *bufferSize = IGF.Builder.CreateZExt(bufferSize32, IGF.IGM.SizeTy);
+      coroStaticFrame = emitAllocYieldOnce2CoroutineFrame(IGF, bufferSize);
+      // TODO: Optimize allocator kind (e.g. async callers only need to use the
+      //     TaskAllocator if the coroutine is suspended across an await).
+      coroAllocator = emitYieldOnce2CoroutineAllocator(
+          IGF, IGF.getDefaultCoroutineAllocatorKind());
+    }
+  }
   void end() override { super::end(); }
   void setFromCallee() override {
     super::setFromCallee();
@@ -2713,14 +2864,17 @@ public:
         SILFunctionTypeRepresentation::CXXMethod)
       passIndirectResults();
 
-    // Pass along the coroutine buffer.
     switch (origCalleeType->getCoroutineKind()) {
     case SILCoroutineKind::YieldOnce2:
-      if (!IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce)
-        llvm::report_fatal_error("unimplemented");
+      // Pass along the coroutine buffer and allocator.
+      if (!IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+        original.transferInto(adjusted, 2);
+        break;
+      }
       LLVM_FALLTHROUGH;
     case SILCoroutineKind::YieldOnce:
     case SILCoroutineKind::YieldMany:
+      // Pass along the coroutine buffer.
       original.transferInto(adjusted, 1);
       break;
 
@@ -2910,6 +3064,10 @@ public:
   llvm::Value *getAsyncContext() override {
     llvm_unreachable("Should not call getAsyncContext on a sync call");
   }
+
+  StackAddress getCoroStaticFrame() override { return coroStaticFrame; }
+
+  llvm::Value *getCoroAllocator() override { return coroAllocator; }
 };
 
 class AsyncCallEmission final : public CallEmission {
@@ -2919,7 +3077,6 @@ class AsyncCallEmission final : public CallEmission {
   Address context;
   llvm::Value *calleeFunction = nullptr;
   llvm::Value *currentResumeFn = nullptr;
-  llvm::Value *thickContext = nullptr;
   Size staticContextSize = Size(0);
   std::optional<AsyncContextLayout> asyncContextLayout;
 
@@ -3363,6 +3520,13 @@ public:
 
   llvm::Value *getAsyncContext() override {
     return contextBuffer.getAddress();
+  }
+
+  StackAddress getCoroStaticFrame() override {
+    llvm_unreachable("Should not call getCoroStaticFrame on an async call");
+  }
+  llvm::Value *getCoroAllocator() override {
+    llvm_unreachable("Should not call getCoroAllocator on an async call");
   }
 };
 
@@ -3985,6 +4149,8 @@ bool Callee::isDirectObjCMethod() const {
 void CallEmission::setFromCallee() {
   assert(state == State::Emitting);
   IsCoroutine = CurCallee.getSubstFunctionType()->isCoroutine();
+  IsCalleeAllocatedCoroutine =
+      CurCallee.getSubstFunctionType()->isCalleeAllocatedCoroutine();
   EmittedCall = false;
 
   unsigned numArgs = CurCallee.getLLVMFunctionType()->getNumParams();
@@ -4808,49 +4974,30 @@ irgen::getCoroutineResumeFunctionPointerAuth(IRGenModule &IGM,
   llvm_unreachable("bad coroutine kind");
 }
 
-static void
-emitRetconCoroutineEntry(IRGenFunction &IGF, CanSILFunctionType fnType,
-                         NativeCCEntryPointArgumentEmission &emission,
-                         llvm::Intrinsic::ID idIntrinsic, Size bufferSize,
-                         Alignment bufferAlignment) {
+static void emitRetconCoroutineEntry(
+    IRGenFunction &IGF, CanSILFunctionType fnType, llvm::Value *buffer,
+    llvm::Intrinsic::ID idIntrinsic, Size bufferSize, Alignment bufferAlignment,
+    ArrayRef<llvm::Value *> extraArguments, llvm::Constant *allocFn,
+    llvm::Constant *deallocFn, ArrayRef<llvm::Value *> finalArguments) {
   auto prototype =
-    IGF.IGM.getOpaquePtr(IGF.IGM.getAddrOfContinuationPrototype(fnType));
-
-  
-
-  // Use free as our deallocator.
-  auto deallocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getFreeFn());
-
+      IGF.IGM.getOpaquePtr(IGF.IGM.getAddrOfContinuationPrototype(fnType));
   // Call the right 'llvm.coro.id.retcon' variant.
-  llvm::Value *buffer = emission.getCoroutineBuffer();
-
-  llvm::Value *id;
-  if (IGF.getOptions().EmitTypeMallocForCoroFrame) {
-    // Use swift_coroFrameAlloc as our allocator.
-    auto coroAllocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getCoroFrameAllocFn());
-    auto mallocTypeId = IGF.getMallocTypeId();
-    id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, {
-      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferSize.getValue()),
-      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferAlignment.getValue()),
-      buffer,
-      prototype,
-      coroAllocFn,
-      deallocFn,
-      mallocTypeId
-    });
-  } else {
-    // Use mallocas our allocator.
-   auto allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
-    id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, {
-      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferSize.getValue()),
-      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferAlignment.getValue()),
-      buffer,
-      prototype,
-      allocFn,
-      deallocFn
-    });
+  SmallVector<llvm::Value *, 8> arguments;
+  arguments.push_back(
+      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferSize.getValue()));
+  arguments.push_back(
+      llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferAlignment.getValue()));
+  for (auto *arg : extraArguments) {
+    arguments.push_back(arg);
   }
-  
+  arguments.push_back(buffer);
+  arguments.push_back(prototype);
+  arguments.push_back(allocFn);
+  arguments.push_back(deallocFn);
+  for (auto *arg : finalArguments) {
+    arguments.push_back(arg);
+  }
+  llvm::Value *id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, arguments);
 
   // Call 'llvm.coro.begin', just for consistency with the normal pattern.
   // This serves as a handle that we can pass around to other intrinsics.
@@ -4939,25 +5086,52 @@ void irgen::emitAsyncFunctionEntry(IRGenFunction &IGF,
 void irgen::emitYieldOnceCoroutineEntry(
     IRGenFunction &IGF, CanSILFunctionType fnType,
     NativeCCEntryPointArgumentEmission &emission) {
-  emitRetconCoroutineEntry(IGF, fnType, emission,
+  // Use malloc and free as our allocator.
+  auto deallocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getFreeFn());
+  auto *buffer = emission.getCoroutineBuffer();
+  llvm::SmallVector<llvm::Value *, 2> finalArgs;
+  llvm::Constant *allocFn = nullptr;
+  if (IGF.getOptions().EmitTypeMallocForCoroFrame) {
+    auto mallocTypeId = IGF.getMallocTypeId();
+    finalArgs.push_back(mallocTypeId);
+    allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getCoroFrameAllocFn());
+  } else {
+    allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
+  }
+  emitRetconCoroutineEntry(IGF, fnType, buffer,
                            llvm::Intrinsic::coro_id_retcon_once,
                            getYieldOnceCoroutineBufferSize(IGF.IGM),
-                           getYieldOnceCoroutineBufferAlignment(IGF.IGM));
+                           getYieldOnceCoroutineBufferAlignment(IGF.IGM), {},
+                           allocFn, deallocFn, finalArgs);
 }
 
 void irgen::emitYieldManyCoroutineEntry(
     IRGenFunction &IGF, CanSILFunctionType fnType,
     NativeCCEntryPointArgumentEmission &emission) {
-  emitRetconCoroutineEntry(IGF, fnType, emission,
-                           llvm::Intrinsic::coro_id_retcon,
+  // Use malloc and free as our allocator.
+  auto allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
+  auto deallocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getFreeFn());
+  auto *buffer = emission.getCoroutineBuffer();
+  emitRetconCoroutineEntry(IGF, fnType, buffer, llvm::Intrinsic::coro_id_retcon,
                            getYieldManyCoroutineBufferSize(IGF.IGM),
-                           getYieldManyCoroutineBufferAlignment(IGF.IGM));
+                           getYieldManyCoroutineBufferAlignment(IGF.IGM), {},
+                           allocFn, deallocFn, {});
 }
 
 void irgen::emitYieldOnce2CoroutineEntry(
-    IRGenFunction &IGF, CanSILFunctionType fnType,
+    IRGenFunction &IGF, LinkEntity coroFunction, CanSILFunctionType fnType,
     NativeCCEntryPointArgumentEmission &emission) {
-  llvm::report_fatal_error("unimplemented");
+  auto *buffer = emission.getCoroutineBuffer();
+  auto cfp = cast<llvm::GlobalVariable>(
+      IGF.IGM.getAddrOfCoroFunctionPointer(coroFunction));
+  llvm::Value *allocator = emission.getCoroutineAllocator();
+  IGF.setCoroutineAllocator(allocator);
+  auto allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getCoroAllocFn());
+  auto deallocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getCoroDeallocFn());
+  emitRetconCoroutineEntry(
+      IGF, fnType, buffer, llvm::Intrinsic::coro_id_retcon_once_dynamic,
+      Size(-1) /*dynamic-to-IRGen size*/, IGF.IGM.getCoroStaticFrameAlignment(),
+      {cfp, allocator}, allocFn, deallocFn, {});
 }
 
 static Address createOpaqueBufferAlloca(IRGenFunction &IGF,
@@ -4978,6 +5152,23 @@ Address irgen::emitAllocYieldManyCoroutineBuffer(IRGenFunction &IGF) {
   return createOpaqueBufferAlloca(IGF, getYieldManyCoroutineBufferSize(IGF.IGM),
                                  getYieldManyCoroutineBufferAlignment(IGF.IGM));
 }
+llvm::Value *
+irgen::emitYieldOnce2CoroutineAllocator(IRGenFunction &IGF,
+                                        std::optional<CoroAllocatorKind> kind) {
+  if (!kind) {
+    return IGF.getCoroutineAllocator();
+  }
+  CoroAllocatorFlags flags(*kind);
+  auto *flagsValue = llvm::ConstantInt::get(IGF.IGM.CoroAllocatorFlagsTy,
+                                            flags.getOpaqueValue());
+
+  return IGF.Builder.CreateCall(
+      IGF.IGM.getCoroGetGlobalAllocatorFunctionPointer(), {flagsValue});
+}
+StackAddress irgen::emitAllocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
+                                                      llvm::Value *size) {
+  return emitAllocCoroStaticFrame(IGF, size);
+}
 
 void irgen::emitDeallocYieldOnceCoroutineBuffer(IRGenFunction &IGF,
                                                 Address buffer) {
@@ -4992,13 +5183,13 @@ void irgen::emitDeallocYieldManyCoroutineBuffer(IRGenFunction &IGF,
 }
 
 void irgen::emitDeallocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
-                                                llvm::Value *allocation) {
+                                                StackAddress frame) {
   if (IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
-    assert(!allocation);
+    assert(!frame.isValid());
     return;
   }
-  assert(allocation);
-  llvm::report_fatal_error("unimplemented");
+  assert(frame.isValid());
+  emitDeallocCoroStaticFrame(IGF, frame);
 }
 
 Address irgen::emitAllocAsyncContext(IRGenFunction &IGF,
@@ -5026,6 +5217,24 @@ Address irgen::emitStaticAllocAsyncContext(IRGenFunction &IGF,
 void irgen::emitStaticDeallocAsyncContext(IRGenFunction &IGF, Address context,
                                           Size size) {
   IGF.Builder.CreateLifetimeEnd(context, size);
+}
+
+StackAddress irgen::emitAllocCoroStaticFrame(IRGenFunction &IGF,
+                                             llvm::Value *size) {
+  // TODO: Avoid swift_task_alloc (async) and malloc (yield_once) if the
+  //       suspension doesn't span an apply of an async function or a yield
+  //       respectively.
+  auto retval =
+      IGF.emitDynamicAlloca(IGF.IGM.Int8Ty, size, Alignment(MaximumAlignment),
+                            /*allowTaskAlloc*/ true, "caller-coro-frame");
+  IGF.Builder.CreateLifetimeStart(retval.getAddress(),
+                                  Size(-1) /*dynamic size*/);
+  return retval;
+}
+void irgen::emitDeallocCoroStaticFrame(IRGenFunction &IGF, StackAddress frame) {
+  IGF.Builder.CreateLifetimeEnd(frame.getAddress(), Size(-1) /*dynamic size*/);
+  IGF.emitDeallocateDynamicAlloca(frame, /*allowTaskAlloc*/ true,
+                                  /*useTaskDeallocThrough*/ true);
 }
 
 llvm::Value *irgen::emitYield(IRGenFunction &IGF,
@@ -5093,8 +5302,16 @@ llvm::Value *irgen::emitYield(IRGenFunction &IGF,
   }
 
   // Perform the yield.
-  auto isUnwind = IGF.Builder.CreateIntrinsicCall(
-      llvm::Intrinsic::coro_suspend_retcon, {IGF.IGM.Int1Ty}, yieldArgs);
+  llvm::Value *isUnwind = nullptr;
+  if (coroutineType->isCalleeAllocatedCoroutine() &&
+      !IGF.IGM.IRGen.Opts.EmitYieldOnce2AsYieldOnce) {
+    IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_suspend_retcon,
+                                    {IGF.IGM.CoroAllocatorPtrTy}, yieldArgs);
+    isUnwind = llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0);
+  } else {
+    isUnwind = IGF.Builder.CreateIntrinsicCall(
+        llvm::Intrinsic::coro_suspend_retcon, {IGF.IGM.Int1Ty}, yieldArgs);
+  }
 
   // We're done with the indirect buffer.
   if (indirectBuffer) {
@@ -6179,6 +6396,17 @@ StringRef FunctionPointer::getName(IRGenModule &IGM) const {
     return IGM
         .getSILFunctionForAsyncFunctionPointer(asyncFnPtr)->getName();
   }
+  case BasicKind::CoroFunctionPointer: {
+    auto *asyncFnPtr = getDirectPointer();
+    // Handle windows style async function pointers.
+    if (auto *ce = dyn_cast<llvm::ConstantExpr>(asyncFnPtr)) {
+      if (ce->getOpcode() == llvm::Instruction::IntToPtr) {
+        asyncFnPtr = cast<llvm::Constant>(asyncFnPtr->getOperand(0));
+      }
+    }
+    asyncFnPtr = cast<llvm::Constant>(asyncFnPtr->stripPointerCasts());
+    return IGM.getSILFunctionForAsyncFunctionPointer(asyncFnPtr)->getName();
+  }
   }
   llvm_unreachable("unhandled case");
 }
@@ -6205,6 +6433,35 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
     auto *descriptorPtr =
         IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.AsyncFunctionPointerPtrTy);
     auto *addrPtr = IGF.Builder.CreateStructGEP(IGF.IGM.AsyncFunctionPointerTy,
+                                                descriptorPtr, 0);
+    auto *result = IGF.emitLoadOfCompactFunctionPointer(
+        Address(addrPtr, IGF.IGM.RelativeAddressTy,
+                IGF.IGM.getPointerAlignment()),
+        /*isFar*/ false,
+        /*expectedType*/ getFunctionType());
+    if (auto codeAuthInfo = AuthInfo.getCorrespondingCodeAuthInfo()) {
+      result = emitPointerAuthSign(IGF, result, codeAuthInfo);
+    }
+    return result;
+  }
+  case BasicKind::CoroFunctionPointer: {
+    if (auto *rawFunction = getRawCoroFunction()) {
+      // If the pointer to the underlying function is available, it means that
+      // this FunctionPointer instance was created via
+      // FunctionPointer::forDirect and as such has no AuthInfo.
+      assert(!AuthInfo && "have PointerAuthInfo for a coro FunctionPointer "
+                          "for which the raw function is known");
+      return rawFunction;
+    }
+    auto *fnPtr = Value;
+    if (auto authInfo = AuthInfo) {
+      fnPtr = emitPointerAuthAuth(IGF, fnPtr, authInfo);
+      if (IGF.IGM.getOptions().IndirectCoroFunctionPointer)
+        fnPtr = emitIndirectCoroFunctionPointer(IGF, fnPtr);
+    }
+    auto *descriptorPtr =
+        IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.CoroFunctionPointerPtrTy);
+    auto *addrPtr = IGF.Builder.CreateStructGEP(IGF.IGM.CoroFunctionPointerTy,
                                                 descriptorPtr, 0);
     auto *result = IGF.emitLoadOfCompactFunctionPointer(
         Address(addrPtr, IGF.IGM.RelativeAddressTy,
@@ -6253,6 +6510,10 @@ FunctionPointer FunctionPointer::getAsFunction(IRGenFunction &IGF) const {
   case FunctionPointer::BasicKind::Function:
     return *this;
   case FunctionPointer::BasicKind::AsyncFunctionPointer: {
+    auto authInfo = AuthInfo.getCorrespondingCodeAuthInfo();
+    return FunctionPointer(Kind::Function, getPointer(IGF), authInfo, Sig);
+  }
+  case FunctionPointer::BasicKind::CoroFunctionPointer: {
     auto authInfo = AuthInfo.getCorrespondingCodeAuthInfo();
     return FunctionPointer(Kind::Function, getPointer(IGF), authInfo, Sig);
   }
@@ -6626,7 +6887,8 @@ llvm::FunctionType *FunctionPointer::getFunctionType() const {
   // Static async function pointers can read the type off the secondary value
   // (the function definition.
   if (SecondaryValue) {
-    assert(kind == FunctionPointer::Kind::AsyncFunctionPointer);
+    assert(kind == FunctionPointer::Kind::AsyncFunctionPointer ||
+           kind == FunctionPointer::Kind::CoroFunctionPointer);
     return cast<llvm::Function>(SecondaryValue)->getFunctionType();
   }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2514,9 +2514,8 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
 }
 
 std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
-    IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
-    FunctionPointer functionPointer, llvm::Value *thickContext,
-    std::pair<bool, bool> values) {
+    IRGenFunction &IGF, FunctionPointer functionPointer,
+    llvm::Value *thickContext, std::pair<bool, bool> values) {
   assert(values.first || values.second);
   assert(functionPointer.getKind() != FunctionPointer::Kind::Function);
 
@@ -2960,8 +2959,7 @@ public:
 
     llvm::Value *dynamicContextSize32;
     std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        IGF, CurCallee.getOrigFunctionType()->getRepresentation(),
-        CurCallee.getFunctionPointer(), thickContext);
+        IGF, CurCallee.getFunctionPointer(), thickContext);
     auto *dynamicContextSize =
         IGF.Builder.CreateZExt(dynamicContextSize32, IGF.IGM.SizeTy);
     if (auto staticSize = dyn_cast<llvm::ConstantInt>(dynamicContextSize)) {

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -141,7 +141,6 @@ namespace irgen {
   /// \return {function, size}
   std::pair<llvm::Value *, llvm::Value *>
   getAsyncFunctionAndSize(IRGenFunction &IGF, FunctionPointer functionPointer,
-                          llvm::Value *thickContext,
                           std::pair<bool, bool> values = {true, true});
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention,

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -139,10 +139,10 @@ namespace irgen {
   ///               be returned for it.
   ///
   /// \return {function, size}
-  std::pair<llvm::Value *, llvm::Value *> getAsyncFunctionAndSize(
-      IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
-      FunctionPointer functionPointer, llvm::Value *thickContext,
-      std::pair<bool, bool> values = {true, true});
+  std::pair<llvm::Value *, llvm::Value *>
+  getAsyncFunctionAndSize(IRGenFunction &IGF, FunctionPointer functionPointer,
+                          llvm::Value *thickContext,
+                          std::pair<bool, bool> values = {true, true});
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention,
                                      bool isAsync);

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -43,6 +43,7 @@ namespace clang {
 }
 
 namespace swift {
+enum class CoroAllocatorKind : uint8_t;
 namespace irgen {
   class Address;
   class Alignment;
@@ -142,6 +143,9 @@ namespace irgen {
   std::pair<llvm::Value *, llvm::Value *>
   getAsyncFunctionAndSize(IRGenFunction &IGF, FunctionPointer functionPointer,
                           std::pair<bool, bool> values = {true, true});
+  std::pair<llvm::Value *, llvm::Value *>
+  getCoroFunctionAndSize(IRGenFunction &IGF, FunctionPointer functionPointer,
+                         std::pair<bool, bool> values = {true, true});
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention,
                                      bool isAsync);
@@ -211,14 +215,20 @@ namespace irgen {
 
   Address emitAllocYieldOnceCoroutineBuffer(IRGenFunction &IGF);
   void emitDeallocYieldOnceCoroutineBuffer(IRGenFunction &IGF, Address buffer);
-  void emitDeallocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
-                                           llvm::Value *allocation);
   void
   emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
                               CanSILFunctionType coroutineType,
                               NativeCCEntryPointArgumentEmission &emission);
+
+  llvm::Value *
+  emitYieldOnce2CoroutineAllocator(IRGenFunction &IGF,
+                                   std::optional<CoroAllocatorKind> kind);
+  StackAddress emitAllocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
+                                                 llvm::Value *size);
+  void emitDeallocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
+                                           StackAddress allocation);
   void
-  emitYieldOnce2CoroutineEntry(IRGenFunction &IGF,
+  emitYieldOnce2CoroutineEntry(IRGenFunction &IGF, LinkEntity coroFunction,
                                CanSILFunctionType coroutineType,
                                NativeCCEntryPointArgumentEmission &emission);
 
@@ -240,6 +250,9 @@ namespace irgen {
                               const AsyncContextLayout &layout,
                               LinkEntity asyncFunction,
                               unsigned asyncContextIndex);
+
+  StackAddress emitAllocCoroStaticFrame(IRGenFunction &IGF, llvm::Value *size);
+  void emitDeallocCoroStaticFrame(IRGenFunction &IGF, StackAddress frame);
 
   /// Yield the given values from the current continuation.
   ///

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3046,8 +3046,8 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
         f->getForwardingSubstitutionMap());
     llvm::Value *dynamicContextSize32;
     llvm::Value *calleeFunction;
-    std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        IGF, asyncFnPtr, nullptr, std::make_pair(false, true));
+    std::tie(calleeFunction, dynamicContextSize32) =
+        getAsyncFunctionAndSize(IGF, asyncFnPtr, std::make_pair(false, true));
     auto *dynamicContextSize =
         Builder.CreateZExt(dynamicContextSize32, IGM.SizeTy);
     auto calleeContextBuffer = emitAllocAsyncContext(IGF, dynamicContextSize);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3047,8 +3047,7 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
     llvm::Value *dynamicContextSize32;
     llvm::Value *calleeFunction;
     std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        IGF, silFunctionType->getRepresentation(), asyncFnPtr, nullptr,
-        std::make_pair(false, true));
+        IGF, asyncFnPtr, nullptr, std::make_pair(false, true));
     auto *dynamicContextSize =
         Builder.CreateZExt(dynamicContextSize32, IGM.SizeTy);
     auto calleeContextBuffer = emitAllocAsyncContext(IGF, dynamicContextSize);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1300,8 +1300,8 @@ public:
   }
   void mapAsyncParameters(FunctionPointer fnPtr) override {
     llvm::Value *dynamicContextSize32;
-    std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        subIGF, fnPtr, nullptr, std::make_pair(true, true));
+    std::tie(calleeFunction, dynamicContextSize32) =
+        getAsyncFunctionAndSize(subIGF, fnPtr, std::make_pair(true, true));
     auto *dynamicContextSize =
         subIGF.Builder.CreateZExt(dynamicContextSize32, subIGF.IGM.SizeTy);
     calleeContextBuffer =

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1301,8 +1301,7 @@ public:
   void mapAsyncParameters(FunctionPointer fnPtr) override {
     llvm::Value *dynamicContextSize32;
     std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
-        subIGF, origType->getRepresentation(), fnPtr, nullptr,
-        std::make_pair(true, true));
+        subIGF, fnPtr, nullptr, std::make_pair(true, true));
     auto *dynamicContextSize =
         subIGF.Builder.CreateZExt(dynamicContextSize32, subIGF.IGM.SizeTy);
     calleeContextBuffer =

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7486,6 +7486,19 @@ llvm::GlobalValue *irgen::emitAsyncFunctionPointer(IRGenModule &IGM,
       entity, builder.finishAndCreateFuture()));
 }
 
+llvm::GlobalValue *irgen::emitCoroFunctionPointer(IRGenModule &IGM,
+                                                  llvm::Function *function,
+                                                  LinkEntity entity,
+                                                  Size size) {
+  ConstantInitBuilder initBuilder(IGM);
+  ConstantStructBuilder builder(
+      initBuilder.beginStruct(IGM.CoroFunctionPointerTy));
+  builder.addCompactFunctionReference(function);
+  builder.addInt32(size.getValue());
+  return cast<llvm::GlobalValue>(
+      IGM.defineCoroFunctionPointer(entity, builder.finishAndCreateFuture()));
+}
+
 static FormalLinkage getExistentialShapeLinkage(CanGenericSignature genSig,
                                                 CanType shapeType) {
   auto typeLinkage = getTypeLinkage(shapeType);

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -298,6 +298,11 @@ namespace irgen {
                                               LinkEntity entity,
                                               Size size);
 
+  llvm::GlobalValue *emitCoroFunctionPointer(IRGenModule &IGM,
+                                             llvm::Function *function,
+                                             LinkEntity entity,
+                                             Size size = Size(0));
+
   /// Determine whether the given opaque type requires a witness table for the
   /// given requirement.
   ///

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -643,9 +643,15 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
 /// Deallocate dynamic alloca's memory if requested by restoring the stack
 /// location before the dynamic alloca's call.
 void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
-                                                bool allowTaskDealloc) {
+                                                bool allowTaskDealloc,
+                                                bool useTaskDeallocThrough) {
   // Async function use taskDealloc.
   if (allowTaskDealloc && isAsync() && address.getAddress().isValid()) {
+    if (useTaskDeallocThrough) {
+      emitTaskDeallocThrough(
+          Address(address.getExtraInfo(), IGM.Int8Ty, address.getAlignment()));
+      return;
+    }
     emitTaskDealloc(
         Address(address.getExtraInfo(), IGM.Int8Ty, address.getAlignment()));
     return;

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -558,6 +558,13 @@ void IRGenFunction::emitTaskDealloc(Address address) {
   call->setCallingConv(IGM.SwiftCC);
 }
 
+void IRGenFunction::emitTaskDeallocThrough(Address address) {
+  auto *call = Builder.CreateCall(IGM.getTaskDeallocThroughFunctionPointer(),
+                                  {address.getAddress()});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGM.SwiftCC);
+}
+
 llvm::Value *IRGenFunction::alignUpToMaximumAlignment(llvm::Type *sizeTy, llvm::Value *val) {
   auto *alignMask = llvm::ConstantInt::get(sizeTy, MaximumAlignment - 1);
   auto *invertedMask = Builder.CreateNot(alignMask);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -783,6 +783,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   DifferentiabilityWitnessTy = createStructType(
       *this, "swift.differentiability_witness", {Int8PtrTy, Int8PtrTy});
+
+  CoroFunctionPointerTy = createStructType(*this, "swift.coro_func_pointer",
+                                           {RelativeAddressTy, Int32Ty}, true);
+  CoroFunctionPointerPtrTy = CoroFunctionPointerTy->getPointerTo();
 }
 
 IRGenModule::~IRGenModule() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -842,6 +842,9 @@ public:
   llvm::StructType *DifferentiabilityWitnessTy; // { i8*, i8* }
   // clang-format on
 
+  llvm::StructType *CoroFunctionPointerTy; // { i32, i32 }
+  llvm::PointerType *CoroFunctionPointerPtrTy;
+
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
 
   llvm::Constant *swiftImmortalRefCount = nullptr;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -844,6 +844,12 @@ public:
 
   llvm::StructType *CoroFunctionPointerTy; // { i32, i32 }
   llvm::PointerType *CoroFunctionPointerPtrTy;
+  llvm::PointerType *CoroAllocationTy;
+  llvm::FunctionType *CoroAllocateFnTy;
+  llvm::FunctionType *CoroDeallocateFnTy;
+  llvm::IntegerType *CoroAllocatorFlagsTy;
+  llvm::StructType *CoroAllocatorTy;
+  llvm::PointerType *CoroAllocatorPtrTy;
 
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
 
@@ -892,6 +898,7 @@ public:
     return getPointerAlignment();
   }
   Alignment getAsyncContextAlignment() const;
+  Alignment getCoroStaticFrameAlignment() const;
 
   /// Return the offset, relative to the address point, of the start of the
   /// type-specific members of an enum metadata.
@@ -1280,6 +1287,7 @@ private:
                                            
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalVars;
   llvm::DenseMap<LinkEntity, llvm::Constant*> IndirectAsyncFunctionPointers;
+  llvm::DenseMap<LinkEntity, llvm::Constant *> IndirectCoroFunctionPointers;
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;
   llvm::DenseSet<const clang::Decl *> GlobalClangDecls;
@@ -1646,6 +1654,11 @@ public:
   llvm::Constant *defineAsyncFunctionPointer(LinkEntity entity,
                                              ConstantInit init);
   SILFunction *getSILFunctionForAsyncFunctionPointer(llvm::Constant *afp);
+
+  llvm::Constant *getAddrOfCoroFunctionPointer(LinkEntity entity);
+  llvm::Constant *getAddrOfCoroFunctionPointer(SILFunction *function);
+  llvm::Constant *defineCoroFunctionPointer(LinkEntity entity,
+                                            ConstantInit init);
 
   llvm::Function *getAddrOfDispatchThunk(SILDeclRef declRef,
                                          ForDefinition_t forDefinition);

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -101,6 +101,11 @@ public:
     addLinkEntity(LinkEntity::forClassMetadataBaseOffset(CD));
   }
 
+  void addCoroFunctionPointer(SILDeclRef declRef) override {
+    addLinkEntity(LinkEntity::forCoroFunctionPointer(declRef),
+                  /*ignoreVisibility=*/true);
+  }
+
   void addDispatchThunk(SILDeclRef declRef) override {
     auto entity = LinkEntity::forDispatchThunk(declRef);
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -550,6 +550,28 @@ std::string LinkEntity::mangleAsString(ASTContext &Ctx) const {
     return mangler.mangleExtendedExistentialTypeShapeSymbol(
                      genSig, existentialType, isUnique);
   }
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer: {
+    std::string Result(
+        getUnderlyingEntityForCoroFunctionPointer().mangleAsString(Ctx));
+    Result.append("Tv");
+    return Result;
+  }
+  case Kind::DistributedThunkCoroFunctionPointer: {
+    std::string Result = getSILDeclRef().mangle();
+    Result.append("TE");
+    Result.append("Tv");
+    return Result;
+  }
+  case Kind::CoroFunctionPointerAST: {
+    std::string Result = getSILDeclRef().mangle();
+    Result.append("Tv");
+    return Result;
+  }
   }
   llvm_unreachable("bad entity kind!");
 }
@@ -907,6 +929,17 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::ExtendedExistentialTypeShape:
     return (isExtendedExistentialTypeShapeShared()
               ? SILLinkage::Shared : SILLinkage::Private);
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+    return getUnderlyingEntityForCoroFunctionPointer().getLinkage(
+        forDefinition);
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
+    return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
   }
   llvm_unreachable("bad link entity kind");
 }
@@ -1001,6 +1034,14 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::DistributedAccessor:
   case Kind::AccessibleFunctionRecord:
   case Kind::ExtendedExistentialTypeShape:
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
     return false;
   }
   llvm_unreachable("invalid descriptor");
@@ -1128,6 +1169,15 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
     return IGM.AccessibleFunctionRecordTy;
   case Kind::ExtendedExistentialTypeShape:
     return IGM.RelativeAddressTy;
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
+    return IGM.CoroFunctionPointerPtrTy;
   default:
     llvm_unreachable("declaration LLVM type not specified");
   }
@@ -1196,6 +1246,14 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::NoncanonicalSpecializedGenericTypeMetadata:
   case Kind::NoncanonicalSpecializedGenericTypeMetadataCacheVariable:
   case Kind::PartialApplyForwarder:
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
     return IGM.getPointerAlignment();
   case Kind::CanonicalPrespecializedGenericTypeCachingOnceToken:
   case Kind::TypeMetadataDemanglingCacheVariable:
@@ -1244,6 +1302,9 @@ bool LinkEntity::isText() const {
   case Kind::AsyncFunctionPointerAST:
   case Kind::ProtocolWitnessTable:
   case Kind::TypeMetadata:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DistributedThunkCoroFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
     return false;
   // The following cases do not currently generate linkable symbols
   // through TBDGen. The full enumeration is captured to ensure
@@ -1303,6 +1364,11 @@ bool LinkEntity::isText() const {
   case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
   case Kind::NoncanonicalSpecializedGenericTypeMetadata:
   case Kind::AccessibleFunctionRecord:
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
     return false;
   }
 }
@@ -1358,6 +1424,8 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
 
   case Kind::AsyncFunctionPointerAST:
   case Kind::DistributedThunkAsyncFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
   case Kind::DispatchThunk:
   case Kind::DispatchThunkDerivative:
   case Kind::DispatchThunkInitializer:
@@ -1450,12 +1518,20 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::DistributedAccessorAsyncPointer:
     return getUnderlyingEntityForAsyncFunctionPointer()
         .isWeakImported(module);
-  case Kind::KnownAsyncFunctionPointer:
+  case Kind::KnownAsyncFunctionPointer: {
     auto &context = module->getASTContext();
     auto deploymentAvailability =
         AvailabilityRange::forDeploymentTarget(context);
     return !deploymentAvailability.isContainedIn(
         context.getConcurrencyAvailability());
+  }
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+    return getUnderlyingEntityForCoroFunctionPointer().isWeakImported(module);
   }
 
   llvm_unreachable("Bad link entity kind");
@@ -1465,6 +1541,8 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   switch (getKind()) {
   case Kind::AsyncFunctionPointerAST:
   case Kind::DistributedThunkAsyncFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
   case Kind::DispatchThunk:
   case Kind::DispatchThunkDerivative:
   case Kind::DispatchThunkInitializer:
@@ -1585,6 +1663,14 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
 
   case Kind::AccessibleFunctionRecord: {
     return getSILFunction()->getParentModule();
+  case Kind::CoroFunctionPointer:
+  case Kind::DispatchThunkCoroFunctionPointer:
+  case Kind::DispatchThunkInitializerCoroFunctionPointer:
+  case Kind::DispatchThunkAllocatorCoroFunctionPointer:
+  case Kind::PartialApplyForwarderCoroFunctionPointer:
+  case Kind::DistributedAccessorCoroFunctionPointer:
+    return getUnderlyingEntityForCoroFunctionPointer()
+        .getDeclContextForEmission();
   }
   }
   llvm_unreachable("invalid decl kind");

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -590,6 +590,8 @@ SILDeclRef::Kind LinkEntity::getSILDeclRefKind() const {
     return SILDeclRef::Kind::Allocator;
   case Kind::DistributedThunkAsyncFunctionPointer:
   case Kind::AsyncFunctionPointerAST:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
     return static_cast<SILDeclRef::Kind>(
         reinterpret_cast<uintptr_t>(SecondaryPointer));
   default:
@@ -874,6 +876,8 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 
   case Kind::AsyncFunctionPointerAST:
   case Kind::DistributedThunkAsyncFunctionPointer:
+  case Kind::CoroFunctionPointerAST:
+  case Kind::DistributedThunkCoroFunctionPointer:
     return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
 
   case Kind::DynamicallyReplaceableFunctionImpl:
@@ -937,8 +941,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::DistributedAccessorCoroFunctionPointer:
     return getUnderlyingEntityForCoroFunctionPointer().getLinkage(
         forDefinition);
-  case Kind::CoroFunctionPointerAST:
-  case Kind::DistributedThunkCoroFunctionPointer:
     return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
   }
   llvm_unreachable("bad link entity kind");

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -17,9 +17,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Runtime/Concurrency.h"
-#include "swift/ABI/Task.h"
 #include "TaskPrivate.h"
+#include "swift/ABI/Task.h"
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Coro.h"
 
 #include <stdlib.h>
 
@@ -66,4 +67,51 @@ void swift::swift_task_dealloc(void *ptr) {
 
 void swift::_swift_task_dealloc_specific(AsyncTask *task, void *ptr) {
   allocator(task).dealloc(ptr);
+}
+
+static void *swift_task_alloc_thunk(size_t size) {
+  return swift_task_alloc(size);
+}
+
+static void swift_task_dealloc_thunk(void *ptr) { swift_task_dealloc(ptr); }
+
+void swift::swift_task_dealloc_through(void *ptr) {
+  allocator(swift_task_getCurrent()).deallocThrough(ptr);
+}
+
+static CoroAllocator CoroTaskAllocatorImpl{
+    CoroAllocatorFlags(/*CoroAllocatorKind::Async*/ 1), swift_task_alloc_thunk,
+    swift_task_dealloc_thunk};
+
+CoroAllocator *const swift::_swift_coro_task_allocator = &CoroTaskAllocatorImpl;
+
+CoroAllocator *swift::swift_coro_getGlobalAllocator(CoroAllocatorFlags flags) {
+  switch (flags.getKind()) {
+  case CoroAllocatorKind::Sync:
+    return nullptr;
+  case CoroAllocatorKind::Async:
+    return _swift_coro_task_allocator;
+  case CoroAllocatorKind::Malloc:
+    return _swift_coro_malloc_allocator;
+  }
+}
+
+static CoroAllocator CoroMallocAllocatorImpl{
+    CoroAllocatorFlags(/*CoroAllocatorKind::Malloc*/ 2), malloc, free};
+
+CoroAllocator *const swift::_swift_coro_malloc_allocator =
+    &CoroMallocAllocatorImpl;
+
+void *swift::swift_coro_alloc(CoroAllocator *allocator, size_t size) {
+  return allocator->allocate(size);
+}
+
+void swift::swift_coro_dealloc(CoroAllocator *allocator, void *ptr) {
+  // Calls to swift_coro_dealloc are emitted in resume funclets for every
+  // live-across dynamic allocation.  Whether such calls immediately deallocate
+  // memory depends on the allocator.
+  if (!allocator->shouldDeallocateImmediately()) {
+    return;
+  }
+  allocator->deallocate(ptr);
 }

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -38,6 +38,7 @@ set(swift_runtime_sources
     Bincompat.cpp
     BytecodeLayouts.cpp
     Casting.cpp
+    Coro.cpp
     CrashReporter.cpp
     Demangle.cpp
     DynamicCast.cpp

--- a/stdlib/public/runtime/Coro.cpp
+++ b/stdlib/public/runtime/Coro.cpp
@@ -1,0 +1,17 @@
+//===------------- Array.cpp - Swift Array Operations Support -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Coro.h"
+#include "swift/ABI/Coro.h"
+#include "swift/Basic/FlagSet.h"
+
+using namespace swift;

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -335,6 +335,17 @@ public:
     lastAllocation = prev;
   }
 
+  void deallocThrough(void *ptr) {
+    void *current = nullptr;
+    do {
+      if (!lastAllocation) {
+        SWIFT_FATAL_ERROR(0, "freed pointer not among allocations");
+      }
+      current = lastAllocation->getAllocatedMemory();
+      dealloc(current);
+    } while (current != ptr);
+  }
+
   /// For unit testing.
   int getNumAllocatedSlabs() { return numAllocatedSlabs; }
 };

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -4,13 +4,11 @@
 // RUN:     -enable-library-evolution                        \
 // RUN: | %IRGenFileCheck %s --check-prefix=CHECK-OLD
 
-// For now, a crash is expected when attempting to use the callee-allocated ABI: 
-// it's not implemented.
-// RUN: not --crash                                             \
-// RUN:     %target-swift-emit-irgen                            \
-// RUN:         %s                                              \
-// RUN:         -enable-experimental-feature CoroutineAccessors \
-// RUN:         -enable-experimental-feature CoroutineAccessorsAllocateInCallee
+// RUN: %target-swift-emit-irgen                                            \
+// RUN:     %s                                                              \
+// RUN:     -enable-experimental-feature CoroutineAccessors                 \
+// RUN:     -enable-experimental-feature CoroutineAccessorsAllocateInCallee \
+// RUN: | %IRGenFileCheck %s --check-prefix=CHECK-NEW
 
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsAllocateInCallee
@@ -22,21 +20,21 @@ public var o: any AnyObject
 public var _i: Int = 0
 
 public var irm: Int {
-// CHECK-OLD-LABEL: define{{.*}} { ptr, {{i64|i32}} } @"$s19coroutine_accessors1SV3irmSivy"(
+// CHECK-LABEL:     define{{.*}} { ptr, {{i64|i32}} } @"$s19coroutine_accessors1SV3irmSivy"(
 // CHECK-OLD-SAME:      ptr noalias dereferenceable({{32|16}}) %0,
 // CHECK-OLD-SAME:      ptr %1,
 // CHECK-OLD-SAME:      [[INT]] %2
-// CHECK-OLD-SAME:  )
-// CHECK-OLD-SAME:  {
-// CHECK-OLD:       }
+// CHECK-SAME:      )
+// CHECK-SAME:      {
+// CHECK:           }
   read {
     yield _i
   }
-// CHECK-OLD-LABEL: define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
+// CHECK-LABEL:     define{{.*}} { ptr, ptr } @"$s19coroutine_accessors1SV3irmSivx"(
 // CHECK-OLD-SAME:      ptr noalias dereferenceable({{32|16}}) %0, 
 // CHECK-OLD-SAME:      ptr nocapture swiftself dereferenceable({{16|8}}) %1
-// CHECK-OLD-SAME:  )
-// CHECK-OLD-SAME:  {
+// CHECK-SAME:      )
+// CHECK-SAME:      {
 // CHECK-OLD:       }
   modify {
     yield &_i

--- a/test/IRGen/run-coroutine_accessors.swift
+++ b/test/IRGen/run-coroutine_accessors.swift
@@ -1,0 +1,105 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift \
+// RUN:     %s \
+// RUN:     -target %target-future-triple \
+// RUN:     -Onone \
+// RUN:     -parse-as-library \
+// RUN:     -module-name main \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -enable-experimental-feature CoroutineAccessorsAllocateInCallee \
+// RUN:     -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_CoroutineAccessorsAllocateInCallee
+
+struct MaybePtrBox<T> {
+  private var ptr: UnsafeMutablePointer<T>
+
+  static func sentinel() -> UnsafeMutablePointer<T> {
+    .init(bitPattern: 0xdeadbeef)!
+  }
+  
+  init() {
+    ptr = .init(MaybePtrBox.sentinel())
+  }
+  func isValid() -> Bool {
+    ptr != MaybePtrBox.sentinel()
+  }
+  mutating func set(_ t: T?) {
+    switch (isValid(), t) {
+    case (true, .some(let t)):
+      ptr.pointee = t
+    case (true, .none):
+      ptr.deallocate()
+      ptr = MaybePtrBox.sentinel()
+    case (false, .some(let t)):
+      ptr = .allocate(capacity: 1)
+      ptr.initialize(to: t)
+    case (false, .none):
+      break
+    }
+  }
+  var value : T? {
+    // Analogous to the implementation of Dictionary's subscript.
+    read {
+      let val: T?
+      if isValid() {
+        val = ptr.pointee
+      } else {
+        val = .none
+      }
+      yield val
+    }
+    modify {
+      var val: T?
+      if isValid() {
+        val = ptr.pointee
+      } else {
+        val = .none
+      }
+      yield &val
+      set(val)
+    }
+  }
+}
+
+protocol AsyncMutatable {
+  mutating func mutate() async
+}
+
+struct Stringg : AsyncMutatable {
+  var value: String
+  mutating func mutate() async {
+    value += value
+  }
+}
+
+@main
+struct M {
+  static func mutate<T : AsyncMutatable>(_ t: inout T?) async {
+    var b = MaybePtrBox<T>()
+    b.set(t)
+    await b.value?.mutate()
+    t = b.value
+  }
+  static func main() async {
+    var v1 = Optional<Stringg>.none
+    // CHECK: nil 
+    print(v1)
+    // CHECK: nil 
+    await mutate(&v1)
+    print(v1)
+    var v2 = Optional.some(Stringg(value: "hi"))
+    // CHECK: "hi"
+    print(v2)
+    await mutate(&v2)
+    // CHECK: "hihi"
+    print(v2)
+  }
+}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -406,3 +406,12 @@ Added: _$ss19DiscardingTaskGroupV05startB28SynchronouslyUnlessCancelled8priority
 Added: _$ss27ThrowingDiscardingTaskGroupV05startC13Synchronously8priority9operationyScPSg_yyYacntF
 // Swift.ThrowingDiscardingTaskGroup.startTaskSynchronouslyUnlessCancelled(priority: Swift.TaskPriority?, operation: __owned () async -> ()) -> ()
 Added: _$ss27ThrowingDiscardingTaskGroupV05startC28SynchronouslyUnlessCancelled8priority9operationyScPSg_yyYacntF
+
+// add callee-allocated coro entrypoints
+// TODO: CoroutineAccessors: several of these symbols should be in swiftCore
+Added: __swift_coro_malloc_allocator
+Added: __swift_coro_task_allocator
+Added: _swift_coro_alloc
+Added: _swift_coro_dealloc
+Added: _swift_coro_getGlobalAllocator
+Added: _swift_task_dealloc_through

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -406,3 +406,12 @@ Added: _$ss19DiscardingTaskGroupV05startB28SynchronouslyUnlessCancelled8priority
 Added: _$ss27ThrowingDiscardingTaskGroupV05startC13Synchronously8priority9operationyScPSg_yyYacntF
 // Swift.ThrowingDiscardingTaskGroup.startTaskSynchronouslyUnlessCancelled(priority: Swift.TaskPriority?, operation: __owned () async -> ()) -> ()
 Added: _$ss27ThrowingDiscardingTaskGroupV05startC28SynchronouslyUnlessCancelled8priority9operationyScPSg_yyYacntF
+
+// add callee-allocated coro entrypoints
+// TODO: CoroutineAccessors: several of these symbols should be in swiftCore
+Added: __swift_coro_malloc_allocator
+Added: __swift_coro_task_allocator
+Added: _swift_coro_alloc
+Added: _swift_coro_dealloc
+Added: _swift_coro_getGlobalAllocator
+Added: _swift_task_dealloc_through


### PR DESCRIPTION
Allocate a coroutine frame in the caller based on the size in the corresponding "function pointer" and pass it along with an allocator to the callee.

Paired with https://github.com/swiftlang/llvm-project/pull/10120 .