### PR TITLE
IDE: Stop requiring availability platforms to be classified as keywords

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1170,8 +1170,6 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
         assert(Next.Range.getStart() == D->getRange().Start &&
                "Attribute's TokenNodes already consumed?");
       }
-    } else {
-        assert(0 && "No TokenNodes?");
     }
     if (!passTokenNodesUntil(D->getRange().End,
                              IncludeNodeAtLocation).shouldContinue)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3782,9 +3782,6 @@ ParserResult<AvailabilitySpec> Parser::parsePlatformVersionConstraintSpec() {
         Context, PlatformIdentifier, PlatformLoc, Version, VersionRange));
   }
 
-  // Register the platform name as a keyword token.
-  TokReceiver->registerTokenKindChange(PlatformLoc, tok::contextual_keyword);
-
   return makeParserResult(AvailabilitySpec::createForDomain(
       Context, AvailabilityDomain::forPlatform(Platform.value()), PlatformLoc,
       Version, VersionRange));

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -510,13 +510,13 @@ func typeAttr3(a: @ escaping () -> Int) {}
 // CHECK: <kw>func</kw> typeAttr2(a: @ <comment-block>/*this is fine...*/</comment-block> escaping () -> <type>Int</type>, b: <attr-builtin>@ escaping</attr-builtin> () -> <type>Int</type>) {}
 func typeAttr2(a: @ /*this is fine...*/ escaping () -> Int, b: @ escaping () -> Int) {}
 
-// CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+// CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
 // CHECK: <kw>var</kw> iHave = <int>10</int>, multipleVars = <int>20</int>
 @available(iOS 99, *)
 var iHave = 10, multipleVars = 20
 
 enum MultipleCaseElements {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
   // CHECK: <kw>case</kw> foo, bar
   @available(iOS 99, *)
   case foo, bar
@@ -524,7 +524,7 @@ enum MultipleCaseElements {
 
 protocol P {}
 enum E {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
   // CHECK: <kw>case</kw> a(<type>P</type>)
   @available(iOS 99, *)
   case a(P)
@@ -533,7 +533,7 @@ enum E {
 // Ideally this would be attr-builtin, but we don't actually have the attribute
 // in the AST at all.
 //
-// CHECK: <attr-id>@available</attr-id>(<kw>iOS</kw> <int>99</int>, *)
+// CHECK: <attr-id>@available</attr-id>(iOS <int>99</int>, *)
 // CHECK: <kw>var</kw> <kw>_</kw> = <int>10</int>
 @available(iOS 99, *)
 var _ = 10
@@ -558,6 +558,6 @@ struct FreeWhere<T> {
 }
 
 // Renamed attribute ('fixed' to @available by the parser after emitting an error, so not treated as a custom attribute)
-// CHECK: @availability(<kw>macOS</kw> <float>10.11</float>, *)
+// CHECK: @availability(macOS <float>10.11</float>, *)
 @availability(macOS 10.11, *)
 class HasMisspelledAttr {}

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -331,14 +331,14 @@ class NestedPoundIf {
 #line 17 "abc.swift"
 
 @available(iOS 8.0, OSX 10.10, *)
-// CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.0</float>, <kw>OSX</kw> <float>10.10</float>, *)
+// CHECK: <attr-builtin>@available</attr-builtin>(iOS <float>8.0</float>, OSX <float>10.10</float>, *)
 func foo() {
-// CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> <float>10.10</float>, <kw>iOS</kw> <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
+// CHECK: <kw>if</kw> <kw>#available</kw> (OSX <float>10.10</float>, iOS <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
   if #available (OSX 10.10, iOS 8.01, *) {let _ = "iOS"}
 }
 
 class AvailableWithOverride {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.01</float>, <kw>OSX</kw> <float>10.10</float>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <float>8.01</float>, OSX <float>10.10</float>, *)
   @available(iOS 8.01, OSX 10.10, *)
   // CHECK: <attr-builtin>public</attr-builtin> <attr-builtin>override</attr-builtin> <kw>var</kw> multiple: <type>Int</type> { <kw>return</kw> <int>24</int> }
   public override var multiple: Int { return 24 }
@@ -346,7 +346,7 @@ class AvailableWithOverride {
 
 // CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
-  // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
+  // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   // CHECK-NEW: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -3291,7 +3291,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6018,
     key.length: 5
   },

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -84,7 +84,7 @@
       key.length: 10
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 191,
       key.length: 3
     },


### PR DESCRIPTION
Don't mark platforms in `@available` attributes as keywords for syntax highlighting.