### PR TITLE
[Dependency Scanning] Ignore `-file-compilation-dir` during Swift Caching Build

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4227,6 +4227,10 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   PPOpts.MacroIncludes.clear();
   PPOpts.Includes.clear();
 
+  // CodeGenOptions.
+  auto &CGOpts = instance.getCodeGenOpts();
+  CGOpts.DebugCompilationDir.clear();
+
   if (Impl.SwiftContext.ClangImporterOpts.UseClangIncludeTree) {
     // FileSystemOptions.
     auto &FSOpts = instance.getFileSystemOpts();

--- a/test/CAS/Xcc_args.swift
+++ b/test/CAS/Xcc_args.swift
@@ -5,7 +5,8 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -Xcc -D_VERSION=1 \
 // RUN:   -Xcc -fmodule-map-file=%t/include/module.modulemap -Xcc -ivfsoverlay -Xcc %t/empty.yaml \
-// RUN:   -Xcc -I%t/empty.hmap -module-load-mode prefer-serialized
+// RUN:   -Xcc -I%t/empty.hmap -module-load-mode prefer-serialized \
+// RUN:   -file-compilation-dir %t
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shims.cmd
 // RUN: %swift_frontend_plain @%t/shims.cmd
@@ -20,6 +21,7 @@
 // RUN: %FileCheck %s --input-file=%t/MyApp.cmd
 
 // CHECK: "-direct-clang-cc1-module-build"
+// CHECK-NOT: "-fdebug-compilation-dir={{.*}}"
 // CHECK: "_VERSION=1"
 // CHECK-NOT: hmap.json
 // CHECK-NOT: -ivfsoverlay


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
https://github.com/swiftlang/swift/pull/79270 taught the dependency scanner to ignore `-file-compilation-dir` when caching is
_not_ in effect but did not make the corresponding change when caching is in effect. This PR teaches the scanner to ignore `-file-compliation-dir` when caching is in effect. 

rdar://146025100 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
