### PR TITLE
[cxx-interop] Make experimental flag ImportNonPublicCxxMembers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -423,6 +423,9 @@ EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
 /// Ignore resilience errors due to C++ types.
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 
+/// Import inherited non-public members when importing C++ classes.
+EXPERIMENTAL_FEATURE(ImportCxxNonPublicBaseMembers, false)
+
 // Isolated deinit
 SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -424,7 +424,7 @@ EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 
 /// Import inherited non-public members when importing C++ classes.
-EXPERIMENTAL_FEATURE(ImportCxxNonPublicBaseMembers, true)
+EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
 // Isolated deinit
 SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -424,7 +424,7 @@ EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 
 /// Import inherited non-public members when importing C++ classes.
-EXPERIMENTAL_FEATURE(ImportCxxNonPublicBaseMembers, false)
+EXPERIMENTAL_FEATURE(ImportCxxNonPublicBaseMembers, true)
 
 // Isolated deinit
 SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -382,7 +382,7 @@ static bool usesFeatureMemorySafetyAttributes(Decl *decl) {
 UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
-UNINTERESTING_FEATURE(ImportCxxNonPublicBaseMembers)
+UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(CoroutineAccessorsAllocateInCallee)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -382,6 +382,7 @@ static bool usesFeatureMemorySafetyAttributes(Decl *decl) {
 UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
+UNINTERESTING_FEATURE(ImportCxxNonPublicBaseMembers)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(CoroutineAccessorsAllocateInCallee)
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6189,23 +6189,6 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
   DeclName name = desc.name;
   ClangInheritanceInfo inheritance = desc.inheritance;
 
-  /*
-  // HACK: the inherited, synthesized, private 'pointee' property used in MSVC's
-  // std::optional implementation causes problems when conforming it to
-  // CxxOptional (see conformToCxxOptionalIfNeeded()), since it clashes with the
-  // public 'pointee' property synthesized from using _Mybase::operator* (where
-  // _Mybase is _Optional_construct_base). The root cause seems to be the
-  // cloned member cache's inability to manage special decls synthesized from
-  // operators.
-  if (auto *decl =
-          dyn_cast_or_null<clang::CXXRecordDecl>(recordDecl->getClangDecl())) {
-    if (decl->isInStdNamespace() && decl->getIdentifier() &&
-        decl->getName() == "_Optional_construct_base" &&
-        desc.name.getBaseName() == "pointee")
-      return {};
-  }
-  */
-
   auto &ctx = recordDecl->getASTContext();
   auto directResults = evaluateOrDefault(
       ctx.evaluator,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6205,7 +6205,7 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
       continue;
 
     if (inheritance &&
-        !ctx.LangOpts.hasFeature(Feature::ImportCxxNonPublicBaseMembers)) {
+        !ctx.LangOpts.hasFeature(Feature::ImportNonPublicCxxMembers)) {
       auto access = found->getAccess();
       if (access == clang::AS_private || access == clang::AS_protected)
         continue;
@@ -6263,7 +6263,7 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
       foundNameArities.insert(getArity(valueDecl));
 
     for (auto base : cxxRecord->bases()) {
-      if (!ctx.LangOpts.hasFeature(Feature::ImportCxxNonPublicBaseMembers) &&
+      if (!ctx.LangOpts.hasFeature(Feature::ImportNonPublicCxxMembers) &&
           base.getAccessSpecifier() != clang::AS_public)
         continue;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9962,6 +9962,12 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
     if (!nd)
       continue;
 
+    if (!swiftDecl->getASTContext().LangOpts.hasFeature(
+            Feature::ImportCxxNonPublicBaseMembers) &&
+        (nd->getAccess() == clang::AS_private ||
+         nd->getAccess() == clang::AS_protected))
+      continue;
+
     // Currently, we don't import unnamed bitfields.
     if (isa<clang::FieldDecl>(m) &&
         cast<clang::FieldDecl>(m)->isUnnamedBitField())
@@ -10029,6 +10035,11 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   // If this is a C++ record, look through the base classes too.
   if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) {
     for (auto base : cxxRecord->bases()) {
+      if (!swiftDecl->getASTContext().LangOpts.hasFeature(
+              Feature::ImportCxxNonPublicBaseMembers) &&
+          base.getAccessSpecifier() != clang::AS_public)
+        continue;
+
       clang::QualType baseType = base.getType();
       if (auto spectType = dyn_cast<clang::TemplateSpecializationType>(baseType))
         baseType = spectType->desugar();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9963,7 +9963,7 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
       continue;
 
     if (inheritance && !swiftDecl->getASTContext().LangOpts.hasFeature(
-                           Feature::ImportCxxNonPublicBaseMembers)) {
+                           Feature::ImportNonPublicCxxMembers)) {
       auto access = nd->getAccess();
       if (access == clang::AS_private || access == clang::AS_protected)
         continue;
@@ -10037,7 +10037,7 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) {
     for (auto base : cxxRecord->bases()) {
       if (!swiftDecl->getASTContext().LangOpts.hasFeature(
-              Feature::ImportCxxNonPublicBaseMembers) &&
+              Feature::ImportNonPublicCxxMembers) &&
           base.getAccessSpecifier() != clang::AS_public)
         continue;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9962,11 +9962,12 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
     if (!nd)
       continue;
 
-    if (!swiftDecl->getASTContext().LangOpts.hasFeature(
-            Feature::ImportCxxNonPublicBaseMembers) &&
-        (nd->getAccess() == clang::AS_private ||
-         nd->getAccess() == clang::AS_protected))
-      continue;
+    if (inheritance && !swiftDecl->getASTContext().LangOpts.hasFeature(
+                           Feature::ImportCxxNonPublicBaseMembers)) {
+      auto access = nd->getAccess();
+      if (access == clang::AS_private || access == clang::AS_protected)
+        continue;
+    }
 
     // Currently, we don't import unnamed bitfields.
     if (isa<clang::FieldDecl>(m) &&

--- a/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -print-access -module-to-print=AccessInversion -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -print-access -module-to-print=AccessInversion -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK: public struct Leaky {
 

--- a/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-typechecker.swift
@@ -4,7 +4,8 @@
 // but does not necessarily specify it (in the deliberate sense). In other words,
 // there may be behaviors captured in these tests that deserve amending.
 
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import AccessInversion
 

--- a/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
@@ -2,7 +2,8 @@
 // Public C++ members should be imported with Swift-public access, and
 // private C++ members should be imported with Swift-private access.
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=AccessSpecifiers -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=AccessSpecifiers -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct PublicPrivate {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/access-specifiers-typechecker.swift
+++ b/test/Interop/Cxx/class/access/access-specifiers-typechecker.swift
@@ -1,6 +1,7 @@
 // Test that C++ access specifiers are honored.
 
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import AccessSpecifiers
 

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/out
 //
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import StdlibUnittest
 import NonPublicInheritance

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -2,12 +2,12 @@
 // Test that all accessible inherited methods can be called.
 //
 // RUN: split-file %s %t
-// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
+// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 //
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import StdlibUnittest
 import NonPublicInheritance

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -2,7 +2,7 @@
 // Test that all accessible inherited methods can be called.
 //
 // RUN: split-file %s %t
-// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default
+// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 //

--- a/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
@@ -7,8 +7,8 @@
 // against message wording changes), but it does require the message to mention
 // something about "private".
 //
-// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct Base {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
@@ -7,7 +7,7 @@
 // against message wording changes), but it does require the message to mention
 // something about "private".
 //
-// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
 
 // CHECK:      public struct Base {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-module-interface.swift
@@ -8,6 +8,7 @@
 // something about "private".
 //
 // RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicInheritance -print-access -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 // CHECK:      public struct Base {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
@@ -1,7 +1,7 @@
 //--- blessed.swift
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -enable-experimental-feature ImportCxxNonPublicBaseMembers
-
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 import NonPublicInheritance
 
 // Extensions of each class test whether we correctly modeled *which* members

--- a/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
@@ -1,6 +1,6 @@
 //--- blessed.swift
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -enable-experimental-feature ImportCxxNonPublicBaseMembers
 
 import NonPublicInheritance
 

--- a/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
@@ -1,7 +1,7 @@
 //--- blessed.swift
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -enable-experimental-feature ImportCxxNonPublicBaseMembers
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 import NonPublicInheritance
 
 // Extensions of each class test whether we correctly modeled *which* members

--- a/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import StdlibUnittest
 import NonPublicShadow

--- a/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
@@ -1,7 +1,7 @@
 // Check that we are resolving the correct member for all unambiguous members
 // in the Shadow struct.
 
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-executable.swift
@@ -1,9 +1,9 @@
 // Check that we are resolving the correct member for all unambiguous members
 // in the Shadow struct.
 
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import StdlibUnittest
 import NonPublicShadow

--- a/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicShadow -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicShadow -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
 
 // We only check the module interface of Shadow to keep this test concise
 

--- a/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicShadow -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 // We only check the module interface of Shadow to keep this test concise
 

--- a/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicShadow -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonPublicShadow -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // We only check the module interface of Shadow to keep this test concise
 

--- a/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 import NonPublicShadow
 
 func f(s: Shadow) {

--- a/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 import NonPublicShadow
 
 func f(s: Shadow) {

--- a/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-typecheck.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default %s
+// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
 import NonPublicShadow
 
 func f(s: Shadow) {

--- a/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
@@ -1,5 +1,6 @@
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -module-name main -suppress-remarks
+// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // This test uses -verify-additional-file, which do not work well on Windows:
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/Cxx/class/access/private-fileid-nested-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-nested-typecheck.swift
@@ -2,8 +2,9 @@
 // works as expected.
 //
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify %t/file1.swift -I %t/include -cxx-interoperability-mode=default -module-name main
-// RUN: %target-swift-frontend -typecheck -verify %t/file2.swift -I %t/include -cxx-interoperability-mode=default -module-name main
+// RUN: %target-swift-frontend -typecheck -verify %t/file1.swift -I %t/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
+// RUN: %target-swift-frontend -typecheck -verify %t/file2.swift -I %t/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 //--- include/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/class/access/private-fileid-template-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-template-typecheck.swift
@@ -15,7 +15,8 @@
 // non-public in different contexts, and variations in module and file names.
 //
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 //--- blessed.swift
 

--- a/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
@@ -3,6 +3,9 @@
 // in the contexts where they should be accessible (i.e., the files blessed by
 // the SWIFT_PRIVATE_FILEID annotation).
 //
+// For now, it requires the following feature to import private members:
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+//
 // The private_fileid mechanism relies on fileIDs, so we need some control over
 // file names:
 //
@@ -16,37 +19,37 @@
 // members are private (default) or protected. The result should be the same
 // no matter the configuration.
 //
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // This test also includes a "cursed.swift", which expects to not have access to
 // non-public members:
 //
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // To check that fileID is agnostic about directory structure within a module,
 // we move blessed.swift into a subdirectory (but keep its filename).
 //
 // RUN: mkdir -p %t/subdir/subsubdir
 // RUN: mv %t/blessed.swift %t/subdir/subsubdir/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // To check that fileID is sensitive to module names, rename cursed.swift to
 // "blessed.swift", but typecheck in a module not called "main".
 //
 // RUN: mv %t/cursed.swift %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 
 //--- blessed.swift
 

--- a/test/Interop/Cxx/class/access/using-non-public-executable.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-executable.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import StdlibUnittest
 import UsingNonPublic

--- a/test/Interop/Cxx/class/access/using-non-public-executable.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-executable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/class/access/using-non-public-executable.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-executable.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import StdlibUnittest
 import UsingNonPublic

--- a/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
 
 // CHECK:      public struct PublUser {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct PublUser {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 // CHECK:      public struct PublUser {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import UsingNonPublic
 

--- a/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import UsingNonPublic
 

--- a/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
 
 import UsingNonPublic
 

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -116,51 +116,13 @@
 
 // CHECK-NEXT: public struct PrivatelyInherited {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private mutating func mutatingInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func constInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func returnsNonTrivialInBase() -> NonTrivial
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   private mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) private func pure() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func sameMethodNameSameSignature() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func sameMethodDifferentSignature() -> Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }
 
 // CHECK-NEXT: public struct ProtectedInherited {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private mutating func mutatingInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func constInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func returnsNonTrivialInBase() -> NonTrivial
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   private mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) private func pure() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func sameMethodNameSameSignature() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   private func sameMethodDifferentSignature() -> Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }
 
 // CHECK-NEXT: public struct EmptyBaseClass {
 // CHECK-NEXT:   public init()
@@ -186,8 +148,8 @@
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> Int32
-// CHECK-NEXT:   private var x: Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }
 
 // CHECK-NEXT: public struct CopyTrackedDerivedClass {
 // CHECK-NEXT:   public init(_ x: Int32)
@@ -199,16 +161,15 @@
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> Int32
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var x: Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }
 
 // CHECK-NEXT: public struct NonEmptyBase {
 // CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getY() -> Int32
-// CHECK-NEXT:   private var y: Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }
 
 // CHECK-NEXT: public struct CopyTrackedDerivedDerivedClass {
 // CHECK-NEXT:   public init(_ x: Int32)
@@ -216,14 +177,12 @@
 // CHECK-NEXT:   @_transparent public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getY() -> Int32
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var y: Int32
-// CHECK-NEXT:   @discardableResult
+// CHECK-NOT:    public
+// CHECK:        @discardableResult
 // CHECK-NEXT:   public func getDerivedX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> Int32
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var x: Int32
-// CHECK-NEXT: }
+// CHECK-NOT:    public
+// CHECK:      }

--- a/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
@@ -2,10 +2,6 @@
 
 import Functions
 
-PrivatelyInherited().constInBase() // expected-error {{'constInBase' is inaccessible due to 'private' protection level}}
-ProtectedInherited().constInBase() // expected-error {{'constInBase' is inaccessible due to 'private' protection level}}
-
-
 extension Base {
   public func swiftFunc() {}
 }

--- a/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
@@ -1,6 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
 //
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import StdlibUnittest
 import UsingBaseMembers

--- a/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
@@ -1,7 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
 //
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import StdlibUnittest
 import UsingBaseMembers

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct PublicBase {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 // CHECK:      public struct PublicBase {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers | %FileCheck %s
 
 // CHECK:      public struct PublicBase {
 // CHECK-NEXT:   public init()

--- a/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
-// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import UsingBaseMembers
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
+// REQUIRES: swift_feature_ImportCxxNonPublicBaseMembers
 
 import UsingBaseMembers
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportCxxNonPublicBaseMembers
 
 import UsingBaseMembers
 

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -71,7 +71,8 @@ let voidReturnTypeResult: HasPreIncrementOperatorWithVoidReturnType = voidReturn
 let immortalIncrement = myCounter.successor() // expected-error {{value of type 'ImmortalCounter' has no member 'successor'}}
 
 let derivedConstIter = DerivedFromConstIteratorPrivately()
-derivedConstIter.pointee // expected-error {{'pointee' is inaccessible due to 'private' protection level}}
+derivedConstIter.pointee // expected-error {{value of type 'DerivedFromConstIteratorPrivately' has no member 'pointee'}}
+// FIXME: inheriting operators is currently flaky. the error should be {{'pointee' is inaccessible due to 'private' protection level}}
 
 let derivedConstIterWithUD = DerivedFromConstIteratorPrivatelyWithUsingDecl()
 let _ = derivedConstIterWithUD.pointee
@@ -95,5 +96,5 @@ let _ = classWithOperatorStarUnavailable.pointee // expected-error {{'pointee' i
 // FIXME: The below test should also fail with 'pointee' is unavailable in Swift error, 
 // but currently pointee is not hidden in derived classes.
 let derivedClassWithOperatorStarUnavailable = DerivedClassWithOperatorStarUnavailable()
-let _ = derivedClassWithOperatorStarUnavailable.pointee  
+let _ = derivedClassWithOperatorStarUnavailable.pointee
 


### PR DESCRIPTION
ClangImporter can now import non-public members as of be73254cdc93c1e8edac14dc6c50b6352872828e and 66c2e2c52b58ae2e89df86433a8ffa0a657c9c00, but doing so triggers some latent ClangImporter bugs in projects that don't use or need those non-public members.

This patch introduces a new experimental feature flag, ImportNonPublicCxxMembers, that guards against the importation of non-public members while we iron out those latent issues. Adopters of the SWIFT_PRIVATE_FILEID feature introduced in bdf22948ce9b2ccb4a96c249f3ce71e00e8ae78e can enable this flag to opt into importing private members they wish to access from Swift.

rdar://145569473
