### PR TITLE
AST/Sema: Adopt `AvailabilityDomain` arguments in diagnostics

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -72,6 +72,7 @@ namespace swift {
   class AbstractFunctionDecl;
   class ASTContext;
   enum class Associativity : unsigned char;
+  class AvailabilityDomain;
   class AvailabilityMacroMap;
   class AvailabilityRange;
   class BoundGenericType;
@@ -1596,9 +1597,10 @@ private:
 public:
   clang::DarwinSDKInfo *getDarwinSDKInfo() const;
 
-  /// Returns the string to use in diagnostics when printing the platform being
-  /// targetted.
-  StringRef getTargetPlatformStringForDiagnostics() const;
+  /// Returns the availability domain corresponding to the target triple. If
+  /// there isn't a `PlatformKind` associated with the current target triple,
+  /// then this returns the universal domain (`*`).
+  AvailabilityDomain getTargetAvailabilityDomain() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AvailabilityInference.h
+++ b/include/swift/AST/AvailabilityInference.h
@@ -24,6 +24,7 @@
 
 namespace swift {
 class ASTContext;
+class AvailabilityDomain;
 class BackDeployedAttr;
 class Decl;
 class SemanticAvailableAttr;
@@ -62,35 +63,35 @@ public:
   /// For the attribute's introduction version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
-  static bool updateIntroducedPlatformForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-      llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
+  static bool updateIntroducedAvailabilityDomainForFallback(
+      const SemanticAvailableAttr &attr, const ASTContext &ctx,
+      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
 
   /// For the attribute's deprecation version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
-  static bool updateDeprecatedPlatformForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-      llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
+  static bool updateDeprecatedAvailabilityDomainForFallback(
+      const SemanticAvailableAttr &attr, const ASTContext &ctx,
+      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
 
   /// For the attribute's obsoletion version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
-  static bool updateObsoletedPlatformForFallback(
-      const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-      llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer);
+  static bool updateObsoletedAvailabilityDomainForFallback(
+      const SemanticAvailableAttr &attr, const ASTContext &ctx,
+      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
 
-  static void updatePlatformStringForFallback(const SemanticAvailableAttr &attr,
-                                              const ASTContext &Ctx,
-                                              llvm::StringRef &Platform);
+  static void
+  updateAvailabilityDomainForFallback(const SemanticAvailableAttr &attr,
+                                      const ASTContext &ctx,
+                                      AvailabilityDomain &domain);
 
   /// For the attribute's before version, update the platform and version
   /// values to the re-mapped platform's, if using a fallback platform.
   /// Returns `true` if a remap occured.
-  static bool updateBeforePlatformForFallback(const BackDeployedAttr *attr,
-                                              const ASTContext &Ctx,
-                                              llvm::StringRef &Platform,
-                                              llvm::VersionTuple &PlatformVer);
+  static bool updateBeforeAvailabilityDomainForFallback(
+      const BackDeployedAttr *attr, const ASTContext &ctx,
+      AvailabilityDomain &domain, llvm::VersionTuple &platformVer);
 };
 
 // FIXME: This should become a utility on Decl.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -19,6 +19,7 @@
 #define SWIFT_BASIC_DIAGNOSTICENGINE_H
 
 #include "swift/AST/ActorIsolation.h"
+#include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/TypeLoc.h"
@@ -143,6 +144,7 @@ namespace swift {
     DescriptiveDeclKind,
     DescriptiveStmtKind,
     DeclAttribute,
+    AvailabilityDomain,
     VersionTuple,
     LayoutConstraint,
     ActorIsolation,
@@ -179,6 +181,7 @@ namespace swift {
       DescriptiveDeclKind DescriptiveDeclKindVal;
       StmtKind DescriptiveStmtKindVal;
       const DeclAttribute *DeclAttributeVal;
+      AvailabilityDomain AvailabilityDomainVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
       ActorIsolation ActorIsolationVal;
@@ -277,6 +280,10 @@ namespace swift {
     DiagnosticArgument(const DeclAttribute *attr)
         : Kind(DiagnosticArgumentKind::DeclAttribute),
           DeclAttributeVal(attr) {}
+
+    DiagnosticArgument(const AvailabilityDomain domain)
+        : Kind(DiagnosticArgumentKind::AvailabilityDomain),
+          AvailabilityDomainVal(domain) {}
 
     DiagnosticArgument(llvm::VersionTuple version)
       : Kind(DiagnosticArgumentKind::VersionTuple),
@@ -398,6 +405,11 @@ namespace swift {
     const DeclAttribute *getAsDeclAttribute() const {
       assert(Kind == DiagnosticArgumentKind::DeclAttribute);
       return DeclAttributeVal;
+    }
+
+    const AvailabilityDomain getAsAvailabilityDomain() const {
+      assert(Kind == DiagnosticArgumentKind::AvailabilityDomain);
+      return AvailabilityDomainVal;
     }
 
     llvm::VersionTuple getAsVersionTuple() const {

--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -30,14 +30,15 @@ WARNING(ide_availability_softdeprecated, Deprecation,
         "%0 will be deprecated"
         " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
         "%select{|: %5}5",
-        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple,
+        (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
          StringRef))
 
 WARNING(ide_availability_softdeprecated_rename, Deprecation,
         "%0 will be deprecated"
         " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
         ": renamed to '%5'",
-        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple, StringRef))
+        (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+         StringRef))
 
 WARNING(ide_recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -75,7 +75,7 @@ ERROR(attr_objc_implementation_resilient_property_deployment_target, none,
       "'@implementation' on %0 %1 does not support stored properties whose "
       "size can change due to library evolution; raise the minimum deployment "
       "target to %0 %2 or store this value in an object or 'any' type",
-      (StringRef, const llvm::VersionTuple, const llvm::VersionTuple))
+      (AvailabilityDomain, const llvm::VersionTuple, const llvm::VersionTuple))
 
 ERROR(unable_to_load_pass_plugin,none,
       "unable to load plugin '%0': '%1'", (StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1841,7 +1841,7 @@ ERROR(attr_objc_implementation_no_conformance,none,
 ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
       "'@implementation' of an Objective-C class requires a minimum deployment "
       "target of at least %0 %1",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 ERROR(attr_implementation_requires_language,none,
       "'@implementation' used without specifying the language being "
       "implemented",
@@ -6383,7 +6383,7 @@ ERROR(objc_in_generic_extension,none,
       "cannot contain '@objc' members", (bool))
 ERROR(objc_in_resilient_extension,none,
       "'@objc' %0 in extension of subclass of %1 requires %2 %3",
-      (DescriptiveDeclKind, Identifier, StringRef, llvm::VersionTuple))
+      (DescriptiveDeclKind, Identifier, AvailabilityDomain, llvm::VersionTuple))
 ERROR(objc_operator, none,
       "operator methods cannot be declared @objc", ())
 ERROR(objc_operator_proto, none,
@@ -6394,7 +6394,7 @@ ERROR(objc_for_generic_class,none,
       "because they are not directly visible from Objective-C", ())
 ERROR(objc_for_resilient_class,none,
       "explicit '@objc' on subclass of %0 requires %1 %2",
-      (Identifier, StringRef, llvm::VersionTuple))
+      (Identifier, AvailabilityDomain, llvm::VersionTuple))
 ERROR(objc_getter_for_nonobjc_property,none,
       "'@objc' getter for non-'@objc' property", ())
 ERROR(objc_getter_for_nonobjc_subscript,none,
@@ -6825,25 +6825,26 @@ ERROR(availability_decl_more_than_enclosing, none,
 
 NOTE(availability_implicit_decl_here, none,
      "%0 implicitly declared here with availability of %1 %2 or newer",
-     (DescriptiveDeclKind, StringRef, llvm::VersionTuple))
+     (DescriptiveDeclKind, AvailabilityDomain, llvm::VersionTuple))
 
 NOTE(availability_decl_more_than_enclosing_here, none,
      "enclosing scope requires availability of %0 %1 or newer",
-     (StringRef, llvm::VersionTuple))
+     (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",
-      (const ValueDecl *, StringRef, llvm::VersionTuple))
+      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_decl_only_version_newer_for_clients, none,
       "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
       " deployment target",
-      (const ValueDecl *, StringRef, llvm::VersionTuple, ModuleDecl *))
+      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple, ModuleDecl *))
 
 WARNING(availability_decl_only_version_newer_for_clients_warn, none,
         "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
         " deployment target",
-        (const ValueDecl *, StringRef, llvm::VersionTuple, ModuleDecl *))
+        (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple,
+         ModuleDecl *))
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",
@@ -6893,7 +6894,7 @@ FIXIT(insert_available_attr,
 
 ERROR(availability_inout_accessor_only_version_newer, none,
       "cannot pass as inout because %0 is only available in %1 %2 or newer",
-      (const ValueDecl *, StringRef, llvm::VersionTuple))
+      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
@@ -6939,7 +6940,8 @@ WARNING(availability_enum_element_no_potential_warn,
 
 ERROR(availability_protocol_requires_version,
       none, "protocol %0 requires %1 to be available in %2 %3 and newer",
-      (const ProtocolDecl *, const ValueDecl *, StringRef, llvm::VersionTuple))
+      (const ProtocolDecl *, const ValueDecl *, AvailabilityDomain,
+       llvm::VersionTuple))
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
@@ -6995,7 +6997,7 @@ GROUPED_WARNING(conformance_availability_deprecated,
 
 ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
-      (Type, Type, StringRef, llvm::VersionTuple))
+      (Type, Type, AvailabilityDomain, llvm::VersionTuple))
 
 //------------------------------------------------------------------------------
 // MARK: if #available(...)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4006,11 +4006,11 @@ ERROR(attr_not_on_decl_with_invalid_access_level,none,
 ERROR(attr_has_no_effect_decl_not_available_before,none,
       "'%0' has no effect because %1 is not "
       "available before %2 %3",
-      (DeclAttribute, const ValueDecl *, StringRef, llvm::VersionTuple))
+      (DeclAttribute, const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(attr_has_no_effect_on_unavailable_decl,none,
       "'%0' has no effect because %1 is unavailable on %2",
-      (DeclAttribute, const ValueDecl *, StringRef))
+      (DeclAttribute, const ValueDecl *, AvailabilityDomain))
 
 ERROR(attr_ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 in '@%1' attribute", (DeclNameRef, StringRef))
@@ -6780,7 +6780,7 @@ ERROR(attr_availability_requires_custom_availability, none,
 
 ERROR(availability_decl_unavailable, none,
       "%0 is unavailable%select{ in %2|}1%select{|: %3}3",
-      (const ValueDecl *, bool, StringRef, StringRef))
+      (const ValueDecl *, bool, AvailabilityDomain, StringRef))
 
 #define REPLACEMENT_DECL_KIND_SELECT "select{| instance method| property}"
 ERROR(availability_decl_unavailable_rename, none,
@@ -6794,17 +6794,17 @@ NOTE(availability_marked_unavailable, none,
 
 NOTE(availability_introduced_in_version, none,
      "%0 was introduced in %1 %2",
-     (const ValueDecl *, StringRef, llvm::VersionTuple))
+     (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
 
 NOTE(availability_obsoleted, none,
      "%0 was obsoleted in %1 %2",
-     (const ValueDecl *, StringRef, llvm::VersionTuple))
+     (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
 
 GROUPED_WARNING(availability_deprecated, DeprecatedDeclaration, Deprecation,
                 "%0 %select{is|%select{is|was}3}1 "
                 "deprecated%select{| in %2%select{| %4}3}1%select{|: %5}5",
-                (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple,
-                 StringRef))
+                (const ValueDecl *, bool, AvailabilityDomain, bool,
+                 llvm::VersionTuple, StringRef))
 
 GROUPED_WARNING(
       availability_deprecated_rename, DeprecatedDeclaration, Deprecation,
@@ -6812,8 +6812,8 @@ GROUPED_WARNING(
       "deprecated%select{| in %2%select{| %4}3}1: "
       "%select{renamed to|replaced by}5%" REPLACEMENT_DECL_KIND_SELECT "6 "
       "'%7'",
-      (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple, bool,
-       unsigned, StringRef))
+      (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+       bool, unsigned, StringRef))
 #undef REPLACEMENT_DECL_KIND_SELECT
 
 NOTE(note_deprecated_rename, none,
@@ -6972,7 +6972,7 @@ NOTE(availability_unavailable_implicit_init, none,
 ERROR(conformance_availability_unavailable, none,
       "conformance of %0 to %1 is unavailable"
       "%select{ in %3|}2%select{|: %4}4",
-      (Type, Type, bool, StringRef, StringRef))
+      (Type, Type, bool, AvailabilityDomain, StringRef))
 
 NOTE(conformance_availability_marked_unavailable, none,
      "conformance of %0 to %1 has been explicitly marked "
@@ -6980,17 +6980,17 @@ NOTE(conformance_availability_marked_unavailable, none,
 
 NOTE(conformance_availability_introduced_in_version, none,
      "conformance of %0 to %1 was introduced in %2 %3",
-     (Type, Type, StringRef, llvm::VersionTuple))
+     (Type, Type, AvailabilityDomain, llvm::VersionTuple))
 
 NOTE(conformance_availability_obsoleted, none,
      "conformance of %0 to %1 was obsoleted in %2 %3",
-     (Type, Type, StringRef, llvm::VersionTuple))
+     (Type, Type, AvailabilityDomain, llvm::VersionTuple))
 
 GROUPED_WARNING(conformance_availability_deprecated,
                 DeprecatedDeclaration, Deprecation,
                 "conformance of %0 to %1 %select{is|%select{is|was}4}2 "
                 "deprecated%select{| in %3%select{| %5}4}2%select{|: %6}6",
-                (Type, Type, bool, StringRef, bool, llvm::VersionTuple,
+                (Type, Type, bool, AvailabilityDomain, bool, llvm::VersionTuple,
                  StringRef))
 
 ERROR(conformance_availability_only_version_newer, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6018,7 +6018,7 @@ ERROR(isolated_deinit_on_value_type,none,
       ())
 ERROR(isolated_deinit_unavailable,none,
       "isolated deinit is only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 //------------------------------------------------------------------------------
 // MARK: String Processing
@@ -6033,7 +6033,7 @@ ERROR(regex_capture_types_failed_to_decode,none,
 
 ERROR(regex_feature_unavailable, none,
       "%0 is only available in %1 %2 or newer",
-      (StringRef, StringRef, llvm::VersionTuple))
+      (StringRef, AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(must_import_regex_builder_module,none,
       "regex builder requires the 'RegexBuilder' module be imported'", ())
@@ -6848,40 +6848,40 @@ WARNING(availability_decl_only_version_newer_for_clients_warn, none,
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_concurrency_only_version_newer, none,
       "concurrency is only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_parameterized_protocol_only_version_newer, none,
       "runtime support for parameterized protocol types is only available in "
       "%0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_isolated_any_only_version_newer, none,
       "runtime support for @isolated(any) function types is only available in "
       "%0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_copyable_generics_casting_only_version_newer, none,
       "runtime support for casting types with noncopyable generic arguments "
       "is only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_escapable_generics_casting_only_version_newer, none,
       "runtime support for casting types with nonescapable generic arguments "
       "is only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_typed_throws_only_version_newer, none,
       "runtime support for typed throws function types is only available in "
       "%0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
@@ -8263,7 +8263,7 @@ ERROR(value_generics_missing_feature,none,
       "value generics require '-enable-experimental-feature ValueGenerics'", ())
 ERROR(availability_value_generic_type_only_version_newer, none,
       "values in generic types are only available in %0 %1 or newer",
-      (StringRef, llvm::VersionTuple))
+      (AvailabilityDomain, llvm::VersionTuple))
 ERROR(invalid_value_for_type_same_type,none,
       "cannot constrain type parameter %0 to be integer %1", (Type, Type))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6755,9 +6755,9 @@ NOTE(type_eraser_init_spi,none,
 
 ERROR(availability_must_occur_alone, none,
       "%0 %select{|version }1availability must be specified alone",
-      (StringRef, bool))
+      (AvailabilityDomain, bool))
 ERROR(availability_unexpected_version, none,
-      "unexpected version number for %0", (StringRef))
+      "unexpected version number for %0", (AvailabilityDomain))
 WARNING(availability_unrecognized_platform_name,
         PointsToFirstBadToken, "unrecognized platform name %0", (Identifier))
 WARNING(availability_suggest_platform_name,
@@ -6766,17 +6766,17 @@ WARNING(availability_suggest_platform_name,
         (Identifier, StringRef))
 
 WARNING(attr_availability_expected_deprecated_version, none,
-       "expected version number with 'deprecated' in '%0' attribute for "
-       "platform '%1'", (StringRef, StringRef))
+       "expected version number with 'deprecated' in '%0' attribute for %1",
+       (const DeclAttribute, AvailabilityDomain))
 WARNING(attr_availability_cannot_be_used_for_domain, none,
-       "'%0' cannot be used in '%1' attribute for platform '%2'",
-       (StringRef, StringRef, StringRef))
+       "'%0' cannot be used in '%1' attribute for %2",
+       (StringRef, const DeclAttribute, AvailabilityDomain))
 WARNING(attr_availability_expected_version_spec, none,
        "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
-       "for platform '%1'", (StringRef, StringRef))
+       "for %1", (const DeclAttribute, AvailabilityDomain))
 ERROR(attr_availability_requires_custom_availability, none,
       "%0 requires '-enable-experimental-feature CustomAvailability'",
-      (StringRef))
+      (AvailabilityDomain))
 
 ERROR(availability_decl_unavailable, none,
       "%0 is unavailable%select{ in %2|}1%select{|: %3}3",
@@ -7003,10 +7003,11 @@ ERROR(conformance_availability_only_version_newer, none,
 
 ERROR(availability_query_not_allowed, none,
       "%0 %select{|version }1checks not allowed in %2(...)",
-      (StringRef, bool, StringRef))
+      (AvailabilityDomain, bool, StringRef))
 
 ERROR(availability_query_already_specified, none,
-      "%select{|version for }0'%1' already specified", (bool, StringRef))
+      "%select{|version for }0%1 already specified",
+      (bool, AvailabilityDomain))
 
 ERROR(availability_query_wildcard_required, none,
       "must handle potential future platforms with '*'", ())

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -7058,6 +7058,10 @@ ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
   llvm_unreachable("exhaustive switch");
 }
 
-StringRef ASTContext::getTargetPlatformStringForDiagnostics() const {
-  return prettyPlatformString(targetPlatform(LangOpts));
+AvailabilityDomain ASTContext::getTargetAvailabilityDomain() const {
+  if (auto domain = AvailabilityDomain::forTargetPlatform(*this))
+    return *domain;
+
+  // Fall back to the universal domain for triples without a platform.
+  return AvailabilityDomain::forUniversal();
 }

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -330,86 +330,86 @@ getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
   return Mapping->mapDeprecatedObsoletedAvailabilityVersion(Version);
 }
 
-bool AvailabilityInference::updateIntroducedPlatformForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-    llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer) {
-  std::optional<llvm::VersionTuple> IntroducedVersion = attr.getIntroduced();
+bool AvailabilityInference::updateIntroducedAvailabilityDomainForFallback(
+    const SemanticAvailableAttr &attr, const ASTContext &ctx,
+    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
+  std::optional<llvm::VersionTuple> introducedVersion = attr.getIntroduced();
   if (attr.getPlatform() == PlatformKind::iOS &&
-      IntroducedVersion.has_value() &&
-      isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
+      introducedVersion.has_value() &&
+      isPlatformActive(PlatformKind::visionOS, ctx.LangOpts)) {
     // We re-map the iOS introduced version to the corresponding visionOS version
-    auto PotentiallyRemappedIntroducedVersion =
-        getRemappedIntroducedVersionForFallbackPlatform(Ctx,
-                                                        *IntroducedVersion);
-    if (PotentiallyRemappedIntroducedVersion.has_value()) {
-      Platform = swift::prettyPlatformString(PlatformKind::visionOS);
-      PlatformVer = PotentiallyRemappedIntroducedVersion.value();
+    auto potentiallyRemappedIntroducedVersion =
+        getRemappedIntroducedVersionForFallbackPlatform(ctx,
+                                                        *introducedVersion);
+    if (potentiallyRemappedIntroducedVersion.has_value()) {
+      domain = AvailabilityDomain::forPlatform(PlatformKind::visionOS);
+      platformVer = potentiallyRemappedIntroducedVersion.value();
       return true;
     }
   }
   return false;
 }
 
-bool AvailabilityInference::updateDeprecatedPlatformForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-    llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer) {
-  std::optional<llvm::VersionTuple> DeprecatedVersion = attr.getDeprecated();
+bool AvailabilityInference::updateDeprecatedAvailabilityDomainForFallback(
+    const SemanticAvailableAttr &attr, const ASTContext &ctx,
+    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
+  std::optional<llvm::VersionTuple> deprecatedVersion = attr.getDeprecated();
   if (attr.getPlatform() == PlatformKind::iOS &&
-      DeprecatedVersion.has_value() &&
-      isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
+      deprecatedVersion.has_value() &&
+      isPlatformActive(PlatformKind::visionOS, ctx.LangOpts)) {
     // We re-map the iOS deprecated version to the corresponding visionOS version
-    auto PotentiallyRemappedDeprecatedVersion =
+    auto potentiallyRemappedDeprecatedVersion =
         getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
-            Ctx, *DeprecatedVersion);
-    if (PotentiallyRemappedDeprecatedVersion.has_value()) {
-      Platform = swift::prettyPlatformString(PlatformKind::visionOS);
-      PlatformVer = PotentiallyRemappedDeprecatedVersion.value();
+            ctx, *deprecatedVersion);
+    if (potentiallyRemappedDeprecatedVersion.has_value()) {
+      domain = AvailabilityDomain::forPlatform(PlatformKind::visionOS);
+      platformVer = potentiallyRemappedDeprecatedVersion.value();
       return true;
     }
   }
   return false;
 }
 
-bool AvailabilityInference::updateObsoletedPlatformForFallback(
-    const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-    llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer) {
-  std::optional<llvm::VersionTuple> ObsoletedVersion = attr.getObsoleted();
-  if (attr.getPlatform() == PlatformKind::iOS && ObsoletedVersion.has_value() &&
-      isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
+bool AvailabilityInference::updateObsoletedAvailabilityDomainForFallback(
+    const SemanticAvailableAttr &attr, const ASTContext &ctx,
+    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
+  std::optional<llvm::VersionTuple> obsoletedVersion = attr.getObsoleted();
+  if (attr.getPlatform() == PlatformKind::iOS && obsoletedVersion.has_value() &&
+      isPlatformActive(PlatformKind::visionOS, ctx.LangOpts)) {
     // We re-map the iOS obsoleted version to the corresponding visionOS version
-    auto PotentiallyRemappedObsoletedVersion =
+    auto potentiallyRemappedObsoletedVersion =
         getRemappedDeprecatedObsoletedVersionForFallbackPlatform(
-            Ctx, *ObsoletedVersion);
-    if (PotentiallyRemappedObsoletedVersion.has_value()) {
-      Platform = swift::prettyPlatformString(PlatformKind::visionOS);
-      PlatformVer = PotentiallyRemappedObsoletedVersion.value();
+            ctx, *obsoletedVersion);
+    if (potentiallyRemappedObsoletedVersion.has_value()) {
+      domain = AvailabilityDomain::forPlatform(PlatformKind::visionOS);
+      platformVer = potentiallyRemappedObsoletedVersion.value();
       return true;
     }
   }
   return false;
 }
 
-void AvailabilityInference::updatePlatformStringForFallback(
+void AvailabilityInference::updateAvailabilityDomainForFallback(
     const SemanticAvailableAttr &attr, const ASTContext &Ctx,
-    llvm::StringRef &Platform) {
+    AvailabilityDomain &domain) {
   if (attr.getPlatform() == PlatformKind::iOS &&
       isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
-    Platform = swift::prettyPlatformString(PlatformKind::visionOS);
+    domain = AvailabilityDomain::forPlatform(PlatformKind::visionOS);
   }
 }
 
-bool AvailabilityInference::updateBeforePlatformForFallback(
-    const BackDeployedAttr *attr, const ASTContext &Ctx,
-    llvm::StringRef &Platform, llvm::VersionTuple &PlatformVer) {
-  auto BeforeVersion = attr->Version;
+bool AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
+    const BackDeployedAttr *attr, const ASTContext &ctx,
+    AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
+  auto beforeVersion = attr->Version;
   if (attr->Platform == PlatformKind::iOS &&
-      isPlatformActive(PlatformKind::visionOS, Ctx.LangOpts)) {
+      isPlatformActive(PlatformKind::visionOS, ctx.LangOpts)) {
     // We re-map the iOS before version to the corresponding visionOS version
     auto PotentiallyRemappedIntroducedVersion =
-        getRemappedIntroducedVersionForFallbackPlatform(Ctx, BeforeVersion);
+        getRemappedIntroducedVersionForFallbackPlatform(ctx, beforeVersion);
     if (PotentiallyRemappedIntroducedVersion.has_value()) {
-      Platform = swift::prettyPlatformString(PlatformKind::visionOS);
-      PlatformVer = PotentiallyRemappedIntroducedVersion.value();
+      domain = AvailabilityDomain::forPlatform(PlatformKind::visionOS);
+      platformVer = PotentiallyRemappedIntroducedVersion.value();
       return true;
     }
   }
@@ -492,10 +492,10 @@ std::optional<SemanticAvailableAttr> Decl::getDeprecatedAttr() const {
 
     auto deprecatedVersion = attr.getDeprecated();
 
-    StringRef deprecatedPlatform;
+    AvailabilityDomain unusedDomain;
     llvm::VersionTuple remappedDeprecatedVersion;
-    if (AvailabilityInference::updateDeprecatedPlatformForFallback(
-            attr, ctx, deprecatedPlatform, remappedDeprecatedVersion))
+    if (AvailabilityInference::updateDeprecatedAvailabilityDomainForFallback(
+            attr, ctx, unusedDomain, remappedDeprecatedVersion))
       deprecatedVersion = remappedDeprecatedVersion;
 
     if (!deprecatedVersion.has_value())
@@ -892,10 +892,10 @@ SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
     return AvailabilityRange::alwaysAvailable();
 
   llvm::VersionTuple IntroducedVersion = getIntroduced().value();
-  StringRef Platform;
+  AvailabilityDomain UnusedDomain;
   llvm::VersionTuple RemappedIntroducedVersion;
-  if (AvailabilityInference::updateIntroducedPlatformForFallback(
-          *this, Ctx, Platform, RemappedIntroducedVersion))
+  if (AvailabilityInference::updateIntroducedAvailabilityDomainForFallback(
+          *this, Ctx, UnusedDomain, RemappedIntroducedVersion))
     IntroducedVersion = RemappedIntroducedVersion;
 
   return AvailabilityRange{VersionRange::allGTE(IntroducedVersion)};

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -154,10 +154,10 @@ getAvailabilityConstraintForAttr(const Decl *decl,
   std::optional<llvm::VersionTuple> obsoletedVersion = attr.getObsoleted();
 
   {
-    StringRef obsoletedPlatform;
+    AvailabilityDomain unusedDomain;
     llvm::VersionTuple remappedObsoletedVersion;
-    if (AvailabilityInference::updateObsoletedPlatformForFallback(
-            attr, ctx, obsoletedPlatform, remappedObsoletedVersion))
+    if (AvailabilityInference::updateObsoletedAvailabilityDomainForFallback(
+            attr, ctx, unusedDomain, remappedObsoletedVersion))
       obsoletedVersion = remappedObsoletedVersion;
   }
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -260,7 +260,7 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
       !ctx.LangOpts.hasFeature(Feature::CustomAvailability) &&
       !declContext->isInSwiftinterface()) {
     diags.diagnose(loc, diag::attr_availability_requires_custom_availability,
-                   domain->getNameForDiagnostics());
+                   *domain);
     return std::nullopt;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -593,9 +593,9 @@ Decl::getBackDeployedBeforeOSVersion(ASTContext &Ctx,
                                      bool forTargetVariant) const {
   if (auto *attr = getAttrs().getBackDeployed(Ctx, forTargetVariant)) {
     auto version = attr->Version;
-    StringRef ignoredPlatformString;
-    AvailabilityInference::updateBeforePlatformForFallback(
-        attr, getASTContext(), ignoredPlatformString, version);
+    AvailabilityDomain ignoredDomain;
+    AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
+        attr, getASTContext(), ignoredDomain, version);
 
     // If the remap for fallback resulted in 1.0, then the
     // backdeployment prior to that is not meaningful.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1051,6 +1051,11 @@ static void formatDiagnosticArgument(StringRef Modifier,
       Out << '@' << Arg.getAsDeclAttribute()->getAttrName();
     break;
 
+  case DiagnosticArgumentKind::AvailabilityDomain:
+    assert(Modifier.empty() &&
+           "Improper modifier for AvailabilityDomain argument");
+    Out << Arg.getAsAvailabilityDomain().getNameForDiagnostics();
+    break;
   case DiagnosticArgumentKind::VersionTuple:
     assert(Modifier.empty() &&
            "Improper modifier for VersionTuple argument");

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -87,14 +87,14 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   // FIXME: Code completion doesn't offer accessors. It only emits 'VarDecl's.
   // So getter/setter specific availability doesn't work in code completion.
 
-  StringRef Platform = Attr.getDomain().getNameForDiagnostics();
+  auto Domain = Attr.getDomain();
   llvm::VersionTuple DeprecatedVersion;
   if (Attr.getDeprecated())
     DeprecatedVersion = Attr.getDeprecated().value();
 
   llvm::VersionTuple RemappedDeprecatedVersion;
-  if (AvailabilityInference::updateDeprecatedPlatformForFallback(
-          Attr, Ctx, Platform, RemappedDeprecatedVersion))
+  if (AvailabilityInference::updateDeprecatedAvailabilityDomainForFallback(
+          Attr, Ctx, Domain, RemappedDeprecatedVersion))
     DeprecatedVersion = RemappedDeprecatedVersion;
 
   auto Message = Attr.getMessage();
@@ -102,18 +102,18 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   if (!isSoftDeprecated) {
     if (Message.empty() && NewName.empty()) {
       getDiagnostics(severity, Out, diag::availability_deprecated, D,
-                     Attr.isPlatformSpecific(), Platform,
+                     Attr.isPlatformSpecific(), Domain,
                      Attr.getDeprecated().has_value(), DeprecatedVersion,
                      /*message*/ StringRef());
     } else if (!Message.empty()) {
       EncodedDiagnosticMessage EncodedMessage(Message);
       getDiagnostics(severity, Out, diag::availability_deprecated, D,
-                     Attr.isPlatformSpecific(), Platform,
+                     Attr.isPlatformSpecific(), Domain,
                      Attr.getDeprecated().has_value(), DeprecatedVersion,
                      EncodedMessage.Message);
     } else {
       getDiagnostics(severity, Out, diag::availability_deprecated_rename, D,
-                     Attr.isPlatformSpecific(), Platform,
+                     Attr.isPlatformSpecific(), Domain,
                      Attr.getDeprecated().has_value(), DeprecatedVersion, false,
                      /*ReplaceKind*/ 0, NewName);
     }
@@ -126,18 +126,18 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 
     if (Message.empty() && NewName.empty()) {
       getDiagnostics(severity, Out, diag::ide_availability_softdeprecated, D,
-                     Attr.isPlatformSpecific(), Platform, !isDistantFuture,
+                     Attr.isPlatformSpecific(), Domain, !isDistantFuture,
                      DeprecatedVersion,
                      /*message*/ StringRef());
     } else if (!Message.empty()) {
       EncodedDiagnosticMessage EncodedMessage(Message);
       getDiagnostics(severity, Out, diag::ide_availability_softdeprecated, D,
-                     Attr.isPlatformSpecific(), Platform, !isDistantFuture,
+                     Attr.isPlatformSpecific(), Domain, !isDistantFuture,
                      DeprecatedVersion, EncodedMessage.Message);
     } else {
       getDiagnostics(severity, Out,
                      diag::ide_availability_softdeprecated_rename, D,
-                     Attr.isPlatformSpecific(), Platform, !isDistantFuture,
+                     Attr.isPlatformSpecific(), Domain, !isDistantFuture,
                      DeprecatedVersion, NewName);
     }
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5193,7 +5193,7 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
         diags.diagnose(
             field.getVarDecl(),
             diag::attr_objc_implementation_resilient_property_deployment_target,
-            ctx.getTargetPlatformStringForDiagnostics(),
+            ctx.getTargetAvailabilityDomain(),
             currentAvailability.getRawMinimumVersion(),
             requiredAvailability.getRawMinimumVersion());
       else

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5147,14 +5147,14 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
     bool hasVersion = !spec.getVersion().empty();
 
     if (!domain.supportsQueries()) {
-      diags.diagnose(loc, diag::availability_query_not_allowed,
-                     domain.getNameForDiagnostics(), hasVersion, queryName);
+      diags.diagnose(loc, diag::availability_query_not_allowed, domain,
+                     hasVersion, queryName);
       return true;
     }
 
     if (!domain.isPlatform() && info->getQueries().size() > 1) {
-      diags.diagnose(loc, diag::availability_must_occur_alone,
-                     domain.getNameForDiagnostics(), hasVersion);
+      diags.diagnose(loc, diag::availability_must_occur_alone, domain,
+                     hasVersion);
       return true;
     }
 
@@ -5164,9 +5164,7 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
         return true;
       }
     } else if (hasVersion) {
-      diags
-          .diagnose(loc, diag::availability_unexpected_version,
-                    domain.getNameForDiagnostics())
+      diags.diagnose(loc, diag::availability_unexpected_version, domain)
           .highlight(parsedSpec->getVersionSrcRange());
       return true;
     }
@@ -5174,7 +5172,7 @@ static bool diagnoseAvailabilityCondition(PoundAvailableInfo *info,
     // Diagnose duplicate domains.
     if (!seenDomains.insert(domain).second) {
       diags.diagnose(loc, diag::availability_query_already_specified,
-                     domain.isVersioned(), domain.getNameForDiagnostics());
+                     domain.isVersioned(), domain);
       return true;
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1896,7 +1896,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       auto diag = diagnose(
           attr->getLocation(),
           diag::attr_objc_implementation_raise_minimum_deployment_target,
-          Ctx.getTargetPlatformStringForDiagnostics(),
+          Ctx.getTargetAvailabilityDomain(),
           Ctx.getSwift50Availability().getRawMinimumVersion());
       if (attr->isEarlyAdopter()) {
         diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
@@ -2431,12 +2431,11 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
         if (D->isImplicit())
           diagnose(enclosingDecl->getLoc(),
                    diag::availability_implicit_decl_here,
-                   D->getDescriptiveKind(),
-                   Ctx.getTargetPlatformStringForDiagnostics(),
+                   D->getDescriptiveKind(), Ctx.getTargetAvailabilityDomain(),
                    AttrRange.getRawMinimumVersion());
         diagnose(enclosingDecl->getLoc(),
                  diag::availability_decl_more_than_enclosing_here,
-                 Ctx.getTargetPlatformStringForDiagnostics(),
+                 Ctx.getTargetAvailabilityDomain(),
                  EnclosingAnnotatedRange->getRawMinimumVersion());
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5006,8 +5006,8 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
         // Only platform availability is allowed to be written groups with more
         // than one member.
         if (!domain.isPlatform()) {
-          diagnose(loc, diag::availability_must_occur_alone,
-                   domain.getNameForDiagnostics(), domain.isVersioned());
+          diagnose(loc, diag::availability_must_occur_alone, domain,
+                   domain.isVersioned());
           continue;
         }
       }
@@ -5015,7 +5015,7 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
       // Diagnose duplicate platforms.
       if (!seenDomains.insert(domain).second) {
         diagnose(loc, diag::availability_query_already_specified,
-                 domain.isVersioned(), domain.getNameForAttributePrinting());
+                 domain.isVersioned(), domain);
         continue;
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -125,11 +125,12 @@ public:
       }
 
       TypeChecker::checkAvailability(
-        attr->getRange(), C.getIsolatedDeinitAvailability(),
-        D->getDeclContext(),
-        [&](StringRef platformName, llvm::VersionTuple version) {
-          return diagnoseAndRemoveAttr(attr, diag::isolated_deinit_unavailable, platformName, version);
-        });
+          attr->getRange(), C.getIsolatedDeinitAvailability(),
+          D->getDeclContext(),
+          [&](AvailabilityDomain domain, llvm::VersionTuple version) {
+            return diagnoseAndRemoveAttr(
+                attr, diag::isolated_deinit_unavailable, domain, version);
+          });
     }
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -583,13 +583,14 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
                                             ResilienceExpansion::Maximal)) {
           auto stubAvailability = getObjCClassStubAvailability(ctx);
           auto *ancestor = getResilientAncestor(mod, classDecl);
-          softenIfAccessNote(value, reason.getAttr(),
-            value->diagnose(diag::objc_in_resilient_extension,
-                            value->getDescriptiveKind(),
-                            ancestor->getName(),
-                            ctx.getTargetPlatformStringForDiagnostics(),
-                            stubAvailability.getRawMinimumVersion())
-                .limitBehavior(behavior));
+          softenIfAccessNote(
+              value, reason.getAttr(),
+              value
+                  ->diagnose(diag::objc_in_resilient_extension,
+                             value->getDescriptiveKind(), ancestor->getName(),
+                             ctx.getTargetAvailabilityDomain(),
+                             stubAvailability.getRawMinimumVersion())
+                  .limitBehavior(behavior));
           reason.describe(value);
           return true;
         }
@@ -1356,7 +1357,7 @@ static std::optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
       auto *ancestor = getResilientAncestor(CD->getParentModule(), CD);
       swift::diagnoseAndRemoveAttr(CD, attr, diag::objc_for_resilient_class,
                                    ancestor->getName(),
-                                   ctx.getTargetPlatformStringForDiagnostics(),
+                                   ctx.getTargetAvailabilityDomain(),
                                    stubAvailability.getRawMinimumVersion())
           .limitBehavior(behavior);
       reason.describe(CD);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4531,7 +4531,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(diagLoc, diag::availability_protocol_requires_version,
                          conformance->getProtocol(), witness,
-                         ctx.getTargetPlatformStringForDiagnostics(),
+                         ctx.getTargetAvailabilityDomain(),
                          check.RequiredAvailability.getRawMinimumVersion());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement,
@@ -5049,8 +5049,7 @@ static bool diagnoseTypeWitnessAvailability(
           ctx.Diags
               .diagnose(loc, diag::availability_protocol_requires_version,
                         conformance->getProtocol(), witness,
-                        ctx.getTargetPlatformStringForDiagnostics(),
-                        requiredVersion)
+                        ctx.getTargetAvailabilityDomain(), requiredVersion)
               .warnUntilSwiftVersion(warnBeforeVersion);
 
           emitDeclaredHereIfNeeded(ctx.Diags, loc, witness);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1040,15 +1040,16 @@ diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 /// is allowed.
 std::optional<Diagnostic> diagnosticIfDeclCannotBeUnavailable(const Decl *D);
 
-bool checkAvailability(
-    SourceRange ReferenceRange, AvailabilityRange RequiredAvailability,
-    const DeclContext *ReferenceDC,
-    llvm::function_ref<InFlightDiagnostic(StringRef, llvm::VersionTuple)>
-        Diagnose);
+bool checkAvailability(SourceRange ReferenceRange,
+                       AvailabilityRange RequiredAvailability,
+                       const DeclContext *ReferenceDC,
+                       llvm::function_ref<InFlightDiagnostic(
+                           AvailabilityDomain, llvm::VersionTuple)>
+                           Diagnose);
 
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityRange RequiredAvailability,
-                       Diag<StringRef, llvm::VersionTuple> Diag,
+                       Diag<AvailabilityDomain, llvm::VersionTuple> Diag,
                        const DeclContext *ReferenceDC);
 
 void checkConcurrencyAvailability(SourceRange ReferenceRange,

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -64,7 +64,7 @@ if #available(macoss 51, *) { // expected-warning {{unrecognized platform name '
 if #available(mac 51, *) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{15-18=macOS}}
 }
 
-if #available(OSX 51, OSX 52, *) {  // expected-error {{version for 'macOS' already specified}}
+if #available(OSX 51, OSX 52, *) {  // expected-error {{version for macOS already specified}}
 }
 
 if #available(OSX 52) { }  // expected-error {{must handle potential future platforms with '*'}} {{21-21=, *}}

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -55,7 +55,7 @@ if #unavailable(macoss 51) { // expected-warning {{unrecognized platform name 'm
 if #unavailable(mac 51) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{17-20=macOS}}
 }
 
-if #unavailable(OSX 51, OSX 52) {  // expected-error {{version for 'macOS' already specified}}
+if #unavailable(OSX 51, OSX 52) {  // expected-error {{version for macOS already specified}}
 }
 
 if #unavailable(OSX 51, iOS 8.0, *) { }  // expected-error {{platform wildcard '*' is always implicit in #unavailable}} {{34-35=}}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -45,23 +45,23 @@ func allPlatformsDeprecatedAndObsoleted() {}
 func allPlatformsDeprecatedAndObsoleted2() {}
 
 @available(swift, unavailable)
-// expected-warning@-1 {{'unavailable' cannot be used in 'available' attribute for platform 'swift'}}
+// expected-warning@-1 {{'unavailable' cannot be used in '@available' attribute for Swift}}
 func swiftUnavailable() {}
 
 @available(swift, unavailable, introduced: 4.2)
-// expected-warning@-1 {{'unavailable' cannot be used in 'available' attribute for platform 'swift'}}
+// expected-warning@-1 {{'unavailable' cannot be used in '@available' attribute for Swift}}
 func swiftUnavailableIntroduced() {}
 
 @available(swift, deprecated)
-// expected-warning@-1 {{expected version number with 'deprecated' in 'available' attribute for platform 'swift'}}
+// expected-warning@-1 {{expected version number with 'deprecated' in '@available' attribute for Swift}}
 func swiftDeprecated() {}
 
 @available(swift, deprecated, obsoleted: 4.2)
-// expected-warning@-1 {{expected version number with 'deprecated' in 'available' attribute for platform 'swift'}}
+// expected-warning@-1 {{expected version number with 'deprecated' in '@available' attribute for Swift}}
 func swiftDeprecatedObsoleted() {}
 
 @available(swift, message: "missing valid option")
-// expected-warning@-1 {{expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'swift'}}
+// expected-warning@-1 {{expected 'introduced', 'deprecated', or 'obsoleted' in '@available' attribute for Swift}}
 func swiftMessage() {}
 
 @available(swift 5, deprecated: 6)

--- a/test/Sema/availability_define_parsing.swift
+++ b/test/Sema/availability_define_parsing.swift
@@ -45,5 +45,5 @@ public func noVersionMulti() {}
 // CHECK-NEXT: _incorrectCase
 
 // FIXME: [availability] Diagnostic needs improvement
-// CHECK: -define-availability argument:1:13: warning: expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'macOS'
+// CHECK: -define-availability argument:1:13: warning: expected 'introduced', 'deprecated', or 'obsoleted' in '@available' attribute for macOS
 // CHECK-NEXT: _noVersion: macOS

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -271,7 +271,7 @@ func iosIsClosestThanMacOS() {}
 // platform it validates the availability.
 @available(iOS 8.0, iDishwasherOS 22.0, iOS 9.0, *)
 // expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
-// expected-error@-2 {{version for 'iOS' already specified}}
+// expected-error@-2 {{version for iOS already specified}}
 func shortFormWithUnrecognizedPlatformContinueValidating() {
 }
 

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -18,11 +18,11 @@ func asyncReplacement() async -> Int { }
 @available(*, noasync, renamed: "IOActor.readString()")
 func readStringFromIO() -> String {}
 
-// expected-warning@+1 {{'noasync' cannot be used in 'available' attribute for platform 'swift'}}
+// expected-warning@+1 {{'noasync' cannot be used in '@available' attribute for Swift}}
 @available(swift, noasync)
 func swiftNoAsync() { }
 
-// expected-warning@+1 {{'noasync' cannot be used in 'available' attribute for platform '_PackageDescription'}}
+// expected-warning@+1 {{'noasync' cannot be used in '@available' attribute for PackageDescription}}
 @available(_PackageDescription, noasync)
 func packageDescriptionNoAsync() { }
 


### PR DESCRIPTION
This simplifies the code to emit availability diagnostics and ensures that they display domain names consistently. While updating existing diagnostics, improve consistency along other dimensions as well.