### PR TITLE
Sema: Fix Sendable generic parameter fixit

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2475,15 +2475,13 @@ static void addSendableFixIt(const NominalTypeDecl *nominal,
 /// Add Fix-It text for the given generic param declaration type to adopt
 /// Sendable.
 static void addSendableFixIt(const GenericTypeParamDecl *genericArgument,
-                             InFlightDiagnostic &diag, bool unchecked) {
+                             InFlightDiagnostic &diag) {
   if (genericArgument->getInherited().empty()) {
     auto fixItLoc = genericArgument->getLoc();
-    diag.fixItInsertAfter(fixItLoc,
-                          unchecked ? ": @unchecked Sendable" : ": Sendable");
+    diag.fixItInsertAfter(fixItLoc, ": Sendable");
   } else {
     auto fixItLoc = genericArgument->getInherited().getEndLoc();
-    diag.fixItInsertAfter(fixItLoc,
-                          unchecked ? ", @unchecked Sendable" : ", Sendable");
+    diag.fixItInsertAfter(fixItLoc, " & Sendable");
   }
 }
 
@@ -2664,7 +2662,7 @@ void NonSendableIsolationCrossingResultDiagnosticEmitter::emit() {
           genericParamTypeDecl->getModuleContext() == moduleDecl) {
         auto diag = genericParamTypeDecl->diagnose(
             diag::rbi_add_generic_parameter_sendable_conformance, type);
-        addSendableFixIt(genericParamTypeDecl, diag, /*unchecked=*/false);
+        addSendableFixIt(genericParamTypeDecl, diag);
         return;
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -767,15 +767,13 @@ static void addSendableFixIt(
 /// Add Fix-It text for the given generic param declaration type to adopt
 /// Sendable.
 static void addSendableFixIt(const GenericTypeParamDecl *genericArgument,
-                             InFlightDiagnostic &diag, bool unchecked) {
+                             InFlightDiagnostic &diag) {
   if (genericArgument->getInherited().empty()) {
     auto fixItLoc = genericArgument->getLoc();
-    diag.fixItInsertAfter(fixItLoc,
-                          unchecked ? ": @unchecked Sendable" : ": Sendable");
+    diag.fixItInsertAfter(fixItLoc, ": Sendable");
   } else {
     auto fixItLoc = genericArgument->getInherited().getEndLoc();
-    diag.fixItInsertAfter(fixItLoc,
-                          unchecked ? ", @unchecked Sendable" : ", Sendable");
+    diag.fixItInsertAfter(fixItLoc, " & Sendable");
   }
 }
 
@@ -1022,7 +1020,7 @@ static bool diagnoseSingleNonSendableType(
             genericParamTypeDecl->getModuleContext() == module) {
           auto diag = genericParamTypeDecl->diagnose(
               diag::add_generic_parameter_sendable_conformance, type);
-          addSendableFixIt(genericParamTypeDecl, diag, /*unchecked=*/false);
+          addSendableFixIt(genericParamTypeDecl, diag);
         }
       }
     }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -131,7 +131,10 @@ protocol P {
   func foo2<T : Sendable>(x : T) async -> ()
 
   func bar2<T>(x : T) async -> ()
-  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{14-14=: Sendable}}
+
+  func bar3<T: Equatable>(x : T) async -> ()
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{25-25= & Sendable}}
 }
 
 // Make sure conformance to protocols checks sendability of
@@ -147,6 +150,9 @@ protocol P {
 
   func bar2<T>(x : T) -> () {}
   // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
+
+  func bar3<T: Equatable>(x : T) -> () {}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar3(x:)' into actor-isolated implementation}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -163,7 +169,11 @@ class Super {
 
   @MainActor
   func bar2<T>(x: T) async {}
-  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{14-14=: Sendable}}
+
+  @MainActor
+  func bar3<T: Equatable>(x: T) async {}
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{25-25= & Sendable}}
 }
 
 // Make sure isolation crossing overrides check sendability
@@ -179,6 +189,9 @@ class Sub : Super {
 
   override nonisolated func bar2<T>(x: T) async {}
   // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar2(x:)' into nonisolated override}}
+
+  override nonisolated func bar3<T>(x: T) async {}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar3(x:)' into nonisolated override}}
 }
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
We were changing `<T: Foo>` into `<T: Foo, Sendable>` which is incorrect. Also remove the unused ability to insert `@unchecked Sendable` for a generic parameter which is not valid.

Fixes rdar://problem/144644342.