### PR TITLE
AST: Reimplement `AvailabilityContext` storage using `TrailingObjects`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -37,10 +37,9 @@ class Decl;
 class AvailabilityContext {
 public:
   class Storage;
+  class DomainInfo;
 
 private:
-  class Info;
-
   /// A non-null pointer to uniqued storage for this availability context.
   const Storage *storage;
 


### PR DESCRIPTION
This makes more efficient use of the permanent memory allocated for `AvailabilityContext` representations and also fixes a leak that was introduced in https://github.com/swiftlang/swift/pull/79718 where the small vector for unavailable domain storage was not being cleaned up on `ASTContext` deallocation.

Resolves rdar://145929932.
