### PR TITLE
AST: Consolidate availability version remapping

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3309,8 +3309,8 @@ public:
   /// The source range of the `introduced:` version component.
   SourceRange getIntroducedSourceRange() const { return attr->IntroducedRange; }
 
-  /// Returns the effective range in which the declaration with this attribute
-  /// was introduced.
+  /// Returns the effective availability range for the attribute's `introduced:`
+  /// component (remapping or canonicalizing if necessary).
   AvailabilityRange getIntroducedRange(const ASTContext &Ctx) const;
 
   /// The version tuple for the `deprecated:` component.
@@ -3319,11 +3319,19 @@ public:
   /// The source range of the `deprecated:` version component.
   SourceRange getDeprecatedSourceRange() const { return attr->DeprecatedRange; }
 
+  /// Returns the effective availability range for the attribute's `deprecated:`
+  /// component (remapping or canonicalizing if necessary).
+  AvailabilityRange getDeprecatedRange(const ASTContext &Ctx) const;
+
   /// The version tuple for the `obsoleted:` component.
   std::optional<llvm::VersionTuple> getObsoleted() const;
 
   /// The source range of the `obsoleted:` version component.
   SourceRange getObsoletedSourceRange() const { return attr->ObsoletedRange; }
+
+  /// Returns the effective availability range for the attribute's `obsoleted:`
+  /// component (remapping or canonicalizing if necessary).
+  AvailabilityRange getObsoletedRange(const ASTContext &Ctx) const;
 
   /// Returns the `message:` field of the attribute, or an empty string.
   StringRef getMessage() const { return attr->Message; }
@@ -3371,12 +3379,6 @@ public:
 
   /// Whether this attribute an attribute that is specific to Embedded Swift.
   bool isEmbeddedSpecific() const { return getDomain().isEmbedded(); }
-
-  /// Returns the active version from the AST context corresponding to
-  /// the available kind. For example, this will return the effective language
-  /// version for swift version-specific availability kind, PackageDescription
-  /// version for PackageDescription version-specific availability.
-  llvm::VersionTuple getActiveVersion(const ASTContext &ctx) const;
 
   /// Returns true if this attribute is considered active in the current
   /// compilation context.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -19,6 +19,7 @@
 #define SWIFT_AST_AVAILABILITY_DOMAIN_H
 
 #include "swift/AST/ASTAllocated.h"
+#include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/Assertions.h"
@@ -214,6 +215,14 @@ public:
   /// Returns true if this domain is considered active in the current
   /// compilation context.
   bool isActive(const ASTContext &ctx) const;
+
+  /// Returns the minimum available range for the attribute's domain. For
+  /// example, for the domain of the platform that compilation is targeting,
+  /// this will be the deployment target. For the Swift language domain, this
+  /// will be the language mode for compilation. For domains which have don't
+  /// have a "deployment target", this returns `std::nullopt`.
+  std::optional<AvailabilityRange>
+  getDeploymentRange(const ASTContext &ctx) const;
 
   /// Returns the string to use in diagnostics to identify the domain. May
   /// return an empty string.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2289,17 +2289,6 @@ bool AvailableAttr::isNoAsync() const {
   llvm_unreachable("Unhandled AvailableAttr::Kind in switch.");
 }
 
-llvm::VersionTuple
-SemanticAvailableAttr::getActiveVersion(const ASTContext &ctx) const {
-  if (isSwiftLanguageModeSpecific()) {
-    return ctx.LangOpts.EffectiveLanguageVersion;
-  } else if (isPackageDescriptionVersionSpecific()) {
-    return ctx.LangOpts.PackageDescriptionVersion;
-  } else {
-    return ctx.LangOpts.getMinPlatformVersion();
-  }
-}
-
 SpecializeAttr::SpecializeAttr(SourceLoc atLoc, SourceRange range,
                                TrailingWhereClause *clause, bool exported,
                                SpecializationKind kind,


### PR DESCRIPTION
Introduce `SemanticAvailableAttr` conveniences to compute the deprecated and obsoleted ranges for an attribute and ensure they remap versions when needed.
