### PR TITLE
Gardening: `AvailabilityContext` and `AvailabilityConstraint` cleanup

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -51,19 +51,21 @@ public:
     /// constraint.
     Obsoleted,
 
-    /// The declaration is only available in a later version. For example,
-    /// the declaration might only be introduced in the Swift 6 language mode
-    /// while the module is being compiled in the Swift 5 language mode.
-    IntroducedInLaterVersion,
+    /// The declaration is not available in the deployment configuration
+    /// specified for this compilation. For example, the declaration might only
+    /// be introduced in the Swift 6 language mode while the module is being
+    /// compiled in the Swift 5 language mode. These availability constraints
+    /// cannot be satisfied by adding constraining contextual availability using
+    /// `@available` attributes or `if #available` queries.
+    UnavailableForDeployment,
 
-    /// The declaration is referenced in a context that does not have an
-    /// adequate minimum version constraint. For example, a reference to a
-    /// declaration that is introduced in macOS 13 from a context that may
-    /// execute on earlier versions of macOS has this constraint. This
-    /// kind of constraint can be satisfied by tightening the minimum
-    /// version of the context with `if #available(...)` or by adding or
-    /// adjusting an `@available` attribute.
-    IntroducedInLaterDynamicVersion,
+    /// The declaration is referenced in a context that does not have adequate
+    /// availability constraints. For example, a reference to a declaration that
+    /// was introduced in macOS 13 from a context that may execute on earlier
+    /// versions of macOS cannot satisfy this constraint. The constraint
+    /// can be satisfied, though, by introducing an `@available` attribute or an
+    /// `if #available(...)` query.
+    PotentiallyUnavailable,
   };
 
   /// Classifies constraints into different high level categories.
@@ -93,14 +95,13 @@ public:
   }
 
   static AvailabilityConstraint
-  introducedInLaterVersion(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::IntroducedInLaterVersion, attr);
+  unavailableForDeployment(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::UnavailableForDeployment, attr);
   }
 
   static AvailabilityConstraint
-  introducedInLaterDynamicVersion(SemanticAvailableAttr attr) {
-    return AvailabilityConstraint(Reason::IntroducedInLaterDynamicVersion,
-                                  attr);
+  potentiallyUnavailable(SemanticAvailableAttr attr) {
+    return AvailabilityConstraint(Reason::PotentiallyUnavailable, attr);
   }
 
   Reason getReason() const { return attrAndReason.getInt(); }
@@ -112,9 +113,9 @@ public:
     switch (getReason()) {
     case Reason::UnconditionallyUnavailable:
     case Reason::Obsoleted:
-    case Reason::IntroducedInLaterVersion:
+    case Reason::UnavailableForDeployment:
       return Kind::Unavailable;
-    case Reason::IntroducedInLaterDynamicVersion:
+    case Reason::PotentiallyUnavailable:
       return Kind::PotentiallyAvailable;
     }
   }

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -52,16 +52,16 @@ public:
   /// Retrieves an `AvailabilityContext` constrained by the given platform
   /// availability range.
   static AvailabilityContext forPlatformRange(const AvailabilityRange &range,
-                                              ASTContext &ctx);
+                                              const ASTContext &ctx);
 
   /// Retrieves the maximally available `AvailabilityContext` for the
   /// compilation. The platform availability range will be set to the minimum
   /// inlining target (which may just be the deployment target).
-  static AvailabilityContext forInliningTarget(ASTContext &ctx);
+  static AvailabilityContext forInliningTarget(const ASTContext &ctx);
 
   /// Retrieves an `AvailabilityContext` with the platform availability range
   /// set to the deployment target.
-  static AvailabilityContext forDeploymentTarget(ASTContext &ctx);
+  static AvailabilityContext forDeploymentTarget(const ASTContext &ctx);
 
   /// Returns the range of platform versions which may execute code in the
   /// availability context, starting at its introduction version.
@@ -77,16 +77,17 @@ public:
   bool isDeprecated() const;
 
   /// Constrain with another `AvailabilityContext`.
-  void constrainWithContext(const AvailabilityContext &other, ASTContext &ctx);
+  void constrainWithContext(const AvailabilityContext &other,
+                            const ASTContext &ctx);
 
   /// Constrain the platform availability range with `platformRange`.
   void constrainWithPlatformRange(const AvailabilityRange &platformRange,
-                                  ASTContext &ctx);
+                                  const ASTContext &ctx);
 
   /// Constrain the context by adding \p domain to the set of unavailable
   /// domains.
   void constrainWithUnavailableDomain(AvailabilityDomain domain,
-                                      ASTContext &ctx);
+                                      const ASTContext &ctx);
 
   /// Constrain with the availability attributes of `decl`.
   void constrainWithDecl(const Decl *decl);
