### PR TITLE
AST/Parse: Parse custom availability domain specs in `if #available(...)`

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -208,6 +208,9 @@ public:
   /// version ranges.
   bool isVersioned() const;
 
+  /// Returns true if the domain supports `#available`/`#unavailable` queries.
+  bool supportsQueries() const;
+
   /// Returns true if this domain is considered active in the current
   /// compilation context.
   bool isActive(const ASTContext &ctx) const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6754,8 +6754,10 @@ NOTE(type_eraser_init_spi,none,
 //------------------------------------------------------------------------------
 
 ERROR(availability_must_occur_alone, none,
-      "'%0' version-availability must be specified alone", (StringRef))
-
+      "%0 %select{|version }1availability must be specified alone",
+      (StringRef, bool))
+ERROR(availability_unexpected_version, none,
+      "unexpected version number for %0", (StringRef))
 WARNING(availability_unrecognized_platform_name,
         PointsToFirstBadToken, "unrecognized platform name %0", (Identifier))
 WARNING(availability_suggest_platform_name,
@@ -6773,11 +6775,8 @@ WARNING(attr_availability_expected_version_spec, none,
        "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
        "for platform '%1'", (StringRef, StringRef))
 ERROR(attr_availability_requires_custom_availability, none,
-      "%0 requires -enable-experimental-feature CustomAvailability",
-      (Identifier))
-WARNING(attr_availability_unexpected_version,none,
-       "unexpected version number in '%0' attribute for '%1'",
-       (const DeclAttribute, StringRef))
+      "%0 requires '-enable-experimental-feature CustomAvailability'",
+      (StringRef))
 
 ERROR(availability_decl_unavailable, none,
       "%0 is unavailable%select{ in %2|}1%select{|: %3}3",
@@ -7002,14 +7001,12 @@ ERROR(conformance_availability_only_version_newer, none,
 // MARK: if #available(...)
 //------------------------------------------------------------------------------
 
-ERROR(availability_query_swift_not_allowed, none,
-      "Swift language version checks not allowed in %0(...)", (StringRef))
+ERROR(availability_query_not_allowed, none,
+      "%0 %select{|version }1checks not allowed in %2(...)",
+      (StringRef, bool, StringRef))
 
-ERROR(availability_query_package_description_not_allowed, none,
-      "PackageDescription version checks not allowed in %0(...)", (StringRef))
-
-ERROR(availability_query_repeated_platform, none,
-      "version for '%0' already specified", (StringRef))
+ERROR(availability_query_already_specified, none,
+      "%select{|version for }0'%1' already specified", (bool, StringRef))
 
 ERROR(availability_query_wildcard_required, none,
       "must handle potential future platforms with '*'", ())

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -75,6 +75,19 @@ bool AvailabilityDomain::isVersioned() const {
   }
 }
 
+bool AvailabilityDomain::supportsQueries() const {
+  switch (getKind()) {
+  case Kind::Universal:
+  case Kind::Embedded:
+  case Kind::SwiftLanguage:
+  case Kind::PackageDescription:
+    return false;
+  case Kind::Platform:
+  case Kind::Custom:
+    return true;
+  }
+}
+
 bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   switch (getKind()) {
   case Kind::Universal:
@@ -94,7 +107,7 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
 llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
   switch (getKind()) {
   case Kind::Universal:
-    return "";
+    return "*";
   case Kind::SwiftLanguage:
     return "Swift";
   case Kind::PackageDescription:
@@ -247,7 +260,7 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
       !ctx.LangOpts.hasFeature(Feature::CustomAvailability) &&
       !declContext->isInSwiftinterface()) {
     diags.diagnose(loc, diag::attr_availability_requires_custom_availability,
-                   identifier);
+                   domain->getNameForDiagnostics());
     return std::nullopt;
   }
 

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -29,22 +29,32 @@ AvailabilitySpec *AvailabilitySpec::createWildcard(ASTContext &ctx,
                                     /*VersionStartLoc=*/{});
 }
 
