### PR TITLE
AST: Remove TypeBase::isOpenedExistential()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -792,12 +792,6 @@ public:
     return getRecursiveProperties().hasOpaqueArchetype();
   }
 
-  /// Determine whether the type is an opened existential type.
-  ///
-  /// To determine whether there is an opened existential type
-  /// anywhere in the type, use \c hasOpenedExistential.
-  bool isOpenedExistential() const;
-
   /// Determine whether the type is an opened existential type with Error inside
   bool isOpenedExistentialWithError();
 
@@ -7930,14 +7924,6 @@ inline bool TypeBase::isClassExistentialType() {
   if (auto existential = dyn_cast<ExistentialType>(T))
     return existential->requiresClass();
   return false;
-}
-
-inline bool TypeBase::isOpenedExistential() const {
-  if (!hasOpenedExistential())
-    return false;
-
-  CanType T = getCanonicalType();
-  return isa<OpenedArchetypeType>(T);
 }
 
 inline bool TypeBase::canDynamicallyBeOptionalType(bool includeExistential) {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -452,12 +452,6 @@ public:
     return getASTType()->isClassExistentialType();
   }
 
-  /// Returns true if the referenced type is an opened existential type
-  /// (which is actually a kind of archetype).
-  bool isOpenedExistential() const {
-    return getASTType()->isOpenedExistential();
-  }
-
   /// Returns true if the referenced type is expressed in terms of one
   /// or more opened existential archetypes.
   bool hasOpenedExistential() const {

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -436,7 +436,7 @@ bool MemoryLocations::analyzeAddrProjection(
       // open_existential_addr).
       if (!isa<OpenExistentialAddrInst>(loc->representativeValue))
         return false;
-      assert(loc->representativeValue->getType().isOpenedExistential());
+      assert(loc->representativeValue->getType().is<OpenedArchetypeType>());
       loc->representativeValue = projection;
     }
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3204,13 +3204,12 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
   if (baseType->isAnyExistentialType()) {
     // Use the opened archetype from the AST for a protocol member, or make a
     // new one (which we'll upcast immediately below) for a class member.
-    ArchetypeType *opened;
+    OpenedArchetypeType *opened;
     if (storage->getDeclContext()->getSelfClassDecl()) {
       opened = OpenedArchetypeType::get(baseType);
     } else {
-      opened = subs.getReplacementTypes()[0]->castTo<ArchetypeType>();
+      opened = subs.getReplacementTypes()[0]->castTo<OpenedArchetypeType>();
     }
-    assert(opened->isOpenedExistential());
 
     FormalEvaluationScope scope(subSGF);
     
@@ -3657,8 +3656,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
 
     // Open an existential lvalue, if necessary.
     if (baseType->isAnyExistentialType()) {
-      auto opened = subs.getReplacementTypes()[0]->castTo<ArchetypeType>();
-      assert(opened->isOpenedExistential());
+      auto opened = subs.getReplacementTypes()[0]->castTo<OpenedArchetypeType>();
       baseType = opened->getCanonicalType();
       lv = subSGF.emitOpenExistentialLValue(loc, std::move(lv),
                                             CanArchetypeType(opened),

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -802,7 +802,7 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
     /// and that the protocol type has a sole conformance, then we can propagate
     /// concrete type for it as well.
     ArchetypeType *archetypeTy;
-    if (SwiftArgType->isOpenedExistential() &&
+    if (isa<OpenedArchetypeType>(SwiftArgType) &&
         (archetypeTy = dyn_cast<ArchetypeType>(SwiftArgType)) &&
         (archetypeTy->getConformsTo().size() == 1)) {
       PD = archetypeTy->getConformsTo()[0];
@@ -1116,7 +1116,7 @@ SILValue SILCombiner::canCastArg(FullApplySite Apply,
                                  const OpenedArchetypeInfo &OAI,
                                  const ConcreteExistentialInfo &CEI,
                                  unsigned ArgIdx) {
-  if (!CEI.ConcreteValue || CEI.ConcreteType->isOpenedExistential() ||
+  if (!CEI.ConcreteValue || isa<OpenedArchetypeType>(CEI.ConcreteType) ||
       !CEI.ConcreteValue->getType().isAddress())
     return SILValue();
 
@@ -1378,7 +1378,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
 
   // If the lookup type is not an opened existential type,
   // it cannot be made more concrete.
-  if (!WMI->getLookupType()->isOpenedExistential())
+  if (!isa<OpenedArchetypeType>(WMI->getLookupType()))
     return nullptr;
 
   // Try to derive the concrete type and the related conformance of self and

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -655,7 +655,6 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
   // their definitions.
   if (IEI && !OEI &&
       !IEI->getLoweredConcreteType().hasOpenedExistential()) {
-    assert(!IEI->getLoweredConcreteType().isOpenedExistential());
     Builder.setCurrentDebugScope(AS->getDebugScope());
     auto varInfo = AS->getVarInfo();
     if (varInfo) {

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -285,7 +285,7 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
 /// ConcreteTypeDef to the definition of that type.
 void ConcreteExistentialInfo::initializeConcreteTypeDef(
     SILInstruction *typeConversionInst) {
-  if (!ConcreteType->isOpenedExistential())
+  if (!isa<OpenedArchetypeType>(ConcreteType))
     return;
 
   assert(isValid());


### PR DESCRIPTION
Back in 2015 (22179164aab58f5899531455dbf5587dc4507aea), OpenedArchetypeType did not exist as a separate subclass of ArchetypeType, so this method did something. Now, it's just equivalent to calling `is<>` or `isa<>`.

I also removed a couple of asserts that were obvious no-ops as a result.