### PR TITLE
Add support for bounds check optimization of Span and InlineArray

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -160,5 +160,8 @@ SEMANTICS_ATTR(DELETE_IF_UNUSED, "sil.optimizer.delete_if_unused")
 // Force the use of the frame pointer for the specified function
 SEMANTICS_ATTR(USE_FRAME_POINTER, "use_frame_pointer")
 
+SEMANTICS_ATTR(FIXED_STORAGE_CHECK_INDEX, "fixed_storage.check_index")
+SEMANTICS_ATTR(FIXED_STORAGE_GET_COUNT, "fixed_storage.get_count")
+
 #undef SEMANTICS_ATTR
 

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_WRAPPERTYPES_H
 #define SWIFT_SIL_WRAPPERTYPES_H
 
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 
 namespace swift {
@@ -361,6 +362,43 @@ public:
   // operation.
   bool visitForwardedValues(function_ref<bool(SILValue)> visitor);
 };
+
+enum class FixedStorageSemanticsCallKind { None, CheckIndex, GetCount };
+
+struct FixedStorageSemanticsCall {
+  ApplyInst *apply = nullptr;
+  FixedStorageSemanticsCallKind kind = FixedStorageSemanticsCallKind::None;
+
+  FixedStorageSemanticsCall(SILInstruction *input) {
+    auto *applyInst = dyn_cast<ApplyInst>(input);
+    if (!applyInst) {
+      return;
+    }
+    auto *callee = applyInst->getReferencedFunctionOrNull();
+    if (!callee) {
+      return;
+    }
+    for (auto &attr : callee->getSemanticsAttrs()) {
+      if (attr == "fixed_storage.check_index") {
+        apply = applyInst;
+        kind = FixedStorageSemanticsCallKind::CheckIndex;
+        break;
+      } else if (attr == "fixed_storage.get_count") {
+        apply = applyInst;
+        kind = FixedStorageSemanticsCallKind::GetCount;
+        break;
+      }
+    }
+  }
+
+  FixedStorageSemanticsCallKind getKind() const { return kind; }
+  explicit operator bool() const { return apply != nullptr; }
+  const ApplyInst *operator->() const { return apply; }
+  ApplyInst *operator->() { return apply; }
+};
+
+bool isFixedStorageSemanticsCallKind(SILFunction *function);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -86,8 +86,8 @@
 
 SWIFT_FUNCTION_PASS(AliasInfoDumper, "dump-alias-info",
      "Dump Alias Analysis over all Pairs")
-PASS(ABCOpt, "abcopts",
-     "Array Bounds Check Optimization")
+PASS(BoundsCheckOpts, "bcopts",
+     "Bounds Check Optimization")
 PASS(AccessEnforcementDom, "access-enforcement-dom",
      "Remove dominated access checks with no nested conflict")
 PASS(AccessEnforcementOpts, "access-enforcement-opts",

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1448,11 +1448,11 @@ bool SILInstruction::isTriviallyDuplicatable() const {
   if (auto *PA = dyn_cast<PartialApplyInst>(this)) {
     return !PA->isOnStack();
   }
-  // Like partial_apply [onstack], mark_dependence [nonescaping] creates a
-  // borrow scope. We currently assume that a set of dominated scope-ending uses
-  // can be found.
+  // Like partial_apply [onstack], mark_dependence [nonescaping] on values
+  // creates a borrow scope. We currently assume that a set of dominated
+  // scope-ending uses can be found.
   if (auto *MD = dyn_cast<MarkDependenceInst>(this)) {
-    return !MD->isNonEscaping();
+    return !MD->isNonEscaping() || MD->getType().isAddress();
   }
 
   if (isa<OpenExistentialAddrInst>(this) || isa<OpenExistentialRefInst>(this) ||

--- a/lib/SIL/Utils/InstWrappers.cpp
+++ b/lib/SIL/Utils/InstWrappers.cpp
@@ -99,3 +99,13 @@ bool ForwardingOperation::visitForwardedValues(
     return visitor(args[0]);
   });
 }
+
+bool swift::isFixedStorageSemanticsCallKind(SILFunction *function) {
+  for (auto &attr : function->getSemanticsAttrs()) {
+    if (attr == "fixed_storage.check_index" ||
+        attr == "fixed_storage.get_count") {
+      return true;
+    }
+  }
+  return false;
+}

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -1,8 +1,8 @@
-//===--- ArrayBoundsCheckOpts.cpp - Bounds check elim ---------------------===//
+//===--- BoundsCheckOpts.cpp - Bounds check elimination -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "sil-abcopts"
+#define DEBUG_TYPE "sil-bcopts"
 
 #include "swift/AST/Builtins.h"
 #include "swift/Basic/Assertions.h"
@@ -52,15 +52,11 @@
 using namespace swift;
 using namespace PatternMatch;
 
-static llvm::cl::opt<bool> ShouldReportBoundsChecks("sil-abcopts-report",
-                                              llvm::cl::init(false));
-
-static llvm::cl::opt<bool> EnableABCOpts("enable-abcopts",
-                                         llvm::cl::init(true));
+static llvm::cl::opt<bool> ShouldReportBoundsChecks("sil-bcopts-report",
+                                                    llvm::cl::init(false));
 
 static llvm::cl::opt<bool> EnableABCHoisting("enable-abc-hoisting",
                                              llvm::cl::init(true));
-
 
 using ArraySet = llvm::SmallPtrSet<SILValue, 16>;
 // A pair of the array pointer and the array check kind (kCheckIndex or
@@ -278,9 +274,8 @@ private:
       return;
     }
 
-    assert(Array ||
-           K == ArrayCallKind::kNone &&
-               "Need to have an array for array semantic functions");
+    assert(Array || K == ArrayCallKind::kNone &&
+                        "Need to have an array for array semantic functions");
 
     // We need to make sure that the array container is not aliased in ways
     // that we don't understand.
@@ -311,16 +306,14 @@ getArrayIndexPair(SILValue Array, SILValue ArrayIndex, ArrayCallKind K) {
           K == ArrayCallKind::kCheckSubscript) &&
          "Must be a bounds check call");
   return std::make_pair(
-      Array,
-      ArrayAccessDesc(ArrayIndex, K == ArrayCallKind::kCheckIndex));
+      Array, ArrayAccessDesc(ArrayIndex, K == ArrayCallKind::kCheckIndex));
 }
 
-
 static CondFailInst *hasCondFailUse(SILValue V) {
-    for (auto *Op : V->getUses())
-      if (auto C = dyn_cast<CondFailInst>(Op->getUser()))
-        return C;
-    return nullptr;
+  for (auto *Op : V->getUses())
+    if (auto C = dyn_cast<CondFailInst>(Op->getUser()))
+      return C;
+  return nullptr;
 }
 
 /// Checks whether the apply instruction is checked for overflow by looking for
@@ -357,8 +350,7 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
       if (match(CF->getOperand(),
                 m_ApplyInst(BuiltinValueKind::Xor,
                             m_ApplyInst(BuiltinValueKind::ICMP_SLE,
-                                        m_Specific(Start),
-                                        m_Specific(End)),
+                                        m_Specific(Start), m_Specific(End)),
                             m_One())))
         return true;
       // Try to match a cond_fail on "SLT End, Start".
