### PR TITLE
utils: target prefix ds2, use a more standard layout

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1951,13 +1951,13 @@ function Build-DS2([Platform]$Platform, $Arch) {
   Build-CMakeProject `
     -Src "$SourceCache\ds2" `
     -Bin "$BinaryCache\$($Arch.LLVMTarget)\ds2" `
-    -InstallTo "$(Get-PlatformRoot $Platform)\Developer\Library\$(Get-ModuleTriple $Arch)" `
+    -InstallTo "$(Get-PlatformRoot $Platform)\Developer\Library\ds2\usr" `
     -Arch $Arch `
     -Platform $Platform `
-    -BuildTargets default `
     -Defines @{
       CMAKE_SYSTEM_NAME = $Platform.ToString();
       DS2_REGSGEN2 = "$(Get-BuildProjectBinaryCache RegsGen2)/regsgen2.exe";
+      DS2_PROGRAM_PREFIX = "$(Get-ModuleTriple $Arch)-";
       BISON_EXECUTABLE = "$(Get-BisonExecutable)";
       FLEX_EXECUTABLE = "$(Get-FlexExecutable)";
     }


### PR DESCRIPTION
This moves ds2 into a separate directory for ds2 rather than keeping it at a top level directory named after the target triple. It also adopts the GCC style target triple prefix. Finally, adjust the build to perform the installation to allow building a complete toolchain image.