### PR TITLE
[IDE] Avoid inferring container type for implicit expressions

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1159,7 +1159,6 @@ public:
     Type OldType = CurrentType;
     if (CurrentType && (Old != nullptr || Options.PrintAsMember)) {
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-        assert(Options.CurrentModule);
         auto Subs = CurrentType->getContextSubstitutionMap(
           NTD->getDeclContext());
         setCurrentType(NTD->getDeclaredInterfaceType().subst(Subs));

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -341,12 +341,13 @@ bool CursorInfoResolver::walkToExprPre(Expr *E) {
   }
 
   if (auto SAE = dyn_cast<SelfApplyExpr>(E)) {
-    if (SAE->getFn()->getStartLoc() == LocToResolve) {
+    auto *fn = SAE->getFn();
+    if (!fn->isImplicit() && fn->getStartLoc() == LocToResolve) {
       ContainerType = SAE->getBase()->getType();
     }
   } else if (auto ME = dyn_cast<MemberRefExpr>(E)) {
     SourceLoc MemberLoc = ME->getNameLoc().getBaseNameLoc();
-    if (MemberLoc.isValid() && MemberLoc == LocToResolve) {
+    if (!ME->isImplicit() && MemberLoc.isValid() && MemberLoc == LocToResolve) {
       ContainerType = ME->getBase()->getType();
     }
   }

--- a/test/SourceKit/CursorInfo/issue-79696.swift
+++ b/test/SourceKit/CursorInfo/issue-79696.swift
@@ -1,0 +1,23 @@
+@resultBuilder
+struct Builder {
+  static func buildBlock<T>(_ x: T) -> T { x }
+  static func buildExpression<T>(_ x: T) -> T { x }
+}
+
+// https://github.com/swiftlang/swift/issues/79696
+// Make sure we don't pick up the builder as the container type.
+struct A {
+  struct B {
+    @Builder
+    var foo: Any {
+      B
+      // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):7 %s -- %s | %FileCheck %s --check-prefix NESTED_TY
+      // NESTED_TY-NOT: Container
+    }
+    @Builder var bar: Any {
+      foo
+      // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):7 %s -- %s | %FileCheck %s --check-prefix PROP
+      // PROP: <Container>$s4main1AV1BVD</Container>
+    }
+  }
+}


### PR DESCRIPTION
For e.g implicit `buildExpression` calls, we have a location that matches the argument, but we don't want to consider the result builder type as the container type.

Resolves #79696