### PR TITLE
[SE-0467] MutableSpan

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -152,6 +152,8 @@ add_library(swiftCore
   Sort.swift
   Span/Span.swift
   Span/RawSpan.swift
+  Span/MutableSpan.swift
+  Span/MutableRawSpan.swift
   StaticString.swift
   StaticPrint.swift
   Stride.swift

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1730,6 +1730,22 @@ extension Array {
     return try unsafe body(&inoutBufferPointer)
   }
 
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(/*inout*/borrow self)
+    @_alwaysEmitIntoClient
+    mutating get {
+      _makeMutableAndUnique()
+      // NOTE: We don't have the ability to schedule a call to
+      //       ContiguousArrayBuffer.endCOWMutation().
+      //       rdar://146785284 (lifetime analysis for end of mutation)
+      let pointer = unsafe _buffer.firstElementAddress
+      let count = _buffer.mutableCount
+      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, mutating: &self)
+    }
+  }
+
   @inlinable
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1116,17 +1116,6 @@ extension ArraySlice: RangeReplaceableCollection {
     }
   }
 
-  @available(SwiftStdlib 6.2, *)
-  public var span: Span<Element> {
-    @lifetime(borrow self)
-    @_alwaysEmitIntoClient
-    borrowing get {
-      let (pointer, count) = (_buffer.firstElementAddress, _buffer.count)
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
-      return unsafe _overrideLifetime(span, borrowing: self)
-    }
-  }
-
   @inlinable
   public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
@@ -1219,6 +1208,17 @@ extension ArraySlice {
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
     return try _buffer.withUnsafeBufferPointer(body)
+  }
+
+  @available(SwiftStdlib 6.2, *)
+  public var span: Span<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    borrowing get {
+      let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
+      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
   }
 
   // Superseded by the typed-throws version of this function, but retained

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1300,6 +1300,21 @@ extension ArraySlice {
     return try unsafe body(&inoutBufferPointer)
   }
 
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(/*inout*/borrow self)
+    @_alwaysEmitIntoClient
+    mutating get {
+      _makeMutableAndUnique()
+      // NOTE: We don't have the ability to schedule a call to
+      //       ContiguousArrayBuffer.endCOWMutation().
+      //       rdar://146785284 (lifetime analysis for end of mutation)
+      let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
+      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, mutating: &self)
+    }
+  }
+
   @inlinable
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -157,6 +157,8 @@ split_embedded_sources(
   EMBEDDED Slice.swift
   EMBEDDED SmallString.swift
   EMBEDDED Sort.swift
+  EMBEDDED Span/MutableRawSpan.swift
+  EMBEDDED Span/MutableSpan.swift
   EMBEDDED Span/RawSpan.swift
   EMBEDDED Span/Span.swift
   EMBEDDED StaticString.swift

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1021,17 +1021,6 @@ extension ContiguousArray: RangeReplaceableCollection {
     }
   }
 
-  @available(SwiftStdlib 6.2, *)
-  public var span: Span<Element> {
-    @lifetime(borrow self)
-    @_alwaysEmitIntoClient
-    borrowing get {
-      let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
-      return unsafe _overrideLifetime(span, borrowing: self)
-    }
-  }
-
   @inlinable
   public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
@@ -1161,6 +1150,18 @@ extension ContiguousArray {
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
     return try unsafe _buffer.withUnsafeBufferPointer(body)
+  }
+
+  @available(SwiftStdlib 6.2, *)
+  public var span: Span<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    borrowing get {
+      let pointer = unsafe _buffer.firstElementAddress
+      let count = _buffer.immutableCount
+      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
   }
 
   // Superseded by the typed-throws version of this function, but retained

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -200,6 +200,8 @@
     "UnsafeRawBufferPointer.swift"
   ],
   "Span": [
+    "MutableRawSpan.swift",
+    "MutableSpan.swift",
     "RawSpan.swift",
     "Span.swift"
   ],

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -297,3 +297,22 @@ internal func _overrideLifetime<
   // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
+
+/// Unsafely discard any lifetime dependency on the `dependent` argument.
+/// Return a value identical to `dependent` with a lifetime dependency
+/// on the caller's exclusive borrow scope of the `source` argument.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(borrow source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T,
+  mutating source: inout U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -30,10 +30,10 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   @lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeMutableRawPointer?,
-    count: Int
+    byteCount: Int
   ) {
     _pointer = pointer
-    _count = count
+    _count = byteCount
   }
 }
 
@@ -49,7 +49,7 @@ extension MutableRawSpan {
     _unsafeBytes bytes: UnsafeMutableRawBufferPointer
   ) {
     let baseAddress = bytes.baseAddress
-    let span = MutableRawSpan(_unchecked: baseAddress, count: bytes.count)
+    let span = MutableRawSpan(_unchecked: baseAddress, byteCount: bytes.count)
     self = _overrideLifetime(span, borrowing: bytes)
   }
 
@@ -69,8 +69,8 @@ extension MutableRawSpan {
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
   ) {
-    precondition(byteCount >= 0, "Count must not be negative")
-    self.init(_unchecked: pointer, count: byteCount)
+    _precondition(byteCount >= 0, "Count must not be negative")
+    self.init(_unchecked: pointer, byteCount: byteCount)
   }
 
   @_alwaysEmitIntoClient
@@ -117,7 +117,7 @@ extension MutableRawSpan {
 
   @_alwaysEmitIntoClient
   public var byteOffsets: Range<Int> {
-    .init(uncheckedBounds: (0, byteCount))
+    .init(_uncheckedBounds: (0, byteCount))
   }
 }
 
