### PR TITLE
Educational notes for actor isolation violations in conformances in overrides

### DIFF
--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -104,6 +104,30 @@ EDUCATIONAL_NOTES(actor_isolated_call,
 EDUCATIONAL_NOTES(actor_isolated_call_decl,
                   "actor-isolated-call.md")
 
+EDUCATIONAL_NOTES(non_sendable_param_in_witness,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+EDUCATIONAL_NOTES(non_sendable_param_in_override,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+EDUCATIONAL_NOTES(non_sendable_result_in_witness,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+EDUCATIONAL_NOTES(non_sendable_result_in_override,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+EDUCATIONAL_NOTES(non_sendable_property_in_witness,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+EDUCATIONAL_NOTES(non_sendable_property_in_override,
+                  "Actor-isolation-violations-in-protocol-conformances-and-overrides.md")
+
+EDUCATIONAL_NOTES(non_sendable_property_exits_actor,
+                  "Getting-non-sendable-values-out-of-actors.md")
+
+EDUCATIONAL_NOTES(actor_isolated_witness,
+                  "Actors-can't-conform-to-global-actor-protocols.md")
+
+EDUCATIONAL_NOTES(non_sendable_result_in_objc,
+                  "Non-sendable-types-and-Objective-C-interoperability.md")
+EDUCATIONAL_NOTES(non_sendable_property_in_objc,
+                  "Non-sendable-types-and-Objective-C-interoperability.md")
+
 EDUCATIONAL_NOTES(error_in_swift_lang_mode,
                   "error-in-future-swift-version.md")
 

--- a/userdocs/diagnostics/Actor-isolated-types-conforming-to-nonisolated-protocols.md
+++ b/userdocs/diagnostics/Actor-isolated-types-conforming-to-nonisolated-protocols.md
@@ -1,0 +1,97 @@
+# Actor isolated types conforming to nonisolated protocols
+
+A conformance to a nonisolated protocol in an actor isolated type will be diagnosed when strict concurrency checking is enabled. For example:
+```swift
+protocol FruitProvider {
+    var favoriteFruit: String { get }
+    func getAllFruits() -> [String]
+}
+
+@MainActor 
+final class MyFruitModel: FruitProvider {
+    var favoriteFruit = "apple" // ❌ Main actor-isolated property 'favoriteFruit' cannot be used to satisfy nonisolated requirement from protocol 'FruitProvider'
+    
+    func getAllFruits() -> [String] { // ❌ Main actor-isolated instance method 'getAllFruits()' cannot be used to satisfy nonisolated requirement from protocol 'FruitProvider'
+        return ["apple", "orange", "pineapple"]
+    }
+}
+```
+This is to guarantee no code can call actor isolated code from a different concurrency region when using a protocol as a type. For example, in this code:
+```swift
+nonisolated func useProtocol(fruitProvider: any FruitProvider) async {
+    print(fruitProvider.favoriteFruit)
+}
+```
+If the compiler allowed creating a `FruitProvider` implementation with `@MainActor` isolation, the code above would be executing main actor isolated code in a non-isolated region, which would break Swift Concurrency isolation guarantees!
+
+There are multiple ways to address this issue.
+
+## Match the isolation of both the protocol and the implementation
+
+If the protocol should be isolated, adding a global actor annotation like `@MainActor` may be the best solution, either for the entire protocol:
+```swift
+@MainActor 
+protocol FruitProvider {
+    var favoriteFruit: String { get }
+    func getAllFruits() -> [String]
+}
+```
+Or for specific requirements only:
+```swift
+protocol FruitProvider {    
+    @MainActor
+    var favoriteFruit: String { get }
+    @MainActor
+    func getAllFruits() -> [String]
+}
+```
+Since adding a global actor attribute to the protocol will cause conforming types to inherit that isolation, per-requirement annotations should be favored if it makes sense to have conforming types on a different global actor.
+
+## Make properties and methods `nonisolated` on the conforming type
+
+If the required methods don't need to access any mutable state protected by the actor, another solution is to opt-out of that isolation with an explicit `nonisolated` annotation in the conforming methods:
+```swift
+@MainActor 
+final class MyFruitModel: FruitProvider {
+    nonisolated let favoriteFruit = "apple" // ✅
+    
+    func getAllFruits() -> [String] { // ✅
+        return ["apple", "orange", "pineapple"]
+    }
+}
+```
+
+## Make protocol requirements `async`
+
+For `async` methods with `Sendable` parameters and results, the implementation can define a different isolation than the protocol. Since the caller needs to add a suspension point to call the method, the execution can be performed in a different concurrency region, and then return to the caller's concurrency region again.
+
+```swift
+protocol FruitProvider {
+    var favoriteFruit: String { get async }
+    func getAllFruits() async -> [String]
+}
+
+@MainActor 
+final class MyFruitModel: FruitProvider {
+    var favoriteFruit = "apple" // ✅
+    
+    func getAllFruits() -> [String] { // ✅
+        return ["apple", "orange", "pineapple"]
+    }
+}
+```
+
+## Use `@preconcurrency`
+
+You can add a `@preconcurrency` annotation to protocol conformances that require methods or properties to be `nonisolated` to supress the compiler diagnostic. Instead, a **runtime** check will be added to ensure the methods are always called from the isolation required by the conforming implementation.
+```swift
+@MainActor 
+final class MyFruitModel: @preconcurrency FruitProvider {
+    var favoriteFruit = "apple" // ✅
+    
+    func getAllFruits() -> [String] { // ✅
+        return ["apple", "orange", "pineapple"]
+    }
+}
+```
+This is particulary useful when you don't own the protocol, or when incrementally migrating a codebase to Swift 6, where it may not be practical to refactor all code at once. But take care! There's still a runtime check, so our code from earlier will crash if you provide a main actor isolated implementation (like `MyFruitModel`) and then attempt to use that conformance from outside the main actor.

--- a/userdocs/diagnostics/Actor-isolation-violations-in-protocol-conformances-and overrides.md
+++ b/userdocs/diagnostics/Actor-isolation-violations-in-protocol-conformances-and overrides.md
@@ -1,0 +1,106 @@
+# Actor isolation violations in protocol conformances and overrides
+
+When adding an `async` method to conform to a protocol or override a method from a superclass, the implementation can specify a different actor isolation than the protocol or superclass. When the method is called, the caller will suspend, and the function will later be resumed in the concurrency domain specified in the implementation. This also applies to `get async` accessors required by protocols.
+
+If the implementation defines a different concurrency region than the protocol or superclass, any parameters or return values would potentially be crossing into (or out of) a different concurrency domain. For non-sendable values this is not safe, and the compiler will prevent it. Non-sendable values can't cross actor boundaries!
+
+For example:
+
+```swift
+class MyModel {
+    var mutableState = 10
+}
+
+protocol ModelLogger {
+    func log(model: MyModel) async
+}
+
+@MainActor 
+class MyModelLogger: ModelLogger {
+    func log(model: MyModel) async { // ❌ Non-sendable parameter type 'MyModel' cannot be sent from caller of protocol requirement 'log(model:)' into main actor-isolated implementation
+        print("Logging model with value \(model.mutableState)")
+        return
+    }
+}
+```
+Building with complete concurrency checking will diagnose the potential crossing of `MyModel` from a non-isolated domain into the main-actor isolated domain of the `MyModelLogger` implementation. A caller using the `log(model: MyModel)` method from a non-isolated domain would be sneaking a non-sendable `MyModel` into a main actor isolated domain!
+
+```swift
+class Repository {
+	let model = MyModel()
+	let logger: any ModelLogger = MyModelLogger()
+
+	func performLog() {
+		logger.log(model: model) // Non-sendable `model` must not cross an actor boundary here!
+	}
+}
+```
+
+There are a few possible ways to address this issue.
+
+## Make all parameters and results `Sendable`
+
+If all the parameters and result types of the function are `Sendable`, it's safe to send them across any actor boundaries. Having a different isolation in the implemenation is no longer a problem:
+```swift
+final class MyModel: Sendable {
+    let state = 10
+}
+
+protocol ModelLogger {
+    func log(model: MyModel) async
+}
+
+@MainActor 
+class MyModelLogger: ModelLogger {
+    func log(model: MyModel) async { // ✅
+        print("Logging model with value \(model.state)")
+        return
+    }
+}
+```
+Types can be made `Sendable` by an explicit `Sendable` conformance, a `@MainActor` annotation, or with `@unchecked Sendable` when the type has been made thread safe by a different synchronization mechanism like a lock or a queue.
+
+## Match the isolation of both the protocol and the implementation
+
+Of course, making all parameters and results `Sendable` may not always be possible. Since the problem arises when the protocol or superclass method and its implementation are in different concurrency domains, another solution is to annotate either the protocol or the implementation to be on the same concurrency domain:
+```swift
+class MyModel: Sendable {
+    var mutableState = 10
+}
+
+@MainActor 
+protocol ModelLogger {
+    func log(model: MyModel) async
+}
+
+@MainActor 
+class MyModelLogger: ModelLogger {
+    func log(model: MyModel) async { // ✅
+        print("Logging model with value \(model.mutableState)")
+        return
+    }
+}
+```
+This means any callers of these methods will also need to be on the same concurrency domain. For the example above, calls to `logger.log(model: model)` need to be performed from a main-actor isolated domain.
+
+## Make non-sendable parameters or results `sending`
+
+If the parameters or results can't be made `Sendable`, and the implementation needs to be on a diferent isolation domain than the protocol or superclass, it may still be possible to make those parameters or results `sending`. The compiler will ensure that crossings of a non-sendable value into a different isolation domain using `sending` are safe, by making those values unavailable in their original domain after being sent.
+```swift
+class MyModel {
+    var mutableState = 10
+}
+
+protocol ModelLogger {
+    func log(model: sending MyModel) async
+}
+
+@MainActor 
+class MyModelLogger: ModelLogger {
+    func log(model: sending MyModel) async { // ✅
+        print("Logging model with value \(model.mutableState)")
+        return
+    }
+}
+```
+

--- a/userdocs/diagnostics/Actors-can't-conform-to-global-actor-protocols.md
+++ b/userdocs/diagnostics/Actors-can't-conform-to-global-actor-protocols.md
@@ -1,0 +1,70 @@
+# Actors can't conform to global actor protocols
+
+Attempting to add a protocol conformance to an actor will emit a compiler error if that protocol requires a global actor isolation. For example:
+
+```swift
+@MainActor protocol SampleProtocol {
+    func foo(value: Int)
+}
+
+actor MyModel: SampleProtocol { // ❌ Actor 'MyModel' cannot conform to global actor isolated protocol 'SampleProtocol'
+    func foo(value: Int) {
+        // ...
+    }
+    func bar(value: Int) {
+        // ...
+    }
+}
+```
+
+This happens because adding a protocol conformance to a protocol requiring global actor isolation (like `SampleProtocol` above) makes all methods and properties on that type inherit that global actor's isolation. But actor types (like `MyModel`) also isolate all methods and properties to the actor!
+
+This makes actors incompatible with protocols that require a global actor isolation. Consider the `foo()` function in the example above: should it be isolated to the `@MainActor`, or to an instance of `MyModel`? What about `bar()`?
+
+The most common fix is to ensure both the protocol and the implementation are in the same concurrency domain. For example, by applying the same global actor isolation to both, instead of using an actor instance for the latter:
+```swift
+@MainActor protocol SampleProtocol {
+    func foo()
+}
+
+@MainActor final class MyModel: SampleProtocol { // ✅
+    func foo(value: Int) {
+        // ...
+    }
+    func bar(value: Int) {
+        // ...
+    }
+}
+```
+
+Alternatively, you can move the global actor isolation annotation from the protocol requirement as a whole to individual methods, and have the conformance use the same isolation for those methods:
+```swift
+protocol SampleProtocol {
+    @MainActor func foo()
+}
+
+actor MyModel: SampleProtocol { // ✅
+    @MainActor func foo(value: Int) {
+        // ...
+    }
+    func bar(value: Int) {
+        // ...
+    }
+}
+```
+
+If the protocol requirements are all `async` functions with `Sendable` parameters and results, it's also possible to have a conformance in a different concurrency region:
+```swift
+protocol SampleProtocol {
+    @MainActor func foo(value: Int) async
+}
+
+actor MyModel: SampleProtocol { // ✅
+    func foo(value: Int) async {
+        // ...
+    }
+    func bar() {
+        // ...
+    }
+}
+```

--- a/userdocs/diagnostics/Getting-non-sendable-values-out-of-actors.md
+++ b/userdocs/diagnostics/Getting-non-sendable-values-out-of-actors.md
@@ -10,12 +10,12 @@ class BankAccount {
 }
 
 actor Bank {
-	let name = "My Bank"
+    let name = "My Bank"
     let account = BankAccount()
 }
 
 nonisolated func depositAndPrintBalance(in bank: Bank, by value: Int) async {
-	let bankName = await bank.name // Fine, `name` is Sendable.
+    let bankName = await bank.name // Fine, `name` is Sendable.
     let account = await bank.account // ❌ Non-sendable type 'BankAccount' of property 'acount' cannot exit actor-isolated context
     account.balance += value
     print("Current balance in \(bankName): \(account.balance)")
@@ -32,13 +32,13 @@ class BankAccount {
 }
 
 actor Bank {
-	let name = "My Bank"
+    let name = "My Bank"
     let account = BankAccount()
 
     func depositAndPrintBalance(_ deposit: Int) {
-		account.balance += deposit // ✅
-		print("Current balance in \(name): \(account.balance)")
-	}
+        account.balance += deposit // ✅
+        print("Current balance in \(name): \(account.balance)")
+    }
 }
 ```
 
@@ -51,7 +51,7 @@ class BankAccount {
 
 @MainActor 
 final class Bank {
-	let name = "My Bank"
+    let name = "My Bank"
     let account = BankAccount()
 }
 

--- a/userdocs/diagnostics/Getting-non-sendable-values-out-of-actors.md
+++ b/userdocs/diagnostics/Getting-non-sendable-values-out-of-actors.md
@@ -1,0 +1,66 @@
+# Getting non-sendable values out of actors
+
+When an actor is used to protect a non-sendable value, the compiler will enforce that the non-sendable value remains in the actor's isolation domain. Accessing an actor's property of non-sendable type from a different concurrency region will be diagnosed when complete concurrency checking is enabled:
+
+For example:
+
+```swift
+class BankAccount {
+    var balance = 0
+}
+
+actor Bank {
+	let name = "My Bank"
+    let account = BankAccount()
+}
+
+nonisolated func depositAndPrintBalance(in bank: Bank, by value: Int) async {
+	let bankName = await bank.name // Fine, `name` is Sendable.
+    let account = await bank.account // ❌ Non-sendable type 'BankAccount' of property 'acount' cannot exit actor-isolated context
+    account.balance += value
+    print("Current balance in \(bankName): \(account.balance)")
+}
+```
+
+Non-sendable types in actor-isolated properties can't be safely accessed concurrently, even when declared with `let`. This is because a `let` declaration can hold a type with internal mutable state, like `BankAccount`'s `balance` in the above example.
+
+A useful pattern when working with with actors is to only use `Sendable` types to get information in and out of the actor. You may be able to achieve this by writing the functions directly in the actor:
+
+```swift
+class BankAccount {
+    var balance = 0
+}
+
+actor Bank {
+	let name = "My Bank"
+    let account = BankAccount()
+
+    func depositAndPrintBalance(_ deposit: Int) {
+		account.balance += deposit // ✅
+		print("Current balance in \(name): \(account.balance)")
+	}
+}
+```
+
+Or, if using a global actor like `@MainActor`, by annotating the call sites that need to access the non-sendable types so they never have to leave the concurrency region isolated to the global actor:
+
+```swift
+class BankAccount {
+    var balance = 0
+}
+
+@MainActor 
+final class Bank {
+	let name = "My Bank"
+    let account = BankAccount()
+}
+
+@MainActor 
+func depositAndPrintBalance(in bank: Bank, by value: Int) {
+    let account = bank.account // ✅
+    account.balance += value
+    print("Current balance in \(bank.name): \(bank.balance)")
+}
+```
+
+By moving entire functions into an actor-isolated region, you may also be able to reduce the number of suspension points, or even make the function syncrhonous. This can result in simpler code, as the compiler guarantees that no other code can modify the actor protected state while you're running code synchronously on that actor.

--- a/userdocs/diagnostics/Non-sendable-types-and-Objective-C-interoperability.md
+++ b/userdocs/diagnostics/Non-sendable-types-and-Objective-C-interoperability.md
@@ -1,0 +1,84 @@
+# Non-sendable types and Objective-C interoperability
+
+Actor-isolated methods that are `async` can be exposed to Objective-C using `@objc`. These methods are imported into Objective-C with a completion handler parameter. When Objective-C code calls any of these methods, a detached task that calls the `async` Swift method will be created, executed in the concurrency domain of the actor, and eventually forward the results to the completion handler.
+
+Since Objective-C does not have knowledge of actor isolation, any types involved in the method's signature —either as parameters or as results— are crossing an actor boundary, and are required to be `Sendable`. Otherwise, an error will be diagnosed under strict concurrency checking. 
+
+For example:
+
+```swift
+@objc 
+class MyObjCModel: NSObject {
+    var mutableState = 10
+}
+
+actor Repository: NSObject {
+    
+    var storedModel = MyObjCModel()
+        
+    @objc 
+    func getModel() async -> MyObjCModel { // ❌ Non-sendable type 'MyObjCModel' returned by actor-isolated '@objc' instance method 'getModel()' cannot cross actor boundary
+        return storedModel
+    }
+    
+    @objc 
+    func setModel(to model: MyObjCModel) async { // ❌ Non-sendable parameter type 'MyObjCModel' of actor-isolated '@objc' instance method 'setModel(to:)' cannot cross actor boundary
+        storedModel = model
+    }
+}
+```
+
+Here, `getModel() async` provides a non-sendable `MyObjCModel` type back to Objective-C, but the Objective-C code receiving the `MyObjCModel` is not part of the actor's concurrency domain, which means that an actor boundary is crossed. Similarly, `setModel(to model: MyObjCModel) async` is passing a `MyObjCModel` from Objective-C code (which can't be isolated to the actor) into the actor's concurrency domain, which also means an actor boundary is crossed. This is not safe for non-sendable types.
+
+There are a few possible ways to address this issue.
+
+## Make all parameters and results `Sendable`
+
+If all the parameters and result types of the method are `Sendable`, it's safe to send them across any actor boundaries.
+
+```swift
+@objc 
+final class MyObjCModel: NSObject, Sendable {
+    let state = 10
+}
+
+actor Repository: NSObject {
+    
+    var storedModel = MyObjCModel()
+        
+    @objc func getModel() async -> MyObjCModel { // ✅
+        return storedModel
+    }
+    
+    @objc func setModel(to model: MyObjCModel) async { // ✅
+        storedModel = model
+    }
+}
+```
+Types can be made `Sendable` by an explicit `Sendable` conformance, a `@MainActor` annotation, or even with `@unchecked Sendable` when the type has been made thread safe by a different synchronization mechanism like a lock or a queue.
+
+## Use a global actor like `@MainActor`
+
+Another solution is to use a global actor (like `@MainActor`) instead of an actor's instance to protect mutable state that needs to be accessed from Objective-C:
+
+```swift
+@objc 
+class MyObjCModel: NSObject {
+    var mutableState = 10
+}
+
+@MainActor 
+final class Repository: NSObject {
+    
+    var storedModel = MyObjCModel()
+        
+    @objc func getModel() async -> MyObjCModel { // ✅
+        return storedModel
+    }
+    
+    @objc func setModel(to model: MyObjCModel) async { // ✅
+        storedModel = model
+    }
+}
+```
+However, on the Objective-C side, care must be taken to only call these methods from the global actor's executor. For the main actor, that means only calling these methods from the main thread.


### PR DESCRIPTION
PR to add educational notes about different compiler messages related to protocol conformances and actors (#79639):

**Actors-can't-conform-to-global actor protocols.md**:
- actor_cannot_conform_to_global_actor_protocol

**Actor-isolation-violations-in-protocol-conformances-and-overrides.md**:
- non_sendable_param_in_witness
- non_sendable_param_in_override
- non_sendable_result_in_witness
- non_sendable_result_in_override
- non_sendable_property_in_witness
- non_sendable_property_in_override

**Getting-non-sendable-values-out-of-actors.md**:
- non_sendable_property_exits_actor

**Actors-can't-conform-to-global-actor-protocols.md**:
- actor_isolated_witness

**Non-sendable-types-and-Objective-C-interoperability.md**:
- non_sendable_result_in_objc
- non_sendable_property_in_objc

**NA**:
-  non_sendable_arg_into_actor
- non_sendable_arg_exits_actor
-  non_sendable_result_into_actor 
- non_sendable_result_exits_actor 
- non_sendable_property_into_actor 