### PR TITLE
[NFC] inline hasDomain into assertion

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3294,8 +3294,7 @@ class SemanticAvailableAttr final {
 public:
   SemanticAvailableAttr(const AvailableAttr *attr) : attr(attr) {
     assert(attr);
-    bool hasDomain = attr->getDomainOrIdentifier().isDomain();
-    assert(hasDomain);
+    assert(attr->getDomainOrIdentifier().isDomain());
   }
 
   const AvailableAttr *getParsedAttr() const { return attr; }


### PR DESCRIPTION
This was causing unused-variable compilation warnings for every file that #includes Attr.h on non-assert builds.