### PR TITLE
[TypeChecker] Simplify ExprPattern from Bool literals in Bool? switch

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1489,3 +1489,30 @@ do {
       case (e: .y, b: true)?: break
   }
 }
+
+// https://github.com/swiftlang/swift/issues/61817
+do {
+  let a: Bool? = true
+  switch a {
+    case true: break
+    case false: break
+    case nil: break
+  }
+
+  let result = {
+    switch a {
+      case true: true
+      case false: true
+      case nil: true
+    }
+  }
+  _ = result()
+
+  let b: Bool?? = true
+  switch b {
+    case true: break
+    case false: break
+    case nil: break
+    case nil?: break
+  }
+}


### PR DESCRIPTION
Resolves: [swiftlang/swift#61817](https://github.com/swiftlang/swift/issues/61817).

Boolean literals are treated as `ExprPattern`s when switching over `Bool?` because they require implicit conversion to Optionals, resulting in them being wrapped in `InjectIntoOptionalExpr`s. Consequently, they do not contribute to exhausting the switch cases.

In this special case, we can instead treat them as `true?`/`false?`.