### PR TITLE
[lldb] Skip test TestThreadSpecificBreakpoint on Windows

### DIFF
--- a/utils/windows-llvm-lit-test-overrides.txt
+++ b/utils/windows-llvm-lit-test-overrides.txt
@@ -136,6 +136,7 @@ skip lldb-api :: commands/thread/backtrace/TestThreadBacktraceRepeat.py
 skip lldb-api :: functionalities/inferior-crashing/TestInferiorCrashing.py
 skip lldb-api :: functionalities/inline-stepping/TestInlineStepping.py
 skip lldb-api :: functionalities/step_scripted/TestStepScripted.py
+skip lldb-api :: functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
 
 ### Tests that pass occasionally ###
 


### PR DESCRIPTION
API test `functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py` timed out after 900sec in build bot run https://ci-external.swift.org/job/swift-PR-windows/37157/