@@ -378,8 +370,7 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
           IsPreInclusiveEndLEQ = true;
         if (match(CF->getOperand(),
                   m_ApplyInst(BuiltinValueKind::ICMP_SLT,
-                              m_Specific(PreInclusiveEnd),
-                              m_Specific(Start))))
+                              m_Specific(PreInclusiveEnd), m_Specific(Start))))
           IsPreInclusiveEndLEQ = true;
         if (match(CF->getOperand(),
                   m_ApplyInst(BuiltinValueKind::Xor,
@@ -408,35 +399,55 @@ static bool isLessThan(SILValue Start, SILValue End) {
 
 static BuiltinValueKind swapCmpID(BuiltinValueKind ID) {
   switch (ID) {
-    case BuiltinValueKind::ICMP_EQ: return BuiltinValueKind::ICMP_EQ;
-    case BuiltinValueKind::ICMP_NE: return BuiltinValueKind::ICMP_NE;
-    case BuiltinValueKind::ICMP_SLE: return BuiltinValueKind::ICMP_SGE;
-    case BuiltinValueKind::ICMP_SLT: return BuiltinValueKind::ICMP_SGT;
-    case BuiltinValueKind::ICMP_SGE: return BuiltinValueKind::ICMP_SLE;
-    case BuiltinValueKind::ICMP_SGT: return BuiltinValueKind::ICMP_SLT;
-    case BuiltinValueKind::ICMP_ULE: return BuiltinValueKind::ICMP_UGE;
-    case BuiltinValueKind::ICMP_ULT: return BuiltinValueKind::ICMP_UGT;
-    case BuiltinValueKind::ICMP_UGE: return BuiltinValueKind::ICMP_ULE;
-    case BuiltinValueKind::ICMP_UGT: return BuiltinValueKind::ICMP_ULT;
-    default:
-      return ID;
+  case BuiltinValueKind::ICMP_EQ:
+    return BuiltinValueKind::ICMP_EQ;
+  case BuiltinValueKind::ICMP_NE:
+    return BuiltinValueKind::ICMP_NE;
+  case BuiltinValueKind::ICMP_SLE:
+    return BuiltinValueKind::ICMP_SGE;
+  case BuiltinValueKind::ICMP_SLT:
+    return BuiltinValueKind::ICMP_SGT;
+  case BuiltinValueKind::ICMP_SGE:
+    return BuiltinValueKind::ICMP_SLE;
+  case BuiltinValueKind::ICMP_SGT:
+    return BuiltinValueKind::ICMP_SLT;
+  case BuiltinValueKind::ICMP_ULE:
+    return BuiltinValueKind::ICMP_UGE;
+  case BuiltinValueKind::ICMP_ULT:
+    return BuiltinValueKind::ICMP_UGT;
+  case BuiltinValueKind::ICMP_UGE:
+    return BuiltinValueKind::ICMP_ULE;
+  case BuiltinValueKind::ICMP_UGT:
+    return BuiltinValueKind::ICMP_ULT;
+  default:
+    return ID;
   }
 }
 
 static BuiltinValueKind invertCmpID(BuiltinValueKind ID) {
   switch (ID) {
-    case BuiltinValueKind::ICMP_EQ: return BuiltinValueKind::ICMP_NE;
-    case BuiltinValueKind::ICMP_NE: return BuiltinValueKind::ICMP_EQ;
-    case BuiltinValueKind::ICMP_SLE: return BuiltinValueKind::ICMP_SGT;
-    case BuiltinValueKind::ICMP_SLT: return BuiltinValueKind::ICMP_SGE;
-    case BuiltinValueKind::ICMP_SGE: return BuiltinValueKind::ICMP_SLT;
-    case BuiltinValueKind::ICMP_SGT: return BuiltinValueKind::ICMP_SLE;
-    case BuiltinValueKind::ICMP_ULE: return BuiltinValueKind::ICMP_UGT;
-    case BuiltinValueKind::ICMP_ULT: return BuiltinValueKind::ICMP_UGE;
-    case BuiltinValueKind::ICMP_UGE: return BuiltinValueKind::ICMP_ULT;
-    case BuiltinValueKind::ICMP_UGT: return BuiltinValueKind::ICMP_ULE;
-    default:
-      return ID;
+  case BuiltinValueKind::ICMP_EQ:
+    return BuiltinValueKind::ICMP_NE;
+  case BuiltinValueKind::ICMP_NE:
+    return BuiltinValueKind::ICMP_EQ;
+  case BuiltinValueKind::ICMP_SLE:
+    return BuiltinValueKind::ICMP_SGT;
+  case BuiltinValueKind::ICMP_SLT:
+    return BuiltinValueKind::ICMP_SGE;
+  case BuiltinValueKind::ICMP_SGE:
+    return BuiltinValueKind::ICMP_SLT;
+  case BuiltinValueKind::ICMP_SGT:
+    return BuiltinValueKind::ICMP_SLE;
+  case BuiltinValueKind::ICMP_ULE:
+    return BuiltinValueKind::ICMP_UGT;
+  case BuiltinValueKind::ICMP_ULT:
+    return BuiltinValueKind::ICMP_UGE;
+  case BuiltinValueKind::ICMP_UGE:
+    return BuiltinValueKind::ICMP_ULT;
+  case BuiltinValueKind::ICMP_UGT:
+    return BuiltinValueKind::ICMP_ULE;
+  default:
+    return ID;
   }
 }
 
@@ -446,11 +457,11 @@ static SILValue getZeroToCountArray(SILValue Start, SILValue End) {
   auto *IL = dyn_cast<IntegerLiteralInst>(Start);
   if (!IL || IL->getValue() != 0)
     return SILValue();
-    
+
   auto *SEI = dyn_cast<StructExtractInst>(End);
   if (!SEI)
     return SILValue();
-    
+
   ArraySemanticsCall SemCall(SEI->getOperand());
   if (SemCall.getKind() != ArrayCallKind::kGetCount)
     return SILValue();
@@ -471,30 +482,30 @@ static bool isLessThanCheck(SILValue Start, SILValue End,
 
   SILValue LeftArg = BI->getOperand(0);
   SILValue RightArg = BI->getOperand(1);
-  
+
   if (RightArg == Start) {
     std::swap(LeftArg, RightArg);
     Id = swapCmpID(Id);
   }
   if (LeftArg != Start || RightArg != End)
     return false;
-  
+
   if (CondBr->getTrueBB() != Preheader) {
     assert(CondBr->getFalseBB() == Preheader);
     Id = invertCmpID(Id);
   }
-  
+
   switch (Id) {
-    case BuiltinValueKind::ICMP_SLT:
-    case BuiltinValueKind::ICMP_ULT:
-      return true;
-    case BuiltinValueKind::ICMP_NE:
-      // Special case: if it is a 0-to-count loop, we know that the count cannot
-      // be negative. In this case the 'Start < End' check can also be done with
-      // 'count != 0'.
-      return getZeroToCountArray(Start, End);
-    default:
-      return false;
+  case BuiltinValueKind::ICMP_SLT:
+  case BuiltinValueKind::ICMP_ULT:
+    return true;
+  case BuiltinValueKind::ICMP_NE:
+    // Special case: if it is a 0-to-count loop, we know that the count cannot
+    // be negative. In this case the 'Start < End' check can also be done with
+    // 'count != 0'.
+    return getZeroToCountArray(Start, End);
+  default:
+    return false;
   }
 }
 
@@ -577,12 +588,12 @@ struct InductionInfo {
 
   SILInstruction *getInstruction() { return Inc; }
 
-  SILValue getFirstValue(SILLocation &Loc, SILBuilder &B, unsigned AddVal) {
-    return AddVal != 0 ? getAdd(Loc, Start, AddVal, B) : Start;
+  SILValue getFirstValue(SILLocation loc, SILBuilder &B, unsigned AddVal) {
+    return AddVal != 0 ? getAdd(loc, Start, AddVal, B) : Start;
   }
 
-  SILValue getLastValue(SILLocation &Loc, SILBuilder &B, unsigned SubVal) {
-    return SubVal != 0 ? getSub(Loc, End, SubVal, B) : End;
+  SILValue getLastValue(SILLocation loc, SILBuilder &B, unsigned SubVal) {
+    return SubVal != 0 ? getSub(loc, End, SubVal, B) : End;
   }
 
   /// If necessary insert an overflow for this induction variable.
@@ -633,9 +644,6 @@ public:
       : DT(D), Preheader(Preheader), Header(Header), ExitingBlk(ExitingBlk),
         ExitBlk(ExitBlk), IVs(IVs) {}
 
-  InductionAnalysis(const InductionAnalysis &) = delete;
-  InductionAnalysis &operator=(const InductionAnalysis &) = delete;
-
   bool analyze() {
     bool FoundIndVar = false;
     for (auto *Arg : Header->getArguments()) {
@@ -648,8 +656,8 @@ public:
 
       InductionInfo *Info;
       if (!(Info = analyzeIndVar(Arg, IV.Inc, IV.IncVal))) {
-        LLVM_DEBUG(llvm::dbgs() << " could not analyze the induction on: "
-                                << *Arg);
+        LLVM_DEBUG(llvm::dbgs()
+                   << " could not analyze the induction on: " << *Arg);
         continue;
       }
 
@@ -661,14 +669,13 @@ public:
   }
 
   InductionInfo *operator[](SILArgument *A) {
-    InductionInfoMap::iterator It =  Map.find(A);
+    InductionInfoMap::iterator It = Map.find(A);
     if (It == Map.end())
       return nullptr;
     return It->second;
   }
 
 private:
-
   /// Analyze one potential induction variable starting at Arg.
   InductionInfo *analyzeIndVar(SILArgument *HeaderVal, BuiltinInst *Inc,
                                IntegerLiteralInst *IncVal) {
@@ -710,9 +717,9 @@ private:
     if (!dominates(DT, End, Preheader))
       return nullptr;
 
-    LLVM_DEBUG(llvm::dbgs() << " found an induction variable (ICMP_EQ): "
-                            << *HeaderVal << "  start: " << *Start
-                            << "  end: " << *End);
+    LLVM_DEBUG(llvm::dbgs()
+               << " found an induction variable (ICMP_EQ): " << *HeaderVal
+               << "  start: " << *Start << "  end: " << *End);
 
     // Check whether the addition is overflow checked by a cond_fail or whether
     // code in the preheader's predecessor ensures that we won't overflow.
@@ -749,7 +756,6 @@ class AccessFunction {
       : Ind(I), preIncrement(isPreIncrement) {}
 
 public:
-
   operator bool() { return Ind != nullptr; }
 
   static AccessFunction getLinearFunction(SILValue Idx,
@@ -771,8 +777,7 @@ public:
     if (!ArrayIndexStruct)
       return nullptr;
 
-    auto AsArg =
-        dyn_cast<SILArgument>(ArrayIndexStruct->getElements()[0]);
+    auto AsArg = dyn_cast<SILArgument>(ArrayIndexStruct->getElements()[0]);
 
     if (!AsArg) {
       auto *TupleExtract =
@@ -805,16 +810,15 @@ public:
     return nullptr;
   }
 
-  /// Returns true if the loop iterates from 0 until count of \p ArrayVal.
-  bool isZeroToCount(SILValue ArrayVal) {
-    return getZeroToCountArray(Ind->Start, Ind->End) == ArrayVal;
+  /// Returns true if the loop iterates from 0 until count of \p selfValue.
+  bool isZeroToCount(SILValue selfValue) {
+    return getZeroToCountOfSelf(Ind->Start, Ind->End) == selfValue;
   }
 
   /// Hoists the necessary check for beginning and end of the induction
   /// encapsulated by this access function to the header.
   void hoistCheckToPreheader(ArraySemanticsCall CheckToHoist,
-                             SILBasicBlock *Preheader,
-                             DominanceInfo *DT) {
+                             SILBasicBlock *Preheader, DominanceInfo *DT) {
     ApplyInst *AI = CheckToHoist;
     SILLocation Loc = AI->getLoc();
     SILBuilderWithScope Builder(Preheader->getTerminator(), AI);
@@ -827,7 +831,7 @@ public:
     // Set the new start index to the first value of the induction.
     Start->setOperand(0, FirstVal);
 
-      // Clone and fixup the load, retain sequence to the header.
+    // Clone and fixup the load, retain sequence to the header.
     auto NewCheck = CheckToHoist.copyTo(Preheader->getTerminator(), DT);
     NewCheck->setOperand(1, Start);
 
@@ -931,7 +935,7 @@ static constexpr int maxRecursionDepth = 500;
 
 /// Remove redundant checks in basic blocks and hoist redundant checks out of
 /// loops.
-class ABCOpt : public SILFunctionTransform {
+class BoundsCheckOpts : public SILFunctionTransform {
 private:
   SILLoopInfo *LI;
   DominanceInfo *DT;
@@ -939,118 +943,129 @@ private:
   RCIdentityFunctionInfo *RCIA;
   DestructorAnalysis *DestAnalysis;
   // Arrays with element type that does not call a deinit function.
-  ArraySet ReleaseSafeArrays;
+  ArraySet releaseSafeArrays;
+
+  /// Collect all release safe arrays in this function. A release is only 'safe'
+  /// if we know its deinitializer does not have sideeffects that could cause
+  /// memory safety issues. A deinit could deallocate array or put a different
+  /// array in its location.
+  void collectReleaseSafeArrays();
+
+  bool optimizeBoundsChecksInBlocks();
+
+  bool optimizeBoundsChecksInLoops();
+
+  std::pair<bool, std::optional<InductionAnalysis>>
+  findAndOptimizeInductionVariables(SILLoop *loop);
+
+  bool optimizeArrayBoundsCheckInLoop(SILLoop *loop,
+                                      std::optional<InductionAnalysis> indVars);
 
   /// Remove redundant checks in a basic block. This function will reset the
   /// state after an instruction that may modify any array allowing removal of
   /// redundant checks up to that point and after that point.
-  bool removeRedundantChecksInBlock(SILBasicBlock &BB);
+  bool removeRedundantArrayChecksInBlock(SILBasicBlock &BB);
   /// Hoist or remove redundant bound checks in \p Loop
-  bool processLoop(SILLoop *Loop);
+  bool optimizeArrayBoundsCheckInLoop(SILLoop *Loop);
   /// Walk down the dominator tree inside the loop, removing redundant checks.
-  bool removeRedundantChecksInLoop(DominanceInfoNode *CurBB, ABCAnalysis &ABC,
-                                   IndexedArraySet &DominatingSafeChecks,
-                                   SILLoop *Loop,
-                                   int recursionDepth);
+  bool removeRedundantArrayBoundsChecksInLoop(
+      DominanceInfoNode *CurBB, ABCAnalysis &ABC,
+      IndexedArraySet &DominatingSafeChecks, SILLoop *Loop, int recursionDepth);
   /// Analyze the loop for arrays that are not modified and perform dominator
   /// tree based redundant bounds check removal.
-  bool hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
-                         InductionAnalysis &IndVars, SILBasicBlock *Preheader,
-                         SILBasicBlock *Header,
-                         SILBasicBlock *SingleExitingBlk,
-                         int recursionDepth);
+  bool hoistArrayBoundsChecksInLoop(SILLoop *loop,
+                                    DominanceInfoNode *currentNode,
+                                    ABCAnalysis &abcAnalysis,
+                                    InductionAnalysis &indVars,
+                                    int recursionDepth);
 
 public:
   void run() override {
-    if (!EnableABCOpts)
-      return;
-
-    SILFunction *F = getFunction();
-    LI = PM->getAnalysis<SILLoopAnalysis>()->get(F);
-    DT = PM->getAnalysis<DominanceAnalysis>()->get(F);
-    IVs = PM->getAnalysis<IVAnalysis>()->get(F);
-    RCIA = PM->getAnalysis<RCIdentityAnalysis>()->get(F);
+    bool changed = false;
+    SILFunction *func = getFunction();
+    LI = PM->getAnalysis<SILLoopAnalysis>()->get(func);
+    DT = PM->getAnalysis<DominanceAnalysis>()->get(func);
+    IVs = PM->getAnalysis<IVAnalysis>()->get(func);
+    RCIA = PM->getAnalysis<RCIdentityAnalysis>()->get(func);
     DestAnalysis = PM->getAnalysis<DestructorAnalysis>();
 
 #ifndef NDEBUG
     if (ShouldReportBoundsChecks) {
-      reportBoundsChecks(F);
+      reportBoundsChecks(func);
     }
 #endif
     LLVM_DEBUG(llvm::dbgs()
-               << "ArrayBoundsCheckOpts on function: " << F->getName() << "\n");
-    // Collect all arrays in this function. A release is only 'safe' if we know
-    // its deinitializer does not have sideeffects that could cause memory
-    // safety issues. A deinit could deallocate array or put a different array
-    // in its location.
-    for (auto &BB : *F) {
-      for (auto &Inst : BB) {
-        ArraySemanticsCall Call(&Inst);
-        if (Call && Call.hasSelf()) {
-          LLVM_DEBUG(llvm::dbgs() << "Gathering " << *(ApplyInst *)Call);
-          auto rcRoot = RCIA->getRCIdentityRoot(Call.getSelf());
-          // Check the type of the array. We need to have an array element type
-          // that is not calling a deinit function.
-          if (DestAnalysis->mayStoreToMemoryOnDestruction(rcRoot->getType()))
-            continue;
-          LLVM_DEBUG(llvm::dbgs() << "ReleaseSafeArray: " << rcRoot << "\n");
-          ReleaseSafeArrays.insert(rcRoot);
-          ReleaseSafeArrays.insert(
-              getArrayStructPointer(ArrayCallKind::kCheckIndex, rcRoot));
-        }
-      }
-    }
-    // Remove redundant checks on a per basic block basis.
-    bool Changed = false;
-    for (auto &BB : *F)
-      Changed |= removeRedundantChecksInBlock(BB);
+               << "BoundsCheckOpts on function: " << func->getName() << "\n");
+
+    collectReleaseSafeArrays();
+    changed |= optimizeBoundsChecksInBlocks();
+    changed |= optimizeBoundsChecksInLoops();
 
 #ifndef NDEBUG
     if (ShouldReportBoundsChecks) {
-      reportBoundsChecks(F);
+      reportBoundsChecks(func);
     }
 #endif
 
-    if (LI->empty()) {
-      LLVM_DEBUG(llvm::dbgs() << "No loops in " << F->getName() << "\n");
-      if (Changed) {
-        PM->invalidateAnalysis(
-            F, SILAnalysis::InvalidationKind::CallsAndInstructions);
-      }
-      return;
-    }
-    // Remove redundant checks along the dominator tree in a loop and hoist
-    // checks.
-    for (auto *LoopIt : *LI) {
-      // Process loops recursively bottom-up in the loop tree.
-      SmallVector<SILLoop *, 8> Worklist;
-      Worklist.push_back(LoopIt);
-      for (unsigned i = 0; i < Worklist.size(); ++i) {
-        auto *L = Worklist[i];
-        for (auto *SubLoop : *L)
-          Worklist.push_back(SubLoop);
-      }
-
-      while (!Worklist.empty()) {
-        Changed |= processLoop(Worklist.pop_back_val());
-      }
-    }
-
-#ifndef NDEBUG
-    if (ShouldReportBoundsChecks) {
-      reportBoundsChecks(F);
-    }
-#endif
-
-    if (Changed) {
+    if (changed) {
       PM->invalidateAnalysis(
-          F, SILAnalysis::InvalidationKind::CallsAndInstructions);
+          func, SILAnalysis::InvalidationKind::CallsAndInstructions);
     }
   }
 };
 
-bool ABCOpt::removeRedundantChecksInBlock(SILBasicBlock &BB) {
-  ABCAnalysis ABC(false, ReleaseSafeArrays, RCIA);
+void BoundsCheckOpts::collectReleaseSafeArrays() {
+  auto *func = getFunction();
+
+  for (auto &block : *func) {
+    for (auto &inst : block) {
+      ArraySemanticsCall semanticsCall(&inst);
+      if (!semanticsCall || !semanticsCall.hasSelf()) {
+        continue;
+      }
+      LLVM_DEBUG(llvm::dbgs() << "Gathering " << *(ApplyInst *)semanticsCall);
+      auto rcRoot = RCIA->getRCIdentityRoot(semanticsCall.getSelf());
+      // Check the type of the array. We need to have an array element type
+      // that is not calling a deinit function.
+      if (DestAnalysis->mayStoreToMemoryOnDestruction(rcRoot->getType()))
+        continue;
+      LLVM_DEBUG(llvm::dbgs() << "ReleaseSafeArray: " << rcRoot << "\n");
+      releaseSafeArrays.insert(rcRoot);
+      releaseSafeArrays.insert(
+          getArrayStructPointer(ArrayCallKind::kCheckIndex, rcRoot));
+    }
+  }
+}
+
+bool BoundsCheckOpts::optimizeBoundsChecksInBlocks() {
+  bool changed = false;
+  for (auto &block : *getFunction()) {
+    changed |= removeRedundantArrayChecksInBlock(block);
+  }
+  return changed;
+}
+
+bool BoundsCheckOpts::optimizeBoundsChecksInLoops() {
+  bool changed = false;
+  // Process loops recursively bottom-up in the loop tree.
+  for (auto *loop : *LI) {
+    SmallVector<SILLoop *, 8> worklist;
+    worklist.push_back(loop);
+    for (unsigned i = 0; i < worklist.size(); ++i) {
+      for (auto *subLoop : *worklist[i]) {
+        worklist.push_back(subLoop);
+      }
+    }
+
+    while (!worklist.empty()) {
+      changed |= optimizeArrayBoundsCheckInLoop(worklist.pop_back_val());
+    }
+  }
+  return changed;
+}
+
+bool BoundsCheckOpts::removeRedundantArrayChecksInBlock(SILBasicBlock &BB) {
+  ABCAnalysis ABC(false, releaseSafeArrays, RCIA);
   IndexedArraySet RedundantChecks;
   bool Changed = false;
 
@@ -1075,7 +1090,6 @@ bool ABCOpt::removeRedundantChecksInBlock(SILBasicBlock &BB) {
     auto Kind = ArrayCall.getKind();
     if (Kind != ArrayCallKind::kCheckSubscript &&
         Kind != ArrayCallKind::kCheckIndex) {
-      LLVM_DEBUG(llvm::dbgs() << " not a check_bounds call " << *Inst);
       continue;
     }
     auto Array = ArrayCall.getSelf();
@@ -1113,11 +1127,9 @@ bool ABCOpt::removeRedundantChecksInBlock(SILBasicBlock &BB) {
   return Changed;
 }
 
-bool ABCOpt::removeRedundantChecksInLoop(DominanceInfoNode *CurBB,
-                                         ABCAnalysis &ABC,
-                                         IndexedArraySet &DominatingSafeChecks,
-                                         SILLoop *Loop,
-                                         int recursionDepth) {
+bool BoundsCheckOpts::removeRedundantArrayBoundsChecksInLoop(
+    DominanceInfoNode *CurBB, ABCAnalysis &ABC,
+    IndexedArraySet &DominatingSafeChecks, SILLoop *Loop, int recursionDepth) {
   auto *BB = CurBB->getBlock();
   if (!Loop->contains(BB))
     return false;
@@ -1142,7 +1154,6 @@ bool ABCOpt::removeRedundantChecksInLoop(DominanceInfoNode *CurBB,
     auto Kind = ArrayCall.getKind();
     if (Kind != ArrayCallKind::kCheckSubscript &&
         Kind != ArrayCallKind::kCheckIndex) {
-      LLVM_DEBUG(llvm::dbgs() << " not a check_bounds call " << *Inst);
       continue;
     }
     auto Array = ArrayCall.getSelf();
@@ -1178,9 +1189,8 @@ bool ABCOpt::removeRedundantChecksInLoop(DominanceInfoNode *CurBB,
 
   // Traverse the children in the dominator tree inside the loop.
   for (auto Child : *CurBB)
-    Changed |=
-        removeRedundantChecksInLoop(Child, ABC, DominatingSafeChecks, Loop,
-        recursionDepth + 1);
+    Changed |= removeRedundantArrayBoundsChecksInLoop(
+        Child, ABC, DominatingSafeChecks, Loop, recursionDepth + 1);
 
   // Remove checks we have seen for the first time.
   std::for_each(SafeChecksToPop.begin(), SafeChecksToPop.end(),
@@ -1191,162 +1201,197 @@ bool ABCOpt::removeRedundantChecksInLoop(DominanceInfoNode *CurBB,
   return Changed;
 }
 
-bool ABCOpt::processLoop(SILLoop *Loop) {
-  auto *Header = Loop->getHeader();
-  if (!Header)
+bool BoundsCheckOpts::optimizeArrayBoundsCheckInLoop(SILLoop *loop) {
+  auto *header = loop->getHeader();
+  if (!header) {
     return false;
+  }
 
-  auto *Preheader = Loop->getLoopPreheader();
-  if (!Preheader) {
+  auto *preheader = loop->getLoopPreheader();
+  if (!preheader) {
     // TODO: create one if necessary.
     return false;
   }
 
   // Only handle innermost loops for now.
-  if (!Loop->getSubLoops().empty())
+  if (!loop->getSubLoops().empty()) {
     return false;
+  }
 
-  LLVM_DEBUG(llvm::dbgs() << "Attempting to remove redundant checks in "
-                          << *Loop);
+  LLVM_DEBUG(
+      llvm::dbgs() << "Attempting to remove redundant array bounds checks in "
+                   << *loop);
 
   // Collect safe arrays. Arrays are safe if there is no function call that
   // could mutate their size in the loop.
-  ABCAnalysis ABC(true, ReleaseSafeArrays, RCIA);
-  for (auto *BB : Loop->getBlocks()) {
+  ABCAnalysis ABC(true, releaseSafeArrays, RCIA);
+  for (auto *BB : loop->getBlocks()) {
     ABC.analyzeBlock(BB);
   }
 
-  // Remove redundant checks down the dominator tree inside the loop,
-  // starting at the header.
-  // We may not go to dominated blocks outside the loop, because we didn't
-  // check for safety outside the loop (with ABCAnalysis).
-  IndexedArraySet DominatingSafeChecks;
-  bool Changed = removeRedundantChecksInLoop(DT->getNode(Header), ABC,
-                                             DominatingSafeChecks, Loop,
-                                             /*recursionDepth*/ 0);
+  bool changed = false;
+  auto result = findAndOptimizeInductionVariables(loop);
+  changed |= result.first;
+  changed |= optimizeArrayBoundsCheckInLoop(loop, std::move(result.second));
 
-  if (!EnableABCHoisting)
-    return Changed;
+  if (changed) {
+    preheader->getParent()->verify(
+        getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+  }
+  return changed;
+}
 
-  LLVM_DEBUG(llvm::dbgs() << "Attempting to hoist checks in " << *Loop);
-
-  // Find an exiting block.
-  SILBasicBlock *SingleExitingBlk = Loop->getExitingBlock();
-  SILBasicBlock *ExitingBlk = SingleExitingBlk;
-  SILBasicBlock *ExitBlk = Loop->getExitBlock();
-  SILBasicBlock *Latch = Loop->getLoopLatch();
-  if (!ExitingBlk || !Latch || !ExitBlk) {
-    LLVM_DEBUG(llvm::dbgs() << "No single exiting block or latch found\n");
-    if (!Latch)
-      return Changed;
-
-    // Look back a split edge.
-    if (!Loop->isLoopExiting(Latch) && Latch->getSinglePredecessorBlock() &&
-        Loop->isLoopExiting(Latch->getSinglePredecessorBlock()))
-      Latch = Latch->getSinglePredecessorBlock();
-    if (Loop->isLoopExiting(Latch) && Latch->getSuccessors().size() == 2) {
-      ExitingBlk = Latch;
-      ExitBlk = Loop->contains(Latch->getSuccessors()[0])
-                    ? Latch->getSuccessors()[1]
-                    : Latch->getSuccessors()[0];
-      LLVM_DEBUG(llvm::dbgs() << "Found a latch ...\n");
-    } else return Changed;
+std::pair<bool, std::optional<InductionAnalysis>>
+BoundsCheckOpts::findAndOptimizeInductionVariables(SILLoop *loop) {
+  SILBasicBlock *singleExitingBlock = loop->getExitingBlock();
+  SILBasicBlock *exitingBlk = singleExitingBlock;
+  SILBasicBlock *exitBlock = loop->getExitBlock();
+  SILBasicBlock *latch = loop->getLoopLatch();
+  if (!exitingBlk || !latch || !exitBlock) {
+    if (!latch) {
+      LLVM_DEBUG(llvm::dbgs() << "No latch found\n");
+      return {false, std::nullopt};
+    }
+    if (!loop->isLoopExiting(latch) || latch->getSuccessors().size() != 2) {
+      return {false, std::nullopt};
+    }
+    exitingBlk = latch;
+    exitBlock = loop->contains(latch->getSuccessors()[0])
+                    ? latch->getSuccessors()[1]
+                    : latch->getSuccessors()[0];
+    LLVM_DEBUG(llvm::dbgs() << "Found a latch ...\n");
   }
 
   // Find canonical induction variables.
-  InductionAnalysis IndVars(DT, *IVs, Preheader, Header, ExitingBlk, ExitBlk);
-  bool IVarsFound = IndVars.analyze();
-  if (!IVarsFound) {
+  InductionAnalysis indVars(DT, *IVs, loop->getLoopPreheader(),
+                            loop->getHeader(), exitingBlk, exitBlock);
+  bool found = indVars.analyze();
+  if (!found) {
     LLVM_DEBUG(llvm::dbgs() << "No induction variables found\n");
+    return {false, std::nullopt};
   }
 
   // Hoist the overflow check of induction variables out of the loop. This also
   // needs to happen for memory safety. Also remove superfluous range checks.
-  if (IVarsFound) {
-    SILValue TrueVal;
-    SILValue FalseVal;
-    for (auto *Arg : Header->getArguments()) {
-      if (auto *IV = IndVars[Arg]) {
-        SILBuilderWithScope B(Preheader->getTerminator(), IV->getInstruction());
+  bool changed = false;
+  SILValue trueVal, falseVal;
+  for (auto *arg : loop->getHeader()->getArguments()) {
+    if (auto *ivar = indVars[arg]) {
+      SILBuilderWithScope builder(loop->getLoopPreheader()->getTerminator(),
+                                  ivar->getInstruction());
 
-        // Only if the loop has a single exiting block (which contains the
-        // induction variable check) we may hoist the overflow check.
-        if (SingleExitingBlk)
-          Changed |= IV->checkOverflow(B);
-
-        if (!IV->IsOverflowCheckInserted)
+      // Only if the loop has a single exiting block (which contains the
+      // induction variable check) we may hoist the overflow check.
+      if (singleExitingBlock) {
+        changed |= ivar->checkOverflow(builder);
+        if (!ivar->IsOverflowCheckInserted) {
           continue;
-        for (auto *BB : Loop->getBlocks())
-          for (auto &Inst : *BB) {
-            auto *Builtin = dyn_cast<BuiltinInst>(&Inst);
-            if (!Builtin)
-              continue;
-            if (isComparisonKnownTrue(Builtin, *IV)) {
-              if (!TrueVal)
-                TrueVal = SILValue(B.createIntegerLiteral(
-                    Builtin->getLoc(), Builtin->getType(), -1));
-              Builtin->replaceAllUsesWith(TrueVal);
-              Changed = true;
-              continue;
+        }
+      }
+      for (auto *block : loop->getBlocks()) {
+        for (auto &inst : *block) {
+          auto *builtin = dyn_cast<BuiltinInst>(&inst);
+          if (!builtin) {
+            continue;
+          }
+          if (isComparisonKnownTrue(builtin, *ivar)) {
+            if (!trueVal)
+              trueVal = builder.createIntegerLiteral(builtin->getLoc(),
+                                                     builtin->getType(), -1);
+            builtin->replaceAllUsesWith(trueVal);
+            changed = true;
+            continue;
+          }
+          if (isComparisonKnownFalse(builtin, *ivar)) {
+            if (!falseVal) {
+              falseVal = builder.createIntegerLiteral(builtin->getLoc(),
+                                                      builtin->getType(), 0);
             }
-            if (isComparisonKnownFalse(Builtin, *IV)) {
-              if (!FalseVal) {
-                FalseVal = SILValue(B.createIntegerLiteral(
-                    Builtin->getLoc(), Builtin->getType(), 0));
+            builtin->replaceAllUsesWith(falseVal);
+            changed = true;
+            continue;
+          }
+          // Check whether a dominating check of the condition let's us
+          // replace
+          // the condition by false.
+          SILValue left, right;
+          if (match(builtin, m_Or(m_SILValue(left), m_SILValue(right)))) {
+            if (isValueKnownFalseAt(left, builtin, DT)) {
+              if (!falseVal) {
+                falseVal = builder.createIntegerLiteral(builtin->getLoc(),
+                                                        builtin->getType(), 0);
               }
-              Builtin->replaceAllUsesWith(FalseVal);
-              Changed = true;
-              continue;
+              builtin->setOperand(0, falseVal);
+              changed = true;
             }
-            // Check whether a dominating check of the condition let's us
-            // replace
-            // the condition by false.
-            SILValue Left, Right;
-            if (match(Builtin, m_Or(m_SILValue(Left), m_SILValue(Right)))) {
-              if (isValueKnownFalseAt(Left, Builtin, DT)) {
-                if (!FalseVal)
-                  FalseVal = SILValue(B.createIntegerLiteral(
-                      Builtin->getLoc(), Builtin->getType(), 0));
-                Builtin->setOperand(0, FalseVal);
-                Changed = true;
+            if (isValueKnownFalseAt(right, builtin, DT)) {
+              if (!falseVal) {
+                falseVal = builder.createIntegerLiteral(builtin->getLoc(),
+                                                        builtin->getType(), 0);
               }
-              if (isValueKnownFalseAt(Right, Builtin, DT)) {
-                if (!FalseVal)
-                  FalseVal = SILValue(B.createIntegerLiteral(
-                      Builtin->getLoc(), Builtin->getType(), 0));
-                Builtin->setOperand(1, FalseVal);
-                Changed = true;
-              }
+              builtin->setOperand(1, falseVal);
+              changed = true;
             }
           }
+        }
       }
     }
   }
-
-  // Hoist bounds checks.
-  Changed |= hoistChecksInLoop(DT->getNode(Header), ABC, IndVars, Preheader,
-                               Header, SingleExitingBlk, /*recursionDepth*/ 0);
-  if (Changed) {
-    Preheader->getParent()->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
-  }
-  return Changed;
+  return {changed, std::make_optional(std::move(indVars))};
 }
 
-bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
-                               InductionAnalysis &IndVars,
-                               SILBasicBlock *Preheader, SILBasicBlock *Header,
-                               SILBasicBlock *SingleExitingBlk,
-                               int recursionDepth) {
+bool BoundsCheckOpts::optimizeArrayBoundsCheckInLoop(
+    SILLoop *loop, std::optional<InductionAnalysis> indVars) {
+
+  // Collect safe arrays. Arrays are safe if there is no function call that
+  // could mutate their size in the loop.
+  ABCAnalysis abcAnalysis(true, releaseSafeArrays, RCIA);
+  for (auto *block : loop->getBlocks()) {
+    abcAnalysis.analyzeBlock(block);
+  }
+
+  // Remove redundant checks down the dominator tree inside the loop,
+  // starting at the header.
+  IndexedArraySet dominatingSafeArrayChecks;
+  bool changed = removeRedundantArrayBoundsChecksInLoop(
+      DT->getNode(loop->getHeader()), abcAnalysis, dominatingSafeArrayChecks,
+      loop,
+      /*recursionDepth*/ 0);
+
+  if (!EnableABCHoisting) {
+    return changed;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Attempting to hoist array bounds checks in "
+                          << *loop);
+
+  if (!indVars) {
+    LLVM_DEBUG(llvm::dbgs() << "No induction variables found\n");
+    return changed;
+  }
+
+  // Hoist bounds checks.
+  changed |=
+      hoistArrayBoundsChecksInLoop(loop, DT->getNode(loop->getHeader()),
+                                   abcAnalysis, *indVars, /*recursionDepth*/ 0);
+  return changed;
+}
+
+bool BoundsCheckOpts::hoistArrayBoundsChecksInLoop(
+    SILLoop *loop, DominanceInfoNode *currentNode, ABCAnalysis &abcAnalysis,
+    InductionAnalysis &indVars, int recursionDepth) {
+  auto preheader = loop->getLoopPreheader();
+  auto singleExitingBlock = loop->getExitingBlock();
   // Avoid a stack overflow for very deep dominator trees.
   if (recursionDepth >= maxRecursionDepth)
     return false;
 
-  bool Changed = false;
-  auto *CurBB = DTNode->getBlock();
+  bool changed = false;
+  auto *curBlock = currentNode->getBlock();
   bool blockAlwaysExecutes =
-      isGuaranteedToBeExecuted(DT, CurBB, SingleExitingBlk);
+      isGuaranteedToBeExecuted(DT, curBlock, singleExitingBlock);
 
-  for (auto Iter = CurBB->begin(); Iter != CurBB->end();) {
+  for (auto Iter = curBlock->begin(); Iter != curBlock->end();) {
     auto Inst = &*Iter;
     ++Iter;
 
@@ -1354,7 +1399,6 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
     auto Kind = ArrayCall.getKind();
     if (Kind != ArrayCallKind::kCheckSubscript &&
         Kind != ArrayCallKind::kCheckIndex) {
-      LLVM_DEBUG(llvm::dbgs() << " not a check_bounds call " << *Inst);
       continue;
     }
     auto ArrayVal = ArrayCall.getSelf();
@@ -1363,7 +1407,7 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
     SILValue Array = getArrayStructPointer(Kind, ArrayVal);
 
     // The array must strictly dominate the header.
-    if (!dominates(DT, Array, Preheader)) {
+    if (!dominates(DT, Array, preheader)) {
       LLVM_DEBUG(llvm::dbgs() << " does not dominated header" << *Array);
       continue;
     }
@@ -1372,7 +1416,7 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
     // This is either a SILValue which is defined outside the loop or it is an
     // array, which loaded from memory and the memory is not changed in the
     // loop.
-    if (!dominates(DT, ArrayVal, Preheader) && ABC.isUnsafe(Array)) {
+    if (!dominates(DT, ArrayVal, preheader) && abcAnalysis.isUnsafe(Array)) {
       LLVM_DEBUG(llvm::dbgs() << " not a safe array argument " << *Array);
       continue;
     }
@@ -1383,15 +1427,15 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
       continue;
 
     // Make sure we know how-to hoist the array call.
-    if (!ArrayCall.canHoist(Preheader->getTerminator(), DT))
+    if (!ArrayCall.canHoist(preheader->getTerminator(), DT))
       continue;
 
     // Invariant check.
-    if (blockAlwaysExecutes && dominates(DT, ArrayIndex, Preheader)) {
-      assert(ArrayCall.canHoist(Preheader->getTerminator(), DT) &&
+    if (blockAlwaysExecutes && dominates(DT, ArrayIndex, preheader)) {
+      assert(ArrayCall.canHoist(preheader->getTerminator(), DT) &&
              "Must be able to hoist the instruction.");
-      Changed = true;
-      ArrayCall.hoist(Preheader->getTerminator(), DT);
+      changed = true;
+      ArrayCall.hoist(preheader->getTerminator(), DT);
       LLVM_DEBUG(llvm::dbgs()
                  << " could hoist invariant bounds check: " << *Inst);
       continue;
@@ -1399,7 +1443,7 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
 
     // Get the access function "a[f(i)]". At the moment this handles only the
     // identity function.
-    auto F = AccessFunction::getLinearFunction(ArrayIndex, IndVars);
+    auto F = AccessFunction::getLinearFunction(ArrayIndex, indVars);
     if (!F) {
       LLVM_DEBUG(llvm::dbgs() << " not a linear function " << *Inst);
       continue;
@@ -1411,7 +1455,7 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
         ArrayVal->getType().getASTType()->isArray()) {
       // We can remove the check. This is even possible if the block does not
       // dominate the loop exit block.
-      Changed = true;
+      changed = true;
       ArrayCall.removeCall();
       LLVM_DEBUG(llvm::dbgs() << "  Bounds check removed\n");
       continue;
@@ -1423,28 +1467,27 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
 
     // Hoist the access function and the check to the preheader for start and
     // end of the induction.
-    assert(ArrayCall.canHoist(Preheader->getTerminator(), DT) &&
+    assert(ArrayCall.canHoist(preheader->getTerminator(), DT) &&
            "Must be able to hoist the call");
 
-    F.hoistCheckToPreheader(ArrayCall, Preheader, DT);
+    F.hoistCheckToPreheader(ArrayCall, preheader, DT);
 
     // Remove the old check in the loop and the match the retain with a release.
     ArrayCall.removeCall();
 
     LLVM_DEBUG(llvm::dbgs() << "  Bounds check hoisted\n");
-    Changed = true;
+    changed = true;
   }
 
   // Traverse the children in the dominator tree.
-  for (auto Child : *DTNode)
-    Changed |= hoistChecksInLoop(Child, ABC, IndVars, Preheader, Header,
-                                 SingleExitingBlk, recursionDepth + 1);
+  for (auto child : *currentNode) {
+    changed |= hoistArrayBoundsChecksInLoop(loop, child, abcAnalysis, indVars,
+                                            recursionDepth + 1);
+  }
 
-  return Changed;
+  return changed;
 }
 
 } // end anonymous namespace
 
-SILTransform *swift::createABCOpt() {
-  return new ABCOpt();
-}
+SILTransform *swift::createBoundsCheckOpts() { return new BoundsCheckOpts(); }

--- a/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
+++ b/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
@@ -1,6 +1,6 @@
 target_sources(swiftSILOptimizer PRIVATE
-  ArrayBoundsCheckOpts.cpp
   ArrayPropertyOpt.cpp
+  BoundsCheckOpts.cpp
   COWArrayOpt.cpp
   LoopRotate.cpp
   LoopUnroll.cpp

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -403,7 +403,7 @@ void addHighLevelLoopOptPasses(SILPassPipelinePlan &P) {
   P.addPerformanceConstantPropagation();
   P.addSimplifyCFG();
   // End of unrolling passes.
-  P.addABCOpt();
+  P.addBoundsCheckOpts();
   // Cleanup.
   P.addDCE();
   P.addCOWArrayOpts();
@@ -474,7 +474,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   if (OpLevel == OptimizationLevelKind::MidLevel) {
     P.addHighLevelLICM();
     P.addArrayCountPropagation();
-    P.addABCOpt();
+    P.addBoundsCheckOpts();
     P.addDCE();
     P.addCOWArrayOpts();
     P.addDCE();

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -860,7 +860,8 @@ static std::optional<bool> shouldInlineGeneric(FullApplySite AI,
   // because they need to be preserved, so that the optimizer
   // can properly optimize a user code later.
   ModuleDecl *SwiftModule = Callee->getModule().getSwiftModule();
-  if (Callee->hasSemanticsAttrThatStartsWith("array.") &&
+  if ((Callee->hasSemanticsAttrThatStartsWith("array.") ||
+       Callee->hasSemanticsAttrThatStartsWith("fixed_storage.")) &&
       (SwiftModule->isStdlibModule() || SwiftModule->isOnoneSupportModule()))
     return false;
 
@@ -1167,8 +1168,9 @@ void SILPerformanceInliner::collectAppliesToInline(
         Weight W(BlockWeight, WeightCorrections.lookup(AI));
 
         if (decideInWarmBlock(AI, W, constTracker, NumCallerBlocks,
-                              BBToWeightMap))
+                              BBToWeightMap)) {
           InitialCandidates.push_back(AI);
+        }
       }
     }
 

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -264,11 +264,11 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I) {
       return false;
     }
   }
-  // Like partial_apply [onstack], mark_dependence [nonescaping] creates a
-  // borrow scope. We currently assume that a set of dominated scope-ending uses
-  // can be found.
+  // Like partial_apply [onstack], mark_dependence [nonescaping] on values
+  // creates a borrow scope. We currently assume that a set of dominated
+  // scope-ending uses can be found.
   if (auto *MD = dyn_cast<MarkDependenceInst>(I)) {
-    return !MD->isNonEscaping();
+    return !MD->isNonEscaping() || MD->getType().isAddress();
   }
   // CodeGen can't build ssa for objc methods.
   if (auto *Method = dyn_cast<MethodInst>(I)) {

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -594,6 +594,11 @@ SemanticFunctionLevel swift::getSemanticFunctionLevel(SILFunction *function) {
   //
   // Compiler "hints" and informational annotations (like remarks) should
   // ideally use a separate annotation rather than @_semantics.
+
+  if (isFixedStorageSemanticsCallKind(function)) {
+    return SemanticFunctionLevel::Fundamental;
+  }
+
   switch (getArraySemanticsKind(function)) {
   case ArrayCallKind::kNone:
     return SemanticFunctionLevel::Transient;

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -235,7 +235,6 @@ extension InlineArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
-  @_transparent
   @_semantics("fixed_storage.get_count")
   @inline(__always)
   public var count: Int {

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -236,6 +236,8 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @_transparent
+  @_semantics("fixed_storage.get_count")
+  @inline(__always)
   public var count: Int {
     count
   }
@@ -320,6 +322,13 @@ extension InlineArray where Element: ~Copyable {
     i &- 1
   }
 
+  @_alwaysEmitIntoClient
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  internal func _checkIndex(_ i: Int) {
+    _precondition(indices.contains(i), "Index out of bounds")
+  }
+
   /// Accesses the element at the specified position.
   ///
   /// The following example accesses an element of an array through its
@@ -345,15 +354,13 @@ extension InlineArray where Element: ~Copyable {
   public subscript(_ i: Int) -> Element {
     @_transparent
     unsafeAddress {
-      _precondition(indices.contains(i), "Index out of bounds")
-
+      _checkIndex(i)
       return unsafe _address + i
     }
 
     @_transparent
     unsafeMutableAddress {
-      _precondition(indices.contains(i), "Index out of bounds")
-
+       _checkIndex(i)
       return unsafe _mutableAddress + i
     }
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -367,6 +367,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_semantics("fixed_storage.get_count")
   public var count: Int { _count }
 
   /// A Boolean value indicating whether the span is empty.
@@ -390,6 +391,12 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftStdlib 6.1, *)
 extension Span where Element: ~Copyable {
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  @_alwaysEmitIntoClient
+  internal func _checkIndex(_ position: Index) {
+    _precondition(indices.contains(position), "Index out of bounds")
+  }
 
   /// Accesses the element at the specified position in the `Span`.
   ///
@@ -401,7 +408,7 @@ extension Span where Element: ~Copyable {
   public subscript(_ position: Index) -> Element {
     //FIXME: change to unsafeRawAddress when ready
     unsafeAddress {
-      _precondition(indices.contains(position), "Index out of bounds")
+      _checkIndex(position)
       return unsafe _unsafeAddressOfElement(unchecked: position)
     }
   }
@@ -437,6 +444,15 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftStdlib 6.1, *)
 extension Span where Element: BitwiseCopyable {
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  @_alwaysEmitIntoClient
+  internal func _checkIndex(_ position: Index) {
+    _precondition(
+      UInt(bitPattern: position) <  UInt(bitPattern: _count),
+      "Index out of bounds"
+    )
+  }
 
   /// Accesses the element at the specified position in the `Span`.
   ///
@@ -447,10 +463,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     get {
-      _precondition(
-        UInt(bitPattern: position) <  UInt(bitPattern: _count),
-        "Index out of bounds"
-      )
+      _checkIndex(position)
       return unsafe self[unchecked: position]
     }
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -444,16 +444,6 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftStdlib 6.1, *)
 extension Span where Element: BitwiseCopyable {
-  @_semantics("fixed_storage.check_index")
-  @inline(__always)
-  @_alwaysEmitIntoClient
-  internal func _checkIndex(_ position: Index) {
-    _precondition(
-      UInt(bitPattern: position) <  UInt(bitPattern: _count),
-      "Index out of bounds"
-    )
-  }
-
   /// Accesses the element at the specified position in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`

--- a/test/SILOptimizer/abcopt_large_cfg.sil.gyb
+++ b/test/SILOptimizer/abcopt_large_cfg.sil.gyb
@@ -3,7 +3,7 @@
 
 // Check that the optimization does not crash due to a stack overflow.
 
-// RUN: %target-sil-opt -sil-verify-none -abcopts  %t/main.sil | %FileCheck %s
+// RUN: %target-sil-opt -sil-verify-none -bcopts  %t/main.sil | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -enable-abcopts=1 %s | %FileCheck %s
-// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -abcopts -dce -enable-abcopts -enable-abc-hoisting %s | %FileCheck %s --check-prefix=HOIST
-// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -abcopts  %s | %FileCheck %s --check-prefix=RANGECHECK
+// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -bcopts %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all -loop-rotate -dce -jumpthread-simplify-cfg -bcopts -dce %s | %FileCheck %s --check-prefix=HOIST
+// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -bcopts  %s | %FileCheck %s --check-prefix=RANGECHECK
 
 sil_stage canonical
 

--- a/test/SILOptimizer/abcopts_ossa_guaranteed.sil
+++ b/test/SILOptimizer/abcopts_ossa_guaranteed.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -abcopts  %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -bcopts  %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/abcopts_ossa_owned.sil
+++ b/test/SILOptimizer/abcopts_ossa_owned.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -abcopts  %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -parse-serialized-sil -enable-sil-verify-all  -bcopts  %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/destructor_analysis.sil
+++ b/test/SILOptimizer/destructor_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -abcopts %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -bcopts %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -11,10 +11,7 @@
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
-// A lower bounds check is left behind in the entry block
-
+// Induction variable optimization eliminates the bounds check in SIL
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A29_sum_iterate_to_count_wo_trapySis11InlineArrayVyxSiGSiRVzlF :
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
@@ -32,9 +29,7 @@ public func inlinearray_sum_iterate_to_count_wo_trap<let N: Int>(_ v: InlineArra
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop
-// A lower bounds check is left behind in the entry block
+// Induction variable optimization eliminates the bounds check in SIL
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A31_sum_iterate_to_count_with_trapySis11InlineArrayVyxSiGSiRVzlF :
 // CHECK-SIL: bb3
@@ -51,13 +46,9 @@ public func inlinearray_sum_iterate_to_count_with_trap<let N: Int>(_ v: InlineAr
 }
 
 // Bounds check should be hoisted
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
-// A lower bounds check is left behind in the entry block
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A31_sum_iterate_to_unknown_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A31_sum_iterate_to_unknown_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -73,13 +64,9 @@ public func inlinearray_sum_iterate_to_unknown_wo_trap<let N: Int>(_ v: InlineAr
 }
 
 // Bounds check should be hoisted
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop
-// A lower bounds check is left behind in the entry block
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A33_sum_iterate_to_unknown_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A33_sum_iterate_to_unknown_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -92,12 +79,9 @@ public func inlinearray_sum_iterate_to_unknown_with_trap<let N: Int>(_ v: Inline
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A40_sum_iterate_to_deducible_count1_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A40_sum_iterate_to_deducible_count1_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -114,12 +98,9 @@ public func inlinearray_sum_iterate_to_deducible_count1_wo_trap<let N: Int>(_ v:
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A42_sum_iterate_to_deducible_count1_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A42_sum_iterate_to_deducible_count1_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -133,12 +114,9 @@ public func inlinearray_sum_iterate_to_deducible_count1_with_trap<let N: Int>(_ 
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes upper bounds check and vectorizes the loop 
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A40_sum_iterate_to_deducible_count2_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A40_sum_iterate_to_deducible_count2_wo_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -155,12 +133,9 @@ public func inlinearray_sum_iterate_to_deducible_count2_wo_trap<let N: Int>(_ v:
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF : 
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis11InlineArrayVyxSiG_SitSiRVzlF'
@@ -174,8 +149,6 @@ public func inlinearray_sum_iterate_to_deducible_count2_with_trap<let N: Int>(_ 
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes upper bounds check and vectorizes the loop 
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A29_iterate_over_indices_wo_trapySis11InlineArrayVyxSiGSiRVzlF : 
 // CHECK-SIL: bb3
@@ -194,8 +167,7 @@ public func inlinearray_iterate_over_indices_wo_trap<let N: Int>(_ v: InlineArra
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
+// Induction variable optimization eliminates the bounds check in SIL
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A31_iterate_over_indices_with_trapySis11InlineArrayVyxSiGSiRVzlF : 
 // CHECK-SIL: bb3
@@ -216,7 +188,6 @@ public func inlinearray_iterate_over_indices_with_trap<let N: Int>(_ v: InlineAr
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A17_element_equalityySbs11InlineArrayVyxSiG_SitSiRVzlF'
-
 public func inlinearray_element_equality<let N: Int>(_ v: InlineArray<N, Int>, _ i: Int) -> Bool {
   return v[i] == v[i]
 }
@@ -290,3 +261,79 @@ public func inlinearray_binary_search_spl<let N: Int>(_ v: InlineArray<N, Int>, 
   return nil;
 }
 
+// InlineArray is copied into a temporary within the loop in the "specialized" version
+// This prevents LoopRotate which prevent bounds checks opts since it depends on induction variable analysis which doesn't work on unrotated loops.
+// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A35_sum_iterate_to_count_with_trap_splySis11InlineArrayVy$63_SiGF :
+// CHECK-SIL: bb2
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A35_sum_iterate_to_count_with_trap_splySis11InlineArrayVy$63_SiGF'
+public func inlinearray_sum_iterate_to_count_with_trap_spl(_ v: InlineArray<64, Int>) -> Int {
+  var sum = 0
+  for i in v.indices {
+    sum &+= v[i]
+  }
+  return sum
+}
+
+// InlineArray is copied into a temporary within the loop in the "specialized" version
+// This prevents LoopRotate which prevent bounds checks opts since it depends on induction variable analysis which doesn't work on unrotated loops. 
+// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A37_sum_iterate_to_unknown_with_trap_splySis11InlineArrayVy$63_SiG_SitF :
+// CHECK-SIL: bb2
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A37_sum_iterate_to_unknown_with_trap_splySis11InlineArrayVy$63_SiG_SitF'
+public func inlinearray_sum_iterate_to_unknown_with_trap_spl(_ v: InlineArray<64, Int>, _ n: Int) -> Int {
+  var sum = 0
+  for i in 0...n {
+    sum &+= v[i]
+  }
+  return sum
+}
+
+// Current codegen for this in SIL is very poor
+// First a temp is created and the elements are stored to it, then they get loaded from the temp to be stored in the let which is then loaded again to get the sum
+// However, LLVM can constant fold everything 
+public func local_inlinearray_sum_iterate_to_count_with_trap_spl() -> Int {
+  var sum = 0
+  let v : InlineArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+  for i in v.indices {
+    sum += v[i]
+  }
+  return sum
+}
+
+// Current codegen for this in SIL is very poor
+// First a temp is created and the elements are stored to it, then they get loaded from the temp to be stored in the let which is then loaded again to get the sum
+// LLVM cannot constant fold, it memsets, memcopies and then loops over to sum  
+public func local_inlinearray_repeating_init_sum_iterate_to_count_trap_spl() -> Int {
+  var sum = 0
+  let v = InlineArray<64, Int>(repeating: 64)
+
+  for i in v.indices {
+    sum += v[i]
+  }
+
+  return sum
+}
+
+// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A11_inc_by_oneyys11InlineArrayVyxSiGz_SitSiRVzlF :
+// CHECK-SIL: bb3({{.*}}):
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+public func inlinearray_inc_by_one<let N: Int>(_ v: inout InlineArray<N, Int>, _ n: Int) {
+  for i in v.indices {
+    v[i] += 1
+  }
+}
+
+// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A15_inc_by_one_splyys11InlineArrayVy$63_SiGz_SitF : 
+// CHECK-SIL: bb2
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A15_inc_by_one_splyys11InlineArrayVy$63_SiGz_SitF'
+public func inlinearray_inc_by_one_spl(_ v: inout InlineArray<64, Int>, _ n: Int) {
+  for i in v.indices {
+    v[i] += 1
+  }
+}

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -1,25 +1,22 @@
 // RUN: %target-swift-frontend %s -emit-sil -O \
 // RUN:   -disable-availability-checking \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   | %FileCheck %s --check-prefix=CHECK-SIL 
+// RUN:   | %FileCheck %s --check-prefix=CHECK-SIL
 
 // RUN: %target-swift-frontend %s -emit-ir -O \
 // RUN:   -disable-availability-checking \
 // RUN:   -enable-experimental-feature LifetimeDependence \
-// RUN:   | %FileCheck %s  --check-prefix=CHECK-IR 
+// RUN:   | %FileCheck %s  --check-prefix=CHECK-IR
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
-// A lower bounds check is left behind in the entry block
-
+// SIL optimizer eliminates bounds checks from the loop
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A29_sum_iterate_to_count_wo_trapySis4SpanVySiGF :
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A29_sum_iterate_to_count_wo_trapySis4SpanVySiGF'
@@ -35,13 +32,12 @@ public func span_sum_iterate_to_count_wo_trap(_ v: Span<Int>) -> Int {
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop
-// A lower bounds check is left behind in the entry block
+// SIL optimizer eliminates bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A31_sum_iterate_to_count_with_trapySis4SpanVySiGF :
+// CHECK-SIL: bb1
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A31_sum_iterate_to_count_with_trapySis4SpanVySiGF'
@@ -55,13 +51,13 @@ public func span_sum_iterate_to_count_with_trap(_ v: Span<Int>) -> Int {
 }
 
 // Bounds check should be hoisted
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
-// A lower bounds check is left behind in the entry block
+// SIL optimizer hoists bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A31_sum_iterate_to_unknown_wo_trapySis4SpanVySiG_SitF :
-// CHECK-SIL: bb3
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A31_sum_iterate_to_unknown_wo_trapySis4SpanVySiG_SitF'
@@ -77,13 +73,13 @@ public func span_sum_iterate_to_unknown_wo_trap(_ v: Span<Int>, _ n: Int) -> Int
 }
 
 // Bounds check should be hoisted
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop
-// A lower bounds check is left behind in the entry block
+// SIL optimizer hoists bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A33_sum_iterate_to_unknown_with_trapySis4SpanVySiG_SitF :
-// CHECK-SIL: bb3
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A33_sum_iterate_to_unknown_with_trapySis4SpanVySiG_SitF'
@@ -96,12 +92,10 @@ public func span_sum_iterate_to_unknown_with_trap(_ v: Span<Int>, _ n: Int) -> I
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes the upper bounds check from the loop and then vectorizes
+// SIL optimizer hoists bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A40_sum_iterate_to_deducible_count1_wo_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb3
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A40_sum_iterate_to_deducible_count1_wo_trapySis4SpanVySiG_SitF'
@@ -118,12 +112,13 @@ public func span_sum_iterate_to_deducible_count1_wo_trap(_ v: Span<Int>, _ n: In
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
+// SIL optimizer hoists bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count1_with_trapySis4SpanVySiG_SitF :
-// CHECK-SIL: bb3
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count1_with_trapySis4SpanVySiG_SitF'
@@ -137,12 +132,13 @@ public func span_sum_iterate_to_deducible_count1_with_trap(_ v: Span<Int>, _ n: 
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes upper bounds check and vectorizes the loop 
+// SIL optimizer hoists bounds checks from the loop
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A40_sum_iterate_to_deducible_count2_wo_trapySis4SpanVySiG_SitF :
-// CHECK-SIL: bb3
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A40_sum_iterate_to_deducible_count2_wo_trapySis4SpanVySiG_SitF'
@@ -159,12 +155,13 @@ public func span_sum_iterate_to_deducible_count2_wo_trap(_ v: Span<Int>, _ n: In
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
+// SIL optimizer hoists bounds checks from the loop
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis4SpanVySiG_SitF : 
-// CHECK-SIL: bb3
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis4SpanVySiG_SitF :
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis4SpanVySiG_SitF'
@@ -178,12 +175,13 @@ public func span_sum_iterate_to_deducible_count2_with_trap(_ v: Span<Int>, _ n: 
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM removes upper bounds check and vectorizes the loop 
+// SIL optimizer hoists bounds checks from the loop
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A29_iterate_over_indices_wo_trapySis4SpanVySiGF : 
-// CHECK-SIL: bb3
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A29_iterate_over_indices_wo_trapySis4SpanVySiGF :
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A29_iterate_over_indices_wo_trapySis4SpanVySiGF'
@@ -199,12 +197,13 @@ public func span_iterate_over_indices_wo_trap(_ v: Span<Int>) -> Int {
 }
 
 // Bounds check should be eliminated
-// SIL removes lower bounds check from the loop
-// LLVM does not eliminate redundant bounds check 
+// SIL optimizer hoists bounds checks from the loop
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A31_iterate_over_indices_with_trapySis4SpanVySiGF : 
-// CHECK-SIL: bb3
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A31_iterate_over_indices_with_trapySis4SpanVySiGF :
+// CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A31_iterate_over_indices_with_trapySis4SpanVySiGF'
@@ -218,7 +217,7 @@ public func span_iterate_over_indices_with_trap(_ v: Span<Int>) -> Int {
 
 // Eliminate duplicate bounds check
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A17_element_equalityySbs4SpanVySiG_SitF : 
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A17_element_equalityySbs4SpanVySiG_SitF :
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A17_element_equalityySbs4SpanVySiG_SitF'
@@ -240,7 +239,7 @@ public func span_element_sum(_ v: Span<Int>, _ i: Int) -> Int {
 
 // Bounds check should be eliminated
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF : 
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF :
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
@@ -257,7 +256,7 @@ public func span_search<T : Equatable>(_ v: Span<T>, _ elem: T) -> Int? {
 
 // Bounds check should be eliminated
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A11_search_splySiSgs4SpanVySiG_SitF : 
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A11_search_splySiSgs4SpanVySiG_SitF :
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
@@ -274,7 +273,7 @@ public func span_search_spl(_ v: Span<Int>, _ elem: Int) -> Int? {
 
 // Bounds check should be eliminated
 
-// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A18_binary_search_splySiSgs4SpanVySiG_SitF : 
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A18_binary_search_splySiSgs4SpanVySiG_SitF :
 // CHECK-SIL: bb2
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -295,5 +294,60 @@ public func span_binary_search_spl(_ v: Span<Int>, _ elem: Int) -> Int? {
   }
 
   return nil;
+}
+
+public struct Wrapper<Int> : ~Escapable {
+  let s: Span<Int>
+}
+
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A41_wrapper_sum_iterate_to_unknown_with_trapySiAA7WrapperVySiG_SitF :
+// CHECK-SIL: bb1
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A41_wrapper_sum_iterate_to_unknown_with_trapySiAA7WrapperVySiG_SitF'
+public func span_wrapper_sum_iterate_to_unknown_with_trap(_ w: Wrapper<Int>, _ n: Int) -> Int {
+  let v = w.s
+  var sum = 0
+  for i in 0...n {
+    sum += v[i]
+  }
+  return sum
+}
+
+@inline(never)
+@_optimize(none)
+public func mutate_span(_ v: inout Span<Int>) { }
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests06inout_A33_sum_iterate_to_unknown_with_trapySis4SpanVySiGz_SitF :
+// CHECK-SIL: bb1
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: bb3
+// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests06inout_A33_sum_iterate_to_unknown_with_trapySis4SpanVySiGz_SitF'
+public func inout_span_sum_iterate_to_unknown_with_trap(_ v: inout Span<Int>, _ n: Int) -> Int {
+  var sum = 0
+  for i in 0...n {
+    sum += v[i]
+  }
+  mutate_span(&v)
+  return sum
+}
+
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests06inout_A41_sum_iterate_to_unknown_with_trap_dontoptySis4SpanVySiGz_SitF :
+// CHECK-SIL: bb3
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_br
+// CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests06inout_A41_sum_iterate_to_unknown_with_trap_dontoptySis4SpanVySiGz_SitF'
+public func inout_span_sum_iterate_to_unknown_with_trap_dontopt(_ v: inout Span<Int>, _ n: Int) -> Int {
+  var sum = 0
+  for i in 0...n {
+    sum += v[i]
+    mutate_span(&v)
+  }
+  return sum
 }
 

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -43,7 +43,6 @@ _swift_complete()
       -disable-sil-ownership-verification \
       -dont-abort-on-memory-lifetime-errors \
       -enable-abc-hoisting \
-      -enable-abcopts \
       -enable-accessed-storage-dump-uses \
       -enable-copyforwarding \
       -enable-destroyhoisting \
@@ -68,7 +67,7 @@ _swift_complete()
       -optremarkgen-visit-implicit-autogen-funcs \
       -print-shortest-path-info \
       -print-swift-mangling-stats \
-      -sil-abcopts-report \
+      -sil-bcopts-report \
       -sil-aggressive-inline \
       -sil-assert-on-exclusivity-failure \
       -sil-break-on-function \


### PR DESCRIPTION
This PR adds support bounds check optimizations to handle Span and InlineArray. 

Bounds check operations and count methods in Span and InlineArray are annotated with @_semantics. The optimization recognizes this and can do the following:

- Eliminate redundant bounds checks when the loop iterates from 0 through count
- Eliminate redundant bounds checks when another dominant bounds check is found 
- Hoist bounds checks for loops iterating through an unknown bound. Hoisting can be done only when the original check always executes in the loop.

Limitations:
- The optimizations currently require the self's definition to dominate the loop, which guarantees self will not be modified within the loop blocking optimizations. This is conservative and can be improved on easily.
- There are limitations to current Induction Analysis which this optimization depends on. Among other issues, the current induction analysis works only on rotated loops with increments of one. 