### PR TITLE
Add verification to catch many incorrect liveness checks

### DIFF
--- a/include/swift/SIL/AddressUseKind.h
+++ b/include/swift/SIL/AddressUseKind.h
@@ -15,7 +15,7 @@
 
 namespace swift {
 
-enum class AddressUseKind { NonEscaping, PointerEscape, Unknown };
+enum class AddressUseKind { NonEscaping, Dependent, PointerEscape, Unknown };
 
 inline AddressUseKind meet(AddressUseKind lhs, AddressUseKind rhs) {
   return (lhs > rhs) ? lhs : rhs;

--- a/include/swift/SIL/OwnershipLiveness.h
+++ b/include/swift/SIL/OwnershipLiveness.h
@@ -241,6 +241,7 @@ class InteriorLiveness : public OSSALiveness {
 public:
   // Summarize address uses
   AddressUseKind addressUseKind = AddressUseKind::Unknown;
+  Operand *escapingUse = nullptr;
 
 public:
   InteriorLiveness(SILValue def): OSSALiveness(def) {}

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -494,7 +494,7 @@ bool OwnershipUseVisitor<Impl>::visitInteriorPointerUses(Operand *use) {
   // just assumes that all scopes are incomplete.
   SmallVector<Operand *, 8> interiorUses;
   auto useKind = InteriorPointerOperand(use).findTransitiveUses(&interiorUses);
-  if (useKind == AddressUseKind::PointerEscape) {
+  if (useKind != AddressUseKind::NonEscaping) {
     if (!asImpl().handlePointerEscape(use))
       return false;
   }

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -150,6 +150,7 @@ struct InteriorLivenessVisitor :
 
   bool handlePointerEscape(Operand *use) {
     interiorLiveness.addressUseKind = AddressUseKind::PointerEscape;
+    interiorLiveness.escapingUse = use;
     if (!handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding))
       return false;
 
@@ -197,6 +198,9 @@ void InteriorLiveness::print(llvm::raw_ostream &OS) const {
     break;
   case AddressUseKind::PointerEscape:
     OS << "Incomplete liveness: Escaping address\n";
+    break;
+  case AddressUseKind::Dependent:
+    OS << "Incomplete liveness: Dependent value\n";
     break;
   case AddressUseKind::Unknown:
     OS << "Incomplete liveness: Unknown address use\n";

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3827,6 +3827,8 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
 
     CopiedLoadBorrowEliminationState state(markedAddress->getFunction());
     CopiedLoadBorrowEliminationVisitor copiedLoadBorrowEliminator(state);
+    // FIXME: should check AddressUseKind::NonEscaping != walk() to handle
+    // PointerEscape.
     if (AddressUseKind::Unknown ==
         std::move(copiedLoadBorrowEliminator).walk(markedAddress)) {
       LLVM_DEBUG(llvm::dbgs() << "Failed copied load borrow eliminator visit: "
@@ -3869,6 +3871,8 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
     RAIILLVMDebug l("main use gathering visitor");
 
     visitor.reset(markedAddress);
+    // FIXME: should check walkResult != AddressUseKind::NonEscaping to handle
+    // PointerEscape.
     if (AddressUseKind::Unknown == std::move(visitor).walk(markedAddress)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Failed access path visit: " << *markedAddress);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -583,6 +583,7 @@ bool siloptimizer::eliminateTemporaryAllocationsFromLet(
   };
   FindCopyAddrWalker walker(copiesToVisit);
   std::move(walker).walk(markedInst);
+  // FIXME: should check walk() == AddressUseKind::NonEscaping.
 
   bool madeChange = false;
 
@@ -612,6 +613,8 @@ bool siloptimizer::eliminateTemporaryAllocationsFromLet(
       nextCAI = nullptr;
       SimpleTemporaryAllocStackElimVisitor visitor(state, cai, nextCAI);
 
+      // FIXME: should check AddressUseKind::NonEscaping != walk() to handle
+      // PointerEscape.
       if (AddressUseKind::Unknown == std::move(visitor).walk(cai->getDest()))
         return false;
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -211,6 +211,8 @@ inferIsolationInfoForTempAllocStack(AllocStackInst *asi) {
   AddressWalker walker(state);
 
   // If we fail to walk, emit an unknown patten error.
+  //
+  // FIXME: check AddressUseKind::NonEscaping != walk().
   if (AddressUseKind::Unknown == std::move(walker).walk(asi)) {
     return SILIsolationInfo();
   }


### PR DESCRIPTION
Some transformations rely on complete (fully computable) liveness. If they don't check for pointer escapes, they can easily cause use-after-free miscompiles, which we have been observing. These miscompiles are not caught by OSSA verification because the verifier bails out (succeeds without completing its checks) under the same conditions that liveness fails!

The goal of the PR is to have a method of catching and debugging these errors. I fixed the passes I could without exposing other failures. I added -verify-lifetime-completion to provide a way to expose and debug the most critical problems. I added FIXMEs for the less-critical cases that I don't know how to test yet and are unlikely to miscompile.

TODO

- unify the logic for findPointerEscape, TransitiveAddressWalker, InteriorLiveness, etc.

- check for pointer escapes in passes before requesting lifetime completion or other transformations that rely on complete liveness

- convert verification checks to release-asserts

Notes:

Uses of these two APIs in particular need to check for pointer escapes but often do not:
- TransitiveAddressWalker
- InteriorLiveness

All uses of these APIs already have a reasonable check or don't need the check:
- findTransitiveUsesForAddress
- findTransitiveUses
- GuaranteedOwnershipExtension::checkAddressOwnership

ClosureLifetimeFixup now bails out on pointer escapes:

OSSALifetimeCompletion is now checked under -sil-verify-all. This should be a release-assert, but passes that use this, like Mem2Reg, are still buggy.

Added FIXMEs to diagnostic passes that I don't want to perturb in this PR:
- MoveOnlyAddressChecker
- MoveOnlyUtils
- SILIsolationInfo
