### PR TITLE
Prohibit isolated conformances with Sendable(Metatype) constraints

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8316,6 +8316,10 @@ ERROR(isolated_conformance_with_sendable,none,
       "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "
       "parameter %3", (Type, DeclName, bool, Type))
+ERROR(isolated_conformance_with_sendable_simple,none,
+      "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
+      "requirement for a `Sendable` type parameter ",
+      (Type, DeclName))
 
 //===----------------------------------------------------------------------===//
 // MARK: @execution Attribute

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2722,23 +2722,8 @@ WARNING(add_predates_concurrency_import,none,
 GROUPED_WARNING(remove_predates_concurrency_import,PreconcurrencyImport,
                 DefaultIgnore,
                 "'@preconcurrency' attribute on module %0 has no effect", (Identifier))
-NOTE(add_isolated_to_conformance,none,
-     "add 'isolated' to the %0 conformance to restrict it to %1 code",
-    (DeclName, ActorIsolation))
 NOTE(add_preconcurrency_to_conformance,none,
      "add '@preconcurrency' to the %0 conformance to defer isolation checking to run time", (DeclName))
-ERROR(isolated_conformance_not_global_actor_isolated,none,
-      "isolated conformance is only permitted on global-actor-isolated types",
-      ())
-ERROR(isolated_conformance_experimental_feature,none,
-      "isolated conformances require experimental feature "
-      " 'IsolatedConformances'", ())
-ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
-      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as 'isolated'",
-      (Type, DeclName, ActorIsolation, Type, DeclName))
-ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
-      "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
-      (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (Identifier))
@@ -8308,6 +8293,29 @@ ERROR(attr_abi_incompatible_with_silgen_name,none,
       "cannot use '@_silgen_name' and '@abi' on the same %0 because they serve "
       "the same purpose",
       (DescriptiveDeclKind))
