### PR TITLE
[cxx-interop] Avoid warnings in strict memory safe mode on in generated code

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -599,7 +599,7 @@ struct CountedOrSizedPointerThunkBuilder: ParamPointerBoundsThunkBuilder {
     let unwrappedCall = ExprSyntax(
       """
         \(ptrRef).\(raw: funcName) { \(unwrappedName) in
-          return \(call)
+          return unsafe \(call)
         }
       """)
     return unwrappedCall
@@ -660,7 +660,7 @@ struct CountedOrSizedPointerThunkBuilder: ParamPointerBoundsThunkBuilder {
         return ExprSyntax(
           """
             if \(name) == nil {
-              \(try base.buildFunctionCall(nullArgs))
+              unsafe \(try base.buildFunctionCall(nullArgs))
             } else {
               \(unwrappedCall)
             }
@@ -1142,7 +1142,7 @@ public struct SwiftifyImportMacro: PeerMacro {
         item: CodeBlockItemSyntax.Item(
           ReturnStmtSyntax(
             returnKeyword: .keyword(.return, trailingTrivia: " "),
-            expression: try builder.buildFunctionCall([:]))))
+            expression: ExprSyntax("unsafe \(try builder.buildFunctionCall([:]))"))))
       let body = CodeBlockSyntax(statements: CodeBlockItemListSyntax(checks + [call]))
       let lifetimeAttrs = lifetimeAttributes(funcDecl, lifetimeDependencies)
       let disfavoredOverload : [AttributeListSyntax.Element] = (onlyReturnTypeChanged ? [

--- a/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
@@ -12,6 +12,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
 // CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, size, count)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt, _ ptr2: UnsafePointer<CInt>
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
@@ -8,6 +8,6 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -9,8 +9,8 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: MutableSpan<CInt>) {
-// CHECK-NEXT:     return ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
@@ -28,31 +28,31 @@ func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func ptrNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return ptrNamed(ptr: ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe ptrNamed(ptr: ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func ptrNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return ptrNamedOther(buf: ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe ptrNamedOther(buf: ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func lenNamed(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return lenNamed(ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe lenNamed(ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func lenNamedOther(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return lenNamedOther(ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe lenNamedOther(ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func allNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return allNamed(ptr: ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe allNamed(ptr: ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient
 // CHECK-NEXT: func allNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return allNamedOther(buf: ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe allNamedOther(buf: ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafePointer<CInt>?, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
-// CHECK-NEXT:     return myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -21,22 +21,22 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-// CHECK-NEXT:     return UnsafeMutableBufferPointer<CInt> (start: myFunc(len), count: Int(len))
+// CHECK-NEXT:     return unsafe UnsafeMutableBufferPointer<CInt> (start: myFunc(len), count: Int(len))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
-// CHECK-NEXT:     return UnsafeBufferPointer<CInt> (start: nonEscaping(len), count: Int(len))
+// CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: nonEscaping(len), count: Int(len))
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(p)
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return Span<CInt> (_unsafeStart:   p.withUnsafeBufferPointer { _pPtr in
-// CHECK-NEXT:         return lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: p.count)!, len2)
+// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart:   p.withUnsafeBufferPointer { _pPtr in
+// CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: p.count)!, len2)
 // CHECK-NEXT:       }, count: Int(len2))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p)
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return Span<CInt> (_unsafeStart: lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
+// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart: lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
@@ -12,12 +12,12 @@ func bar(_ ptr: Swift.UnsafePointer<Swift.CInt>, _ len: Swift.Int) -> () {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func foo(_ ptr: Swift.UnsafeBufferPointer<Swift.Int>) -> Swift.Void {
-// CHECK-NEXT:     return foo(ptr.baseAddress!, ptr.count)
+// CHECK-NEXT:     return unsafe foo(ptr.baseAddress!, ptr.count)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func bar(_ ptr: Swift.UnsafeBufferPointer<Swift.CInt>) -> () {
-// CHECK-NEXT:     return bar(ptr.baseAddress!, ptr.count)
+// CHECK-NEXT:     return unsafe bar(ptr.baseAddress!, ptr.count)
 // CHECK-NEXT: }
 
 

--- a/test/Macros/SwiftifyImport/CountedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Return.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) -> CInt {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
@@ -16,5 +16,5 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt
 // CHECK-NEXT:     if ptr2.count < _ptr2Count || _ptr2Count < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, ptr2.baseAddress!, len)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -8,7 +8,7 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) {
-// CHECK-NEXT:     return ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -8,7 +8,7 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) -> CInt {
-// CHECK-NEXT:     return ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -8,8 +8,8 @@ func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CIn
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return ptr1.withUnsafeBufferPointer { _ptr1Ptr in
-// CHECK-NEXT:         return myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: ptr1.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
+// CHECK-NEXT:         return unsafe myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: ptr1.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -8,6 +8,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -2,7 +2,7 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-frontend %s -enable-experimental-cxx-interop -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -enable-experimental-cxx-interop -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -dump-macro-expansions -verify -strict-memory-safety 2>&1 | %FileCheck --match-full-lines %s
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -35,25 +35,25 @@ struct X {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(span)
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc(SpanOfInt(span))))
+// CHECK-NEXT:     return unsafe _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc(SpanOfInt(span))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
-// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc2(vec)))
+// CHECK-NEXT:     return unsafe _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc2(vec)))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(span1, span2)
 // CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2))))
+// CHECK-NEXT:     return unsafe _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, span)
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span))))
+// CHECK-NEXT:     return unsafe _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span))))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self) @_disfavoredOverload
 // CHECK-NEXT: func myFunc5() -> Span<CInt> {
-// CHECK-NEXT:     return _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc5()))
+// CHECK-NEXT:     return unsafe _unsafeRemoveLifetime(Span(_unsafeCxxSpan: myFunc5()))
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -12,5 +12,5 @@ func myFunc(_ span: SpanOfInt, _ secondSpan: SpanOfInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>, _ secondSpan: SpanOfInt) {
-// CHECK-NEXT:     return myFunc(SpanOfInt(span), secondSpan)
+// CHECK-NEXT:     return unsafe myFunc(SpanOfInt(span), secondSpan)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ ptr2: UnsafeRawPointer, _ s
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableRawBufferPointer) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -9,7 +9,7 @@ func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: MutableRawSpan) {
-// CHECK-NEXT:     return ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafeRawPointer?, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     return myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -30,41 +30,41 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nonnullUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     return nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     return unsafe nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), CInt(exactly: ptr?.count ?? 0)!)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nonnullSpan(_ ptr: RawSpan) {
-// CHECK-NEXT:     return ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nullableSpan(_ ptr: RawSpan?) {
-// CHECK-NEXT:     return if ptr == nil {
-// CHECK-NEXT:         nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:     return unsafe if ptr == nil {
+// CHECK-NEXT:         unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
 // CHECK-NEXT:     } else {
 // CHECK-NEXT:         ptr!.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:             return nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:             return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func impNullableSpan(_ ptr: RawSpan) {
-// CHECK-NEXT:     return ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/SizedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Return.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) -> CInt {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
@@ -16,5 +16,5 @@ func myFunc(_ ptr: UnsafeRawPointer, _ ptr2: UnsafeRawPointer, _ size: CInt) {
 // CHECK-NEXT:     if ptr2.count < _ptr2Count || _ptr2Count < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, ptr2.baseAddress!, size)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -8,7 +8,7 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) {
-// CHECK-NEXT:     return ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -8,7 +8,7 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) -> CInt {
-// CHECK-NEXT:     return ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
@@ -8,5 +8,5 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
@@ -12,5 +12,5 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ count: CInt) {
 // CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, size, count)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -8,6 +8,6 @@ func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
 


### PR DESCRIPTION
The generated safe wrappers need to call unsafe code. Make sure those calls are qualified with unsafe to avoid warnings that are not actionable (users cannot fix them).
