### PR TITLE
Fix TransitiveAddressWalker with mark_dependence

### DIFF
--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -293,8 +293,11 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) && {
     }
 
     if (auto *mdi = dyn_cast<MarkDependenceInst>(user)) {
-      // If this is the base, just treat it as a liveness use.
+      // TODO: continue walking the dependent value, which may not be an
+      // address. See AddressUtils.swift. Until that is implemented, this must
+      // be considered a pointer escape.
       if (op->get() == mdi->getBase()) {
+        meet(AddressUseKind::PointerEscape);
         callVisitUse(op);
         continue;
       }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -1798,7 +1798,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $C):
 // CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
-// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: last user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $*C on %{{.*}} : $*C
 // CHECK-NEXT: testInteriorMarkDepAddressBase: interior_liveness with: %0
 
@@ -1832,7 +1832,7 @@ bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
 // CHECK-NEXT: regular user:   %{{.*}} = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: regular user:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $*C
 // CHECK-NEXT: regular user:   end_access %{{.*}} : $*C
-// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Incomplete liveness: Escaping address
 // CHECK-NEXT: last user:   end_access %{{.*}} : $*C
 // CHECK-NEXT: testInteriorMarkDepAddressDependent: interior_liveness with: %0
 


### PR DESCRIPTION
This utility was simply ignoring the dependent value. But the dependent value logically uses the base address. Until this is correctly implemented, conservatively consider it a pointer-escape.
