### PR TITLE
[stdlib] Integers are safe

### DIFF
--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -217,7 +217,7 @@ extension Hasher {
 
       // Load first unaligned partial word of data
       do {
-        let start = unsafe UInt(bitPattern: data)
+        let start = UInt(bitPattern: data)
         let end = _roundUp(start, toAlignment: MemoryLayout<UInt64>.alignment)
         let c = min(remaining, Int(end - start))
         if c > 0 {
@@ -227,7 +227,7 @@ extension Hasher {
           remaining -= c
         }
       }
-      unsafe _internalInvariant(
+      _internalInvariant(
         remaining == 0 ||
         Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -96,7 +96,7 @@ public class AnyKeyPath: _AppendKeyPath {
     }
 
 #if _pointerBitWidth(_64)
-    let offset = unsafe (0 &- Int(bitPattern: _kvcKeyPathStringPtr)) &- 1
+    let offset = (0 &- Int(bitPattern: _kvcKeyPathStringPtr)) &- 1
     guard _fastPath(offset >= 0) else {
       // This happens to be an actual _kvcKeyPathStringPtr, not an offset, if
       // we get here.
@@ -2046,7 +2046,7 @@ internal struct KeyPathBuffer {
     internal mutating func pushRaw(size: Int, alignment: Int)
         -> UnsafeMutableRawBufferPointer {
       var baseAddress = unsafe buffer.baseAddress._unsafelyUnwrappedUnchecked
-      var misalign = unsafe Int(bitPattern: baseAddress) & (alignment - 1)
+      var misalign = Int(bitPattern: baseAddress) & (alignment - 1)
       if misalign != 0 {
         misalign = alignment - misalign
         unsafe baseAddress = unsafe baseAddress.advanced(by: misalign)
@@ -2969,7 +2969,7 @@ internal func _getTypeByMangledNameInEnvironmentOrContext(
   genericEnvironmentOrContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type? {
-  let taggedPointer = unsafe UInt(bitPattern: genericEnvironmentOrContext)
+  let taggedPointer = UInt(bitPattern: genericEnvironmentOrContext)
   if taggedPointer & 1 == 0 {
     return unsafe _getTypeByMangledNameInEnvironment(name, nameLength,
                       genericEnvironment: genericEnvironmentOrContext,
@@ -2990,7 +2990,7 @@ internal func _resolveKeyPathGenericArgReference(
     arguments: UnsafeRawPointer?)
     -> UnsafeRawPointer {
   // If the low bit is clear, it's a direct reference to the argument.
-  if unsafe (UInt(bitPattern: reference) & 0x01 == 0) {
+  if (UInt(bitPattern: reference) & 0x01 == 0) {
     return unsafe reference
   }
 
@@ -3682,7 +3682,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
   ) {
     let alignment = MemoryLayout<T>.alignment
     var baseAddress = unsafe destData.baseAddress._unsafelyUnwrappedUnchecked
-    var misalign = unsafe Int(bitPattern: baseAddress) & (alignment - 1)
+    var misalign = Int(bitPattern: baseAddress) & (alignment - 1)
     if misalign != 0 {
       misalign = alignment - misalign
       unsafe baseAddress = unsafe baseAddress.advanced(by: misalign)

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -276,7 +276,7 @@ extension MemoryLayout where T: ~Copyable {
   }
 
   internal static func _roundingUpBaseToAlignment(_ value: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
-    let baseAddressBits = unsafe Int(bitPattern: value.baseAddress)
+    let baseAddressBits = Int(bitPattern: value.baseAddress)
     var misalignment = baseAddressBits & _alignmentMask
     if misalignment != 0 {
       misalignment = _alignmentMask & -misalignment
@@ -288,7 +288,7 @@ extension MemoryLayout where T: ~Copyable {
   }
 
   internal static func _roundingUpBaseToAlignment(_ value: UnsafeMutableRawBufferPointer) -> UnsafeMutableRawBufferPointer {
-    let baseAddressBits = unsafe Int(bitPattern: value.baseAddress)
+    let baseAddressBits = Int(bitPattern: value.baseAddress)
     var misalignment = baseAddressBits & _alignmentMask
     if misalignment != 0 {
       misalignment = _alignmentMask & -misalignment

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -639,7 +639,7 @@ extension _NativeDictionary where Value: Equatable {
   @inlinable
   @inline(__always)
   func isEqual(to other: _NativeDictionary) -> Bool {
-    if unsafe self._storage === other._storage { return true }
+    if self._storage === other._storage { return true }
     if self.count != other.count { return false }
 
     for (key, value) in self {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -487,7 +487,7 @@ extension _NativeSet {
   @inlinable
   @inline(__always)
   func isEqual(to other: _NativeSet) -> Bool {
-    if unsafe self._storage === other._storage { return true }
+    if self._storage === other._storage { return true }
     if self.count != other.count { return false }
 
     for member in self {

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -340,6 +340,7 @@ extension Int {
   ///
   /// - Parameter pointer: The pointer to use as the source for the new
   ///   integer.
+  @safe
   @_transparent
   public init<P: _Pointer>(bitPattern pointer: P?) {
     if let pointer = pointer {
@@ -358,6 +359,7 @@ extension UInt {
   ///
   /// - Parameter pointer: The pointer to use as the source for the new
   ///   integer.
+  @safe
   @_transparent
   public init<P: _Pointer>(bitPattern pointer: P?) {
     if let pointer = pointer {

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -550,12 +550,11 @@ func _uint64ToString(
 
 @inlinable
 internal func _rawPointerToString(_ value: Builtin.RawPointer) -> String {
-  var result = unsafe _uint64ToString(
-    UInt64(
-      UInt(bitPattern: UnsafeRawPointer(value))),
-      radix: 16,
-      uppercase: false
-    )
+  var result = _uint64ToString(
+    UInt64(UInt(bitPattern: UnsafeRawPointer(value))),
+    radix: 16,
+    uppercase: false
+  )
   for _ in unsafe 0..<(2 * MemoryLayout<UnsafeRawPointer>.size - result.utf16.count) {
     result = "0" + result
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -102,7 +102,7 @@ extension Span where Element: ~Copyable {
   ) {
     //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = unsafe UnsafeRawPointer(buffer.baseAddress)
-    unsafe _precondition(
+    _precondition(
       ((Int(bitPattern: baseAddress) &
         (MemoryLayout<Element>.alignment &- 1)) == 0),
       "baseAddress must be properly aligned to access Element"
@@ -224,7 +224,7 @@ extension Span where Element: BitwiseCopyable {
   ) {
     //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = buffer.baseAddress
-    unsafe _precondition(
+    _precondition(
       ((Int(bitPattern: baseAddress) &
         (MemoryLayout<Element>.alignment &- 1)) == 0),
       "baseAddress must be properly aligned to access Element"

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -451,7 +451,7 @@ extension UnsafePointer {
   ) -> UnsafePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
-    unsafe _debugPrecondition(
+    _debugPrecondition(
       !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )
@@ -1343,7 +1343,7 @@ extension UnsafeMutablePointer {
   ) -> UnsafePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
-    unsafe _debugPrecondition(
+    _debugPrecondition(
       !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )
@@ -1365,7 +1365,7 @@ extension UnsafeMutablePointer {
   ) -> UnsafeMutablePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
-    unsafe _debugPrecondition(
+    _debugPrecondition(
       !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -816,7 +816,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }  
 
     _debugPrecondition(
-      unsafe Int(bitPattern: base) & (MemoryLayout<S.Element>.alignment-1) == 0,
+      Int(bitPattern: base) & (MemoryLayout<S.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access S.Element"
     )
 
@@ -875,7 +875,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         return unsafe .init(start: nil, count: 0)
       }
       _debugPrecondition(
-        unsafe Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
+        Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
         "buffer base address must be properly aligned to access C.Element"
       )
       _precondition(
@@ -900,7 +900,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
     _internalInvariant(unsafe _end != nil)
     _debugPrecondition(
-      unsafe Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
+      Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access C.Element"
     )
     var iterator = source.makeIterator()
@@ -961,7 +961,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return unsafe .init(start: nil, count: 0)
     }
     _debugPrecondition(
-      unsafe Int(bitPattern: baseAddress) & (MemoryLayout<T>.alignment-1) == 0,
+      Int(bitPattern: baseAddress) & (MemoryLayout<T>.alignment-1) == 0,
       "buffer base address must be properly aligned to access T"
     )
     _precondition(
@@ -1103,7 +1103,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return try unsafe body(.init(start: nil, count: 0))
     }
     _debugPrecondition(
-      unsafe Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0,
+      Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0,
       "baseAddress must be a properly aligned pointer for type T"
     )
     // initializer ensures _end is nil only when _position is nil.

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -399,7 +399,7 @@ extension UnsafeRawPointer {
     capacity count: Int,
     _ body: (_ pointer: UnsafePointer<T>) throws(E) -> Result
   ) throws(E) -> Result {
-    unsafe _debugPrecondition(
+    _debugPrecondition(
       Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0,
       "self must be a properly aligned pointer for type T"
     )
@@ -1016,7 +1016,7 @@ extension UnsafeMutableRawPointer {
     capacity count: Int,
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws(E) -> Result
   ) throws(E) -> Result {
-    unsafe _debugPrecondition(
+    _debugPrecondition(
       Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0,
       "self must be a properly aligned pointer for type T"
     )


### PR DESCRIPTION
The two pointer-sized integer initializers of the form `[U]Int.init(bitPattern: (some _Pointer)?)` require an `unsafe` annotation since the implementation of [SE-0458](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md) was merged.

Getting integers from pointers isn't unsafe. It's just a way to get an integer. (Mostly a bad way to get an integer.)

This adds `@safe` to the two initializers in `Pointers.swift`, then removes many `unsafe` annotations that become unneeded as a result.
