### PR TITLE
Ensure that isolated conformances originate in the same isolation domain

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8320,6 +8320,9 @@ ERROR(isolated_conformance_with_sendable_simple,none,
       "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
       "requirement for a `Sendable` type parameter ",
       (Type, DeclName))
+ERROR(isolated_conformance_wrong_domain,none,
+      "%0 isolated conformance of %1 to %2 cannot be used in %3 context",
+      (ActorIsolation, Type, DeclName, ActorIsolation))
 
 //===----------------------------------------------------------------------===//
 // MARK: @execution Attribute

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -703,6 +703,37 @@ void introduceUnsafeInheritExecutorReplacements(
 /// the immediate conformance, not any conformances on which it depends.
 ActorIsolation getConformanceIsolation(ProtocolConformance *conformance);
 
+/// Check for correct use of isolated conformances in the given reference.
+///
+/// This checks that any isolated conformances that occur in the given
+/// declaration reference match the isolated of the context.
+bool checkIsolatedConformancesInContext(
+    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc);
+
+/// Check for correct use of isolated conformances in the set given set of
+/// protocol conformances.
+///
+/// This checks that any isolated conformances that occur in the given
+/// declaration reference match the isolated of the context.
+bool checkIsolatedConformancesInContext(
+    ArrayRef<ProtocolConformanceRef> conformances, SourceLoc loc,
+    const DeclContext *dc);
+
+/// Check for correct use of isolated conformances in the given substitution
+/// map.
+///
+/// This checks that any isolated conformances that occur in the given
+/// substitution map match the isolated of the context.
+bool checkIsolatedConformancesInContext(
+    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc);
+
+/// Check for correct use of isolated conformances in the given type.
+///
+/// This checks that any isolated conformances that occur in the given
+/// type match the isolated of the context.
+bool checkIsolatedConformancesInContext(
+    Type type, SourceLoc loc, const DeclContext *dc);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -240,6 +240,38 @@ bool witnessHasImplementsAttrForRequiredName(ValueDecl *witness,
 bool witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
                                                  ValueDecl *requirement);
 
+/// Visit each conformance within the given type.
+///
+/// If `body` returns true for any conformance, this function stops the
+/// traversal and returns true.
+bool forEachConformance(
+    Type type, llvm::function_ref<bool(ProtocolConformanceRef)> body);
+
+/// Visit each conformance within the given conformance (including the given
+/// one).
+///
+/// If `body` returns true for any conformance, this function stops the
+/// traversal and returns true.
+bool forEachConformance(
+    ProtocolConformanceRef conformance,
+    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+
+/// Visit each conformance within the given substitution map.
+///
+/// If `body` returns true for any conformance, this function stops the
+/// traversal and returns true.
+bool forEachConformance(
+    SubstitutionMap subs,
+    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+
+/// Visit each conformance within the given declaration reference.
+///
+/// If `body` returns true for any conformance, this function stops the
+/// traversal and returns true.
+bool forEachConformance(
+    ConcreteDeclRef declRef,
+    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -240,12 +240,15 @@ bool witnessHasImplementsAttrForRequiredName(ValueDecl *witness,
 bool witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
                                                  ValueDecl *requirement);
 
+using VisitedConformances = llvm::SmallPtrSet<void *, 16>;
+
 /// Visit each conformance within the given type.
 ///
 /// If `body` returns true for any conformance, this function stops the
 /// traversal and returns true.
 bool forEachConformance(
-    Type type, llvm::function_ref<bool(ProtocolConformanceRef)> body);
+    Type type, llvm::function_ref<bool(ProtocolConformanceRef)> body,
+    VisitedConformances *visitedConformances = nullptr);
 
 /// Visit each conformance within the given conformance (including the given
 /// one).
@@ -254,7 +257,8 @@ bool forEachConformance(
 /// traversal and returns true.
 bool forEachConformance(
     ProtocolConformanceRef conformance,
-    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+    llvm::function_ref<bool(ProtocolConformanceRef)> body,
+    VisitedConformances *visitedConformances = nullptr);
 
 /// Visit each conformance within the given substitution map.
 ///
@@ -262,7 +266,8 @@ bool forEachConformance(
 /// traversal and returns true.
 bool forEachConformance(
     SubstitutionMap subs,
-    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+    llvm::function_ref<bool(ProtocolConformanceRef)> body,
+    VisitedConformances *visitedConformances = nullptr);
 
 /// Visit each conformance within the given declaration reference.
 ///
@@ -270,7 +275,8 @@ bool forEachConformance(
 /// traversal and returns true.
 bool forEachConformance(
     ConcreteDeclRef declRef,
-    llvm::function_ref<bool(ProtocolConformanceRef)> body);
+    llvm::function_ref<bool(ProtocolConformanceRef)> body,
+    VisitedConformances *visitedConformances = nullptr);
 
 }
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -119,3 +119,9 @@ func testIsolationConformancesInCall(c: C) {
   acceptSendableP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
   acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
 }
+
+func testIsolationConformancesFromOutside(c: C) {
+  acceptP(c) // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _: any P = c // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _ = PWrapper<C>() // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+}


### PR DESCRIPTION
This is the missing check for "rule #1" in the isolated conformances proposal, which states that an isolated conformance can only be referenced within the same isolation domain as the conformance. For example, a main-actor-isolated conformance can only be used within main-actor code.