@@ -114,7 +115,7 @@ public:
   SWIFT_DEBUG_DUMP;
 
   /// Returns true if all internal invariants are satisfied.
-  bool verify(ASTContext &ctx) const;
+  bool verify(const ASTContext &ctx) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -48,7 +48,7 @@ public:
   /// restrictive than the current values. Returns true if any field was
   /// updated.
   bool constrainWith(const DeclAvailabilityConstraints &constraints,
-                     ASTContext &ctx);
+                     const ASTContext &ctx);
 
   bool constrainUnavailability(
       const llvm::SmallVectorImpl<AvailabilityDomain> &domains);
@@ -63,7 +63,7 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) const;
 
   /// Returns true if all internal invariants are satisfied.
-  bool verify(ASTContext &ctx) const;
+  bool verify(const ASTContext &ctx) const;
 };
 
 /// As an implementation detail, the values that make up an `Availability`
@@ -74,7 +74,7 @@ class AvailabilityContext::Storage final : public llvm::FoldingSetNode {
 public:
   Info info;
 
-  static const Storage *get(const Info &info, ASTContext &ctx);
+  static const Storage *get(const Info &info, const ASTContext &ctx);
 
   void Profile(llvm::FoldingSetNodeID &ID) const { info.Profile(ID); }
 };

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -29,7 +29,7 @@ class DeclAvailabilityConstraints;
 class AvailabilityContext::Info {
 public:
   /// The introduction version.
-  AvailabilityRange Range;
+  AvailabilityRange PlatformRange;
 
   /// A sorted collection of disjoint domains that are known to be
   /// unavailable in this context.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5714,7 +5714,7 @@ SubstitutionMap::Storage *SubstitutionMap::Storage::get(
 }
 
 const AvailabilityContext::Storage *
