### PR TITLE
[cxx-interop] Interpret Self as a static shorthand for FRTs

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3017,6 +3017,10 @@ namespace {
               /*Obsoleted=*/{});
           classDecl->getAttrs().add(AvAttr);
         }
+
+        if (decl->isEffectivelyFinal())
+          classDecl->getAttrs().add(new (Impl.SwiftContext)
+                                    FinalAttr(/*IsImplicit=*/true));
       }
 
       // If this module is declared as a C++ module, try to synthesize

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -709,7 +709,8 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
         if (DeclContext *typeContext = DC->getInnermostTypeContext()){
           Type SelfType = typeContext->getSelfInterfaceType();
 
-          if (typeContext->getSelfClassDecl())
+          if (typeContext->getSelfClassDecl() &&
+              !typeContext->getSelfClassDecl()->isForeignReferenceType())
             SelfType = DynamicSelfType::get(SelfType, Context);
           return new (Context)
               TypeExpr(new (Context) SelfTypeRepr(SelfType, Loc));

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1680,8 +1680,7 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
     return SelfTypeKind::StaticSelf;
 
   // For foreign reference types `Self` is a shorthand for the nominal type.
-  if (typeDC->getSelfClassDecl() &&
-      typeDC->getSelfClassDecl()->isForeignReferenceType())
+  if (typeDC->getSelfClassDecl()->isForeignReferenceType())
     return SelfTypeKind::StaticSelf;
 
   // In class methods, 'Self' is the DynamicSelfType and can only appear in

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1679,6 +1679,11 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
   if (!typeDC->getSelfClassDecl())
     return SelfTypeKind::StaticSelf;
 
+  // For foreign reference types `Self` is a shorthand for the nominal type.
+  if (typeDC->getSelfClassDecl() &&
+      typeDC->getSelfClassDecl()->isForeignReferenceType())
+    return SelfTypeKind::StaticSelf;
+
   // In class methods, 'Self' is the DynamicSelfType and can only appear in
   // the return type.
   switch (options.getBaseContext()) {

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -109,7 +109,7 @@ DerivedFromValueTypeAndAnnotated *returnDerivedFromValueTypeAndAnnotated() { // 
     return new DerivedFromValueTypeAndAnnotated();
 }
 
-struct DerivedFromRefType : RefType {};
+struct DerivedFromRefType final : RefType {};
 DerivedFromRefType *returnDerivedFromRefType() {
     return new DerivedFromRefType();
 }
@@ -180,7 +180,7 @@ __attribute__((swift_attr("release:RCRelease"))) RefType {};
 
 RefType *returnRefType() { return new RefType(); }; // expected-warning {{'returnRefType' should be annotated with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED as it is returning a SWIFT_SHARED_REFERENC}}
 
-struct DerivedFromRefType : RefType {};
+struct DerivedFromRefType final : RefType {};
 DerivedFromRefType *returnDerivedFromRefType() { // TODO: rdar://145098078 Missing SWIFT_RETURNS_(UN)RETAINED annotation warning should trigger for inferred foreeign reference types as well
   return new DerivedFromRefType();
 };

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -14,7 +14,7 @@ namespace NS {
 
 struct __attribute__((swift_attr("import_as_ref")))
 __attribute__((swift_attr("retain:LCRetain")))
-__attribute__((swift_attr("release:LCRelease"))) LocalCount {
+__attribute__((swift_attr("release:LCRelease"))) LocalCount final {
   int value = 0;
 
   static LocalCount *create() {

--- a/test/Interop/Cxx/foreign-reference/extensions.swift
+++ b/test/Interop/Cxx/foreign-reference/extensions.swift
@@ -1,26 +1,50 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking -Onone)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
 // REQUIRES: executable_test
+
+// Metadata for foreign reference types is not supported on Windows.
+// UNSUPPORTED: OS=windows-msvc
 
 import ReferenceCounted
 
 protocol MyProto {
+    static func g()
     func foo() -> Self
+    func bar(_ x: Self)
+    func baz()
+}
+
+extension NS.LocalCount: MyProto {
+    static func g() {
+        print("Static method g called")
+    }
+
+    public func foo() -> Self {
+        Self.g()
+        return self
+    }
+
+    public func bar(_ x: Self) {
+    }
+}
+
+extension MyProto {
+    func baz() {
+        Self.g()
+    }
 }
 
 extension NS.LocalCount {
-    static func g() {}
-
     public func f() {
         Self.g()
     }
 }
 
-extension NS.LocalCount: MyProto {
-    public func foo() -> Self {
-        return self
-    }
-}
 
 let x = NS.LocalCount.create()
 x.f()
+// CHECK: Static method g called
 let _ = x.foo()
+// CHECK-NEXT: Static method g called
+let _ = x.baz()
+// CHECK-NEXT: Static method g called
+x.bar(x)

--- a/test/Interop/Cxx/foreign-reference/extensions.swift
+++ b/test/Interop/Cxx/foreign-reference/extensions.swift
@@ -1,0 +1,12 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking -Onone)
+// REQUIRES: executable_test
+
+import ReferenceCounted
+
+extension NS.LocalCount {
+    static func g() {}
+
+    public func f() {
+        Self.g()
+    }
+}

--- a/test/Interop/Cxx/foreign-reference/extensions.swift
+++ b/test/Interop/Cxx/foreign-reference/extensions.swift
@@ -3,6 +3,10 @@
 
 import ReferenceCounted
 
+protocol MyProto {
+    func foo() -> Self
+}
+
 extension NS.LocalCount {
     static func g() {}
 
@@ -10,3 +14,13 @@ extension NS.LocalCount {
         Self.g()
     }
 }
+
+extension NS.LocalCount: MyProto {
+    public func foo() -> Self {
+        return self
+    }
+}
+
+let x = NS.LocalCount.create()
+x.f()
+let _ = x.foo()


### PR DESCRIPTION
We do not have dynamic self metadata for foreign reference types.

rdar://145066864
