### PR TITLE
[cxx-importer] Do not import pointers to non-escapable types

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -39,6 +39,7 @@
 
 namespace clang {
 class NamedDecl;
+class Type;
 }
 
 namespace swift {
@@ -150,7 +151,8 @@ namespace swift {
     ActorIsolation,
     IsolationSource,
     Diagnostic,
-    ClangDecl
+    ClangDecl,
+    ClangType,
   };
 
   namespace diag {
@@ -188,6 +190,7 @@ namespace swift {
       IsolationSource IsolationSourceVal;
       DiagnosticInfo *DiagnosticVal;
       const clang::NamedDecl *ClangDecl;
+      const clang::Type *ClangType;
     };
     
   public:
@@ -310,6 +313,9 @@ namespace swift {
 
     DiagnosticArgument(const clang::NamedDecl *ND)
         : Kind(DiagnosticArgumentKind::ClangDecl), ClangDecl(ND) {}
+
+    DiagnosticArgument(const clang::Type *Ty)
+        : Kind(DiagnosticArgumentKind::ClangType), ClangType(Ty) {}
 
     /// Initializes a diagnostic argument using the underlying type of the
     /// given enum.
@@ -440,6 +446,11 @@ namespace swift {
     const clang::NamedDecl *getAsClangDecl() const {
       assert(Kind == DiagnosticArgumentKind::ClangDecl);
       return ClangDecl;
+    }
+
+    const clang::Type *getAsClangType() const {
+      assert(Kind == DiagnosticArgumentKind::ClangType);
+      return ClangType;
     }
   };
 
@@ -1796,6 +1807,7 @@ namespace swift {
   }
 
   void printClangDeclName(const clang::NamedDecl *ND, llvm::raw_ostream &os);
+  void printClangTypeName(const clang::Type *Ty, llvm::raw_ostream &os);
 
   /// Temporary on-stack storage and unescaping for encoded diagnostic
   /// messages.

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -365,5 +365,9 @@ NOTE(bridged_pointer_type_not_found,none,
      "for bridging; module 'Swift' may be broken",
      (unsigned))
 
+NOTE(ptr_to_nonescapable,none,
+     "pointer to non-escapable type %0 cannot be imported",
+     (const clang::Type*))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -39,6 +39,8 @@
 #include "swift/Parse/Lexer.h" // bad dependency
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/PrettyPrinter.h"
+#include "clang/AST/Type.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
@@ -752,6 +754,11 @@ void swift::printClangDeclName(const clang::NamedDecl *ND,
   ND->getNameForDiagnostic(os, ND->getASTContext().getPrintingPolicy(), false);
 }
 
+void swift::printClangTypeName(const clang::Type *Ty, llvm::raw_ostream &os) {
+  clang::QualType::print(Ty, clang::Qualifiers(), os,
+                         clang::PrintingPolicy{clang::LangOptions()}, "");
+}
+
 /// Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier,
@@ -1092,6 +1099,13 @@ static void formatDiagnosticArgument(StringRef Modifier,
     assert(Modifier.empty() && "Improper modifier for ClangDecl argument");
     Out << FormatOpts.OpeningQuotationMark;
     printClangDeclName(Arg.getAsClangDecl(), Out);
+    Out << FormatOpts.ClosingQuotationMark;
+    break;
+
+  case DiagnosticArgumentKind::ClangType:
+    assert(Modifier.empty() && "Improper modifier for ClangDecl argument");
+    Out << FormatOpts.OpeningQuotationMark;
+    printClangTypeName(Arg.getAsClangType(), Out);
     Out << FormatOpts.ClosingQuotationMark;
     break;
   }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -480,6 +480,17 @@ namespace {
       if (pointeeQualType->isDependentType())
         return Type();
 
+      // FIXME: remove workaround once Unsafe*Pointer supports
+      //        nonescapable pointees.
+      if (evaluateOrDefault(
+              Impl.SwiftContext.evaluator,
+              ClangTypeEscapability({pointeeQualType.getTypePtr(), nullptr}),
+              CxxEscapability::Unknown) == CxxEscapability::NonEscapable) {
+        addImportDiagnostic(Diagnostic(diag::ptr_to_nonescapable,
+                                       pointeeQualType.getTypePtr()));
+        return Type();
+      }
+
       // All other C pointers to concrete types map to
       // UnsafeMutablePointer<T> or OpaquePointer.
 

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -91,6 +91,10 @@ using OwnerVector = std::vector<Owner>;
 ViewVector l1();
 OwnerVector l2();
 
+const View* usedToCrash(const View* p) {
+    return p;
+}
+
 //--- test.swift
 import Test
 import CxxStdlib
@@ -139,11 +143,23 @@ public func noAnnotations() -> View {
     // CHECK: nonescapable.h:77:12: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
     // CHECK-NO-LIFETIMES: nonescapable.h:77:12: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     l2();
-    // CHECK-NOT: error
-    // CHECK-NOT: warning
     return View()
     // CHECK-NO-LIFETIMES: nonescapable.h:5:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     // CHECK-NO-LIFETIMES: nonescapable.h:6:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
+}
+
+public func test3(_ x: inout View) {
+    usedToCrash(&x)
+    // CHECK: error: cannot find 'usedToCrash' in scope
+    // CHECK: note: function 'usedToCrash' unavailable (cannot import)
+    // CHECK: note: return type unavailable (cannot import)
+    // CHECK: pointer to non-escapable type 'View' cannot be imported
+    // CHECK-NO-LIFETIMES: error: cannot find 'usedToCrash' in scope
+    // CHECK-NO-LIFETIMES: note: function 'usedToCrash' unavailable (cannot import)
+    // CHECK-NO-LIFETIMES: note: return type unavailable (cannot import)
+    // CHECK-NO-LIFETIMES: pointer to non-escapable type 'View' cannot be imported
+}
+    // CHECK-NOT: error
+    // CHECK-NOT: warning
     // CHECK-NO-LIFETIMES-NOT: error
     // CHECK-NO-LIFETIMES-NOT: warning
-}


### PR DESCRIPTION
Unfortunately, Unsafe*Pointer types do not support non-escapable pointees so we do not really have anything to map these types to at the moment. Previously, importing such code resulted in crashes.

rdar://145800679