### PR TITLE
[CSSolver] Properly record opened pack expansion types

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -318,7 +318,7 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
                                            expansionVar, openedPackExpansion,
                                            expansionLoc));
 
-  OpenedPackExpansionTypes[openedPackExpansion] = expansionVar;
+  recordOpenedPackExpansionType(openedPackExpansion, expansionVar);
   return expansionVar;
 }
 


### PR DESCRIPTION
This is a bug which leads to accumulation of data in the constraint system even though most of it is out of scope.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
