### PR TITLE
Add a test for index of overriding an Objc protocol method in Swift

### DIFF
--- a/test/Index/index_imported_objc.swift
+++ b/test/Index/index_imported_objc.swift
@@ -42,3 +42,9 @@ func test() { // CHECK: [[@LINE]]:6 | function/Swift | test() | [[s:.*]] | Def |
   c.protocolAddedMethod()
   // CHECK: [[@LINE-1]]:5 | instance-method/Swift | protocolAddedMethod() | c:objc(pl)MemberAdding(im)protocolAddedMethod | Ref,Call,Dyn,RelRec,RelCall,RelCont | rel: 2 
 }
+class SubObjCClass: ObjCClass {
+  override func protocolAddedMethod() {}
+  // CHECK: [[@LINE-1]]:17 | instance-method/Swift | protocolAddedMethod() | c:@M@swift_ide_test@objc(cs)SubObjCClass(im)protocolAddedMethod | Def,Dyn,RelChild,RelOver | rel: 2
+  // CHECK-NEXT: RelOver | instance-method/Swift | protocolAddedMethod() | c:objc(pl)MemberAdding(im)protocolAddedMethod
+  // CHECK-NEXT: RelChild | class/Swift | SubObjCClass | c:@M@swift_ide_test@objc(cs)SubObjCClass
+}


### PR DESCRIPTION
There is a regression in the index outputs in this scenario in Swift 6.0 and it wasn't detected by the existing test suite. Fortunately, the regression is resolved in Swift 6.1 and forward. I don't know which change(s) resolved the missing data.

The regression is that the "override of" relationship on the overriding declaration, in Swift, was missing. The declaration is overriding _something_, since it requires the `override` annotation, so linking to the declaration that it's overriding seems appropriate.

I propose adding this test to provide additional coverage