+static SourceRange getSpecSourceRange(SourceLoc domainLoc,
+                                      SourceRange versionRange) {
+  if (domainLoc.isInvalid())
+    return SourceRange();
+
+  if (versionRange.isValid())
+    return SourceRange(domainLoc, versionRange.End);
+
+  return SourceRange(domainLoc);
+}
+
 AvailabilitySpec *AvailabilitySpec::createForDomain(ASTContext &ctx,
                                                     AvailabilityDomain domain,
                                                     SourceLoc loc,
                                                     llvm::VersionTuple version,
                                                     SourceRange versionRange) {
-  DEBUG_ASSERT(!version.empty());
-  return new (ctx) AvailabilitySpec(domain, SourceRange(loc, versionRange.End),
-                                    version, versionRange.Start);
+  return new (ctx)
+      AvailabilitySpec(domain, getSpecSourceRange(loc, versionRange), version,
+                       versionRange.Start);
 }
 
 AvailabilitySpec *AvailabilitySpec::createForDomainIdentifier(
     ASTContext &ctx, Identifier domainIdentifier, SourceLoc loc,
     llvm::VersionTuple version, SourceRange versionRange) {
-  DEBUG_ASSERT(!version.empty());
   return new (ctx)
-      AvailabilitySpec(domainIdentifier, SourceRange(loc, versionRange.End),
+      AvailabilitySpec(domainIdentifier, getSpecSourceRange(loc, versionRange),
                        version, versionRange.Start);
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -284,6 +284,7 @@ extension ASTGenVisitor {
     var result: [BridgedAvailabilitySpec] = []
 
     func handle(domainNode: TokenSyntax, versionNode: VersionTupleSyntax?) {
+      // FIXME: [availability] Add support for custom domains
       let nameLoc = self.generateSourceLoc(domainNode)
       let version = self.generate(versionTuple: versionNode)
       let versionRange = self.generateSourceRange(versionNode)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3715,9 +3715,11 @@ ParserResult<AvailabilitySpec> Parser::parseAvailabilitySpec() {
   llvm::VersionTuple Version;
   SourceRange VersionRange;
 
-  if (parseVersionTuple(Version, VersionRange,
-                        diag::avail_query_expected_version_number)) {
-    return nullptr;
+  if (Tok.isAny(tok::integer_literal, tok::floating_literal)) {
+    if (parseVersionTuple(Version, VersionRange,
+                          diag::avail_query_expected_version_number)) {
+      return nullptr;
+    }
   }
 
   return makeParserResult(AvailabilitySpec::createForDomainIdentifier(

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1481,7 +1481,7 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs,
                      diag::avail_query_meant_introduced)
                 .fixItInsert(PlatformNameEndLoc, ", introduced:");
           }
-
+          consumeToken();
           Status.setIsParseError();
           break;
         }

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -30,7 +30,7 @@ if #available( { // expected-error {{expected platform name}} expected-error {{e
 if #available() { // expected-error {{expected platform name}}
 }
 
-if #available(OSX { // expected-error {{expected version number}} expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #available(OSX { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
 if #available(OSX) { // expected-error {{expected version number}}
@@ -46,8 +46,7 @@ if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to mat
 }
 
 if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
-// expected-error@-1 {{must handle potential future platforms with '*'}}
-// expected-error@-2 {{condition required for target platform}}
+// expected-error@-1 {{condition required for target platform}}
 }
 
 if #available(iDishwasherOS 51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
@@ -75,7 +74,9 @@ if #available(OSX 51, iOS 8.0) { }  // expected-error {{must handle potential fu
 if #available(iOS 8.0, *) {
 }
 
-if #available(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+if #available(iOSApplicationExtension, unavailable) { // expected-error {{'unavailable' can't be combined with shorthand specification 'iOSApplicationExtension'}}
+// expected-error@-1 {{condition required for target platform}}
+// expected-note@-2 {{did you mean to specify an introduction version?}}
 }
 	
 // Want to make sure we can parse this. Perhaps we should not let this validate, though.
