### PR TITLE
Re-enable -static-executable test.

### DIFF
--- a/test/Driver/static-executable.swift
+++ b/test/Driver/static-executable.swift
@@ -1,15 +1,11 @@
 // Create a self contained binary
 
-// REQUIRES: rdar74148842
-// libc.a and libm.a have duplicate definitions of '__isnanl', so this test
-// fails to build.
-
 // REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -static-executable -o %t/static-executable %s
 // RUN: %t/static-executable | %FileCheck %s
-// RUN: %llvm-readelf -program-headers %t/static-executable | %FileCheck %s --check-prefix=ELF
+// RUN: %llvm-readelf --program-headers %t/static-executable | %FileCheck %s --check-prefix=ELF
 // CHECK: hello world!
 // ELF-NOT: INTERP


### PR DESCRIPTION
-static-executable was broken in 6.0 and this test would have caught issue #79153

The tests now passes on supported platforms. 
