### PR TITLE
[ASTGen] Rework type specifiers

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2459,27 +2459,9 @@ BridgedOpaqueReturnTypeOfTypeAttr_createParsed(
 // MARK: TypeReprs
 //===----------------------------------------------------------------------===//
 
-/// Bridged parameter specifiers
-enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : size_t {
-  BridgedAttributedTypeSpecifierInOut,
-  BridgedAttributedTypeSpecifierBorrowing,
-  BridgedAttributedTypeSpecifierConsuming,
-  BridgedAttributedTypeSpecifierLegacyShared,
-  BridgedAttributedTypeSpecifierLegacyOwned,
-  BridgedAttributedTypeSpecifierConst,
-  BridgedAttributedTypeSpecifierIsolated,
-  BridgedAttributedTypeSpecifierSending,
-};
-
 SWIFT_NAME("BridgedUnqualifiedIdentTypeRepr.createParsed(_:loc:name:)")
 BridgedUnqualifiedIdentTypeRepr BridgedUnqualifiedIdentTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLoc, BridgedIdentifier id);
-
-SWIFT_NAME(
-    "BridgedSpecifierTypeRepr.createParsed(_:base:specifier:specifierLoc:)")
-BridgedSpecifierTypeRepr BridgedSpecifierTypeRepr_createParsed(
-    BridgedASTContext cContext, BridgedTypeRepr base,
-    BridgedAttributedTypeSpecifier specifier, BridgedSourceLoc cSpecifierLoc);
 
 SWIFT_NAME(
     "BridgedArrayTypeRepr.createParsed(_:base:leftSquareLoc:rightSquareLoc:)")
@@ -2503,6 +2485,19 @@ BridgedCompositionTypeRepr
 BridgedCompositionTypeRepr_createParsed(BridgedASTContext cContext,
                                         BridgedArrayRef types,
                                         BridgedSourceLoc cFirstAmpLoc);
+
+SWIFT_NAME("BridgedCompileTimeConstTypeRepr.createParsed(_:base:specifierLoc:)")
+BridgedCompileTimeConstTypeRepr
+BridgedCompileTimeConstTypeRepr_createParsed(BridgedASTContext cContext,
+                                             BridgedTypeRepr base,
+                                             BridgedSourceLoc cSpecifierLoc);
+
+SWIFT_NAME("BridgedDeclRefTypeRepr.createParsed(_:base:name:nameLoc:"
+           "genericArguments:angleRange:)")
+BridgedDeclRefTypeRepr BridgedDeclRefTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr cBase, BridgedIdentifier cName,
+    BridgedSourceLoc cLoc, BridgedArrayRef cGenericArguments,
+    BridgedSourceRange cAngleRange);
 
 SWIFT_NAME("BridgedDictionaryTypeRepr.createParsed(_:leftSquareLoc:keyType:"
            "colonLoc:valueType:rightSquareLoc:)")
@@ -2549,17 +2544,29 @@ BridgedInverseTypeRepr_createParsed(BridgedASTContext cContext,
                                     BridgedSourceLoc cTildeLoc,
                                     BridgedTypeRepr cConstraint);
 
-SWIFT_NAME("BridgedDeclRefTypeRepr.createParsed(_:base:name:nameLoc:genericArguments:angleRange:)")
-BridgedDeclRefTypeRepr BridgedDeclRefTypeRepr_createParsed(
-    BridgedASTContext cContext, BridgedTypeRepr cBase, BridgedIdentifier cName,
-    BridgedSourceLoc cLoc, BridgedArrayRef cGenericArguments,
-    BridgedSourceRange cAngleRange);
+SWIFT_NAME("BridgedIsolatedTypeRepr.createParsed(_:base:specifierLoc:)")
+BridgedIsolatedTypeRepr
+BridgedIsolatedTypeRepr_createParsed(BridgedASTContext cContext,
+                                     BridgedTypeRepr base,
+                                     BridgedSourceLoc cSpecifierLoc);
+
+SWIFT_NAME("BridgedLifetimeDependentTypeRepr.createParsed(_:base:entry:)")
+BridgedLifetimeDependentTypeRepr
+BridgedLifetimeDependentTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr base,
+                                              BridgedLifetimeEntry cEntry);
 
 SWIFT_NAME("BridgedMetatypeTypeRepr.createParsed(_:base:typeKeywordLoc:)")
 BridgedMetatypeTypeRepr
 BridgedMetatypeTypeRepr_createParsed(BridgedASTContext cContext,
                                      BridgedTypeRepr baseType,
                                      BridgedSourceLoc cTypeLoc);
