### PR TITLE
AST: Allow multiple unavailable domains in `AvailabilityContext`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -48,13 +48,6 @@ private:
     assert(storage);
   };
 
-  /// Retrieves an `AvailabilityContext` with the given platform availability
-  /// parameters.
-  static AvailabilityContext
-  get(const AvailabilityRange &platformAvailability,
-      std::optional<AvailabilityDomain> unavailableDomain, bool deprecated,
-      ASTContext &ctx);
-
 public:
   /// Retrieves an `AvailabilityContext` constrained by the given platform
   /// availability range.

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -112,6 +112,9 @@ public:
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP;
+
+  /// Returns true if all internal invariants are satisfied.
+  bool verify(ASTContext &ctx) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -61,6 +61,9 @@ public:
   bool isContainedIn(const Info &other) const;
 
   void Profile(llvm::FoldingSetNodeID &ID) const;
+
+  /// Returns true if all internal invariants are satisfied.
+  bool verify(ASTContext &ctx) const;
 };
 
 /// As an implementation detail, the values that make up an `Availability`

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -31,8 +31,9 @@ public:
   /// The introduction version.
   AvailabilityRange Range;
 
-  /// The broadest unavailable domain.
-  std::optional<AvailabilityDomain> UnavailableDomain;
+  /// A sorted collection of disjoint domains that are known to be
+  /// unavailable in this context.
+  llvm::SmallVector<AvailabilityDomain, 1> UnavailableDomains;
 
   /// Whether or not the context is considered deprecated on the current
   /// platform.
@@ -49,20 +50,17 @@ public:
   bool constrainWith(const DeclAvailabilityConstraints &constraints,
                      ASTContext &ctx);
 
-  bool constrainUnavailability(std::optional<AvailabilityDomain> domain);
+  bool constrainUnavailability(
+      const llvm::SmallVectorImpl<AvailabilityDomain> &domains);
+  bool constrainUnavailability(AvailabilityDomain domain) {
+    return constrainUnavailability(
+        llvm::SmallVector<AvailabilityDomain>{domain});
+  }
 
   /// Returns true if `other` is as available or is more available.
   bool isContainedIn(const Info &other) const;
 
-  void Profile(llvm::FoldingSetNodeID &ID) const {
-    Range.getRawVersionRange().Profile(ID);
-    if (UnavailableDomain) {
-      UnavailableDomain->Profile(ID);
-    } else {
-      ID.AddPointer(nullptr);
-    }
-    ID.AddBoolean(IsDeprecated);
-  }
+  void Profile(llvm::FoldingSetNodeID &ID) const;
 };
 
 /// As an implementation detail, the values that make up an `Availability`

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -265,6 +265,14 @@ inline void simple_display(llvm::raw_ostream &os,
   domain.print(os);
 }
 
