### PR TITLE
[cxx-interop] Suppress Microsoft STL compiler compatibility checks

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -673,6 +673,9 @@ void importer::getNormalInvocationArguments(
     }
   }
 
+  if (triple.isOSWindows() && EnableCXXInterop)
+    invocationArgStrs.push_back("-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
+
   // If we support SendingArgsAndResults, set the -D flag to signal that it
   // is supported.
   if (LangOpts.hasFeature(Feature::SendingArgsAndResults))


### PR DESCRIPTION
Microsoft STL only officially supports very recent versions of Clang, while the Clang version that is embedded in Swift might be lagging behind. This triggers incompatibility errors coming from STL:
```
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.43.34808\include\yvals_core.h:927:1: error: static assertion failed: error STL1000: Unexpected compiler version, expected Clang 18.0.0 or newer.
_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 18.0.0 or newer.");
```

There is no obvious way for the user to solve these, apart from downgrading the MSVC version. Let's pass the `_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH` macro to Clang to suppress these errors.

rdar://145883764 / resolves https://github.com/swiftlang/swift/issues/79709

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