@@ -216,7 +216,7 @@ extension MutableRawSpan {
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
-    precondition(
+    _precondition(
       UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
       MemoryLayout<T>.size <= (_count &- offset),
       "Byte offset range out of bounds"
@@ -271,7 +271,7 @@ extension MutableRawSpan {
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
-    precondition(
+    _precondition(
       UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
       MemoryLayout<T>.size <= (_count &- offset),
       "Byte offset range out of bounds"
@@ -308,7 +308,7 @@ extension MutableRawSpan {
   public func storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
-    precondition(
+    _precondition(
       UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
       MemoryLayout<T>.size <= (_count &- offset),
       "Byte offset range out of bounds"
@@ -367,7 +367,7 @@ extension MutableRawSpan {
 
     var elements = source.makeIterator()
     let lastOffset = update(startingAt: byteOffset, from: &elements)
-    precondition(
+    _precondition(
       elements.next() == nil,
       "destination span cannot contain every element from source."
     )

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -439,13 +439,13 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(_ bounds: Range<Int>) -> Self {
+  mutating public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "Index range out of bounds"
     )
-    return unsafe _extracting(unchecked: bounds)
+    return unsafe extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -466,7 +466,7 @@ extension MutableRawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(unchecked bounds: Range<Int>) -> Self {
+  mutating public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
     return unsafe _overrideLifetime(newSpan, mutating: &self)
@@ -487,10 +487,10 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(
+  mutating public func extracting(
     _ bounds: some RangeExpression<Int>
   ) -> Self {
-    _extracting(bounds.relative(to: byteOffsets))
+    extracting(bounds.relative(to: byteOffsets))
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -511,11 +511,11 @@ extension MutableRawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+  mutating public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound+1)
     )
-    return unsafe _extracting(unchecked: range)
+    return unsafe extracting(unchecked: range)
   }
 
   /// Constructs a new span over all the items of this span.
@@ -529,7 +529,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(_: UnboundedRange) -> Self {
+  mutating public func extracting(_: UnboundedRange) -> Self {
     let newSpan = unsafe Self(_unchecked: _start(), byteCount: _count)
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
@@ -556,7 +556,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(first maxLength: Int) -> Self {
+  mutating public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, byteCount)
     let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
@@ -579,7 +579,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(droppingLast k: Int) -> Self {
+  mutating public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, byteCount)
     let newCount = byteCount &- droppedCount
@@ -604,7 +604,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(last maxLength: Int) -> Self {
+  mutating public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, byteCount)
     let newStart = unsafe _pointer?.advanced(by: byteCount &- newCount)
@@ -628,7 +628,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(droppingFirst k: Int) -> Self {
+  mutating public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let newStart = unsafe _pointer?.advanced(by: droppedCount)

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -125,7 +125,7 @@ extension MutableRawSpan {
 
   @_alwaysEmitIntoClient
   public var byteOffsets: Range<Int> {
-    .init(_uncheckedBounds: (0, byteCount))
+    unsafe Range(_uncheckedBounds: (0, byteCount))
   }
 }
 

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -417,3 +417,231 @@ extension MutableRawSpan {
     update(startingAt: byteOffset, from: source.bytes)
   }
 }
+
+// MARK: sub-spans
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(_ bounds: Range<Int>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Index range out of bounds"
+    )
+    return _extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(unchecked bounds: Range<Int>) -> Self {
+    let newStart = _pointer?.advanced(by: bounds.lowerBound)
+    let newSpan = Self(_unchecked: newStart, byteCount: bounds.count)
+    return _overrideLifetime(newSpan, mutating: &self)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(
+    _ bounds: some RangeExpression<Int>
+  ) -> Self {
+    _extracting(bounds.relative(to: byteOffsets).clamped(to: byteOffsets))
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(
+    unchecked bounds: some RangeExpression<Int>
+  ) -> Self {
+    _extracting(
+      unchecked: bounds.relative(to: byteOffsets).clamped(to: byteOffsets)
+    )
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(
+    unchecked bounds: ClosedRange<Int>
+  ) -> Self {
+    let range = Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound&+1)
+    )
+    return _extracting(unchecked: range)
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `MutableSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(_: UnboundedRange) -> Self {
+    let newSpan = Self(_unchecked: _start(), byteCount: _count)
+    return _overrideLifetime(newSpan, mutating: &self)
+  }
+}
+
+// MARK: prefixes and suffixes
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newSpan = Self(_unchecked: _pointer, byteCount: newCount)
+    return _overrideLifetime(newSpan, mutating: &self)
+  }
+
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let dropped = min(k, byteCount)
+    let newSpan = Self(_unchecked: _pointer, byteCount: byteCount &- dropped)
+    return _overrideLifetime(newSpan, mutating: &self)
+  }
+
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, byteCount)
+    let newStart = _pointer?.advanced(by: byteCount &- newCount)
+    let newSpan = Self(_unchecked: newStart, byteCount: newCount)
+    return _overrideLifetime(newSpan, copying: self)
+  }
+
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  mutating public func _extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let dropped = min(k, byteCount)
+    let newStart = _pointer?.advanced(by: dropped)
+    let newSpan = Self(_unchecked: newStart, byteCount: byteCount &- dropped)
+    return _overrideLifetime(newSpan, mutating: &self)
+  }
+}

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -1,0 +1,419 @@
+//===--- MutableRawSpan.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// A MutableRawSpan represents a span of memory which
+// contains initialized `Element` instances.
+@frozen
+@available(SwiftStdlib 6.2, *)
+public struct MutableRawSpan: ~Copyable & ~Escapable {
+  @usableFromInline
+  internal let _pointer: UnsafeMutableRawPointer?
+
+  @usableFromInline
+  internal let _count: Int
+
+  @_alwaysEmitIntoClient
+  internal func _start() -> UnsafeMutableRawPointer {
+    _pointer.unsafelyUnwrapped
+  }
+
+  @usableFromInline @inline(__always)
+  @lifetime(borrow pointer)
+  init(
+    _unchecked pointer: UnsafeMutableRawPointer?,
+    count: Int
+  ) {
+    _pointer = pointer
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan: @unchecked Sendable {}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow bytes)
+  public init(
+    _unsafeBytes bytes: UnsafeMutableRawBufferPointer
+  ) {
+    let baseAddress = bytes.baseAddress
+    let span = MutableRawSpan(_unchecked: baseAddress, count: bytes.count)
+    self = _overrideLifetime(span, borrowing: bytes)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow bytes)
+  public init(
+    _unsafeBytes bytes: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    let rebased = UnsafeMutableRawBufferPointer(rebasing: bytes)
+    let span = MutableRawSpan(_unsafeBytes: rebased)
+    self = _overrideLifetime(span, borrowing: bytes)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
+  public init(
+    _unsafeStart pointer: UnsafeMutableRawPointer,
+    byteCount: Int
+  ) {
+    precondition(byteCount >= 0, "Count must not be negative")
+    self.init(_unchecked: pointer, count: byteCount)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow elements)
+  public init<Element: BitwiseCopyable>(
+    _unsafeElements elements: UnsafeMutableBufferPointer<Element>
+  ) {
+    let bytes = UnsafeMutableRawBufferPointer(elements)
+    let span = MutableRawSpan(_unsafeBytes: bytes)
+    self = _overrideLifetime(span, borrowing: elements)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow elements)
+  public init<Element: BitwiseCopyable>(
+    _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    let rebased = UnsafeMutableBufferPointer(rebasing: elements)
+    let span = MutableRawSpan(_unsafeElements: rebased)
+    self = _overrideLifetime(span, borrowing: elements)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(elements)
+  public init<Element: BitwiseCopyable>(
+    _elements elements: consuming MutableSpan<Element>
+  ) {
+    let bytes = UnsafeMutableRawBufferPointer(
+      start: elements._pointer,
+      count: elements.count &* MemoryLayout<Element>.stride
+    )
+    let span = MutableRawSpan(_unsafeBytes: bytes)
+    self = _overrideLifetime(span, copying: elements)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+  @_alwaysEmitIntoClient
+  public var byteCount: Int { _count }
+
+  @_alwaysEmitIntoClient
+  public var isEmpty: Bool { byteCount == 0 }
+
+  @_alwaysEmitIntoClient
+  public var byteOffsets: Range<Int> {
+    .init(uncheckedBounds: (0, byteCount))
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  @_alwaysEmitIntoClient
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    guard let pointer = _pointer, _count > 0 else {
+      return try body(.init(start: nil, count: 0))
+    }
+    return try body(.init(start: pointer, count: _count))
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
+    _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    guard let pointer = _pointer, _count > 0 else {
+      return try body(.init(start: nil, count: 0))
+    }
+    return try body(.init(start: pointer, count: _count))
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension RawSpan {
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow mutableSpan)
+  public init(_unsafeMutableRawSpan mutableSpan: borrowing MutableRawSpan) {
+    let start = mutableSpan._start()
+    let span = RawSpan(_unsafeStart: start, byteCount: mutableSpan.byteCount)
+    self = _overrideLifetime(span, borrowing: mutableSpan)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  public var bytes: RawSpan {
+    @_alwaysEmitIntoClient
+    @lifetime(borrow self)
+    borrowing get {
+      return RawSpan(_unsafeMutableRawSpan: self)
+    }
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  public borrowing func _unsafeView<T: BitwiseCopyable>(
+    as type: T.Type
+  ) -> Span<T> {
+    let bytes = UnsafeRawBufferPointer(start: _pointer, count: _count)
+    let span = Span<T>(_unsafeBytes: bytes)
+    return _overrideLifetime(span, borrowing: self)
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(borrow self)
+  public mutating func _unsafeMutableView<T: BitwiseCopyable>(
+    as type: T.Type
+  ) -> MutableSpan<T> {
+    let bytes = UnsafeMutableRawBufferPointer(start: _pointer, count: _count)
+    let span = MutableSpan<T>(_unsafeBytes: bytes)
+    return _overrideLifetime(span, mutating: &self)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance is memory-managed and unassociated
+  ///     with the value in the memory referenced by this pointer.
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func unsafeLoad<T>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access, and failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance is memory-managed and unassociated
+  ///     with the value in the memory referenced by this pointer.
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func unsafeLoad<T>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start().load(fromByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be initialized to `T`
+  /// or another type that is layout compatible with `T`.
+  ///
+  /// This is an unsafe operation. Failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance isn't associated
+  ///     with the value in the range of memory referenced by this pointer.
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    return unsafeLoadUnaligned(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The memory at this pointer plus `offset` must be initialized to `T`
+  /// or another type that is layout compatible with `T`.
+  ///
+  /// This is an unsafe operation. This function does not validate the bounds
+  /// of the memory access, and failure to meet the preconditions
+  /// above may produce an invalid value of `T`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///     `offset`. The returned instance isn't associated
+  ///     with the value in the range of memory referenced by this pointer.
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+
+  @_alwaysEmitIntoClient
+  public func storeBytes<T: BitwiseCopyable>(
+    of value: T, toByteOffset offset: Int = 0, as type: T.Type
+  ) {
+    precondition(
+      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
+      MemoryLayout<T>.size <= (_count &- offset),
+      "Byte offset range out of bounds"
+    )
+    storeBytes(of: value, toUncheckedByteOffset: offset, as: type)
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  public func storeBytes<T: BitwiseCopyable>(
+    of value: T, toUncheckedByteOffset offset: Int, as type: T.Type
+  ) {
+    _start().storeBytes(of: value, toByteOffset: offset, as: type)
+  }
+}
+
+//MARK: copyMemory
+@available(SwiftStdlib 6.2, *)
+extension MutableRawSpan {
+
+  @_alwaysEmitIntoClient
+  public mutating func update<S: Sequence>(
+    startingAt byteOffset: Int = 0,
+    from source: S
+  ) -> (unwritten: S.Iterator, byteOffset: Int) where S.Element: BitwiseCopyable {
+    var iterator = source.makeIterator()
+    let offset = update(startingAt: byteOffset, from: &iterator)
+    return (iterator, offset)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<Element: BitwiseCopyable>(
+    startingAt byteOffset: Int = 0,
+    from elements: inout some IteratorProtocol<Element>
+  ) -> Int {
+    var offset = byteOffset
+    while offset + MemoryLayout<Element>.stride <= _count {
+      guard let element = elements.next() else { break }
+      storeBytes(of: element, toUncheckedByteOffset: offset, as: Element.self)
+      offset &+= MemoryLayout<Element>.stride
+    }
+    return offset
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<C: Collection>(
+    startingAt byteOffset: Int = 0,
+    fromContentsOf source: C
+  ) -> Int where C.Element: BitwiseCopyable {
+    let newOffset = source.withContiguousStorageIfAvailable {
+      self.update(
+        startingAt: byteOffset, fromContentsOf: Span(_unsafeElements: $0)
+      )
+    }
+    if let newOffset { return newOffset }
+
+    var elements = source.makeIterator()
+    let lastOffset = update(startingAt: byteOffset, from: &elements)
+    precondition(
+      elements.next() == nil,
+      "destination span cannot contain every element from source."
+    )
+    return lastOffset
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<Element: BitwiseCopyable>(
+    startingAt byteOffset: Int = 0,
+    fromContentsOf source: Span<Element>
+  ) -> Int {
+//    update(startingAt: byteOffset, from: source.bytes)
+    source.withUnsafeBytes {
+      update(startingAt: byteOffset, fromContentsOf: $0)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<Element: BitwiseCopyable>(
+    startingAt byteOffset: Int = 0,
+    fromContentsOf source: borrowing MutableSpan<Element>
+  ) -> Int {
+//    update(startingAt: byteOffset, from: source.storage.bytes)
+    source.withUnsafeBytes {
+      update(startingAt: byteOffset, fromContentsOf: $0)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    startingAt byteOffset: Int = 0,
+    from source: RawSpan
+  ) -> Int {
+    if source.byteCount == 0 { return byteOffset }
+    source.withUnsafeBytes {
+      _start().advanced(by: byteOffset)
+              .copyMemory(from: $0.baseAddress!, byteCount: $0.count)
+    }
+    return byteOffset &+ source.byteCount
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    startingAt byteOffset: Int = 0,
+    from source: borrowing MutableRawSpan
+  ) -> Int {
+    update(startingAt: byteOffset, from: source.bytes)
+  }
+}

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -102,7 +102,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(elements)
+  @lifetime(copy elements)
   public init<Element: BitwiseCopyable>(
     _elements elements: consuming MutableSpan<Element>
   ) {
@@ -143,6 +143,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
@@ -315,6 +316,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -328,6 +330,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toUncheckedByteOffset offset: Int, as type: T.Type
   ) {
@@ -340,6 +343,7 @@ extension MutableRawSpan {
 extension MutableRawSpan {
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, byteOffset: Int) where S.Element: BitwiseCopyable {
@@ -349,6 +353,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<Element: BitwiseCopyable>(
     from elements: inout some IteratorProtocol<Element>
   ) -> Int {
@@ -364,6 +369,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<C: Collection>(
     fromContentsOf source: C
   ) -> Int where C.Element: BitwiseCopyable {
@@ -382,6 +388,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<Element: BitwiseCopyable>(
     fromContentsOf source: Span<Element>
   ) -> Int {
@@ -392,6 +399,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<Element: BitwiseCopyable>(
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Int {
@@ -402,6 +410,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: RawSpan
   ) -> Int {
@@ -413,6 +422,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: borrowing MutableRawSpan
   ) -> Int {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -26,9 +26,9 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
     _pointer.unsafelyUnwrapped
   }
 
-  @usableFromInline @inline(__always)
+  @_alwaysEmitIntoClient
   @lifetime(borrow pointer)
-  init(
+  internal init(
     _unchecked pointer: UnsafeMutableRawPointer?,
     count: Int
   ) {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -24,7 +24,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
 
   @_alwaysEmitIntoClient
   internal func _start() -> UnsafeMutableRawPointer {
-    unsafe _pointer.unsafelyUnwrapped
+    unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -645,13 +645,13 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(_ bounds: Range<Index>) -> Self {
+  mutating public func extracting(_ bounds: Range<Index>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "Index range out of bounds"
     )
-    return unsafe _extracting(unchecked: bounds)
+    return unsafe extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -672,7 +672,7 @@ extension MutableSpan where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(unchecked bounds: Range<Index>) -> Self {
+  mutating public func extracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
     let newStart = unsafe _pointer?.advanced(by: delta)
     let newSpan = unsafe Self(_unchecked: newStart, count: bounds.count)
@@ -694,10 +694,10 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(
+  mutating public func extracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
-    _extracting(bounds.relative(to: indices))
+    extracting(bounds.relative(to: indices))
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -718,13 +718,13 @@ extension MutableSpan where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(
+  mutating public func extracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound&+1)
     )
-    return unsafe _extracting(unchecked: range)
+    return unsafe extracting(unchecked: range)
   }
 
   /// Constructs a new span over all the items of this span.
@@ -738,7 +738,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(_: UnboundedRange) -> Self {
+  mutating public func extracting(_: UnboundedRange) -> Self {
     let newSpan = unsafe Self(_unchecked: _start(), count: _count)
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
@@ -765,7 +765,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(first maxLength: Int) -> Self {
+  mutating public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, count)
     let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
@@ -788,7 +788,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(droppingLast k: Int) -> Self {
+  mutating public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
     let newCount = count &- droppedCount
@@ -813,7 +813,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(last maxLength: Int) -> Self {
+  mutating public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, count)
     let offset = (count &- newCount) * MemoryLayout<Element>.stride
@@ -838,7 +838,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
-  mutating public func _extracting(droppingFirst k: Int) -> Self {
+  mutating public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
     let offset = droppedCount * MemoryLayout<Element>.stride

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -258,6 +258,7 @@ extension MutableSpan where Element: ~Copyable {
       _precondition(indices.contains(position), "index out of bounds")
       return unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: position))
     }
+    @lifetime(self: copy self)
     unsafeMutableAddress {
       _precondition(indices.contains(position), "index out of bounds")
        return unsafe _unsafeAddressOfElement(unchecked: position)
@@ -278,6 +279,7 @@ extension MutableSpan where Element: ~Copyable {
     unsafeAddress {
       unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: position))
     }
+    @lifetime(self: copy self)
     unsafeMutableAddress {
       unsafe _unsafeAddressOfElement(unchecked: position)
     }
@@ -298,6 +300,7 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     _precondition(indices.contains(Index(i)))
     _precondition(indices.contains(Index(j)))
@@ -306,6 +309,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @unsafe
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let pi = unsafe _unsafeAddressOfElement(unchecked: i)
     let pj = unsafe _unsafeAddressOfElement(unchecked: j)
@@ -330,6 +334,7 @@ extension MutableSpan where Element: BitwiseCopyable {
       _precondition(indices.contains(position), "index out of bounds")
       return unsafe self[unchecked: position]
     }
+    @lifetime(self: copy self)
     set {
       _precondition(indices.contains(position), "index out of bounds")
       unsafe self[unchecked: position] = newValue
@@ -353,6 +358,7 @@ extension MutableSpan where Element: BitwiseCopyable {
         fromByteOffset: offset, as: Element.self
       )
     }
+    @lifetime(self: copy self)
     set {
       let offset = position&*MemoryLayout<Element>.stride
       unsafe _start().storeBytes(
@@ -375,6 +381,7 @@ extension MutableSpan where Element: ~Copyable {
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func withUnsafeMutableBufferPointer<
     E: Error, Result: ~Copyable
   >(
@@ -405,6 +412,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
@@ -421,6 +429,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 extension MutableSpan {
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(repeating repeatedValue: consuming Element) {
     unsafe _start().withMemoryRebound(to: Element.self, capacity: count) {
       unsafe $0.update(repeating: repeatedValue, count: count)
@@ -428,6 +437,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index) where S.Element == Element {
@@ -437,6 +447,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     from elements: inout some IteratorProtocol<Element>
   ) -> Index {
@@ -450,6 +461,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: some Collection<Element>
   ) -> Index {
@@ -472,6 +484,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(fromContentsOf source: Span<Element>) -> Index {
     guard !source.isEmpty else { return 0 }
     _precondition(
@@ -489,6 +502,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Index {
@@ -517,6 +531,7 @@ extension MutableSpan where Element: ~Copyable {
 //  }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func moveUpdate(
     fromContentsOf source: UnsafeMutableBufferPointer<Element>
   ) -> Index {
@@ -532,6 +547,7 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan {
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func moveUpdate(
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
   ) -> Index {
@@ -543,6 +559,7 @@ extension MutableSpan {
 extension MutableSpan where Element: BitwiseCopyable {
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     repeating repeatedValue: Element
   ) where Element: BitwiseCopyable {
@@ -556,6 +573,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index)
@@ -566,6 +584,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     from elements: inout some IteratorProtocol<Element>
   ) -> Index {
@@ -579,6 +598,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: some Collection<Element>
   ) -> Index where Element: BitwiseCopyable {
@@ -601,6 +621,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: Span<Element>
   ) -> Index where Element: BitwiseCopyable {
@@ -619,6 +640,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
+  @lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Index where Element: BitwiseCopyable {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -15,7 +15,7 @@
 @safe
 @frozen
 @available(SwiftStdlib 6.2, *)
-public struct MutableSpan<Element: ~Copyable & ~Escapable>
+public struct MutableSpan<Element: ~Copyable>
 : ~Copyable, ~Escapable {
   @usableFromInline
   internal let _pointer: UnsafeMutableRawPointer?
@@ -212,7 +212,7 @@ extension MutableSpan where Element: ~Copyable {
 
 //MARK: Collection, RandomAccessCollection
 @available(SwiftStdlib 6.2, *)
-extension MutableSpan where Element: ~Copyable & ~Escapable {
+extension MutableSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   public var count: Int { _count }

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -25,7 +25,7 @@ public struct MutableSpan<Element: ~Copyable & ~Escapable>
 
   @_alwaysEmitIntoClient
   internal func _start() -> UnsafeMutableRawPointer {
-    unsafe _pointer.unsafelyUnwrapped
+    unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -497,9 +497,9 @@ extension MutableSpan where Element: ~Copyable {
 //      source.count <= self.count,
 //      "destination span cannot contain every element from source."
 //    )
-//    let buffer = source.relinquishBorrowedMemory()
+//    let buffer = unsafe source.relinquishBorrowedMemory()
 //    // we must now deinitialize the returned UMBP
-//    _start().moveInitializeMemory(
+//    unsafe _start().moveInitializeMemory(
 //      as: Element.self, from: buffer.baseAddress!, count: buffer.count
 //    )
 //    return buffer.count
@@ -524,9 +524,7 @@ extension MutableSpan {
   public mutating func moveUpdate(
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
   ) -> Index {
-    unsafe moveUpdate(
-      fromContentsOf: UnsafeMutableBufferPointer(rebasing: source)
-    )
+    moveUpdate(fromContentsOf: unsafe .init(rebasing: source))
   }
 }
 
@@ -707,14 +705,6 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @unsafe
-  @_alwaysEmitIntoClient
-  @lifetime(borrow self)
-  mutating public func _extracting(
-    unchecked bounds: some RangeExpression<Index>
-  ) -> Self {
-    unsafe _extracting(unchecked: bounds.relative(to: indices))
-  }
-
   @_alwaysEmitIntoClient
   @lifetime(borrow self)
   mutating public func _extracting(

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -58,7 +58,7 @@ extension MutableSpan where Element: ~Copyable {
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
-    precondition(
+    _precondition(
       ((Int(bitPattern: buffer.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
       "baseAddress must be properly aligned to access Element"
@@ -73,7 +73,7 @@ extension MutableSpan where Element: ~Copyable {
     _unsafeStart start: UnsafeMutablePointer<Element>,
     count: Int
   ) {
-    precondition(count >= 0, "Count must not be negative")
+    _precondition(count >= 0, "Count must not be negative")
     let buffer = UnsafeMutableBufferPointer(start: start, count: count)
     let ms = MutableSpan(_unsafeElements: buffer)
     self = _overrideLifetime(ms, borrowing: start)
@@ -102,14 +102,14 @@ extension MutableSpan where Element: BitwiseCopyable {
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
-    precondition(
+    _precondition(
       ((Int(bitPattern: buffer.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
       "baseAddress must be properly aligned to access Element"
     )
     let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
     let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
-    precondition(remainder == 0, "Span must contain a whole number of elements")
+    _precondition(remainder == 0, "Span must contain a whole number of elements")
     let elements = UnsafeMutableBufferPointer<Element>(
       start: buffer.baseAddress?.assumingMemoryBound(to: Element.self),
       count: count
@@ -124,7 +124,7 @@ extension MutableSpan where Element: BitwiseCopyable {
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
   ) {
-    precondition(byteCount >= 0, "Count must not be negative")
+    _precondition(byteCount >= 0, "Count must not be negative")
     let bytes = UnsafeMutableRawBufferPointer(start: pointer, count: byteCount)
     let ms = MutableSpan(_unsafeBytes: bytes)
     self = _overrideLifetime(ms, borrowing: pointer)
@@ -229,7 +229,7 @@ extension MutableSpan where Element: ~Copyable & ~Escapable {
 
   @_alwaysEmitIntoClient
   public var indices: Range<Index> {
-    Range(uncheckedBounds: (0, _count))
+    Range(_uncheckedBounds: (0, _count))
   }
 }
 
@@ -260,11 +260,11 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     unsafeAddress {
-      precondition(indices.contains(position), "index out of bounds")
+      _precondition(indices.contains(position), "index out of bounds")
       return UnsafePointer(_unsafeAddressOfElement(unchecked: position))
     }
     unsafeMutableAddress {
-      precondition(indices.contains(position), "index out of bounds")
+      _precondition(indices.contains(position), "index out of bounds")
        return _unsafeAddressOfElement(unchecked: position)
     }
   }
@@ -303,8 +303,8 @@ extension MutableSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   public mutating func swapAt(_ i: Index, _ j: Index) {
-    precondition(indices.contains(Index(i)))
-    precondition(indices.contains(Index(j)))
+    _precondition(indices.contains(Index(i)))
+    _precondition(indices.contains(Index(j)))
     swapAt(unchecked: i, unchecked: j)
   }
 
@@ -330,11 +330,11 @@ extension MutableSpan where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     get {
-      precondition(indices.contains(position), "index out of bounds")
+      _precondition(indices.contains(position), "index out of bounds")
       return self[unchecked: position]
     }
     set {
-      precondition(indices.contains(position), "index out of bounds")
+      _precondition(indices.contains(position), "index out of bounds")
       self[unchecked: position] = newValue
     }
   }
@@ -460,7 +460,7 @@ extension MutableSpan {
 
     var iterator = source.makeIterator()
     let index = update(from: &iterator)
-    precondition(
+    _precondition(
       iterator.next() == nil,
       "destination buffer view cannot contain every element from source."
     )
@@ -470,7 +470,7 @@ extension MutableSpan {
   @_alwaysEmitIntoClient
   public mutating func update(fromContentsOf source: Span<Element>) -> Index {
     guard !source.isEmpty else { return 0 }
-    precondition(
+    _precondition(
       source.count <= self.count,
       "destination span cannot contain every element from source."
     )
@@ -498,7 +498,7 @@ extension MutableSpan where Element: ~Copyable {
 //    fromContentsOf source: consuming OutputSpan<Element>
 //  ) -> Index {
 //    guard !source.isEmpty else { return 0 }
-//    precondition(
+//    _precondition(
 //      source.count <= self.count,
 //      "destination span cannot contain every element from source."
 //    )
@@ -586,7 +586,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
     var iterator = source.makeIterator()
     let index = update(from: &iterator)
-    precondition(
+    _precondition(
       iterator.next() == nil,
       "destination buffer view cannot contain every element from source."
     )
@@ -598,7 +598,7 @@ extension MutableSpan where Element: BitwiseCopyable {
     fromContentsOf source: Span<Element>
   ) -> Index where Element: BitwiseCopyable {
     guard !source.isEmpty else { return 0 }
-    precondition(
+    _precondition(
       source.count <= self.count,
       "destination span cannot contain every element from source."
     )

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -1,0 +1,619 @@
+//===--- MutableSpan.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// A MutableSpan<Element> represents a span of memory which
+// contains initialized `Element` instances.
+@frozen
+@available(SwiftStdlib 6.2, *)
+public struct MutableSpan<Element: ~Copyable & ~Escapable>
+: ~Copyable, ~Escapable {
+  @usableFromInline
+  internal let _pointer: UnsafeMutableRawPointer?
+
+  @usableFromInline
+  internal let _count: Int
+
+  @_alwaysEmitIntoClient
+  internal func _start() -> UnsafeMutableRawPointer {
+    _pointer.unsafelyUnwrapped
+  }
+
+  @usableFromInline @inline(__always)
+  @lifetime(borrow start)
+  init(
+    _unchecked start: UnsafeMutableRawPointer?,
+    count: Int
+  ) {
+    _pointer = start
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan: @unchecked Sendable where Element: Sendable {}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  @usableFromInline
+  @lifetime(borrow elements)
+  internal init(
+    _unchecked elements: UnsafeMutableBufferPointer<Element>
+  ) {
+    _pointer = .init(elements.baseAddress)
+    _count = elements.count
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  public init(
+    _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
+  ) {
+    precondition(
+      ((Int(bitPattern: buffer.baseAddress) &
+        (MemoryLayout<Element>.alignment&-1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let ms = MutableSpan<Element>(_unchecked: buffer)
+    self = _overrideLifetime(ms, borrowing: buffer)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow start)
+  public init(
+    _unsafeStart start: UnsafeMutablePointer<Element>,
+    count: Int
+  ) {
+    precondition(count >= 0, "Count must not be negative")
+    let buffer = UnsafeMutableBufferPointer(start: start, count: count)
+    let ms = MutableSpan(_unsafeElements: buffer)
+    self = _overrideLifetime(ms, borrowing: start)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan {
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow elements)
+  public init(
+    _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    let rb = UnsafeMutableBufferPointer(rebasing: elements)
+    let ms = MutableSpan(_unsafeElements: rb)
+    self = _overrideLifetime(ms, borrowing: elements)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: BitwiseCopyable {
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  public init(
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+  ) {
+    precondition(
+      ((Int(bitPattern: buffer.baseAddress) &
+        (MemoryLayout<Element>.alignment&-1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    precondition(remainder == 0, "Span must contain a whole number of elements")
+    let elements = UnsafeMutableBufferPointer<Element>(
+      start: buffer.baseAddress?.assumingMemoryBound(to: Element.self),
+      count: count
+    )
+    let ms = MutableSpan(_unsafeElements: elements)
+    self = _overrideLifetime(ms, borrowing: buffer)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
+  public init(
+    _unsafeStart pointer: UnsafeMutableRawPointer,
+    byteCount: Int
+  ) {
+    precondition(byteCount >= 0, "Count must not be negative")
+    let bytes = UnsafeMutableRawBufferPointer(start: pointer, count: byteCount)
+    let ms = MutableSpan(_unsafeBytes: bytes)
+    self = _overrideLifetime(ms, borrowing: pointer)
+  }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  public init(
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer)
+    let ms = MutableSpan(_unsafeBytes: bytes)
+    self = _overrideLifetime(ms, borrowing: buffer)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension Span where Element: ~Copyable {
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow mutableSpan)
+  public init(_unsafeMutableSpan mutableSpan: borrowing MutableSpan<Element>) {
+    let pointer = mutableSpan._pointer?.assumingMemoryBound(to: Element.self)
+    let buffer = UnsafeBufferPointer(start: pointer, count: mutableSpan.count)
+    let span = Span(_unsafeElements: buffer)
+    self = _overrideLifetime(span, borrowing: mutableSpan)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  @_alwaysEmitIntoClient
+  public var span: Span<Element> {
+    @lifetime(borrow self)
+    borrowing get {
+      Span(_unsafeMutableSpan: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension RawSpan {
+
+  @_alwaysEmitIntoClient
+  public init<Element: BitwiseCopyable>(
+    _unsafeMutableSpan mutableSpan: borrowing MutableSpan<Element>
+  ) {
+    let pointer = mutableSpan._pointer
+    let byteCount = mutableSpan.count &* MemoryLayout<Element>.stride
+    let buffer = UnsafeRawBufferPointer(start: pointer, count: byteCount)
+    let rawSpan = RawSpan(_unsafeBytes: buffer)
+    self = _overrideLifetime(rawSpan, borrowing: mutableSpan)
+  }
+}
+
+//@available(SwiftStdlib 6.2, *)
+//extension MutableSpan where Element: Equatable {
+//
+//  @_alwaysEmitIntoClient
+//  public func _elementsEqual(_ other: borrowing Self) -> Bool {
+//    _elementsEqual(Span(_unsafeMutableSpan: other))
+//  }
+//
+//  @_alwaysEmitIntoClient
+//  public func _elementsEqual(_ other: Span<Element>) -> Bool {
+//    Span(_unsafeMutableSpan: self)._elementsEqual(other)
+//  }
+//
+//  @_alwaysEmitIntoClient
+//  public func _elementsEqual(_ other: some Collection<Element>) -> Bool {
+//    Span(_unsafeMutableSpan: self)._elementsEqual(other)
+//  }
+//
+//  @_alwaysEmitIntoClient
+//  public func _elementsEqual(_ other: some Sequence<Element>) -> Bool {
+//    Span(_unsafeMutableSpan: self)._elementsEqual(other)
+//  }
+//}
+//
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  @_alwaysEmitIntoClient
+  public var _description: String {
+    let addr = String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
+    return "(0x\(addr), \(_count))"
+  }
+}
+
+//MARK: Collection, RandomAccessCollection
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable & ~Escapable {
+
+  @_alwaysEmitIntoClient
+  public var count: Int { _count }
+
+  @_alwaysEmitIntoClient
+  public var isEmpty: Bool { _count == 0 }
+
+  public typealias Index = Int
+
+  @_alwaysEmitIntoClient
+  public var indices: Range<Index> {
+    Range(uncheckedBounds: (0, _count))
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: BitwiseCopyable {
+
+  /// Construct a RawSpan over the memory represented by this span
+  ///
+  /// - Returns: a RawSpan over the memory represented by this span
+  @_alwaysEmitIntoClient
+  public var bytes: RawSpan {
+    @lifetime(borrow self)
+    borrowing get {
+      RawSpan(_unsafeMutableSpan: self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Index) -> Element {
+    unsafeAddress {
+      precondition(indices.contains(position), "index out of bounds")
+      return UnsafePointer(_unsafeAddressOfElement(unchecked: position))
+    }
+    unsafeMutableAddress {
+      precondition(indices.contains(position), "index out of bounds")
+       return _unsafeAddressOfElement(unchecked: position)
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Index) -> Element {
+    unsafeAddress {
+      UnsafePointer(_unsafeAddressOfElement(unchecked: position))
+    }
+    unsafeMutableAddress {
+      _unsafeAddressOfElement(unchecked: position)
+    }
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal func _unsafeAddressOfElement(
+    unchecked position: Index
+  ) -> UnsafeMutablePointer<Element> {
+    let elementOffset = position &* MemoryLayout<Element>.stride
+    let address = _start().advanced(by: elementOffset)
+    return address.assumingMemoryBound(to: Element.self)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  @_alwaysEmitIntoClient
+  public mutating func swapAt(_ i: Index, _ j: Index) {
+    precondition(indices.contains(Index(i)))
+    precondition(indices.contains(Index(j)))
+    swapAt(unchecked: i, unchecked: j)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
+    let pi = _unsafeAddressOfElement(unchecked: i)
+    let pj = _unsafeAddressOfElement(unchecked: j)
+    let temporary = pi.move()
+    pi.initialize(to: pj.move())
+    pj.initialize(to: consume temporary)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: BitwiseCopyable {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Index) -> Element {
+    get {
+      precondition(indices.contains(position), "index out of bounds")
+      return self[unchecked: position]
+    }
+    set {
+      precondition(indices.contains(position), "index out of bounds")
+      self[unchecked: position] = newValue
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Index) -> Element {
+    get {
+      let offset = position&*MemoryLayout<Element>.stride
+      return _start().loadUnaligned(fromByteOffset: offset, as: Element.self)
+    }
+    set {
+      let offset = position&*MemoryLayout<Element>.stride
+      _start().storeBytes(of: newValue, toByteOffset: offset, as: Element.self)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+  //FIXME: mark closure parameter as non-escaping
+  @_alwaysEmitIntoClient
+  public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    try Span(_unsafeMutableSpan: self).withUnsafeBufferPointer(body)
+  }
+
+  //FIXME: mark closure parameter as non-escaping
+  @_alwaysEmitIntoClient
+  public mutating func withUnsafeMutableBufferPointer<E: Error, Result: ~Copyable>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> Result {
+    guard let pointer = _pointer, count > 0 else {
+      return try body(.init(start: nil, count: 0))
+    }
+    // bind memory by hand to sidestep alignment concerns
+    let binding = Builtin.bindMemory(
+      pointer._rawValue, count._builtinWordValue, Element.self
+    )
+    defer { Builtin.rebindMemory(pointer._rawValue, binding) }
+    return try body(.init(start: .init(pointer._rawValue), count: count))
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: BitwiseCopyable {
+
+  //FIXME: mark closure parameter as non-escaping
+  @_alwaysEmitIntoClient
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try RawSpan(_unsafeMutableSpan: self).withUnsafeBytes(body)
+  }
+
+  //FIXME: mark closure parameter as non-escaping
+  @_alwaysEmitIntoClient
+  public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = UnsafeMutableRawBufferPointer(
+      start: (_count == 0) ? nil : _start(),
+      count: _count &* MemoryLayout<Element>.stride
+    )
+    return try body(bytes)
+  }
+}
+
+//MARK: bulk-update functions
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan {
+
+  @_alwaysEmitIntoClient
+  public mutating func update(repeating repeatedValue: consuming Element) {
+    _start().withMemoryRebound(to: Element.self, capacity: count) {
+      $0.update(repeating: repeatedValue, count: count)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<S: Sequence>(
+    from source: S
+  ) -> (unwritten: S.Iterator, index: Index) where S.Element == Element {
+    var iterator = source.makeIterator()
+    let index = update(from: &iterator)
+    return (iterator, index)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    from elements: inout some IteratorProtocol<Element>
+  ) -> Index {
+    var index = 0
+    while index < _count {
+      guard let element = elements.next() else { break }
+      self[unchecked: index] = element
+      index &+= 1
+    }
+    return index
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index {
+    let updated = source.withContiguousStorageIfAvailable {
+      self.update(fromContentsOf: Span(_unsafeElements: $0))
+    }
+    if let updated {
+      return updated
+    }
+
+    //TODO: use _copyContents here
+
+    var iterator = source.makeIterator()
+    let index = update(from: &iterator)
+    precondition(
+      iterator.next() == nil,
+      "destination buffer view cannot contain every element from source."
+    )
+    return index
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(fromContentsOf source: Span<Element>) -> Index {
+    guard !source.isEmpty else { return 0 }
+    precondition(
+      source.count <= self.count,
+      "destination span cannot contain every element from source."
+    )
+    _start().withMemoryRebound(to: Element.self, capacity: source.count) { dest in
+      source.withUnsafeBufferPointer {
+        dest.update(from: $0.baseAddress!, count: $0.count)
+      }
+    }
+    return source.count
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    fromContentsOf source: borrowing MutableSpan<Element>
+  ) -> Index {
+    update(fromContentsOf: source.span)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: ~Copyable {
+
+//  @_alwaysEmitIntoClient
+//  public mutating func moveUpdate(
+//    fromContentsOf source: consuming OutputSpan<Element>
+//  ) -> Index {
+//    guard !source.isEmpty else { return 0 }
+//    precondition(
+//      source.count <= self.count,
+//      "destination span cannot contain every element from source."
+//    )
+//    let buffer = source.relinquishBorrowedMemory()
+//    // we must now deinitialize the returned UMBP
+//    _start().moveInitializeMemory(
+//      as: Element.self, from: buffer.baseAddress!, count: buffer.count
+//    )
+//    return buffer.count
+//  }
+
+  @_alwaysEmitIntoClient
+  public mutating func moveUpdate(
+    fromContentsOf source: UnsafeMutableBufferPointer<Element>
+  ) -> Index {
+//    let source = OutputSpan(_initializing: source, initialized: source.count)
+//    return self.moveUpdate(fromContentsOf: source)
+    withUnsafeMutableBufferPointer {
+      $0.moveUpdate(fromContentsOf: source)
+    }
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan {
+
+  @_alwaysEmitIntoClient
+  public mutating func moveUpdate(
+    fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
+  ) -> Index {
+    moveUpdate(fromContentsOf: UnsafeMutableBufferPointer(rebasing: source))
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension MutableSpan where Element: BitwiseCopyable {
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    repeating repeatedValue: Element
+  ) where Element: BitwiseCopyable {
+    guard count > 0 else { return }
+    // rebind _start manually in order to avoid assumptions about alignment.
+    let rp = _start()._rawValue
+    let binding = Builtin.bindMemory(rp, count._builtinWordValue, Element.self)
+    UnsafeMutablePointer(rp).update(repeating: repeatedValue, count: count)
+    Builtin.rebindMemory(rp, binding)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update<S: Sequence>(
+    from source: S
+  ) -> (unwritten: S.Iterator, index: Index)
+  where S.Element == Element, Element: BitwiseCopyable {
+    var iterator = source.makeIterator()
+    let index = update(from: &iterator)
+    return (iterator, index)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    from elements: inout some IteratorProtocol<Element>
+  ) -> Index {
+    var index = 0
+    while index < _count {
+      guard let element = elements.next() else { break }
+      self[unchecked: index] = element
+      index &+= 1
+    }
+    return index
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index where Element: BitwiseCopyable {
+    let updated = source.withContiguousStorageIfAvailable {
+      self.update(fromContentsOf: Span(_unsafeElements: $0))
+    }
+    if let updated {
+      return updated
+    }
+
+    //TODO: use _copyContents here
+
+    var iterator = source.makeIterator()
+    let index = update(from: &iterator)
+    precondition(
+      iterator.next() == nil,
+      "destination buffer view cannot contain every element from source."
+    )
+    return index
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    fromContentsOf source: Span<Element>
+  ) -> Index where Element: BitwiseCopyable {
+    guard !source.isEmpty else { return 0 }
+    precondition(
+      source.count <= self.count,
+      "destination span cannot contain every element from source."
+    )
+    source.withUnsafeBufferPointer {
+      _start().copyMemory(
+        from: $0.baseAddress!, byteCount: $0.count&*MemoryLayout<Element>.stride
+      )
+    }
+    return source.count
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func update(
+    fromContentsOf source: borrowing MutableSpan<Element>
+  ) -> Index where Element: BitwiseCopyable {
+    update(fromContentsOf: source.span)
+  }
+}

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -224,7 +224,7 @@ extension MutableSpan where Element: ~Copyable & ~Escapable {
 
   @_alwaysEmitIntoClient
   public var indices: Range<Index> {
-    Range(_uncheckedBounds: (0, _count))
+    unsafe Range(_uncheckedBounds: (0, _count))
   }
 }
 
@@ -721,7 +721,7 @@ extension MutableSpan where Element: ~Copyable {
   mutating public func _extracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
-    let range = Range(
+    let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound&+1)
     )
     return unsafe _extracting(unchecked: range)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -27,9 +27,9 @@ public struct MutableSpan<Element: ~Copyable & ~Escapable>
     _pointer.unsafelyUnwrapped
   }
 
-  @usableFromInline @inline(__always)
+  @_alwaysEmitIntoClient
   @lifetime(borrow start)
-  init(
+  internal init(
     _unchecked start: UnsafeMutableRawPointer?,
     count: Int
   ) {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
@@ -11,6 +11,7 @@
 // RUN: %target-run %t/swift-cxx-execution
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_LifetimeDependence
 
 //--- header.h
 enum class SomeEnum {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
@@ -12,6 +12,7 @@
 // RUN: %target-run %t/swift-cxx-execution | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_LifetimeDependence
 
 //--- header.h
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
+
+// REQUIRES: swift_feature_LifetimeDependence
 
 // CHECK: namespace swift SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("swift") {
 

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -817,8 +817,8 @@ Added: _$ss7RawSpanVN
 // SE-0467 MutableSpan and MutableRawSpan
 Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
+Added: _$ss11MutableSpanVsRi_zrlE6_countSivg
+Added: _$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg
 Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -838,6 +838,11 @@ Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
 Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
 
+// SE-0467 mutableSpan properties
+Added: _$sSa11mutableSpans07MutableB0VyxGvr
+Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
+Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
+
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -817,11 +817,9 @@ Added: _$ss7RawSpanVN
 // SE-0467 MutableSpan and MutableRawSpan
 Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE10_unchecked5countAByxGSvSg_SitcfC
 Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
 Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
 Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
-Added: _$ss14MutableRawSpanV10_unchecked5countABSvSg_SitcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg
 Added: _$ss14MutableRawSpanVMa

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -814,7 +814,21 @@ Added: _$ss7RawSpanVMa
 Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
 
-// Span-providing properties
+// SE-0467 MutableSpan and MutableRawSpan
+Added: _$ss11MutableSpanVMa
+Added: _$ss11MutableSpanVMn
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE10_unchecked5countAByxGSvSg_SitcfC
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
+Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
+Added: _$ss14MutableRawSpanV10_unchecked5countABSvSg_SitcfC
+Added: _$ss14MutableRawSpanV6_countSivg
+Added: _$ss14MutableRawSpanV8_pointerSvSgvg
+Added: _$ss14MutableRawSpanVMa
+Added: _$ss14MutableRawSpanVMn
+Added: _$ss14MutableRawSpanVN
+
+// SE-0456 Span-providing properties
 Added: _$sSRsRi_zrlE4spans4SpanVyxGvpMV
 Added: _$sSW5bytess7RawSpanVvpMV
 Added: _$sSa4spans4SpanVyxGvpMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -815,7 +815,21 @@ Added: _$ss7RawSpanVMa
 Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
 
-// Span-providing properties
+// SE-0467 MutableSpan and MutableRawSpan
+Added: _$ss11MutableSpanVMa
+Added: _$ss11MutableSpanVMn
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE10_unchecked5countAByxGSvSg_SitcfC
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
+Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
+Added: _$ss14MutableRawSpanV10_unchecked5countABSvSg_SitcfC
+Added: _$ss14MutableRawSpanV6_countSivg
+Added: _$ss14MutableRawSpanV8_pointerSvSgvg
+Added: _$ss14MutableRawSpanVMa
+Added: _$ss14MutableRawSpanVMn
+Added: _$ss14MutableRawSpanVN
+
+// SE-0456 Span-providing properties
 Added: _$sSRsRi_zrlE4spans4SpanVyxGvpMV
 Added: _$sSW5bytess7RawSpanVvpMV
 Added: _$sSa4spans4SpanVyxGvpMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -818,11 +818,9 @@ Added: _$ss7RawSpanVN
 // SE-0467 MutableSpan and MutableRawSpan
 Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE10_unchecked5countAByxGSvSg_SitcfC
 Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
 Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
 Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
-Added: _$ss14MutableRawSpanV10_unchecked5countABSvSg_SitcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg
 Added: _$ss14MutableRawSpanVMa

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -839,6 +839,11 @@ Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
 Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
 
+// SE-0467 mutableSpan properties
+Added: _$sSa11mutableSpans07MutableB0VyxGvr
+Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
+Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
+
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -818,8 +818,8 @@ Added: _$ss7RawSpanVN
 // SE-0467 MutableSpan and MutableRawSpan
 Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE6_countSivg
-Added: _$ss11MutableSpanVsRi_zRi0_zrlE8_pointerSvSgvg
+Added: _$ss11MutableSpanVsRi_zrlE6_countSivg
+Added: _$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg
 Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg

--- a/test/stdlib/Span/ArraySpanProperties.swift
+++ b/test/stdlib/Span/ArraySpanProperties.swift
@@ -34,6 +34,20 @@ suite.test("Array.span property")
   expectEqual(span[0], a[0])
 }
 
+suite.test("Array.mutableSpan property")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var a = Array(0..<capacity)
+  var span = a.mutableSpan
+  expectEqual(span.count, capacity)
+  expectEqual(span[0], 0)
+  span[0] = 100
+  _ = consume span
+  expectEqual(a[0], 100)
+}
+
 suite.test("ContiguousArray.span property")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
@@ -47,6 +61,20 @@ suite.test("ContiguousArray.span property")
   let span = a.span
   expectEqual(span.count, capacity)
   expectEqual(span[0], a[0])
+}
+
+suite.test("ContiguousArray.mutableSpan property")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var a = ContiguousArray(0..<capacity)
+  var span = a.mutableSpan
+  expectEqual(span.count, capacity)
+  expectEqual(span[0], 0)
+  span[0] = 100
+  _ = consume span
+  expectEqual(a[0], 100)
 }
 
 suite.test("ArraySlice.span property")
@@ -89,4 +117,23 @@ suite.test("KeyValuePairs.span property")
   for i in span.indices {
     expectEqual(span[i], pairs[i])
   }
+}
+
+suite.test("ArraySlice.mutableSpan property")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  let a = Array(0..<capacity)
+
+  var s = a[...]
+  var span = s.mutableSpan
+  expectEqual(span.count, capacity)
+  expectEqual(span[0], a[0])
+
+  span[0] += 100
+  expectEqual(span[0], a[0]+100)
+
+  _ = consume span
+  expectEqual(s[0], a[0]+100)
 }

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -1,0 +1,484 @@
+//===--- MutableRawSpanTests.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("MutableRawSpan Tests")
+defer { runAllTests() }
+
+suite.test("Basic Initializer")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var s = Array("\(#file)+\(#function)--\(Int.random(in: 1000...9999))".utf8)
+  s.withUnsafeMutableBytes {
+    let b = MutableRawSpan(_unsafeBytes: $0)
+    expectEqual(b.byteCount, $0.count)
+    expectFalse(b.isEmpty)
+    expectEqual(b.byteOffsets, 0..<$0.count)
+  }
+}
+
+suite.test("isEmpty property")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var array = [0, 1, 2]
+  array.withUnsafeMutableBufferPointer {
+    var span = MutableRawSpan(_unsafeElements: $0)
+    expectFalse(span.isEmpty)
+
+    let e = $0.extracting(0..<0)
+    span = MutableRawSpan(_unsafeElements: e)
+    expectTrue(span.isEmpty)
+  }
+}
+
+suite.test("indices property")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4 as UInt8
+  var a = Array(0..<capacity)
+  a.withUnsafeMutableBytes {
+    let view = MutableRawSpan(_unsafeBytes: $0)
+    expectEqual(view.byteCount, view.byteOffsets.count)
+    expectTrue(view.byteOffsets.elementsEqual(0..<view.byteCount))
+  }
+}
+
+suite.test("withUnsafeBytes()")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 64
+  var a = Array(0..<capacity)
+  let i = Int.random(in: a.indices)
+  a.withUnsafeMutableBytes {
+    var view = MutableRawSpan(_unsafeBytes: $0)
+    view.withUnsafeBytes {
+      expectEqual($0.load(fromByteOffset: i, as: UInt8.self), $0[i])
+    }
+
+    let empty = UnsafeMutableRawBufferPointer(start: $0.baseAddress, count: 0)
+    view = MutableRawSpan(_unsafeBytes: empty)
+    view.withUnsafeBytes {
+      expectEqual($0.count, 0)
+      expectNil($0.baseAddress)
+    }
+  }
+}
+
+suite.test("withUnsafeMutableBytes")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 16
+  var a = Array(0..<capacity)
+  let i = Int.random(in: a.indices)
+  a.withUnsafeMutableBytes {
+    var view = MutableRawSpan(_unsafeBytes: $0)
+    let o = view.unsafeLoad(fromByteOffset: i, as: UInt8.self)
+    view.withUnsafeMutableBytes {
+      $0.storeBytes(of: UInt8(i+1), toByteOffset: i, as: UInt8.self)
+    }
+    let m = view.unsafeLoad(fromByteOffset: i, as: UInt8.self)
+    expectEqual(m, o+1)
+
+    let empty = UnsafeMutableRawBufferPointer(start: $0.baseAddress, count: 0)
+    view = MutableRawSpan(_unsafeBytes: empty)
+    view.withUnsafeMutableBytes {
+      expectEqual($0.count, 0)
+      expectNil($0.baseAddress)
+    }
+  }
+  expectEqual(Int(a[i]), i+1)
+}
+
+suite.test("bytes property")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var array = [0, 1, 2]
+  array.withUnsafeMutableBufferPointer {
+    let mutable = MutableRawSpan(_unsafeElements: $0)
+    let immutable = mutable.bytes
+    expectEqual(mutable.byteCount, immutable.byteCount)
+  }
+}
+
+suite.test("unsafeView(as:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var array = [0, 1, 2]
+  array.withUnsafeMutableBufferPointer {
+    let mutable = MutableRawSpan(_unsafeElements: $0)
+    let view = mutable._unsafeView(as: Int.self)
+    expectEqual($0[1], view[1])
+  }
+}
+
+suite.test("unsafeMutableView(as:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var array = [0, 1, 2]
+  let value = Int.random(in: 0..<1000)
+  array.withUnsafeMutableBufferPointer {
+    var mutable = MutableRawSpan(_unsafeElements: $0)
+    var view = mutable._unsafeMutableView(as: Int.self)
+    view[1] = value
+  }
+  expectEqual(array[1], value)
+}
+
+suite.test("unsafeLoad(as:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var s = (0..<capacity).map({ "\(#file)+\(#function) #\($0)" })
+  s.withUnsafeMutableBytes {
+    let span = MutableRawSpan(_unsafeBytes: $0)
+    let stride = MemoryLayout<String>.stride
+
+    let s0 = span.unsafeLoad(as: String.self)
+    expectEqual(s0.contains("0"), true)
+    let s1 = span.unsafeLoad(fromByteOffset: stride, as: String.self)
+    expectEqual(s1.contains("1"), true)
+    let s2 = span.unsafeLoad(fromUncheckedByteOffset: 2*stride, as: String.self)
+    expectEqual(s2.contains("2"), true)
+  }
+}
+
+suite.test("unsafeLoadUnaligned(as:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 64
+  var a = Array(0..<UInt8(capacity))
+  a.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+
+    let suffix = span._extracting(droppingFirst: 2)
+    let u0 = suffix.unsafeLoadUnaligned(as: UInt64.self)
+    expectEqual(u0 & 0xff, 2)
+    expectEqual(u0.byteSwapped & 0xff, 9)
+    let u1 = span.unsafeLoadUnaligned(fromByteOffset: 6, as: UInt64.self)
+    expectEqual(u1 & 0xff, 6)
+    let u3 = span.unsafeLoadUnaligned(fromUncheckedByteOffset: 7, as: UInt32.self)
+    expectEqual(u3 & 0xff, 7)
+  }
+}
+
+suite.test("storeBytes(of:as:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let count = 4
+  var a = Array(repeating: 0, count: count)
+  a.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    span.storeBytes(of: .max, as: UInt8.self)
+    span.storeBytes(
+      of: .max, toByteOffset: MemoryLayout<UInt>.stride/2, as: UInt.self
+    )
+  }
+  expectEqual(a[0].littleEndian & 0xffff, 0xff)
+  expectEqual(a[0].bigEndian & 0xffff, 0xffff)
+}
+
+suite.test("update(from: some Sequence<some BitwiseCopyable>)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let empty = UnsafeMutableBufferPointer<Int>(start: nil, count: 0)
+    var span = MutableRawSpan(_unsafeElements: empty)
+    var (iterator, updated) = span.update(from: 0..<0)
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    span = MutableRawSpan(_unsafeElements: $0)
+    (iterator, updated) = span.update(from: 0..<0)
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    (iterator, updated) = span.update(from: 0..<10000)
+    expectNotNil(iterator.next())
+    expectEqual(updated, capacity*MemoryLayout<Int>.stride)
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(from: some Collection<some BitwiseCopyable>)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  let e = Array(EmptyCollection<UInt>())
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBytes {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableRawSpan(_unsafeBytes: emptyPrefix)
+    var updated = span.update(fromContentsOf: e)
+    expectEqual(updated, 0)
+
+
+    updated = span.update(fromContentsOf: AnyCollection(e))
+    expectEqual(updated, 0)
+
+    span = MutableRawSpan(_unsafeBytes: $0)
+    updated = span.update(fromContentsOf: 0..<capacity)
+    expectEqual(updated, capacity*MemoryLayout<Int>.stride)
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(fromContentsOf:) (contiguous memory)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    let array = Array(0..<capacity)
+    var updated = span.update(fromContentsOf: array.prefix(0))
+    expectEqual(updated, 0)
+
+    updated = span.update(fromContentsOf: array)
+    expectEqual(updated, capacity*MemoryLayout<Int>.stride)
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+
+  a.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    var array = Array(repeating: Int.min, count: capacity)
+    array.withUnsafeMutableBytes {
+      let source = MutableRawSpan(_unsafeBytes: $0)
+      let updated = span.update(fromContentsOf: source)
+      expectEqual(updated, capacity*MemoryLayout<Int>.stride)
+    }
+  }
+  expectEqual(a.allSatisfy({ $0 == Int.min }), true)
+
+  a.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    let array = Array(0..<capacity)
+    array.withUnsafeBufferPointer {
+      let source = Span(_unsafeElements: $0)
+      let updated = span.update(fromContentsOf: source)
+      expectEqual(updated, capacity*MemoryLayout<Int>.stride)
+    }
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("_extracting()")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var b = (0..<capacity).map(Int8.init)
+  b.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0)
+
+    var sub = span._extracting(0..<2)
+    expectEqual(sub.byteCount, 2)
+    expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
+
+    sub = span._extracting(..<2)
+    expectEqual(sub.byteCount, 2)
+    expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
+
+    sub = span._extracting(...)
+    expectEqual(sub.byteCount, 4)
+    expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
+
+    sub = span._extracting(2...)
+    expectEqual(sub.byteCount, 2)
+    expectEqual(sub.unsafeLoad(as: UInt8.self), 2)
+  }
+}
+
+suite.test("_extracting(unchecked:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 32
+  var b = (0..<capacity).map(UInt8.init)
+  b.withUnsafeMutableBytes {
+    var span = MutableRawSpan(_unsafeBytes: $0.prefix(8))
+    let beyond = span._extracting(unchecked: 16...23)
+    expectEqual(beyond.byteCount, 8)
+    let fromBeyond = beyond.unsafeLoad(as: UInt8.self)
+    expectEqual(fromBeyond, 16)
+  }
+}
+
+suite.test("_extracting prefixes")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var a = Array(0..<UInt8(capacity))
+  a.withUnsafeMutableBytes {
+    var prefix: MutableRawSpan
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    expectEqual(span.byteCount, capacity)
+
+    prefix = span._extracting(first: 1)
+    expectEqual(prefix.unsafeLoad(as: UInt8.self), 0)
+
+    prefix = span._extracting(first: capacity)
+    expectEqual(
+      prefix.unsafeLoad(fromByteOffset: capacity-1, as: UInt8.self),
+      UInt8(capacity-1)
+    )
+
+    prefix = span._extracting(droppingLast: capacity)
+    expectEqual(prefix.isEmpty, true)
+
+    prefix = span._extracting(droppingLast: 1)
+    expectEqual(
+      prefix.unsafeLoad(fromByteOffset: capacity-2, as: UInt8.self),
+      UInt8(capacity-2)
+    )
+  }
+
+  do {
+    let b = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+    var span = MutableRawSpan(_unsafeBytes: b)
+    expectEqual(span.byteCount, b.count)
+    expectEqual(span._extracting(first: 1).byteCount, b.count)
+    expectEqual(span._extracting(droppingLast: 1).byteCount, b.count)
+  }
+}
+
+suite.test("_extracting suffixes")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var a = Array(0..<UInt8(capacity))
+  a.withUnsafeMutableBytes {
+    var prefix: MutableRawSpan
+    var span = MutableRawSpan(_unsafeBytes: $0)
+    expectEqual(span.byteCount, capacity)
+
+    prefix = span._extracting(last: capacity)
+    expectEqual(prefix.unsafeLoad(as: UInt8.self), 0)
+
+    prefix = span._extracting(last: capacity-1)
+    expectEqual(prefix.unsafeLoad(as: UInt8.self), 1)
+
+    prefix = span._extracting(last: 1)
+    expectEqual(prefix.unsafeLoad(as: UInt8.self), UInt8(capacity-1))
+
+    prefix = span._extracting(droppingFirst: capacity)
+    expectTrue(prefix.isEmpty)
+
+    prefix = span._extracting(droppingFirst: 1)
+    expectEqual(prefix.unsafeLoad(as: UInt8.self), 1)
+  }
+
+  do {
+    let b = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+    var span = MutableRawSpan(_unsafeBytes: b)
+    expectEqual(span.byteCount, b.count)
+    expectEqual(span._extracting(last: 1).byteCount, b.count)
+    expectEqual(span._extracting(droppingFirst: 1).byteCount, b.count)
+  }
+}

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -214,7 +214,7 @@ suite.test("unsafeLoadUnaligned(as:)")
   a.withUnsafeMutableBytes {
     var span = MutableRawSpan(_unsafeBytes: $0)
 
-    let suffix = span._extracting(droppingFirst: 2)
+    let suffix = span.extracting(droppingFirst: 2)
     let u0 = suffix.unsafeLoadUnaligned(as: UInt64.self)
     expectEqual(u0 & 0xff, 2)
     expectEqual(u0.byteSwapped & 0xff, 9)
@@ -350,7 +350,7 @@ suite.test("update(fromContentsOf:) (contiguous memory)")
   expectEqual(a.elementsEqual(0..<capacity), true)
 }
 
-suite.test("_extracting()")
+suite.test("extracting()")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -363,25 +363,25 @@ suite.test("_extracting()")
   b.withUnsafeMutableBytes {
     var span = MutableRawSpan(_unsafeBytes: $0)
 
-    var sub = span._extracting(0..<2)
+    var sub = span.extracting(0..<2)
     expectEqual(sub.byteCount, 2)
     expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
 
-    sub = span._extracting(..<2)
+    sub = span.extracting(..<2)
     expectEqual(sub.byteCount, 2)
     expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
 
-    sub = span._extracting(...)
+    sub = span.extracting(...)
     expectEqual(sub.byteCount, 4)
     expectEqual(sub.unsafeLoad(as: UInt8.self), 0)
 
-    sub = span._extracting(2...)
+    sub = span.extracting(2...)
     expectEqual(sub.byteCount, 2)
     expectEqual(sub.unsafeLoad(as: UInt8.self), 2)
   }
 }
 
-suite.test("_extracting(unchecked:)")
+suite.test("extracting(unchecked:)")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -393,14 +393,14 @@ suite.test("_extracting(unchecked:)")
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBytes {
     var span = MutableRawSpan(_unsafeBytes: $0.prefix(8))
-    let beyond = span._extracting(unchecked: 16...23)
+    let beyond = span.extracting(unchecked: 16...23)
     expectEqual(beyond.byteCount, 8)
     let fromBeyond = beyond.unsafeLoad(as: UInt8.self)
     expectEqual(fromBeyond, 16)
   }
 }
 
-suite.test("_extracting prefixes")
+suite.test("extracting prefixes")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -415,19 +415,19 @@ suite.test("_extracting prefixes")
     var span = MutableRawSpan(_unsafeBytes: $0)
     expectEqual(span.byteCount, capacity)
 
-    prefix = span._extracting(first: 1)
+    prefix = span.extracting(first: 1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), 0)
 
-    prefix = span._extracting(first: capacity)
+    prefix = span.extracting(first: capacity)
     expectEqual(
       prefix.unsafeLoad(fromByteOffset: capacity-1, as: UInt8.self),
       UInt8(capacity-1)
     )
 
-    prefix = span._extracting(droppingLast: capacity)
+    prefix = span.extracting(droppingLast: capacity)
     expectEqual(prefix.isEmpty, true)
 
-    prefix = span._extracting(droppingLast: 1)
+    prefix = span.extracting(droppingLast: 1)
     expectEqual(
       prefix.unsafeLoad(fromByteOffset: capacity-2, as: UInt8.self),
       UInt8(capacity-2)
@@ -438,12 +438,12 @@ suite.test("_extracting prefixes")
     let b = UnsafeMutableRawBufferPointer(start: nil, count: 0)
     var span = MutableRawSpan(_unsafeBytes: b)
     expectEqual(span.byteCount, b.count)
-    expectEqual(span._extracting(first: 1).byteCount, b.count)
-    expectEqual(span._extracting(droppingLast: 1).byteCount, b.count)
+    expectEqual(span.extracting(first: 1).byteCount, b.count)
+    expectEqual(span.extracting(droppingLast: 1).byteCount, b.count)
   }
 }
 
-suite.test("_extracting suffixes")
+suite.test("extracting suffixes")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -458,19 +458,19 @@ suite.test("_extracting suffixes")
     var span = MutableRawSpan(_unsafeBytes: $0)
     expectEqual(span.byteCount, capacity)
 
-    prefix = span._extracting(last: capacity)
+    prefix = span.extracting(last: capacity)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), 0)
 
-    prefix = span._extracting(last: capacity-1)
+    prefix = span.extracting(last: capacity-1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), 1)
 
-    prefix = span._extracting(last: 1)
+    prefix = span.extracting(last: 1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), UInt8(capacity-1))
 
-    prefix = span._extracting(droppingFirst: capacity)
+    prefix = span.extracting(droppingFirst: capacity)
     expectTrue(prefix.isEmpty)
 
-    prefix = span._extracting(droppingFirst: 1)
+    prefix = span.extracting(droppingFirst: 1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), 1)
   }
 
@@ -478,7 +478,7 @@ suite.test("_extracting suffixes")
     let b = UnsafeMutableRawBufferPointer(start: nil, count: 0)
     var span = MutableRawSpan(_unsafeBytes: b)
     expectEqual(span.byteCount, b.count)
-    expectEqual(span._extracting(last: 1).byteCount, b.count)
-    expectEqual(span._extracting(droppingFirst: 1).byteCount, b.count)
+    expectEqual(span.extracting(last: 1).byteCount, b.count)
+    expectEqual(span.extracting(droppingFirst: 1).byteCount, b.count)
   }
 }

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -102,7 +102,7 @@ suite.test("Span from MutableSpan")
   var array = [0, 1, 2]
   array.withUnsafeMutableBufferPointer {
     let mutable = MutableSpan(_unsafeElements: $0)
-    let immutable  = Span(_unsafeMutableSpan: mutable)
+    let immutable  = Span(_mutableSpan: mutable)
     expectEqual(mutable.count, immutable.count)
   }
 }

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -1,0 +1,574 @@
+//===--- MutableSpanTests.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("MutableSpan Tests")
+defer { runAllTests() }
+
+suite.test("Initialize with ordinary element")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  let capacity = 4
+  var s = (0..<capacity).map({ "\(#file)+\(#function)--\($0)" })
+  s.withUnsafeMutableBufferPointer {
+    let b = MutableSpan(_unsafeElements: $0)
+    let c = b.count
+    expectEqual(c, $0.count)
+  }
+}
+
+suite.test("Initialize with BitwiseCopyable element")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  let capacity = 4
+  var a = Array(0..<capacity)
+  a.withUnsafeMutableBufferPointer {
+    let b = MutableSpan(_unsafeElements: $0)
+    let c = b.count
+    expectEqual(c, $0.count)
+  }
+
+  a.withUnsafeMutableBytes {
+    let (rp, bc) = ($0.baseAddress!, $0.count)
+    let b = MutableSpan<UInt>(_unsafeStart: rp, byteCount: bc)
+    expectEqual(b.count, capacity)
+
+    let stride = MemoryLayout<Int>.stride
+    let r = MutableSpan<Int8>(_unsafeBytes: $0.dropFirst(stride))
+    expectEqual(r.count, (capacity-1)*stride)
+    expectEqual(r.count, bc-stride)
+  }
+
+  let v = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+  let m = MutableSpan<Int>(_unsafeBytes: v)
+  expectEqual(m.count, 0)
+}
+
+suite.test("isEmpty")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  var array = [0, 1, 2]
+  array.withUnsafeMutableBufferPointer {
+    let span = MutableSpan(_unsafeElements: $0)
+    let e = span.isEmpty
+    expectFalse(e)
+  }
+
+  array = []
+  array.withUnsafeMutableBufferPointer {
+    let span = MutableSpan(_unsafeElements: $0)
+    let e = span.isEmpty
+    expectTrue(e)
+  }
+}
+
+suite.test("Span from MutableSpan")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  var array = [0, 1, 2]
+  array.withUnsafeMutableBufferPointer {
+    let mutable = MutableSpan(_unsafeElements: $0)
+    let immutable  = Span(_unsafeMutableSpan: mutable)
+    expectEqual(mutable.count, immutable.count)
+  }
+}
+
+suite.test("RawSpan from MutableSpan")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  let count = 4
+  var array = Array(0..<count)
+  array.withUnsafeMutableBufferPointer {
+    let (p, c) = ($0.baseAddress!, $0.count)
+    let span = MutableSpan(_unsafeStart: p, count: c)
+    let bytes  = span.bytes
+    expectEqual(bytes.byteCount, count*MemoryLayout<Int>.stride)
+  }
+}
+
+suite.test("indices property")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+  
+  let capacity = 4
+  var a = Array(0..<capacity)
+  a.withUnsafeMutableBufferPointer {
+    let view = MutableSpan(_unsafeElements: $0)
+    expectEqual(view.count, view.indices.count)
+    let equal = view.indices.elementsEqual(0..<view.count)
+    expectTrue(equal)
+  }
+}
+
+suite.test("IndexingSubscript")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  var a = Array(0..<capacity)
+  a.withUnsafeMutableBufferPointer {
+    [first = a.first] in
+    var v = MutableSpan(_unsafeElements: $0)
+    expectEqual(v[0], first)
+
+    v[0] += 1
+    expectEqual(v[0], first?.advanced(by: 1))
+  }
+
+  var b = a.map(String.init)
+  b.withUnsafeMutableBufferPointer {
+    [first = b.first] in
+    var v = MutableSpan(_unsafeElements: $0)
+    expectEqual(v[0], first)
+
+    v[0].append("!")
+    expectEqual(v[0], first.map({$0+"!"}))
+  }
+}
+
+suite.test("withUnsafeBufferPointer")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 64
+  var a = Array(0..<capacity)
+  a.withUnsafeMutableBufferPointer {
+    let view = MutableSpan(_unsafeElements: $0)
+    view.withUnsafeBufferPointer { b in
+      let i = Int(capacity/2)
+      expectEqual(b[i], b[i])
+    }
+  }
+}
+
+suite.test("withUnsafeBytes")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 64
+  var a = Array(0..<capacity)
+  let i = Int.random(in: a.indices)
+  a.withUnsafeMutableBufferPointer {
+    let view = MutableSpan(_unsafeElements: $0)
+    view.withUnsafeBytes {
+      expectEqual($0.load(fromByteOffset: i, as: UInt8.self), $0[i])
+    }
+  }
+}
+
+suite.test("withUnsafeMutableBufferPointer")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 64
+  var a = Array(0..<capacity)
+  let i = Int.random(in: a.indices)
+  a.withUnsafeMutableBufferPointer {
+    var view = MutableSpan(_unsafeElements: $0)
+    view.withUnsafeMutableBufferPointer {
+      $0[i] += 1
+    }
+
+    let empty0 = UnsafeMutableBufferPointer(start: $0.baseAddress, count: 0)
+    var emptySpan = MutableSpan(_unsafeElements: empty0)
+    emptySpan.withUnsafeMutableBufferPointer {
+      expectEqual($0.count, 0)
+      expectNil($0.baseAddress)
+    }
+  }
+  expectEqual(Int(a[i]), i+1)
+}
+
+suite.test("withUnsafeMutableBytes")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity: UInt8 = 64
+  var a = Array(0..<capacity)
+  let i = Int.random(in: a.indices)
+  a.withUnsafeMutableBufferPointer {
+    var view = MutableSpan(_unsafeElements: $0)
+    view.withUnsafeMutableBytes {
+      $0.storeBytes(of: UInt8(i+1), toByteOffset: i, as: UInt8.self)
+    }
+
+    let empty0 = UnsafeMutableBufferPointer(start: $0.baseAddress, count: 0)
+    var emptySpan = MutableSpan(_unsafeElements: empty0)
+    emptySpan.withUnsafeMutableBytes {
+      expectEqual($0.count, 0)
+      expectNil($0.baseAddress)
+    }
+  }
+  expectEqual(Int(a[i]), i+1)
+}
+
+private class ID {
+  let id: Int
+  init(id: Int) {
+    self.id = id
+  }
+  deinit {
+    // print(id)
+  }
+}
+
+suite.test("update(repeating:)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var a = (0..<8).map(ID.init(id:))
+  expectEqual(a.map(\.id).contains(.max), false)
+  a.withUnsafeMutableBufferPointer {
+    var span = MutableSpan(_unsafeElements: $0)
+    span.update(repeating: ID(id: .max))
+  }
+  expectEqual(a.allSatisfy({ $0.id == .max }), true)
+}
+
+suite.test("update(repeating:) - BitwiseCopyable")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var a = Array(0..<8)
+  expectEqual(a.contains(.max), false)
+  a.withUnsafeMutableBufferPointer {
+    var span = MutableSpan(_unsafeElements: $0)
+    span.update(repeating: .max)
+  }
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+}
+
+suite.test("update(from: some Sequence)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: ID(id: .max), count: capacity)
+  expectEqual(a.allSatisfy({ $0.id == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableSpan(_unsafeElements: emptyPrefix)
+    var (iterator, updated) = span.update(from: [])
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    (iterator, updated) = span.update(from: [])
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    (iterator, updated) = span.update(from: (0..<12).map(ID.init(id:)))
+    expectNotNil(iterator.next())
+    expectEqual(updated, capacity)
+  }
+  expectEqual(a.map(\.id).elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(from: some Sequence) - BitwiseCopyable")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let empty = UnsafeMutableBufferPointer<Int>(start: nil, count: 0)
+    var span = MutableSpan(_unsafeElements: empty)
+    var (iterator, updated) = span.update(from: 0..<0)
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    (iterator, updated) = span.update(from: 0..<0)
+    expectNil(iterator.next())
+    expectEqual(updated, 0)
+
+    (iterator, updated) = span.update(from: 0..<10000)
+    expectNotNil(iterator.next())
+    expectEqual(updated, capacity)
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(fromContentsOf: some Collection)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: ID(id: .max), count: capacity)
+  expectEqual(a.allSatisfy({ $0.id == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableSpan(_unsafeElements: emptyPrefix)
+    var updated = span.update(fromContentsOf: [])
+    expectEqual(updated, 0)
+
+    updated = span.update(fromContentsOf: AnyCollection([]))
+    expectEqual(updated, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    let elements = (0..<capacity).map(ID.init(id:))
+    updated = span.update(fromContentsOf: AnyCollection(elements))
+    expectEqual(updated, capacity)
+  }
+  expectEqual(a.map(\.id).elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(fromContentsOf: some Collection) - BitwiseCopyable")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableSpan(_unsafeElements: emptyPrefix)
+    var updated = span.update(fromContentsOf: [])
+    expectEqual(updated, 0)
+
+
+    updated = span.update(fromContentsOf: AnyCollection([]))
+    expectEqual(updated, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    updated = span.update(fromContentsOf: 0..<capacity)
+    expectEqual(updated, capacity)
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(fromContentsOf: Span)")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: ID(id: .max), count: capacity)
+  expectEqual(a.allSatisfy({ $0.id == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableSpan(_unsafeElements: emptyPrefix)
+    let updated = span.update(
+      fromContentsOf: UnsafeBufferPointer(start: nil, count: 0)
+    )
+    expectEqual(updated, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    var elements = (0..<capacity).map(ID.init(id:))
+    elements.withUnsafeMutableBufferPointer {
+      let source = MutableSpan(_unsafeElements: $0)
+      let updated = span.update(fromContentsOf: source)
+      expectEqual(updated, capacity)
+    }
+  }
+  expectEqual(a.map(\.id).elementsEqual(0..<capacity), true)
+}
+
+suite.test("update(fromContentsOf: Span) - BitwiseCopyable")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: Int.max, count: capacity)
+  expectEqual(a.allSatisfy({ $0 == .max }), true)
+  a.withUnsafeMutableBufferPointer {
+    let emptyPrefix = $0.prefix(0)
+    var span = MutableSpan(_unsafeElements: emptyPrefix)
+    let update = span.update(fromContentsOf: [])
+    expectEqual(update, 0)
+
+    span = MutableSpan(_unsafeElements: $0)
+    var array = Array(0..<capacity)
+    array.withUnsafeMutableBufferPointer {
+      let source = MutableSpan(_unsafeElements: $0)
+      let update = span.update(fromContentsOf: source)
+      expectEqual(update, capacity)      
+    }
+  }
+  expectEqual(a.elementsEqual(0..<capacity), true)
+}
+
+suite.test("moveUpdate()")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 8
+  var a = Array(repeating: ID(id: .max), count: capacity)
+
+  a.withUnsafeMutableBufferPointer {
+    var span = MutableSpan(_unsafeElements: $0)
+    let empty = UnsafeMutableBufferPointer(start: $0.baseAddress, count: 0)
+    let updated = span.moveUpdate(fromContentsOf: empty)
+    expectEqual(updated, 0)
+  }
+  expectEqual(a.allSatisfy({ $0.id == .max }), true)
+
+  let b = UnsafeMutableBufferPointer<ID>.allocate(capacity: 2*capacity)
+  let i = b.initialize(fromContentsOf: (0..<2*capacity).map(ID.init(id:)))
+  expectEqual(i, 2*capacity)
+
+  a.withUnsafeMutableBufferPointer {
+    var span = MutableSpan(_unsafeElements: $0)
+    let updated = span.moveUpdate(fromContentsOf: b.suffix(capacity))
+    expectEqual(updated, capacity)
+  }
+  expectEqual(a.map(\.id).elementsEqual(capacity..<2*capacity), true)
+
+  a = []
+  b.prefix(capacity).deinitialize()
+  b.deallocate()
+}
+
+suite.test("span property")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let count = 8
+  let b = UnsafeMutableBufferPointer<Int>.allocate(capacity: count)
+  _ = b.initialize(fromContentsOf: 0..<count)
+  defer { b.deallocate() }
+  let e = UnsafeBufferPointer<Int>(start: nil, count: 0)
+  defer { _ = e }
+
+  var m = MutableSpan<Int>(_unsafeElements: b)
+  m[0] = 100
+  expectEqual(m.count, count)
+  expectEqual(m[0], 100)
+
+  var s = m.span
+  expectEqual(s.count, m.count)
+  expectEqual(s[0], m[0])
+
+  // we're done using `s` before it gets reassigned
+  m.update(repeating: 7)
+
+  s = m.span
+
+//    m[0] = -1 // exclusivity violation
+
+  expectEqual(s.count, m.count)
+  expectEqual(s[0], m[0])
+}
+
+suite.test("swapAt")
+.skip(.custom(
+  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
+  reason: "Requires Swift 6.2's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let count = 8
+  var array = Array(0..<count)
+  array.withUnsafeMutableBufferPointer {
+    var m = MutableSpan(_unsafeElements: $0)
+    for i in 0..<(count/2) {
+      m.swapAt(i, count - i - 1)
+    }
+  }
+
+  expectEqual(array, (0..<count).reversed())
+}

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -573,7 +573,7 @@ suite.test("swapAt")
   expectEqual(array, (0..<count).reversed())
 }
 
-suite.test("_extracting()")
+suite.test("extracting()")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -586,25 +586,25 @@ suite.test("_extracting()")
   b.withUnsafeMutableBufferPointer {
     var span = MutableSpan(_unsafeElements: $0)
 
-    var sub = span._extracting(0..<2)
+    var sub = span.extracting(0..<2)
     expectEqual(sub.count, 2)
     expectEqual(sub[0], 0)
 
-    sub = span._extracting(..<2)
+    sub = span.extracting(..<2)
     expectEqual(sub.count, 2)
     expectEqual(sub[0], 0)
 
-    sub = span._extracting(...)
+    sub = span.extracting(...)
     expectEqual(sub.count, 4)
     expectEqual(sub[0], 0)
 
-    sub = span._extracting(2...)
+    sub = span.extracting(2...)
     expectEqual(sub.count, 2)
     expectEqual(sub[0], 2)
   }
 }
 
-suite.test("_extracting(unchecked:)")
+suite.test("extracting(unchecked:)")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -616,14 +616,14 @@ suite.test("_extracting(unchecked:)")
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBufferPointer {
     var span = MutableSpan(_unsafeElements: $0.prefix(8))
-    let beyond = span._extracting(unchecked: 16...23)
+    let beyond = span.extracting(unchecked: 16...23)
     expectEqual(beyond.count, 8)
     let fromBeyond = beyond[0]
     expectEqual(fromBeyond, 16)
   }
 }
 
-suite.test("_extracting prefixes")
+suite.test("extracting prefixes")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -638,16 +638,16 @@ suite.test("_extracting prefixes")
     var span = MutableSpan(_unsafeElements: $0)
     expectEqual(span.count, capacity)
 
-    prefix = span._extracting(first: 1)
+    prefix = span.extracting(first: 1)
     expectEqual(prefix[0], 0)
 
-    prefix = span._extracting(first: capacity)
+    prefix = span.extracting(first: capacity)
     expectEqual(prefix[capacity-1], UInt8(capacity-1))
 
-    prefix = span._extracting(droppingLast: capacity)
+    prefix = span.extracting(droppingLast: capacity)
     expectEqual(prefix.isEmpty, true)
 
-    prefix = span._extracting(droppingLast: 1)
+    prefix = span.extracting(droppingLast: 1)
     expectEqual(prefix[capacity-2], UInt8(capacity-2))
   }
 
@@ -655,12 +655,12 @@ suite.test("_extracting prefixes")
     let b = UnsafeMutableBufferPointer<Int>(start: nil, count: 0)
     var span = MutableSpan(_unsafeElements: b)
     expectEqual(span.count, b.count)
-    expectEqual(span._extracting(first: 1).count, b.count)
-    expectEqual(span._extracting(droppingLast: 1).count, b.count)
+    expectEqual(span.extracting(first: 1).count, b.count)
+    expectEqual(span.extracting(droppingLast: 1).count, b.count)
   }
 }
 
-suite.test("_extracting suffixes")
+suite.test("extracting suffixes")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -675,19 +675,19 @@ suite.test("_extracting suffixes")
     var span = MutableSpan(_unsafeElements: $0)
     expectEqual(span.count, capacity)
 
-    suffix = span._extracting(last: capacity)
+    suffix = span.extracting(last: capacity)
     expectEqual(suffix[0], 0)
 
-    suffix = span._extracting(last: capacity-1)
+    suffix = span.extracting(last: capacity-1)
     expectEqual(suffix[0], 1)
 
-    suffix = span._extracting(last: 1)
+    suffix = span.extracting(last: 1)
     expectEqual(suffix[0], UInt8(capacity-1))
 
-    suffix = span._extracting(droppingFirst: capacity)
+    suffix = span.extracting(droppingFirst: capacity)
     expectTrue(suffix.isEmpty)
 
-    suffix = span._extracting(droppingFirst: 1)
+    suffix = span.extracting(droppingFirst: 1)
     expectEqual(suffix[0], 1)
   }
 
@@ -695,7 +695,7 @@ suite.test("_extracting suffixes")
     let b = UnsafeMutableBufferPointer<ObjectIdentifier>(start: nil, count: 0)
     var span = MutableSpan(_unsafeElements: b)
     expectEqual(span.count, b.count)
-    expectEqual(span._extracting(last: 1).count, b.count)
-    expectEqual(span._extracting(droppingFirst: 1).count, b.count)
+    expectEqual(span.extracting(last: 1).count, b.count)
+    expectEqual(span.extracting(droppingFirst: 1).count, b.count)
   }
 }


### PR DESCRIPTION
Implementation of [`MutableSpan` and `MutableRawSpan`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0467-MutableSpan.md), pitched to the forums [here](https://forums.swift.org/t/77790), reviewed [here](https://forums.swift.org/t/78454), and accepted [here](https://forums.swift.org/t/78875).

Adds the `mutableSpan` properties to `Array`, `ArraySlice` and `ContiguousArray`. The other properties proposed in [SE-0467](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0467-MutableSpan.md) will be added in a separate pull request.

Addresses rdar://138440979
