### PR TITLE
[6.1][NFC] CHANGELOG: Log new existential `any` diagnostic behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## Swift 6.1
 
+* [#78389][]:
+  Errors pertaining to the enforcement of [`any` syntax][SE-0335] on boxed
+  protocol types (aka existential types), including those produced by enabling
+  the upcoming feature `ExistentialAny`, are downgraded to warnings until a
+  future language mode.
+
+  These warnings can be escalated back to errors with `-Werror ExistentialAny`.
+
 * Projected value initializers are now correctly injected into calls when
   an argument exactly matches a parameter with an external property wrapper.
 
@@ -10714,4 +10722,5 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 [#56139]: <https://github.com/apple/swift/issues/56139>
 [#70065]: <https://github.com/apple/swift/pull/70065>
 [#71075]: <https://github.com/apple/swift/pull/71075>
+[#78389]: <https://github.com/swiftlang/swift/pull/78389>
 [swift-syntax]: https://github.com/apple/swift-syntax


### PR DESCRIPTION
  - **Explanation**: Add a changelog entry for #78389.
  - **Scope**: Changelog.
  - **Issues**: —
  - **Original PRs**: #79653.
  - **Risk**: None.
  - **Testing**: None.
  - **Reviewers**: TBD
