### PR TITLE
Track down "the textual interface may be broken by project issues or a compiler bug" (wip)

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,lldb,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,
+set TestArg= 
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 
@@ -77,6 +77,8 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
   %TestArg% ^
+  -AndroidSDKs aarch64 ^
+  -WindowsSDKs X64 ^
   -Stage %PackageRoot% ^
   -Summary || (exit /b 1)
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3235,7 +3235,7 @@ if (-not $SkipBuild) {
     Invoke-BuildStep Build-Dispatch Android $Arch
 
     # FIXME
-    Get-ChildItem -Path $AndroidX64.SDKInstallRoot -Filter "*.swiftinterface" -Recurse | Remove-Item -Force
+    Get-ChildItem -Path "$(Get-TargetProjectBinaryCache $Arch Runtime)\lib\swift" -Filter "*.swiftinterface" -Recurse
 
     Invoke-BuildStep Build-Foundation Android $Arch
     Invoke-BuildStep Build-Sanitizers Android $Arch

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3233,6 +3233,10 @@ if (-not $SkipBuild) {
     # Build platform: SDK, Redist and XCTest
     Invoke-BuildStep Build-Runtime Android $Arch
     Invoke-BuildStep Build-Dispatch Android $Arch
+
+    # FIXME
+    Get-ChildItem -Path $AndroidX64.SDKInstallRoot -Filter "*.swiftinterface" -Recurse | Remove-Item -Force
+
     Invoke-BuildStep Build-Foundation Android $Arch
     Invoke-BuildStep Build-Sanitizers Android $Arch
     Invoke-BuildStep Build-XCTest Android $Arch


### PR DESCRIPTION
We don't yet build the Android SDK with the Windows toolchain continuously. This issue came up in a recent PR:
```
T:/x64/Android.platform/Developer/SDKs/Android.sdk\usr\lib\swift\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.private.swiftinterface:5:8:
error: failed to build module 'Android' for importation due to the errors above;
the textual interface may be broken by project issues or a compiler bug
```

Attaching the full log here: [swift-PR-windows-37178-android.log](https://github.com/user-attachments/files/19052555/swift-PR-windows-37178-android.log) Let's try and track this down in isolation.
