### PR TITLE
stdlib: Fix the signature of `_taskEscalate` to return a priority

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1494,7 +1494,8 @@ internal func _taskCurrentPriority(_ task: Builtin.NativeObject) -> UInt8
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_escalate")
-internal func _taskEscalate(_ task: Builtin.NativeObject, newPriority: UInt8)
+@discardableResult
+internal func _taskEscalate(_ task: Builtin.NativeObject, newPriority: UInt8) -> UInt8
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_basePriority")


### PR DESCRIPTION
The `swift_task_escalate` is defined to return the new priority of the task after the escalation but the silgen_name'd function did not have the return type specified.

This is revealed by the following wasm linker warning:
```
wasm-ld: warning: function signature mismatch: swift_task_escalate
>>> defined as (i32, i32, i32, i32) -> void in /home/bot/.swiftpm/swift-sdks/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-02-28-a-wasm32-unknown-wasi.artifactbundle/DEVELOPMENT-SNAPSHOT-2025-02-28-a-wasm32-unknown-wasi/wasm32-unknown-wasi/swift.xctoolchain/usr/lib/swift_static/wasi/libswift_Concurrency.a(_Concurrency.o)
>>> defined as (i32, i32, i32, i32) -> i32 in /home/bot/.swiftpm/swift-sdks/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-02-28-a-wasm32-unknown-wasi.artifactbundle/DEVELOPMENT-SNAPSHOT-2025-02-28-a-wasm32-unknown-wasi/wasm32-unknown-wasi/swift.xctoolchain/usr/lib/swift_static/wasi/libswift_Concurrency.a(TaskStatus.cpp.o)
```

Follow up to 18c25845d67dc52a8ae82068e4f0e130356f0e76

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
