### PR TITLE
[Experiment] Lift restriction on explicit CallExpr specialization

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14283,9 +14283,8 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     }
   }
 
-  // FIXME: We could support explicit function specialization.
   if (openedGenericParams.empty() ||
-      (isa<AbstractFunctionDecl>(decl) && !hasParameterPack)) {
+      openedGenericParams.size() != genericParams->size()) {
     return recordFix(AllowFunctionSpecialization::create(
                *this, decl, getConstraintLocator(locator)))
                ? SolutionKind::Error

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -20,7 +20,7 @@ protocol Fungible {}
 func meta<T>(_ m: T.Type) {}
 func meta2<T>(_ m: T.Type, _ x: Int) {}
 
-func generic<T>(_ x: T) {} // expected-note {{'generic' declared here}}
+func generic<T>(_ x: T) {}
 
 var a, b, c, d : Int
 
@@ -41,9 +41,7 @@ _ = (a < b, c > d)
 _ = a>(b)
 _ = a > (b)
 
-generic<Int>(0)
-// expected-swift5-warning@-1{{cannot explicitly specialize global function 'generic'}}
-// expected-swift6-error@-2 {{cannot explicitly specialize global function 'generic'}}
+generic<Int>(0) // ok, explicit specialization is allowed
 
 A<B>.c()
 A<A<B>>.c()

--- a/test/Sema/generic_specialization.swift
+++ b/test/Sema/generic_specialization.swift
@@ -10,7 +10,7 @@ extension Int {
   func baz() -> Int {}
   func baz(_ x: Int = 0) -> Int {}
 
-  func gen<T>() -> T {} // expected-note 2 {{in call to function 'gen()'}} expected-note 2 {{'gen()' declared here}}
+  func gen<T>(_ x: T) -> T {}
 }
 
 // https://github.com/swiftlang/swift/issues/74857
@@ -19,19 +19,15 @@ func test(i: Int) {
   // expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'foo()'}}
   // expected-swift6-error@-2 {{cannot explicitly specialize instance method 'foo()'}}
 
-  let _ = i.gen<Int>()
-  // expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'gen()'}}
-  // expected-swift6-error@-2 {{cannot explicitly specialize instance method 'gen()'}}
-  // expected-error@-3 {{generic parameter 'T' could not be inferred}}
+  let _ = i.gen<Int>(0) // ok, explicit specialization is allowed
 
   let _ = 0.foo<Int>()
   // expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'foo()'}}
   // expected-swift6-error@-2 {{cannot explicitly specialize instance method 'foo()'}}
 
-  let _ = i.gen<Int>
-  // expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'gen()'}}
-  // expected-swift6-error@-2 {{cannot explicitly specialize instance method 'gen()'}}
-  // expected-error@-3 {{generic parameter 'T' could not be inferred}}
+  let genInt = i.gen<Int> // ok, forms function reference to explicitly specialized method
+  let _ = genInt(0)
+
   let _ = i.bar<Int>
   // expected-swift5-error@-1 {{cannot specialize non-generic type 'Int'}}
   // expected-swift6-error@-2 {{cannot specialize non-generic type 'Int'}}
@@ -47,12 +43,12 @@ func testOptionalChain(i: Int?) {
 }
 
 extension Bool {
-  func foo<T>() -> T {} // expected-note {{'foo()' declared here}}
+  func foo<T>() -> T {}
 }
 
 let _: () -> Bool = false.foo<Int>
-// expected-swift5-warning@-1 {{cannot explicitly specialize instance method 'foo()'}}
-// expected-swift6-error@-2 {{cannot explicitly specialize instance method 'foo()'}}
+// expected-error@-1 {{type of expression is ambiguous}}
+let _: () -> Bool = false.foo
 
 func foo(_ x: Int) {
   _ = {


### PR DESCRIPTION
This lifts the restriction banning explicit specialization of functions at the call site, which is fully supported in Sema already but explicitly banned because the syntax has not gone through Evolution.

This would allow constructions like this (assuming the type parameter is defaulted in the `decode` function.
```swift
let x = decoder.decode<MyType>(from: data)
```