### PR TITLE
[Dependency Scanning] Remove Unnecessary Code that Computes Module Output Path

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -172,7 +172,7 @@ public:
     SwiftInterfaceModuleOutputPathResolution::ResultTy swiftInterfaceOutputPath;
     if (resolvingDepInfo.isSwiftInterfaceModule()) {
       pruneUnusedVFSOverlay(swiftInterfaceOutputPath);
-      updateSwiftInterfaceModuleOutputPath(swiftInterfaceOutputPath);
+      addSwiftInterfaceModuleOutputPathToCommandLine(swiftInterfaceOutputPath);
     }
 
     // Update the dependency in the cache with the modified command-line.
@@ -455,19 +455,12 @@ private:
     return;
   }
 
-  void updateSwiftInterfaceModuleOutputPath(
+  void addSwiftInterfaceModuleOutputPathToCommandLine(
       const SwiftInterfaceModuleOutputPathResolution::ResultTy &outputPath) {
     StringRef outputName = outputPath.outputPath.str();
 
-    bool isOutputPath = false;
-    for (auto &A : commandline) {
-      if (isOutputPath) {
-        A = outputName.str();
-        break;
-      } else if (A == "-o") {
-        isOutputPath = true;
-      }
-    }
+    commandline.push_back("-o");
+    commandline.push_back(outputName.str());
 
     return;
   }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -225,7 +225,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
                                                       compiledCandidates.end());
 
         // If this interface specified '-autolink-force-load', add it to the
-        // set of linked libraries for this moduole.
+        // set of linked libraries for this module.
         std::vector<LinkLibrary> linkLibraries;
         if (llvm::find(ArgsRefs, "-autolink-force-load") != ArgsRefs.end()) {
           std::string linkName = realModuleName.str().str();

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -205,15 +205,6 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
           Args.push_back(candidate);
         }
 
-        // Compute the output path and add it to the command line
-        SmallString<128> outputPathBase(moduleOutputPath);
-        llvm::sys::path::append(
-            outputPathBase,
-            moduleName.str() + "-" + Hash + "." +
-                file_types::getExtension(file_types::TY_SwiftModuleFile));
-        Args.push_back("-o");
-        Args.push_back(outputPathBase.str().str());
-
         // Open the interface file.
         auto &fs = *Ctx.SourceMgr.getFileSystem();
         auto interfaceBuf = fs.getBufferForFile(moduleInterfacePath);
@@ -234,7 +225,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
                                                       compiledCandidates.end());
 
         // If this interface specified '-autolink-force-load', add it to the
-        // set of linked libraries for this module.
+        // set of linked libraries for this moduole.
         std::vector<LinkLibrary> linkLibraries;
         if (llvm::find(ArgsRefs, "-autolink-force-load") != ArgsRefs.end()) {
           std::string linkName = realModuleName.str().str();
@@ -250,11 +241,6 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
         Result = ModuleDependencyInfo::forSwiftInterfaceModule(
             InPath, compiledCandidatesRefs, ArgsRefs, {}, {}, linkLibraries,
             isFramework, isStatic, {}, /*module-cache-key*/ "", UserModVer);
-
-        // We do NOT need the code below to set output path in the dependency
-        // info because it will be calculated again later. We do not want to
-        // create output paths that do not exist in the end.
-        // Result->setOutputPathAndHash(outputPathBase.str().str(), Hash);
 
         if (Ctx.CASOpts.EnableCaching) {
           std::vector<std::string> clangDependencyFiles;

--- a/test/ScanDependencies/FilterClangSearchPaths.swift
+++ b/test/ScanDependencies/FilterClangSearchPaths.swift
@@ -28,8 +28,8 @@ import C
 // CHECK-NEXT:          "moduleInterfacePath": "{{.*}}{{/|\\}}Inputs{{/|\\}}Swift{{/|\\}}A.swiftinterface",
 // CHECK:          "commandLine": [
 // CHECK:            "-fobjc-disable-direct-methods-for-testing"
-// CHECK:            "-o",
-// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
 // CHECK-NOT:        "/tmp/foo"
 // CHECK-NOT:        "-I/tmp/bar"
+// CHECK:            "-o",
+// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule"
 // CHECK:          ]

--- a/test/ScanDependencies/ObjCStrict.swift
+++ b/test/ScanDependencies/ObjCStrict.swift
@@ -29,7 +29,7 @@ import C
 // CHECK:          "commandLine": [
 // CHECK:            "-fobjc-disable-direct-methods-for-testing"
 // CHECK:            "-o",
-// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule"
 
             
 

--- a/test/ScanDependencies/eliminate_unused_vfs.swift
+++ b/test/ScanDependencies/eliminate_unused_vfs.swift
@@ -79,10 +79,10 @@ import F
 // MOD-HASH-NEXT:   "swift": {
 // MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
 // MOD-HASH:   "commandLine": [
-// MOD-HASH:     "-o",
-// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH:.*]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH:.*]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH:.*]].swiftmodule",
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH:.*]].swiftmodule"
 // MOD-HASH:     ],
 // MOD-HASH: "mainModuleName": "deps1",
 // MOD-HASH: "linkLibraries": [],
@@ -90,10 +90,10 @@ import F
 // MOD-HASH-NEXT:   "swift": {
 // MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
 // MOD-HASH:   "commandLine": [
-// MOD-HASH:     "-o",
-// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH]].swiftmodule",
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule"
 // MOD-HASH:     ],
 // MOD-HASH: "mainModuleName": "deps2",
 // MOD-HASH: "linkLibraries": [],
@@ -101,8 +101,8 @@ import F
 // MOD-HASH-NEXT:   "swift": {
 // MOD-HASH-NEXT:   "moduleInterfacePath": "{{.*}}{{/|\\}}F.swiftinterface",
 // MOD-HASH:   "commandLine": [
-// MOD-HASH:     "-o",
-// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-[[SHASH]].swiftmodule",
 // MOD-HASH:     "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-[[SOSHASH]].swiftmodule",
+// MOD-HASH:     "-o",
+// MOD-HASH-NEXT:     "{{.*}}{{/|\\}}F-[[FHASH]].swiftmodule"
 // MOD-HASH:     ],

--- a/test/ScanDependencies/explicit-swift-dependencies.swift
+++ b/test/ScanDependencies/explicit-swift-dependencies.swift
@@ -47,9 +47,9 @@ import F
 // CHECK-NEXT:            "-fno-implicit-modules",
 // CHECK-NEXT:            "-Xcc",
 // CHECK-NEXT:            "-fno-implicit-module-maps",
-// CHECK-NEXT:            "-o",
-// CHECK-NEXT:            "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule"
 // CHECK-DAG:             "-swift-module-file=Swift={{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule"
 // CHECK-DAG:             "-swift-module-file=SwiftOnoneSupport={{.*}}{{/|\\}}SwiftOnoneSupport-{{.*}}.swiftmodule"
 // CHECK-DAG:             "-fmodule-file=F={{.*}}{{/|\\}}F-{{.*}}.pcm"
 // CHECK-DAG:             "-fmodule-file=SwiftShims={{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm"
+// CHECK-NEXT:            "-o",
+// CHECK-NEXT:            "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule"


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
https://github.com/swiftlang/swift/pull/79297 implemented current working directory pruning but left some unnecessary code
that computes Swift interface module output path prematurely. This PR removes the code that computes the output path too 
early. The `ExplicitModuleDependencyResolver` now adds the path to the command line after it can correctly compute it. 

Context: https://github.com/swiftlang/swift/pull/79297/files#r1955314542

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
