### PR TITLE
AST/Parse: Always delay AvailabilityDomain lookup to type-checking

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -691,13 +691,6 @@ struct BridgedAvailabilityMacroDefinition {
   BridgedArrayRef specs;
 };
 
-enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedAvailabilitySpecKind {
-  BridgedAvailabilitySpecKindPlatformVersionConstraint,
-  BridgedAvailabilitySpecKindWildcard,
-  BridgedAvailabilitySpecKindLanguageVersionConstraint,
-  BridgedAvailabilitySpecKindPackageDescriptionVersionConstraint,
-};
-
 struct BridgedAvailabilityDomain;
 
 SWIFT_NAME("BridgedAvailabilitySpec.createWildcard(_:loc:)")

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1972,13 +1972,6 @@ ERROR(avail_query_expected_version_number,PointsToFirstBadToken,
 ERROR(avail_query_expected_rparen,PointsToFirstBadToken,
       "expected ')' in availability query", ())
 
-WARNING(avail_query_unrecognized_platform_name,
-        PointsToFirstBadToken, "unrecognized platform name %0", (Identifier))
-WARNING(avail_query_suggest_platform_name,
-        PointsToFirstBadToken, "unrecognized platform name %0;"
-        " did you mean '%1'?",
-        (Identifier, StringRef))
-
 ERROR(avail_query_disallowed_operator, PointsToFirstBadToken,
       "'%0' cannot be used in an availability condition", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6738,6 +6738,16 @@ NOTE(type_eraser_init_spi,none,
 // MARK: @available
 //------------------------------------------------------------------------------
 
+ERROR(availability_must_occur_alone, none,
+      "'%0' version-availability must be specified alone", (StringRef))
+
+WARNING(availability_unrecognized_platform_name,
+        PointsToFirstBadToken, "unrecognized platform name %0", (Identifier))
+WARNING(availability_suggest_platform_name,
+        PointsToFirstBadToken, "unrecognized platform name %0;"
+        " did you mean '%1'?",
+        (Identifier, StringRef))
+
 WARNING(attr_availability_expected_deprecated_version, none,
        "expected version number with 'deprecated' in '%0' attribute for "
        "platform '%1'", (StringRef, StringRef))
@@ -6972,9 +6982,6 @@ GROUPED_WARNING(conformance_availability_deprecated,
 ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
       (Type, Type, StringRef, llvm::VersionTuple))
-
-ERROR(availability_must_occur_alone, none,
-      "'%0' version-availability must be specified alone", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: if #available(...)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2035,8 +2035,6 @@ public:
                                    SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   ParserResult<AvailabilitySpec> parseAvailabilitySpec();
-  ParserResult<AvailabilitySpec> parsePlatformVersionConstraintSpec();
-  ParserResult<AvailabilitySpec> parsePlatformAgnosticVersionConstraintSpec();
   bool
   parseAvailability(bool parseAsPartOfSpecializeAttr, StringRef AttrName,
                     bool &DiscardAttribute, SourceRange &attrRange,

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -13,7 +13,6 @@
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
@@ -234,11 +233,11 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
     auto domainString = identifier.str();
     if (auto suggestion = closestCorrectedPlatformString(domainString)) {
       diags
-          .diagnose(loc, diag::avail_query_suggest_platform_name, identifier,
+          .diagnose(loc, diag::availability_suggest_platform_name, identifier,
                     *suggestion)
           .fixItReplace(SourceRange(loc), *suggestion);
     } else {
-      diags.diagnose(loc, diag::avail_query_unrecognized_platform_name,
+      diags.diagnose(loc, diag::availability_unrecognized_platform_name,
                      identifier);
     }
     return std::nullopt;

--- a/lib/AST/Bridging/AvailabilityBridging.cpp
+++ b/lib/AST/Bridging/AvailabilityBridging.cpp
@@ -111,17 +111,22 @@ bool BridgedAvailabilitySpec_isWildcard(BridgedAvailabilitySpec spec) {
   return spec.unbridged()->isWildcard();
 }
 
+// FIXME: [availability] Remove this (re-implement ASTGen to match ParseDecl)
 BridgedAvailabilityDomain
 BridgedAvailabilitySpec_getDomain(BridgedAvailabilitySpec spec) {
-  auto domain = spec.unbridged()->getDomain();
+  auto domain = spec.unbridged()->getDomainOrIdentifier().getAsDomain();
   if (domain)
     return *domain;
   return BridgedAvailabilityDomain();
 }
 
+// FIXME: [availability] Remove this (re-implement ASTGen to match ParseDecl)
 BridgedPlatformKind
 BridgedAvailabilitySpec_getPlatform(BridgedAvailabilitySpec spec) {
-  return bridge(spec.unbridged()->getPlatform());
+  auto domain = spec.unbridged()->getDomainOrIdentifier().getAsDomain();
+  if (domain)
+    return bridge(domain->getPlatformKind());
+  return bridge(PlatformKind::none);
 }
 
 BridgedVersionTuple

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1170,8 +1170,6 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
         assert(Next.Range.getStart() == D->getRange().Start &&
                "Attribute's TokenNodes already consumed?");
       }
-    } else {
-        assert(0 && "No TokenNodes?");
     }
     if (!passTokenNodesUntil(D->getRange().End,
                              IncludeNodeAtLocation).shouldContinue)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3674,8 +3674,6 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
   }
 }
 
-
-
 /// Parse availability query specification.
 ///
 ///  availability-spec:
@@ -3690,51 +3688,7 @@ ParserResult<AvailabilitySpec> Parser::parseAvailabilitySpec() {
 
     return makeParserResult(AvailabilitySpec::createWildcard(Context, StarLoc));
   }
-  if (Tok.isIdentifierOrUnderscore() &&
-       (Tok.getText() == "swift" || Tok.getText() == "_PackageDescription"))
-      return parsePlatformAgnosticVersionConstraintSpec();
 
-  return parsePlatformVersionConstraintSpec();
-}
-
-/// Parse platform-agnostic version constraint specification.
-///
-///  language-version-constraint-spec:
-///     "swift" version-tuple
-///  package-description-version-constraint-spec:
-///     "_PackageDescription" version-tuple
-ParserResult<AvailabilitySpec>
-Parser::parsePlatformAgnosticVersionConstraintSpec() {
-  SourceLoc PlatformAgnosticNameLoc;
-  llvm::VersionTuple Version;
-  std::optional<AvailabilityDomain> Domain;
-  SourceRange VersionRange;
-
-  if (Tok.isIdentifierOrUnderscore()) {
-    if (Tok.getText() == "swift")
-      Domain = AvailabilityDomain::forSwiftLanguage();
-    else if (Tok.getText() == "_PackageDescription")
-      Domain = AvailabilityDomain::forPackageDescription();
-  }
-
-  if (!Domain.has_value())
-    return nullptr;
-
-  PlatformAgnosticNameLoc = Tok.getLoc();
-  consumeToken();
-  if (parseVersionTuple(Version, VersionRange,
-                        diag::avail_query_expected_version_number)) {
-    return nullptr;
-  }
-  return makeParserResult(AvailabilitySpec::createForDomain(
-      Context, Domain.value(), PlatformAgnosticNameLoc, Version, VersionRange));
-}
-
-/// Parse platform-version constraint specification.
-///
-///  platform-version-constraint-spec:
-///     identifier version-comparison version-tuple
-ParserResult<AvailabilitySpec> Parser::parsePlatformVersionConstraintSpec() {
   Identifier PlatformIdentifier;
   SourceLoc PlatformLoc;
   if (Tok.is(tok::code_complete)) {
@@ -3765,24 +3719,6 @@ ParserResult<AvailabilitySpec> Parser::parsePlatformVersionConstraintSpec() {
     return nullptr;
   }
 
-  std::optional<PlatformKind> Platform =
-      platformFromString(PlatformIdentifier.str());
-
-  if (!Platform.has_value() || Platform.value() == PlatformKind::none) {
-    if (auto CorrectedPlatform =
-            closestCorrectedPlatformString(PlatformIdentifier.str())) {
-      diagnose(PlatformLoc, diag::avail_query_suggest_platform_name,
-               PlatformIdentifier, *CorrectedPlatform)
-          .fixItReplace(PlatformLoc, *CorrectedPlatform);
-    } else {
-      diagnose(PlatformLoc, diag::avail_query_unrecognized_platform_name,
-               PlatformIdentifier);
-    }
-    return makeParserResult(AvailabilitySpec::createForUnknownDomain(
-        Context, PlatformIdentifier, PlatformLoc, Version, VersionRange));
-  }
-
-  return makeParserResult(AvailabilitySpec::createForDomain(
-      Context, AvailabilityDomain::forPlatform(Platform.value()), PlatformLoc,
-      Version, VersionRange));
+  return makeParserResult(AvailabilitySpec::createForDomainIdentifier(
+      Context, PlatformIdentifier, PlatformLoc, Version, VersionRange));
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3782,9 +3782,6 @@ ParserResult<AvailabilitySpec> Parser::parsePlatformVersionConstraintSpec() {
         Context, PlatformIdentifier, PlatformLoc, Version, VersionRange));
   }
 
-  // Register the platform name as a keyword token.
-  TokReceiver->registerTokenKindChange(PlatformLoc, tok::contextual_keyword);
-
   return makeParserResult(AvailabilitySpec::createForDomain(
       Context, AvailabilityDomain::forPlatform(Platform.value()), PlatformLoc,
       Version, VersionRange));

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -510,13 +510,13 @@ func typeAttr3(a: @ escaping () -> Int) {}
 // CHECK: <kw>func</kw> typeAttr2(a: @ <comment-block>/*this is fine...*/</comment-block> escaping () -> <type>Int</type>, b: <attr-builtin>@ escaping</attr-builtin> () -> <type>Int</type>) {}
 func typeAttr2(a: @ /*this is fine...*/ escaping () -> Int, b: @ escaping () -> Int) {}
 
-// CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+// CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
 // CHECK: <kw>var</kw> iHave = <int>10</int>, multipleVars = <int>20</int>
 @available(iOS 99, *)
 var iHave = 10, multipleVars = 20
 
 enum MultipleCaseElements {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
   // CHECK: <kw>case</kw> foo, bar
   @available(iOS 99, *)
   case foo, bar
@@ -524,7 +524,7 @@ enum MultipleCaseElements {
 
 protocol P {}
 enum E {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <int>99</int>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <int>99</int>, *)
   // CHECK: <kw>case</kw> a(<type>P</type>)
   @available(iOS 99, *)
   case a(P)
@@ -533,7 +533,7 @@ enum E {
 // Ideally this would be attr-builtin, but we don't actually have the attribute
 // in the AST at all.
 //
-// CHECK: <attr-id>@available</attr-id>(<kw>iOS</kw> <int>99</int>, *)
+// CHECK: <attr-id>@available</attr-id>(iOS <int>99</int>, *)
 // CHECK: <kw>var</kw> <kw>_</kw> = <int>10</int>
 @available(iOS 99, *)
 var _ = 10
@@ -558,6 +558,6 @@ struct FreeWhere<T> {
 }
 
 // Renamed attribute ('fixed' to @available by the parser after emitting an error, so not treated as a custom attribute)
-// CHECK: @availability(<kw>macOS</kw> <float>10.11</float>, *)
+// CHECK: @availability(macOS <float>10.11</float>, *)
 @availability(macOS 10.11, *)
 class HasMisspelledAttr {}

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -331,14 +331,14 @@ class NestedPoundIf {
 #line 17 "abc.swift"
 
 @available(iOS 8.0, OSX 10.10, *)
-// CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.0</float>, <kw>OSX</kw> <float>10.10</float>, *)
+// CHECK: <attr-builtin>@available</attr-builtin>(iOS <float>8.0</float>, OSX <float>10.10</float>, *)
 func foo() {
-// CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> <float>10.10</float>, <kw>iOS</kw> <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
+// CHECK: <kw>if</kw> <kw>#available</kw> (OSX <float>10.10</float>, iOS <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
   if #available (OSX 10.10, iOS 8.01, *) {let _ = "iOS"}
 }
 
 class AvailableWithOverride {
-  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.01</float>, <kw>OSX</kw> <float>10.10</float>, *)
+  // CHECK: <attr-builtin>@available</attr-builtin>(iOS <float>8.01</float>, OSX <float>10.10</float>, *)
   @available(iOS 8.01, OSX 10.10, *)
   // CHECK: <attr-builtin>public</attr-builtin> <attr-builtin>override</attr-builtin> <kw>var</kw> multiple: <type>Int</type> { <kw>return</kw> <int>24</int> }
   public override var multiple: Int { return 24 }
@@ -346,7 +346,7 @@ class AvailableWithOverride {
 
 // CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
-  // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
+  // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   // CHECK-NEW: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 

--- a/test/Sema/availability_define_parsing.swift
+++ b/test/Sema/availability_define_parsing.swift
@@ -13,6 +13,9 @@
 @available(_brokenPlatforms)
 public func brokenPlatforms() {}
 
+@available(_incorrectCase)
+public func incorrectCase() {}
+
 // CHECK: -define-availability argument:1:16: error: expected version number
 // CHECK-NEXT: _brokenParse:a b c d
 
@@ -22,17 +25,17 @@ public func brokenPlatforms() {}
 // CHECK: -define-availability argument:1:11: error: expected ':' after '_justAName' in availability macro definition
 // CHECK-NEXT: _justAName
 
-// CHECK: -define-availability argument:1:18: warning: unrecognized platform name 'spaceOS'
-// CHECK-NEXT: _brokenPlatforms:spaceOS 10.11
-
 // CHECK: -define-availability argument:1:27: error: future platforms identified by '*' cannot be used in an availability macro
 // CHECK-NEXT: _refuseWildcard
 
-// CHECK: -define-availability argument:1:16: warning: unrecognized platform name 'ios'; did you mean 'iOS'?
-// CHECK-NEXT: _incorrectCase
+// CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
+// CHECK-NEXT: _duplicateVersion
+
+// CHECK: -define-availability argument:1:18: warning: unrecognized platform name 'spaceOS'; did you mean 'macOS'?
+// CHECK-NEXT: _brokenPlatforms:spaceOS 10.11
 
 // CHECK: -define-availability argument:1:26: warning: unrecognized platform name 'macos'; did you mean 'macOS'?
 // CHECK-NEXT: _incorrectCase
 
-// CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
-// CHECK-NEXT: _duplicateVersion
+// CHECK: -define-availability argument:1:16: warning: unrecognized platform name 'ios'; did you mean 'iOS'?
+// CHECK-NEXT: _incorrectCase

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -3291,7 +3291,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6018,
     key.length: 5
   },

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -84,7 +84,7 @@
       key.length: 10
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 191,
       key.length: 3
     },

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -252,6 +252,11 @@ func shortFormWithUnrecognizedPlatform() {
 func shortFormWithTwoUnrecognizedPlatforms() {
 }
 
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, iDishwasherOS 22.0, visionOS 1.0, *)
+// expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
+func shortFormWithInteriorUnrecognizedPlatform() {
+}
+
 @available(ios 8.0, macos 10.12, *)
 // expected-warning@-1 {{unrecognized platform name 'ios'; did you mean 'iOS'?}}
 // expected-warning@-2 {{unrecognized platform name 'macos'; did you mean 'macOS'?}}


### PR DESCRIPTION
This will unblock parsing and type-checking availability queries that specify
custom availability domains, e.g.:

```
if #available(CustomDomain) {
  // Use declarations protected by @available(CustomDomain)
}
```