+/// A comparator that implements a stable, total ordering on
+/// `AvailabilityDomain` that can be used for sorting in contexts where the
+/// result must be stable and deterministic across compilations.
+struct StableAvailabilityDomainComparator {
+  bool operator()(const AvailabilityDomain &lhs,
+                  const AvailabilityDomain &rhs) const;
+};
+
 /// Represents an availability domain that has been defined in a module.
 class CustomAvailabilityDomain : public ASTAllocated<CustomAvailabilityDomain> {
 public:

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -168,46 +168,11 @@ void AvailabilityInference::applyInferredAvailableAttrs(
     Decl *ToDecl, ArrayRef<const Decl *> InferredFromDecls) {
   auto &Context = ToDecl->getASTContext();
 
-  /// A wrapper for AvailabilityDomain that implements a stable, total ordering for
-  /// domains. This is needed to ensure that the inferred attributes are added to
-  /// the declaration in a consistent order, preserving interface printing output
-  /// stability across compilations.
-  class OrderedAvailabilityDomain {
-  public:
-    AvailabilityDomain domain;
-
-    OrderedAvailabilityDomain(AvailabilityDomain domain) : domain(domain) {}
-
-    bool operator<(const OrderedAvailabilityDomain &other) const {
-      auto kind = domain.getKind();
-      auto otherKind = other.domain.getKind();
-      if (kind != otherKind)
-        return kind < otherKind;
-
-      switch (kind) {
-      case AvailabilityDomain::Kind::Universal:
-      case AvailabilityDomain::Kind::SwiftLanguage:
-      case AvailabilityDomain::Kind::PackageDescription:
-      case AvailabilityDomain::Kind::Embedded:
-        return false;
-      case AvailabilityDomain::Kind::Platform:
-        return domain.getPlatformKind() < other.domain.getPlatformKind();
-      case AvailabilityDomain::Kind::Custom: {
-        auto mod = domain.getModule();
-        auto otherMod = other.domain.getModule();
-        if (mod != otherMod)
-          return mod->getName() < otherMod->getName();
-
-        return domain.getNameForAttributePrinting() <
-               other.domain.getNameForAttributePrinting();
-      }
-      }
-    }
-  };
-
   // Iterate over the declarations and infer required availability on
-  // a per-platform basis.
-  std::map<OrderedAvailabilityDomain, InferredAvailability> Inferred;
+  // a per-domain basis.
+  std::map<AvailabilityDomain, InferredAvailability,
+           StableAvailabilityDomainComparator>
+      Inferred;
   for (const Decl *D : InferredFromDecls) {
     llvm::SmallVector<SemanticAvailableAttr, 8> MergedAttrs;
 
@@ -242,8 +207,7 @@ void AvailabilityInference::applyInferredAvailableAttrs(
   // Create an availability attribute for each observed platform and add
   // to ToDecl.
   for (auto &Pair : Inferred) {
-    if (auto Attr =
-            createAvailableAttr(Pair.first.domain, Pair.second, Context))
+    if (auto Attr = createAvailableAttr(Pair.first, Pair.second, Context))
       Attrs.add(Attr);
   }
 }

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -155,6 +155,16 @@ void AvailabilityContext::Info::Profile(llvm::FoldingSetNodeID &ID) const {
   ID.AddBoolean(IsDeprecated);
 }
 
+bool AvailabilityContext::Info::verify(ASTContext &ctx) const {
+  // Unavailable domains must be sorted to ensure folding set node lookups yield
+  // consistent results.
+  if (!llvm::is_sorted(UnavailableDomains,
+                       StableAvailabilityDomainComparator()))
+    return false;
+
+  return true;
+}
+
 AvailabilityContext
 AvailabilityContext::forPlatformRange(const AvailabilityRange &range,
                                       ASTContext &ctx) {
@@ -278,3 +288,7 @@ void AvailabilityContext::print(llvm::raw_ostream &os) const {
 }
 
 void AvailabilityContext::dump() const { print(llvm::errs()); }
+
+bool AvailabilityContext::verify(ASTContext &ctx) const {
+  return storage->info.verify(ctx);
+}

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -38,27 +38,10 @@ static bool constrainRange(AvailabilityRange &existing,
   return true;
 }
 
-static bool constrainUnavailableDomain(
-    std::optional<AvailabilityDomain> &domain,
-    const std::optional<AvailabilityDomain> &otherDomain) {
-  // If the other domain is absent or is the same domain, it's a noop.
-  if (!otherDomain || domain == otherDomain)
-    return false;
-
-  // Check if the other domain is a superset and constrain to it if it is.
-  if (!domain || otherDomain->contains(*domain)) {
-    domain = otherDomain;
-    return true;
-  }
-
-  return false;
-}
-
 bool AvailabilityContext::Info::constrainWith(const Info &other) {
   bool isConstrained = false;
   isConstrained |= constrainRange(Range, other.Range);
-  if (other.UnavailableDomain)
-    isConstrained |= constrainUnavailability(other.UnavailableDomain);
+  isConstrained |= constrainUnavailability(other.UnavailableDomains);
   isConstrained |= CONSTRAIN_BOOL(IsDeprecated, other.IsDeprecated);
 
   return isConstrained;
@@ -89,9 +72,51 @@ bool AvailabilityContext::Info::constrainWith(
   return isConstrained;
 }
 
+/// Returns true if `domain` is not already contained in `unavailableDomains`.
+/// Also, removes domains from `unavailableDomains` that are contained in
+/// `domain`.
+static bool shouldConstrainUnavailableDomains(
+    AvailabilityDomain domain,
+    llvm::SmallVectorImpl<AvailabilityDomain> &unavailableDomains) {
+  bool didRemove = false;
+  for (auto iter = unavailableDomains.rbegin(), end = unavailableDomains.rend();
+       iter != end; ++iter) {
+    auto const &existingDomain = *iter;
+
+    // Check if the domain is already unavailable.
+    if (existingDomain.contains(domain)) {
+      ASSERT(!didRemove); // This would indicate that the context is malformed.
+      return false;
+    }
+
+    // Check if the existing domain would be absorbed by the new domain.
+    if (domain.contains(existingDomain)) {
+      unavailableDomains.erase((iter + 1).base());
+      didRemove = true;
+    }
+  }
+
+  return true;
+}
+
 bool AvailabilityContext::Info::constrainUnavailability(
-    std::optional<AvailabilityDomain> domain) {
-  return constrainUnavailableDomain(UnavailableDomain, domain);
+    const llvm::SmallVectorImpl<AvailabilityDomain> &domains) {
+  llvm::SmallVector<AvailabilityDomain, 2> domainsToAdd;
+
+  for (auto domain : domains) {
+    if (shouldConstrainUnavailableDomains(domain, UnavailableDomains))
+      domainsToAdd.push_back(domain);
+  }
+
+  if (domainsToAdd.size() < 1)
+    return false;
+
+  // Add the candidate domain and then re-sort.
+  for (auto domain : domainsToAdd)
+    UnavailableDomains.push_back(domain);
+
+  llvm::sort(UnavailableDomains, StableAvailabilityDomainComparator());
+  return true;
 }
 
 bool AvailabilityContext::Info::isContainedIn(const Info &other) const {
@@ -99,14 +124,20 @@ bool AvailabilityContext::Info::isContainedIn(const Info &other) const {
   if (!Range.isContainedIn(other.Range))
     return false;
 
-  // The set of unavailable domains should be the same or larger.
-  if (auto otherUnavailableDomain = other.UnavailableDomain) {
-    if (!UnavailableDomain)
-      return false;
+  // Every unavailable domain in the other context should be contained in some
+  // unavailable domain in this context.
+  bool disjointUnavailability = llvm::any_of(
+      other.UnavailableDomains,
+      [&](const AvailabilityDomain &otherUnavailableDomain) {
+        return llvm::none_of(
+            UnavailableDomains,
+            [&otherUnavailableDomain](const AvailabilityDomain &domain) {
+              return domain.contains(otherUnavailableDomain);
+            });
+      });
 
-    if (!UnavailableDomain->contains(otherUnavailableDomain.value()))
-      return false;
-  }
+  if (disjointUnavailability)
+    return false;
 
   // The set of deprecated domains should be the same or larger.
   if (!IsDeprecated && other.IsDeprecated)
@@ -115,10 +146,19 @@ bool AvailabilityContext::Info::isContainedIn(const Info &other) const {
   return true;
 }
 
+void AvailabilityContext::Info::Profile(llvm::FoldingSetNodeID &ID) const {
+  Range.getRawVersionRange().Profile(ID);
+  ID.AddInteger(UnavailableDomains.size());
+  for (auto domain : UnavailableDomains) {
+    domain.Profile(ID);
+  }
+  ID.AddBoolean(IsDeprecated);
+}
+
 AvailabilityContext
 AvailabilityContext::forPlatformRange(const AvailabilityRange &range,
                                       ASTContext &ctx) {
-  Info info{range, /*UnavailableDomain*/ std::nullopt,
+  Info info{range, /*UnavailableDomains*/ {},
             /*IsDeprecated*/ false};
   return AvailabilityContext(Storage::get(info, ctx));
 }
@@ -133,27 +173,20 @@ AvailabilityContext AvailabilityContext::forDeploymentTarget(ASTContext &ctx) {
       AvailabilityRange::forDeploymentTarget(ctx), ctx);
 }
 
-AvailabilityContext
-AvailabilityContext::get(const AvailabilityRange &platformAvailability,
-                         std::optional<AvailabilityDomain> unavailableDomain,
-                         bool deprecated, ASTContext &ctx) {
-  Info info{platformAvailability, unavailableDomain, deprecated};
-  return AvailabilityContext(Storage::get(info, ctx));
-}
-
 AvailabilityRange AvailabilityContext::getPlatformRange() const {
   return storage->info.Range;
 }
 
 bool AvailabilityContext::isUnavailable() const {
-  return storage->info.UnavailableDomain.has_value();
+  return storage->info.UnavailableDomains.size() > 0;
 }
 
 bool AvailabilityContext::containsUnavailableDomain(
     AvailabilityDomain domain) const {
-  if (auto unavailableDomain = storage->info.UnavailableDomain)
-    return unavailableDomain->contains(domain);
-
+  for (auto unavailableDomain : storage->info.UnavailableDomains) {
+    if (unavailableDomain.contains(domain))
+      return true;
+  }
   return false;
 }
 
@@ -217,10 +250,7 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
 }
 
 bool AvailabilityContext::isContainedIn(const AvailabilityContext other) const {
-  if (!storage->info.isContainedIn(other.storage->info))
-    return false;
-
-  return true;
+  return storage->info.isContainedIn(other.storage->info);
 }
 
 static std::string
@@ -236,8 +266,12 @@ stringForAvailability(const AvailabilityRange &availability) {
 void AvailabilityContext::print(llvm::raw_ostream &os) const {
   os << "version=" << stringForAvailability(getPlatformRange());
 
-  if (auto unavailableDomain = storage->info.UnavailableDomain)
-    os << " unavailable=" << unavailableDomain->getNameForAttributePrinting();
+  if (storage->info.UnavailableDomains.size() > 0) {
+    os << " unavailable=";
+    llvm::interleave(
+        storage->info.UnavailableDomains, os,
+        [&](const AvailabilityDomain &domain) { domain.print(os); }, ",");
+  }
 
   if (isDeprecated())
     os << " deprecated";

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -147,26 +147,19 @@ ModuleDecl *AvailabilityDomain::getModule() const {
 }
 
 bool AvailabilityDomain::contains(const AvailabilityDomain &other) const {
-  // FIXME: [availability] This currently implements something closer to a
-  // total ordering instead of the more flexible partial ordering that it
-  // would ideally represent. Until AvailabilityContext supports tracking
-  // multiple unavailable domains simultaneously, a stricter ordering is
-  // necessary to support source compatibility.
   switch (getKind()) {
   case Kind::Universal:
     return true;
   case Kind::SwiftLanguage:
-    return !other.isUniversal();
   case Kind::PackageDescription:
   case Kind::Embedded:
-    return !other.isUniversal() && !other.isSwiftLanguage();
+  case Kind::Custom:
+    return other == *this;
   case Kind::Platform:
     if (getPlatformKind() == other.getPlatformKind())
       return true;
     return inheritsAvailabilityFromPlatform(other.getPlatformKind(),
                                             getPlatformKind());
-  case Kind::Custom:
-    return getCustomDomain() == other.getCustomDomain();
   }
 }
 

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -581,7 +581,11 @@ void AvailabilityScope::verify(const AvailabilityScope *parent,
                         {{"child", this}, {"parent", parent}});
   }
 
-  if (!getAvailabilityContext().isContainedIn(parent->getAvailabilityContext()))
+  auto context = getAvailabilityContext();
+  if (!context.verify(ctx))
+    verificationError(ctx, "context is invalid", {{"node", this}});
+
+  if (!context.isContainedIn(parent->getAvailabilityContext()))
     verificationError(ctx, "child availability range not contained",
                       {{"child", this}, {"parent", parent}});
 }

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -44,9 +44,9 @@ AvailabilityScope::AvailabilityScope(ASTContext &Ctx, IntroNode Node,
                                      const AvailabilityContext Info)
     : Node(Node), SrcRange(SrcRange), AvailabilityInfo(Info) {
   if (Parent) {
-    assert(SrcRange.isValid());
+    ASSERT(SrcRange.isValid());
     Parent->addChild(this, Ctx);
-    assert(Info.isContainedIn(Parent->getAvailabilityContext()));
+    DEBUG_ASSERT(Info.isContainedIn(Parent->getAvailabilityContext()));
   }
   Ctx.addDestructorCleanup(Children);
 }
@@ -54,7 +54,7 @@ AvailabilityScope::AvailabilityScope(ASTContext &Ctx, IntroNode Node,
 AvailabilityScope *
 AvailabilityScope::createForSourceFile(SourceFile *SF,
                                        const AvailabilityContext Info) {
-  assert(SF);
+  ASSERT(SF);
 
   ASTContext &Ctx = SF->getASTContext();
 
@@ -93,16 +93,16 @@ AvailabilityScope::createForSourceFile(SourceFile *SF,
 AvailabilityScope *AvailabilityScope::createForDecl(
     ASTContext &Ctx, Decl *D, AvailabilityScope *Parent,
     const AvailabilityContext Info, SourceRange SrcRange) {
-  assert(D);
-  assert(Parent);
+  ASSERT(D);
+  ASSERT(Parent);
   return new (Ctx) AvailabilityScope(Ctx, D, Parent, SrcRange, Info);
 }
 
 AvailabilityScope *AvailabilityScope::createForDeclImplicit(
     ASTContext &Ctx, Decl *D, AvailabilityScope *Parent,
     const AvailabilityContext Info, SourceRange SrcRange) {
-  assert(D);
-  assert(Parent);
+  ASSERT(D);
+  ASSERT(Parent);
   return new (Ctx) AvailabilityScope(Ctx, IntroNode(D, Reason::DeclImplicit),
                                      Parent, SrcRange, Info);
 }
@@ -110,8 +110,8 @@ AvailabilityScope *AvailabilityScope::createForDeclImplicit(
 AvailabilityScope *AvailabilityScope::createForIfStmtThen(
     ASTContext &Ctx, IfStmt *S, const DeclContext *DC,
     AvailabilityScope *Parent, const AvailabilityContext Info) {
-  assert(S);
-  assert(Parent);
+  ASSERT(S);
+  ASSERT(Parent);
   return new (Ctx)
       AvailabilityScope(Ctx, IntroNode(S, DC, /*IsThen=*/true), Parent,
                         S->getThenStmt()->getSourceRange(), Info);
@@ -120,8 +120,8 @@ AvailabilityScope *AvailabilityScope::createForIfStmtThen(
 AvailabilityScope *AvailabilityScope::createForIfStmtElse(
     ASTContext &Ctx, IfStmt *S, const DeclContext *DC,
     AvailabilityScope *Parent, const AvailabilityContext Info) {
-  assert(S);
-  assert(Parent);
+  ASSERT(S);
+  ASSERT(Parent);
   return new (Ctx)
       AvailabilityScope(Ctx, IntroNode(S, DC, /*IsThen=*/false), Parent,
                         S->getElseStmt()->getSourceRange(), Info);
@@ -131,8 +131,8 @@ AvailabilityScope *AvailabilityScope::createForConditionFollowingQuery(
     ASTContext &Ctx, PoundAvailableInfo *PAI,
     const StmtConditionElement &LastElement, const DeclContext *DC,
     AvailabilityScope *Parent, const AvailabilityContext Info) {
-  assert(PAI);
-  assert(Parent);
+  ASSERT(PAI);
+  ASSERT(Parent);
   SourceRange Range(PAI->getEndLoc(), LastElement.getEndLoc());
   return new (Ctx)
       AvailabilityScope(Ctx, IntroNode(PAI, DC), Parent, Range, Info);
@@ -142,9 +142,9 @@ AvailabilityScope *AvailabilityScope::createForGuardStmtFallthrough(
     ASTContext &Ctx, GuardStmt *RS, BraceStmt *ContainingBraceStmt,
     const DeclContext *DC, AvailabilityScope *Parent,
     const AvailabilityContext Info) {
-  assert(RS);
-  assert(ContainingBraceStmt);
-  assert(Parent);
+  ASSERT(RS);
+  ASSERT(ContainingBraceStmt);
+  ASSERT(Parent);
   SourceRange Range(RS->getEndLoc(), ContainingBraceStmt->getEndLoc());
   return new (Ctx) AvailabilityScope(
       Ctx, IntroNode(RS, DC, /*IsFallthrough=*/true), Parent, Range, Info);
@@ -153,8 +153,8 @@ AvailabilityScope *AvailabilityScope::createForGuardStmtFallthrough(
 AvailabilityScope *AvailabilityScope::createForGuardStmtElse(
     ASTContext &Ctx, GuardStmt *RS, const DeclContext *DC,
     AvailabilityScope *Parent, const AvailabilityContext Info) {
-  assert(RS);
-  assert(Parent);
+  ASSERT(RS);
+  ASSERT(Parent);
   return new (Ctx)
       AvailabilityScope(Ctx, IntroNode(RS, DC, /*IsFallthrough=*/false), Parent,
                         RS->getBody()->getSourceRange(), Info);
@@ -163,14 +163,15 @@ AvailabilityScope *AvailabilityScope::createForGuardStmtElse(
 AvailabilityScope *AvailabilityScope::createForWhileStmtBody(
     ASTContext &Ctx, WhileStmt *S, const DeclContext *DC,
     AvailabilityScope *Parent, const AvailabilityContext Info) {
-  assert(S);
-  assert(Parent);
+  ASSERT(S);
+  ASSERT(Parent);
   return new (Ctx) AvailabilityScope(Ctx, IntroNode(S, DC), Parent,
                                      S->getBody()->getSourceRange(), Info);
 }
 
 void AvailabilityScope::addChild(AvailabilityScope *Child, ASTContext &Ctx) {
-  assert(Child->getSourceRange().isValid());
+  bool validSourceRange = Child->getSourceRange().isValid();
+  ASSERT(validSourceRange);
 
   // Handle the first child.
   if (Children.empty()) {
@@ -200,14 +201,14 @@ void AvailabilityScope::addChild(AvailabilityScope *Child, ASTContext &Ctx) {
 
 AvailabilityScope *
 AvailabilityScope::findMostRefinedSubContext(SourceLoc Loc, ASTContext &Ctx) {
-  assert(Loc.isValid());
+  DEBUG_ASSERT(Loc.isValid());
 
   if (SrcRange.isValid() && !Ctx.SourceMgr.containsTokenLoc(SrcRange, Loc))
     return nullptr;
 
   (void)evaluateOrDefault(Ctx.evaluator,
                           ExpandChildAvailabilityScopesRequest{this}, {});
-  assert(!getNeedsExpansion());
+  DEBUG_ASSERT(!getNeedsExpansion());
 
   // Do a binary search to find the first child with a source range that
   // ends after the given location.

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -52,16 +52,10 @@ TEST_F(AvailabilityDomainLattice, Contains) {
     // The universal domain is the bottom domain and contains all others.
     EXPECT_TRUE(Universal.contains(domain));
 
-    // FIXME: [availability] The following assertions should change when
-    // AvailabilityContext can support multiple simultaneous unavailable
-    // domains.
-
-    // The Swift domain is second from the bottom.
-    EXPECT_EQ(Swift.contains(domain), !domain.isUniversal());
-
-    // Package and Embedded are both third from the bottom.
-    EXPECT_EQ(Package.contains(domain), !domain.isUniversal() && !domain.isSwiftLanguage());
-    EXPECT_EQ(Embedded.contains(domain), !domain.isUniversal() && !domain.isSwiftLanguage());
+    // These domains only contain themselves.
+    EXPECT_EQ(Swift.contains(domain), domain.isSwiftLanguage());
+    EXPECT_EQ(Package.contains(domain), domain.isPackageDescription());
+    EXPECT_EQ(Embedded.contains(domain), domain.isEmbedded());
   }
 
   // Platform kind domains form their own lattice in which app extension domains


### PR DESCRIPTION
This is needed to allow multiple custom availability domains to be simultaneously unavailable.