### PR TITLE
[AST] Look through specializations in `getDirectCallee`

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1753,6 +1753,13 @@ Expr *CallExpr::getDirectCallee() const {
       continue;
     }
 
+    // Explicit specializations are currently invalid for function calls, but
+    // look through them for better recovery.
+    if (auto *spec = dyn_cast<UnresolvedSpecializeExpr>(fn)) {
+      fn = spec->getSubExpr();
+      continue;
+    }
+
     return fn;
   }
 }

--- a/test/Constraints/rdar145593552.swift
+++ b/test/Constraints/rdar145593552.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// rdar://145593552 - Make sure we don't crash.
+func foo(_ x: Int) {} // expected-note {{'foo' declared here}}
+foo<Void>("")
+// expected-error@-1 {{cannot explicitly specialize global function 'foo'}}
+// expected-error@-2 {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+func bar(x: Int = 0) {} // expected-note {{'bar(x:)' declared here}}
+bar<Void>() // expected-error {{cannot explicitly specialize global function 'bar(x:)'}}

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -12,10 +12,10 @@ enum E {
     case A<UndefinedTy>(): // expected-error {{cannot find type 'UndefinedTy' in scope}}
     // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
     // expected-error@-2 {{cannot specialize non-generic type 'E'}}
-    // expected-error@-3 {{cannot call value of non-function type 'E'}}
+    // expected-error@-3 {{enum case 'A' has no associated values}}
       break
     case B<Int>(): // expected-error {{cannot specialize non-generic type 'E'}}
-    // expected-error@-1 {{cannot call value of non-function type 'E'}}
+    // expected-error@-1 {{enum case 'B' has no associated values}}
       break
     default:
       break;
@@ -28,10 +28,10 @@ func testE(e: E) {
   case E.A<UndefinedTy>(): // expected-error {{cannot find type 'UndefinedTy' in scope}}
   // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
   // expected-error@-2 {{cannot specialize non-generic type 'E'}}
-  // expected-error@-3 {{cannot call value of non-function type 'E'}}
+  // expected-error@-3 {{enum case 'A' has no associated values}}
     break
   case E.B<Int>(): // expected-error {{cannot specialize non-generic type 'E'}}
-  // expected-error@-1 {{cannot call value of non-function type 'E'}}
+  // expected-error@-1 {{enum case 'B' has no associated values}}
     break
   case .C(): // expected-error {{pattern with associated values does not match enum case 'C'}}
              // expected-note@-1 {{remove associated values to make the pattern match}} {{10-12=}} 


### PR DESCRIPTION
This results in better recovery and fixes an assertion failure in cases where we're attempting to diagnose a failure with the call.

rdar://145593552