### PR TITLE
Fix hoisting array semantics call with non-dominant self in ossa

### DIFF
--- a/test/SILOptimizer/array_property_opt.sil
+++ b/test/SILOptimizer/array_property_opt.sil
@@ -118,6 +118,11 @@ bb0(%0: $MyArray<MyClass>):
   unreachable
 }
 
+sil public_external [_semantics "array.props.isNativeTypeChecked"] @arrayPropertyIsNativeGuaranteed : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool {
+bb0(%0: $MyArray<MyClass>):
+  unreachable
+}
+
 // Make sure we can handle try_apply when splitting edges. This test used to crash.
 
 sil @throwing_fun : $@convention(thin) () -> (MyBool, @error any Error)
@@ -409,3 +414,30 @@ bb12(%69 : $Builtin.Int64):
   %70 = struct $MyInt (%69 : $Builtin.Int64)
   return %70 : $MyInt
 }
+
+// CHECK-LABEL: sil @load_copy_within_loop : 
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNativeGuaranteed : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+// CHECK: apply [[FUNC1]]
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNativeGuaranteed : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+// CHECK: apply [[FUNC2]]
+// CHECK-LABEL: } // end sil function 'load_copy_within_loop'
+sil @load_copy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
+bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
+  br bb1
+
+bb1:
+  %3 = load %0
+  retain_value %3
+  %5 = load %1
+  %6 = function_ref @arrayPropertyIsNativeGuaranteed : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  %7 = apply %6(%3) : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  release_value %3
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  return %5
+}
+ 

--- a/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
+++ b/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
@@ -26,6 +26,56 @@ bb0(%0: @guaranteed $MyArray<MyClass>):
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @load_copy_within_loop : 
+// CHECK: [[FUNC:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC]]
+// CHECK-NOT: function_ref @arrayPropertyIsNative
+// CHECK-NOT: apply [[FUNC]]
+// CHECK-LABEL: } // end sil function 'load_copy_within_loop'
+sil [ossa] @load_copy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
+bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
+  br bb1
+
+bb1:
+  %3 = load [copy] %0 : $*MyArray<MyClass>
+  %4 = load [trivial] %1 : $*MyBool
+  %2 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  %5 = apply %2(%3) : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  destroy_value %3 : $MyArray<MyClass>
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  return %4 : $MyBool
+}
+
+// CHECK-LABEL: sil [ossa] @load_borrow_within_loop : 
+// CHECK: [[FUNC:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC]]
+// CHECK-NOT: function_ref @arrayPropertyIsNative
+// CHECK-NOT: apply [[FUNC]]
+// CHECK-LABEL: } // end sil function 'load_borrow_within_loop'
+sil [ossa] @load_borrow_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
+bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
+  br bb1
+
+bb1:
+  %3 = load_borrow %0 : $*MyArray<MyClass>
+  %4 = load [trivial] %1 : $*MyBool
+  %2 = function_ref @arrayPropertyIsNative : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  %5 = apply %2(%3) : $@convention(method) (@guaranteed MyArray<MyClass>) -> Bool
+  end_borrow %3 : $MyArray<MyClass>
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  return %4 : $MyBool
+}
+
 // CHECK-LABEL: sil [ossa] @load_and_copy_within_loop : 
 // CHECK: bb1:
 // CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative

--- a/test/SILOptimizer/array_property_opt_ossa_owned.sil
+++ b/test/SILOptimizer/array_property_opt_ossa_owned.sil
@@ -26,6 +26,35 @@ bb0(%0: @owned $MyArray<MyClass>):
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @load_within_loop : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK: cond_br {{.*}}
+// CHECK: bb2:
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC2]]
+// CHECK-LABEL: } // end sil function 'load_within_loop'
+sil [ossa] @load_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
+bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
+  br bb1
+
+bb1:
+  %3 = load [copy] %0 : $*MyArray<MyClass>
+  %4 = load [trivial] %1 : $*MyBool
+  %2 = function_ref @arrayPropertyIsNative : $@convention(method) (@owned MyArray<MyClass>) -> Bool
+  %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  return %4 : $MyBool
+}
+
 // CHECK-LABEL: sil [ossa] @load_and_copy_within_loop : 
 // CHECK: bb1:
 // CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative


### PR DESCRIPTION
If we have a self value that does not dominate loop preheader, and the array semantics call does not consume the self value, that means there will be instructions that consume the self value within the loop.

In ossa, we cannot hoist such semantic calls because there is no support for creating destroys for them in the preheader. Add a bailout to avoid the ownership error.

rdar://145673368

