### PR TITLE
Index: Accept more deserialization inconsistencies during index-while-building

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -380,6 +380,12 @@ public:
   /// files?
   bool IgnoreAdjacentModules = false;
 
+  /// Override to accept reading errors from swiftmodules and being generally
+  /// more tolerant to inconsistencies. This is enabled for
+  /// index-while-building as it runs last and it can afford to read an AST
+  /// with inconsistencies.
+  bool ForceAllowModuleWithCompilerErrors = false;
+
   // Define the set of known identifiers.
 #define IDENTIFIER_WITH_NAME(Name, IdStr) Identifier Id_##Name;
 #include "swift/AST/KnownIdentifiers.def"

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
@@ -2154,6 +2155,7 @@ void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
 }
 
 void index::indexModule(ModuleDecl *module, IndexDataConsumer &consumer) {
+  PrettyStackTraceDecl trace("indexing module", module);
   assert(module);
   auto mName = module->getRealName().str();
   if (module->getASTContext().blockListConfig.hasBlockListAction(mName,

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -2156,14 +2156,19 @@ void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
 
 void index::indexModule(ModuleDecl *module, IndexDataConsumer &consumer) {
   PrettyStackTraceDecl trace("indexing module", module);
+  ASTContext &ctx = module->getASTContext();
   assert(module);
+
   auto mName = module->getRealName().str();
-  if (module->getASTContext().blockListConfig.hasBlockListAction(mName,
+  if (ctx.blockListConfig.hasBlockListAction(mName,
       BlockListKeyKind::ModuleName,
       BlockListAction::SkipIndexingModule)) {
     return;
   }
-  IndexSwiftASTWalker walker(consumer, module->getASTContext());
+
+  llvm::SaveAndRestore<bool> S(ctx.ForceAllowModuleWithCompilerErrors, true);
+
+  IndexSwiftASTWalker walker(consumer, ctx);
   walker.visitModule(*module);
   consumer.finish();
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -135,7 +135,8 @@ ModuleFile::ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core)
 }
 
 bool ModuleFile::allowCompilerErrors() const {
-  return getContext().LangOpts.AllowModuleWithCompilerErrors;
+  return getContext().LangOpts.AllowModuleWithCompilerErrors ||
+         getContext().ForceAllowModuleWithCompilerErrors;
 }
 
 Status


### PR DESCRIPTION
Force allowing reading from modules with compiler errors during index-while-building as a way to recover from more deserialization issues. That setting enables reconstituting an AST with inconsistencies, this should be safe for indexing but needs to be avoided by code generation and such.