+
+SWIFT_NAME(
+    "BridgedOwnershipTypeRepr.createParsed(_:base:specifier:specifierLoc:)")
+BridgedOwnershipTypeRepr BridgedOwnershipTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr base,
+    BridgedParamSpecifier cSpecifier, BridgedSourceLoc cSpecifierLoc);
 
 SWIFT_NAME("BridgedProtocolTypeRepr.createParsed(_:base:protocolKeywordLoc:)")
 BridgedProtocolTypeRepr
@@ -2579,6 +2586,12 @@ BridgedPackExpansionTypeRepr
 BridgedPackExpansionTypeRepr_createParsed(BridgedASTContext cContext,
                                           BridgedTypeRepr base,
                                           BridgedSourceLoc cRepeatLoc);
+
+SWIFT_NAME("BridgedSendingTypeRepr.createParsed(_:base:specifierLoc:)")
+BridgedSendingTypeRepr
+BridgedSendingTypeRepr_createParsed(BridgedASTContext cContext,
+                                    BridgedTypeRepr base,
+                                    BridgedSourceLoc cSpecifierLoc);
 
 SWIFT_NAME(
     "BridgedTupleTypeRepr.createParsed(_:elements:leftParenLoc:rightParenLoc:)")

--- a/lib/AST/Bridging/TypeReprBridging.cpp
+++ b/lib/AST/Bridging/TypeReprBridging.cpp
@@ -109,6 +109,22 @@ BridgedInverseTypeRepr_createParsed(BridgedASTContext cContext,
       InverseTypeRepr(cTildeLoc.unbridged(), cConstraint.unbridged());
 }
 
+BridgedIsolatedTypeRepr
+BridgedIsolatedTypeRepr_createParsed(BridgedASTContext cContext,
+                                     BridgedTypeRepr base,
+                                     BridgedSourceLoc cSpecifierLoc) {
+  return new (cContext.unbridged())
+      IsolatedTypeRepr(base.unbridged(), cSpecifierLoc.unbridged());
+}
+
+BridgedLifetimeDependentTypeRepr
+BridgedLifetimeDependentTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr base,
+                                              BridgedLifetimeEntry cEntry) {
+  return new (cContext.unbridged())
+      LifetimeDependentTypeRepr(base.unbridged(), cEntry.unbridged());
+}
+
 BridgedMetatypeTypeRepr
 BridgedMetatypeTypeRepr_createParsed(BridgedASTContext cContext,
                                      BridgedTypeRepr baseType,
@@ -116,6 +132,13 @@ BridgedMetatypeTypeRepr_createParsed(BridgedASTContext cContext,
   ASTContext &context = cContext.unbridged();
   SourceLoc tyLoc = cTypeLoc.unbridged();
   return new (context) MetatypeTypeRepr(baseType.unbridged(), tyLoc);
+}
+
+BridgedOwnershipTypeRepr BridgedOwnershipTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr base,
+    BridgedParamSpecifier cSpecifier, BridgedSourceLoc cSpecifierLoc) {
+  return new (cContext.unbridged()) OwnershipTypeRepr(
+      base.unbridged(), unbridge(cSpecifier), cSpecifierLoc.unbridged());
 }
 
 BridgedProtocolTypeRepr
