### PR TITLE
[SE-0458] Improved disambiguation for `unsafe` expressions

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -439,7 +439,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   if (Tok.isContextualKeyword("unsafe") &&
       !(peekToken().isAtStartOfLine() ||
         peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square,
-                          tok::equal) ||
+                          tok::equal, tok::colon, tok::comma) ||
+        (isExprBasic && peekToken().is(tok::l_brace)) ||
         peekToken().is(tok::period))) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -179,17 +179,25 @@ enum Color {
 case red
 }
 
+func acceptBools(_: Bool, _: Bool) { }
+
+func acceptBoolsUnsafeLabel(unsafe _: Bool, _: Bool) { }
+
 func unsafeFun() {
   var unsafe = true
   unsafe = false
   unsafe.toggle()
   _ = [unsafe]
   _ = { unsafe }
+  acceptBools(unsafe, unsafe)
+  acceptBoolsUnsafeLabel(unsafe: unsafe, unsafe)
 
   let color: Color
   // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
   color = unsafe .red
   _ = color
+
+  if unsafe { }
 }
 
 // @safe suppresses unsafe-type-related diagnostics on an entity


### PR DESCRIPTION
Disambiguate `unsafe` in a few more common contexts:
* Before a comma in a list of whatever form
* Before a left brace somewhere that we cannot have a closure

Fixes a few more source compatibility regressions found in the wild, rdar://146125433.
