### PR TITLE
[cxx-interop] Fix circular reference, remove feature flag check

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -80,9 +80,7 @@ __attribute__((swift_attr("release:immortal"))) ImmortalRefType {};
 
 ImmortalRefType *returnImmortalRefType() { return new ImmortalRefType(); };
 
-// Doubt: Is it fine to not infer in the case of SWIFT_IMMORTAL_REFERENCE
-// rdar://145193396
-struct DerivedFromImmortalRefType : ImmortalRefType {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'DerivedFromImmortalRefType', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+struct DerivedFromImmortalRefType : ImmortalRefType {};
 DerivedFromImmortalRefType *returnDerivedFromImmortalRefType() {
     return new DerivedFromImmortalRefType();
 };
@@ -284,7 +282,8 @@ __attribute__((swift_attr("retain:sameretain")))
 __attribute__((swift_attr("release:samerelease"))) B2 {};  // expected-error {{multiple functions 'sameretain' found; there must be exactly one retain function for reference type 'B2'}}
                                                             // expected-error@-1 {{multiple functions 'samerelease' found; there must be exactly one release function for reference type 'B2'}}
 
-struct D : B1, B2 {}; // expected-warning {{unable to infer SWIFT_SHARED_REFERENCE for 'D', although one of its transitive base types is marked as SWIFT_SHARED_REFERENCE}}
+struct D : B1, B2 {}; // expected-error {{multiple functions 'sameretain' found; there must be exactly one retain function for reference type 'D'}}
+                      // expected-error@-1 {{multiple functions 'samerelease' found; there must be exactly one release function for reference type 'D'}}
 D *returnD() { return new D(); };
 } // namespace OverloadedRetainRelease
 

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -50,7 +50,7 @@ FrtInheritanceTestSuite.test("ParentChild") {
 
   let derivedFromImmortalRefType = ImmortalRefereceExample.returnDerivedFromImmortalRefType()
   expectTrue(
-    !(type(of: derivedFromImmortalRefType) is AnyObject.Type),
+    type(of: derivedFromImmortalRefType) is AnyObject.Type,
     "Expected derivedFromImmortalRefType to be a value type, but it’s a reference type")
 
   let valType = ExplicitAnnotationHasPrecedence1.returnValueType()


### PR DESCRIPTION
It turns out the query to check the reference semantics of a type had the side effect of importing some functions/types. This could introduce circular reference errors with our queries. This PR removes this side effect from the query and updates the test files. Since we do the same work later on in another query, the main change is just the wording of the diagnostics (and we now can also infer immortal references based on the base types). This PR also reorders some operations, specifically now we mark base classes as imported before we attempt to import template arguments.

After these changes it is possible to remove the last feature check for strict memory safe mode. We want to mark types as @unsafe in both language modes so we can diagnose redundant unsafe markers even when the feature is off.