@@ -96,7 +97,7 @@ if #available(OSX 51, { // expected-error {{expected platform name}} // expected
 if #available(OSX 51,) { // expected-error {{expected platform name}}
 }
 
-if #available(OSX 51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #available(OSX 51, iOS { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
 if #available(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -28,7 +28,7 @@ if #unavailable( { // expected-error {{expected platform name}} expected-error {
 if #unavailable() { // expected-error {{expected platform name}}
 }
 
-if #unavailable(OSX { // expected-error {{expected version number}} expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #unavailable(OSX { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
 if #unavailable(OSX) { // expected-error {{expected version number}}
@@ -62,7 +62,8 @@ if #unavailable(OSX 51, iOS 8.0, *) { }  // expected-error {{platform wildcard '
 if #unavailable(iOS 8.0) {
 }
 
-if #unavailable(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+if #unavailable(iOSApplicationExtension, unavailable) { // expected-error {{'unavailable' can't be combined with shorthand specification 'iOSApplicationExtension'}}
+// expected-note@-1 {{did you mean to specify an introduction version?}}
 }
 
 // Should this be a valid spelling since `#unvailable(*)` cannot be written?
@@ -80,7 +81,7 @@ if #unavailable(OSX 51, iOS 8.0) {
 if #unavailable(OSX 51, { // expected-error {{expected platform name}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(OSX 51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #unavailable(OSX 51, iOS { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
 if #unavailable(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -33,15 +33,15 @@ func twoShorthandsFollowedByDeprecated() {}
 // Missing/wrong warning message for '*' or 'swift' platform.
 
 @available(*, deprecated: 4.2)
-// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
+// expected-warning@-1 {{unexpected version number for *}}
 func allPlatformsDeprecatedVersion() {}
 
 @available(*, deprecated, obsoleted: 4.2)
-// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
+// expected-warning@-1 {{unexpected version number for *}}
 func allPlatformsDeprecatedAndObsoleted() {}
 
 @available(*, introduced: 4.0, deprecated: 4.1, obsoleted: 4.2)
-// expected-warning@-1 {{unexpected version number in '@available' attribute for '*'}}
+// expected-warning@-1 {{unexpected version number for *}}
 func allPlatformsDeprecatedAndObsoleted2() {}
 
 @available(swift, unavailable)

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -72,7 +72,7 @@ func client() {
     onMacOS51_0()
   }
 
