### PR TITLE
[Sema] Remove generic environment tracking from StmtChecker

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2432,8 +2432,6 @@ private:
   llvm::SmallDenseMap<PackElementExpr *, PackExpansionExpr *, 2>
       PackElementExpansions;
 
-  llvm::SmallVector<GenericEnvironment *, 4> PackElementGenericEnvironments;
-
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
       resultBuilderTransformed;

--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -165,7 +165,6 @@ private:
       ForEachStmt *stmt;
       DeclContext *dc;
       Pattern *pattern;
-      GenericEnvironment *packElementEnv;
       ForEachStmtInfo info;
     } forEachPreamble;
 
@@ -244,12 +243,10 @@ public:
     uninitializedVar.type = patternTy;
   }
 
-  SyntacticElementTarget(ForEachStmt *stmt, DeclContext *dc,
-                         GenericEnvironment *packElementEnv)
+  SyntacticElementTarget(ForEachStmt *stmt, DeclContext *dc)
       : kind(Kind::forEachPreamble) {
     forEachPreamble.stmt = stmt;
     forEachPreamble.dc = dc;
-    forEachPreamble.packElementEnv = packElementEnv;
   }
 
   /// Form a target for the initialization of a pattern from an expression.
@@ -271,8 +268,9 @@ public:
   /// Form a target for the preamble of a for-in loop, excluding its where
   /// clause and body.
   static SyntacticElementTarget
-  forForEachPreamble(ForEachStmt *stmt, DeclContext *dc,
-                     GenericEnvironment *packElementEnv = nullptr);
+  forForEachPreamble(ForEachStmt *stmt, DeclContext *dc) {
+    return {stmt, dc};
+  }
 
   /// Form a target for a property with an attached property wrapper that is
   /// initialized out-of-line.
@@ -548,11 +546,6 @@ public:
   unsigned getInitializationPatternBindingIndex() const {
     assert(isForInitialization());
     return expression.initialization.patternBindingIndex;
-  }
-
-  GenericEnvironment *getPackElementEnv() const {
-    assert(isForEachPreamble());
-    return forEachPreamble.packElementEnv;
   }
 
   const ForEachStmtInfo &getForEachStmtInfo() const {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4936,13 +4936,6 @@ bool ConstraintSystem::generateConstraints(
   }
 
   case SyntacticElementTarget::Kind::forEachPreamble: {
-
-    // Cache the outer generic environment, if it exists.
-    if (target.getPackElementEnv()) {
-      PackElementGenericEnvironments.push_back(target.getPackElementEnv());
-      ASSERT(!solverState && "Need to record a change");
-    }
-
     // For a for-each statement, generate constraints for the pattern, where
     // clause, and sequence traversal.
     auto resultTarget = generateForEachPreambleConstraints(*this, target);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -887,9 +887,7 @@ ConstraintSystem::getPackExpansionEnvironment(PackExpansionExpr *expr) const {
 
 GenericEnvironment *ConstraintSystem::createPackExpansionEnvironment(
     PackExpansionExpr *expr, CanGenericTypeParamType shapeParam) {
-  auto *contextEnv = PackElementGenericEnvironments.empty()
-                         ? DC->getGenericEnvironmentOfContext()
-                         : PackElementGenericEnvironments.back();
+  auto *contextEnv = DC->getGenericEnvironmentOfContext();
   auto elementSig = getASTContext().getOpenedElementSignature(
       contextEnv->getGenericSignature().getCanonicalSignature(), shapeParam);
   auto contextSubs = contextEnv->getForwardingSubstitutionMap();

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -193,13 +193,6 @@ SyntacticElementTarget::forReturn(ReturnStmt *returnStmt, Type contextTy,
   return target;
 }
 
-SyntacticElementTarget
-SyntacticElementTarget::forForEachPreamble(ForEachStmt *stmt, DeclContext *dc,
-                                           GenericEnvironment *packElementEnv) {
-  SyntacticElementTarget target(stmt, dc, packElementEnv);
-  return target;
-}
-
 SyntacticElementTarget SyntacticElementTarget::forPropertyWrapperInitializer(
     VarDecl *wrappedVar, DeclContext *dc, Expr *initializer) {
   SyntacticElementTarget target(initializer, dc, CTP_Initialization,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -871,8 +871,7 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   return hadError;
 }
 
-bool TypeChecker::typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
-                                           GenericEnvironment *packElementEnv) {
+bool TypeChecker::typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt) {
   auto &Context = dc->getASTContext();
   FrontendStatsTracer statsTracer(Context.Stats, "typecheck-for-each", stmt);
   PrettyStackTraceStmt stackTrace(Context, "type-checking-for-each", stmt);
@@ -888,8 +887,7 @@ bool TypeChecker::typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
     return true;
   };
 
-  auto target =
-      SyntacticElementTarget::forForEachPreamble(stmt, dc, packElementEnv);
+  auto target = SyntacticElementTarget::forForEachPreamble(stmt, dc);
   if (!typeCheckTarget(target))
     return failed();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -764,8 +764,7 @@ bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
 /// together.
 ///
 /// \returns true if a failure occurred.
-bool typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
-                              GenericEnvironment *packElementEnv);
+bool typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt);
 
 /// Compute the set of captures for the given closure.
 void computeCaptures(AbstractClosureExpr *ACE);


### PR DESCRIPTION
This is no longer necessary now that we use `mapLocalArchetypesOutOfContext` to assign depths for generic signatures involving element archetypes.