+
+//===----------------------------------------------------------------------===//
+// MARK: Isolated conformances
+//===----------------------------------------------------------------------===//
+ERROR(isolated_conformance_not_global_actor_isolated,none,
+      "isolated conformance is only permitted on global-actor-isolated types",
+      ())
+ERROR(isolated_conformance_experimental_feature,none,
+      "isolated conformances require experimental feature "
+      " 'IsolatedConformances'", ())
+ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
+      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as 'isolated'",
+      (Type, DeclName, ActorIsolation, Type, DeclName))
+ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
+      "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
+      (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
+NOTE(add_isolated_to_conformance,none,
+     "add 'isolated' to the %0 conformance to restrict it to %1 code",
+    (DeclName, ActorIsolation))
+ERROR(isolated_conformance_with_sendable,none,
+      "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
+      "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "
+      "parameter %3", (Type, DeclName, bool, Type))
 
 //===----------------------------------------------------------------------===//
 // MARK: @execution Attribute

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -140,6 +140,14 @@ public:
   bool forEachMissingConformance(
       llvm::function_ref<bool(BuiltinProtocolConformance *missing)> fn) const;
 
+  /// Enumerate all of the isolated conformances in the given conformance.
+  ///
+  /// The given `body` will be called on each isolated conformance. If it ever
+  /// returns `true`, this function will abort the search and return `true`.
+  bool forEachIsolatedConformance(
+      llvm::function_ref<bool(ProtocolConformance*)> body
+  ) const;
+
   using OpaqueValue = void*;
   OpaqueValue getOpaqueValue() const { return Union.getOpaqueValue(); }
   static ProtocolConformanceRef getFromOpaqueValue(OpaqueValue value) {

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -187,9 +187,13 @@ public:
   /// \param subReqs An out parameter initialized to a list of simpler
   /// requirements which the caller must check to ensure this
   /// requirement is completely satisfied.
+  /// \param isolatedConformances If non-NULL, will be provided with all of the
+  /// isolated conformances that
   CheckRequirementResult checkRequirement(
       SmallVectorImpl<Requirement> &subReqs,
-      bool allowMissing = false) const;
+      bool allowMissing = false,
+      SmallVectorImpl<ProtocolConformance *> *isolatedConformances = nullptr
+  ) const;
 
   /// Determines if this substituted requirement can ever be satisfied,
   /// possibly with additional substitutions.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -487,6 +487,9 @@ enum class FixKind : uint8_t {
   /// Ignore when an 'InlineArray' literal has mismatched number of elements to
   /// the type it's attempting to bind to.
   AllowInlineArrayLiteralCountMismatch,
+
+  /// Ignore that a conformance is isolated but is not allowed to be.
+  IgnoreIsolatedConformance,
 };
 
 class ConstraintFix {
@@ -3862,6 +3865,35 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInlineArrayLiteralCountMismatch;
+  }
+};
+
+class IgnoreIsolatedConformance : public ConstraintFix {
+  ProtocolConformance *conformance;
+
+  IgnoreIsolatedConformance(ConstraintSystem &cs,
+                            ConstraintLocator *locator,
+                            ProtocolConformance *conformance)
+      : ConstraintFix(cs, FixKind::IgnoreIsolatedConformance, locator),
+        conformance(conformance) { }
+
+public:
+  std::string getName() const override {
+    return "ignore isolated conformance";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreIsolatedConformance *create(ConstraintSystem &cs,
+                                           ConstraintLocator *locator,
+                                           ProtocolConformance *conformance);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreIsolatedConformance;
   }
 };
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -85,6 +85,9 @@ enum class ConstraintKind : char {
   /// class type).
   SubclassOf,
   /// The first type must conform to the second type (which is a
+  /// protocol type) and the conformance must not be an isolated conformance.
+  NonisolatedConformsTo,
+  /// The first type must conform to the second type (which is a
   /// protocol type).
   ConformsTo,
   /// The first type describes a literal that conforms to the second
@@ -689,6 +692,7 @@ public:
     case ConstraintKind::OperatorArgumentConversion:
     case ConstraintKind::SubclassOf:
     case ConstraintKind::ConformsTo:
+    case ConstraintKind::NonisolatedConformsTo:
     case ConstraintKind::LiteralConformsTo:
     case ConstraintKind::TransitivelyConformsTo:
     case ConstraintKind::CheckedCast:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3666,7 +3666,8 @@ public:
 
   /// Add a requirement as a constraint to the constraint system.
   void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
-                     bool isFavored = false);
+                     bool isFavored,
+                     bool prohibitNonisolatedConformance);
 
   void addApplicationConstraint(
       FunctionType *appliedFn, Type calleeType,
@@ -4363,6 +4364,7 @@ public:
 
   // Record the given requirement in the constraint system.
   void openGenericRequirement(DeclContext *outerDC,
+                              GenericSignature signature,
                               unsigned index,
                               const Requirement &requirement,
                               bool skipProtocolSelfConstraint,

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -82,7 +82,9 @@ ProtocolDecl *Requirement::getProtocolDecl() const {
 
 CheckRequirementResult Requirement::checkRequirement(
     SmallVectorImpl<Requirement> &subReqs,
-    bool allowMissing) const {
+    bool allowMissing,
+    SmallVectorImpl<ProtocolConformance *> *isolatedConformances
+) const {
   if (hasError())
     return CheckRequirementResult::SubstitutionFailure;
 
@@ -121,6 +123,15 @@ CheckRequirementResult Requirement::checkRequirement(
         firstType, proto, allowMissing);
     if (!conformance)
       return CheckRequirementResult::RequirementFailure;
+
+    // Collect isolated conformances.
+    if (isolatedConformances) {
+      conformance.forEachIsolatedConformance(
+          [&](ProtocolConformance *isolatedConformance) {
+            isolatedConformances->push_back(isolatedConformance);
+            return false;
+          });
+    }
 
     auto condReqs = conformance.getConditionalRequirements();
     if (condReqs.empty())

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -300,7 +300,7 @@ static void desugarSuperclassRequirement(
 
   SmallVector<Requirement, 2> subReqs;
 
-  switch (req.checkRequirement(subReqs)) {
+  switch (req.checkRequirement(subReqs, /*allowMissing=*/false)) {
   case CheckRequirementResult::Success:
   case CheckRequirementResult::PackRequirement:
     break;
@@ -333,7 +333,7 @@ static void desugarLayoutRequirement(
 
   SmallVector<Requirement, 2> subReqs;
 
-  switch (req.checkRequirement(subReqs)) {
+  switch (req.checkRequirement(subReqs, /*allowMissing=*/false)) {
   case CheckRequirementResult::Success:
   case CheckRequirementResult::PackRequirement:
     break;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -363,7 +363,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
         while (!subReqs.empty()) {
           auto req = subReqs.pop_back_val();
-          switch (req.checkRequirement(subReqs)) {
+          switch (req.checkRequirement(subReqs, /*allowMissing=*/false)) {
           case CheckRequirementResult::Success:
           case CheckRequirementResult::PackRequirement:
           case CheckRequirementResult::ConditionalConformance:

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -51,6 +51,7 @@ BindingSet::BindingSet(ConstraintSystem &CS, TypeVariableType *TypeVar,
 
   for (auto *constraint : info.Constraints) {
     switch (constraint->getKind()) {
+    case ConstraintKind::NonisolatedConformsTo:
     case ConstraintKind::ConformsTo:
       if (constraint->getSecondType()->is<ProtocolType>())
         Protocols.push_back(constraint);
@@ -256,7 +257,8 @@ bool BindingSet::isPotentiallyIncomplete() const {
     // that's done as a last resort effort at resolving first member.
     if (auto *constraint = binding.getSource()) {
       if (binding.BindingType->is<ProtocolType>() &&
-          constraint->getKind() == ConstraintKind::ConformsTo)
+          (constraint->getKind() == ConstraintKind::ConformsTo ||
+           constraint->getKind() == ConstraintKind::NonisolatedConformsTo))
         return true;
     }
   }
@@ -1941,6 +1943,7 @@ void PotentialBindings::infer(ConstraintSystem &CS,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::SameShape:
   case ConstraintKind::MaterializePackExpansion:
+  case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::Defaultable:

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9562,3 +9562,19 @@ bool IncorrectInlineArrayLiteralCount::diagnoseAsError() {
   emitDiagnostic(diag::inlinearray_literal_incorrect_count, lhsCount, rhsCount);
   return true;
 }
+
+bool DisallowedIsolatedConformance::diagnoseAsError() {
+  emitDiagnostic(diag::isolated_conformance_with_sendable_simple,
+                 conformance->getType(),
+                 conformance->getProtocol()->getName());
+
+  auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
+  if (!selectedOverload)
+    return true;
+
+  if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
+    emitDiagnosticAt(decl, diag::decl_declared_here, decl);
+  }
+
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3252,6 +3252,21 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose when an isolated conformance is used in a place where one cannot
+/// be, e.g., due to a Sendable or SendableMetatype requirement on the
+/// corresponding type parameter.
+class DisallowedIsolatedConformance final : public FailureDiagnostic {
+  ProtocolConformance *conformance;
+
+public:
+  DisallowedIsolatedConformance(const Solution &solution,
+                                ProtocolConformance *conformance,
+                                ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), conformance(conformance) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2740,3 +2740,18 @@ bool AllowInlineArrayLiteralCountMismatch::diagnose(const Solution &solution,
                                            getLocator());
   return failure.diagnose(asNote);
 }
+
+IgnoreIsolatedConformance *
+IgnoreIsolatedConformance::create(ConstraintSystem &cs,
+                                  ConstraintLocator *locator,
+                                  ProtocolConformance *conformance) {
+  assert(conformance && "Must have an isolated conformance");
+  return new (cs.getAllocator())
+      IgnoreIsolatedConformance(cs, locator, conformance);
+}
+
+bool IgnoreIsolatedConformance::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  DisallowedIsolatedConformance failure(solution, conformance, getLocator());
+  return failure.diagnose(asNote);
+}

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2556,6 +2556,7 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
         switch (constraint->getKind()) {
         case ConstraintKind::Conversion:
         case ConstraintKind::Defaultable:
+        case ConstraintKind::NonisolatedConformsTo:
         case ConstraintKind::ConformsTo:
         case ConstraintKind::LiteralConformsTo:
         case ConstraintKind::TransitivelyConformsTo:

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -73,6 +73,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
   case ConstraintKind::SubclassOf:
+  case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::TransitivelyConformsTo:
@@ -154,6 +155,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
   case ConstraintKind::SubclassOf:
+  case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::TransitivelyConformsTo:
@@ -316,6 +318,7 @@ Constraint::Constraint(FunctionType *appliedFn, Type calleeType,
 
 ProtocolDecl *Constraint::getProtocol() const {
   assert((Kind == ConstraintKind::ConformsTo ||
+          Kind == ConstraintKind::NonisolatedConformsTo ||
           Kind == ConstraintKind::LiteralConformsTo ||
           Kind == ConstraintKind::TransitivelyConformsTo)
           && "Not a conformance constraint");
@@ -413,6 +416,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
       Out << " operator arg conv "; break;
   case ConstraintKind::SubclassOf: Out << " subclass of "; break;
   case ConstraintKind::ConformsTo: Out << " conforms to "; break;
+  case ConstraintKind::NonisolatedConformsTo:
+      Out << " nonisolated conforms to ";
+      break;
   case ConstraintKind::LiteralConformsTo: Out << " literal conforms to "; break;
   case ConstraintKind::TransitivelyConformsTo: Out << " transitive conformance to "; break;
   case ConstraintKind::CheckedCast: Out << " checked cast to "; break;
@@ -695,6 +701,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::OptionalObject:
   case ConstraintKind::Defaultable:
   case ConstraintKind::SubclassOf:
+  case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::TransitivelyConformsTo:
@@ -765,6 +772,7 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
 
   // Conformance constraints expect an existential on the right-hand side.
   assert((kind != ConstraintKind::ConformsTo &&
+          kind != ConstraintKind::NonisolatedConformsTo &&
           kind != ConstraintKind::TransitivelyConformsTo) ||
          second->isExistentialType());
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7669,43 +7669,6 @@ bool swift::diagnoseNonSendableFromDeinit(
                                 var->getDescriptiveKind(), var->getName());
 }
 
-bool swift::forEachIsolatedConformance(
-    ProtocolConformanceRef conformance,
-    llvm::function_ref<bool(ProtocolConformance*)> body
-) {
-  if (conformance.isInvalid() || conformance.isAbstract())
-    return false;
-
-  if (conformance.isPack()) {
-    auto pack = conformance.getPack()->getPatternConformances();
-    for (auto conformance : pack) {
-      if (forEachIsolatedConformance(conformance, body))
-        return true;
-    }
-
-    return false;
-  }
-
-  // Is this an isolated conformance?
-  auto concrete = conformance.getConcrete();
-  if (auto normal =
-          dyn_cast<NormalProtocolConformance>(concrete->getRootConformance())) {
-    if (normal->isIsolated()) {
-      if (body(concrete))
-        return true;
-    }
-  }
-
-  // Check conformances that are part of this conformance.
-  auto subMap = concrete->getSubstitutionMap();
-  for (auto conformance : subMap.getConformances()) {
-    if (forEachIsolatedConformance(conformance, body))
-      return true;
-  }
-
-  return false;
-}
-
 ActorIsolation swift::getConformanceIsolation(ProtocolConformance *conformance) {
   auto rootNormal =
       dyn_cast<NormalProtocolConformance>(conformance->getRootConformance());

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -699,15 +699,6 @@ void introduceUnsafeInheritExecutorReplacements(
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
-/// Enumerate all of the isolated conformances in the given conformance.
-/// 
-/// The given `body` will be called on each isolated conformance. If it ever
-/// returns `true`, this function will abort the search and return `true`.
-bool forEachIsolatedConformance(
-    ProtocolConformanceRef conformance, 
-    llvm::function_ref<bool(ProtocolConformance*)> body
-);
-
 /// Determine the isolation of the given conformance. This only applies to
 /// the immediate conformance, not any conformances on which it depends.
 ActorIsolation getConformanceIsolation(ProtocolConformance *conformance);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -905,7 +905,7 @@ void TypeChecker::diagnoseRequirementFailure(
   const auto &req = reqFailureInfo.Req;
   const auto &substReq = reqFailureInfo.SubstReq;
 
-  Diag<Type, Type, Type> diagnostic;
+  std::optional<Diag<Type, Type, Type>> diagnostic;
   Diag<Type, Type, StringRef> diagnosticNote;
 
   const auto reqKind = req.getKind();
@@ -923,6 +923,24 @@ void TypeChecker::diagnoseRequirementFailure(
     break;
 
   case RequirementKind::Conformance: {
+    // If this was a failure due to isolated conformances conflicting with
+    // a Sendable or MetatypeSendable requirement, diagnose that.
+    if (reqFailureInfo.IsolatedConformanceProto) {
+      ASTContext &ctx =
+          reqFailureInfo.IsolatedConformanceProto->getASTContext();
+      auto isolatedConformance = reqFailureInfo.IsolatedConformances.front();
+      ctx.Diags.diagnose(
+          errorLoc, diag::isolated_conformance_with_sendable,
+          isolatedConformance->getType(),
+          isolatedConformance->getProtocol()->getName(),
+          reqFailureInfo
+            .IsolatedConformanceProto->isSpecificProtocol(
+              KnownProtocolKind::SendableMetatype),
+          req.getFirstType());
+      diagnosticNote = diag::type_does_not_inherit_or_conform_requirement;
+      break;
+    }
+
     diagnoseConformanceFailure(substReq.getFirstType(),
                                substReq.getProtocolDecl(), nullptr, errorLoc);
 
@@ -951,9 +969,12 @@ void TypeChecker::diagnoseRequirementFailure(
   }
 
   ASTContext &ctx = targetTy->getASTContext();
-  // FIXME: Poor source-location information.
-  ctx.Diags.diagnose(errorLoc, diagnostic, targetTy, substReq.getFirstType(),
-                     substSecondTy);
+
+  if (diagnostic) {
+    // FIXME: Poor source-location information.
+    ctx.Diags.diagnose(errorLoc, *diagnostic, targetTy, substReq.getFirstType(),
+                       substSecondTy);
+  }
 
   const auto genericParamBindingsText = gatherGenericParamBindingsText(
       {req.getFirstType(), secondTy}, genericParams, substitutions);
@@ -966,6 +987,7 @@ void TypeChecker::diagnoseRequirementFailure(
 }
 
 CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
+    GenericSignature signature,
     ArrayRef<Requirement> requirements,
     TypeSubstitutionFn substitutions) {
   using ParentConditionalConformances =
@@ -1004,7 +1026,9 @@ CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
     auto substReq = item.SubstReq;
 
     SmallVector<Requirement, 2> subReqs;
-    switch (substReq.checkRequirement(subReqs, /*allowMissing=*/true)) {
+    SmallVector<ProtocolConformance *, 2> isolatedConformances;
+    switch (substReq.checkRequirement(subReqs, /*allowMissing=*/true,
+                                      &isolatedConformances)) {
     case CheckRequirementResult::Success:
       break;
 
@@ -1035,6 +1059,38 @@ CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
     case CheckRequirementResult::SubstitutionFailure:
       hadSubstFailure = true;
       break;
+    }
+
+    if (!isolatedConformances.empty()) {
+      // Dig out the original type parameter for the requirement.
+      // FIXME: req might not be the right pre-substituted requirement,
+      // if this came from a conditional requirement.
+      auto firstType = req.getFirstType();
+
+      // An isolated conformance cannot be used in a context where the type
+      // parameter can escape the isolation domain in which the conformance
+      // was formed. To establish this, we look for Sendable or SendableMetatype
+      // requirements on the type parameter itself.
+      ASTContext &ctx = firstType->getASTContext();
+      auto sendableProto = ctx.getProtocol(KnownProtocolKind::Sendable);
+      auto sendableMetatypeProto =
+          ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+      if (firstType->isTypeParameter()) {
+        std::optional<ProtocolDecl *> failedProtocol;
+        if (sendableProto &&
+            signature->requiresProtocol(firstType, sendableProto))
+          failedProtocol = sendableProto;
+        else if (sendableMetatypeProto &&
+                 signature->requiresProtocol(firstType, sendableMetatypeProto))
+          failedProtocol = sendableMetatypeProto;
+
+        if (failedProtocol) {
+          return CheckGenericArgumentsResult::createIsolatedConformanceFailure(
+            req, substReq,
+            TinyPtrVector<ProtocolConformance *>(isolatedConformances),
+            *failedProtocol);
+        }
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5100,6 +5100,7 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
   }
 
   const auto result = TypeChecker::checkGenericArgumentsForDiagnostics(
+      proto->getGenericSignature(),
       reqSig, QuerySubstitutionMap{substitutions});
   switch (result.getKind()) {
   case CheckRequirementsResult::Success:
@@ -5233,8 +5234,8 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
       }
 
       if (!diagnosedIsolatedConformanceIssue) {
-        bool foundIssue = forEachIsolatedConformance(
-            ProtocolConformanceRef(assocConf),
+        bool foundIssue = ProtocolConformanceRef(assocConf)
+          .forEachIsolatedConformance(
             [&](ProtocolConformance *isolatedConformance) {
               // If the conformance we're checking isn't isolated at all, it
               // needs "isolated".

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -667,7 +667,7 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
   };
 
   const auto result = TypeChecker::checkGenericArgumentsForDiagnostics(
-      genericSig.getRequirements(), substitutions);
+      genericSig, substitutions);
   switch (result.getKind()) {
   case CheckRequirementsResult::RequirementFailure:
     if (loc.isValid()) {
@@ -684,6 +684,14 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
     return true;
   }
   llvm_unreachable("invalid requirement check type");
+}
+
+CheckGenericArgumentsResult
+TypeChecker::checkGenericArgumentsForDiagnostics(
+    GenericSignature signature,
+    TypeSubstitutionFn substitutions) {
+  return checkGenericArgumentsForDiagnostics(
+      signature, signature.getRequirements(), substitutions);
 }
 
 void swift::diagnoseInvalidGenericArguments(SourceLoc loc,
@@ -1288,7 +1296,7 @@ Type TypeResolution::applyUnboundGenericArguments(
     };
 
     const auto result = TypeChecker::checkGenericArgumentsForDiagnostics(
-        genericSig.getRequirements(), substitutions);
+        genericSig, substitutions);
     switch (result.getKind()) {
     case CheckRequirementsResult::RequirementFailure:
       if (loc.isValid()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1550,6 +1550,15 @@ bool maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
 /// Emit delayed diagnostics regarding imports that should be added to the
 /// source file.
 void diagnoseMissingImports(SourceFile &sf);
+
+/// Determine whether the type parameter has requirements that would prohibit
+/// it from using any isolated conformances.
+///
+/// Returns the protocol to which the type conforms that causes the conflict,
+/// which can be either Sendable or SendableMetatype.
+std::optional<ProtocolDecl *> typeParameterProhibitsIsolatedConformance(
+    Type type, GenericSignature signature);
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1168,19 +1168,21 @@ void ConstraintSystem::openGenericRequirements(
   for (unsigned pos = 0, n = requirements.size(); pos != n; ++pos) {
     auto openedGenericLoc =
       locator.withPathElement(LocatorPathElt::OpenedGeneric(signature));
-    openGenericRequirement(outerDC, pos, requirements[pos],
+    openGenericRequirement(outerDC, signature, pos, requirements[pos],
                            skipProtocolSelfConstraint, openedGenericLoc,
                            substFn);
   }
 }
 
 void ConstraintSystem::openGenericRequirement(
-    DeclContext *outerDC, unsigned index, const Requirement &req,
+    DeclContext *outerDC, GenericSignature signature,
+    unsigned index, const Requirement &req,
     bool skipProtocolSelfConstraint, ConstraintLocatorBuilder locator,
     llvm::function_ref<Type(Type)> substFn) {
   std::optional<Requirement> openedReq;
   auto openedFirst = substFn(req.getFirstType());
 
+  bool prohibitIsolatedConformance = false;
   auto kind = req.getKind();
   switch (kind) {
   case RequirementKind::Conformance: {
@@ -1190,6 +1192,12 @@ void ConstraintSystem::openGenericRequirement(
     if (skipProtocolSelfConstraint && protoDecl == outerDC &&
         protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
       return;
+
+    // Check whether the given type parameter has requirements that
+    // prohibit it from using an isolated conformance.
+    if (typeParameterProhibitsIsolatedConformance(req.getFirstType(),
+                                                  signature))
+      prohibitIsolatedConformance = true;
 
     openedReq = Requirement(kind, openedFirst, req.getSecondType());
     break;
@@ -1206,7 +1214,8 @@ void ConstraintSystem::openGenericRequirement(
 
   addConstraint(*openedReq,
                 locator.withPathElement(
-                    LocatorPathElt::TypeParameterRequirement(index, kind)));
+                    LocatorPathElt::TypeParameterRequirement(index, kind)),
+                /*isFavored=*/false, prohibitIsolatedConformance);
 }
 
 /// Add the constraint on the type used for the 'Self' type for a member

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -103,3 +103,19 @@ func testIsolationConformancesInTypes() {
   typealias A2 = PSendableWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter 'T'}}
   typealias A3 = PSendableMetaWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `SendableMetatype` type parameter 'T'}}
 }
+
+func acceptP<T: P>(_: T) { }
+
+func acceptSendableP<T: Sendable & P>(_: T) { }
+// expected-note@-1{{'acceptSendableP' declared here}}
+
+func acceptSendableMetaP<T: SendableMetatype & P>(_: T) { }
+// expected-note@-1{{'acceptSendableMetaP' declared here}}
+
+@MainActor
+func testIsolationConformancesInCall(c: C) {
+  acceptP(c) // okay
+
+  acceptSendableP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+}

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -6,6 +6,10 @@ protocol P {
   func f() // expected-note 2{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
 }
 
+// ----------------------------------------------------------------------------
+// Definition of isolated conformances
+// ----------------------------------------------------------------------------
+
 // expected-note@+3{{add '@preconcurrency' to the 'P' conformance to defer isolation checking to run time}}{{25-25=@preconcurrency }}
 // expected-note@+2{{add 'isolated' to the 'P' conformance to restrict it to main actor-isolated code}}{{25-25=isolated }}
 @MainActor
@@ -77,4 +81,25 @@ struct S: isolated Q {
 @MainActor
 struct SMismatchedActors: isolated Q {
   typealias A = C2
+}
+
+// ----------------------------------------------------------------------------
+// Use checking of isolated conformances.
+// ----------------------------------------------------------------------------
+
+// expected-note@+1{{requirement specified as 'T' : 'P' [with T = C]}}
+struct PSendableWrapper<T: P & Sendable>: P {
+  func f() { }
+}
+
+// expected-note@+1{{requirement specified as 'T' : 'P' [with T = C]}}
+struct PSendableMetaWrapper<T: P & SendableMetatype>: P {
+  func f() { }
+}
+
+@MainActor
+func testIsolationConformancesInTypes() {
+  typealias A1 = PWrapper<C>
+  typealias A2 = PSendableWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter 'T'}}
+  typealias A3 = PSendableMetaWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `SendableMetatype` type parameter 'T'}}
 }


### PR DESCRIPTION
Isolated conformances can only safely be used in a manner that will never escape out of the isolation domain to which they are restricted. There are two rules governing this:
1. The isolated conformance can only be referenced within the same isolation domain, e.g., a `@MainActor` conformance can only be referenced from `@MainActor` code.
2. The isolated conformance cannot escape out of the domain, e.g., by being used in conjunction with generic code that treats the type as `Sendable` or whose metatype is `Sendable`.

This pull request implements the second rule by prohibiting isolated conformances from being used to satisfy constraints on generic parameters that conform to either `Sendable` or `SendableMetatype`. There are two places we need this same check: when checking the wellformedness of substitution maps in general (e.g., for forming types), and within the constraint system. The first is mostly straightforward, although there are gaps in this implementation that involve associated conformances.

Within the constraint system, we introduce a new kind of conformance constraint, a "nonisolated conforms-to" constraint, which can only be satisfied by nonisolated conformances. Introduce this constraint instead of the normal conforms-to constraint whenever the subject type is a type parameter that has either a `Sendable` or `SendableMetatype` constraint, i.e., when the type or its values can escape the current isolation domain.