-  if #available(_unknownMacro, *) { } // expected-error {{expected version number}}
+  if #available(_unknownMacro, *) { } // expected-warning {{unrecognized platform name '_unknownMacro'}}
 }
 
 public func doIt(_ closure: () -> ()) {

--- a/test/Sema/availability_define_parsing.swift
+++ b/test/Sema/availability_define_parsing.swift
@@ -5,6 +5,7 @@
 // RUN:   -define-availability "_brokenPlatforms:spaceOS 10.11" \
 // RUN:   -define-availability "_refuseWildcard:iOS 13.0, *, macOS 11.0" \
 // RUN:   -define-availability "_incorrectCase:ios 13.0, macos 11.0" \
+// RUN:   -define-availability "_noVersion: macOS" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   2>&1 | %FileCheck %s
@@ -16,8 +17,11 @@ public func brokenPlatforms() {}
 @available(_incorrectCase)
 public func incorrectCase() {}
 
-// CHECK: -define-availability argument:1:16: error: expected version number
-// CHECK-NEXT: _brokenParse:a b c d
+@available(_noVersion)
+public func noVersion() {}
+
+@available(_noVersionMulti)
+public func noVersionMulti() {}
 
 // CHECK: -define-availability argument:1:1: error: expected an identifier to begin an availability macro definition
 // CHECK-NEXT: :a b c d
@@ -39,3 +43,7 @@ public func incorrectCase() {}
 
 // CHECK: -define-availability argument:1:16: warning: unrecognized platform name 'ios'; did you mean 'iOS'?
 // CHECK-NEXT: _incorrectCase
+
+// FIXME: [availability] Diagnostic needs improvement
+// CHECK: -define-availability argument:1:13: warning: expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'macOS'
+// CHECK-NEXT: _noVersion: macOS

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -8,16 +8,42 @@
 
 // REQUIRES: swift_feature_CustomAvailability
 
+// FIXME: [availability] Test custom domains in availability macros
+
 @available(EnabledDomain)
 func availableInEnabledDomain() { }
 
-@available(EnabledDomain, introduced: 1.0) // expected-warning {{unexpected version number in '@available' attribute for 'EnabledDomain'}}
+@available(EnabledDomain, *) // expected-error {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
+// expected-error@-1 {{expected declaration}}
+func availableInEnabledDomainWithWildcard() { }
+
+@available(EnabledDomain, introduced: 1.0) // expected-error {{unexpected version number for EnabledDomain}}
 func introducedInEnabledDomain() { }
 
-@available(EnabledDomain, deprecated: 1.0) // expected-warning {{unexpected version number in '@available' attribute for 'EnabledDomain'}}
+@available(EnabledDomain 1.0) // expected-error {{unexpected version number for EnabledDomain}}
+func introducedInEnabledDomainShort() { }
+
+@available(EnabledDomain 1.0, *) // expected-error {{unexpected version number for EnabledDomain}}
+func introducedInEnabledDomainShortWithWildcard() { }
+
+@available(macOS 10.10, EnabledDomain, *) // expected-error {{EnabledDomain availability must be specified alone}}
+func introducedInMacOSAndAvailableInEnabledDomain() { }
+
+@available(EnabledDomain, macOS 10.10, *) // expected-error {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
+// expected-error@-1 {{expected declaration}}
+func availableInEnabledDomainAndIntroducedInMacOS() { }
+
+@available(EnabledDomain, DisabledDomain) // expected-error {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
+func availableInMultipleCustomDomainsShort() { }
+
+@available(EnabledDomain, DisabledDomain, *) // expected-error {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
+// expected-error@-1 {{expected declaration}}
+func availableInMultipleCustomDomainsShortWithWildcard() { }
+
+@available(EnabledDomain, deprecated: 1.0) // expected-error {{unexpected version number for EnabledDomain}}
 func deprecatedInEnabledDomain() { }
 
-@available(EnabledDomain, obsoleted: 1.0) // expected-warning {{unexpected version number in '@available' attribute for 'EnabledDomain'}}
+@available(EnabledDomain, obsoleted: 1.0) // expected-error {{unexpected version number for EnabledDomain}}
 func obsoletedInEnabledDomain() { }
 
 @available(DisabledDomain, unavailable)
@@ -32,7 +58,31 @@ func availableInDynamicDomain() { }
 @available(UnknownDomain) // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
-func test() {
+func testQuerySyntax() {
+  if #available(EnabledDomain) {}
+  // expected-error@-1 {{condition required for target platform}}
+  if #available(RedefinedDomain) {}
+  // expected-error@-1 {{condition required for target platform}}
+  if #available(DisabledDomain) {}
+  // expected-error@-1 {{condition required for target platform}}
+  if #available(DynamicDomain) {}
+  // expected-error@-1 {{condition required for target platform}}
+  if #available(UnknownDomain) {} // expected-warning {{unrecognized platform name 'UnknownDomain'}}
+  // expected-error@-1 {{condition required for target platform}}
+
+  if #unavailable(EnabledDomain) {}
+  if #unavailable(RedefinedDomain) {}
+  if #unavailable(DisabledDomain) {}
+  if #unavailable(DynamicDomain) {}
+  if #unavailable(UnknownDomain) {} // expected-warning {{unrecognized platform name 'UnknownDomain'}}
+
+  if #available(EnabledDomain 1.0) {} // expected-error {{unexpected version number for EnabledDomain}}
+  // expected-error@-1 {{condition required for target platform}}
+  if #available(EnabledDomain, DisabledDomain) {} // expected-error {{EnabledDomain availability must be specified alone}}
+  // expected-error@-1 {{condition required for target platform}}
+}
+
+func testAvailability() {
   availableInEnabledDomain() // FIXME: [availability] should be diagnosed
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   deprecatedInRedefinedDomain() // expected-warning {{'deprecatedInRedefinedDomain()' is deprecated: Use something else}}

--- a/test/attr/attr_availability_custom_domains_experimental_feature_required.swift
+++ b/test/attr/attr_availability_custom_domains_experimental_feature_required.swift
@@ -1,5 +1,9 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:  -define-enabled-availability-domain SomeDomain
 
-@available(SomeDomain, unavailable) // expected-error {{'SomeDomain' requires -enable-experimental-feature CustomAvailability}}
+@available(SomeDomain, unavailable) // expected-error {{SomeDomain requires '-enable-experimental-feature CustomAvailability'}}
 func availableInSomeDomain() { }
+
+if #available(SomeDomain) {} // expected-error {{SomeDomain requires '-enable-experimental-feature CustomAvailability'}}
+// expected-error@-1 {{condition required for target platform}}
+if #unavailable(SomeDomain) {} // expected-error {{SomeDomain requires '-enable-experimental-feature CustomAvailability'}}

--- a/test/attr/attr_availability_swift.swift
+++ b/test/attr/attr_availability_swift.swift
@@ -4,31 +4,31 @@
 func foo() {
 }
 
-@available(swift 3.0, *) // expected-error {{'swift' version-availability must be specified alone}}
+@available(swift 3.0, *) // expected-error {{Swift version availability must be specified alone}}
 func foo2() {
 }
 
-@available(swift 3.0, iOS 10, *) // expected-error {{'swift' version-availability must be specified alone}}
+@available(swift 3.0, iOS 10, *) // expected-error {{Swift version availability must be specified alone}}
 func bar() {
 }
 
-@available(iOS 10, swift 3.0, *) // expected-error {{'swift' version-availability must be specified alone}}
+@available(iOS 10, swift 3.0, *) // expected-error {{Swift version availability must be specified alone}}
 func bar2() {
 }
 
-@available(iOS 10, *, swift 3.0) // expected-error {{'swift' version-availability must be specified alone}}
+@available(iOS 10, *, swift 3.0) // expected-error {{Swift version availability must be specified alone}}
 func bar3() {
 }
 
 func baz() {
-  if #available(swift 4) { // expected-error {{Swift language version checks not allowed in #available}}
+  if #available(swift 4) { // expected-error {{Swift version checks not allowed in #available}}
                            // expected-error @-1 {{condition required for target platform}}
     print("yes")
   } else {
     print("no")
   }
 
-  if #unavailable(swift 4) { // expected-error {{Swift language version checks not allowed in #unavailable}}
+  if #unavailable(swift 4) { // expected-error {{Swift version checks not allowed in #unavailable}}
     print("no")
   } else {
     print("yes")

--- a/test/attr/attr_availability_swiftpm_v4.swift
+++ b/test/attr/attr_availability_swiftpm_v4.swift
@@ -62,11 +62,11 @@ func unconditionallyDeprecated() {}
 
 unconditionallyDeprecated() // expected-warning {{test deprecated}}
 
-@available(_PackageDescription 4.0, iOS 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}}
-func shouldBeAlone() {} 
+@available(_PackageDescription 4.0, iOS 2.0, *) // expected-error {{PackageDescription version availability must be specified alone}}
+func shouldBeAlone() {}
 
-@available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}} // expected-error {{'swift' version-availability must be specified alone}}
-func shouldBeAlone2() {} 
+@available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{PackageDescription version availability must be specified alone}} // expected-error {{Swift version availability must be specified alone}}
+func shouldBeAlone2() {}
 
 @available(*, unavailable, renamed: "shortFour")
 @available(_PackageDescription 3)


### PR DESCRIPTION
Delay resolution of availability domain identifiers parsed in availability specifications until type-checking. This allows custom domain specifications to be written in `if #available` queries.