### PR TITLE
More disambiguation for "unsafe" expressions

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -437,8 +437,10 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   }
 
   if (Tok.isContextualKeyword("unsafe") &&
-      !peekToken().isAtStartOfLine() &&
-      !peekToken().is(tok::r_paren)) {
+      !(peekToken().isAtStartOfLine() ||
+        peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square,
+                          tok::equal) ||
+        peekToken().is(tok::period))) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();
     ParserResult<Expr> sub =

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -175,6 +175,23 @@ func testUnsafePositionError() -> Int {
   return 3 + unsafe unsafeInt() // expected-error{{'unsafe' cannot appear to the right of a non-assignment operator}}
 }
 
+enum Color {
+case red
+}
+
+func unsafeFun() {
+  var unsafe = true
+  unsafe = false
+  unsafe.toggle()
+  _ = [unsafe]
+  _ = { unsafe }
+
+  let color: Color
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  color = unsafe .red
+  _ = color
+}
+
 // @safe suppresses unsafe-type-related diagnostics on an entity
 struct MyArray<Element> {
   @safe func withUnsafeBufferPointer<R, E>(


### PR DESCRIPTION
Fixes rdar://145870868 / #79704
