### PR TITLE
[embedded][Concurrency] Fix missing swift_deletedAsyncMethodError

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2129,6 +2129,15 @@ FUNCTION(DeletedMethodError, Swift, swift_deletedMethodError, C_CC, AlwaysAvaila
         EFFECT(NoEffect),
          UNKNOWN_MEMEFFECTS)
 
+// void swift_deletedAsyncMethodError();
+FUNCTION(DeletedAsyncMethodError, _Concurrency, swift_deletedAsyncMethodError, SwiftAsyncCC,
+        ConcurrencyAvailability,
+        RETURNS(VoidTy),
+        ARGS(),
+        ATTRS(NoUnwind),
+        EFFECT(Concurrency),
+        UNKNOWN_MEMEFFECTS)
+
 FUNCTION(AllocError, Swift, swift_allocError, SwiftCC, AlwaysAvailable,
          RETURNS(ErrorPtrTy, OpaquePtrTy),
          ARGS(TypeMetadataPtrTy, WitnessTablePtrTy, OpaquePtrTy, Int1Ty),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3863,8 +3863,11 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
 
   // Clang may have defined the variable already.
-  if (auto existing = Module.getNamedGlobal(link.getName()))
-    return getElementBitCast(existing, defaultType);
+  if (auto existing = Module.getNamedGlobal(link.getName())) {
+    auto var = getElementBitCast(existing, defaultType);
+    GlobalVars[entity] = var;
+    return var;
+  }
 
   const LazyConstantInitializer *lazyInitializer = nullptr;
   std::optional<ConstantInitBuilder> lazyBuilder;
@@ -4003,6 +4006,7 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity) {
   getAddrOfLLVMVariable(entity, ConstantInit(), DebugTypeInfo());
 
   auto entry = GlobalVars[entity];
+  assert(entry);
   
   /// Returns a direct reference.
   auto direct = [&]() -> ConstantReference {

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import _Concurrency
+
+actor MyActor {
+    var value: Int = 42
+    func foo() async {
+        print("value: \(value)")
+    }
+
+    func thisIsUnused() async {
+        print("unused")
+    }
+}
+
+@main struct Main {
+    static func main() async {
+        let n = MyActor()
+        await n.foo()
+    }
+}
+
+// CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
+// CHECK-IR:      @"$e4main7MyActorCN" = global <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ 
+// CHECK-IR-SAME:   ptr null,
+// CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD",
+// CHECK-IR-SAME:   ptr null,
+// CHECK-IR-SAME:   ptr @swift_deletedMethodError,
+// CHECK-IR-SAME:   ptr @swift_deletedMethodError,
+// CHECK-IR-SAME:   ptr @swift_deletedMethodError,
+// CHECK-IR-SAME:   ptr @"$e4main7MyActorC3fooyyYaFTu",
+// CHECK-IR-SAME:   ptr @got.swift_deletedAsyncMethodErrorTu,
+// CHECK-IR-SAME:   ptr @"$e4main7MyActorCACycfC"
+// CHECK-IR-SAME: }>, align 8
+
+// CHECK-IR-NOT:  $e4main7MyActorC12thisIsUnusedyyYaF
+
+// CHECK-IR: define swifttailcc void @swift_deletedAsyncMethodError(ptr swiftasync %0)
+
+// CHECK: value: 42


### PR DESCRIPTION
The attached testcase demonstrates the problem: If the optimizer eliminates an async method, the vtable pointer is replaced with a swift_deletedAsyncMethodError, and in Embedded Swift we ended up failing to link in such a situation because swift_deletedAsyncMethodError wasn't getting imported at the SIL level (there's no visible link to it at the SIL level). To fix that let's declare it in RuntimeFunctions.def, plus we need to adjust the GOT creating code to be able to handle the situation when the link entity is in the current module already.

rdar://145584159