-AvailabilityContext::Storage::get(const Info &info, ASTContext &ctx) {
+AvailabilityContext::Storage::get(const Info &info, const ASTContext &ctx) {
   llvm::FoldingSetNodeID id;
   info.Profile(id);
 

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -48,7 +48,7 @@ bool AvailabilityContext::Info::constrainWith(const Info &other) {
 }
 
 bool AvailabilityContext::Info::constrainWith(
-    const DeclAvailabilityConstraints &constraints, ASTContext &ctx) {
+    const DeclAvailabilityConstraints &constraints, const ASTContext &ctx) {
   bool isConstrained = false;
 
   for (auto constraint : constraints) {
@@ -155,7 +155,7 @@ void AvailabilityContext::Info::Profile(llvm::FoldingSetNodeID &ID) const {
   ID.AddBoolean(IsDeprecated);
 }
 
-bool AvailabilityContext::Info::verify(ASTContext &ctx) const {
+bool AvailabilityContext::Info::verify(const ASTContext &ctx) const {
   // Unavailable domains must be sorted to ensure folding set node lookups yield
   // consistent results.
   if (!llvm::is_sorted(UnavailableDomains,
@@ -167,18 +167,20 @@ bool AvailabilityContext::Info::verify(ASTContext &ctx) const {
 
 AvailabilityContext
 AvailabilityContext::forPlatformRange(const AvailabilityRange &range,
-                                      ASTContext &ctx) {
+                                      const ASTContext &ctx) {
   Info info{range, /*UnavailableDomains*/ {},
             /*IsDeprecated*/ false};
   return AvailabilityContext(Storage::get(info, ctx));
 }
 
-AvailabilityContext AvailabilityContext::forInliningTarget(ASTContext &ctx) {
+AvailabilityContext
+AvailabilityContext::forInliningTarget(const ASTContext &ctx) {
   return AvailabilityContext::forPlatformRange(
       AvailabilityRange::forInliningTarget(ctx), ctx);
 }
 
-AvailabilityContext AvailabilityContext::forDeploymentTarget(ASTContext &ctx) {
+AvailabilityContext
+AvailabilityContext::forDeploymentTarget(const ASTContext &ctx) {
   return AvailabilityContext::forPlatformRange(
       AvailabilityRange::forDeploymentTarget(ctx), ctx);
 }
@@ -205,7 +207,7 @@ bool AvailabilityContext::isDeprecated() const {
 }
 
 void AvailabilityContext::constrainWithContext(const AvailabilityContext &other,
-                                               ASTContext &ctx) {
+                                               const ASTContext &ctx) {
   bool isConstrained = false;
 
   Info info{storage->info};
@@ -218,7 +220,7 @@ void AvailabilityContext::constrainWithContext(const AvailabilityContext &other,
 }
 
 void AvailabilityContext::constrainWithPlatformRange(
-    const AvailabilityRange &platformRange, ASTContext &ctx) {
+    const AvailabilityRange &platformRange, const ASTContext &ctx) {
 
   Info info{storage->info};
   if (!constrainRange(info.Range, platformRange))
@@ -228,7 +230,7 @@ void AvailabilityContext::constrainWithPlatformRange(
 }
 
 void AvailabilityContext::constrainWithUnavailableDomain(
-    AvailabilityDomain domain, ASTContext &ctx) {
+    AvailabilityDomain domain, const ASTContext &ctx) {
   Info info{storage->info};
   if (!info.constrainUnavailability(domain))
     return;
@@ -289,6 +291,6 @@ void AvailabilityContext::print(llvm::raw_ostream &os) const {
 
 void AvailabilityContext::dump() const { print(llvm::errs()); }
 
-bool AvailabilityContext::verify(ASTContext &ctx) const {
+bool AvailabilityContext::verify(const ASTContext &ctx) const {
   return storage->info.verify(ctx);
 }

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -57,10 +57,10 @@ bool AvailabilityContext::Info::constrainWith(
     switch (constraint.getReason()) {
     case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
     case AvailabilityConstraint::Reason::Obsoleted:
-    case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+    case AvailabilityConstraint::Reason::UnavailableForDeployment:
       isConstrained |= constrainUnavailability(domain);
       break;
-    case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
       // FIXME: [availability] Support versioning for other kinds of domains.
       DEBUG_ASSERT(domain.isPlatform());
       if (domain.isPlatform())
@@ -188,7 +188,6 @@ AvailabilityContext::forDeploymentTarget(const ASTContext &ctx) {
 
 AvailabilityRange AvailabilityContext::getPlatformRange() const {
   return storage->info.PlatformRange;
-}
 }
 
 bool AvailabilityContext::isUnavailable() const {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3007,9 +3007,9 @@ bool shouldHideDomainNameForConstraintDiagnostic(
   case AvailabilityDomain::Kind::SwiftLanguage:
     switch (constraint.getReason()) {
     case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
-    case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+    case AvailabilityConstraint::Reason::UnavailableForDeployment:
       return false;
-    case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
     case AvailabilityConstraint::Reason::Obsoleted:
       return true;
     }
@@ -3058,7 +3058,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
                   proto)
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+  case AvailabilityConstraint::Reason::UnavailableForDeployment:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
                    type, proto, domain, *attr.getIntroduced());
     break;
@@ -3068,7 +3068,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
                   domain, *attr.getObsoleted())
         .highlight(attr.getParsedAttr()->getRange());
     break;
-  case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+  case AvailabilityConstraint::Reason::PotentiallyUnavailable:
     llvm_unreachable("unexpected constraint");
   }
   return true;
@@ -3478,7 +3478,7 @@ bool diagnoseExplicitUnavailability(
     diags.diagnose(D, diag::availability_marked_unavailable, D)
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+  case AvailabilityConstraint::Reason::UnavailableForDeployment:
     diags
         .diagnose(D, diag::availability_introduced_in_version, D, domain,
                   *Attr.getIntroduced())
@@ -3490,7 +3490,7 @@ bool diagnoseExplicitUnavailability(
                   *Attr.getObsoleted())
         .highlight(sourceRange);
     break;
-  case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+  case AvailabilityConstraint::Reason::PotentiallyUnavailable:
     llvm_unreachable("unexpected constraint");
     break;
   }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -251,10 +251,10 @@ static bool isUnavailableInAllVersions(ValueDecl *decl) {
   for (auto constraint : constraints) {
     switch (constraint.getReason()) {
     case AvailabilityConstraint::Reason::UnconditionallyUnavailable:
-    case AvailabilityConstraint::Reason::IntroducedInLaterVersion:
+    case AvailabilityConstraint::Reason::UnavailableForDeployment:
       return true;
     case AvailabilityConstraint::Reason::Obsoleted:
-    case AvailabilityConstraint::Reason::IntroducedInLaterDynamicVersion:
+    case AvailabilityConstraint::Reason::PotentiallyUnavailable:
       break;
     }
   }


### PR DESCRIPTION
- Use `const` consistently for `ASTContext` parameters.
- Rename `Range` to `PlatformRange` in `AvailabilityContext::Info`.
- Rename a couple of `AvailabilityConstraint::Reason` cases. Choose names that don't imply availability is versioned, since custom availability will support domains that are version-less (they are simply available or unavailable).