### PR TITLE
[Diagnostics] Reference markdown files for educational notes and diagnostic group documentation

### DIFF
--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -28,6 +28,9 @@ void swift_ASTGen_addQueuedSourceFile(
 void swift_ASTGen_addQueuedDiagnostic(
     void *_Nonnull queued, const char *_Nonnull text, ptrdiff_t textLength,
     BridgedDiagnosticSeverity severity, const void *_Nullable sourceLoc,
+    const char *_Nullable categoryName, ptrdiff_t categoryNameLength,
+    const char *_Nullable documentationPath,
+    ptrdiff_t documentationPathLength,
     const void *_Nullable *_Nullable highlightRanges,
     ptrdiff_t numHighlightRanges);
 void swift_ASTGen_renderQueuedDiagnostics(

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -64,9 +64,17 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
     highlightRanges.push_back(range.getEnd().getOpaquePointerValue());
   }
 
+  StringRef documentationPath;
+  if (info.EducationalNotePaths.size() > 0)
+    documentationPath = info.EducationalNotePaths[0];
+
   // FIXME: Translate Fix-Its.
   swift_ASTGen_addQueuedDiagnostic(queuedDiagnostics, text.data(), text.size(),
                                    severity, info.Loc.getOpaquePointerValue(),
+                                   info.Category.data(),
+                                   info.Category.size(),
+                                   documentationPath.data(),
+                                   documentationPath.size(),
                                    highlightRanges.data(),
                                    highlightRanges.size() / 2);
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1337,6 +1337,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
 
   auto groupID = diagnostic.getGroupID();
   StringRef Category;
+  const char * const *associatedNotes = nullptr;
   if (isAPIDigesterBreakageDiagnostic(diagnostic.getID()))
     Category = "api-digester-breaking-change";
   else if (isNoUsageDiagnostic(diagnostic.getID()))
@@ -1345,6 +1346,10 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
     Category = getDiagGroupInfoByID(groupID).name;
   else if (isDeprecationDiagnostic(diagnostic.getID()))
     Category = "deprecation";
+  else if ((associatedNotes = educationalNotes[(uint32_t)diagnostic.getID()]) &&
+           *associatedNotes) {
+    Category = llvm::sys::path::stem(*associatedNotes);
+  }
 
   auto fixIts = diagnostic.getFixIts();
   if (loc.isValid()) {

--- a/test/diagnostics/educational_notes_serialization.swift
+++ b/test/diagnostics/educational_notes_serialization.swift
@@ -7,13 +7,13 @@
 
 typealias Fn = () -> ()
 extension Fn {}
-// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Fn' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] []
+// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Fn' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] [nominal-types]
 
 
 // Shares the flag record with `Fn`
 typealias Dup = () -> ()
 extension Dup {}
-// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Dup' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] []
+// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Dup' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] [nominal-types]
 
 do {
   func noNote(_: Int) {}


### PR DESCRIPTION
Start including diagnostic category and category documentation in diagnostics. These are rendered by the updated diagnostic formatter as a reference like `[#StrictMemorySafety]`. That reference will be a link to the Markdown documentation in the toolchain:
```
t.swift:2:7: warning: expression uses unsafe constructs but is not marked with 'unsafe' [#StrictMemorySafety]
1 | func somethingUnsafe(x: Int) {
2 |   _ = UnsafeRawPointer(bitPattern: x)
  |       |- warning: expression uses unsafe constructs but is not marked with 'unsafe' [#StrictMemorySafety]
  |       |- note: reference to unsafe type 'UnsafeRawPointer'
  |       |- note: reference to initializer 'init(bitPattern:)' involves unsafe type 'UnsafeRawPointer'
  |       `- note: @unsafe conformance of 'UnsafeRawPointer' to protocol '_Pointer' involves unsafe code
3 | }
4 | 
```
