### PR TITLE
Fix TempLValueOpt for init_enum_data_addr

### DIFF
--- a/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
+++ b/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
@@ -113,8 +113,6 @@ void TempLValueOptPass::run() {
 }
 
 static SingleValueInstruction *isMovableProjection(SILValue addr) {
-  if (auto *enumData = dyn_cast<InitEnumDataAddrInst>(addr))
-    return enumData;
   if (auto *existentialAddr = dyn_cast<InitExistentialAddrInst>(addr))
     return existentialAddr;
     

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -84,14 +84,14 @@ struct AddressOnlyPayload {
 //
 // CHECK-LABEL: sil @test_initialize_struct :
 // CHECK:      bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
-// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
-// CHECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
-// CHECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   copy_addr %1 to [init] [[A]]
-// CHECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   store %2 to [[I]]
-// CHECK-NEXT:   inject_enum_addr [[E]]
-// CHECK-NOT:    copy_addr
+// HECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
+// HECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
+// HECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
+// HECK-NEXT:   copy_addr %1 to [init] [[A]]
+// HECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
+// HECK-NEXT:   store %2 to [[I]]
+// HECK-NEXT:   inject_enum_addr [[E]]
+// HECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_initialize_struct'
 sil @test_initialize_struct : $@convention(method) (@in Any, Int) -> @out TestStruct {
 bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
@@ -165,14 +165,14 @@ struct StructWithEnum : Proto {
 
 // CHECK-LABEL: sil @move_projections :
 // CHECK:      bb0(%0 : $*any Proto, %1 : $*Any):
-// CHECK-NEXT:   [[S:%[0-9]+]] = init_existential_addr %0 : $*any Proto, $StructWithEnum
-// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
-// CHECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
-// CHECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
-// CHECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
-// CHECK-NOT:    copy_addr
+// HECK-NEXT:   [[S:%[0-9]+]] = init_existential_addr %0 : $*any Proto, $StructWithEnum
+// HECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
+// HECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
+// HECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// HECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
+// HECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// HECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
+// HECK-NOT:    copy_addr
 // CHECK: } // end sil function 'move_projections'
 sil @move_projections : $@convention(thin) (@in Any) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*Any):
@@ -278,3 +278,35 @@ bb0(%ret_addr : $*T):
   return %15 : $()
 }
 
+class Klass {
+  init()
+}
+
+enum FakeOptional {
+  case none
+  case some(Klass)
+}
+
+sil @initfn : $@convention(thin) () -> @out Klass
+
+// CHECK-LABEL: sil @test_enum
+// CHECK: alloc_stack
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_enum'
+sil @test_enum : $@convention(thin) () -> @out FakeOptional {
+bb0(%0 : $*FakeOptional):
+  %1 = alloc_stack [lexical] [var_decl] $Klass
+  %2 = function_ref @initfn : $@convention(thin) () -> @out Klass
+  %3 = apply %2(%1) : $@convention(thin) () -> @out Klass
+  %4 = alloc_stack $Klass
+  %5 = apply %2(%4) : $@convention(thin) () -> @out Klass
+  destroy_addr %1
+  copy_addr [take] %4 to [init] %1
+  dealloc_stack %4
+  %9 = init_enum_data_addr %0, #FakeOptional.some!enumelt
+  copy_addr [take] %1 to [init] %9
+  inject_enum_addr %0, #FakeOptional.some!enumelt
+  dealloc_stack %1
+  %13 = tuple ()
+  return %13
+}

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -84,14 +84,14 @@ struct AddressOnlyPayload {
 //
 // CHECK-LABEL: sil [ossa] @test_initialize_struct :
 // CHECK:      bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
-// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
-// CHECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
-// CHECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   copy_addr [take] %1 to [init] [[A]]
-// CHECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   store %2 to [trivial] [[I]]
-// CHECK-NEXT:   inject_enum_addr [[E]]
-// CHECK-NOT:    copy_addr
+// HECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
+// HECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
+// HECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
+// HECK-NEXT:   copy_addr [take] %1 to [init] [[A]]
+// HECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
+// HECK-NEXT:   store %2 to [trivial] [[I]]
+// HECK-NEXT:   inject_enum_addr [[E]]
+// HECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_initialize_struct'
 sil [ossa] @test_initialize_struct : $@convention(method) (@in Any, Int) -> @out TestStruct {
 bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
@@ -165,14 +165,14 @@ struct StructWithEnum : Proto {
 
 // CHECK-LABEL: sil [ossa] @move_projections :
 // CHECK:      bb0(%0 : $*any Proto, %1 : $*Any):
-// CHECK-NEXT:   [[S:%[0-9]+]] = init_existential_addr %0 : $*any Proto, $StructWithEnum
-// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
-// CHECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
-// CHECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
-// CHECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
-// CHECK-NOT:    copy_addr
+// HECK-NEXT:   [[S:%[0-9]+]] = init_existential_addr %0 : $*any Proto, $StructWithEnum
+// HECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
+// HECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
+// HECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// HECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
+// HECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// HECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
+// HECK-NOT:    copy_addr
 // CHECK: } // end sil function 'move_projections'
 sil [ossa] @move_projections : $@convention(thin) (@in Any) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*Any):


### PR DESCRIPTION
`TempLValueOpt` eliminates copies from a temporary to destination and supports hoisting projections of the destination.

An enum is fully initialized with the pair `init_enum_data_addr` and `inject_enum_addr`. Calling `destroy_addr` before initializing the tag with `inject_enum_addr` can cause a runtime crash.

`TempLValueOpt` can eliminate `copy_addr` and hoist `init_enum_data_addr` such that enum is not fully initialized before it's use.

Disable this case for now.
Fixes rdar://145941433

To correctly do this optimization we have to find the corresponding `inject_enum_addr` and hoist it as well or ensure the result of `init_enum_data_addr `  is not read until fully initialized by `inject_enum_addr`.

