### PR TITLE
[SE-0458] Improve backward compatibility of generated Swift interfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2901,14 +2901,12 @@ void PrintAST::printInherited(const Decl *decl) {
         Printer << "@preconcurrency ";
       switch (inherited.getExplicitSafety()) {
       case ExplicitSafety::Unspecified:
-        break;
-
       case ExplicitSafety::Safe:
-        Printer << "@safe ";
         break;
 
       case ExplicitSafety::Unsafe:
-        Printer << "@unsafe ";
+        if (!llvm::is_contained(Options.ExcludeAttrList, TypeAttrKind::Unsafe))
+          Printer << "@unsafe ";
         break;
       }
       if (inherited.isSuppressed())
@@ -3218,6 +3216,12 @@ suppressingFeatureMemorySafetyAttributes(PrintOptions &options,
                                        llvm::function_ref<void()> action) {
   ExcludeAttrRAII scope(options.ExcludeAttrList, DeclAttrKind::Unsafe);
   ExcludeAttrRAII scope2(options.ExcludeAttrList, DeclAttrKind::Safe);
+  options.ExcludeAttrList.push_back(TypeAttrKind::Unsafe);
+  SWIFT_DEFER {
+    assert(options.ExcludeAttrList.back() == TypeAttrKind::Unsafe);
+    options.ExcludeAttrList.pop_back();
+  };
+
   action();
 }
 

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -552,6 +552,10 @@ fileprivate class RemoveUnsafeExprSyntaxRewriter: SyntaxRewriter {
   override func visit(_ node: UnsafeExprSyntax) -> ExprSyntax {
     return node.expression.with(\.leadingTrivia, node.leadingTrivia)
   }
+
+  override func visit(_ node: ForStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(node.with(\.unsafeKeyword, nil))
+  }
 }
 
 extension SyntaxProtocol {

--- a/test/Unsafe/module-interface.swift
+++ b/test/Unsafe/module-interface.swift
@@ -9,10 +9,21 @@
 // CHECK: #endif
 @unsafe public func getIntUnsafely() -> Int { 0 }
 
+public struct UnsafeIterator: @unsafe IteratorProtocol {
+  @unsafe public mutating func next() -> Int? { nil }
+}
+
+public struct SequenceWithUnsafeIterator: Sequence {
+  public init() { }
+  public func makeIterator() -> UnsafeIterator { UnsafeIterator() }
+}
+
 // CHECK: @inlinable public func useUnsafeCode()
 @inlinable public func useUnsafeCode() {
   // CHECK-NOT: unsafe
   print( unsafe getIntUnsafely())
+
+  for unsafe _ in SequenceWithUnsafeIterator() { }
 }
 
 // CHECK: public protocol P

--- a/test/Unsafe/module-interface.swift
+++ b/test/Unsafe/module-interface.swift
@@ -20,11 +20,12 @@ public protocol P {
   func f()
 }
 
+// CHECK:  #if compiler(>=5.3) && $MemorySafetyAttributes
 // CHECK: public struct X : @unsafe UserModule.P
 public struct X: @unsafe P {
-// CHECK:  #if compiler(>=5.3) && $MemorySafetyAttributes
 // CHECK:  @unsafe public func f()
 // CHECK:  #else
+// CHECK: public struct X : UserModule.P
 // CHECK:  public func f()
 // CHECK:  #endif
   @unsafe public func f() { }


### PR DESCRIPTION
Handle two cases where code making use of strict memory safety features would make it into Swift interfaces and potentially trip up older Swift compilers:
* `@unsafe` conformances, which will be placed behind a `$MemorySafeAttributes` `#if` guard
* `unsafe` effect on a `for..in` loop in inlinable code, which is removed from the interface