@@ -166,43 +189,12 @@ BridgedAttributedTypeRepr_createParsed(BridgedASTContext cContext,
                                     base.unbridged());
 }
 
-BridgedSpecifierTypeRepr BridgedSpecifierTypeRepr_createParsed(
-    BridgedASTContext cContext, BridgedTypeRepr base,
-    BridgedAttributedTypeSpecifier specifier, BridgedSourceLoc cSpecifierLoc) {
-  ASTContext &context = cContext.unbridged();
-  SourceLoc loc = cSpecifierLoc.unbridged();
-  TypeRepr *baseType = base.unbridged();
-  switch (specifier) {
-  case BridgedAttributedTypeSpecifierInOut: {
-    return new (context)
-        OwnershipTypeRepr(baseType, ParamSpecifier::InOut, loc);
-  }
-  case BridgedAttributedTypeSpecifierBorrowing: {
-    return new (context)
-        OwnershipTypeRepr(baseType, ParamSpecifier::Borrowing, loc);
-  }
-  case BridgedAttributedTypeSpecifierConsuming: {
-    return new (context)
-        OwnershipTypeRepr(baseType, ParamSpecifier::Consuming, loc);
-  }
-  case BridgedAttributedTypeSpecifierLegacyShared: {
-    return new (context)
-        OwnershipTypeRepr(baseType, ParamSpecifier::LegacyShared, loc);
-  }
-  case BridgedAttributedTypeSpecifierLegacyOwned: {
-    return new (context)
-        OwnershipTypeRepr(baseType, ParamSpecifier::LegacyOwned, loc);
-  }
-  case BridgedAttributedTypeSpecifierSending: {
-    return new (context) SendingTypeRepr(baseType, loc);
-  }
-  case BridgedAttributedTypeSpecifierConst: {
-    return new (context) CompileTimeConstTypeRepr(baseType, loc);
-  }
-  case BridgedAttributedTypeSpecifierIsolated: {
-    return new (context) IsolatedTypeRepr(baseType, loc);
-  }
-  }
+BridgedSendingTypeRepr
+BridgedSendingTypeRepr_createParsed(BridgedASTContext cContext,
+                                    BridgedTypeRepr base,
+                                    BridgedSourceLoc cSpecifierLoc) {
+  return new (cContext.unbridged())
+      SendingTypeRepr(base.unbridged(), cSpecifierLoc.unbridged());
 }
 
 BridgedVarargTypeRepr
@@ -273,6 +265,14 @@ BridgedCompositionTypeRepr_createParsed(BridgedASTContext cContext,
   return CompositionTypeRepr::create(
       context, types, types.front()->getStartLoc(),
       SourceRange{firstAmpLoc, types.back()->getEndLoc()});
+}
+
+BridgedCompileTimeConstTypeRepr
+BridgedCompileTimeConstTypeRepr_createParsed(BridgedASTContext cContext,
+                                             BridgedTypeRepr base,
+                                             BridgedSourceLoc cSpecifierLoc) {
+  return new (cContext.unbridged())
+      CompileTimeConstTypeRepr(base.unbridged(), cSpecifierLoc.unbridged());
 }
 
 BridgedFunctionTypeRepr BridgedFunctionTypeRepr_createParsed(

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -68,3 +68,5 @@ struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 typealias SomeGlobalActorIsolated = @SomeGlobalActor () -> Void
+typealias TestSpecifiers<Value, Result, E> = (inout sending Value) throws(E) -> sending Result where Value: ~Copyable, Result: ~Copyable, E: Error
+typealias TestSpecifierAndAttr<T> = (__owned @Sendable @escaping () async -> T) -> T


### PR DESCRIPTION
* Handle multiple specifiers.
* Handle previously missing `sending` specifiers.
* Replicate C++ parser's specifier type wrapping logic.