### PR TITLE
utils: track CPU load for build steps in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3274,6 +3274,8 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-XML2 Windows $HostArch
   Invoke-BuildStep Build-Compilers $HostArch
 
+  Plot-CPUUsage -maxLines 50
+
   foreach ($Arch in $WindowsSDKArchs) {
     Invoke-BuildStep Build-ZLib Windows $Arch
     Invoke-BuildStep Build-XML2 Windows $Arch


### PR DESCRIPTION
Tracking CPU utilization during the build might help to identify bottlenecks and reduce wall time