### PR TITLE
Update ucrt.modulemap for Windows SDK 10.0.26100

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -10,13 +10,38 @@
 //
 //===----------------------------------------------------------------------===//
 
-module _complex [system] {
+// The following modules have to be standalone top-level modules to deal with
+// version 10.0.26100 of the Windows SDK.
+module _malloc [system] [extern_c] [no_undeclared_includes] {
+  use corecrt
+  header "malloc.h"
+  export *
+}
+
+module _complex [system] [extern_c] [no_undeclared_includes] {
   header "complex.h"
   export *
 }
 
+module _stddef [system] [extern_c] [no_undeclared_includes] {
+  header "stddef.h"
+  export *
+}
+
+module _stdlib [system] [extern_c] [no_undeclared_includes] {
+  use corecrt
+  header "stdlib.h"
+  export *
+}
+
 module ucrt [system] {
+  export _malloc
+
   module C {
+    export _complex
+    export _stddef
+    export _stdlib
+
     module ctype {
       header "ctype.h"
       export *
@@ -57,11 +82,6 @@ module ucrt [system] {
       export *
     }
 
-    module stddef {
-      header "stddef.h"
-      export *
-    }
-
     module stdio {
       header "stdio.h"
       export *
@@ -72,11 +92,6 @@ module ucrt [system] {
       // resulting in undefined symbols.  The legacy_stdio_definitions provides
       // out-of-line definitions for these functions.
       link "legacy_stdio_definitions"
-    }
-
-    module stdlib {
-      header "stdlib.h"
-      export *
     }
 
     module string {
@@ -129,11 +144,6 @@ module ucrt [system] {
 
   module dos {
     header "dos.h"
-    export *
-  }
-
-  module malloc {
-    header "malloc.h"
     export *
   }
 

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -19,6 +19,7 @@ module _malloc [system] [extern_c] [no_undeclared_includes] {
 }
 
 module _complex [system] [extern_c] [no_undeclared_includes] {
+  use corecrt
   header "complex.h"
   export *
 }

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -12,24 +12,24 @@
 
 // The following modules have to be standalone top-level modules to deal with
 // version 10.0.26100 of the Windows SDK.
-module _malloc [system] [extern_c] [no_undeclared_includes] {
+module _malloc [system] [no_undeclared_includes] {
   use corecrt
   header "malloc.h"
   export *
 }
 
-module _complex [system] [extern_c] [no_undeclared_includes] {
+module _complex [system] [no_undeclared_includes] {
   use corecrt
   header "complex.h"
   export *
 }
 
-module _stddef [system] [extern_c] [no_undeclared_includes] {
+module _stddef [system] [no_undeclared_includes] {
   header "stddef.h"
   export *
 }
 
-module _stdlib [system] [extern_c] [no_undeclared_includes] {
+module _stdlib [system] [no_undeclared_includes] {
   use corecrt
   header "stdlib.h"
   export *

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -24,6 +24,19 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
+module _fenv [system] [no_undeclared_includes] {
+  use corecrt
+  use _float
+  header "fenv.h"
+  export *
+}
+
+module _float [system] [no_undeclared_includes] {
+  use corecrt
+  header "float.h"
+  export *
+}
+
 module _stddef [system] [no_undeclared_includes] {
   header "stddef.h"
   export *
@@ -40,6 +53,8 @@ module ucrt [system] {
 
   module C {
     export _complex
+    export _fenv
+    export _float
     export _stddef
     export _stdlib
 
@@ -50,16 +65,6 @@ module ucrt [system] {
 
     module errno {
       header "errno.h"
-      export *
-    }
-
-    module fenv {
-      header "fenv.h"
-      export *
-    }
-
-    module float {
-      header "float.h"
       export *
     }
 
@@ -86,13 +91,11 @@ module ucrt [system] {
     module stdio {
       header "stdio.h"
       export *
+    }
 
-      // NOTE(compnerd) this is a horrible workaround for the fact that
-      // Microsoft has fully inlined nearly all of the printf family of
-      // functions in the headers which results in the definitions being elided
-      // resulting in undefined symbols.  The legacy_stdio_definitions provides
-      // out-of-line definitions for these functions.
-      link "legacy_stdio_definitions"
+    module stdlib {
+      header "stdlib.h"
+      export *
     }
 
     module string {

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -20,6 +20,7 @@ module _malloc [system] [no_undeclared_includes] {
 
 module _complex [system] [no_undeclared_includes] {
   use corecrt
+  use std
   header "complex.h"
   export *
 }

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import ucrt // Clang module
+// Extra clang module that's split out from ucrt:
+@_exported import _complex
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -13,6 +13,8 @@
 @_exported import ucrt // Clang module
 // Extra clang module that's split out from ucrt:
 @_exported import _complex
+@_exported import _stddef
+@_exported import _stdlib
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -11,13 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import ucrt // Clang module
-// Extra clang module that's split out from ucrt:
-@_exported import _complex
-@_exported import _fenv
-@_exported import _float
-@_exported import _malloc
-@_exported import _stddef
-@_exported import _stdlib
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -13,6 +13,9 @@
 @_exported import ucrt // Clang module
 // Extra clang module that's split out from ucrt:
 @_exported import _complex
+@_exported import _fenv
+@_exported import _float
+@_exported import _malloc
 @_exported import _stddef
 @_exported import _stdlib
 


### PR DESCRIPTION
Windows SDK 10.0.26100 added an include to compiler intrinsics headers in `wchar.h`. In turn, these headers include `malloc.h`, `stdlib.h` and `stddef.h` from `ucrt`, this leads to a cyclic dependency between the `ucrt` and compiler intrinsics modules. Furthermore, Clang 19 (from Swift 6.1) intrinsics headers sometimes clash with the ucrt headers dependencies.

These changes separate the problematic headers into different standalone modules.

Fixes: compnerd/swift-build#909
Fixes: #79745