### PR TITLE
[Stdlib performance] Make integer conversion operations transparent

### DIFF
--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -938,6 +938,16 @@ static void substituteConstants(FoldState &foldState) {
   for (SILValue constantSILValue : foldState.getConstantSILValues()) {
     SymbolicValue constantSymbolicVal =
         evaluator.lookupConstValue(constantSILValue).value();
+    CanType instType = constantSILValue->getType().getASTType();
+
+    // If the SymbolicValue is a string but the instruction that is folded is
+    // not String typed, we are tracking a StaticString which is represented as
+    // a raw pointer. Skip folding StaticString as they are already efficiently
+    // represented.
+    if (constantSymbolicVal.getKind() == SymbolicValue::String &&
+        !instType->isString())
+      continue;
+
     // Make sure that the symbolic value tracked in the foldState is a constant.
     // In the case of ArraySymbolicValue, the array storage could be a non-constant
     // if some instruction in the array initialization sequence was not evaluated
@@ -976,7 +986,6 @@ static void substituteConstants(FoldState &foldState) {
 
     SILBuilderWithScope builder(insertionPoint);
     SILLocation loc = insertionPoint->getLoc();
-    CanType instType = constantSILValue->getType().getASTType();
     SILValue foldedSILVal = emitCodeForSymbolicValue(
         constantSymbolicVal, instType, builder, loc, foldState.stringInfo);
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3040,8 +3040,7 @@ extension UnsignedInteger where Self: FixedWidthInteger {
   /// - Parameter source: A value to convert to this type of integer. The value
   ///   passed as `source` must be representable in this type.
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init<T: BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned {
@@ -3056,8 +3055,7 @@ extension UnsignedInteger where Self: FixedWidthInteger {
   }
 
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init?<T: BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source < (0 as T) {
@@ -3255,8 +3253,7 @@ extension SignedInteger where Self: FixedWidthInteger {
   /// - Parameter source: A value to convert to this type of integer. The value
   ///   passed as `source` must be representable in this type.
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init<T: BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth {
@@ -3273,8 +3270,7 @@ extension SignedInteger where Self: FixedWidthInteger {
   }
 
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init?<T: BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth && source < Self.min {

--- a/test/IRGen/integer_conversion.swift
+++ b/test/IRGen/integer_conversion.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
+// REQUIRES: CPU=x86_64 || CPU=arm64
+
+// https://github.com/swiftlang/swift/issues/78501
+public struct PcgRandom {
+  private var state: UInt64 = 0;
+
+  // CHECK-LABEL: define{{.*}}swiftcc i32 @"$s18integer_conversion9PcgRandomV6next32s6UInt32VyF"
+  public mutating func next32() -> UInt32 {
+    // CHECK-NOT: sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
+    // CHECK-NOT: sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
+    // CHECK: ret i32
+    let oldstate : UInt64 = state
+    state = oldstate &* 6364136223846793005 &+ 1;
+    let shifted = oldstate >> 18
+    let xor = shifted ^ oldstate
+    let xorshifted64 = xor >> 27
+    let xorshifted = UInt32((xorshifted64 << 32) >> 32)
+    let rot : UInt32 = UInt32(oldstate >> 59)
+    let nrot : UInt32 = UInt32(bitPattern: -Int32(rot))
+    return (xorshifted >> rot) | (xorshifted << (nrot & 31))
+  }
+
+  init() {}
+}

--- a/test/Interop/Cxx/templates/function-template-silgen.swift
+++ b/test/Interop/Cxx/templates/function-template-silgen.swift
@@ -16,10 +16,8 @@ import FunctionTemplates
 // CHECK:   [[ADD_TWO_FN:%.*]] = function_ref @{{_Z18addMixedTypeParamsIiiET_S0_T0_|\?\?\$addMixedTypeParams@HH@@YAHHH@Z}} : $@convention(c) (Int32, Int32) -> Int32
 // CHECK:   [[C:%.*]] = apply [[ADD_TWO_FN]]([[A]], [[B]]) : $@convention(c) (Int32, Int32) -> Int32
 
-// CHECK:   [[C_32_ADDR:%.*]] = alloc_stack $Int32
-// CHECK:   [[C_32:%.*]] = load [[C_32_ADDR]] : $*Int32
 // CHECK:   [[ADD_FN:%.*]] = function_ref @{{_Z17addSameTypeParamsIiET_S0_S0_|\?\?\$addSameTypeParams@H@@YAHHH@Z}} : $@convention(c) (Int32, Int32) -> Int32
-// CHECK:   [[OUT:%.*]] = apply [[ADD_FN]]([[B]], [[C_32]]) : $@convention(c) (Int32, Int32) -> Int32
+// CHECK:   [[OUT:%.*]] = apply [[ADD_FN]]([[B]], [[C_32:%.*]]) : $@convention(c) (Int32, Int32) -> Int32
 // CHECK:   return [[OUT]] : $Int32
 
 // CHECK-LABEL: end sil function '$s4main4test1xs5Int32VAE_tF'

--- a/test/SILOptimizer/Inputs/constant_evaluable.swift
+++ b/test/SILOptimizer/Inputs/constant_evaluable.swift
@@ -174,8 +174,7 @@ internal func interpretIntTruncations() -> Int8 {
 internal func testInvalidIntTruncations(a: Int32) -> Int8 {
   return Int8(a)
     // CHECK: note: {{.*}}: Not enough bits to represent the passed value
-    // CHECK: note: operation performed during this call traps
-    // CHECK: function_ref @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
+    // CHECK: note: operation traps
 }
 
 @_semantics("test_driver")
@@ -220,8 +219,7 @@ internal func interpretSingedUnsignedConversions() -> UInt32 {
 internal func testInvalidSingedUnsignedConversions(a: Int64) -> UInt64 {
   return UInt64(a)
     // CHECK: note: {{.*}}: Negative value is not representable
-    // CHECK: note: operation performed during this call traps
-    // CHECK: function_ref @$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
+    // CHECK: note: operation traps
 }
 
 @_semantics("test_driver")

--- a/test/SILOptimizer/constant_evaluable_subset_test_arch64.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test_arch64.swift
@@ -71,8 +71,7 @@ internal func interpretIntTruncations() -> Int16 {
 internal func testInvalidIntTruncations(a: Int64) -> Int8 {
   return Int8(a)
     // CHECK: note: {{.*}} Not enough bits to represent the passed value
-    // CHECK: note: operation performed during this call traps
-    // CHECK: function_ref @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
+    // CHECK: note: operation traps
 }
 
 @_semantics("test_driver")


### PR DESCRIPTION
The integer conversion operations were inlinable, but aren't getting inlined in debug builds, which results in unreasonably poor performance. Mark them as transparent so we don't end up with unspecialized generic code in the hot path.

Fixes https://github.com/swiftlang/swift/issues/78501
