### PR TITLE
AST: Centralize AvailabilityDomain lookup

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -765,18 +765,15 @@ public:
   /// has been resolved successfully.
   bool hasCachedDomain() const { return DomainOrIdentifier.isDomain(); }
 
+  AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
+    return DomainOrIdentifier;
+  }
+
   /// Returns the `AvailabilityDomain` associated with the attribute, or
   /// `std::nullopt` if it has either not yet been resolved or could not be
   /// resolved successfully.
   std::optional<AvailabilityDomain> getCachedDomain() const {
     return DomainOrIdentifier.getAsDomain();
-  }
-
-  /// If the attribute does not already have a cached `AvailabilityDomain`, this
-  /// returns the domain identifier that was written in source, from which an
-  /// `AvailabilityDomain` can be resolved.
-  std::optional<Identifier> getDomainIdentifier() const {
-    return DomainOrIdentifier.getAsIdentifier();
   }
 
   SourceLoc getDomainLoc() const { return DomainLoc; }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -165,14 +165,20 @@ protected:
       /// Whether this attribute was spelled `@_spi_available`.
       IsSPI : 1,
 
-      /// Whether this attribute belongs to a chain of adjacent `@available` attributes that were generated from a single attribute written in source using short form syntax e.g. (`@available(macOS 15, iOS 18, *)`).
+      /// Whether this attribute belongs to a chain of adjacent `@available`
+      /// attributes that were generated from a single attribute written in
+      /// source using short form syntax, e.g.
+      ///
+      ///     @available(macOS 15, iOS 18, *)
+      ///
       IsGroupMember : 1,
 
       /// Whether this attribute is the final one in its group.
       IsGroupTerminator : 1,
 
-      /// Whether this attribute's specification was followed by `, *` in source.
-      IsAdjacentToWildcard : 1
+      /// Whether any members of the group were written as a wildcard
+      /// specification (`*`) in source.
+      IsGroupedWithWildcard : 1
     );
 
     SWIFT_INLINE_BITFIELD(ClangImporterSynthesizedTypeAttr, DeclAttribute, 1,
@@ -848,12 +854,13 @@ public:
   }
   void setIsGroupTerminator() { Bits.AvailableAttr.IsGroupTerminator = true; }
 
