### PR TITLE
[Dependency Scanning] Remove hard failure mode (crash) during cross-import resolution

### DIFF
--- a/test/ScanDependencies/test_clang_gmodules.swift
+++ b/test/ScanDependencies/test_clang_gmodules.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import X


### PR DESCRIPTION
When failing to resolve an `import` to a module ID, proceed ignoring this `import`, instead of crashing. 
Unresolved imports will be properly handled downstream in the scanner, with corresponding diagnostics.