-  /// Whether this attribute's specification was followed by `, *` in source.
-  bool isAdjacentToWildcard() const {
-    return Bits.AvailableAttr.IsAdjacentToWildcard;
+  /// Whether any members of the group were written as a wildcard specification
+  /// (`*`) in source.
+  bool isGroupedWithWildcard() const {
+    return Bits.AvailableAttr.IsGroupedWithWildcard;
   }
-  void setIsAdjacentToWildcard() {
-    Bits.AvailableAttr.IsAdjacentToWildcard = true;
+  void setIsGroupedWithWildcard() {
+    Bits.AvailableAttr.IsGroupedWithWildcard = true;
   }
 
   /// Returns the kind of availability the attribute specifies.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -746,6 +746,7 @@ public:
 
 private:
   friend class SemanticAvailableAttr;
+  friend class SemanticAvailableAttrRequest;
 
   AvailabilityDomainOrIdentifier DomainOrIdentifier;
   const SourceLoc DomainLoc;
@@ -767,13 +768,6 @@ public:
 
   AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
     return DomainOrIdentifier;
-  }
-
-  /// Returns the `AvailabilityDomain` associated with the attribute, or
-  /// `std::nullopt` if it has either not yet been resolved or could not be
-  /// resolved successfully.
-  std::optional<AvailabilityDomain> getCachedDomain() const {
-    return DomainOrIdentifier.getAsDomain();
   }
 
   SourceLoc getDomainLoc() const { return DomainLoc; }
@@ -917,11 +911,6 @@ private:
 
 private:
   friend class SemanticAvailableAttrRequest;
-
-  void setCachedDomain(AvailabilityDomain domain) {
-    assert(!DomainOrIdentifier.isDomain());
-    DomainOrIdentifier.setDomain(domain);
-  }
 
   bool hasComputedSemanticAttr() const {
     return Bits.AvailableAttr.HasComputedSemanticAttr;
@@ -3305,12 +3294,13 @@ class SemanticAvailableAttr final {
 public:
   SemanticAvailableAttr(const AvailableAttr *attr) : attr(attr) {
     assert(attr);
-    assert(attr->hasCachedDomain());
+    bool hasDomain = attr->getDomainOrIdentifier().isDomain();
+    assert(hasDomain);
   }
 
   const AvailableAttr *getParsedAttr() const { return attr; }
   const AvailabilityDomain getDomain() const {
-    return attr->getCachedDomain().value();
+    return attr->getDomainOrIdentifier().getAsDomain().value();
   }
 
   /// The version tuple for the `introduced:` component.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -248,11 +248,18 @@ public:
     ID.AddPointer(getOpaqueValue());
   }
 
+  void print(llvm::raw_ostream &os) const;
+
 private:
   friend class AvailabilityDomainOrIdentifier;
 
   AvailabilityDomain copy(ASTContext &ctx) const;
 };
+
+inline void simple_display(llvm::raw_ostream &os,
+                           const AvailabilityDomain &domain) {
+  domain.print(os);
+}
 
 /// Represents an availability domain that has been defined in a module.
 class CustomAvailabilityDomain : public ASTAllocated<CustomAvailabilityDomain> {
@@ -327,6 +334,8 @@ public:
   /// members of the original into the given `ASTContext` in case it is
   /// different than the context that the original was created for.
   AvailabilityDomainOrIdentifier copy(ASTContext &ctx) const;
+
+  void print(llvm::raw_ostream &os) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -23,6 +23,7 @@
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -294,10 +295,20 @@ public:
 class AvailabilityDomainOrIdentifier {
   friend struct llvm::PointerLikeTypeTraits<AvailabilityDomainOrIdentifier>;
 
-  using Storage = llvm::PointerUnion<AvailabilityDomain, Identifier>;
+  using DomainOrIdentifier = llvm::PointerUnion<AvailabilityDomain, Identifier>;
+
+  /// Stores an extra bit representing whether the domain has been resolved.
+  using Storage = llvm::PointerIntPair<DomainOrIdentifier, 1, bool>;
   Storage storage;
 
   AvailabilityDomainOrIdentifier(Storage storage) : storage(storage) {}
+
+  static AvailabilityDomainOrIdentifier fromOpaque(void *opaque) {
+    return AvailabilityDomainOrIdentifier(Storage::getFromOpaqueValue(opaque));
+  }
+
+  std::optional<AvailabilityDomain>
+  lookUpInDeclContext(SourceLoc loc, const DeclContext *declContext) const;
 
 public:
   AvailabilityDomainOrIdentifier(Identifier identifier)
@@ -305,12 +316,10 @@ public:
   AvailabilityDomainOrIdentifier(AvailabilityDomain domain)
       : storage(domain) {};
 
-  static AvailabilityDomainOrIdentifier fromOpaque(void *opaque) {
-    return AvailabilityDomainOrIdentifier(Storage::getFromOpaqueValue(opaque));
+  bool isDomain() const {
+    return storage.getPointer().is<AvailabilityDomain>();
   }
-
-  bool isDomain() const { return storage.is<AvailabilityDomain>(); }
-  bool isIdentifier() const { return storage.is<Identifier>(); }
+  bool isIdentifier() const { return storage.getPointer().is<Identifier>(); }
 
   /// Overwrites the existing domain or identifier with the given domain.
   void setDomain(AvailabilityDomain domain) { storage = Storage(domain); }
@@ -318,7 +327,7 @@ public:
   /// Returns the resolved domain, or `std::nullopt` if there isn't one.
   std::optional<AvailabilityDomain> getAsDomain() const {
     if (isDomain())
-      return storage.get<AvailabilityDomain>();
+      return storage.getPointer().get<AvailabilityDomain>();
     return std::nullopt;
   }
 
@@ -326,8 +335,23 @@ public:
   /// been resolved.
   std::optional<Identifier> getAsIdentifier() const {
     if (isIdentifier())
-      return storage.get<Identifier>();
+      return storage.getPointer().get<Identifier>();
     return std::nullopt;
+  }
+
+  std::optional<AvailabilityDomain>
+  resolveInDeclContext(SourceLoc loc, const DeclContext *declContext) {
+    // Return the domain directly if already resolved.
+    if (storage.getInt() || isDomain())
+      return getAsDomain();
+
+    // Look up the domain and cache the result.
+    auto result = lookUpInDeclContext(loc, declContext);
+    if (result)
+      storage.setPointer(*result);
+    storage.setInt(true);
+
+    return result;
   }
 
   /// Creates a new `AvailabilityDomainOrIdentifier`, defensively copying

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -56,9 +56,6 @@ class AvailabilitySpec : public ASTAllocated<AvailabilitySpec> {
       : Storage(Storage), SrcRange(SrcRange), Version(Version),
         VersionStartLoc(VersionStartLoc) {}
 
-  AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
-    return Storage.getPointer();
-  }
 
 public:
   /// Creates a wildcard availability specification that guards execution
@@ -101,6 +98,10 @@ public:
     return false;
   }
 
+  AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
+    return Storage.getPointer();
+  }
+
   std::optional<AvailabilityDomain> getDomain() const {
     return getDomainOrIdentifier().getAsDomain();
   }
@@ -123,7 +124,14 @@ public:
   // Location of the macro expanded to create this spec.
   SourceLoc getMacroLoc() const { return MacroLoc; }
   void setMacroLoc(SourceLoc loc) { MacroLoc = loc; }
+
+  void print(llvm::raw_ostream &os) const;
 };
+
+inline void simple_display(llvm::raw_ostream &os,
+                           const AvailabilitySpec *spec) {
+  spec->print(os);
+}
 
 /// The type-checked representation of `AvailabilitySpec` which guaranatees that
 /// the spec has a valid `AvailabilityDomain`.
@@ -153,6 +161,8 @@ public:
   // This is required to support beta versions of macOS Big Sur that
   // report 10.16 at run time.
   llvm::VersionTuple getRuntimeVersion() const { return spec->getRawVersion(); }
+
+  void print(llvm::raw_ostream &os) const { spec->print(os); }
 };
 
 /// Wraps an array of availability specs and provides an iterator for their

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -35,8 +35,7 @@ class SemanticAvailabilitySpec;
 /// The root class for specifications of API availability in availability
 /// queries.
 class AvailabilitySpec : public ASTAllocated<AvailabilitySpec> {
-  using DomainStorage = llvm::PointerIntPair<AvailabilityDomainOrIdentifier, 1>;
-  DomainStorage Storage;
+  AvailabilityDomainOrIdentifier DomainOrIdentifier;
 
   /// The range of the entire spec, including the version if there is one.
   SourceRange SrcRange;
@@ -51,11 +50,11 @@ class AvailabilitySpec : public ASTAllocated<AvailabilitySpec> {
   // Location of the availability macro expanded to create this spec.
   SourceLoc MacroLoc;
 
-  AvailabilitySpec(DomainStorage Storage, SourceRange SrcRange,
-                   llvm::VersionTuple Version, SourceLoc VersionStartLoc)
-      : Storage(Storage), SrcRange(SrcRange), Version(Version),
-        VersionStartLoc(VersionStartLoc) {}
-
+  AvailabilitySpec(AvailabilityDomainOrIdentifier DomainOrIdentifier,
+                   SourceRange SrcRange, llvm::VersionTuple Version,
+                   SourceLoc VersionStartLoc)
+      : DomainOrIdentifier(DomainOrIdentifier), SrcRange(SrcRange),
+        Version(Version), VersionStartLoc(VersionStartLoc) {}
 
 public:
   /// Creates a wildcard availability specification that guards execution
@@ -99,7 +98,7 @@ public:
   }
 
   AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
-    return Storage.getPointer();
+    return DomainOrIdentifier;
   }
 
   std::optional<AvailabilityDomain> getDomain() const {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6748,9 +6748,8 @@ WARNING(attr_availability_expected_version_spec, none,
        "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
        "for platform '%1'", (StringRef, StringRef))
 ERROR(attr_availability_requires_custom_availability, none,
-      "specifying '%0' in '%1' attribute requires "
-      "-enable-experimental-feature CustomAvailability",
-      (StringRef, const DeclAttribute))
+      "%0 requires -enable-experimental-feature CustomAvailability",
+      (Identifier))
 WARNING(attr_availability_unexpected_version,none,
        "unexpected version number in '%0' attribute for '%1'",
        (const DeclAttribute, StringRef))

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1103,11 +1103,11 @@ namespace {
       printRecArbitrary(
           [&](Label label) {
             printHead("availability_spec", PatternColor, label);
-            StringRef domainName =
-                Spec->isWildcard()
-                    ? "*"
-                    : Spec->getDomain()->getNameForAttributePrinting();
-            printField(domainName, Label::always("domain"));
+            printFieldRaw(
+                [&](llvm::raw_ostream &OS) {
+                  Spec->getDomainOrIdentifier().print(OS);
+                },
+                Label::always("domain"));
             if (!Spec->getRawVersion().empty())
               printFieldRaw(
                   [&](llvm::raw_ostream &OS) { OS << Spec->getRawVersion(); },
@@ -4944,13 +4944,8 @@ public:
   void visitAvailableAttr(AvailableAttr *Attr, Label label) {
     printCommon(Attr, "available_attr", label);
 
-    if (auto domain = Attr->getCachedDomain()) {
-      printField(domain->getNameForAttributePrinting(),
-                 Label::always("domain"));
-    } else {
-      printField(*Attr->getDomainIdentifier(),
-                 Label::always("domainIdentifier"));
-    }
+    printFieldRaw([&](auto &out) { Attr->getDomainOrIdentifier().print(out); },
+                  Label::always("domain"));
 
     switch (Attr->getKind()) {
     case swift::AvailableAttr::Kind::Default:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2146,7 +2146,7 @@ AvailableAttr::AvailableAttr(
   Bits.AvailableAttr.IsSPI = IsSPI;
   Bits.AvailableAttr.IsGroupMember = false;
   Bits.AvailableAttr.IsGroupTerminator = false;
-  Bits.AvailableAttr.IsAdjacentToWildcard = false;
+  Bits.AvailableAttr.IsGroupedWithWildcard = false;
 }
 
 AvailableAttr *AvailableAttr::createUniversallyUnavailable(ASTContext &C,

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -797,26 +797,11 @@ bool AvailabilityInference::isAvailableAsSPI(const Decl *D) {
   return false;
 }
 
-static std::optional<AvailabilityDomain>
-getAvailabilityDomainForName(Identifier identifier,
-                             const DeclContext *declContext) {
-  if (auto builtinDomain = AvailabilityDomain::builtinDomainForString(
-          identifier.str(), declContext))
-    return builtinDomain;
-
-  auto &ctx = declContext->getASTContext();
-  if (auto customDomain =
-          ctx.MainModule->getAvailabilityDomainForIdentifier(identifier))
-    return customDomain;
-
-  return std::nullopt;
-}
-
 std::optional<SemanticAvailableAttr>
 SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
                                        const AvailableAttr *attr,
                                        const Decl *decl) const {
-  if (attr->hasCachedDomain())
+  if (attr->getDomainOrIdentifier().isDomain())
     return SemanticAvailableAttr(attr);
 
   auto &ctx = decl->getASTContext();
@@ -824,42 +809,13 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   auto attrLoc = attr->getLocation();
   auto attrName = attr->getAttrName();
   auto domainLoc = attr->getDomainLoc();
+  auto declContext = decl->getInnermostDeclContext();
   auto mutableAttr = const_cast<AvailableAttr *>(attr);
-  auto domain = attr->getCachedDomain();
+  auto domain = mutableAttr->DomainOrIdentifier.resolveInDeclContext(
+      domainLoc, declContext);
 
-  if (!domain) {
-    auto domainIdentifier = attr->getDomainOrIdentifier().getAsIdentifier();
-    ASSERT(domainIdentifier);
-
-    // Attempt to resolve the domain specified for the attribute and diagnose
-    // if no domain is found.
-    auto declContext = decl->getInnermostDeclContext();
-    domain = getAvailabilityDomainForName(*domainIdentifier, declContext);
-    if (!domain) {
-      auto domainString = domainIdentifier->str();
-      if (auto suggestion = closestCorrectedPlatformString(domainString)) {
-        diags
-            .diagnose(domainLoc, diag::attr_availability_suggest_platform,
-                      domainString, attrName, *suggestion)
-            .fixItReplace(SourceRange(domainLoc), *suggestion);
-      } else {
-        diags.diagnose(attrLoc, diag::attr_availability_unknown_platform,
-                       domainString, attrName);
-      }
-      return std::nullopt;
-    }
-
-    if (domain->isCustom() &&
-        !ctx.LangOpts.hasFeature(Feature::CustomAvailability) &&
-        !declContext->isInSwiftinterface()) {
-      diags.diagnose(domainLoc,
-                     diag::attr_availability_requires_custom_availability,
-                     domain->getNameForAttributePrinting(), attr);
-      return std::nullopt;
-    }
-
-    mutableAttr->setCachedDomain(*domain);
-  }
+  if (!domain)
+    return std::nullopt;
 
   auto domainName = domain->getNameForAttributePrinting();
   auto semanticAttr = SemanticAvailableAttr(attr);

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -828,7 +828,7 @@ SemanticAvailableAttrRequest::evaluate(swift::Evaluator &evaluator,
   auto domain = attr->getCachedDomain();
 
   if (!domain) {
-    auto domainIdentifier = attr->getDomainIdentifier();
+    auto domainIdentifier = attr->getDomainOrIdentifier().getAsIdentifier();
     ASSERT(domainIdentifier);
 
     // Attempt to resolve the domain specified for the attribute and diagnose

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -168,6 +168,10 @@ AvailabilityDomain AvailabilityDomain::getABICompatibilityDomain() const {
   return *this;
 }
 
+void AvailabilityDomain::print(llvm::raw_ostream &os) const {
+  os << getNameForAttributePrinting();
+}
+
 AvailabilityDomain AvailabilityDomain::copy(ASTContext &ctx) const {
   switch (getKind()) {
   case Kind::Universal:
@@ -204,4 +208,11 @@ AvailabilityDomainOrIdentifier::copy(ASTContext &ctx) const {
 
   DEBUG_ASSERT(isDomain());
   return getAsDomain()->copy(ctx);
+}
+
+void AvailabilityDomainOrIdentifier::print(llvm::raw_ostream &os) const {
+  if (auto identifier = getAsIdentifier())
+    os << identifier->str();
+  else
+    getAsDomain()->print(os);
 }

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -13,6 +13,9 @@
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "llvm/ADT/StringSwitch.h"
 
@@ -199,6 +202,57 @@ CustomAvailabilityDomain *
 CustomAvailabilityDomain::create(const ASTContext &ctx, StringRef name,
                                  ModuleDecl *mod, Kind kind) {
   return new (ctx) CustomAvailabilityDomain(ctx.getIdentifier(name), mod, kind);
+}
+
+static std::optional<AvailabilityDomain>
+getAvailabilityDomainForName(Identifier identifier,
+                             const DeclContext *declContext) {
+  if (auto builtinDomain = AvailabilityDomain::builtinDomainForString(
+          identifier.str(), declContext))
+    return builtinDomain;
+
+  auto &ctx = declContext->getASTContext();
+  if (auto customDomain =
+          ctx.MainModule->getAvailabilityDomainForIdentifier(identifier))
+    return customDomain;
+
+  return std::nullopt;
+}
+
+std::optional<AvailabilityDomain>
+AvailabilityDomainOrIdentifier::lookUpInDeclContext(
+    SourceLoc loc, const DeclContext *declContext) const {
+  DEBUG_ASSERT(isIdentifier());
+
+  auto &ctx = declContext->getASTContext();
+  auto &diags = ctx.Diags;
+  std::optional<AvailabilityDomain> domain;
+  auto identifier = getAsIdentifier().value();
+  domain = getAvailabilityDomainForName(identifier, declContext);
+
+  if (!domain) {
+    auto domainString = identifier.str();
+    if (auto suggestion = closestCorrectedPlatformString(domainString)) {
+      diags
+          .diagnose(loc, diag::avail_query_suggest_platform_name, identifier,
+                    *suggestion)
+          .fixItReplace(SourceRange(loc), *suggestion);
+    } else {
+      diags.diagnose(loc, diag::avail_query_unrecognized_platform_name,
+                     identifier);
+    }
+    return std::nullopt;
+  }
+
+  if (domain->isCustom() &&
+      !ctx.LangOpts.hasFeature(Feature::CustomAvailability) &&
+      !declContext->isInSwiftinterface()) {
+    diags.diagnose(loc, diag::attr_availability_requires_custom_availability,
+                   identifier);
+    return std::nullopt;
+  }
+
+  return domain;
 }
 
 AvailabilityDomainOrIdentifier

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -23,10 +23,9 @@ using namespace swift;
 
 AvailabilitySpec *AvailabilitySpec::createWildcard(ASTContext &ctx,
                                                    SourceLoc starLoc) {
-  return new (ctx)
-      AvailabilitySpec({AvailabilityDomain::forUniversal(), true}, starLoc,
-                       /*Version=*/{},
-                       /*VersionStartLoc=*/{});
+  return new (ctx) AvailabilitySpec(AvailabilityDomain::forUniversal(), starLoc,
+                                    /*Version=*/{},
+                                    /*VersionStartLoc=*/{});
 }
 
 AvailabilitySpec *AvailabilitySpec::createForDomain(ASTContext &ctx,
@@ -35,23 +34,22 @@ AvailabilitySpec *AvailabilitySpec::createForDomain(ASTContext &ctx,
                                                     llvm::VersionTuple version,
                                                     SourceRange versionRange) {
   DEBUG_ASSERT(!version.empty());
-  return new (ctx)
-      AvailabilitySpec({domain, true}, SourceRange(loc, versionRange.End),
-                       version, versionRange.Start);
+  return new (ctx) AvailabilitySpec(domain, SourceRange(loc, versionRange.End),
+                                    version, versionRange.Start);
 }
 
 AvailabilitySpec *AvailabilitySpec::createForUnknownDomain(
     ASTContext &ctx, Identifier domainIdentifier, SourceLoc loc,
     llvm::VersionTuple version, SourceRange versionRange) {
-  return new (ctx) AvailabilitySpec({domainIdentifier, true},
-                                    SourceRange(loc, versionRange.End), version,
-                                    versionRange.Start);
+  DEBUG_ASSERT(!version.empty());
+  return new (ctx)
+      AvailabilitySpec(domainIdentifier, SourceRange(loc, versionRange.End),
+                       version, versionRange.Start);
 }
 
 AvailabilitySpec *AvailabilitySpec::clone(ASTContext &ctx) const {
-  return new (ctx)
-      AvailabilitySpec({getDomainOrIdentifier().copy(ctx), true},
-                       SrcRange, Version, VersionStartLoc);
+  return new (ctx) AvailabilitySpec(getDomainOrIdentifier().copy(ctx), SrcRange,
+                                    Version, VersionStartLoc);
 }
 
 void AvailabilitySpec::print(llvm::raw_ostream &os) const {

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -54,6 +54,13 @@ AvailabilitySpec *AvailabilitySpec::clone(ASTContext &ctx) const {
                        SrcRange, Version, VersionStartLoc);
 }
 
+void AvailabilitySpec::print(llvm::raw_ostream &os) const {
+  getDomainOrIdentifier().print(os);
+
+  if (!getRawVersion().empty())
+    os << " " << getRawVersion().getAsString();
+}
+
 llvm::VersionTuple SemanticAvailabilitySpec::getVersion() const {
   // For macOS Big Sur, we canonicalize 10.16 to 11.0 for compile-time
   // checking since clang canonicalizes availability markup. However, to

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2725,7 +2725,7 @@ SemanticAvailableAttrRequest::getCachedResult() const {
   if (!attr->hasComputedSemanticAttr())
     return std::nullopt;
 
-  if (!attr->hasCachedDomain()) {
+  if (!attr->getDomainOrIdentifier().isDomain()) {
     return std::optional<SemanticAvailableAttr>{};
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -790,13 +790,13 @@ bool Parser::parseAvailability(
     // we will synthesize
     //   @available(_PackageDescription, introduced: 4.2)
 
+    bool groupContainsWildcard = llvm::any_of(
+        Specs, [](AvailabilitySpec *Spec) { return Spec->isWildcard(); });
+
     AvailableAttr *PrevAttr = nullptr;
     for (auto *Spec : Specs) {
-      if (Spec->isWildcard()) {
-        if (PrevAttr)
-          PrevAttr->setIsAdjacentToWildcard();
+      if (Spec->isWildcard())
         continue;
-      }
 
       std::optional<AvailabilityDomain> Domain = Spec->getDomain();
       if (!Domain)
@@ -817,6 +817,8 @@ bool Parser::parseAvailability(
       addAttribute(Attr);
 
       Attr->setIsGroupMember();
+      if (groupContainsWildcard)
+        Attr->setIsGroupedWithWildcard();
       if (!PrevAttr)
         Attr->setIsGroupTerminator();
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -17,26 +17,26 @@ func noArgs() {}
 @available(*) // expected-error {{expected ',' in 'available' attribute}}
 func noKind() {}
 
-@available(badPlatform, unavailable) // expected-warning {{unknown platform 'badPlatform' for attribute 'available'}}
+@available(badPlatform, unavailable) // expected-warning {{unrecognized platform name 'badPlatform'}}
 func unavailable_bad_platform() {}
 
-@available(macos, unavailable) // expected-warning {{unknown platform 'macos' for attribute 'available'; did you mean 'macOS'?}} {{12-17=macOS}}
+@available(macos, unavailable) // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{12-17=macOS}}
 func incorrect_platform_case() {}
 
-@available(mscos, unavailable) // expected-warning {{unknown platform 'mscos' for attribute 'available'; did you mean 'macOS'?}} {{12-17=macOS}}
+@available(mscos, unavailable) // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{12-17=macOS}}
 func incorrect_platform_similar1() {}
 
-@available(macoss, unavailable) // expected-warning {{unknown platform 'macoss' for attribute 'available'; did you mean 'macOS'?}} {{12-18=macOS}}
+@available(macoss, unavailable) // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{12-18=macOS}}
 func incorrect_platform_similar2() {}
 
-@available(mac, unavailable) // expected-warning {{unknown platform 'mac' for attribute 'available'; did you mean 'macOS'?}} {{12-15=macOS}}
+@available(mac, unavailable) // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{12-15=macOS}}
 func incorrect_platform_similar3() {}
 
-@available(notValid, unavailable) // expected-warning {{unknown platform 'notValid' for attribute 'available'}} {{none}}
+@available(notValid, unavailable) // expected-warning {{unrecognized platform name 'notValid'}} {{none}}
 func incorrect_platform_not_similar() {}
 
 // Handle unknown platform.
-@available(HAL9000, unavailable) // expected-warning {{unknown platform 'HAL9000'}}
+@available(HAL9000, unavailable) // expected-warning {{unrecognized platform name 'HAL9000'}}
 func availabilityUnknownPlatform() {}
 
 // <rdar://problem/17669805> Availability can't appear on a typealias

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -29,7 +29,7 @@ func deprecatedInRedefinedDomain() { }
 @available(DynamicDomain)
 func availableInDynamicDomain() { }
 
-@available(UnknownDomain) // expected-warning {{unknown platform 'UnknownDomain' for attribute 'available'}}
+@available(UnknownDomain) // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
 func test() {

--- a/test/attr/attr_availability_custom_domains_experimental_feature_required.swift
+++ b/test/attr/attr_availability_custom_domains_experimental_feature_required.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:  -define-enabled-availability-domain SomeDomain
 
-@available(SomeDomain, unavailable) // expected-error {{specifying 'SomeDomain' in '@available' attribute requires -enable-experimental-feature CustomAvailability}}
+@available(SomeDomain, unavailable) // expected-error {{'SomeDomain' requires -enable-experimental-feature CustomAvailability}}
 func availableInSomeDomain() { }

--- a/test/decl/protocol/special/case_iterable/case_iterable_supported.swift
+++ b/test/decl/protocol/special/case_iterable/case_iterable_supported.swift
@@ -40,6 +40,6 @@ extension FromOtherFile: CaseIterable {
 
 enum InvalidAvailableAttribute: CaseIterable {
   case a
-  @available(deprecated, renamed: "a") // expected-warning {{unknown platform 'deprecated' for attribute 'available'}}
+  @available(deprecated, renamed: "a") // expected-warning {{unrecognized platform name 'deprecated'}}
   case b
 }


### PR DESCRIPTION
Implement lookup of availability domains for identifiers on `AvailabilityDomainOrIdentifier`. Add a bit to that type which represents whether or not lookup has already been attempted. This allows both `AvailableAttr` and `AvailabilitySpec` to share a common implementation of domain lookup.

Also, fix a bug in the diagnostics for missing wildcards in `@available` attributes.